### PR TITLE
Fix reactivation race in `StatelessWorkerGrainContext`

### DIFF
--- a/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
+++ b/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
@@ -1,164 +1,111 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.ExceptionServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
-using Orleans.GrainReferences;
 using Orleans.Metadata;
-using Orleans.Runtime.Internal;
 using Orleans.Runtime.Scheduler;
 
-namespace Orleans.Runtime
+namespace Orleans.Runtime;
+
+internal partial class ActivationDataActivatorProvider(
+    GrainClassMap grainClassMap,
+    IServiceProvider serviceProvider,
+    GrainTypeSharedContextResolver sharedComponentsResolver,
+    ILogger<WorkItemGroup> workItemGroupLogger,
+    ILogger<ActivationTaskScheduler> activationTaskSchedulerLogger,
+    IOptions<SchedulingOptions> schedulingOptions,
+    IOptions<StatelessWorkerOptions> statelessWorkerOptions) : IGrainContextActivatorProvider
 {
-    internal partial class ActivationDataActivatorProvider : IGrainContextActivatorProvider
+    public bool TryGet(GrainType grainType, [NotNullWhen(true)] out IGrainContextActivator? activator)
     {
-        private readonly IServiceProvider _serviceProvider;
-        private readonly IActivationWorkingSet _activationWorkingSet;
+        if (!grainClassMap.TryGetGrainClass(grainType, out var grainClass) || !typeof(IGrain).IsAssignableFrom(grainClass))
+        {
+            activator = null;
+            return false;
+        }
+
+        var sharedContext = sharedComponentsResolver.GetComponents(grainType);
+        var instanceActivator = sharedContext.GetComponent<IGrainActivator>();
+        if (instanceActivator is null)
+        {
+            throw new InvalidOperationException($"Could not find a suitable {nameof(IGrainActivator)} implementation for grain type {grainType}");
+        }
+
+        var innerActivator = new ActivationDataActivator(
+            instanceActivator,
+            serviceProvider,
+            sharedContext,
+            workItemGroupLogger,
+            activationTaskSchedulerLogger,
+            schedulingOptions);
+
+        if (sharedContext.PlacementStrategy is StatelessWorkerPlacement)
+        {
+            var statelessWorkerSharedContext = new StatelessWorkerGrainTypeSharedContext(sharedContext, statelessWorkerOptions);
+            activator = new StatelessWorkerActivator(statelessWorkerSharedContext, innerActivator);
+        }
+        else
+        {
+            activator = innerActivator;
+        }
+
+        return true;
+    }
+
+    private partial class ActivationDataActivator : IGrainContextActivator
+    {
         private readonly ILogger<WorkItemGroup> _workItemGroupLogger;
-        private readonly ILogger<Grain> _grainLogger;
         private readonly ILogger<ActivationTaskScheduler> _activationTaskSchedulerLogger;
         private readonly IOptions<SchedulingOptions> _schedulingOptions;
-        private readonly GrainTypeSharedContextResolver _sharedComponentsResolver;
-        private readonly GrainClassMap _grainClassMap;
-        private readonly ILoggerFactory _loggerFactory;
-        private readonly GrainReferenceActivator _grainReferenceActivator;
+        private readonly IGrainActivator _grainActivator;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly GrainTypeSharedContext _sharedComponents;
+        private readonly Func<IGrainContext, WorkItemGroup> _createWorkItemGroup;
+        private readonly Action<object?> _startActivation;
 
-        public ActivationDataActivatorProvider(
-            GrainClassMap grainClassMap,
+        public ActivationDataActivator(
+            IGrainActivator grainActivator,
             IServiceProvider serviceProvider,
-            ILoggerFactory loggerFactory,
-            GrainReferenceActivator grainReferenceActivator,
-            GrainTypeSharedContextResolver sharedComponentsResolver,
-            IActivationWorkingSet activationWorkingSet,
-            ILogger<Grain> grainLogger,
+            GrainTypeSharedContext sharedComponents,
             ILogger<WorkItemGroup> workItemGroupLogger,
             ILogger<ActivationTaskScheduler> activationTaskSchedulerLogger,
             IOptions<SchedulingOptions> schedulingOptions)
         {
-            _activationWorkingSet = activationWorkingSet;
             _workItemGroupLogger = workItemGroupLogger;
-            _grainLogger = grainLogger;
             _activationTaskSchedulerLogger = activationTaskSchedulerLogger;
             _schedulingOptions = schedulingOptions;
-            _sharedComponentsResolver = sharedComponentsResolver;
-            _grainClassMap = grainClassMap;
+            _grainActivator = grainActivator;
             _serviceProvider = serviceProvider;
-            _loggerFactory = loggerFactory;
-            _grainReferenceActivator = grainReferenceActivator;
-        }
-
-        public bool TryGet(GrainType grainType, [NotNullWhen(true)] out IGrainContextActivator? activator)
-        {
-            if (!_grainClassMap.TryGetGrainClass(grainType, out var grainClass) || !typeof(IGrain).IsAssignableFrom(grainClass))
-            {
-                activator = null;
-                return false;
-            }
-
-            var sharedContext = _sharedComponentsResolver.GetComponents(grainType);
-            var instanceActivator = sharedContext.GetComponent<IGrainActivator>();
-            if (instanceActivator is null)
-            {
-                throw new InvalidOperationException($"Could not find a suitable {nameof(IGrainActivator)} implementation for grain type {grainType}");
-            }
-
-            var innerActivator = new ActivationDataActivator(
-                instanceActivator,
-                _serviceProvider,
-                sharedContext,
-                _grainLogger,
+            _sharedComponents = sharedComponents;
+            _createWorkItemGroup = context => new WorkItemGroup(
+                context,
                 _workItemGroupLogger,
                 _activationTaskSchedulerLogger,
                 _schedulingOptions);
-
-            if (sharedContext.PlacementStrategy is StatelessWorkerPlacement)
-            {
-                activator = new StatelessWorkerActivator(sharedContext, innerActivator);
-            }
-            else
-            {
-                activator = innerActivator;
-            }
-
-            return true;
+             _startActivation = state => ((ActivationData)state!).Start(_grainActivator);
         }
 
-        private partial class ActivationDataActivator : IGrainContextActivator
+        public IGrainContext CreateContext(GrainAddress activationAddress)
         {
-            private readonly ILogger<WorkItemGroup> _workItemGroupLogger;
-            private readonly ILogger<ActivationTaskScheduler> _activationTaskSchedulerLogger;
-            private readonly IOptions<SchedulingOptions> _schedulingOptions;
-            private readonly IGrainActivator _grainActivator;
-            private readonly IServiceProvider _serviceProvider;
-            private readonly GrainTypeSharedContext _sharedComponents;
-            private readonly ILogger<Grain> _grainLogger;
-            private readonly Func<IGrainContext, WorkItemGroup> _createWorkItemGroup;
-            private readonly Action<object?> _startActivation;
+            var context = new ActivationData(
+                activationAddress,
+                _createWorkItemGroup,
+                _serviceProvider,
+                _sharedComponents);
 
-            public ActivationDataActivator(
-                IGrainActivator grainActivator,
-                IServiceProvider serviceProvider,
-                GrainTypeSharedContext sharedComponents,
-                ILogger<Grain> grainLogger,
-                ILogger<WorkItemGroup> workItemGroupLogger,
-                ILogger<ActivationTaskScheduler> activationTaskSchedulerLogger,
-                IOptions<SchedulingOptions> schedulingOptions)
-            {
-                _workItemGroupLogger = workItemGroupLogger;
-                _activationTaskSchedulerLogger = activationTaskSchedulerLogger;
-                _schedulingOptions = schedulingOptions;
-                _grainActivator = grainActivator;
-                _serviceProvider = serviceProvider;
-                _sharedComponents = sharedComponents;
-                _grainLogger = grainLogger;
-                _createWorkItemGroup = context => new WorkItemGroup(
-                    context,
-                    _workItemGroupLogger,
-                    _activationTaskSchedulerLogger,
-                    _schedulingOptions);
-                 _startActivation = state => ((ActivationData)state!).Start(_grainActivator);
-            }
-
-            public IGrainContext CreateContext(GrainAddress activationAddress)
-            {
-                var context = new ActivationData(
-                    activationAddress,
-                    _createWorkItemGroup,
-                    _serviceProvider,
-                    _sharedComponents);
-
-                using var ecSuppressor = ExecutionContext.SuppressFlow();
-                _ = Task.Factory.StartNew(
-                    _startActivation,
-                    context,
-                    CancellationToken.None,
-                    TaskCreationOptions.DenyChildAttach,
-                    context.ActivationTaskScheduler);
-                return context;
-            }
-
-            [LoggerMessage(
-                Level = LogLevel.Error,
-                Message = "Failed to dispose grain '{GrainId}'."
-            )]
-            private static partial void LogErrorFailedToDisposeGrain(ILogger logger, Exception exception, GrainId grainId);
+            using var ecSuppressor = ExecutionContext.SuppressFlow();
+            _ = Task.Factory.StartNew(
+                _startActivation,
+                context,
+                CancellationToken.None,
+                TaskCreationOptions.DenyChildAttach,
+                context.ActivationTaskScheduler);
+            return context;
         }
     }
+}
 
-    internal class StatelessWorkerActivator : IGrainContextActivator
-    {
-        private readonly IGrainContextActivator _innerActivator;
-        private readonly GrainTypeSharedContext _sharedContext;
-
-        public StatelessWorkerActivator(GrainTypeSharedContext sharedContext, IGrainContextActivator innerActivator)
-        {
-            _innerActivator = innerActivator;
-            _sharedContext = sharedContext;
-        }
-
-        public IGrainContext CreateContext(GrainAddress address) => new StatelessWorkerGrainContext(address, _sharedContext, _innerActivator);
-    }
+internal class StatelessWorkerActivator(StatelessWorkerGrainTypeSharedContext sharedContext, IGrainContextActivator innerActivator) : IGrainContextActivator
+{
+    public IGrainContext CreateContext(GrainAddress address) => new StatelessWorkerGrainContext(address, sharedContext, innerActivator);
 }

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -21,8 +21,7 @@ namespace Orleans.Runtime;
 public sealed class GrainTypeSharedContext
 {
     private readonly IServiceProvider _serviceProvider;
-    private readonly Dictionary<Type, object> _components = new();
-    private InternalGrainRuntime? _internalGrainRuntime;
+    private readonly Dictionary<Type, object> _components = [];
 
     public GrainTypeSharedContext(
         GrainType grainType,
@@ -32,7 +31,6 @@ public sealed class GrainTypeSharedContext
         IOptions<SiloMessagingOptions> messagingOptions,
         IOptions<GrainCollectionOptions> collectionOptions,
         IOptions<SchedulingOptions> schedulingOptions,
-        IOptions<StatelessWorkerOptions> statelessWorkerOptions,
         IGrainRuntime grainRuntime,
         ILoggerFactory loggerFactory,
         GrainReferenceActivator grainReferenceActivator,
@@ -56,7 +54,6 @@ public sealed class GrainTypeSharedContext
         var grainDirectoryResolver = serviceProvider.GetRequiredService<GrainDirectoryResolver>();
         GrainDirectory = PlacementStrategy.IsUsingGrainDirectory ? grainDirectoryResolver.Resolve(grainType) : null;
         SchedulingOptions = schedulingOptions.Value;
-        StatelessWorkerOptions = statelessWorkerOptions.Value;
         Runtime = grainRuntime;
         MigrationManager = _serviceProvider.GetService<IActivationMigrationManager>();
 
@@ -205,11 +202,6 @@ public sealed class GrainTypeSharedContext
     public SchedulingOptions SchedulingOptions { get; }
 
     /// <summary>
-    /// Gets the stateless worker options.
-    /// </summary>
-    public StatelessWorkerOptions StatelessWorkerOptions { get; }
-
-    /// <summary>
     /// Gets the grain runtime.
     /// </summary>
     public IGrainRuntime Runtime { get; }
@@ -222,7 +214,7 @@ public sealed class GrainTypeSharedContext
     /// <summary>
     /// Gets the internal grain runtime.
     /// </summary>
-    internal InternalGrainRuntime InternalRuntime => _internalGrainRuntime ??= _serviceProvider.GetRequiredService<InternalGrainRuntime>();
+    internal InternalGrainRuntime InternalRuntime => field ??= _serviceProvider.GetRequiredService<InternalGrainRuntime>();
 
     /// <summary>
     /// Called on creation of an activation.

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -13,7 +13,7 @@ namespace Orleans.Runtime;
 internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDisposable, IActivationLifecycleObserver
 {
     private static readonly object CollectIdleWorkersSentinel = new();
-    private readonly GrainTypeSharedContext _shared;
+    private readonly StatelessWorkerGrainTypeSharedContext _shared;
     private readonly IGrainContextActivator _innerActivator;
     private readonly int _maxWorkers;
     private readonly List<ActivationData> _workers = [];
@@ -42,32 +42,29 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
     public StatelessWorkerGrainContext(
         GrainAddress address,
-        GrainTypeSharedContext sharedContext,
+        StatelessWorkerGrainTypeSharedContext sharedContext,
         IGrainContextActivator innerActivator)
     {
         Address = address;
         _shared = sharedContext;
         _innerActivator = innerActivator;
 
-        var strategy = (StatelessWorkerPlacement)_shared.PlacementStrategy;
-        var options = _shared.StatelessWorkerOptions;
-
-        _isIdleWorkerRemovalStrategy = strategy.RemoveIdleWorkers && options.RemoveIdleWorkers;
+        _isIdleWorkerRemovalStrategy = _shared.RemoveIdleWorkers;
         if (_isIdleWorkerRemovalStrategy)
         {
-            _minIdleCyclesBeforeRemoval = options.MinIdleCyclesBeforeRemoval > 0 ? options.MinIdleCyclesBeforeRemoval : 1;
             _inspectionTimer = new Timer(
                 static state => ((StatelessWorkerGrainContext)state!).EnqueueWorkItem(WorkItemType.CollectIdleWorkers, CollectIdleWorkersSentinel),
                 this,
-                options.IdleWorkersInspectionPeriod,
-                options.IdleWorkersInspectionPeriod);
+                _shared.IdleWorkersInspectionPeriod,
+                _shared.IdleWorkersInspectionPeriod);
+            _minIdleCyclesBeforeRemoval = _shared.MinIdleCyclesBeforeRemoval;
         }
 
-        _maxWorkers = strategy.MaxLocal;
+        _maxWorkers = _shared.MaxLocalWorkers;
         _messageLoopTask = Task.Run(RunMessageLoop);
     }
 
-    public GrainReference GrainReference => _grainReference ??= _shared.GrainReferenceActivator.CreateReference(GrainId, default);
+    public GrainReference GrainReference => _grainReference ??= _shared.Shared.GrainReferenceActivator.CreateReference(GrainId, default);
 
     public GrainId GrainId => Address.GrainId;
 
@@ -83,7 +80,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
     public IWorkItemScheduler Scheduler => throw new NotImplementedException();
 
-    public PlacementStrategy PlacementStrategy => _shared.PlacementStrategy;
+    public PlacementStrategy PlacementStrategy => _shared.Shared.PlacementStrategy;
 
     public Task Deactivated
     {
@@ -120,7 +117,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
     public object? GetComponent(Type componentType)
     {
         if (componentType.IsAssignableFrom(GetType())) return this;
-        return _shared.GetComponent(componentType);
+        return _shared.Shared.GetComponent(componentType);
     }
 
     public void SetComponent<TComponent>(TComponent? instance) where TComponent : class
@@ -130,7 +127,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
             throw new ArgumentException($"Cannot set a component of type '{typeof(TComponent)}' on a {nameof(StatelessWorkerGrainContext)}");
         }
 
-        _shared.SetComponent(instance);
+        _shared.Shared.SetComponent(instance);
     }
 
     public object? GetTarget() => throw new NotImplementedException();
@@ -173,8 +170,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
                                 if (_workers.Count == 0)
                                 {
-                                    // When the last worker is destroyed, we can consider the stateless worker grain activation to be destroyed as well
-                                    _shared.InternalRuntime.Catalog.UnregisterMessageTarget(this);
+                                    _shared.Shared.InternalRuntime.Catalog.UnregisterMessageTarget(this);
 
                                     if (_isIdleWorkerRemovalStrategy)
                                     {
@@ -186,7 +182,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
                                         {
                                             if (t.Exception is { } ex)
                                             {
-                                                LogErrorInMessageLoop(_shared.Logger, ex);
+                                                LogErrorInMessageLoop(_shared.Shared.Logger, ex);
                                             }
                                         }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Current);
                                     }
@@ -205,7 +201,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
             }
             catch (Exception exception)
             {
-                LogErrorInMessageLoop(_shared.Logger, exception);
+                LogErrorInMessageLoop(_shared.Shared.Logger, exception);
             }
         }
     }
