### PR TITLE
feat: support semantic versioning for grain interfaces

### DIFF
--- a/src/Orleans.Core.Abstractions/CodeGeneration/VersionAttribute.cs
+++ b/src/Orleans.Core.Abstractions/CodeGeneration/VersionAttribute.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Orleans.Metadata;
+using Orleans.Runtime.Versions;
 
 namespace Orleans.CodeGeneration
 {
@@ -22,15 +23,25 @@ namespace Orleans.CodeGeneration
             Version = version;
         }
 
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VersionAttribute"/> class with a semantic version string.
+        /// </summary>
+        /// <param name="version">The semantic version string (e.g. "1.2.0", "2.0.0-beta.1").</param>
+        public VersionAttribute(string version)
+        {
+            Version = new GrainInterfaceVersion(SemanticVersion.Parse(version));
+        }
+
         /// <summary>
         /// Gets the version.
         /// </summary>
-        public ushort Version { get; private set; }
+        public GrainInterfaceVersion Version { get; private set; }
 
         /// <inheritdoc />
         void IGrainInterfacePropertiesProviderAttribute.Populate(IServiceProvider services, Type type, Dictionary<string, string> properties)
         {
-            properties[WellKnownGrainInterfaceProperties.Version] = this.Version.ToString(CultureInfo.InvariantCulture);
+            properties[WellKnownGrainInterfaceProperties.Version] = this.Version.ToString();
         }
     }
 }

--- a/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceVersion.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceVersion.cs
@@ -1,0 +1,107 @@
+﻿using Orleans.Runtime.Versions;
+
+namespace Orleans.Runtime.Versions
+{
+    public readonly struct GrainInterfaceVersion : IEquatable<GrainInterfaceVersion>, IComparable<GrainInterfaceVersion>
+    {
+        public static readonly GrainInterfaceVersion Zero = new((ushort)0);
+
+        private enum VersionKind : byte { Numeric, Semantic }
+
+        private readonly VersionKind _kind;
+        private readonly ushort _numeric;
+        private readonly SemanticVersion _semantic;
+
+        public GrainInterfaceVersion(ushort version)
+        {
+            _kind = VersionKind.Numeric;
+            _numeric = version;
+            _semantic = default;
+        }
+
+        public GrainInterfaceVersion(SemanticVersion version)
+        {
+            _kind = VersionKind.Semantic;
+            _numeric = 0;
+            _semantic = version;
+        }
+
+        /// <summary>Whether this is a legacy numeric version.</summary>
+        public bool IsNumeric => _kind == VersionKind.Numeric;
+
+        /// <summary>Whether this is a semantic version.</summary>
+        public bool IsSemantic => _kind == VersionKind.Semantic;
+
+        /// <summary>Gets the numeric value. Throws if this is a semantic version.</summary>
+        public ushort NumericValue => IsNumeric ? _numeric : throw new InvalidOperationException("Not a numeric version.");
+
+        /// <summary>Gets the semantic version value. Throws if this is a numeric version.</summary>
+        public SemanticVersion SemanticValue => IsSemantic ? _semantic : throw new InvalidOperationException("Not a semantic version.");
+
+        /// <summary>Whether this represents the default/zero version.</summary>
+        public bool IsDefault => IsNumeric ? _numeric == 0 : _semantic.Equals(SemanticVersion.Zero);
+
+        /// <summary>
+        /// Parses a version string from grain interface properties.
+        /// If the string is a valid ushort, creates a numeric version (backward compatible).
+        /// Otherwise attempts to parse as SemVer.
+        /// Falls back to Zero on null/empty.
+        /// </summary>
+        public static GrainInterfaceVersion Parse(string? versionString)
+        {
+            if (string.IsNullOrEmpty(versionString))
+                return Zero;
+
+            if (ushort.TryParse(versionString, out var numeric))
+                return new GrainInterfaceVersion(numeric);
+
+            if (SemanticVersion.TryParse(versionString, out var semver))
+                return new GrainInterfaceVersion(semver);
+
+            return Zero;
+        }
+
+        public static implicit operator GrainInterfaceVersion(ushort v) => new(v);
+        public static implicit operator GrainInterfaceVersion(SemanticVersion v) => new(v);
+
+        public int CompareTo(GrainInterfaceVersion other)
+        {
+            if (_kind != other._kind)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot compare {_kind} version with {other._kind} version. "
+                    + "All versions for a grain interface must use the same versioning scheme.");
+            }
+
+
+            return _kind == VersionKind.Numeric
+                ? _numeric.CompareTo(other._numeric)
+                : _semantic.CompareTo(other._semantic);
+        }
+
+        public bool Equals(GrainInterfaceVersion other)
+        {
+            if (_kind != other._kind) return false;
+            return _kind == VersionKind.Numeric
+                ? _numeric == other._numeric
+                : _semantic.Equals(other._semantic);
+        }
+
+        public override bool Equals(object? obj) => obj is GrainInterfaceVersion other && Equals(other);
+
+        public override int GetHashCode() => _kind == VersionKind.Numeric
+            ? HashCode.Combine(0, _numeric)
+            : HashCode.Combine(1, _semantic);
+
+        public static bool operator ==(GrainInterfaceVersion left, GrainInterfaceVersion right) => left.Equals(right);
+        public static bool operator !=(GrainInterfaceVersion left, GrainInterfaceVersion right) => !left.Equals(right);
+        public static bool operator <(GrainInterfaceVersion left, GrainInterfaceVersion right) => left.CompareTo(right) < 0;
+        public static bool operator >(GrainInterfaceVersion left, GrainInterfaceVersion right) => left.CompareTo(right) > 0;
+        public static bool operator <=(GrainInterfaceVersion left, GrainInterfaceVersion right) => left.CompareTo(right) <= 0;
+        public static bool operator >=(GrainInterfaceVersion left, GrainInterfaceVersion right) => left.CompareTo(right) >= 0;
+
+        public override string ToString() => _kind == VersionKind.Numeric ? _numeric.ToString() : _semantic.ToString();
+    }
+
+}
+

