### PR TITLE
Add configurable storage type to NATS streaming provider

### DIFF
--- a/src/Orleans.Streaming.NATS/NatsOptions.cs
+++ b/src/Orleans.Streaming.NATS/NatsOptions.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Orleans.Runtime;
 using NATS.Client.Core;
+using NATS.Client.JetStream.Models;
 
 namespace Orleans.Streaming.NATS;
 
@@ -60,6 +61,19 @@ public class NatsOptions
     /// Defaults to 1. Set to 3 for production clusters with ≥ 3 nodes.
     /// </summary>
     public int NumReplicas { get; set; } = 1;
+
+    /// <summary>
+    /// The storage backend used by the NATS JetStream stream.
+    /// Use <see cref="StreamConfigStorage.File"/> for durability across NATS
+    /// server restarts, or <see cref="StreamConfigStorage.Memory"/> for lower
+    /// latency when durability is not required and the NATS server is
+    /// configured with a memory store. The NATS server must have the
+    /// corresponding storage type enabled; requesting a storage type the
+    /// server has not provisioned results in an "insufficient storage
+    /// resources available" error at stream creation.
+    /// Defaults to <see cref="StreamConfigStorage.File"/>.
+    /// </summary>
+    public StreamConfigStorage StorageType { get; set; } = StreamConfigStorage.File;
 }
 
 public class NatsStreamOptionsValidator(NatsOptions options, string? name = null) : IConfigurationValidator

--- a/src/Orleans.Streaming.NATS/Providers/NatsConnectionManager.cs
+++ b/src/Orleans.Streaming.NATS/Providers/NatsConnectionManager.cs
@@ -133,6 +133,7 @@ internal sealed partial class NatsConnectionManager
     {
         Retention = StreamConfigRetention.Workqueue,
         NumReplicas = this._options.NumReplicas,
+        Storage = this._options.StorageType,
         SubjectTransform = new SubjectTransform
         {
             Src = $"{this._providerName}.*.*",

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsOptionsTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsOptionsTests.cs
@@ -20,6 +20,14 @@ public sealed class NatsOptionsTests
         Assert.Equal(1, options.NumReplicas);
     }
 
+    [Fact]
+    public void DefaultStorageType_ShouldBeFile()
+    {
+        var options = new NatsOptions();
+
+        Assert.Equal(StreamConfigStorage.File, options.StorageType);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
@@ -133,4 +141,53 @@ public sealed class NatsOptionsTests
     // cluster. A single NATS node only supports NumReplicas = 1. R3 integration
     // testing should be done in a CI environment with a 3-node cluster configured
     // via docker-compose or similar infrastructure.
+
+    [SkippableTheory]
+    [InlineData(StreamConfigStorage.File)]
+    [InlineData(StreamConfigStorage.Memory)]
+    public async Task StorageType_IsAppliedToJetStreamConfig(StreamConfigStorage storageType)
+    {
+        if (!NatsTestConstants.IsNatsAvailable)
+        {
+            throw new SkipException("Nats Server is not available");
+        }
+
+        var providerName = $"test-storage-{Guid.NewGuid():N}";
+        var streamName = $"test-storage-stream-{Guid.NewGuid():N}";
+        var options = new NatsOptions
+        {
+            StreamName = streamName,
+            NumReplicas = 1,
+            PartitionCount = 2,
+            ProducerCount = 1,
+            StorageType = storageType
+        };
+
+        var connectionManager = new NatsConnectionManager(providerName, NullLoggerFactory.Instance, options);
+        await connectionManager.Initialize();
+
+        await using var natsConnection = new NatsConnection();
+        var natsContext = new NatsJSContext(natsConnection);
+        await natsConnection.ConnectAsync();
+
+        try
+        {
+            var stream = await natsContext.GetStreamAsync(streamName);
+            var info = stream.Info;
+
+            Assert.Equal(storageType, info.Config.Storage);
+        }
+        finally
+        {
+            try
+            {
+                var stream = await natsContext.GetStreamAsync(streamName);
+                await stream.DeleteAsync();
+            }
+            catch (NatsJSApiException)
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
 }


### PR DESCRIPTION
Passes StorageType into StreamConfig so operators can target servers configured with only memoryStore (or only fileStore). Requesting a storage type the server has not provisioned otherwise fails with "insufficient storage resources available" at stream creation, since JetStream reports a 0-byte budget for the disabled backend.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10028)