### PR TITLE
Auto-register `ITimerRegistry` component on `SystemTargets`

### DIFF
--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Internal;
 using Orleans.Runtime.Scheduler;
 using Orleans.Serialization.Invocation;
+using Orleans.Timers;
 
 namespace Orleans.Runtime
 {
@@ -112,6 +113,10 @@ namespace Orleans.Runtime
             else if (typeof(TComponent) == typeof(PlacementStrategy))
             {
                 result = (TComponent)(object)SystemTargetPlacementStrategy.Instance;
+            }
+            else if (typeof(TComponent) == typeof(ITimerRegistry))
+            {
+                result = (TComponent)(object)_shared.TimerRegistry;
             }
             else
             {


### PR DESCRIPTION
Grain service's (which inherit from sys target) can not declare `IAsyncEnumerable<T>` methods because the under the hood, the extension requires the tegistry component to schedule BG cleanup timers for abandoned enumerators. We could inject the registry in the grain service, and manually register the registry, but maybe we can consider making it "on" by default 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10038)