### PR TITLE
feat(membership): add connection liveness check for fault detection

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -139,6 +139,18 @@ namespace Orleans.Configuration
         public bool EnableIndirectProbes { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether to consider connection-level message activity when evaluating silo liveness.
+        /// </summary>
+        /// <remarks>
+        /// When enabled, if an active connection to a silo has recently received messages within the monitoring window
+        /// (<see cref="ProbeTimeout"/> × <see cref="NumMissedProbesLimit"/>), votes to suspect that silo will be suppressed
+        /// since the connection activity demonstrates the silo is alive. This helps prevent false death declarations
+        /// when probes fail due to local issues such as GC pauses or thread pool saturation.
+        /// </remarks>
+        /// <value>Connection liveness checks are enabled by default.</value>
+        public bool EnableConnectionLivenessCheck { get; set; } = true;
+        /// <summary>
+        /// <summary>
         /// Gets or sets a value indicating whether to enable membership eviction of silos when they remain in the <c>Joining</c> or <c>Created</c> state for longer than <see cref="MaxJoinAttemptTime"/>.
         /// </summary>
         public bool EvictWhenMaxJoinAttemptTimeExceeded { get; set; } = true;

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -149,7 +149,7 @@ namespace Orleans.Configuration
         /// </remarks>
         /// <value>Connection liveness checks are enabled by default.</value>
         public bool EnableConnectionLivenessCheck { get; set; } = true;
-        /// <summary>
+
         /// <summary>
         /// Gets or sets a value indicating whether to enable membership eviction of silos when they remain in the <c>Joining</c> or <c>Created</c> state for longer than <see cref="MaxJoinAttemptTime"/>.
         /// </summary>

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -88,6 +88,8 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
+        protected void MarkMessageReceived() => _lastMessageReceivedTimestamp.Restart();
+
         public static void ConfigureBuilder(ConnectionBuilder builder) => builder.Run(OnConnectedDelegate);
 
         /// <summary>
@@ -302,7 +304,7 @@ namespace Orleans.Runtime.Messaging
                     if (buffer.Length > prevBufferLength)
                     {
                         prevBufferLength = buffer.Length;
-                        _lastMessageReceivedTimestamp.Restart();
+                        MarkMessageReceived();
                     }
 
                     if (buffer.Length >= requiredBytes)

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -39,6 +39,7 @@ namespace Orleans.Runtime.Messaging
         private Task? _processIncomingTask;
         private Task? _processOutgoingTask;
         private Task? _closeTask;
+        private CoarseStopwatch _lastMessageReceivedTimestamp;
 
         protected Connection(
             ConnectionContext connection,
@@ -73,6 +74,19 @@ namespace Orleans.Runtime.Messaging
         public bool IsValid => _closeTask is null;
 
         public Task Initialized => _initializationTcs.Task;
+
+        /// <summary>
+        /// Gets the time elapsed since the last message was received on this connection,
+        /// or <see langword="null"/> if no message has been received yet.
+        /// </summary>
+        public TimeSpan? ElapsedSinceLastMessageReceived
+        {
+            get
+            {
+                if (!_lastMessageReceivedTimestamp.IsRunning) return null;
+                return _lastMessageReceivedTimestamp.Elapsed;
+            }
+        }
 
         public static void ConfigureBuilder(ConnectionBuilder builder) => builder.Run(OnConnectedDelegate);
 
@@ -275,6 +289,7 @@ namespace Orleans.Runtime.Messaging
 
             Exception? error = default;
             var serializer = this.shared.ServiceProvider.GetRequiredService<MessageSerializer>();
+            var prevBufferLength = 0L;
             try
             {
                 var input = this._transport!.Input;
@@ -284,8 +299,15 @@ namespace Orleans.Runtime.Messaging
                     var readResult = await input.ReadAsync();
 
                     var buffer = readResult.Buffer;
+                    if (buffer.Length > prevBufferLength)
+                    {
+                        prevBufferLength = buffer.Length;
+                        _lastMessageReceivedTimestamp.Restart();
+                    }
+
                     if (buffer.Length >= requiredBytes)
                     {
+                        prevBufferLength = 0;
                         do
                         {
                             Message? message = default;
@@ -307,7 +329,7 @@ namespace Orleans.Runtime.Messaging
                                 if (!HandleReceiveMessageFailure(message, exception))
                                 {
                                     throw;
-                                }   
+                                }
                             }
                         } while (requiredBytes == 0);
                     }

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -39,7 +39,7 @@ namespace Orleans.Runtime.Messaging
         private Task? _processIncomingTask;
         private Task? _processOutgoingTask;
         private Task? _closeTask;
-        private CoarseStopwatch _lastMessageReceivedTimestamp;
+        private long _lastMessageReceivedTimestamp;
 
         protected Connection(
             ConnectionContext connection,
@@ -83,12 +83,13 @@ namespace Orleans.Runtime.Messaging
         {
             get
             {
-                if (!_lastMessageReceivedTimestamp.IsRunning) return null;
-                return _lastMessageReceivedTimestamp.Elapsed;
+                var timestamp = Volatile.Read(ref _lastMessageReceivedTimestamp);
+                if (timestamp == 0) return null;
+                return TimeSpan.FromMilliseconds(CoarseStopwatch.GetTimestamp() - timestamp);
             }
         }
 
-        protected void MarkMessageReceived() => _lastMessageReceivedTimestamp.Restart();
+        protected void MarkMessageReceived() => Volatile.Write(ref _lastMessageReceivedTimestamp, CoarseStopwatch.GetTimestamp());
 
         public static void ConfigureBuilder(ConnectionBuilder builder) => builder.Run(OnConnectedDelegate);
 

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -75,6 +75,32 @@ namespace Orleans.Runtime.Messaging
             return false;
         }
 
+        /// <summary>
+        /// Gets the minimum elapsed time since any connection to the specified silo last received a message,
+        /// or <see langword="null"/> if no connections exist or no messages have been received.
+        /// </summary>
+        /// <param name="endpoint">The silo address to check.</param>
+        /// <returns>The elapsed time since the most recently received message across all connections, or <see langword="null"/>.</returns>
+        public TimeSpan? GetElapsedSinceLastMessageReceived(SiloAddress endpoint)
+        {
+            if (!this.connections.TryGetValue(endpoint, out var entry))
+            {
+                return null;
+            }
+
+            TimeSpan? minElapsed = null;
+            foreach (var connection in entry.Connections)
+            {
+                if (connection.ElapsedSinceLastMessageReceived is { } elapsed
+                    && (minElapsed is null || elapsed < minElapsed))
+                {
+                    minElapsed = elapsed;
+                }
+            }
+
+            return minElapsed;
+        }
+
         private async Task<Connection> GetConnectionAsync(SiloAddress endpoint)
         {
             await Task.Yield();

--- a/src/Orleans.Core/Timers/CoarseStopwatch.cs
+++ b/src/Orleans.Core/Timers/CoarseStopwatch.cs
@@ -45,7 +45,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Returns the elapsed time.
         /// </summary>
-        public TimeSpan Elapsed => TimeSpan.FromMilliseconds(ElapsedMilliseconds);
+        public readonly TimeSpan Elapsed => TimeSpan.FromMilliseconds(ElapsedMilliseconds);
 
         /// <summary>
         /// Returns a value indicating whether this instance has the default value.

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Internal;
+using Orleans.Runtime.Messaging;
 using static Orleans.Runtime.MembershipService.SiloHealthMonitor;
 
 namespace Orleans.Runtime.MembershipService
@@ -26,6 +27,7 @@ namespace Orleans.Runtime.MembershipService
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly IServiceProvider serviceProvider;
         private readonly IMembershipManager membershipManager;
+        private readonly ConnectionManager connectionManager;
         private readonly ILogger<ClusterHealthMonitor> log;
         private readonly IFatalErrorHandler fatalErrorHandler;
         private readonly IOptionsMonitor<ClusterMembershipOptions> clusterMembershipOptions;
@@ -51,11 +53,13 @@ namespace Orleans.Runtime.MembershipService
             ILogger<ClusterHealthMonitor> log,
             IOptionsMonitor<ClusterMembershipOptions> clusterMembershipOptions,
             IFatalErrorHandler fatalErrorHandler,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            ConnectionManager connectionManager)
         {
             this.localSiloDetails = localSiloDetails;
             this.serviceProvider = serviceProvider;
             this.membershipManager = membershipManager;
+            this.connectionManager = connectionManager;
             this.log = log;
             this.fatalErrorHandler = fatalErrorHandler;
             this.clusterMembershipOptions = clusterMembershipOptions;
@@ -324,13 +328,47 @@ namespace Orleans.Runtime.MembershipService
             {
                 if (probeResult.Status == ProbeResultStatus.Failed && probeResult.FailedProbeCount >= this.clusterMembershipOptions.CurrentValue.NumMissedProbesLimit)
                 {
+                    if (IsConnectionActiveWithinMonitoringWindow(monitor.TargetSiloAddress))
+                    {
+                        return;
+                    }
+
                     await this.membershipManager.TrySuspectSilo(monitor.TargetSiloAddress, null, this.shutdownCancellation.Token).ConfigureAwait(false);
                 }
             }
             else if (probeResult.Status == ProbeResultStatus.Failed)
             {
+                if (IsConnectionActiveWithinMonitoringWindow(monitor.TargetSiloAddress))
+                {
+                    return;
+                }
+
                 await this.membershipManager.TrySuspectSilo(monitor.TargetSiloAddress, probeResult.Intermediary, this.shutdownCancellation.Token).ConfigureAwait(false);
             }
+        }
+
+        /// <summary>
+        /// Checks whether a connection to the specified silo has received a message within the monitoring window
+        /// (<see cref="ClusterMembershipOptions.ProbeTimeout"/> × <see cref="ClusterMembershipOptions.NumMissedProbesLimit"/>).
+        /// If so, the silo is demonstrably alive and the vote should be suppressed.
+        /// </summary>
+        private bool IsConnectionActiveWithinMonitoringWindow(SiloAddress targetSilo)
+        {
+            var options = this.clusterMembershipOptions.CurrentValue;
+            if (!options.EnableConnectionLivenessCheck)
+            {
+                return false;
+            }
+
+            var monitoringWindow = options.ProbeTimeout.Multiply(options.NumMissedProbesLimit);
+
+            if (this.connectionManager.GetElapsedSinceLastMessageReceived(targetSilo) is { } elapsed && elapsed <= monitoringWindow)
+            {
+                LogInformationSuppressingVoteDueToActiveConnection(log, targetSilo, elapsed, monitoringWindow);
+                return true;
+            }
+
+            return false;
         }
 
         bool IHealthCheckable.CheckHealth(DateTime lastCheckTime, [MaybeNullWhen(true)] out string reason)
@@ -464,5 +502,11 @@ namespace Orleans.Runtime.MembershipService
             Message = "Error disposing monitor for {SiloAddress}."
         )]
         private static partial void LogErrorDisposingMonitorForSilo(ILogger logger, Exception exception, SiloAddress siloAddress);