--- a/src/Orleans.Core.Abstractions/Manifest/SemanticVersion.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/SemanticVersion.cs
@@ -1,0 +1,124 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Orleans.Runtime.Versions
+{
+    public readonly struct SemanticVersion : IEquatable<SemanticVersion>, IComparable<SemanticVersion>
+    {
+        public static readonly SemanticVersion Zero = new(0, 0, 0);
+
+        private int Major { get; }
+        private int Minor { get; }
+        private int Patch { get; }
+        private string? PreRelease { get; }
+
+        private bool HasPreRelease => !string.IsNullOrEmpty(PreRelease);
+
+        public SemanticVersion(int major, int minor, int patch, string? preRelease = null)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(major);
+            ArgumentOutOfRangeException.ThrowIfNegative(minor);
+            ArgumentOutOfRangeException.ThrowIfNegative(patch);
+
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+            PreRelease = string.IsNullOrWhiteSpace(preRelease) ? null : preRelease;
+        }
+
+        public static SemanticVersion Parse(string value)
+        {
+            if (!TryParse(value, out var result))
+                throw new FormatException($"Invalid semantic version: '{value}'");
+            return result;
+        }
+
+        public static bool TryParse(string? value, [NotNullWhen(true)] out SemanticVersion result)
+        {
+            result = default;
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            var span = value.AsSpan().Trim();
+
+            // Strip leading 'v' or 'V'
+            if (span.Length > 0 && (span[0] == 'v' || span[0] == 'V'))
+                span = span.Slice(1);
+
+            // Split off pre-release: everything after first '-'
+            string? preRelease = null;
+            var hyphenIdx = span.IndexOf('-');
+            if (hyphenIdx >= 0)
+            {
+                preRelease = span.Slice(hyphenIdx + 1).ToString();
+                span = span.Slice(0, hyphenIdx);
+            }
+
+            // Strip build metadata (+...)
+            var plusIdx = preRelease?.IndexOf('+') ?? span.IndexOf('+');
+            if (preRelease != null && plusIdx >= 0)
+            {
+                preRelease = preRelease.Substring(0, plusIdx);
+            }
+            else if (plusIdx >= 0)
+            {
+                span = span.Slice(0, plusIdx);
+            }
+
+            // Parse Major.Minor.Patch
+            var parts = span.ToString().Split('.');
+            if (parts.Length < 2 || parts.Length > 3)
+                return false;
+
+            if (!int.TryParse(parts[0], out var major) || major < 0)
+                return false;
+            if (!int.TryParse(parts[1], out var minor) || minor < 0)
+                return false;
+
+            var patch = 0;
+            if (parts.Length == 3 && (!int.TryParse(parts[2], out patch) || patch < 0))
+                return false;
+
+            result = new SemanticVersion(major, minor, patch, preRelease);
+            return true;
+        }
+
+        public int CompareTo(SemanticVersion other)
+        {
+            var cmp = Major.CompareTo(other.Major);
+            if (cmp != 0) return cmp;
+
+            cmp = Minor.CompareTo(other.Minor);
+            if (cmp != 0) return cmp;
+
+            cmp = Patch.CompareTo(other.Patch);
+            if (cmp != 0) return cmp;
+
+            // No pre-release > has pre-release (1.0.0 > 1.0.0-alpha)
+            if (!HasPreRelease && other.HasPreRelease) return 1;
+            if (HasPreRelease && !other.HasPreRelease) return -1;
+            if (!HasPreRelease && !other.HasPreRelease) return 0;
+
+            return string.Compare(PreRelease, other.PreRelease, StringComparison.Ordinal);
+        }
+
+        public bool Equals(SemanticVersion other)
+            => Major == other.Major
+               && Minor == other.Minor
+               && Patch == other.Patch
+               && string.Equals(PreRelease, other.PreRelease, StringComparison.Ordinal);
+
+        public override bool Equals(object? obj) => obj is SemanticVersion other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(Major, Minor, Patch, PreRelease);
+
+        public static bool operator ==(SemanticVersion left, SemanticVersion right) => left.Equals(right);
+        public static bool operator !=(SemanticVersion left, SemanticVersion right) => !left.Equals(right);
+        public static bool operator <(SemanticVersion left, SemanticVersion right) => left.CompareTo(right) < 0;
+        public static bool operator >(SemanticVersion left, SemanticVersion right) => left.CompareTo(right) > 0;
+        public static bool operator <=(SemanticVersion left, SemanticVersion right) => left.CompareTo(right) <= 0;
+        public static bool operator >=(SemanticVersion left, SemanticVersion right) => left.CompareTo(right) >= 0;
+
+        public override string ToString() => HasPreRelease ? $"{Major}.{Minor}.{Patch}-{PreRelease}" : $"{Major}.{Minor}.{Patch}";
+    }
+}
+

