### PR TITLE
Fix stuck deactivation recovery

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1138,6 +1138,8 @@ internal sealed partial class ActivationData :
                         DeactivationReason = new(DeactivationReasonCode.ActivationUnresponsive,
                             $"{DeactivationReason.Description}. Activation {this} has been deactivating since {DeactivationStartTime.Value} and is likely stuck");
                     }
+
+                    AbandonStuckDeactivatingActivation();
                 }
 
                 if (!IsStuckDeactivating && !IsStuckProcessingMessage)
@@ -1159,6 +1161,20 @@ internal sealed partial class ActivationData :
                 // Reject all pending messages
                 RejectAllQueuedMessages();
             }
+        }
+
+        void AbandonStuckDeactivatingActivation()
+        {
+            var forwardingAddress = ForwardingAddress;
+            LogWarningAbandoningStuckDeactivatingActivation(_shared.Logger, this, forwardingAddress);
+
+            // The migration target is not proven until deactivation reaches StartMigrationAsync.
+            // If deactivation is stuck before then, re-address messages instead of forwarding to a
+            // target which may not have a valid replacement activation.
+            ForwardingAddress = null;
+            UnregisterMessageTarget();
+            _shared.InternalRuntime.GrainLocator.Unregister(Address, UnregistrationCause.Force).Ignore();
+            GetDeactivationCompletionSource().TrySetResult(true);
         }
 
         bool MayInvokeRequest(Message incoming)
@@ -2588,6 +2604,11 @@ internal sealed partial class ActivationData :
         ActivationDataLogValue grain,
         Message blockingRequest,
         Message message);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Abandoning stuck deactivating activation {Activation}. ForwardingAddress={ForwardingAddress}")]
+    private static partial void LogWarningAbandoningStuckDeactivatingActivation(ILogger logger, ActivationData activation, SiloAddress? forwardingAddress);
 
     private readonly struct ActivationDataLogValue(ActivationData activation, bool includeExtraDetails = false)
     {

--- a/test/Orleans.DefaultCluster.Tests/Migration/MigrationTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/Migration/MigrationTests.cs
@@ -1,5 +1,8 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Orleans.Concurrency;
+using Orleans.Configuration;
 using Orleans.Core.Internal;
 using Orleans.Placement;
 using Orleans.Runtime;
@@ -299,6 +302,110 @@ namespace DefaultCluster.Tests.General
             // The grain should have lost its state during the failed migration.
             var newState = await grain.GetState();
             Assert.NotEqual(expectedState, newState);
+        }
+    }
+
+    public class StuckDeactivationRecoveryTests : TestClusterPerTest
+    {
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.AddSiloBuilderConfigurator<Configurator>();
+        }
+
+        [Fact, TestCategory("BVT")]
+        public async Task StuckDeactivatingActivationIsAbandoned()
+        {
+            var grain = GrainFactory.GetGrain<IStuckDeactivationTestGrain>(GetRandomGrainId());
+            var grainId = grain.GetGrainId();
+            var originalAddress = await grain.GetGrainAddress();
+            var targetHost = HostedCluster.GetActiveSilos().Select(s => s.SiloAddress).First(address => !address.Equals(originalAddress.SiloAddress));
+            var blockingCall = grain.BlockUntilReleased();
+
+            try
+            {
+                await grain.WaitUntilBlocked().WaitAsync(TimeSpan.FromSeconds(10));
+                await grain.StartMigrationTo(targetHost).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+                await Task.Delay(TimeSpan.FromSeconds(1));
+
+                var newAddress = await grain.GetGrainAddress().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+
+                Assert.NotEqual(originalAddress.ActivationId, newAddress.ActivationId);
+            }
+            finally
+            {
+                StuckDeactivationTestGrain.Release(grainId);
+            }
+
+            var completed = await Task.WhenAny(blockingCall, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.Same(blockingCall, completed);
+            await blockingCall;
+        }
+
+        private sealed class Configurator : ISiloConfigurator
+        {
+            public void Configure(ISiloBuilder hostBuilder)
+            {
+                hostBuilder
+                    .Configure<SiloMessagingOptions>(options =>
+                    {
+                        options.MaxRequestProcessingTime = TimeSpan.FromMilliseconds(250);
+                        options.ResponseTimeout = TimeSpan.FromSeconds(20);
+                    })
+                    .Configure<GrainCollectionOptions>(options => options.DeactivationTimeout = TimeSpan.FromMilliseconds(250));
+            }
+        }
+    }
+
+    public interface IStuckDeactivationTestGrain : IGrainWithIntegerKey
+    {
+        Task BlockUntilReleased();
+
+        [AlwaysInterleave]
+        Task WaitUntilBlocked();
+
+        [AlwaysInterleave]
+        ValueTask StartMigrationTo(SiloAddress targetHost);
+
+        ValueTask<GrainAddress> GetGrainAddress();
+    }
+
+    [RandomPlacement]
+    public class StuckDeactivationTestGrain : Grain, IStuckDeactivationTestGrain
+    {
+        private static readonly ConcurrentDictionary<GrainId, BlockState> BlockStates = new();
+
+        public Task BlockUntilReleased()
+        {
+            var state = GetBlockState();
+            state.Started.TrySetResult();
+            return state.Released.Task;
+        }
+
+        public Task WaitUntilBlocked() => GetBlockState().Started.Task;
+
+        public ValueTask StartMigrationTo(SiloAddress targetHost)
+        {
+            RequestContext.Set(IPlacementDirector.PlacementHintKey, targetHost);
+            MigrateOnIdle();
+            return default;
+        }
+
+        public ValueTask<GrainAddress> GetGrainAddress() => new(GrainContext.Address);
+
+        public static void Release(GrainId grainId)
+        {
+            if (BlockStates.TryRemove(grainId, out var state))
+            {
+                state.Released.TrySetResult();
+            }
+        }
+
+        private BlockState GetBlockState() => BlockStates.GetOrAdd(GrainContext.GrainId, static _ => new());
+
+        private sealed class BlockState
+        {
+            public readonly TaskCompletionSource Started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            public readonly TaskCompletionSource Released = new(TaskCreationOptions.RunContinuationsAsynchronously);
         }
     }
 


### PR DESCRIPTION
## Summary

- abandon a deactivating activation once it crosses the stuck threshold by removing it from the local catalog and force-unregistering its directory entry
- clear any unproven migration forwarding address before rerouting queued messages so they are re-addressed instead of forwarded to a target whose replacement activation might not exist
- add a focused migration test which blocks deactivation behind a long-running request and verifies a new activation handles subsequent calls

Fixes #10045

## Testing

- `dotnet test test\Orleans.DefaultCluster.Tests\Orleans.DefaultCluster.Tests.csproj --filter "FullyQualifiedName~StuckDeactivationRecoveryTests" --no-restore`
- `dotnet test test\Orleans.DefaultCluster.Tests\Orleans.DefaultCluster.Tests.csproj --filter "FullyQualifiedName~DefaultCluster.Tests.General.MigrationTests|FullyQualifiedName~DefaultCluster.Tests.General.StuckDeactivationRecoveryTests" --no-restore`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10046)