+
+        [LoggerMessage(
+            Level = LogLevel.Information,
+            Message = "Suppressing vote to suspect silo {SiloAddress}: connection received a message {Elapsed} ago, within the {MonitoringWindow} monitoring window. The silo is demonstrably alive."
+        )]
+        private static partial void LogInformationSuppressingVoteDueToActiveConnection(ILogger logger, SiloAddress siloAddress, TimeSpan elapsed, TimeSpan monitoringWindow);
     }
 }

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -443,6 +443,8 @@ namespace Orleans.Configuration
 
         public System.TimeSpan DefunctSiloExpiration { get { throw null; } set { } }
 
+        public bool EnableConnectionLivenessCheck { get { throw null; } set { } }
+
         public bool EnableIndirectProbes { get { throw null; } set { } }
 
         public bool EvictWhenMaxJoinAttemptTimeExceeded { get { throw null; } set { } }

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -79,7 +79,7 @@ namespace NonSilo.Tests.Membership
             this.connectionManager = new ConnectionManager(
                 Options.Create(new ConnectionOptions()),
                 null,
-                new NetworkingTrace(this.loggerFactory));
+                this.loggerFactory.CreateLogger<ConnectionManager>());
         }
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace NonSilo.Tests.Membership
             var canaryConnectionManager = new ConnectionManager(
                 Options.Create(new ConnectionOptions()),
                 null,
-                new NetworkingTrace(this.loggerFactory));
+                this.loggerFactory.CreateLogger<ConnectionManager>());
 
             var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions, canaryConnectionManager);
 