--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Threading;
+using Orleans.Runtime.Versions;
 
 namespace Orleans.Runtime
 {
@@ -23,7 +24,7 @@ namespace Orleans.Runtime
         public GrainReferenceShared(
             GrainType grainType,
             GrainInterfaceType grainInterfaceType,
-            ushort interfaceVersion,
+            GrainInterfaceVersion interfaceVersion,
             IGrainReferenceRuntime runtime,
             InvokeMethodOptions invokeMethodOptions,
             CodecProvider codecProvider,
@@ -78,7 +79,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Gets the interface version.
         /// </summary>
-        public ushort InterfaceVersion { get; }
+        public GrainInterfaceVersion InterfaceVersion { get; }
     }
 
     /// <summary>
@@ -386,7 +387,7 @@ namespace Orleans.Runtime
         /// <summary>
         /// Gets the interface version.
         /// </summary>
-        public ushort InterfaceVersion => Shared.InterfaceVersion;
+        public GrainInterfaceVersion InterfaceVersion => Shared.InterfaceVersion;
 
         /// <summary>
         /// Gets the interface name.

--- a/src/Orleans.Core.Abstractions/Versions/Compatibility/ICompatibilityDirector.cs
+++ b/src/Orleans.Core.Abstractions/Versions/Compatibility/ICompatibilityDirector.cs
@@ -1,4 +1,5 @@
 using System;
+using Orleans.Runtime.Versions;
 
 namespace Orleans.Versions.Compatibility
 {
@@ -13,7 +14,7 @@ namespace Orleans.Versions.Compatibility
         /// <param name="requestedVersion">The requested interface version.</param>
         /// <param name="currentVersion">The currently available interface version.</param>
         /// <returns><see langword="true"/> if the current version of an interface is compatible with the requested version, <see langword="false"/> otherwise.</returns>
-        bool IsCompatible(ushort requestedVersion, ushort currentVersion);
+        bool IsCompatible(GrainInterfaceVersion requestedVersion, GrainInterfaceVersion currentVersion);
     }
 
     /// <summary>

--- a/src/Orleans.Core.Abstractions/Versions/Selector/IVersionSelector.cs
+++ b/src/Orleans.Core.Abstractions/Versions/Selector/IVersionSelector.cs
@@ -1,4 +1,5 @@
 using System;
+using Orleans.Runtime.Versions;
 using Orleans.Versions.Compatibility;
 
 namespace Orleans.Versions.Selector
@@ -15,7 +16,7 @@ namespace Orleans.Versions.Selector
         /// <param name="availableVersions">The collection of available interface versions.</param>
         /// <param name="compatibilityDirector">The compatibility director.</param>
         /// <returns>A collection of suitable interface versions for a given request.</returns>
-        ushort[] GetSuitableVersion(ushort requestedVersion, ushort[] availableVersions, ICompatibilityDirector compatibilityDirector);
+        GrainInterfaceVersion[] GetSuitableVersion(GrainInterfaceVersion requestedVersion, GrainInterfaceVersion[] availableVersions, ICompatibilityDirector compatibilityDirector);
     }
 
     /// <summary>

--- a/src/Orleans.Core/Manifest/GrainVersionManifest.cs
+++ b/src/Orleans.Core/Manifest/GrainVersionManifest.cs
@@ -20,7 +20,7 @@ namespace Orleans.Runtime.Versions
         private readonly ConcurrentDictionary<GrainInterfaceType, GrainInterfaceType> _genericInterfaceMapping = new ConcurrentDictionary<GrainInterfaceType, GrainInterfaceType>();
         private readonly ConcurrentDictionary<GrainType, GrainType> _genericGrainTypeMapping = new ConcurrentDictionary<GrainType, GrainType>();
         private readonly IClusterManifestProvider _clusterManifestProvider;
