### PR TITLE
Fix NATS GitHub Actions filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,10 @@ jobs:
     - name: Wait for NATS
       run: |
         echo "Waiting for NATS to be ready..."
-        timeout 60 bash -c 'until nc -z 127.0.0.1 4222 && nc -z 127.0.0.1 8222; do sleep 1; done'
+        if ! timeout 60 bash -c 'until docker logs nats 2>&1 | grep -q "Server is ready"; do sleep 1; done'; then
+          docker logs nats
+          exit 1
+        fi
         echo "NATS is ready"
     - uses: actions/checkout@v4
     - name: Setup .NET

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,7 +585,10 @@ jobs:
     - name: Start NATS
       run: docker run -d --name nats -p 4222:4222 -p 8222:8222 nats:latest --js --http-port=8222
     - name: Wait for NATS
-      run: sleep 5
+      run: |
+        echo "Waiting for NATS to be ready..."
+        timeout 60 bash -c 'until nc -z 127.0.0.1 4222 && nc -z 127.0.0.1 8222; do sleep 1; done'
+        echo "NATS is ready"
     - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,8 +593,9 @@ jobs:
         global-json-file: global.json
     - name: Test
       run: dotnet test
+        test/Extensions/Orleans.Streaming.NATS.Tests/Orleans.Streaming.NATS.Tests.csproj
         --framework ${{ matrix.framework }}
-        --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)"
+        --filter "Category=${{ matrix.provider }}"
         --blame-hang-timeout 10m
         --blame-crash-dump-type full
         --blame-hang-dump-type full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,7 +583,7 @@ jobs:
 #          HTTP_PORT: 8222
     steps:
     - name: Start NATS
-      run: docker run -d --name nats -p 4222:4222 -p 8222:8222 nats:latest --js --http-port=8222
+      run: docker run -d --name nats -p 4222:4222 -p 8222:8222 nats:latest --js --http_port=8222
     - name: Wait for NATS
       run: |
         echo "Waiting for NATS to be ready..."

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsAdapterTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsAdapterTests.cs
@@ -107,6 +107,7 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
 
         int receivedBatches = 0;
         var streamsPerQueue = new ConcurrentDictionary<QueueId, HashSet<StreamId>>();
+        var firstTokensPerQueue = new ConcurrentDictionary<(QueueId QueueId, StreamId StreamId), StreamSequenceToken>();
 
         // reader threads (at most 2 active queues because only two streams)
         var work = new List<Task>();
@@ -134,6 +135,10 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
                                 set.Add(message.StreamId);
                                 return set;
                             });