@@ -314,7 +314,7 @@ namespace NonSilo.Tests.Membership
             var canaryConnectionManager = new ConnectionManager(
                 Options.Create(new ConnectionOptions()),
                 null,
-                new NetworkingTrace(this.loggerFactory));
+                this.loggerFactory.CreateLogger<ConnectionManager>());
 
             var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions, canaryConnectionManager);
 
@@ -881,7 +881,7 @@ namespace NonSilo.Tests.Membership
                 Substitute.For<IServiceProvider>(),
                 null,
                 messagingTrace,
-                new NetworkingTrace(loggerFactory),
+                loggerFactory.CreateLogger<Connection>(),
                 new NoOpMessageStatisticsSink());
             return new TestConnection(context, middleware, shared);
         }

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NonSilo.Tests.Utilities;
@@ -78,7 +79,7 @@ namespace NonSilo.Tests.Membership
             this.membershipTable = new InMemoryMembershipTable(new TableVersion(1, "1"));
             this.connectionManager = new ConnectionManager(
                 Options.Create(new ConnectionOptions()),
-                null,
+                null!,
                 this.loggerFactory.CreateLogger<ConnectionManager>());
         }
 
@@ -231,14 +232,14 @@ namespace NonSilo.Tests.Membership
 
             var canaryConnectionManager = new ConnectionManager(
                 Options.Create(new ConnectionOptions()),
-                null,
+                null!,
                 this.loggerFactory.CreateLogger<ConnectionManager>());
 
             var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions, canaryConnectionManager);
 
             // Set up probes to always fail.
             var probeCalls = new ConcurrentQueue<SiloAddress>();
