### PR TITLE
ActivationCollector: Fix ArgumentException when cancelling indefinite keep-alive

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -412,6 +412,11 @@ namespace Orleans.Runtime
         private void ThrowIfTicketIsInvalid(DateTime ticket)
         {
             if (ticket.Ticks == 0) throw new ArgumentException("Empty ticket is not allowed in this context.");
+            // DateTime.MaxValue is a sentinel produced by MakeTicketFromDateTime when the
+            // rounded-up tick overflows (e.g., ScanStale rescheduling an activation whose
+            // KeepAliveUntil is DateTime.MaxValue). Its ticks aren't quantum-aligned, but
+            // it is a valid ticket and must not be rejected here.
+            if (ticket == DateTime.MaxValue) return;
             if (0 != ticket.Ticks % _grainCollectionOptions.CollectionQuantum.Ticks)
             {
                 throw new ArgumentException(string.Format("invalid ticket ({0})", ticket));

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -87,9 +87,15 @@ namespace UnitTests.Runtime
             collector.ScheduleCollection(activation, farFuture, now);
             Assert.Equal(DateTime.MaxValue, activation.CollectionTicket);
 
-            var exception = Record.Exception(() => collector.TryRescheduleCollection(activation));
+            var rescheduled = false;
+            var exception = Record.Exception(() =>
+            {
+                rescheduled = collector.TryRescheduleCollection(activation);
+            });
 
             Assert.Null(exception);
+            Assert.True(rescheduled);
+            Assert.NotEqual(default, activation.CollectionTicket);
             Assert.NotEqual(DateTime.MaxValue, activation.CollectionTicket);
         }
 

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -65,6 +65,34 @@ namespace UnitTests.Runtime
             });
         }
 
+        [Fact, TestCategory("Activation")]
+        public void TryRescheduleCollection_DoesNotThrow_WhenCollectionTicketIsMaxValue()
+        {
+            // Simulate an activation whose collection ticket sits in the DateTime.MaxValue bucket.
+            // That state arises when ScanStale reschedules an activation with
+            // KeepAliveUntil = DateTime.MaxValue (from DelayDeactivation(Timeout.InfiniteTimeSpan))
+            // and MakeTicketFromDateTime clamps the overflowed timestamp to DateTime.MaxValue
+            // (see MakeTicketFromDateTime_MaxValue).
+            //
+            // Cancelling the keep-alive via DelayDeactivation(TimeSpan.Zero) drives
+            // ActivationData into TryRescheduleCollection, which must be able to move the
+            // activation out of the MaxValue bucket without throwing.
+            var activation = Substitute.For<ICollectibleGrainContext, IActivationWorkingSetMember>();
+            activation.CollectionAgeLimit.Returns(TimeSpan.FromMinutes(5));
+            activation.IsValid.Returns(true);
+            activation.IsExemptFromCollection.Returns(false);
+
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+            var farFuture = DateTime.MaxValue - now;
+            collector.ScheduleCollection(activation, farFuture, now);
+            Assert.Equal(DateTime.MaxValue, activation.CollectionTicket);
+
+            var exception = Record.Exception(() => collector.TryRescheduleCollection(activation));
+
+            Assert.Null(exception);
+            Assert.NotEqual(DateTime.MaxValue, activation.CollectionTicket);
+        }
+
         [Theory, TestCategory("MemoryBasedDeactivations")]
         [InlineData(80.0, 70.0, 1000, 150, 100, true, 82)] // Over threshold, need to deactivate
         [InlineData(80.0, 70.0, 1000, 250, 100, false, 0)] // Below threshold, no deactivation


### PR DESCRIPTION
Fixes #10013.

## Root cause

`ActivationCollector.MakeTicketFromDateTime` produces `DateTime.MaxValue` as a valid sentinel on tick overflow (see `MakeTicketFromDateTime_MaxValue`), but `ThrowIfTicketIsInvalid` rejects it because `DateTime.MaxValue.Ticks % CollectionQuantum.Ticks != 0`. The path became reachable via `ActivationData.DelayDeactivation(TimeSpan.Zero)` in 10.1.0 (#9945) for any activation whose `CollectionTicket` was rebucketed to `DateTime.MaxValue` by `ScanStale` while `KeepAliveUntil = DateTime.MaxValue`.

## Fix

Accept `DateTime.MaxValue` in `ThrowIfTicketIsInvalid`. The rest of `TryRescheduleCollection_Impl` already handles the case correctly — it removes the activation from the `MaxValue` bucket and adds it to a normal quantum-aligned bucket.

## Test

Added `TryRescheduleCollection_DoesNotThrow_WhenCollectionTicketIsMaxValue`. Without the fix it reproduces the exact stack from the linked issue; with the fix it passes and the activation's ticket is moved out of the `MaxValue` bucket.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10014)