### PR TITLE
NATS consumer retry and replicas

### DIFF
--- a/src/Orleans.Streaming.NATS/NatsOptions.cs
+++ b/src/Orleans.Streaming.NATS/NatsOptions.cs
@@ -55,8 +55,8 @@ public class NatsOptions
     /// <summary>
     /// The number of stream replicas in the NATS JetStream cluster.
     /// Higher values improve availability during node restarts (R3 survives
-    /// single-node failures in a 3-node cluster). Must be an odd number
-    /// and cannot exceed the number of NATS nodes.
+    /// single-node failures in a 3-node cluster). The NATS server enforces
+    /// that the value is odd and does not exceed the cluster size.
     /// Defaults to 1. Set to 3 for production clusters with ≥ 3 nodes.
     /// </summary>
     public int NumReplicas { get; set; } = 1;

--- a/src/Orleans.Streaming.NATS/NatsOptions.cs
+++ b/src/Orleans.Streaming.NATS/NatsOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Orleans.Runtime;
 using NATS.Client.Core;
 
@@ -51,6 +51,15 @@ public class NatsOptions
     /// System.Text.Json serializer options to be used by the NATS provider.
     /// </summary>
     public JsonSerializerOptions? JsonSerializerOptions { get; set; }
+
+    /// <summary>
+    /// The number of stream replicas in the NATS JetStream cluster.
+    /// Higher values improve availability during node restarts (R3 survives
+    /// single-node failures in a 3-node cluster). Must be an odd number
+    /// and cannot exceed the number of NATS nodes.
+    /// Defaults to 1. Set to 3 for production clusters with ≥ 3 nodes.
+    /// </summary>
+    public int NumReplicas { get; set; } = 1;
 }
 
 public class NatsStreamOptionsValidator(NatsOptions options, string? name = null) : IConfigurationValidator
@@ -61,6 +70,12 @@ public class NatsStreamOptionsValidator(NatsOptions options, string? name = null
         {
             throw new OrleansConfigurationException(
                 $"The {nameof(NatsOptions.StreamName)} is required for the NATS stream provider '{name}'.");
+        }
+
+        if (options.NumReplicas < 1)
+        {
+            throw new OrleansConfigurationException(
+                $"The {nameof(NatsOptions.NumReplicas)} must be at least 1 for the NATS stream provider '{name}'.");
         }
     }
 }