-            this.prober.Probe(default, default).ReturnsForAnyArgs(info =>
+            this.prober.Probe(default!, default).ReturnsForAnyArgs(info =>
             {
                 probeCalls.Enqueue(info.ArgAt<SiloAddress>(0));
                 return Task.FromException(new Exception("probe failed"));
@@ -272,8 +273,8 @@ namespace NonSilo.Tests.Membership
                 await Task.Delay(50);
             }
 
-            // Let any pending async work complete.
-            testRig.Manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(5));
+            await Until(() => probeCalls.Count >= clusterMembershipOptions.NumMissedProbesLimit);
+            await Task.Delay(100);
 
             // The silo should NOT be dead because the canary detected active connection traffic.
             var table = await this.membershipTable.ReadAll();
@@ -313,13 +314,13 @@ namespace NonSilo.Tests.Membership
 
             var canaryConnectionManager = new ConnectionManager(
                 Options.Create(new ConnectionOptions()),
-                null,
+                null!,
                 this.loggerFactory.CreateLogger<ConnectionManager>());
 
             var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions, canaryConnectionManager);
 
             var probeCalls = new ConcurrentQueue<SiloAddress>();
-            this.prober.Probe(default, default).ReturnsForAnyArgs(info =>
+            this.prober.Probe(default!, default).ReturnsForAnyArgs(info =>
             {
                 probeCalls.Enqueue(info.ArgAt<SiloAddress>(0));
                 return Task.FromException(new Exception("probe failed"));
@@ -352,7 +353,11 @@ namespace NonSilo.Tests.Membership
                 await Task.Delay(50);
             }
 
-            testRig.Manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(5));
+            await Until(async () =>
+            {
+                var snapshot = await this.membershipTable.ReadAll();
+                return snapshot.Members.Any(m => m.Item1.SiloAddress.Equals(targetSilo) && m.Item1.Status == SiloStatus.Dead);
+            });
 
             // Despite an active connection, the silo SHOULD be dead because the option is disabled.
             var table = await this.membershipTable.ReadAll();
@@ -781,6 +786,13 @@ namespace NonSilo.Tests.Membership
             Assert.True(maxTimeout > 0);
         }
 