+                        firstTokensPerQueue.AddOrUpdate(
+                            (queueId, message.StreamId),
+                            message.SequenceToken,
+                            (_, existing) => message.SequenceToken.CompareTo(existing) < 0 ? message.SequenceToken : existing);
                         output.WriteLine("Queue {0} received message on stream {1}", queueId,
                             message.StreamId);
                         Assert.Equal(NumMessagesPerBatch / 2,
@@ -163,8 +168,7 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
         // Make sure we got back everything we sent
         Assert.Equal(NumBatches, receivedBatches);
 
-        // check to see if all the events are in the cache and we can enumerate through them
-        StreamSequenceToken firstInCache = new EventSequenceTokenV2(0);
+        // NATS sequence numbers are stream-global and start above zero, so use the first token observed for each stream.
         foreach (KeyValuePair<QueueId, HashSet<StreamId>> kvp in streamsPerQueue)
         {
             var receiver = receivers[kvp.Key];
@@ -172,6 +176,8 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
 
             foreach (StreamId streamGuid in kvp.Value)
             {
+                Assert.True(firstTokensPerQueue.TryGetValue((kvp.Key, streamGuid), out var firstInCache));
+
                 // read all messages in cache for stream
                 IQueueCacheCursor cursor = qCache.GetCacheCursor(streamGuid, firstInCache);
                 int messageCount = 0;

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsAdapterTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsAdapterTests.cs
@@ -37,7 +37,7 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
         this.output = output;
         this.fixture = fixture;
 
-        this.natsConnection = new NatsConnection();
+        this.natsConnection = NatsTestConstants.CreateConnection();
         this.natsContext = new NatsJSContext(this.natsConnection);
 
         this.testStreamName = $"test-stream-{Guid.NewGuid()}";
@@ -74,7 +74,7 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
     [SkippableFact]
     public async Task SendAndReceiveFromNats()
     {
-        var options = new NatsOptions { StreamName = testStreamName };
+        var options = new NatsOptions { StreamName = testStreamName, NatsClientOptions = NatsTestConstants.NatsClientOptions };
         var adapterFactory = new NatsAdapterFactory(
             NATS_STREAM_PROVIDER_NAME,
             options,

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsClientStreamTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsClientStreamTests.cs
@@ -27,7 +27,7 @@ public class NatsClientStreamTests : TestClusterPerTest
             throw new SkipException("Nats Server is not available");
         }
 
-        this.natsConnection = new NatsConnection();
+        this.natsConnection = NatsTestConstants.CreateConnection();
         this.natsContext = new NatsJSContext(this.natsConnection);
     }
 
@@ -84,6 +84,7 @@ public class NatsClientStreamTests : TestClusterPerTest
                 .AddNatsStreams(NatsStreamProviderName, options =>
                 {
                     options.StreamName = TestStreamName;
+                    options.NatsClientOptions = NatsTestConstants.NatsClientOptions;
                 })
                 .AddMemoryGrainStorage("PubSubStore")
                 .Configure<SiloMessagingOptions>(options => options.ClientDropTimeout = TimeSpan.FromSeconds(5));
@@ -98,6 +99,7 @@ public class NatsClientStreamTests : TestClusterPerTest
                 .AddNatsStreams(NatsStreamProviderName, options =>
                 {
                     options.StreamName = TestStreamName;
+                    options.NatsClientOptions = NatsTestConstants.NatsClientOptions;
                 });
             ;
         }

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsStreamTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsStreamTests.cs
@@ -27,7 +27,7 @@ public class NatsStreamTests : TestClusterPerTest
             throw new SkipException("Nats Server is not available");
         }
 
-        this.natsConnection = new NatsConnection();
+        this.natsConnection = NatsTestConstants.CreateConnection();
         this.natsContext = new NatsJSContext(this.natsConnection);
     }
 
@@ -50,10 +50,12 @@ public class NatsStreamTests : TestClusterPerTest
                 .AddNatsStreams(NatsStreamProviderName, options =>
                 {
                     options.StreamName = TestStreamName;
+                    options.NatsClientOptions = NatsTestConstants.NatsClientOptions;
                 })
                 .AddNatsStreams($"{NatsStreamProviderName}2", options =>
                 {
                     options.StreamName = $"{TestStreamName}2";
+                    options.NatsClientOptions = NatsTestConstants.NatsClientOptions;
                 })
                 .AddMemoryGrainStorage("PubSubStore", opt => opt.NumStorageGrains = 1)
                 .AddMemoryGrainStorage("MemoryStore", op => op.NumStorageGrains = 1);
@@ -69,6 +71,7 @@ public class NatsStreamTests : TestClusterPerTest
                 .AddNatsStreams(NatsStreamProviderName, options =>
                 {
                     options.StreamName = TestStreamName;
+                    options.NatsClientOptions = NatsTestConstants.NatsClientOptions;
                 });
         }
     }

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsSubscriptionMultiplicityTests.cs
@@ -26,7 +26,7 @@ public class NatsSubscriptionMultiplicityTests : TestClusterPerTest
             throw new SkipException("Nats Server is not available");
         }
 
-        this.natsConnection = new NatsConnection();
+        this.natsConnection = NatsTestConstants.CreateConnection();
         this.natsContext = new NatsJSContext(this.natsConnection);
     }
 
