### PR TITLE
Fix AQ filtering CI coverage

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AQStreamFilteringTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AQStreamFilteringTests.cs
@@ -14,6 +14,7 @@ namespace Tester.AzureUtils.Streaming
     /// <summary>
     /// Tests for stream filtering functionality with Azure Queue streaming providers.
     /// </summary>
+    [TestCategory("AzureStorage"), TestCategory("AzureQueue")]
     public class AQStreamFilteringTests : StreamFilteringTestsBase, IClassFixture<AQStreamFilteringTests.Fixture>, IAsyncLifetime
     {
         private const int queueCount = 1;
@@ -66,7 +67,7 @@ namespace Tester.AzureUtils.Streaming
 
             protected override void CheckPreconditionsOrThrow()
             {
-                TestUtils.CheckForEventHub();
+                TestUtils.CheckForAzureStorage();
             }
         }
 


### PR DESCRIPTION
## Summary
- fix AQ stream filtering preconditions to use Azure Storage instead of Event Hubs
- add Azure Storage / Azure Queue provider categories so the existing Azure Storage CI job includes these tests

## Validation
- ran `dotnet test test/Extensions/Orleans.Azure.Tests/Orleans.Azure.Tests.csproj -f net10.0 --filter "FullyQualifiedName~AQStreamFilteringTests" -- -parallel none -noshadow` against local Azurite
- result: total 3, failed 0, succeeded 3, skipped 0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10001)