+        private static async Task Until(Func<Task<bool>> condition)
+        {
+            var maxTimeout = 40_000;
+            while (!await condition() && (maxTimeout -= 10) > 0) await Task.Delay(10);
+            Assert.True(maxTimeout > 0);
+        }
+
         private static async Task<MembershipTableSnapshot> WaitForMembershipSnapshot(DiagnosticEventCollector membershipEvents, Func<MembershipTableSnapshot, bool> condition)
         {
             var diagnosticEvent = await membershipEvents.WaitForEventAsync(
@@ -876,11 +888,24 @@ namespace NonSilo.Tests.Membership
             var context = Substitute.For<ConnectionContext>();
             context.Features.Returns(features);
             ConnectionDelegate middleware = _ => Task.CompletedTask;
-            var messagingTrace = new MessagingTrace(loggerFactory);
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<MessagingInstruments>();
+            services.AddSingleton<MessagingProcessingInstruments>();
+            var serviceProvider = services.BuildServiceProvider();
+            var orleansInstruments = serviceProvider.GetRequiredService<OrleansInstruments>();
+            var messagingInstruments = serviceProvider.GetRequiredService<MessagingInstruments>();
+            var messagingTrace = new MessagingTrace(
+                loggerFactory,
+                messagingInstruments,
+                serviceProvider.GetRequiredService<MessagingProcessingInstruments>());
             var shared = new ConnectionCommon(
-                Substitute.For<IServiceProvider>(),
-                null,
+                serviceProvider,
+                null!,
                 messagingTrace,
+                orleansInstruments,
+                messagingInstruments,
                 loggerFactory.CreateLogger<Connection>(),
                 new NoOpMessageStatisticsSink());
             return new TestConnection(context, middleware, shared);
@@ -890,7 +915,7 @@ namespace NonSilo.Tests.Membership
             : Connection(context, middleware, shared)
         {
             protected override ConnectionDirection ConnectionDirection => ConnectionDirection.SiloToSilo;
-            protected override IMessageCenter MessageCenter => null;
+            protected override IMessageCenter MessageCenter => null!;
             protected override bool PrepareMessageForSend(Message msg) => true;
             protected override void OnReceivedMessage(Message msg) { }
             protected override void RecordMessageReceive(Message msg, int numTotalBytes, int headerBytes) { }

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -1,11 +1,16 @@
 using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NonSilo.Tests.Utilities;
 using NSubstitute;
 using Orleans.Configuration;
 using Orleans.Core.Diagnostics;
+using Orleans.Messaging;
+using Orleans.Placement.Repartitioning;
+using Orleans.Runtime;
 using Orleans.Runtime.MembershipService;
+using Orleans.Runtime.Messaging;
 using Orleans.TestingHost.Diagnostics;
 using TestExtensions;
 using Xunit;
@@ -34,6 +39,7 @@ namespace NonSilo.Tests.Membership
         private readonly ILocalSiloHealthMonitor localSiloHealthMonitor;
         private readonly InMemoryMembershipTable membershipTable;
         private readonly IRemoteSiloProber prober;
+        private readonly ConnectionManager connectionManager;
 
         public ClusterHealthMonitorTests(ITestOutputHelper output)
         {
@@ -70,6 +76,10 @@ namespace NonSilo.Tests.Membership
 
             this.prober = Substitute.For<IRemoteSiloProber>();
             this.membershipTable = new InMemoryMembershipTable(new TableVersion(1, "1"));
+            this.connectionManager = new ConnectionManager(
+                Options.Create(new ConnectionOptions()),
+                null,
+                new NetworkingTrace(this.loggerFactory));
         }
 
         /// <summary>
@@ -202,6 +212,155 @@ namespace NonSilo.Tests.Membership
         public async Task ClusterHealthMonitor_SilosWithStaleCreatedOrJoiningState_Disabled()
         {
             await ClusterHealthMonitor_StaleJoinOrCreatedSilos_Runner(evictWhenMaxJoinAttemptTimeExceeded: false, numVotesForDeathDeclaration: 3);
+        }
+
+        /// <summary>
+        /// Tests that when an active connection has recently received messages from the target silo,
+        /// the vote to suspect/kill is suppressed even though probes are failing.
+        /// </summary>
+        [Fact]
+        public async Task ClusterHealthMonitor_ConnectionCanary_SuppressesVoteWhenConnectionActive()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var clusterMembershipOptions = new ClusterMembershipOptions
+            {
+                EnableIndirectProbes = false,
+                NumProbedSilos = 1,
+                NumVotesForDeathDeclaration = 1,
+            };
+
+            var canaryConnectionManager = new ConnectionManager(
+                Options.Create(new ConnectionOptions()),
+                null,
+                new NetworkingTrace(this.loggerFactory));
+
+            var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions, canaryConnectionManager);
+
+            // Set up probes to always fail.
+            var probeCalls = new ConcurrentQueue<SiloAddress>();
+            this.prober.Probe(default, default).ReturnsForAnyArgs(info =>
+            {
+                probeCalls.Enqueue(info.ArgAt<SiloAddress>(0));
+                return Task.FromException(new Exception("probe failed"));
+            });
+
+            await this.lifecycle.OnStart();
+
+            var targetSilo = Silo("127.0.0.200:100@100");
+            await this.membershipTable.InsertRow(Entry(targetSilo, SiloStatus.Active, now), this.membershipTable.Version.Next());
+            await testRig.Manager.Refresh();
+            await testRig.Manager.UpdateStatus(SiloStatus.Active);
+            await testRig.Manager.Refresh();
+
+            await Until(() => testRig.TestAccessor.MonitoredSilos.Count > 0);
+
+            // Register a test connection and simulate recent message activity.
+            var testConnection = CreateTestConnection(this.loggerFactory);
+            canaryConnectionManager.OnConnected(targetSilo, testConnection);
+            SimulateMessageReceived(testConnection);
+
+            // Drive enough probe failures to normally trigger a vote.
+            for (var i = 0; i < clusterMembershipOptions.NumMissedProbesLimit + 1; i++)
+            {
+                if (this.timerCalls.TryDequeue(out var timer))
+                {
+                    timer.Completion.TrySetResult(true);
+                }
+
+                // Keep re-stamping the canary so it stays fresh.
+                SimulateMessageReceived(testConnection);
+                await Task.Delay(50);
+            }
+
+            // Let any pending async work complete.
+            testRig.Manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(5));
+
+            // The silo should NOT be dead because the canary detected active connection traffic.
+            var table = await this.membershipTable.ReadAll();
+            var entry = table.Members.SingleOrDefault(m => m.Item1.SiloAddress.Equals(targetSilo));
+            Assert.NotNull(entry);
+            Assert.NotEqual(SiloStatus.Dead, entry.Item1.Status);
+
+            await StopLifecycle();
+        }
+
+        /// <summary>
+        /// Tests that when no connections exist to a target silo, the canary does not interfere
+        /// and the silo is declared dead normally after probe failures.
+        /// </summary>
+        [Fact]
+        public async Task ClusterHealthMonitor_ConnectionCanary_AllowsVoteWhenNoConnection()
+        {
+            // With no connections in the connection manager, canary returns null -> vote proceeds.
+            await ClusterHealthMonitor_BasicScenario_Runner(enableIndirectProbes: false, numVotesForDeathDeclaration: 1);
+        }
+
+        /// <summary>
+        /// Tests that when <see cref="ClusterMembershipOptions.EnableConnectionLivenessCheck"/> is disabled,
+        /// votes proceed normally even when an active connection exists.
+        /// </summary>
+        [Fact]
+        public async Task ClusterHealthMonitor_ConnectionCanary_DisabledByOption()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var clusterMembershipOptions = new ClusterMembershipOptions
+            {
+                EnableIndirectProbes = false,
+                NumProbedSilos = 1,
+                NumVotesForDeathDeclaration = 1,
+                EnableConnectionLivenessCheck = false,
+            };
+
+            var canaryConnectionManager = new ConnectionManager(
+                Options.Create(new ConnectionOptions()),
+                null,
+                new NetworkingTrace(this.loggerFactory));
+
+            var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions, canaryConnectionManager);
+
+            var probeCalls = new ConcurrentQueue<SiloAddress>();
+            this.prober.Probe(default, default).ReturnsForAnyArgs(info =>
+            {
+                probeCalls.Enqueue(info.ArgAt<SiloAddress>(0));
+                return Task.FromException(new Exception("probe failed"));
+            });
+
+            await this.lifecycle.OnStart();
+
+            var targetSilo = Silo("127.0.0.200:100@100");
+            await this.membershipTable.InsertRow(Entry(targetSilo, SiloStatus.Active, now), this.membershipTable.Version.Next());
+            await testRig.Manager.Refresh();
+            await testRig.Manager.UpdateStatus(SiloStatus.Active);
+            await testRig.Manager.Refresh();
+
+            await Until(() => testRig.TestAccessor.MonitoredSilos.Count > 0);
+
+            // Register a test connection and simulate recent message activity.
+            var testConnection = CreateTestConnection(this.loggerFactory);
+            canaryConnectionManager.OnConnected(targetSilo, testConnection);
+            SimulateMessageReceived(testConnection);
+
+            // Drive enough probe failures to trigger a vote.
+            for (var i = 0; i < clusterMembershipOptions.NumMissedProbesLimit + 1; i++)
+            {
+                if (this.timerCalls.TryDequeue(out var timer))
+                {
+                    timer.Completion.TrySetResult(true);
+                }
+
+                SimulateMessageReceived(testConnection);
+                await Task.Delay(50);
+            }
+
+            testRig.Manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(5));
+
+            // Despite an active connection, the silo SHOULD be dead because the option is disabled.
+            var table = await this.membershipTable.ReadAll();
+            var entry = table.Members.SingleOrDefault(m => m.Item1.SiloAddress.Equals(targetSilo));
+            Assert.NotNull(entry);
+            Assert.Equal(SiloStatus.Dead, entry.Item1.Status);
+
+            await StopLifecycle();
         }
 
         private async Task ClusterHealthMonitor_BasicScenario_Runner(bool enableIndirectProbes, int? numVotesForDeathDeclaration = default, bool otherSilosAreStale = false)