@@ -49,6 +49,7 @@ public class NatsSubscriptionMultiplicityTests : TestClusterPerTest
                 .AddNatsStreams(NatsStreamProviderName, options =>
                 {
                     options.StreamName = TestStreamName;
+                    options.NatsClientOptions = NatsTestConstants.NatsClientOptions;
                 })
                 .AddMemoryGrainStorage("PubSubStore", opt => opt.NumStorageGrains = 1);
         }
@@ -62,6 +63,7 @@ public class NatsSubscriptionMultiplicityTests : TestClusterPerTest
                 .AddNatsStreams(NatsStreamProviderName, options =>
                 {
                     options.StreamName = TestStreamName;
+                    options.NatsClientOptions = NatsTestConstants.NatsClientOptions;
                 });
         }
     }

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsTestConstants.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsTestConstants.cs
@@ -4,13 +4,16 @@ namespace NATS.Tests;
 
 public static class NatsTestConstants
 {
+    public static readonly NatsOpts NatsClientOptions = NatsOpts.Default with
+    {
+        Url = "nats://127.0.0.1:4222"
+    };
+
     private static readonly Lazy<bool> _isNatsAvailable = new(() =>
     {
         try
         {
-            var nats = new NatsConnection();
-            nats.ConnectAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2)).Wait();
-            return nats.ConnectionState == NatsConnectionState.Open;
+            return IsNatsAvailableAsync().GetAwaiter().GetResult();
         }
         catch
         {
@@ -19,4 +22,16 @@ public static class NatsTestConstants
     });
 
     public static bool IsNatsAvailable => _isNatsAvailable.Value;
+
+    public static NatsConnection CreateConnection() => new(NatsClientOptions);
+
+    private static async Task<bool> IsNatsAvailableAsync()
+    {
+        await using var nats = CreateConnection();
+
+        await nats.ConnectAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await nats.PingAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+
+        return nats.ConnectionState == NatsConnectionState.Open && nats.ServerInfo?.JetStreamAvailable == true;
+    }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/ClientStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ClientStreamTestRunner.cs
@@ -2,6 +2,7 @@ using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
+using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
 using Xunit.Abstractions;
@@ -108,17 +109,28 @@ namespace Tester.StreamingTests
 
         private async Task ProduceEventsFromClient(string streamProviderName, Guid streamGuid, string streamNamespace, int eventsProduced)
         {
+            using var observer = StreamingDiagnosticObserver.Create();
+            using var cts = new CancellationTokenSource(_timeout);
+            var streamId = StreamId.Create(streamNamespace, streamGuid);
+
             // get reference to a consumer
             var consumer = this.testHost.GrainFactory.GetGrain<ISampleStreaming_ConsumerGrain>(Guid.NewGuid());
 
-            // subscribe
-            await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
+            try
+            {
+                // subscribe
+                await consumer.BecomeConsumer(streamGuid, streamNamespace, streamProviderName);
 
-            // generate events
-            await GenerateEvents(streamProviderName, streamGuid, streamNamespace, eventsProduced);
+                // generate events
+                await GenerateEvents(streamProviderName, streamGuid, streamNamespace, eventsProduced);
 
-            // make sure all went well
-            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(() => consumer.GetNumberConsumed(), () => Task.FromResult(eventsProduced), lastTry), _timeout);
+                await observer.WaitForItemDeliveryCountAsync(streamId, eventsProduced, streamProviderName, cts.Token);
+                Assert.Equal(eventsProduced, await consumer.GetNumberConsumed());
+            }
+            finally
+            {
+                await consumer.StopConsuming();
+            }
         }
 
         private async Task GenerateEvents(string streamProviderName, Guid streamGuid, string streamNamespace, int produceCount)

--- a/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
@@ -4,6 +4,7 @@ using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestingHost.Utils;
 using Tester;
+using TestExtensions;
 using UnitTests.GrainInterfaces;
 using UnitTests.Grains;
 using Xunit;
