### PR TITLE
Handle missing Cosmos reminder deletes

### DIFF
--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
@@ -221,7 +221,7 @@ internal partial class CosmosReminderTable : IReminderTable
 
             return true;
         }
-        catch (CosmosException dce) when (dce.StatusCode is HttpStatusCode.PreconditionFailed)
+        catch (CosmosException dce) when (dce.StatusCode is HttpStatusCode.PreconditionFailed or HttpStatusCode.NotFound)
         {
             return false;
         }

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -197,6 +197,11 @@ namespace Orleans.Runtime.ReminderService
 
             // remove from persistent/memory store
             var success = await reminderTable.RemoveRow(grainId, reminderName, eTag);
+            if (!success)
+            {
+                success = await IsReminderAlreadyRemoved(grainId, reminderName, reminder);
+            }
+
             if (success)
             {
                 if (localReminders.Remove(new(grainId, reminderName), out var localRem))
@@ -218,6 +223,17 @@ namespace Orleans.Runtime.ReminderService
                 LogErrorUnregisterReminder(reminder);
                 throw new ReminderException($"Could not unregister reminder {reminder} from the reminder table, due to tag mismatch. You can retry.");
             }
+        }
+
+        private async Task<bool> IsReminderAlreadyRemoved(GrainId grainId, string reminderName, IGrainReminder reminder)
+        {
+            if (await reminderTable.ReadRow(grainId, reminderName) is not null)
+            {
+                return false;
+            }
+
+            LogDebugReminderAlreadyRemoved(reminder);
+            return true;
         }
 
         private void ObserveLocalReminderStop(Task stopTask, GrainId grainId, string reminderName)
@@ -902,6 +918,12 @@ namespace Orleans.Runtime.ReminderService
             Message = "Removed reminder from table which I didn't have locally: {Entry}."
         )]
         private partial void LogRemovedReminderFromTable(IGrainReminder entry);
+
+        [LoggerMessage(
+            Level = LogLevel.Debug,
+            Message = "Reminder was already absent from the reminder table during unregister: {Entry}."
+        )]
+        private partial void LogDebugReminderAlreadyRemoved(IGrainReminder entry);
 
         [LoggerMessage(
             Level = LogLevel.Error,

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosRemindersTableTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosRemindersTableTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Reminders.Cosmos;
+using TestExtensions;
+using UnitTests;
+using UnitTests.RemindersTest;
+using Xunit;
+
+namespace Tester.Cosmos.Reminders;
+
+/// <summary>
+/// Tests for operation of the Orleans reminders table using Azure Cosmos DB.
+/// </summary>
+[TestCategory("Reminders"), TestCategory("Cosmos")]
+public class CosmosRemindersTableTests : ReminderTableTestsBase
+{
+    public CosmosRemindersTableTests(ConnectionStringFixture fixture, TestEnvironmentFixture environment)
+        : base(fixture, environment, CreateFilters())
+    {
+        CosmosTestUtils.CheckCosmosStorage();
+    }
+
+    private static LoggerFilterOptions CreateFilters()
+    {
+        var filters = new LoggerFilterOptions();
+        filters.AddFilter(typeof(CosmosReminderTable).FullName, LogLevel.Trace);
+        return filters;
+    }
+
+    protected override IReminderTable CreateRemindersTable()
+    {
+        CosmosTestUtils.CheckCosmosStorage();
+
+        var options = new CosmosReminderTableOptions();
+        options.ConfigureTestDefaults();
+        return new CosmosReminderTable(loggerFactory, this.ClusterFixture.Services, Options.Create(options), this.clusterOptions);
+    }
+
+    protected override Task<string> GetConnectionString()
+    {
+        return Task.FromResult(TestDefaultConfiguration.CosmosDBAccountKey);
+    }
+
+    [SkippableFact, TestCategory("Functional")]
+    public void RemindersTable_Cosmos_Init()
+    {
+    }
+
+    [SkippableFact, TestCategory("Functional")]
+    public async Task RemindersTable_Cosmos_RemindersRange()
+    {
+        await RemindersRange(50);
+    }
+
+    [SkippableFact, TestCategory("Functional")]
+    public async Task RemindersTable_Cosmos_RemindersParallelUpsert()
+    {
+        await RemindersParallelUpsert();
+    }
+
+    [SkippableFact, TestCategory("Functional")]
+    public async Task RemindersTable_Cosmos_ReminderSimple()
+    {
+        await ReminderSimple();
+    }
+}


### PR DESCRIPTION
## Summary
- treat missing Cosmos reminder deletes as a normal unsuccessful remove operation
- let `LocalReminderService` treat already-removed reminders as a successful unregister
- add Cosmos reminder table coverage for shared reminder-table semantics

## Testing
- `dotnet build test\Extensions\Orleans.Cosmos.Tests\Orleans.Cosmos.Tests.csproj -f net8.0 -nologo -v minimal --no-restore`
- `dotnet test test\Extensions\Orleans.Cosmos.Tests\Orleans.Cosmos.Tests.csproj -f net8.0 -nologo -v minimal --no-build --filter "FullyQualifiedName~CosmosRemindersTableTests"`
- `dotnet test test\Orleans.Reminders.Tests\Orleans.Reminders.Tests.csproj -nologo -v minimal --no-restore --filter "FullyQualifiedName~ReminderTests_TableGrain.Rem_Grain_Basic_StopByRef|FullyQualifiedName~ReminderTests_TableGrain.Rem_Grain_Basic_ListOps|FullyQualifiedName~MinimalReminderTests.MinimalReminderInterval"`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10037)