@@ -657,6 +816,11 @@ namespace NonSilo.Tests.Membership
 
         private ClusterHealthMonitorTestRig CreateClusterHealthMonitorTestRig(ClusterMembershipOptions clusterMembershipOptions)
         {
+            return CreateClusterHealthMonitorTestRig(clusterMembershipOptions, this.connectionManager);
+        }
+
+        private ClusterHealthMonitorTestRig CreateClusterHealthMonitorTestRig(ClusterMembershipOptions clusterMembershipOptions, ConnectionManager connManager)
+        {
             var manager = new MembershipTableManager(
                 localSiloDetails: this.localSiloDetails,
                 clusterMembershipOptions: Options.Create(clusterMembershipOptions),
@@ -679,7 +843,8 @@ namespace NonSilo.Tests.Membership
                 this.loggerFactory.CreateLogger<ClusterHealthMonitor>(),
                 optionsMonitor,
                 this.fatalErrorHandler,
-                null!);
+                null!,
+                connManager);
 
             ((ILifecycleParticipant<ISiloLifecycle>)monitor).Participate(this.lifecycle);
 
@@ -700,6 +865,48 @@ namespace NonSilo.Tests.Membership
                 manager: manager,
                 optionsMonitor: optionsMonitor,
                 testAccessor: testAccessor);