@@ -422,6 +423,9 @@ public class SingleStreamTestRunner
 
     public async Task BasicTestAsync(bool fullTest = true)
     {
+        using var observer = StreamingDiagnosticObserver.Create();
+        using var cts = new CancellationTokenSource(_timeout);
+
         logger.LogInformation("\n** Starting Test {TestNumber} BasicTestAsync.\n", testNumber);
         var producerCount = await producer.ProducerCount;
         var consumerCount = await consumer.ConsumerCount;
@@ -432,19 +436,26 @@ public class SingleStreamTestRunner
             consumerCount);
 
         await producer.ProduceSequentialSeries(ItemCount);
-        await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, false), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
-        await CheckCounters(producer, consumer);
+        await WaitForItemDeliveryCountAndAssertCountersAsync(observer, cts.Token);
         if (runFullTest)
         {
             await producer.ProduceParallelSeries(ItemCount);
-            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, false), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
-            await CheckCounters(producer, consumer);
+            await WaitForItemDeliveryCountAndAssertCountersAsync(observer, cts.Token);
        
             await producer.ProducePeriodicSeries(ItemCount);
-            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, false), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
-            await CheckCounters(producer, consumer);
+            await WaitForItemDeliveryCountAndAssertCountersAsync(observer, cts.Token);
         }
         await ValidatePubSub(producer.StreamId, producer.ProviderName);
+    }
+
+    private async Task WaitForItemDeliveryCountAndAssertCountersAsync(StreamingDiagnosticObserver observer, CancellationToken cancellationToken)
+    {
+        var consumerCount = await consumer.ConsumerCount;
+        Assert.NotEqual(0, consumerCount);
+
+        var expectedConsumed = await producer.ExpectedItemsProduced * consumerCount;
+        await observer.WaitForItemDeliveryCountAsync(producer.StreamId, expectedConsumed, producer.ProviderName, cancellationToken);
+        await CheckCounters(producer, consumer);
     }
 
     public async Task StopProxies()

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamTestHelperClasses.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamTestHelperClasses.cs
@@ -376,14 +376,14 @@ namespace UnitTests.StreamingTests
 
         public StreamId StreamId { get; }
 
-        private ProducerProxy(IStreaming_ProducerGrain[] targets, Guid streamId, string providerName, ILogger logger)
+        private ProducerProxy(IStreaming_ProducerGrain[] targets, Guid streamId, string providerName, string streamNamespace, ILogger logger)
         {
             _targets = targets;
             _logger = logger;
             _streamId = streamId;
             _providerName = providerName;
             _cleanedUpFlag = new InterlockedFlag();
-            StreamId = StreamId.Create(null, streamId);
+            StreamId = StreamId.Create(streamNamespace, streamId);
         }
 
         private static async Task<ProducerProxy> NewProducerProxy(IStreaming_ProducerGrain[] targets, Guid streamId, string streamProvider, string streamNamespace, ILogger logger)
@@ -395,7 +395,7 @@ namespace UnitTests.StreamingTests
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
 
-            ProducerProxy newObj = new ProducerProxy(targets, streamId, streamProvider, logger);
+            ProducerProxy newObj = new ProducerProxy(targets, streamId, streamProvider, streamNamespace, logger);
             await newObj.BecomeProducer(streamId, streamProvider, streamNamespace);
             return newObj;
         }


### PR DESCRIPTION
## Summary
- run the dedicated NATS test project in the NATS provider job
- filter on `Category=NATS` so the NATS test assembly actually matches
- avoid the repo-wide no-match behavior which currently leaves the NATS job effectively empty

## Validation
- direct `dotnet test test/Extensions/Orleans.Streaming.NATS.Tests/Orleans.Streaming.NATS.Tests.csproj --filter "Category=NATS"` discovery on net8.0 and net10.0 now finds the NATS tests instead of reporting no matches
- this local environment does not have a running NATS server, so the discovered tests are not executed here
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10000)