@@ -233,7 +229,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
         _detectedIdleCyclesCount = controlSignal < 0 ? ++_detectedIdleCyclesCount : 0;
 
-        if (_detectedIdleCyclesCount >= _minIdleCyclesBeforeRemoval)
+        if (_detectedIdleCyclesCount >= _shared.MinIdleCyclesBeforeRemoval)
         {
             var inactiveWorkers = _workers.Where(w => w.IsInactive).ToImmutableArray();
             if (inactiveWorkers.Length > 0)
@@ -303,7 +299,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
         }
         catch (Exception exception) when (message is Message msg)
         {
-            _shared.InternalRuntime.MessageCenter.RejectMessage(
+            _shared.Shared.InternalRuntime.MessageCenter.RejectMessage(
                 msg,
                 Message.RejectionTypes.Transient,
                 exception,
@@ -321,7 +317,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
         // If this is a new worker and there is a message in scope, try to get the request context and activate the worker
         var requestContext = (message as Message)?.RequestContextData ?? [];
-        var cancellation = new CancellationTokenSource(_shared.InternalRuntime.CollectionOptions.Value.ActivationTimeout);
+        var cancellation = new CancellationTokenSource(_shared.Shared.InternalRuntime.CollectionOptions.Value.ActivationTimeout);
 
         newWorker.Activate(requestContext, cancellation.Token);
         _workers.Add(newWorker);

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -2,11 +2,13 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Orleans.Runtime.Diagnostics;
 
 namespace Orleans.Runtime;
 
@@ -15,10 +17,10 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
     private static readonly object CollectIdleWorkersSentinel = new();
     private readonly StatelessWorkerGrainTypeSharedContext _shared;
     private readonly IGrainContextActivator _innerActivator;
-    private readonly int _maxWorkers;
     private readonly List<ActivationData> _workers = [];
     private readonly ConcurrentQueue<(WorkItemType Type, object State)> _workItems = new();
     private readonly SingleWaiterAutoResetEvent _workSignal = new() { RunContinuationsAsynchronously = false };
+    private readonly TaskCompletionSource _disposalTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
 #pragma warning disable IDE0052 // Remove unread private members
     /// <summary>
@@ -30,15 +32,13 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
     private readonly Task _messageLoopTask;
 #pragma warning restore IDE0052 // Remove unread private members
 
-    private GrainReference? _grainReference;
+    private bool _terminated;
 
     // Idle worker removal fields
     private Timer? _inspectionTimer;
-    private double _previousError = 0d;
-    private double _integralTerm = 0d;
-    private int _detectedIdleCyclesCount = 0;
-    private readonly int _minIdleCyclesBeforeRemoval;
-    private readonly bool _isIdleWorkerRemovalStrategy;
+    private double _previousError;
+    private double _integralTerm;
+    private int _detectedIdleCyclesCount;
 
     public StatelessWorkerGrainContext(
         GrainAddress address,
@@ -49,22 +49,19 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
         _shared = sharedContext;
         _innerActivator = innerActivator;
 
-        _isIdleWorkerRemovalStrategy = _shared.RemoveIdleWorkers;
-        if (_isIdleWorkerRemovalStrategy)
+        if (_shared.RemoveIdleWorkers)
         {
             _inspectionTimer = new Timer(
                 static state => ((StatelessWorkerGrainContext)state!).EnqueueWorkItem(WorkItemType.CollectIdleWorkers, CollectIdleWorkersSentinel),
                 this,
                 _shared.IdleWorkersInspectionPeriod,
                 _shared.IdleWorkersInspectionPeriod);
-            _minIdleCyclesBeforeRemoval = _shared.MinIdleCyclesBeforeRemoval;
         }
 
-        _maxWorkers = _shared.MaxLocalWorkers;
         _messageLoopTask = Task.Run(RunMessageLoop);
     }
 
-    public GrainReference GrainReference => _grainReference ??= _shared.Shared.GrainReferenceActivator.CreateReference(GrainId, default);
+    public GrainReference GrainReference => field ??= _shared.Shared.GrainReferenceActivator.CreateReference(GrainId, default);
 
     public GrainId GrainId => Address.GrainId;
 
@@ -101,9 +98,8 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
     public async ValueTask DisposeAsync()
     {
-        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        EnqueueWorkItem(WorkItemType.DisposeAsync, new DisposeAsyncWorkItemState(completion));
-        await completion.Task;
+        EnqueueWorkItem(WorkItemType.DisposeAsync, DisposeAsyncWorkItemState.Instance);
+        await _disposalTask.Task;
     }
 
     private void EnqueueWorkItem(WorkItemType type, object state)
@@ -159,8 +155,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
                             }
                         case WorkItemType.DisposeAsync:
                             {
-                                var state = (DisposeAsyncWorkItemState)workItem.State;
-                                _ = DisposeAsyncInternal(state.Completion);
+                                _ = DisposeAsyncInternal();
                                 break;
                             }
                         case WorkItemType.OnDestroyActivation:
@@ -170,21 +165,14 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
                                 if (_workers.Count == 0)
                                 {
+                                    Debug.Assert(!_terminated, "OnDestroyActivation should only terminate the context once.");
+                                    _terminated = true;
                                     _shared.Shared.InternalRuntime.Catalog.UnregisterMessageTarget(this);
+                                    StatelessWorkerEvents.EmitContextTerminated(this, _workers.Count);
 
-                                    if (_isIdleWorkerRemovalStrategy)
+                                    if (_shared.RemoveIdleWorkers)
                                     {
-                                        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                                        EnqueueWorkItem(WorkItemType.DisposeAsync, new DisposeAsyncWorkItemState(completion));
-
-                                        // DO NOT await this as it would deadlock the work loop!
-                                        _ = completion.Task.ContinueWith(t =>
-                                        {
-                                            if (t.Exception is { } ex)
-                                            {
-                                                LogErrorInMessageLoop(_shared.Shared.Logger, ex);
-                                            }
-                                        }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Current);
+                                        EnqueueWorkItem(WorkItemType.DisposeAsync, DisposeAsyncWorkItemState.Instance);
                                     }
                                 }
                                 break;
@@ -247,6 +235,12 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
     private void ReceiveMessageInternal(object message)
     {
+        if (_terminated)
+        {
+            ForwardToReplacementContext((Message)message);
+            return;
+        }
+
         try
         {
             ActivationData? worker = null;
@@ -284,7 +278,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
                 if (worker is null)
                 {
-                    if (_workers.Count >= _maxWorkers)
+                    if (_workers.Count >= _shared.MaxLocalWorkers)
                     {
                         // Pick the one with the lowest waiting count
                         worker = minimumWaitingCountWorker;
@@ -307,8 +301,24 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
         }
     }
 
+    private void ForwardToReplacementContext(Message message)
+    {
+        // The catalog cannot return this context because we set _terminated before
+        // unregistering it, and a terminated context is never re-registered.
+        // Therefore the replacement is always a fresh context for the same grain id.
+        Debug.Assert(_terminated);
+        var replacement = _shared.Shared.InternalRuntime.Catalog.GetOrCreateActivation(
+            GrainId,
+            message.RequestContextData ?? [],
+            rehydrationContext: null);
+        Debug.Assert(!ReferenceEquals(replacement, this), "Catalog must not resolve to a terminated stateless worker context.");
+        StatelessWorkerEvents.EmitMessageForwarded(this, replacement, message);
+        replacement.ReceiveMessage(message);
+    }
+
     private ActivationData CreateWorker(object? message)
     {
+        Debug.Assert(!_terminated, "CreateWorker must not be called on a terminated stateless worker context.");
         var address = GrainAddress.GetAddress(Address.SiloAddress, Address.GrainId, ActivationId.NewId());
         var newWorker = (ActivationData)_innerActivator.CreateContext(address);
 
@@ -321,6 +331,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
         newWorker.Activate(requestContext, cancellation.Token);
         _workers.Add(newWorker);
+        StatelessWorkerEvents.EmitWorkerCreated(this, newWorker, _workers.Count);
 
         return newWorker;
     }
@@ -352,18 +363,17 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
         }
     }
 
-    private async Task DisposeAsyncInternal(TaskCompletionSource completion)
+    private async Task DisposeAsyncInternal()
     {
-        if (_inspectionTimer != null)
-        {
-            await _inspectionTimer.DisposeAsync().AsTask()
-                .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
-
-            _inspectionTimer = null;
-        }
-
         try
         {
+            if (_inspectionTimer is { } inspectionTimer)
+            {
+                _inspectionTimer = null;
+                await inspectionTimer.DisposeAsync().AsTask()
+                    .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+            }
+
             var tasks = new List<Task>(_workers.Count);
             var deactivationReason = new DeactivationReason(DeactivationReasonCode.RuntimeRequested, "Stateless worker grain context is being disposed.");
             foreach (var worker in _workers)
@@ -380,11 +390,12 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
             }
 
             await Task.WhenAll(tasks);
-            completion.TrySetResult();
+            _disposalTask.TrySetResult();
         }
         catch (Exception exception)
         {
-            completion.TrySetException(exception);
+            LogErrorInDisposeAsync(_shared.Shared.Logger, exception);
+            _disposalTask.TrySetException(exception);
         }
     }
 
@@ -417,11 +428,17 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
     private record ActivateWorkItemState(Dictionary<string, object>? RequestContext, CancellationToken CancellationToken);
     private record DeactivateWorkItemState(DeactivationReason DeactivationReason, CancellationToken CancellationToken);
     private record DeactivatedTaskWorkItemState(TaskCompletionSource Completion);
-    private record DisposeAsyncWorkItemState(TaskCompletionSource Completion);
+    private record DisposeAsyncWorkItemState { public static readonly DisposeAsyncWorkItemState Instance = new(); }
 
     [LoggerMessage(
         Level = LogLevel.Error,
-        Message = "Error in stateless worker message loop"
+        Message = "Error in stateless worker message loop."
     )]
     private static partial void LogErrorInMessageLoop(ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Error disposing stateless worker."
+    )]
+    private static partial void LogErrorInDisposeAsync(ILogger logger, Exception exception);
 }

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainTypeSharedContext.cs
@@ -1,0 +1,57 @@
+using System;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+
+namespace Orleans.Runtime;
+
+/// <summary>
+/// Functionality which is shared between all instances of a stateless worker grain type.
+/// </summary>
+internal sealed class StatelessWorkerGrainTypeSharedContext
+{
+    public StatelessWorkerGrainTypeSharedContext(
+        GrainTypeSharedContext shared,
+        IOptions<StatelessWorkerOptions> statelessWorkerOptions)
+    {
+        Shared = shared;
+        StatelessWorkerOptions = statelessWorkerOptions.Value;
+
+        var placement = (StatelessWorkerPlacement)shared.PlacementStrategy;
+        MaxLocalWorkers = placement.MaxLocal;
+        RemoveIdleWorkers = placement.RemoveIdleWorkers && StatelessWorkerOptions.RemoveIdleWorkers;
+        MinIdleCyclesBeforeRemoval = StatelessWorkerOptions.MinIdleCyclesBeforeRemoval > 0
+            ? StatelessWorkerOptions.MinIdleCyclesBeforeRemoval
+            : 1;
+        IdleWorkersInspectionPeriod = StatelessWorkerOptions.IdleWorkersInspectionPeriod;
+    }
+
+    /// <summary>
+    /// Gets the general grain-type-wide shared context.
+    /// </summary>
+    public GrainTypeSharedContext Shared { get; }
+
+    /// <summary>
+    /// Gets the stateless worker options.
+    /// </summary>
+    public StatelessWorkerOptions StatelessWorkerOptions { get; }
+
+    /// <summary>
+    /// Gets the maximum number of local worker activations permitted for a grain id of this type.
+    /// </summary>
+    public int MaxLocalWorkers { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether idle workers should be proactively removed.
+    /// </summary>
+    public bool RemoveIdleWorkers { get; }
+
+    /// <summary>
+    /// Gets the minimum number of consecutive idle inspection cycles required before a worker may be removed.
+    /// </summary>
+    public int MinIdleCyclesBeforeRemoval { get; }
+
+    /// <summary>
+    /// Gets the period between idle worker inspections.
+    /// </summary>
+    public TimeSpan IdleWorkersInspectionPeriod { get; }
+}

--- a/src/Orleans.Runtime/Diagnostics/StatelessWorkerEvents.cs
+++ b/src/Orleans.Runtime/Diagnostics/StatelessWorkerEvents.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Orleans.Runtime.Diagnostics;
+
+internal static class StatelessWorkerEvents
+{
+    internal const string ListenerName = "Orleans.StatelessWorker";
+
+    private static readonly DiagnosticListener Listener = new(ListenerName);
+
+    internal static IObservable<StatelessWorkerEvent> AllEvents { get; } = new Observable();
+
+    internal abstract class StatelessWorkerEvent(IGrainContext context)
+    {
+        public readonly IGrainContext Context = context;
+        public readonly GrainId GrainId = context.GrainId;
+    }
+
+    internal sealed class WorkerCreated(
+        IGrainContext context,
+        IGrainContext workerContext,
+        int workerCount) : StatelessWorkerEvent(context)
+    {
+        public readonly IGrainContext WorkerContext = workerContext;
+        public readonly int WorkerCount = workerCount;
+    }
+
+    internal sealed class ContextTerminated(
+        IGrainContext context,
+        int workerCount) : StatelessWorkerEvent(context)
+    {
+        public readonly int WorkerCount = workerCount;
+    }
+
+    internal sealed class MessageForwarded(
+        IGrainContext context,
+        IGrainContext replacementContext,
+        Message message) : StatelessWorkerEvent(context)
+    {
+        public readonly IGrainContext ReplacementContext = replacementContext;
+        public readonly Message Message = message;
+    }
+
+    internal static void EmitWorkerCreated(IGrainContext context, IGrainContext workerContext, int workerCount)
+    {
+        if (!Listener.IsEnabled(nameof(WorkerCreated)))
+        {
+            return;
+        }
+
+        Emit(context, workerContext, workerCount);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(IGrainContext context, IGrainContext workerContext, int workerCount)
+        {
+            Listener.Write(nameof(WorkerCreated), new WorkerCreated(context, workerContext, workerCount));
+        }
+    }
+
+    internal static void EmitContextTerminated(IGrainContext context, int workerCount)
+    {
+        if (!Listener.IsEnabled(nameof(ContextTerminated)))
+        {
+            return;
+        }
+
+        Emit(context, workerCount);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(IGrainContext context, int workerCount)
+        {
+            Listener.Write(nameof(ContextTerminated), new ContextTerminated(context, workerCount));
+        }
+    }
+
+    internal static void EmitMessageForwarded(IGrainContext context, IGrainContext replacementContext, Message message)
+    {
+        if (!Listener.IsEnabled(nameof(MessageForwarded)))
+        {
+            return;
+        }
+
+        Emit(context, replacementContext, message);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(IGrainContext context, IGrainContext replacementContext, Message message)
+        {
+            Listener.Write(nameof(MessageForwarded), new MessageForwarded(context, replacementContext, message));
+        }
+    }
+
+    private sealed class Observable : IObservable<StatelessWorkerEvent>
+    {
+        public IDisposable Subscribe(IObserver<StatelessWorkerEvent> observer) => Listener.Subscribe(new Observer(observer));
+
+        private sealed class Observer(IObserver<StatelessWorkerEvent> observer) : IObserver<KeyValuePair<string, object?>>
+        {
+            public void OnCompleted() => observer.OnCompleted();
+
+            public void OnError(Exception error) => observer.OnError(error);
+
+            public void OnNext(KeyValuePair<string, object?> value)
+            {
+                if (value.Value is StatelessWorkerEvent evt)
+                {
+                    observer.OnNext(evt);
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.TestingHost/Diagnostics/DiagnosticEventCollector.cs
+++ b/src/Orleans.TestingHost/Diagnostics/DiagnosticEventCollector.cs
@@ -1,11 +1,5 @@
-#nullable enable
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Orleans.TestingHost.Diagnostics;
 
@@ -33,9 +27,9 @@ public sealed class DiagnosticEventCollector : IDisposable, IObserver<Diagnostic
 {
     private readonly ConcurrentQueue<DiagnosticEvent> _events = new();
     private readonly ConcurrentDictionary<string, List<EventWaiter>> _waiters = new();
-    private readonly List<IDisposable> _subscriptions = new();
+    private readonly List<IDisposable> _subscriptions = [];
     private readonly HashSet<string> _listenerPrefixes;
-    private IDisposable? _allListenersSubscription;
+    private readonly IDisposable? _allListenersSubscription;
     private bool _disposed;
 
     /// <summary>

--- a/src/api/Orleans.Runtime/Orleans.Runtime.cs
+++ b/src/api/Orleans.Runtime/Orleans.Runtime.cs
@@ -624,7 +624,7 @@ namespace Orleans.Runtime
 
     public sealed partial class GrainTypeSharedContext
     {
-        public GrainTypeSharedContext(GrainType grainType, IClusterManifestProvider clusterManifestProvider, Orleans.Metadata.GrainClassMap grainClassMap, Placement.PlacementStrategyResolver placementStrategyResolver, Microsoft.Extensions.Options.IOptions<Orleans.Configuration.SiloMessagingOptions> messagingOptions, Microsoft.Extensions.Options.IOptions<Orleans.Configuration.GrainCollectionOptions> collectionOptions, Microsoft.Extensions.Options.IOptions<Orleans.Configuration.SchedulingOptions> schedulingOptions, Microsoft.Extensions.Options.IOptions<Orleans.Configuration.StatelessWorkerOptions> statelessWorkerOptions, IGrainRuntime grainRuntime, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, GrainReferences.GrainReferenceActivator grainReferenceActivator, System.IServiceProvider serviceProvider, Orleans.Serialization.Session.SerializerSessionPool serializerSessionPool) { }
+        public GrainTypeSharedContext(GrainType grainType, IClusterManifestProvider clusterManifestProvider, Orleans.Metadata.GrainClassMap grainClassMap, Placement.PlacementStrategyResolver placementStrategyResolver, Microsoft.Extensions.Options.IOptions<Orleans.Configuration.SiloMessagingOptions> messagingOptions, Microsoft.Extensions.Options.IOptions<Orleans.Configuration.GrainCollectionOptions> collectionOptions, Microsoft.Extensions.Options.IOptions<Orleans.Configuration.SchedulingOptions> schedulingOptions, IGrainRuntime grainRuntime, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory, GrainReferences.GrainReferenceActivator grainReferenceActivator, System.IServiceProvider serviceProvider, Orleans.Serialization.Session.SerializerSessionPool serializerSessionPool) { }
 
         public System.TimeSpan CollectionAgeLimit { get { throw null; } }
 
@@ -649,8 +649,6 @@ namespace Orleans.Runtime
         public Orleans.Configuration.SchedulingOptions SchedulingOptions { get { throw null; } }
 
         public Orleans.Serialization.Session.SerializerSessionPool SerializerSessionPool { get { throw null; } }
-
-        public Orleans.Configuration.StatelessWorkerOptions StatelessWorkerOptions { get { throw null; } }
 
         public object? GetComponent(System.Type componentType) { throw null; }
 

--- a/test/Grains/TestGrainInterfaces/IStatelessWorkerSingleActivationGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStatelessWorkerSingleActivationGrain.cs
@@ -1,0 +1,6 @@
+namespace UnitTests.GrainInterfaces;
+
+public interface IStatelessWorkerSingleActivationGrain : IGrainWithIntegerKey
+{
+    Task DoWork();
+}

--- a/test/Grains/TestGrains/StatelessWorkerSingleActivationGrain.cs
+++ b/test/Grains/TestGrains/StatelessWorkerSingleActivationGrain.cs
@@ -1,0 +1,67 @@
+using Orleans.Concurrency;
+using Orleans.Runtime;
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains;
+
+/// <summary>
+/// Tracks live (not-yet-deactivated) activations of stateless worker grains so tests can assert
+/// the configured per-silo concurrent activation limit is never exceeded across deactivation races.
+/// </summary>
+public sealed class StatelessWorkerSingleActivationTracker
+{
+    private int _current;
+    private int _maxObserved;
+
+    public int Current => Volatile.Read(ref _current);
+
+    public int MaxObserved => Volatile.Read(ref _maxObserved);
+
+    public void OnActivate()
+    {
+        var c = Interlocked.Increment(ref _current);
+        InterlockedMax(ref _maxObserved, c);
+    }
+
+    public void OnDeactivate() => Interlocked.Decrement(ref _current);
+
+    public void Reset()
+    {
+        Interlocked.Exchange(ref _current, 0);
+        Interlocked.Exchange(ref _maxObserved, 0);
+    }
+
+    private static void InterlockedMax(ref int location, int value)
+    {
+        int initial;
+        do
+        {
+            initial = Volatile.Read(ref location);
+            if (value <= initial)
+            {
+                return;
+            }
+        }
+        while (Interlocked.CompareExchange(ref location, value, initial) != initial);
+    }
+}
+
+[StatelessWorker(maxLocalWorkers: 1)]
+public class StatelessWorkerSingleActivationGrain : Grain, IStatelessWorkerSingleActivationGrain
+{
+    private readonly StatelessWorkerSingleActivationTracker _tracker;
+
+    public StatelessWorkerSingleActivationGrain(StatelessWorkerSingleActivationTracker tracker)
+    {
+        _tracker = tracker;
+        _tracker.OnActivate();
+    }
+
+    public Task DoWork() => Task.CompletedTask;
+
+    public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+    {
+        _tracker.OnDeactivate();
+        return Task.CompletedTask;
+    }
+}

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/StatelessWorkerSingleActivationRaceTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/StatelessWorkerSingleActivationRaceTests.cs
@@ -1,0 +1,247 @@
+#nullable enable
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.CodeGeneration;
+using Orleans.Configuration;
+using Orleans.Runtime.Diagnostics;
+using Orleans.Serialization.Invocation;
+using Orleans.TestingHost;
+using Orleans.TestingHost.Diagnostics;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using UnitTests.Grains;
+using Xunit;
+
+namespace UnitTests.ActivationsLifeCycleTests;
+
+/// <summary>
+/// Regression tests for a race in <c>StatelessWorkerGrainContext</c> where the work loop
+/// could create a "phantom" worker on a context that had already been unregistered from
+/// the catalog, allowing more than the configured <see cref="StatelessWorkerAttribute.MaxLocalWorkers"/>
+/// activations to coexist on a single silo for the same grain id.
+/// </summary>
+public class StatelessWorkerSingleActivationRaceTests(StatelessWorkerSingleActivationRaceTests.Fixture fixture)
+        : IClassFixture<StatelessWorkerSingleActivationRaceTests.Fixture>
+{
+    public class Fixture : BaseTestClusterFixture
+    {
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.Options.InitialSilosCount = 1;
+            builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+        }
+
+        private class SiloConfigurator : ISiloConfigurator
+        {
+            public void Configure(ISiloBuilder hostBuilder)
+            {
+                hostBuilder.Services.AddSingleton<StatelessWorkerSingleActivationTracker>();
+                hostBuilder.Services.Configure<StatelessWorkerOptions>(options =>
+                {
+                    options.RemoveIdleWorkers = true;
+                    options.IdleWorkersInspectionPeriod = TimeSpan.FromMilliseconds(5);
+                    options.MinIdleCyclesBeforeRemoval = 1;
+                });
+            }
+        }
+    }
+
+    private readonly Fixture _fixture = fixture;
+
+    private InProcessSiloHandle PrimarySilo => (InProcessSiloHandle)_fixture.HostedCluster.Primary;
+
+    /// <summary>
+    /// Deterministically verifies that once the last worker of a stateless worker context is
+    /// destroyed, the context is marked terminated, is removed from the activation directory,
+    /// and forwards a late delivery to a fresh wrapper instead of resurrecting a worker.
+    /// </summary>
+    [Fact, TestCategory("BVT"), TestCategory("StatelessWorker")]
+    public async Task TerminatedContextForwardsLateDeliveryToFreshWrapper()
+    {
+        using var collector = new DiagnosticEventCollector(StatelessWorkerEvents.ListenerName);
+        var directory = PrimarySilo.SiloHost.Services.GetRequiredService<ActivationDirectory>();
+
+        var grain = _fixture.GrainFactory.GetGrain<IStatelessWorkerSingleActivationGrain>(7654321);
+        var grainId = ((GrainReference)grain).GrainId;
+
+        await grain.DoWork();
+
+        var c1 = Assert.IsType<StatelessWorkerGrainContext>(directory.FindTarget(grainId));
+        collector.Clear();
+
+        c1.Deactivate(new DeactivationReason(DeactivationReasonCode.RuntimeRequested, "test"), CancellationToken.None);
+
+        var terminated = await WaitForContextTerminatedAsync(collector, c1);
+        Assert.Equal(0, terminated.WorkerCount);
+        Assert.Null(directory.FindTarget(grainId));
+
+        collector.Clear();
+
+        c1.ReceiveMessage(CreateLateDeliveryMessage(grainId));
+
+        var forwarded = await WaitForMessageForwardedAsync(collector, c1);
+        var workerCreated = await WaitForWorkerCreatedAsync(collector, forwarded.ReplacementContext);
+
+        Assert.NotSame(c1, forwarded.ReplacementContext);
+        Assert.Same(forwarded.ReplacementContext, directory.FindTarget(grainId));
+        Assert.Same(forwarded.ReplacementContext, workerCreated.Context);
+        Assert.Empty(GetWorkerCreatedEvents(collector, c1));
+    }
+
+    /// <summary>
+    /// Deterministically exercises the original race by combining a late delivery to an
+    /// orphaned wrapper with a fresh grain call through the directory. Both operations
+    /// must use the same replacement activation so that <c>maxLocalWorkers: 1</c> is
+    /// preserved even when a terminated wrapper receives another message.
+    /// </summary>
+    [Fact, TestCategory("BVT"), TestCategory("StatelessWorker")]
+    public async Task LateDeliveryAndFreshCallUseSingleReplacementActivation()
+    {
+        using var collector = new DiagnosticEventCollector(StatelessWorkerEvents.ListenerName);
+        var tracker = PrimarySilo.SiloHost.Services.GetRequiredService<StatelessWorkerSingleActivationTracker>();
+        var directory = PrimarySilo.SiloHost.Services.GetRequiredService<ActivationDirectory>();
+
+        var grain = _fixture.GrainFactory.GetGrain<IStatelessWorkerSingleActivationGrain>(424242);
+        var grainId = ((GrainReference)grain).GrainId;
+
+        tracker.Reset();
+        await grain.DoWork();
+
+        var c1 = Assert.IsType<StatelessWorkerGrainContext>(directory.FindTarget(grainId));
+        collector.Clear();
+
+        c1.Deactivate(new DeactivationReason(DeactivationReasonCode.RuntimeRequested, "test"), CancellationToken.None);
+        _ = await WaitForContextTerminatedAsync(collector, c1);
+
+        tracker.Reset();
+        collector.Clear();
+
+        var freshCallTask = grain.DoWork();
+        c1.ReceiveMessage(CreateLateDeliveryMessage(grainId));
+        await freshCallTask;
+
+        var forwarded = await WaitForMessageForwardedAsync(collector, c1);
+        _ = await WaitForWorkerCreatedAsync(collector, forwarded.ReplacementContext);
+
+        var workerCreatedEvents = GetWorkerCreatedEvents(collector);
+        var replacementCreations = Assert.Single(workerCreatedEvents);
+
+        Assert.NotSame(c1, forwarded.ReplacementContext);
+        Assert.Same(forwarded.ReplacementContext, replacementCreations.Context);
+        Assert.Empty(GetWorkerCreatedEvents(collector, c1));
+        Assert.True(
+            tracker.MaxObserved <= 1,
+            $"Observed up to {tracker.MaxObserved} concurrent activations after a late delivery and a fresh call on a [StatelessWorker(maxLocalWorkers:1)] grain; expected at most 1.");
+    }
+
+    private Message CreateLateDeliveryMessage(GrainId grainId)
+    {
+        var services = PrimarySilo.SiloHost.Services;
+        var messageFactory = services.GetRequiredService<MessageFactory>();
+        var localSiloDetails = services.GetRequiredService<ILocalSiloDetails>();
+
+        var message = messageFactory.CreateMessage(new DoWorkRequest(), InvokeMethodOptions.OneWay);
+        message.SetInfiniteTimeToLive();
+        message.IsLocalOnly = true;
+        message.SendingGrain = grainId;
+        message.TargetGrain = grainId;
+        message.SendingSilo = localSiloDetails.SiloAddress;
+        message.TargetSilo = localSiloDetails.SiloAddress;
+        return message;
+    }
+
+    private static IReadOnlyList<StatelessWorkerEvents.WorkerCreated> GetWorkerCreatedEvents(DiagnosticEventCollector collector)
+    {
+        return [.. collector.Events
+            .Select(static evt => evt.Payload)
+            .OfType<StatelessWorkerEvents.WorkerCreated>()];
+    }
+
+    private static IReadOnlyList<StatelessWorkerEvents.WorkerCreated> GetWorkerCreatedEvents(DiagnosticEventCollector collector, IGrainContext context)
+    {
+        return [.. GetWorkerCreatedEvents(collector)
+            .Where(evt => ReferenceEquals(evt.Context, context))];
+    }
+
+    private static async Task<StatelessWorkerEvents.ContextTerminated> WaitForContextTerminatedAsync(
+        DiagnosticEventCollector collector,
+        IGrainContext context)
+    {
+        var evt = await collector.WaitForEventAsync(
+            nameof(StatelessWorkerEvents.ContextTerminated),
+            diagnosticEvent => diagnosticEvent.Payload is StatelessWorkerEvents.ContextTerminated terminated
+                && ReferenceEquals(terminated.Context, context),
+            TimeSpan.FromSeconds(10));
+        return Assert.IsType<StatelessWorkerEvents.ContextTerminated>(evt.Payload);
+    }
+
+    private static async Task<StatelessWorkerEvents.MessageForwarded> WaitForMessageForwardedAsync(
+        DiagnosticEventCollector collector,
+        IGrainContext context)
+    {
+        var evt = await collector.WaitForEventAsync(
+            nameof(StatelessWorkerEvents.MessageForwarded),
+            diagnosticEvent => diagnosticEvent.Payload is StatelessWorkerEvents.MessageForwarded forwarded
+                && ReferenceEquals(forwarded.Context, context),
+            TimeSpan.FromSeconds(10));
+        return Assert.IsType<StatelessWorkerEvents.MessageForwarded>(evt.Payload);
+    }
+
+    private static async Task<StatelessWorkerEvents.WorkerCreated> WaitForWorkerCreatedAsync(
+        DiagnosticEventCollector collector,
+        IGrainContext context)
+    {
+        var evt = await collector.WaitForEventAsync(
+            nameof(StatelessWorkerEvents.WorkerCreated),
+            diagnosticEvent => diagnosticEvent.Payload is StatelessWorkerEvents.WorkerCreated workerCreated
+                && ReferenceEquals(workerCreated.Context, context),
+            TimeSpan.FromSeconds(10));
+        return Assert.IsType<StatelessWorkerEvents.WorkerCreated>(evt.Payload);
+    }
+
+    private sealed class DoWorkRequest : IInvokable
+    {
+        private static readonly MethodInfo Method = typeof(IStatelessWorkerSingleActivationGrain).GetMethod(nameof(IStatelessWorkerSingleActivationGrain.DoWork))!;
+        private IStatelessWorkerSingleActivationGrain? _target;
+
+        public object? GetTarget() => _target;
+
+        public void SetTarget(ITargetHolder holder)
+        {
+            _target = (IStatelessWorkerSingleActivationGrain)holder.GetTarget()!;
+        }
+
+        public async ValueTask<Response> Invoke()
+        {
+            try
+            {
+                await _target!.DoWork();
+                return Response.FromResult<object?>(null);
+            }
+            catch (Exception exception)
+            {
+                return Response.FromException(exception);
+            }
+        }
+
+        public int GetArgumentCount() => 0;
+
+        public object? GetArgument(int index) => throw new ArgumentOutOfRangeException(nameof(index));
+
+        public void SetArgument(int index, object value) => throw new ArgumentOutOfRangeException(nameof(index));
+
+        public string GetMethodName() => nameof(IStatelessWorkerSingleActivationGrain.DoWork);
+
+        public string GetInterfaceName() => typeof(IStatelessWorkerSingleActivationGrain).FullName!;
+
+        public string GetActivityName() => $"{GetInterfaceName()}/{GetMethodName()}";
+
+        public MethodInfo GetMethod() => Method;
+
+        public Type GetInterfaceType() => typeof(IStatelessWorkerSingleActivationGrain);
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes a reactivation race in `StatelessWorkerGrainContext`. The race is a theoretical corner case that we have not necessarily seen any instances of, but it was found while investigating something else and I wanted to fix it and clean things up while I was there.

- Prevents `StatelessWorkerGrainContext` from processing incoming messages after it has unregistered itself from the catalog.
- Reduces the memory footprint of `StatelessWorkerGrainContext`
- Refactors `GrainTypeSharedContext` to remove a `StatelessWorker`-specific property.
- Adds `StatelessWorkerEvents` for monitoring some events for testing purposes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10016)