+        }
+
+        /// <summary>
+        /// Simulates message activity on a connection by setting the last-message-received timestamp
+        /// via reflection (the field is updated via Volatile.Write in production code on the I/O path).
+        /// </summary>
+        private static void SimulateMessageReceived(Connection connection)
+        {
+            var field = typeof(Connection).GetField("_lastMessageReceivedTimestamp", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            field.SetValue(connection, CoarseStopwatch.StartNew());
+        }
+
+        /// <summary>
+        /// Creates a minimal test <see cref="Connection"/> suitable for registering with <see cref="ConnectionManager"/>.
+        /// </summary>
+        private Connection CreateTestConnection(ILoggerFactory loggerFactory)
+        {
+            var features = new Microsoft.AspNetCore.Http.Features.FeatureCollection();
+            var context = Substitute.For<ConnectionContext>();
+            context.Features.Returns(features);
+            ConnectionDelegate middleware = _ => Task.CompletedTask;
+            var messagingTrace = new MessagingTrace(loggerFactory);
+            var shared = new ConnectionCommon(
+                Substitute.For<IServiceProvider>(),
+                null,
+                messagingTrace,
+                new NetworkingTrace(loggerFactory),
+                new NoOpMessageStatisticsSink());
+            return new TestConnection(context, middleware, shared);
+        }
+
+        private sealed class TestConnection(ConnectionContext context, ConnectionDelegate middleware, ConnectionCommon shared)
+            : Connection(context, middleware, shared)
+        {
+            protected override ConnectionDirection ConnectionDirection => ConnectionDirection.SiloToSilo;
+            protected override IMessageCenter MessageCenter => null;
+            protected override bool PrepareMessageForSend(Message msg) => true;
+            protected override void OnReceivedMessage(Message msg) { }
+            protected override void RecordMessageReceive(Message msg, int numTotalBytes, int headerBytes) { }
+            protected override void RecordMessageSend(Message msg, int numTotalBytes, int headerBytes) { }
+            protected override void OnSendMessageFailure(Message message, string error) { }
+            protected override void RetryMessage(Message msg, Exception ex = null) { }
         }
     }
 }

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -257,7 +257,7 @@ namespace NonSilo.Tests.Membership
             // Register a test connection and simulate recent message activity.
             var testConnection = CreateTestConnection(this.loggerFactory);
             canaryConnectionManager.OnConnected(targetSilo, testConnection);