--- a/src/Orleans.Streaming.NATS/Providers/NatsConnectionManager.cs
+++ b/src/Orleans.Streaming.NATS/Providers/NatsConnectionManager.cs
@@ -111,6 +111,7 @@ internal sealed class NatsConnectionManager
                 var streamConfig = new StreamConfig(this._options.StreamName, [$"{this._providerName}.>"])
                 {
                     Retention = StreamConfigRetention.Workqueue,
+                    NumReplicas = this._options.NumReplicas,
                     SubjectTransform = new SubjectTransform
                     {
                         Src = $"{this._providerName}.*.*",
@@ -124,6 +125,28 @@ internal sealed class NatsConnectionManager
             catch (NatsJSApiException e) when (e.Error.ErrCode == 10065)
             {
                 // ignore, stream already exists
+            }
+            catch (NatsJSApiException e) when (e.Error.ErrCode == 10058)
+            {
+                // Stream exists with different config — attempt in-place update
+                // (safe for NumReplicas changes; NATS allows replica count upgrades)
+                this._logger.LogInformation(
+                    "Stream {Stream} exists with different config — updating.",
+                    this._options.StreamName);
+
+                var streamConfig = new StreamConfig(this._options.StreamName, [$"{this._providerName}.>"])
+                {
+                    Retention = StreamConfigRetention.Workqueue,
+                    NumReplicas = this._options.NumReplicas,
+                    SubjectTransform = new SubjectTransform
+                    {
+                        Src = $"{this._providerName}.*.*",
+                        Dest =
+                            @$"{this._providerName}.{{{{partition({this._options.PartitionCount},1,2)}}}}.{{{{wildcard(1)}}}}.{{{{wildcard(2)}}}}"
+                    }
+                };
+
+                await this._natsContext.UpdateStreamAsync(streamConfig, cancellationToken);
             }
 
             this._logger.LogTrace(

--- a/src/Orleans.Streaming.NATS/Providers/NatsConnectionManager.cs
+++ b/src/Orleans.Streaming.NATS/Providers/NatsConnectionManager.cs
@@ -108,19 +108,7 @@ internal sealed class NatsConnectionManager
 
             try
             {
-                var streamConfig = new StreamConfig(this._options.StreamName, [$"{this._providerName}.>"])
-                {
-                    Retention = StreamConfigRetention.Workqueue,
-                    NumReplicas = this._options.NumReplicas,
-                    SubjectTransform = new SubjectTransform
-                    {
-                        Src = $"{this._providerName}.*.*",
-                        Dest =
-                            @$"{this._providerName}.{{{{partition({this._options.PartitionCount},1,2)}}}}.{{{{wildcard(1)}}}}.{{{{wildcard(2)}}}}"
-                    }
-                };
-
-                await this._natsContext.CreateStreamAsync(streamConfig, cancellationToken);
+                await this._natsContext.CreateStreamAsync(BuildStreamConfig(), cancellationToken);
             }
             catch (NatsJSApiException e) when (e.Error.ErrCode == 10065)
             {
@@ -134,19 +122,7 @@ internal sealed class NatsConnectionManager
                     "Stream {Stream} exists with different config — updating.",
                     this._options.StreamName);
 
-                var streamConfig = new StreamConfig(this._options.StreamName, [$"{this._providerName}.>"])
-                {
-                    Retention = StreamConfigRetention.Workqueue,
-                    NumReplicas = this._options.NumReplicas,
-                    SubjectTransform = new SubjectTransform
-                    {
-                        Src = $"{this._providerName}.*.*",
-                        Dest =
-                            @$"{this._providerName}.{{{{partition({this._options.PartitionCount},1,2)}}}}.{{{{wildcard(1)}}}}.{{{{wildcard(2)}}}}"
-                    }
-                };
-
-                await this._natsContext.UpdateStreamAsync(streamConfig, cancellationToken);
+                await this._natsContext.UpdateStreamAsync(BuildStreamConfig(), cancellationToken);
             }
 
             this._logger.LogTrace(
@@ -160,6 +136,18 @@ internal sealed class NatsConnectionManager
             throw;
         }
     }
+
+    private StreamConfig BuildStreamConfig() => new(this._options.StreamName, [$"{this._providerName}.>"])
+    {
+        Retention = StreamConfigRetention.Workqueue,
+        NumReplicas = this._options.NumReplicas,
+        SubjectTransform = new SubjectTransform
+        {
+            Src = $"{this._providerName}.*.*",
+            Dest =
+                @$"{this._providerName}.{{{{partition({this._options.PartitionCount},1,2)}}}}.{{{{wildcard(1)}}}}.{{{{wildcard(2)}}}}"
+        }
+    };
 
     /// <summary>
     /// Enqueue a message to NATS JetStream stream

--- a/src/Orleans.Streaming.NATS/Providers/NatsStreamConsumer.cs
+++ b/src/Orleans.Streaming.NATS/Providers/NatsStreamConsumer.cs
@@ -38,10 +38,30 @@ internal sealed class NatsStreamConsumer(
     {
         if (this._consumer is null)
         {
-            this._logger.LogError(
-                "Internal NATS Consumer is not initialized. Provider: {Provider} | Stream: {Stream} | Partition: {Partition}.",
-                provider, stream, partition);
-            return ([], 0);
+            // Lazy retry: attempt re-initialization on each poll cycle.
+            // This handles transient failures during initial Initialize()
+            // (leader election, timeout, network blip).
+            try
+            {
+                this._logger.LogWarning(
+                    "NATS Consumer not initialized — attempting re-initialization. Provider: {Provider} | Stream: {Stream} | Partition: {Partition}.",
+                    provider, stream, partition);
+
+                await Initialize(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                this._logger.LogWarning(ex,
+                    "NATS Consumer re-initialization failed. Provider: {Provider} | Stream: {Stream} | Partition: {Partition}. Will retry on next poll.",
+                    provider, stream, partition);
+                return ([], 0);
+            }
+
+            // If still null after retry, bail (next poll will retry again)
+            if (this._consumer is null)
+            {
+                return ([], 0);
+            }
         }
 
         var batchCount = messageCount > 0 && messageCount < batchSize ? messageCount : batchSize;

--- a/src/Orleans.Streaming.NATS/Providers/NatsStreamConsumer.cs
+++ b/src/Orleans.Streaming.NATS/Providers/NatsStreamConsumer.cs
@@ -32,6 +32,10 @@ internal sealed class NatsStreamConsumer(
     };
 
     private INatsJSConsumer? _consumer;
+    private int _consecutiveInitFailures;
+
+    // Log on the 1st attempt, then every 100th to avoid flooding at ~100ms poll cadence.
+    private const int InitLogInterval = 100;
 
     public async Task<(NatsStreamMessage[] Messages, int Count)> GetMessages(int messageCount = 0,
         CancellationToken cancellationToken = default)
@@ -41,19 +45,39 @@ internal sealed class NatsStreamConsumer(
             // Lazy retry: attempt re-initialization on each poll cycle.
             // This handles transient failures during initial Initialize()
             // (leader election, timeout, network blip).
+            var shouldLog = this._consecutiveInitFailures % InitLogInterval == 0;
             try
             {
-                this._logger.LogWarning(
-                    "NATS Consumer not initialized — attempting re-initialization. Provider: {Provider} | Stream: {Stream} | Partition: {Partition}.",
-                    provider, stream, partition);
+                if (shouldLog)
+                {
+                    this._logger.LogWarning(
+                        "NATS Consumer not initialized — attempting re-initialization (attempt {Attempt}). "
+                        + "Provider: {Provider} | Stream: {Stream} | Partition: {Partition}.",
+                        this._consecutiveInitFailures + 1, provider, stream, partition);
+                }
 
                 await Initialize(cancellationToken);
+                if (this._consecutiveInitFailures > 0)
+                {
+                    this._logger.LogInformation(
+                        "NATS Consumer re-initialized successfully after {Attempts} failed attempt(s). "
+                        + "Provider: {Provider} | Stream: {Stream} | Partition: {Partition}.",
+                        this._consecutiveInitFailures, provider, stream, partition);
+                }
+
+                this._consecutiveInitFailures = 0;
             }
             catch (Exception ex)
             {
-                this._logger.LogWarning(ex,
-                    "NATS Consumer re-initialization failed. Provider: {Provider} | Stream: {Stream} | Partition: {Partition}. Will retry on next poll.",
-                    provider, stream, partition);
+                this._consecutiveInitFailures++;
+                if (shouldLog)
+                {
+                    this._logger.LogWarning(ex,
+                        "NATS Consumer re-initialization failed (attempt {Attempt}). "
+                        + "Provider: {Provider} | Stream: {Stream} | Partition: {Partition}. Will retry on next poll.",
+                        this._consecutiveInitFailures, provider, stream, partition);
+                }
+
                 return ([], 0);
             }
 

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsOptionsTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsOptionsTests.cs
@@ -1,0 +1,129 @@
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+using Orleans.Runtime;
+using Orleans.Streaming.NATS;
+using TestExtensions;
+using Xunit;
+
+namespace NATS.Tests;
+
+[TestCategory("NATS")]
+public sealed class NatsOptionsTests
+{
+    [Fact]
+    public void DefaultNumReplicas_ShouldBeOne()
+    {
+        var options = new NatsOptions();
+
+        Assert.Equal(1, options.NumReplicas);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Validator_InvalidNumReplicas_ShouldThrow(int numReplicas)
+    {
+        var options = new NatsOptions
+        {
+            StreamName = "test-stream",
+            NumReplicas = numReplicas
+        };
+
+        var validator = new NatsStreamOptionsValidator(options, "test-provider");
+
+        Assert.Throws<OrleansConfigurationException>(validator.ValidateConfiguration);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    [InlineData(5)]
+    public void Validator_ValidNumReplicas_ShouldNotThrow(int numReplicas)
+    {
+        var options = new NatsOptions
+        {
+            StreamName = "test-stream",
+            NumReplicas = numReplicas
+        };
+
+        var validator = new NatsStreamOptionsValidator(options, "test-provider");
+
+        validator.ValidateConfiguration();
+    }
+
+    [Fact]
+    public void Validator_MissingStreamName_ShouldThrow()
+    {
+        var options = new NatsOptions
+        {
+            StreamName = null!,
+            NumReplicas = 1
+        };
+
+        var validator = new NatsStreamOptionsValidator(options, "test-provider");
+
+        Assert.Throws<OrleansConfigurationException>(validator.ValidateConfiguration);
+    }
+
+    [Fact]
+    public void Validator_EmptyStreamName_ShouldThrow()
+    {
+        var options = new NatsOptions
+        {
+            StreamName = "  ",
+            NumReplicas = 1
+        };
+
+        var validator = new NatsStreamOptionsValidator(options, "test-provider");
+
+        Assert.Throws<OrleansConfigurationException>(validator.ValidateConfiguration);
+    }
+
+    [SkippableFact]
+    public async Task NumReplicas_IsAppliedToJetStreamConfig()
+    {
+        if (!NatsTestConstants.IsNatsAvailable)
+        {
+            throw new SkipException("Nats Server is not available");
+        }
+
+        var streamName = $"test-replicas-{Guid.NewGuid()}";
+        await using var natsConnection = new NatsConnection();
+        var natsContext = new NatsJSContext(natsConnection);
+
+        await natsConnection.ConnectAsync();
+
+        try
+        {
+            var streamConfig = new StreamConfig(streamName, [$"test-replicas-provider.>"])
+            {
+                Retention = StreamConfigRetention.Workqueue,
+                NumReplicas = 1
+            };
+
+            var stream = await natsContext.CreateStreamAsync(streamConfig);
+            var info = stream.Info;
+
+            Assert.Equal(1, info.Config.NumReplicas);
+        }
+        finally
+        {
+            try
+            {
+                var stream = await natsContext.GetStreamAsync(streamName);
+                await stream.DeleteAsync();
+            }
+            catch (NatsJSApiException)
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+
+    // NOTE: Testing NumReplicas > 1 (e.g. R3) requires a multi-node NATS JetStream
+    // cluster. A single NATS node only supports NumReplicas = 1. R3 integration
+    // testing should be done in a CI environment with a 3-node cluster configured
+    // via docker-compose or similar infrastructure.
+}

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsOptionsTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsOptionsTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using NATS.Client.Core;
 using NATS.Client.JetStream;
 using NATS.Client.JetStream.Models;
@@ -89,24 +90,30 @@ public sealed class NatsOptionsTests
             throw new SkipException("Nats Server is not available");
         }
 
-        var streamName = $"test-replicas-{Guid.NewGuid()}";
+        var providerName = $"test-replicas-{Guid.NewGuid():N}";
+        var streamName = $"test-replicas-stream-{Guid.NewGuid():N}";
+        var options = new NatsOptions
+        {
+            StreamName = streamName,
+            NumReplicas = 1,
+            PartitionCount = 2,
+            ProducerCount = 1
+        };
+
+        var connectionManager = new NatsConnectionManager(providerName, NullLoggerFactory.Instance, options);
+        await connectionManager.Initialize();
+
         await using var natsConnection = new NatsConnection();
         var natsContext = new NatsJSContext(natsConnection);
-
         await natsConnection.ConnectAsync();
 
         try
         {
-            var streamConfig = new StreamConfig(streamName, [$"test-replicas-provider.>"])
-            {
-                Retention = StreamConfigRetention.Workqueue,
-                NumReplicas = 1
-            };
-
-            var stream = await natsContext.CreateStreamAsync(streamConfig);
+            var stream = await natsContext.GetStreamAsync(streamName);
             var info = stream.Info;
 
             Assert.Equal(1, info.Config.NumReplicas);
+            Assert.Equal(StreamConfigRetention.Workqueue, info.Config.Retention);
         }
         finally
         {


### PR DESCRIPTION
## NATS streaming consumer permanent failure after transient JetStream errors

### Problem

When running Orleans against a multi-node NATS JetStream cluster, a **rolling restart of NATS nodes** (routine maintenance, crash recovery, scaling) causes permanent consumer failure with no recovery path short of restarting the Orleans silo.

Two issues combine to produce this:

**1. No retry on consumer initialization**

`NatsStreamConsumer.Initialize()` is called exactly once during startup. If it fails due to a transient error — timeout during JetStream leader election, network blip, temporary unavailability — the internal `_consumer` field stays `null` permanently. Every subsequent `GetMessages()` poll (~100ms) logs at `Error` level:

```
Internal NATS Consumer is not initialized. Provider: {Provider} | Stream: {Stream} | Partition: {Partition}.
```

…and returns empty, indefinitely, with no self-healing path.

**2. Hardcoded R1 streams**

`NatsConnectionManager.Initialize()` creates the JetStream stream without setting `NumReplicas`, defaulting to R1 (single replica). R1 streams have exactly one leader; any node restart makes the stream temporarily unavailable during leader election — which is the trigger for bug #1.

**Combined effect:** After a NATS rolling update, Orleans consumers enter a permanent error loop on every poll cycle, producing a flood of error logs and zero message delivery until the entire Orleans pod is restarted.

### Root Cause

```
NATS node restart
  → R1 stream leader temporarily unavailable
    → NatsStreamConsumer.Initialize() throws (timeout / leader election)
      → _consumer stays null permanently
        → Every GetMessages() poll logs Error + returns empty
          → No recovery without full silo restart
```

### Changes

| File | Change |
|------|--------|
| `NatsStreamConsumer.cs` | When `_consumer` is null in `GetMessages()`, attempt lazy re-initialization before returning empty. Piggybacks on the existing Orleans pulling agent poll cadence. Log level changed from `Error` to `Warning` — transient retries during rolling updates are expected, not permanent failures. |
| `NatsOptions.cs` | Added `NumReplicas` property (default `1`, backward compatible). Added validation in `NatsStreamOptionsValidator` ensuring `NumReplicas >= 1`. |
| `NatsConnectionManager.cs` | Passes `NumReplicas` to `StreamConfig` when creating JetStream streams. Handles NATS error code 10058 (stream exists with different config) by attempting an in-place `UpdateStreamAsync`, enabling replica count upgrades without manual stream deletion. |
| `NatsOptionsTests.cs` *(new)* | Unit tests for validator (invalid/valid `NumReplicas`, missing/empty `StreamName`), default value assertion, and an integration test verifying `NumReplicas` flows through to JetStream stream config. |

### Usage

```csharp
siloBuilder.AddNatsStreams("my-provider", options =>
{
    options.StreamName = "my-stream";
    options.NumReplicas = 3; // R3 for production HA clusters (≥ 3 NATS nodes)
});
```

### Backward Compatibility

- `NumReplicas` defaults to `1` — existing deployments are unaffected.
- The retry in `GetMessages()` is purely additive — previously broken consumers now self-heal.
- Error 10058 handling is additive — previously this was an unhandled exception that crashed the adapter factory.

### Testing

- All 50 existing NATS integration tests pass (stream, subscription multiplicity, client stream).
- 10 new tests added: validator unit tests (no NATS required) + integration test verifying `NumReplicas` is applied to JetStream stream config.
- The 2 pre-existing `NatsAdapterTests.SendAndReceiveFromNats` failures are unrelated (cache cursor requests `SeqNum=0` but JetStream sequences start at 1).
- R3 integration testing requires a multi-node NATS cluster and should be validated in CI with a 3-node docker-compose setup.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9975)