### PR TITLE
Add an option to exclusively lock Transactional State

### DIFF
--- a/src/Orleans.Transactions.TestKit.Base/Grains/ExclusiveLockCoordinatorGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/ExclusiveLockCoordinatorGrain.cs
@@ -1,0 +1,23 @@
+﻿using Orleans.Concurrency;
+
+namespace Orleans.Transactions.TestKit
+{
+    [StatelessWorker]
+    [Reentrant]
+    public class ExclusiveLockCoordinatorGrain : Grain, IExclusiveLockCoordinatorGrain
+    {
+        public async Task ReadThenWrite(ITransactionTestGrain grain, int value)
+        {
+            await grain.Get();
+            await Task.Delay(TimeSpan.FromMilliseconds(100)); // add some delay to make concurrent txs interleave each other
+            await grain.Add(value);
+        }
+
+        public async Task ReadThenWriteWithExclusiveLock(IExclusiveLockTransactionTestGrain grain, int value)
+        {
+            await grain.Get();
+            await Task.Delay(TimeSpan.FromMilliseconds(100)); // add some delay to make concurrent txs interleave each other
+            await grain.Add(value);
+        }
+    }
+}

--- a/src/Orleans.Transactions.TestKit.Base/Grains/ExclusiveLockTransactionTestGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/ExclusiveLockTransactionTestGrain.cs
@@ -9,7 +9,7 @@ namespace Orleans.Transactions.TestKit
     {
         private readonly ITransactionalState<GrainData> data;
         private readonly ILoggerFactory loggerFactory;
-        private ILogger logger;
+        protected ILogger logger;
 
         public ExclusiveLockTransactionTestGrain(
             [TransactionalState("data", TransactionTestConstants.TransactionStore)]

--- a/src/Orleans.Transactions.TestKit.Base/Grains/ExclusiveLockTransactionTestGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/ExclusiveLockTransactionTestGrain.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.Logging;
+using Orleans.Concurrency;
+using Orleans.Transactions.Abstractions;
+
+namespace Orleans.Transactions.TestKit
+{
+    [Reentrant]
+    public class ExclusiveLockTransactionTestGrain : Grain, IExclusiveLockTransactionTestGrain
+    {
+        private readonly ITransactionalState<GrainData> data;
+        private readonly ILoggerFactory loggerFactory;
+        private ILogger logger;
+
+        public ExclusiveLockTransactionTestGrain(
+            [TransactionalState("data", TransactionTestConstants.TransactionStore)]
+            ITransactionalState<GrainData> data,
+            ILoggerFactory loggerFactory)
+        {
+            this.data = data;
+            this.loggerFactory = loggerFactory;
+        }
+
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
+        {
+            this.logger = this.loggerFactory.CreateLogger(this.GetGrainId().ToString());
+            return base.OnActivateAsync(cancellationToken);
+        }
+
+        public async Task Set(int newValue)
+        {
+            await data.PerformUpdate(state =>
+            {
+                this.logger.LogInformation("Setting from {Value} to {NewValue}.", state.Value, newValue);
+                state.Value = newValue;
+                this.logger.LogInformation("Set to {Value}.", state.Value);
+            });
+        }
+
+        public async Task<int[]> Add(int numberToAdd)
+        {
+            var result = await data.PerformUpdate(state =>
+            {
+                this.logger.LogInformation("Adding {NumberToAdd} to value {Value}.", numberToAdd, state.Value);
+                state.Value += numberToAdd;
+                this.logger.LogInformation("Value after Adding {NumberToAdd} is {Value}.", numberToAdd, state.Value);
+                return state.Value;
+            });
+            return new int[] { result };
+        }
+
+        public async Task<int[]> Get()
+        {
+            var result = await data.PerformRead(state =>
+            {
+                this.logger.LogInformation("Get {Value}.", state.Value);
+                return state.Value;
+            });
+            return new int[] { result };
+        }
+    }
+}

--- a/src/Orleans.Transactions.TestKit.Base/Grains/ExclusiveLockTransactionTestGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/ExclusiveLockTransactionTestGrain.cs
@@ -9,7 +9,7 @@ namespace Orleans.Transactions.TestKit
     {
         private readonly ITransactionalState<GrainData> data;
         private readonly ILoggerFactory loggerFactory;
-        protected ILogger logger;
+        protected ILogger logger = null!;
 
         public ExclusiveLockTransactionTestGrain(
             [TransactionalState("data", TransactionTestConstants.TransactionStore)]

--- a/src/Orleans.Transactions.TestKit.Base/Grains/IExclusiveLockCoordinatorGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/IExclusiveLockCoordinatorGrain.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+
+namespace Orleans.Transactions.TestKit
+{
+    public interface IExclusiveLockCoordinatorGrain : IGrainWithGuidKey
+    {
+        /// <summary>
+        /// Performs a Read-then-Write pattern on a grain without exclusive lock.
+        /// </summary>
+        [Transaction(TransactionOption.Create)]
+        Task ReadThenWrite(ITransactionTestGrain grain, int value);
+
+        /// <summary>
+        /// Performs a Read-then-Write pattern on a grain with exclusive lock on reads.
+        /// The exclusive lock prevents lock upgrade conflicts under concurrent execution.
+        /// </summary>
+        [Transaction(TransactionOption.Create)]
+        Task ReadThenWriteWithExclusiveLock(IExclusiveLockTransactionTestGrain grain, int value);
+    }
+}

--- a/src/Orleans.Transactions.TestKit.Base/Grains/IExclusiveLockTransactionTestGrain.cs
+++ b/src/Orleans.Transactions.TestKit.Base/Grains/IExclusiveLockTransactionTestGrain.cs
@@ -1,0 +1,29 @@
+﻿namespace Orleans.Transactions.TestKit
+{
+    public interface IExclusiveLockTransactionTestGrain : IGrainWithGuidKey
+    {
+        /// <summary>
+        /// apply set operation to every transaction state
+        /// </summary>
+        /// <param name="newValue"></param>
+        /// <returns></returns>
+        [Transaction(TransactionOption.CreateOrJoin)]
+        Task Set(int newValue);
+
+        /// <summary>
+        /// apply add operation to every transaction state
+        /// </summary>
+        /// <param name="numberToAdd"></param>
+        /// <returns></returns>
+        [Transaction(TransactionOption.CreateOrJoin)]
+        Task<int[]> Add(int numberToAdd);
+
+        /// <summary>
+        /// apply get operation to every transaction state with exclusive lock
+        /// </summary>
+        /// <returns></returns>
+        [UseExclusiveLock]
+        [Transaction(TransactionOption.CreateOrJoin)]
+        Task<int[]> Get();
+    }
+}

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/ExclusiveLockTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/ExclusiveLockTransactionTestRunner.cs
@@ -5,7 +5,9 @@ namespace Orleans.Transactions.TestKit
     public abstract class ExclusiveLockTransactionTestRunner : TransactionTestRunnerBase
     {
         protected ExclusiveLockTransactionTestRunner(IGrainFactory grainFactory, Action<string> output)
-        : base(grainFactory, output) { }
+            : base(grainFactory, output)
+        {
+        }
 
         /// <summary>
         /// Verifies that concurrent Read-then-Write transactions on the same grain

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/ExclusiveLockTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/ExclusiveLockTransactionTestRunner.cs
@@ -1,0 +1,114 @@
+﻿using AwesomeAssertions;
+
+namespace Orleans.Transactions.TestKit
+{
+    public abstract class ExclusiveLockTransactionTestRunner : TransactionTestRunnerBase
+    {
+        protected ExclusiveLockTransactionTestRunner(IGrainFactory grainFactory, Action<string> output)
+        : base(grainFactory, output) { }
+
+        /// <summary>
+        /// Verifies that concurrent Read-then-Write transactions on the same grain
+        /// cause OrleansTransactionLockUpgradeException or OrleansBrokenTransactionLockException
+        /// when no exclusive lock is used.
+        ///
+        /// Scenario (LockUpgradeException):
+        ///   TX1: PerformRead → shared lock acquired
+        ///   TX2: PerformRead → shared lock acquired (same group)
+        ///   TX1: PerformUpdate → lock upgrade fails
+        ///
+        /// Scenario (BrokenTransactionLockException):
+        ///   TX1: PerformRead → shared lock acquired
+        ///   TX2: PerformRead → shared lock acquired (same group)
+        ///   TX2: PerformUpdate → upgraded, TX1 rolled back
+        ///   TX1: PerformUpdate → broken lock detected
+        /// </summary>
+        public virtual async Task ConcurrentReadThenWriteWithoutExclusiveLock_ThrowsLockException(string grainStates)
+        {
+            const int concurrentTransactions = 10;
+            const int addValue = 5;
+
+            ITransactionTestGrain grain = RandomTestGrain(grainStates);
+
+            var tasks = new List<Task>(concurrentTransactions);
+            for (int i = 0; i < concurrentTransactions; i++)
+            {
+                var coordinator = this.grainFactory.GetGrain<IExclusiveLockCoordinatorGrain>(Guid.NewGuid());
+                tasks.Add(coordinator.ReadThenWrite(grain, addValue));
+            }
+
+            var exceptions = new List<Exception>();
+            foreach (var task in tasks)
+            {
+                try
+                {
+                    await task;
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+
+            this.testOutput($"Total exceptions: {exceptions.Count} out of {concurrentTransactions} transactions");
+            foreach (var ex in exceptions)
+            {
+                this.testOutput($"  Exception type: {ex.GetType().Name}");
+            }
+
+            exceptions.Should().Contain(ex =>
+                ex is OrleansTransactionLockUpgradeException
+                || ex is OrleansBrokenTransactionLockException);
+
+            var values = await grain.Get();
+            values[0].Should().Be((concurrentTransactions - exceptions.Count) * addValue);
+        }
+
+        /// <summary>
+        /// Verifies that using [UseExclusiveLock] on the read method prevents
+        /// lock upgrade exceptions when concurrent transactions perform Read-then-Write on the same grain.
+        /// </summary>
+        public virtual async Task ConcurrentReadThenWriteWithExclusiveLock_NoLockException(string grainStates)
+        {
+            const int concurrentTransactions = 10;
+            const int addValue = 5;
+
+            var grain = RandomTestGrain<IExclusiveLockTransactionTestGrain>(
+                TransactionTestConstants.ExclusiveLockTransactionTestGrain);
+
+            var tasks = new List<Task>(concurrentTransactions);
+            for (int i = 0; i < concurrentTransactions; i++)
+            {
+                var coordinator = this.grainFactory.GetGrain<IExclusiveLockCoordinatorGrain>(Guid.NewGuid());
+                tasks.Add(coordinator.ReadThenWriteWithExclusiveLock(grain, addValue));
+            }
+
+            var lockExceptions = new List<Exception>();
+            foreach (var task in tasks)
+            {
+                try
+                {
+                    await task;
+                }
+                catch (OrleansTransactionLockUpgradeException ex)
+                {
+                    lockExceptions.Add(ex);
+                }
+                catch (OrleansBrokenTransactionLockException ex)
+                {
+                    lockExceptions.Add(ex);
+                }
+            }
+
+            this.testOutput($"Lock exceptions: {lockExceptions.Count} out of {concurrentTransactions} transactions");
+
+            // No lock upgrade or broken lock exceptions should occur
+            lockExceptions.Should().BeEmpty("UseExclusiveLock should prevent lock upgrade conflicts by acquiring exclusive locks from the start");
+
+            // Verify the grain state is consistent - all successful transactions should have added their value
+            int[] values = await grain.Get();
+            this.testOutput($"Final grain value: {values[0]}");
+            (values[0]).Should().Be(concurrentTransactions * addValue);
+        }
+    }
+}

--- a/src/Orleans.Transactions.TestKit.Base/TransactionTestConstants.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TransactionTestConstants.cs
@@ -13,11 +13,12 @@ namespace Orleans.Transactions.TestKit
 
         // committer service
         public const string RemoteCommitService = "RemoteCommitService";
-        
+
         // grain implementations
         public const string NoStateTransactionalGrain = "NoStateTransactionalGrain";
         public const string SingleStateTransactionalGrain = "SingleStateTransactionalGrain";
         public const string DoubleStateTransactionalGrain = "DoubleStateTransactionalGrain";
         public const string MaxStateTransactionalGrain = "MaxStateTransactionalGrain";
+        public const string ExclusiveLockTransactionTestGrain = "ExclusiveLockTransactionTestGrain";
     }
 }

--- a/src/Orleans.Transactions.TestKit.xUnit/ExclusiveLockTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/ExclusiveLockTransactionTestRunner.cs
@@ -6,7 +6,9 @@ namespace Orleans.Transactions.TestKit.xUnit
     public abstract class ExclusiveLockTransactionTestRunnerxUnit : ExclusiveLockTransactionTestRunner
     {
         protected ExclusiveLockTransactionTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
-            : base(grainFactory, output.WriteLine) { }
+            : base(grainFactory, output.WriteLine)
+        {
+        }
 
         [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]

--- a/src/Orleans.Transactions.TestKit.xUnit/ExclusiveLockTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/ExclusiveLockTransactionTestRunner.cs
@@ -1,0 +1,25 @@
+﻿using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.TestKit.xUnit
+{
+    public abstract class ExclusiveLockTransactionTestRunnerxUnit : ExclusiveLockTransactionTestRunner
+    {
+        protected ExclusiveLockTransactionTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
+            : base(grainFactory, output.WriteLine) { }
+
+        [SkippableTheory]
+        [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]
+        public override Task ConcurrentReadThenWriteWithoutExclusiveLock_ThrowsLockException(string grainStates)
+        {
+            return base.ConcurrentReadThenWriteWithoutExclusiveLock_ThrowsLockException(grainStates);
+        }
+
+        [SkippableTheory]
+        [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]
+        public override Task ConcurrentReadThenWriteWithExclusiveLock_NoLockException(string grainStates)
+        {
+            return base.ConcurrentReadThenWriteWithExclusiveLock_NoLockException(grainStates);
+        }
+    }
+}

--- a/src/Orleans.Transactions/DistributedTM/TransactionClient.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionClient.cs
@@ -18,7 +18,13 @@ internal class TransactionClient : ITransactionClient
         _serializer = serializer;
     }
 
-    public async Task RunTransaction(TransactionOption transactionOption, Func<Task> transactionDelegate)
+    public Task RunTransaction(TransactionOption transactionOption, Func<Task> transactionDelegate)
+        => RunTransaction(transactionOption, transactionDelegate, useExclusiveLock: false);
+
+    public Task RunTransaction(TransactionOption transactionOption, Func<Task<bool>> transactionDelegate)
+        => RunTransaction(transactionOption, transactionDelegate, useExclusiveLock: false);
+
+    public async Task RunTransaction(TransactionOption transactionOption, Func<Task> transactionDelegate, bool useExclusiveLock)
     {
         if (transactionDelegate is null)
         {
@@ -29,10 +35,10 @@ internal class TransactionClient : ITransactionClient
         {
             await transactionDelegate();
             return true;
-        });
+        }, useExclusiveLock);
     }
 
-    public async Task RunTransaction(TransactionOption transactionOption, Func<Task<bool>> transactionDelegate)
+    public async Task RunTransaction(TransactionOption transactionOption, Func<Task<bool>> transactionDelegate, bool useExclusiveLock)
     {
         if (transactionDelegate is null)
         {
@@ -57,13 +63,13 @@ internal class TransactionClient : ITransactionClient
             switch (transactionOption)
             {
                 case TransactionOption.Create:
-                    await RunDelegateWithTransaction(null, transactionDelegate);
+                    await RunDelegateWithTransaction(null, transactionDelegate, useExclusiveLock);
                     break;
                 case TransactionOption.Join:
-                    await RunDelegateWithTransaction(ambientTransactionInfo, transactionDelegate);
+                    await RunDelegateWithTransaction(ambientTransactionInfo, transactionDelegate, useExclusiveLock);
                     break;
                 case TransactionOption.CreateOrJoin:
-                    await RunDelegateWithTransaction(ambientTransactionInfo, transactionDelegate);
+                    await RunDelegateWithTransaction(ambientTransactionInfo, transactionDelegate, useExclusiveLock);
                     break;
                 case TransactionOption.Suppress:
                     await RunDelegateWithSupressedTransaction(ambientTransactionInfo, transactionDelegate);
@@ -128,7 +134,7 @@ internal class TransactionClient : ITransactionClient
         }
     }
 
-    private async Task RunDelegateWithTransaction(TransactionInfo ambientTransactionInfo, Func<Task<bool>> transactionDelegate)
+    private async Task RunDelegateWithTransaction(TransactionInfo ambientTransactionInfo, Func<Task<bool>> transactionDelegate, bool useExclusiveLock)
     {
         TransactionInfo transactionInfo;
 
@@ -144,6 +150,12 @@ internal class TransactionClient : ITransactionClient
         {
             // Fork ambient transaction
             transactionInfo = ambientTransactionInfo.Fork();
+        }
+
+        // Apply exclusive lock flag if requested
+        if (useExclusiveLock)
+        {
+            transactionInfo.UseExclusiveLock = true;
         }
 
         // Set transaction context

--- a/src/Orleans.Transactions/DistributedTM/TransactionInfo.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionInfo.cs
@@ -34,6 +34,7 @@ namespace Orleans.Transactions
             this.TransactionId = other.TransactionId;
             this.TryToCommit = other.TryToCommit;
             this.IsReadOnly = other.IsReadOnly;
+            this.UseExclusiveLock = other.UseExclusiveLock;
             this.TimeStamp = other.TimeStamp;
             this.Priority = other.Priority;
         }
@@ -62,6 +63,9 @@ namespace Orleans.Transactions
 
         [Id(6)]
         public bool TryToCommit { get; internal set; } = true;
+
+        [Id(7)]
+        public bool UseExclusiveLock { get; set; } = false;
 
         [NonSerialized]
         public int PendingCalls;

--- a/src/Orleans.Transactions/DistributedTM/TransactionRecord.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionRecord.cs
@@ -47,6 +47,9 @@ namespace Orleans.Transactions
         public long SequenceNumber;
         public bool HasCopiedState;
 
+        // indicate that this transaction holds an exclusive lock
+        public bool IsExclusiveLock;
+
         public void AddRead()
         {
             NumberReads++;

--- a/src/Orleans.Transactions/ITransactionClient.cs
+++ b/src/Orleans.Transactions/ITransactionClient.cs
@@ -21,4 +21,24 @@ public interface ITransactionClient
     /// <param name="transactionDelegate"></param>
     /// <returns>True if the transaction should commit</returns>
     Task RunTransaction(TransactionOption transactionOption, Func<Task<bool>> transactionDelegate);
+
+    /// <summary>
+    /// Run transaction delegate with exclusive lock option
+    /// </summary>
+    /// <param name="transactionOption"></param>
+    /// <param name="transactionDelegate"></param>
+    /// <param name="useExclusiveLock">When <see langword="true"/>, all transactional states accessed during this transaction
+    /// will acquire exclusive locks even for read operations, preventing lock upgrade conflicts under high contention.</param>
+    /// <returns><see cref="Task"/></returns>
+    Task RunTransaction(TransactionOption transactionOption, Func<Task> transactionDelegate, bool useExclusiveLock);
+
+    /// <summary>
+    /// Run transaction delegate with exclusive lock option
+    /// </summary>
+    /// <param name="transactionOption"></param>
+    /// <param name="transactionDelegate"></param>
+    /// <param name="useExclusiveLock">When <see langword="true"/>, all transactional states accessed during this transaction
+    /// will acquire exclusive locks even for read operations, preventing lock upgrade conflicts under high contention.</param>
+    /// <returns>True if the transaction should commit</returns>
+    Task RunTransaction(TransactionOption transactionOption, Func<Task<bool>> transactionDelegate, bool useExclusiveLock);
 }

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -385,7 +385,7 @@ namespace Orleans.Transactions.State
                         return true;
                     }
 
-                    // i we have not found a place to insert this op yet, and there is room, and no conflicts, use this one
+                    // if we have not found a place to insert this op yet, and there is room, and no conflicts, use this one
                     if (group == null
                         && pos.FillCount < this.options.MaxLockGroupSize
                         && !HasConflict(isRead, DateTime.MaxValue, guid, pos, out _))

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -159,6 +159,11 @@ namespace Orleans.Transactions.State
                 completion();
             }
 
+            if (!isRead || exclusiveLock)
+            {
+                record.IsExclusiveLock = true;
+            }
+
             if (isRead)
             {
                 record.AddRead();
@@ -380,7 +385,7 @@ namespace Orleans.Transactions.State
                         return true;
                     }
 
-                    // if we have not found a place to insert this op yet, and there is room, and no conflicts, use this one
+                    // i we have not found a place to insert this op yet, and there is room, and no conflicts, use this one
                     if (group == null
                         && pos.FillCount < this.options.MaxLockGroupSize
                         && !HasConflict(isRead, DateTime.MaxValue, guid, pos, out _))
@@ -412,7 +417,7 @@ namespace Orleans.Transactions.State
             {
                 if (kvp.Key != transactionId)
                 {
-                    if (isRead && kvp.Value.NumberWrites == 0)
+                    if (isRead && kvp.Value.NumberWrites == 0 && !kvp.Value.IsExclusiveLock)
                     {
                         continue;
                     }

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -59,7 +59,7 @@ namespace Orleans.Transactions.State
         }
 
         public async Task<TResult> EnterLock<TResult>(Guid transactionId, DateTime priority,
-                                   AccessCounter counter, bool isRead, Func<TResult> task)
+                                   AccessCounter counter, bool isRead, bool exclusiveLock, Func<TResult> task)
         {
             bool rollbacksOccurred = false;
             List<Task> cleanup = new List<Task>();
@@ -67,7 +67,7 @@ namespace Orleans.Transactions.State
             await this.queue.Ready();
 
             // search active transactions
-            if (Find(transactionId, isRead, out var group, out var record))
+            if (Find(transactionId, isRead && !exclusiveLock, out var group, out var record))
             {
                 // check if we lost some reads or writes already
                 if (counter.Reads > record.NumberReads || counter.Writes > record.NumberWrites)
@@ -76,7 +76,7 @@ namespace Orleans.Transactions.State
                 }
 
                 // check if the operation conflicts with other transactions in the group
-                if (HasConflict(isRead, priority, transactionId, group, out var resolvable))
+                if (HasConflict(isRead && !exclusiveLock, priority, transactionId, group, out var resolvable))
                 {
                     if (!resolvable)
                     {

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -66,7 +66,7 @@ namespace Orleans.Transactions
             info.Participants.TryGetValue(this.participantId, out var recordedaccesses);
 
             // schedule read access to happen under the lock
-            return this.queue.RWLock.EnterLock<TResult>(info.TransactionId, info.Priority, recordedaccesses, true,
+            return this.queue.RWLock.EnterLock<TResult>(info.TransactionId, info.Priority, recordedaccesses, true, info.UseExclusiveLock,
                 () =>
                 {
                     // check if our record is gone because we expired while waiting
@@ -126,7 +126,7 @@ namespace Orleans.Transactions
 
             info.Participants.TryGetValue(this.participantId, out var recordedaccesses);
 
-            return this.queue.RWLock.EnterLock<TResult>(info.TransactionId, info.Priority, recordedaccesses, false,
+            return this.queue.RWLock.EnterLock<TResult>(info.TransactionId, info.Priority, recordedaccesses, false, info.UseExclusiveLock,
                 () =>
                 {
                     // check if we expired while waiting

--- a/src/Orleans.Transactions/TOC/TransactionCommitter.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitter.cs
@@ -61,7 +61,7 @@ namespace Orleans.Transactions
 
             info.Participants.TryGetValue(this.participantId, out var recordedaccesses);
 
-            return this.queue.RWLock.EnterLock<bool>(info.TransactionId, info.Priority, recordedaccesses, false,
+            return this.queue.RWLock.EnterLock<bool>(info.TransactionId, info.Priority, recordedaccesses, false, info.UseExclusiveLock,
                 () =>
                 {
                     // check if we expired while waiting

--- a/src/Orleans.Transactions/TransactionAttribute.cs
+++ b/src/Orleans.Transactions/TransactionAttribute.cs
@@ -38,6 +38,23 @@ namespace Orleans
         public bool ReadOnly { get; set; }
     }
 
+    /// <summary>
+    /// The UseExclusiveLock attribute is used to mark transactional methods that should acquire
+    /// exclusive locks even for read operations. This prevents frequent lock upgrade conflicts under high contention.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// [UseExclusiveLock]
+    /// [Transaction(TransactionOption.CreateOrJoin)]
+    /// Task&lt;uint&gt; GetBalance();
+    /// </code>
+    /// </example>
+    [InvokableCustomInitializer("SetExclusiveLock", true)]
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class UseExclusiveLockAttribute : Attribute
+    {
+    }
+
     public enum TransactionOption
     {
         Suppress,     // Logic is not transactional but can be called from within a transaction.  If called within the context of a transaction, the context will not be passed to the call.
@@ -74,6 +91,9 @@ namespace Orleans
         [Id(1)]
         public TransactionInfo TransactionInfo { get; set; }
 
+        [Id(2)]
+        public bool UseExclusiveLock { get; set; }
+
         [GeneratedActivatorConstructor]
         protected TransactionRequestBase(Serializer<OrleansTransactionAbortedException> exceptionSerializer, IServiceProvider serviceProvider)
         {
@@ -103,6 +123,11 @@ namespace Orleans
         protected void SetTransactionOptions(TransactionOption txOption)
         {
             this.TransactionOption = txOption;
+        }
+
+        protected void SetExclusiveLock(bool value)
+        {
+            this.UseExclusiveLock = value;
         }
 
         async Task IOutgoingGrainCallFilter.Invoke(IOutgoingGrainCallContext context)
@@ -183,6 +208,12 @@ namespace Orleans
                     var isReadOnly = this.Options.HasFlag(InvokeMethodOptions.ReadOnly);
                     transactionInfo = await TransactionAgent.StartTransaction(isReadOnly, transactionTimeout);
                     startedNewTransaction = true;
+                }
+
+                // Apply this flag if requested by Attribute
+                if (this.UseExclusiveLock && transactionInfo != null)
+                {
+                    transactionInfo.UseExclusiveLock = true;
                 }
 
                 TransactionContext.SetTransactionInfo(transactionInfo);

--- a/test/Transactions/Orleans.Transactions.Azure.Test/ExclusiveLockTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/ExclusiveLockTests.cs
@@ -1,0 +1,16 @@
+﻿using Orleans.Transactions.TestKit.xUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.AzureStorage.Tests
+{
+    [TestCategory("AzureStorage"), TestCategory("Transactions"), TestCategory("Functional")]
+    public class ExclusiveLockTests : ExclusiveLockTransactionTestRunnerxUnit, IClassFixture<TestFixture>
+    {
+        public ExclusiveLockTests(TestFixture fixture, ITestOutputHelper output)
+            : base(fixture.GrainFactory, output)
+        {
+            fixture.EnsurePreconditionsMet();
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/ExclusiveLockTransactionMemoryTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/ExclusiveLockTransactionMemoryTests.cs
@@ -1,0 +1,14 @@
+﻿using Orleans.Transactions.TestKit.xUnit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.Tests;
+
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class ExclusiveLockTransactionMemoryTests : ExclusiveLockTransactionTestRunnerxUnit, IClassFixture<MemoryTransactionsFixture>
+{
+    public ExclusiveLockTransactionMemoryTests(MemoryTransactionsFixture fixture, ITestOutputHelper output)
+        : base(fixture.GrainFactory, output)
+    {
+    }
+}


### PR DESCRIPTION
## Motivation
The detailed motivation is described in #9898.

## Changes.
The core idea in this PR is to change how `isRead` param is propagated when an exclusive lock is requested, in the `ReaderWriterLock.cs`

- `Find(..., isRead, ...)` -> `Find(..., isRead && !exclusiveLock, ...)`
- `HasConflict(isRead, ...)` -> `HasConflict(isRead && !exclusiveLock, ...)`

All other changes are made to support this behavior.

## Example
Users attach `UseExclusiveLockAttribute` to acquire an exclusive lock.

```cs
[UseExclusiveLock]
[Transaction(TransactionOption.CreateOrJoin)]
Task<uint> GetBalance();
```

Since default value of `UseExclusiveLock ` is false, this this change is backward-compatible, and existing code paths remain unaffected unless the attribute is explicitly attached.

## DIsclamer
This change has not been fully tested and should not be merged into the main branch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9970)