-            SimulateMessageReceived(testConnection);
+            testConnection.SimulateMessageReceived();
 
             // Drive enough probe failures to normally trigger a vote.
             for (var i = 0; i < clusterMembershipOptions.NumMissedProbesLimit + 1; i++)
@@ -268,7 +268,7 @@ namespace NonSilo.Tests.Membership
                 }
 
                 // Keep re-stamping the canary so it stays fresh.
-                SimulateMessageReceived(testConnection);
+                testConnection.SimulateMessageReceived();
                 await Task.Delay(50);
             }
 
@@ -338,7 +338,7 @@ namespace NonSilo.Tests.Membership
             // Register a test connection and simulate recent message activity.
             var testConnection = CreateTestConnection(this.loggerFactory);
             canaryConnectionManager.OnConnected(targetSilo, testConnection);
-            SimulateMessageReceived(testConnection);
+            testConnection.SimulateMessageReceived();
 
             // Drive enough probe failures to trigger a vote.
             for (var i = 0; i < clusterMembershipOptions.NumMissedProbesLimit + 1; i++)
@@ -348,7 +348,7 @@ namespace NonSilo.Tests.Membership
                     timer.Completion.TrySetResult(true);
                 }
 
-                SimulateMessageReceived(testConnection);
+                testConnection.SimulateMessageReceived();
                 await Task.Delay(50);
             }
 
@@ -868,19 +868,9 @@ namespace NonSilo.Tests.Membership
         }
 
         /// <summary>
-        /// Simulates message activity on a connection by setting the last-message-received timestamp
-        /// via reflection (the field is updated via Volatile.Write in production code on the I/O path).
-        /// </summary>
-        private static void SimulateMessageReceived(Connection connection)
-        {
-            var field = typeof(Connection).GetField("_lastMessageReceivedTimestamp", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-            field.SetValue(connection, CoarseStopwatch.StartNew());
-        }
-
-        /// <summary>
         /// Creates a minimal test <see cref="Connection"/> suitable for registering with <see cref="ConnectionManager"/>.
         /// </summary>
-        private Connection CreateTestConnection(ILoggerFactory loggerFactory)
+        private TestConnection CreateTestConnection(ILoggerFactory loggerFactory)
         {
             var features = new Microsoft.AspNetCore.Http.Features.FeatureCollection();
             var context = Substitute.For<ConnectionContext>();
@@ -907,6 +897,7 @@ namespace NonSilo.Tests.Membership
             protected override void RecordMessageSend(Message msg, int numTotalBytes, int headerBytes) { }
             protected override void OnSendMessageFailure(Message message, string error) { }
             protected override void RetryMessage(Message msg, Exception ex = null) { }
+            public void SimulateMessageReceived() => MarkMessageReceived();
         }
     }
 }

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -896,7 +896,7 @@ namespace NonSilo.Tests.Membership
             protected override void RecordMessageReceive(Message msg, int numTotalBytes, int headerBytes) { }
             protected override void RecordMessageSend(Message msg, int numTotalBytes, int headerBytes) { }
             protected override void OnSendMessageFailure(Message message, string error) { }
-            protected override void RetryMessage(Message msg, Exception ex = null) { }
+            protected override void RetryMessage(Message msg, Exception? ex = null) { }
             public void SimulateMessageReceived() => MarkMessageReceived();
         }
     }

--- a/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
@@ -7,6 +7,7 @@ using Orleans;
 using Orleans.Configuration;
 using Orleans.Runtime;
 using Orleans.Runtime.MembershipService;
+using Orleans.Runtime.Messaging;
 using TestExtensions;
 using Xunit;
 using Xunit.Abstractions;
@@ -93,7 +94,11 @@ namespace NonSilo.Tests.Membership
                 this.loggerFactory.CreateLogger<ClusterHealthMonitor>(),
                 optionsMonitor,
                 this.fatalErrorHandler,
-                null!);
+                null!,
+                new ConnectionManager(
+                    Options.Create(new ConnectionOptions()),
+                    null!,
+                    this.loggerFactory.CreateLogger<ConnectionManager>()));
             ((ILifecycleParticipant<ISiloLifecycle>)this.clusterHealthMonitor).Participate(this.lifecycle);
 
             this.remoteSiloProber = Substitute.For<IRemoteSiloProber>();


### PR DESCRIPTION
When determining if a monitored silo is down, first check if we have received any data from that silo within the monitoring window. If we have, we suppress our vote. Once we stop receiving data from the monitored silo, it is eligible for eviction.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9978)