### PR TITLE
Clamp immediate reminder due times

### DIFF
--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -18,6 +18,7 @@ namespace Orleans.Runtime.ReminderService
         private const int InitialReadRetryCountBeforeFastFailForUpdates = 2;
         private static readonly TimeSpan InitialReadMaxWaitTimeForUpdates = TimeSpan.FromSeconds(20);
         private static readonly TimeSpan InitialReadRetryPeriod = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan MinimumReminderDueTime = TimeSpan.FromMilliseconds(1);
         private readonly ILogger logger;
         private readonly ReminderOptions reminderOptions;
         private readonly Dictionary<ReminderIdentity, LocalReminderData> localReminders = new();
@@ -579,6 +580,44 @@ namespace Orleans.Runtime.ReminderService
 
         private IRemindable GetGrain(GrainId grainId) => (IRemindable)_referenceActivator.CreateReference(grainId, _grainInterfaceType);
 
+        internal static TimeSpan CalculateInitialDueTime(ReminderEntry entry, DateTime now)
+        {
+            ArgumentNullException.ThrowIfNull(entry);
+            if (entry.Period <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(entry), entry.Period, "Reminder period must be greater than zero.");
+            }
+
+            TimeSpan dueTimeSpan;
+            if (now < entry.StartAt) // if the time for first tick hasn't passed yet
+            {
+                dueTimeSpan = entry.StartAt.Subtract(now); // then duetime is duration between now and the first tick time
+            }
+            else // the first tick happened in the past ... compute duetime based on the first tick time, and period
+            {
+                // formula used:
+                // due = period - 'time passed since last tick (==sinceLast)'
+                // due = period - ((Now - FirstTickTime) % period)
+                // explanation of formula:
+                // (Now - FirstTickTime) => gives amount of time since first tick happened
+                // (Now - FirstTickTime) % period => gives amount of time passed since the last tick should have triggered
+                var sinceFirstTick = now.Subtract(entry.StartAt);
+                var sinceLastTick = TimeSpan.FromTicks(sinceFirstTick.Ticks % entry.Period.Ticks);
+                dueTimeSpan = entry.Period.Subtract(sinceLastTick);
+
+                // in corner cases, dueTime can be equal to period ... so, take another mod
+                dueTimeSpan = TimeSpan.FromTicks(dueTimeSpan.Ticks % entry.Period.Ticks);
+            }
+
+            // PeriodicTimer requires a positive period, so clamp immediate ticks to a small positive delay.
+            if (dueTimeSpan < MinimumReminderDueTime)
+            {
+                dueTimeSpan = MinimumReminderDueTime;
+            }
+
+            return dueTimeSpan;
+        }
+
         private sealed class LocalReminderData
         {
             private readonly LocalReminderService _shared;
@@ -802,29 +841,7 @@ namespace Orleans.Runtime.ReminderService
 
             private TimeSpan GetInitialDueTime(ReminderEntry entry)
             {
-                TimeSpan dueTimeSpan;
-                var now = _shared._timeProvider.GetUtcNow().UtcDateTime;
-                if (now < entry.StartAt) // if the time for first tick hasn't passed yet
-                {
-                    dueTimeSpan = entry.StartAt.Subtract(now); // then duetime is duration between now and the first tick time
-                }
-                else // the first tick happened in the past ... compute duetime based on the first tick time, and period
-                {
-                    // formula used:
-                    // due = period - 'time passed since last tick (==sinceLast)'
-                    // due = period - ((Now - FirstTickTime) % period)
-                    // explanation of formula:
-                    // (Now - FirstTickTime) => gives amount of time since first tick happened
-                    // (Now - FirstTickTime) % period => gives amount of time passed since the last tick should have triggered
-                    var sinceFirstTick = now.Subtract(entry.StartAt);
-                    var sinceLastTick = TimeSpan.FromTicks(sinceFirstTick.Ticks % entry.Period.Ticks);
-                    dueTimeSpan = entry.Period.Subtract(sinceLastTick);
-
-                    // in corner cases, dueTime can be equal to period ... so, take another mod
-                    dueTimeSpan = TimeSpan.FromTicks(dueTimeSpan.Ticks % entry.Period.Ticks);
-                }
-
-                return dueTimeSpan;
+                return CalculateInitialDueTime(entry, _shared._timeProvider.GetUtcNow().UtcDateTime);
             }
 
             private static TimeSpan CalculateTardiness(TickStatus status)

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -1,0 +1,72 @@
+using Orleans.Runtime;
+using Orleans.Runtime.ReminderService;
+using Xunit;
+
+namespace UnitTests.TimerTests;
+
+public class LocalReminderServiceTests
+{
+    [Fact, TestCategory("BVT")]
+    public void CalculateInitialDueTime_ReturnsMinimumDueTime_WhenNextTickIsDueNow()
+    {
+        var period = TimeSpan.FromSeconds(12);
+        var startAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var entry = CreateReminderEntry(startAt, period);
+        var now = startAt + period;
+
+        var dueTime = LocalReminderService.CalculateInitialDueTime(entry, now);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(1), dueTime);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void CalculateInitialDueTime_ReturnsMinimumDueTime_WhenNextTickIsWithinMinimumDueTime()
+    {
+        var period = TimeSpan.FromSeconds(12);
+        var startAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var entry = CreateReminderEntry(startAt, period);
+        var now = startAt + period - TimeSpan.FromTicks(1);
+
+        var dueTime = LocalReminderService.CalculateInitialDueTime(entry, now);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(1), dueTime);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void CalculateInitialDueTime_ReturnsRemainingDueTime_WhenNextTickIsAtLeastMinimumDueTime()
+    {
+        var period = TimeSpan.FromSeconds(12);
+        var startAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var entry = CreateReminderEntry(startAt, period);
+        var now = startAt + period - TimeSpan.FromMilliseconds(10);
+
+        var dueTime = LocalReminderService.CalculateInitialDueTime(entry, now);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(10), dueTime);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void CalculateInitialDueTime_ReturnsRemainingPeriod_WhenNextTickIsInFuture()
+    {
+        var period = TimeSpan.FromSeconds(12);
+        var startAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var entry = CreateReminderEntry(startAt, period);
+        var now = startAt + TimeSpan.FromSeconds(3);
+
+        var dueTime = LocalReminderService.CalculateInitialDueTime(entry, now);
+
+        Assert.Equal(TimeSpan.FromSeconds(9), dueTime);
+    }
+
+    private static ReminderEntry CreateReminderEntry(DateTime startAt, TimeSpan period)
+    {
+        return new ReminderEntry
+        {
+            GrainId = GrainId.Create("test", "grain"),
+            ReminderName = "reminder",
+            StartAt = startAt,
+            Period = period,
+            ETag = "etag",
+        };
+    }
+}


### PR DESCRIPTION
## Why

Reminder scheduling can compute an initial due time of zero, or less than the practical positive delay used by PeriodicTimer, when the next reminder tick is due now. PeriodicTimer rejects non-positive periods, causing reminder registration to throw ArgumentOutOfRangeException.

## What changed

- factor initial reminder due-time calculation into a testable helper
- clamp zero/sub-millisecond initial due times to 1ms
- preserve due times which are already at least 1ms
- add focused unit coverage for the immediate and near-immediate boundaries

## Validation

- dotnet test test\Orleans.Reminders.Tests\Orleans.Reminders.Tests.csproj --filter "FullyQualifiedName~LocalReminderServiceTests" -nologo
- dotnet test test\Extensions\Orleans.Cosmos.Tests\Orleans.Cosmos.Tests.csproj --filter "FullyQualifiedName~ReminderTests_Cosmos.Rem_Azure_1J_MultiGrainMultiReminders" -nologo (skipped locally because Cosmos preconditions are not configured)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10039)