-        private readonly Dictionary<GrainInterfaceType, ushort> _localVersions;
+        private readonly Dictionary<GrainInterfaceType, GrainInterfaceVersion> _localVersions;
         private Cache _cache;
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Orleans.Runtime.Versions
         /// </summary>
         /// <param name="interfaceType">The grain interface type name.</param>
         /// <returns>The version of the specified grain interface.</returns>
-        public ushort GetLocalVersion(GrainInterfaceType interfaceType)
+        public GrainInterfaceVersion GetLocalVersion(GrainInterfaceType interfaceType)
         {
             if (_localVersions.TryGetValue(interfaceType, out var result))
             {
@@ -70,7 +70,7 @@ namespace Orleans.Runtime.Versions
         /// </summary>
         /// <param name="interfaceType">The grain interface type name.</param>
         /// <returns>All known versions for the specified grain interface.</returns>
-        public (MajorMinorVersion Version, ushort[] Result) GetAvailableVersions(GrainInterfaceType interfaceType)
+        public (MajorMinorVersion Version, GrainInterfaceVersion[] Result) GetAvailableVersions(GrainInterfaceType interfaceType)
         {
             var cache = GetCache();
             if (cache.AvailableVersions.TryGetValue(interfaceType, out var result))
@@ -90,7 +90,7 @@ namespace Orleans.Runtime.Versions
             }
 
             // No versions available.
-            return (cache.Version, Array.Empty<ushort>());
+            return (cache.Version, Array.Empty<GrainInterfaceVersion>());
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Orleans.Runtime.Versions
         /// <param name="interfaceType">The grain interface type name.</param>
         /// <param name="version">The grain interface version.</param>
         /// <returns>The set of silos which support the specified grain interface type and version.</returns>
-        public (MajorMinorVersion Version, SiloAddress[] Result) GetSupportedSilos(GrainInterfaceType interfaceType, ushort version)
+        public (MajorMinorVersion Version, SiloAddress[] Result) GetSupportedSilos(GrainInterfaceType interfaceType, GrainInterfaceVersion version)
         {
             var cache = GetCache();
             if (cache.SupportedSilosByInterface.TryGetValue((interfaceType, version), out var result))
@@ -157,9 +157,9 @@ namespace Orleans.Runtime.Versions
         /// <param name="interfaceType">The grain interface type name.</param>
         /// <param name="versions">The grain interface version.</param>
         /// <returns>The set of silos which support the specified grain.</returns>
-        public (MajorMinorVersion Version, Dictionary<ushort, SiloAddress[]> Result) GetSupportedSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort[] versions)
+        public (MajorMinorVersion Version, Dictionary<GrainInterfaceVersion, SiloAddress[]> Result) GetSupportedSilos(GrainType grainType, GrainInterfaceType interfaceType, GrainInterfaceVersion[] versions)
         {
-            var result = new Dictionary<ushort, SiloAddress[]>();
+            var result = new Dictionary<GrainInterfaceVersion, SiloAddress[]>();
 
             // Track the minimum version in case of inconsistent reads, since the caller can use that information to
             // ensure they refresh on the next call.
@@ -215,20 +215,21 @@ namespace Orleans.Runtime.Versions
             }
         }
 
-        private static Dictionary<GrainInterfaceType, ushort> BuildLocalVersionMap(GrainManifest manifest)
+        private static Dictionary<GrainInterfaceType, GrainInterfaceVersion> BuildLocalVersionMap(GrainManifest manifest)
         {
-            var result = new Dictionary<GrainInterfaceType, ushort>();
+            var result = new Dictionary<GrainInterfaceType, GrainInterfaceVersion>();
             foreach (var grainInterface in manifest.Interfaces)
             {
                 var id = grainInterface.Key;
 
-                if (!grainInterface.Value.Properties.TryGetValue(WellKnownGrainInterfaceProperties.Version, out var versionString)
-                    || !ushort.TryParse(versionString, out var version))
-                {
-                    version = 0;
-                }
+                grainInterface.Value.Properties.TryGetValue(WellKnownGrainInterfaceProperties.Version, out var versionString);
+                result[id] = GrainInterfaceVersion.Parse(versionString);
 
-                result[id] = version;
+                // if (!grainInterface.Value.Properties.TryGetValue(WellKnownGrainInterfaceProperties.Version, out var versionString)
+                //     || !ushort.TryParse(versionString, out var version))
+                // {
+                //     version = 0;
+                // } // result[id] = version;
             }
 
             return result;
@@ -236,8 +237,8 @@ namespace Orleans.Runtime.Versions
 
         private static Cache BuildCache(ClusterManifest clusterManifest)
         {
-            var available = new Dictionary<GrainInterfaceType, List<ushort>>();
-            var supportedInterfaces = new Dictionary<(GrainInterfaceType, ushort), List<SiloAddress>>();
+            var available = new Dictionary<GrainInterfaceType, List<GrainInterfaceVersion>>();
+            var supportedInterfaces = new Dictionary<(GrainInterfaceType, GrainInterfaceVersion), List<SiloAddress>>();
             var supportedGrains = new Dictionary<GrainType, List<SiloAddress>>();
 
             foreach (var entry in clusterManifest.Silos)
@@ -255,15 +256,12 @@ namespace Orleans.Runtime.Versions
                 {
                     var id = grainInterface.Key;
 
-                    if (!grainInterface.Value.Properties.TryGetValue(WellKnownGrainInterfaceProperties.Version, out var versionString)
-                        || !ushort.TryParse(versionString, out var version))
-                    {
-                        version = 0;
-                    }
+                    grainInterface.Value.Properties.TryGetValue(WellKnownGrainInterfaceProperties.Version, out var versionString);
+                    var version = GrainInterfaceVersion.Parse(versionString);
 
                     if (!available.TryGetValue(id, out var versions))
                     {
-                        available[id] = new List<ushort> { version };
+                        available[id] = new List<GrainInterfaceVersion> { version };
                     }
                     else if (!versions.Contains(version))
                     {
@@ -294,14 +292,14 @@ namespace Orleans.Runtime.Versions
                 }
             }
 
-            var resultAvailable = new Dictionary<GrainInterfaceType, ushort[]>();
+            var resultAvailable = new Dictionary<GrainInterfaceType, GrainInterfaceVersion[]>();
             foreach (var entry in available)
             {
                 entry.Value.Sort();
                 resultAvailable[entry.Key] = entry.Value.ToArray();
             }
 
-            var resultSupportedByInterface = new Dictionary<(GrainInterfaceType, ushort), SiloAddress[]>();
+            var resultSupportedByInterface = new Dictionary<(GrainInterfaceType, GrainInterfaceVersion), SiloAddress[]>();
             foreach (var entry in supportedInterfaces)
             {
                 entry.Value.Sort();
@@ -322,8 +320,8 @@ namespace Orleans.Runtime.Versions
         {
             public Cache(
                 MajorMinorVersion version,
-                Dictionary<GrainInterfaceType, ushort[]> availableVersions,
-                Dictionary<(GrainInterfaceType, ushort), SiloAddress[]> supportedSilosByInterface,
+                Dictionary<GrainInterfaceType, GrainInterfaceVersion[]> availableVersions,
+                Dictionary<(GrainInterfaceType, GrainInterfaceVersion), SiloAddress[]> supportedSilosByInterface,
                 Dictionary<GrainType, SiloAddress[]> supportedSilosByGrainType)
             {
                 this.Version = version;
@@ -333,8 +331,8 @@ namespace Orleans.Runtime.Versions
             }
 
             public MajorMinorVersion Version { get; }
-            public Dictionary<GrainInterfaceType, ushort[]> AvailableVersions { get; } 
-            public Dictionary<(GrainInterfaceType, ushort), SiloAddress[]> SupportedSilosByInterface { get; } = new Dictionary<(GrainInterfaceType, ushort), SiloAddress[]>();
+            public Dictionary<GrainInterfaceType, GrainInterfaceVersion[]> AvailableVersions { get; }
+            public Dictionary<(GrainInterfaceType, GrainInterfaceVersion), SiloAddress[]> SupportedSilosByInterface { get; } = new Dictionary<(GrainInterfaceType, GrainInterfaceVersion), SiloAddress[]>();
             public Dictionary<GrainType, SiloAddress[]> SupportedSilosByGrainType { get; } = new Dictionary<GrainType, SiloAddress[]>();
         }
     }

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Orleans.Runtime.Versions;
 
 namespace Orleans.Runtime
 {
@@ -30,7 +31,7 @@ namespace Orleans.Runtime
         public SiloAddress? _sendingSilo;
         public GrainId _sendingGrain;
 
-        public ushort _interfaceVersion;
+        public GrainInterfaceVersion _interfaceVersion;
         public GrainInterfaceType _interfaceType;
 
         public List<GrainAddressCacheUpdate>? _cacheInvalidationHeader;
@@ -190,13 +191,13 @@ namespace Orleans.Runtime
             }
         }
 
-        public ushort InterfaceVersion
+        public GrainInterfaceVersion InterfaceVersion
         {
             get => _interfaceVersion;
             set
             {
                 _interfaceVersion = value;
-                _headers.SetFlag(MessageFlags.HasInterfaceVersion, value is not 0);
+                _headers.SetFlag(MessageFlags.HasInterfaceVersion, !value.IsDefault);
             }
         }
 
@@ -386,10 +387,10 @@ grow:
             HasTimeToLive = 1 << 8,
 
             // Message cannot be forwarded to another activation.
-            IsLocalOnly = 1 << 9, 
+            IsLocalOnly = 1 << 9,
 
             // Message must not trigger grain activation or extend an activation's lifetime.
-            SuppressKeepAlive = 1 << 10,  
+            SuppressKeepAlive = 1 << 10,
 
             // The most significant bit is reserved, possibly for use to indicate more data follows.
             Reserved = 1 << 15,

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Orleans.Configuration;
 using Orleans.Networking.Shared;
+using Orleans.Runtime.Versions;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Codecs;
 using Orleans.Serialization.GeneratedCodeHelpers;
@@ -241,7 +242,17 @@ namespace Orleans.Runtime.Messaging
 
             if (headers.HasFlag(MessageFlags.HasInterfaceVersion))
             {
-                writer.WriteVarUInt32(value.InterfaceVersion);
+                var ver = value.InterfaceVersion;
+                if (ver.IsNumeric)
+                {
+                    writer.WriteByte(0);
+                    writer.WriteVarUInt32(ver.NumericValue);
+                }
+                else
+                {
+                    writer.WriteByte(1);
+                    _idSpanCodec.WriteRaw(ref writer, IdSpan.Create(ver.SemanticValue.ToString()));
+                }
             }
 
             if (headers.HasFlag(MessageFlags.HasCacheInvalidationHeader))
@@ -284,7 +295,16 @@ namespace Orleans.Runtime.Messaging
 
             if (headers.HasFlag(MessageFlags.HasInterfaceVersion))
             {
-                result.InterfaceVersion = (ushort)reader.ReadVarUInt32();
+                var kind = reader.ReadByte();
+                if (kind == 0)
+                {
+                    result.InterfaceVersion = (ushort)reader.ReadVarUInt32();
+                }
+                else
+                {
+                    var idSpan = _idSpanCodec.ReadRaw(ref reader);
+                    result.InterfaceVersion = GrainInterfaceVersion.Parse(idSpan.ToString());
+                }
             }
 
             if (headers.HasFlag(MessageFlags.HasCacheInvalidationHeader))

--- a/src/Orleans.Core/Placement/IPlacementContext.cs
+++ b/src/Orleans.Core/Placement/IPlacementContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Orleans.Runtime.Versions;
 
 namespace Orleans.Runtime.Placement
 {
@@ -23,7 +24,7 @@ namespace Orleans.Runtime.Placement
         /// A description of the grain being placed as well as contextual information about the request which is triggering placement.
         /// </param>
         /// <returns>The collection of silos which are compatible with the provided placement target, along with the versions of the grain interface which each server supports.</returns>
-        IReadOnlyDictionary<ushort, SiloAddress[]> GetCompatibleSilosWithVersions(PlacementTarget target);
+        IReadOnlyDictionary<GrainInterfaceVersion, SiloAddress[]> GetCompatibleSilosWithVersions(PlacementTarget target);
 
         /// <summary>
         /// Gets the local silo's identity.

--- a/src/Orleans.Core/Placement/PlacementTarget.cs
+++ b/src/Orleans.Core/Placement/PlacementTarget.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Orleans.Runtime.Versions;
 
 namespace Orleans.Runtime.Placement
 {
@@ -14,7 +15,7 @@ namespace Orleans.Runtime.Placement
         /// <param name="requestContextData">The <see cref="RequestContext"/> dictionary for the request which triggered placement.</param>
         /// <param name="interfaceType">The interface being requested.</param>
         /// <param name="interfaceVersion">The interface version being requested.</param>
-        public PlacementTarget(GrainId grainIdentity, Dictionary<string, object> requestContextData, GrainInterfaceType interfaceType, ushort interfaceVersion)
+        public PlacementTarget(GrainId grainIdentity, Dictionary<string, object> requestContextData, GrainInterfaceType interfaceType, GrainInterfaceVersion interfaceVersion)
         {
             this.GrainIdentity = grainIdentity;
             this.InterfaceType = interfaceType;
@@ -35,7 +36,7 @@ namespace Orleans.Runtime.Placement
         /// <summary>
         /// Gets the interface version being requested.
         /// </summary>
-        public ushort InterfaceVersion { get; }
+        public GrainInterfaceVersion InterfaceVersion { get; }
 
         /// <summary>
         /// Gets the <see cref="RequestContext"/> dictionary for the request which triggered placement.

--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -166,7 +166,7 @@ namespace Orleans.Runtime.Placement
             }
         }
 
-        public IReadOnlyDictionary<ushort, SiloAddress[]> GetCompatibleSilosWithVersions(PlacementTarget target)
+        public IReadOnlyDictionary<GrainInterfaceVersion, SiloAddress[]> GetCompatibleSilosWithVersions(PlacementTarget target)
         {
             if (target.InterfaceVersion == 0)
             {

--- a/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
+++ b/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
@@ -10,7 +10,7 @@ namespace Orleans.Runtime.Versions
 {
     internal class CachedVersionSelectorManager
     {
-        private readonly ConcurrentDictionary<(GrainType Type, GrainInterfaceType Interface, ushort Version), CachedEntry> suitableSilosCache;
+        private readonly ConcurrentDictionary<(GrainType Type, GrainInterfaceType Interface, GrainInterfaceVersion Version), CachedEntry> suitableSilosCache;
         private readonly GrainVersionManifest grainInterfaceVersions;
 
         public CachedVersionSelectorManager(GrainVersionManifest grainInterfaceVersions, VersionSelectorManager versionSelectorManager, CompatibilityDirectorManager compatibilityDirectorManager)
@@ -18,14 +18,14 @@ namespace Orleans.Runtime.Versions
             this.grainInterfaceVersions = grainInterfaceVersions;
             this.VersionSelectorManager = versionSelectorManager;
             this.CompatibilityDirectorManager = compatibilityDirectorManager;
-            this.suitableSilosCache = new ConcurrentDictionary<(GrainType Type, GrainInterfaceType Interface, ushort Version), CachedEntry>();
+            this.suitableSilosCache = new ConcurrentDictionary<(GrainType Type, GrainInterfaceType Interface, GrainInterfaceVersion Version), CachedEntry>();
         }
 
         public VersionSelectorManager VersionSelectorManager { get; }
 
         public CompatibilityDirectorManager CompatibilityDirectorManager { get; }
 
-        public CachedEntry GetSuitableSilos(GrainType grainType, GrainInterfaceType interfaceId, ushort requestedVersion)
+        public CachedEntry GetSuitableSilos(GrainType grainType, GrainInterfaceType interfaceId, GrainInterfaceVersion requestedVersion)
         {
             var key = ValueTuple.Create(grainType, interfaceId, requestedVersion);
             if (!suitableSilosCache.TryGetValue(key, out var entry) || entry.Version < this.grainInterfaceVersions.LatestVersion)
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.Versions
             this.suitableSilosCache.Clear();
         }
 
-        private CachedEntry GetSuitableSilosImpl((GrainType Type, GrainInterfaceType Interface, ushort Version) key)
+        private CachedEntry GetSuitableSilosImpl((GrainType Type, GrainInterfaceType Interface, GrainInterfaceVersion Version) key)
         {
             var grainType = key.Type;
             var interfaceType = key.Interface;
@@ -51,8 +51,8 @@ namespace Orleans.Runtime.Versions
             var compatibilityDirector = this.CompatibilityDirectorManager.GetDirector(interfaceType);
             (var version, var available) = this.grainInterfaceVersions.GetAvailableVersions(interfaceType);
             var versions = versionSelector.GetSuitableVersion(
-                requestedVersion, 
-                available, 
+                requestedVersion,
+                available,
                 compatibilityDirector);
 
             (_, var result) = this.grainInterfaceVersions.GetSupportedSilos(grainType, interfaceType, versions);
@@ -71,7 +71,7 @@ namespace Orleans.Runtime.Versions
 
             public SiloAddress[] SuitableSilos { get; set; }
 
-            public Dictionary<ushort, SiloAddress[]> SuitableSilosByVersion { get; set; }
+            public Dictionary<GrainInterfaceVersion, SiloAddress[]> SuitableSilosByVersion { get; set; }
         }
     }
 }

--- a/src/Orleans.Runtime/Versions/Compatibility/AllVersionsCompatibilityDirector.cs
+++ b/src/Orleans.Runtime/Versions/Compatibility/AllVersionsCompatibilityDirector.cs
@@ -4,7 +4,7 @@ namespace Orleans.Runtime.Versions.Compatibility
 {
     internal class AllVersionsCompatibilityDirector : ICompatibilityDirector
     {
-        public bool IsCompatible(ushort requestedVersion, ushort currentVersion)
+        public bool IsCompatible(GrainInterfaceVersion requestedVersion, GrainInterfaceVersion currentVersion)
         {
             return true;
         }

--- a/src/Orleans.Runtime/Versions/Compatibility/BackwardCompatilityDirector.cs
+++ b/src/Orleans.Runtime/Versions/Compatibility/BackwardCompatilityDirector.cs
@@ -4,7 +4,7 @@ namespace Orleans.Runtime.Versions.Compatibility
 {
     internal class BackwardCompatilityDirector : ICompatibilityDirector
     {
-        public bool IsCompatible(ushort requestedVersion, ushort currentVersion)
+        public bool IsCompatible(GrainInterfaceVersion requestedVersion, GrainInterfaceVersion currentVersion)
         {
             return requestedVersion <= currentVersion;
         }

--- a/src/Orleans.Runtime/Versions/Compatibility/StrictVersionCompatibilityDirector.cs
+++ b/src/Orleans.Runtime/Versions/Compatibility/StrictVersionCompatibilityDirector.cs
@@ -4,7 +4,7 @@ namespace Orleans.Runtime.Versions.Compatibility
 {
     internal class StrictVersionCompatibilityDirector : ICompatibilityDirector
     {
-        public bool IsCompatible(ushort requestedVersion, ushort currentVersion)
+        public bool IsCompatible(GrainInterfaceVersion requestedVersion, GrainInterfaceVersion currentVersion)
         {
             return requestedVersion == currentVersion;
         }

--- a/src/Orleans.Runtime/Versions/Selector/AllCompatibleVersionsSelector.cs
+++ b/src/Orleans.Runtime/Versions/Selector/AllCompatibleVersionsSelector.cs
@@ -6,7 +6,7 @@ namespace Orleans.Runtime.Versions.Selector
 {
     internal class AllCompatibleVersionsSelector : IVersionSelector
     {
-        public ushort[] GetSuitableVersion(ushort requestedVersion, ushort[] availableVersions, ICompatibilityDirector compatibilityDirector)
+        public GrainInterfaceVersion[] GetSuitableVersion(GrainInterfaceVersion requestedVersion, GrainInterfaceVersion[] availableVersions, ICompatibilityDirector compatibilityDirector)
         {
             return availableVersions.Where(v => compatibilityDirector.IsCompatible(requestedVersion, v)).ToArray();
         }

--- a/src/Orleans.Runtime/Versions/Selector/LatestVersionDirector.cs
+++ b/src/Orleans.Runtime/Versions/Selector/LatestVersionDirector.cs
@@ -6,20 +6,20 @@ namespace Orleans.Runtime.Versions.Selector
 {
     internal sealed class LatestVersionSelector : IVersionSelector
     {
-        public ushort[] GetSuitableVersion(ushort requestedVersion, ushort[] availableVersions, ICompatibilityDirector compatibilityDirector)
+        public GrainInterfaceVersion[] GetSuitableVersion(GrainInterfaceVersion requestedVersion, GrainInterfaceVersion[] availableVersions, ICompatibilityDirector compatibilityDirector)
         {
-            var max = int.MinValue;
+            GrainInterfaceVersion? max = null;
             foreach (var version in availableVersions)
             {
-                if (compatibilityDirector.IsCompatible(requestedVersion, version) && version > max)
+                if (compatibilityDirector.IsCompatible(requestedVersion, version) && (max is null || version > max))
                 {
                     max = version;
                 }
             }
 
-            if (max < 0) return Array.Empty<ushort>();
+            if (max is null) return Array.Empty<GrainInterfaceVersion>();
 
-            return new[] { (ushort)max };
+            return new[] { max.Value };
         }
     }
 }

--- a/src/Orleans.Runtime/Versions/Selector/MinimumVersionSelector.cs
+++ b/src/Orleans.Runtime/Versions/Selector/MinimumVersionSelector.cs
@@ -6,7 +6,7 @@ namespace Orleans.Runtime.Versions.Selector
 {
     internal sealed class MinimumVersionSelector : IVersionSelector
     {
-        public ushort[] GetSuitableVersion(ushort requestedVersion, ushort[] availableVersions, ICompatibilityDirector compatibilityDirector)
+        public GrainInterfaceVersion[] GetSuitableVersion(GrainInterfaceVersion requestedVersion, GrainInterfaceVersion[] availableVersions, ICompatibilityDirector compatibilityDirector)
         {
             return new[]
             {

--- a/test/Grains/TestGrains/VersionAwarePlacementDirector.cs
+++ b/test/Grains/TestGrains/VersionAwarePlacementDirector.cs
@@ -1,5 +1,6 @@
 using Orleans.Runtime;
 using Orleans.Runtime.Placement;
+using Orleans.Runtime.Versions;
 
 namespace UnitTests.Grains
 {
@@ -18,7 +19,7 @@ namespace UnitTests.Grains
             {
                 var silosByVersion = context.GetCompatibleSilosWithVersions(target);
                 var maxSiloCount = 0;
-                ushort version = 0;
+                GrainInterfaceVersion version = 0;
                 foreach (var kvp in silosByVersion)
                 {
                     if (kvp.Value.Length > maxSiloCount)


### PR DESCRIPTION
## Summary

Add semantic versioning (SemVer) support for grain interfaces alongside the existing `ushort` versioning.

## Motivation

The current `ushort`-only versioning limits grain interfaces to a simple numeric counter. This change allows developers to use SemVer strings (e.g. `"1.2.0"`, `"2.0.0-beta.1"`) while maintaining full backward compatibility with existing numeric versions.

## Changes

- `SemanticVersion` struct (SemVer 2.0.0 compliant)
- `GrainInterfaceVersion` unified wrapper supporting both `ushort` and `SemanticVersion`
- `VersionAttribute` now accepts `string` for SemVer
- `GrainVersionManifest` updated to use `GrainInterfaceVersion`
- Message serialization updated with kind marker for protocol-level support

## Backward Compatibility

- Existing `[Version(2)]` usage works unchanged
- `GrainInterfaceVersion.Parse()` auto-detects numeric vs SemVer
- Cross-kind comparison (numeric vs semantic) throws to prevent misconfiguration
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/9996)