### PR TITLE
fix(message-serializer): cap request context initial capacity

### DIFF
--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -23,6 +23,7 @@ namespace Orleans.Runtime.Messaging
     {
         private const int FramingLength = Message.LENGTH_HEADER_SIZE;
         private const int MessageSizeHint = 4096;
+        private const int MaxRequestContextInitialCapacity = 1024;
         private readonly Dictionary<Type, ResponseCodec> _rawResponseCodecs = [];
         private readonly CodecProvider _codecProvider;
         private readonly IFieldCodec<GrainAddressCacheUpdate> _grainAddressCacheUpdateCodec;
@@ -381,7 +382,7 @@ namespace Orleans.Runtime.Messaging
         private static Dictionary<string, object> ReadRequestContext<TInput>(ref Reader<TInput> reader)
         {
             var size = (int)reader.ReadVarUInt32();
-            var result = new Dictionary<string, object>(size);
+            var result = new Dictionary<string, object>(GetRequestContextInitialCapacity(size));
             for (var i = 0; i < size; i++)
             {
                 var key = ReadString(ref reader);
@@ -393,6 +394,8 @@ namespace Orleans.Runtime.Messaging
 
             return result;
         }
+
+        internal static int GetRequestContextInitialCapacity(int size) => size > MaxRequestContextInitialCapacity ? MaxRequestContextInitialCapacity : size;
 
         private GrainId ReadGrainId<TInput>(ref Reader<TInput> reader)
         {

--- a/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
+++ b/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Net;
 using Microsoft.Extensions.DependencyInjection;
@@ -145,6 +146,40 @@ namespace UnitTests.Serialization
             var (requiredBytes, _, _) = this.messageSerializer.TryRead(ref reader, out var deserializedMessage);
             Assert.Equal(0, requiredBytes);
             return deserializedMessage;
+        }
+
+        [Theory, TestCategory("Functional"), TestCategory("Serialization")]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(1024, 1024)]
+        [InlineData(1025, 1024)]
+        [InlineData(2048, 1024)]
+        public void Message_RequestContextInitialCapacity_IsBounded(int size, int expected)
+        {
+            Assert.Equal(expected, MessageSerializer.GetRequestContextInitialCapacity(size));
+        }
+
+        [Fact, TestCategory("Functional"), TestCategory("Serialization")]
+        public void Message_RequestContextBeyondInitialCapacity_RoundTrips()
+        {
+            const int entryCount = 2048;
+            var requestContext = new Dictionary<string, object>(entryCount);
+            for (var i = 0; i < entryCount; i++)
+            {
+                requestContext[$"key-{i}"] = i;
+            }
+
+            var message = this.messageFactory.CreateMessage(null, InvokeMethodOptions.None);
+            message.RequestContextData = requestContext;
+
+            var deserializedMessage = RoundTripMessage(message);
+
+            Assert.NotNull(deserializedMessage.RequestContextData);
+            Assert.Equal(entryCount, deserializedMessage.RequestContextData.Count);
+            for (var i = 0; i < entryCount; i++)
+            {
+                Assert.Equal(i, deserializedMessage.RequestContextData[$"key-{i}"]);
+            }
         }
 
         [Fact, TestCategory("BVT")]


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10017)