### PR TITLE
Preserve Cosmos reminder ETags for stale delete checks

### DIFF
--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
@@ -356,6 +356,7 @@ internal partial class CosmosReminderTable : IReminderTable
         return new ReminderEntity
         {
             Id = ReminderEntity.ConstructId(entry.GrainId, entry.ReminderName),
+            ETag = entry.ETag,
             PartitionKey = ReminderEntity.ConstructPartitionKey(_clusterOptions.ServiceId, entry.GrainId),
             ServiceId = _clusterOptions.ServiceId,
             GrainHash = entry.GrainId.GetUniformHashCode(),

--- a/test/Orleans.Runtime.Internal.Tests/RemindersTest/ReminderTableTestsBase.cs
+++ b/test/Orleans.Runtime.Internal.Tests/RemindersTest/ReminderTableTestsBase.cs
@@ -93,6 +93,7 @@ namespace UnitTests.RemindersTest
             Assert.Equal(readReminder.StartAt, reminder.StartAt);
             Assert.NotNull(etagTemp);
 
+            reminder.StartAt = reminder.StartAt.AddSeconds(1);
             reminder.ETag = await remindersTable.UpsertRow(reminder);
 
             var removeRowRes = await remindersTable.RemoveRow(reminder.GrainId, reminder.ReminderName, etagTemp);


### PR DESCRIPTION
Split out from #9993.

## Why

Cosmos reminder updates should preserve the reminder ETag so existing conditional operations can detect stale writes/deletes correctly. The shared stale-ETag reminder table test also needs to perform a real update before validating stale delete behavior.

## What changed

- Preserve reminder ETags when converting reminder entries to Cosmos entities.
- Update the shared stale-ETag reminder table test to modify the row before attempting deletion with the old ETag.

`CosmosReminderTable.RemoveRow` continues to issue a direct conditional delete using `ItemRequestOptions.IfMatchEtag`; this PR no longer performs a pre-delete read to validate the ETag.

## Validation

- `dotnet test test\Extensions\Orleans.Cosmos.Tests\Orleans.Cosmos.Tests.csproj -nologo --filter "FullyQualifiedName~CosmosRemindersTableTests"` (compiled; Cosmos precondition skips in local environment)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10041)