### PR TITLE
Cap distributed directory ownership transfer batch size

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Orleans.Configuration;
 using Orleans.Runtime.Utilities;
@@ -76,32 +75,7 @@ internal sealed class DirectoryMembershipSnapshot
             return left.MemberIndex.CompareTo(right.MemberIndex);
         });
 
-        Dictionary<int, ImmutableArray<RingRange>.Builder> rangesByMemberPartitionBuilders = [];
-        for (var i = 0; i < hashIndexPairs.Count; i++)
-        {
-            var (_, memberIndex, _) = hashIndexPairs[i];
-            ref var builder = ref CollectionsMarshal.GetValueRefOrAddDefault(rangesByMemberPartitionBuilders, memberIndex, out _);
-            builder ??= ImmutableArray.CreateBuilder<RingRange>(PartitionsPerSilo);
-            var (entryStart, _, _) = hashIndexPairs[i];
-            var (nextStart, _, _) = hashIndexPairs[(i + 1) % hashIndexPairs.Count];
-            var range = (entryStart == nextStart) switch
-            {
-                true when hashIndexPairs.Count == 1 => RingRange.Full,
-                true => RingRange.Empty,
-                _ => RingRange.Create(entryStart, nextStart)
-            };
-            builder.Add(range);
-        }
-
-        var rangesByMemberPartition = ImmutableArray.CreateBuilder<ImmutableArray<RingRange>>(sortedActiveMembers.Count);
-        for (var i = 0; i < sortedActiveMembers.Count; i++)
-        {
-            rangesByMemberPartition.Add(rangesByMemberPartitionBuilders[i].ToImmutable());
-        }
-
-        _rangesByMemberPartition = rangesByMemberPartition.ToImmutable();
-
-        // Remove empty ranges.
+        // Remove empty ranges caused by hash collisions.
         if (hashIndexPairs.Count > 1)
         {
             for (var i = 1; i < hashIndexPairs.Count;)
@@ -118,9 +92,35 @@ internal sealed class DirectoryMembershipSnapshot
         }
 
         _ringBoundaries = hashIndexPairs.ToImmutable();
-
         Members = sortedActiveMembers.ToImmutable();
 
+        var rangesByMemberPartitionBuilders = new RingRange[sortedActiveMembers.Count][];
+        for (var i = 0; i < sortedActiveMembers.Count; i++)
+        {
+            rangesByMemberPartitionBuilders[i] = new RingRange[PartitionsPerSilo];
+        }
+
+        var rangesByMemberPartition = ImmutableArray.CreateBuilder<ImmutableArray<RingRange>>(sortedActiveMembers.Count);
+        for (var i = 0; i < hashIndexPairs.Count; i++)
+        {
+            var (entryStart, memberIndex, partitionIndex) = hashIndexPairs[i];
+            var (nextStart, _, _) = hashIndexPairs[(i + 1) % hashIndexPairs.Count];
+            var range = (entryStart == nextStart) switch
+            {
+                true when hashIndexPairs.Count == 1 => RingRange.Full,
+                true => RingRange.Empty,
+                _ => RingRange.Create(entryStart, nextStart)
+            };
+
+            rangesByMemberPartitionBuilders[memberIndex][partitionIndex] = range;
+        }
+
+        for (var i = 0; i < sortedActiveMembers.Count; i++)
+        {
+            rangesByMemberPartition.Add(ImmutableArray.CreateRange(rangesByMemberPartitionBuilders[i]));
+        }
+
+        _rangesByMemberPartition = rangesByMemberPartition.ToImmutable();
         _rangesByMember = new RingRangeCollection[Members.Length];
         ClusterMembershipSnapshot = snapshot;
     }

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
@@ -20,12 +20,21 @@ internal sealed class DirectoryMembershipSnapshot
     private readonly ImmutableArray<ImmutableArray<IGrainDirectoryPartition>> _partitionsByMember;
     private readonly ImmutableArray<ImmutableArray<RingRange>> _rangesByMemberPartition;
 
-    public DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory) : this(snapshot, grainFactory, static (silo, count) => silo.GetUniformHashCodes(count))
+    public DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory)
+        : this(snapshot, grainFactory, PartitionsPerSilo, static (silo, count) => silo.GetUniformHashCodes(count))
     {
     }
 
     internal DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory, Func<SiloAddress, int, uint[]> getRingBoundaries)
+        : this(snapshot, grainFactory, PartitionsPerSilo, getRingBoundaries)
     {
+    }
+
+    internal DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory, int partitionCount, Func<SiloAddress, int, uint[]> getRingBoundaries)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(partitionCount, 1);
+        PartitionCount = partitionCount;
+
         var sortedActiveMembers = ImmutableArray.CreateBuilder<SiloAddress>(snapshot.Members.Count(static m => m.Value.Status == SiloStatus.Active));
         foreach (var member in snapshot.Members)
         {
@@ -37,15 +46,15 @@ internal sealed class DirectoryMembershipSnapshot
         }
 
         sortedActiveMembers.Sort(static (left, right) => left.CompareTo(right));
-        var hashIndexPairs = ImmutableArray.CreateBuilder<(uint Hash, int MemberIndex, int PartitionIndex)>(PartitionsPerSilo * sortedActiveMembers.Count);
+        var hashIndexPairs = ImmutableArray.CreateBuilder<(uint Hash, int MemberIndex, int PartitionIndex)>(partitionCount * sortedActiveMembers.Count);
         var memberPartitions = ImmutableArray.CreateBuilder<ImmutableArray<IGrainDirectoryPartition>>();
         for (var memberIndex = 0; memberIndex < sortedActiveMembers.Count; memberIndex++)
         {
             var activeMember = sortedActiveMembers[memberIndex];
-            var hashCodes = getRingBoundaries(activeMember, PartitionsPerSilo).ToList();
+            var hashCodes = getRingBoundaries(activeMember, partitionCount).ToList();
             hashCodes.Sort();
-            Debug.Assert(hashCodes.Count == PartitionsPerSilo);
-            var partitionReferences = ImmutableArray.CreateBuilder<IGrainDirectoryPartition>(PartitionsPerSilo);
+            Debug.Assert(hashCodes.Count == partitionCount);
+            var partitionReferences = ImmutableArray.CreateBuilder<IGrainDirectoryPartition>(partitionCount);
             for (var partitionIndex = 0; partitionIndex < hashCodes.Count; partitionIndex++)
             {
                 var hashCode = hashCodes[partitionIndex];
@@ -97,7 +106,7 @@ internal sealed class DirectoryMembershipSnapshot
         var rangesByMemberPartitionBuilders = new RingRange[sortedActiveMembers.Count][];
         for (var i = 0; i < sortedActiveMembers.Count; i++)
         {
-            rangesByMemberPartitionBuilders[i] = new RingRange[PartitionsPerSilo];
+            rangesByMemberPartitionBuilders[i] = new RingRange[partitionCount];
         }
 
         var rangesByMemberPartition = ImmutableArray.CreateBuilder<ImmutableArray<RingRange>>(sortedActiveMembers.Count);
@@ -130,12 +139,14 @@ internal sealed class DirectoryMembershipSnapshot
 
     public MembershipVersion Version => ClusterMembershipSnapshot.Version;
 
+    internal int PartitionCount { get; }
+
     public ImmutableArray<SiloAddress> Members { get; }
 
     public RingRange GetRange(SiloAddress address, int partitionIndex)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(partitionIndex, 0);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(partitionIndex, PartitionsPerSilo - 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(partitionIndex, PartitionCount - 1);
 
         var memberIndex = TryGetMemberIndex(address);
         if (memberIndex < 0)

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
@@ -51,11 +51,10 @@ internal sealed class DirectoryMembershipSnapshot
         for (var memberIndex = 0; memberIndex < sortedActiveMembers.Count; memberIndex++)
         {
             var activeMember = sortedActiveMembers[memberIndex];
-            var hashCodes = getRingBoundaries(activeMember, partitionCount).ToList();
-            hashCodes.Sort();
-            Debug.Assert(hashCodes.Count == partitionCount);
+            var hashCodes = getRingBoundaries(activeMember, partitionCount);
+            Debug.Assert(hashCodes.Length == partitionCount);
             var partitionReferences = ImmutableArray.CreateBuilder<IGrainDirectoryPartition>(partitionCount);
-            for (var partitionIndex = 0; partitionIndex < hashCodes.Count; partitionIndex++)
+            for (var partitionIndex = 0; partitionIndex < hashCodes.Length; partitionIndex++)
             {
                 var hashCode = hashCodes[partitionIndex];
                 hashIndexPairs.Add((hashCode, memberIndex, partitionIndex));

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
@@ -13,26 +13,24 @@ internal sealed partial class GrainDirectoryPartition
         ArgumentNullException.ThrowIfNull(address);
         LogRegisterAsync(version, address, currentRegistration);
 
-        // Ensure that the current membership version is new enough.
-        await WaitForRange(address.GrainId, version);
-        if (!IsOwner(CurrentView, address.GrainId))
+        var currentView = await WaitForOwnershipViewAsync(address.GrainId, version);
+        if (!IsOwner(currentView, address.GrainId))
         {
-            return DirectoryResult.RefreshRequired<GrainAddress>(CurrentView.Version);
+            return DirectoryResult.RefreshRequired<GrainAddress>(currentView.Version);
         }
 
-        DebugAssertOwnership(address.GrainId);
-        return DirectoryResult.FromResult(RegisterCore(address, currentRegistration), version);
+        DebugAssertOwnership(currentView, address.GrainId);
+        return DirectoryResult.FromResult(RegisterCore(address, currentRegistration, currentView.Version), version);
     }
 
     async ValueTask<DirectoryResult<GrainAddress?>> IGrainDirectoryPartition.LookupAsync(MembershipVersion version, GrainId grainId)
     {
         LogLookupAsync(version, grainId);
 
-        // Ensure we can serve the request.
-        await WaitForRange(grainId, version);
-        if (!IsOwner(CurrentView, grainId))
+        var currentView = await WaitForOwnershipViewAsync(grainId, version);
+        if (!IsOwner(currentView, grainId))
         {
-            return DirectoryResult.RefreshRequired<GrainAddress?>(CurrentView.Version);
+            return DirectoryResult.RefreshRequired<GrainAddress?>(currentView.Version);
         }
 
         return DirectoryResult.FromResult(LookupCore(grainId), version);
@@ -43,13 +41,13 @@ internal sealed partial class GrainDirectoryPartition
         ArgumentNullException.ThrowIfNull(address);
         LogDeregisterAsync(version, address);
 
-        await WaitForRange(address.GrainId, version);
-        if (!IsOwner(CurrentView, address.GrainId))
+        var currentView = await WaitForOwnershipViewAsync(address.GrainId, version);
+        if (!IsOwner(currentView, address.GrainId))
         {
-            return DirectoryResult.RefreshRequired<bool>(CurrentView.Version);
+            return DirectoryResult.RefreshRequired<bool>(currentView.Version);
         }
 
-        DebugAssertOwnership(address.GrainId);
+        DebugAssertOwnership(currentView, address.GrainId);
         return DirectoryResult.FromResult(DeregisterCore(address), version);
     }
 
@@ -73,13 +71,29 @@ internal sealed partial class GrainDirectoryPartition
         return null;
     }
 
-    private GrainAddress RegisterCore(GrainAddress newAddress, GrainAddress? existingAddress)
+    private async ValueTask<DirectoryMembershipSnapshot> WaitForOwnershipViewAsync(GrainId grainId, MembershipVersion version)
+    {
+        while (true)
+        {
+            // Requests which arrive with a stale membership version must still wait for any in-flight ownership
+            // transition in the current view before deciding whether this partition can serve them.
+            var currentView = CurrentView;
+            var waitVersion = currentView.Version > version ? currentView.Version : version;
+            await WaitForRange(grainId, waitVersion);
+            if (ReferenceEquals(currentView, CurrentView))
+            {
+                return currentView;
+            }
+        }
+    }
+
+    private GrainAddress RegisterCore(GrainAddress newAddress, GrainAddress? existingAddress, MembershipVersion currentVersion)
     {
         ref var existing = ref CollectionsMarshal.GetValueRefOrAddDefault(_directory, newAddress.GrainId, out _);
 
         if (existing is null || existing.Matches(existingAddress) || IsSiloDead(existing))
         {
-            if (newAddress.MembershipVersion != CurrentView.Version)
+            if (newAddress.MembershipVersion != currentVersion)
             {
                 // Set the membership version to match the view number in which it was registered.
                 newAddress = new()
@@ -87,7 +101,7 @@ internal sealed partial class GrainDirectoryPartition
                     GrainId = newAddress.GrainId,
                     SiloAddress = newAddress.SiloAddress,
                     ActivationId = newAddress.ActivationId,
-                    MembershipVersion = CurrentView.Version
+                    MembershipVersion = currentVersion
                 };
             }
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -326,7 +326,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         Debug.Assert(!addedRange.Intersects(removedRange));
         Debug.Assert(addedRange.IsEmpty || addedRange.Intersects(_currentRange));
         Debug.Assert(!addedRange.Intersects(previousRange));
-        Debug.Assert(previousRange.IsEmpty || _currentRange.IsEmpty || previousRange.Start == _currentRange.Start);
+        Debug.Assert(previousRange.IsEmpty || previousRange.IsFull || _currentRange.IsEmpty || _currentRange.IsFull || previousRange.Start == _currentRange.Start);
 #endif
 
         if (!removedRange.IsEmpty)
@@ -440,7 +440,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                         var previousOwnerRange = previousOwnerRanges[partitionIndex];
                         if (previousOwnerRange.Intersects(addedRange))
                         {
-                            tasks.Add(TransferSnapshotAsync(current, addedRange, previousOwner, partitionIndex, previous.Version));
+                            tasks.Add(TransferSnapshotAsync(current, previousOwnerRange, addedRange, previousOwner, partitionIndex, previous.Version));
                         }
                     }
                 }
@@ -501,22 +501,52 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         }
     }
 
-    private async Task<bool> TransferSnapshotAsync(DirectoryMembershipSnapshot current, RingRange addedRange, SiloAddress previousOwner, int partitionIndex, MembershipVersion previousVersion)
+    private async Task<bool> TransferSnapshotAsync(
+        DirectoryMembershipSnapshot current,
+        RingRange previousOwnerRange,
+        RingRange addedRange,
+        SiloAddress previousOwner,
+        int partitionIndex,
+        MembershipVersion previousVersion)
     {
+        var currentTransferRange = addedRange;
         try
         {
             var stopwatch = ValueStopwatch.StartNew();
-            LogTraceRequestingEntries(_logger, addedRange, previousOwner, previousVersion);
 
             var partition = GetPartitionReference(previousOwner, partitionIndex);
-
-            // Alternatively, the previous owner could push the snapshot. The pull-based approach is used here because it is simpler.
-            var snapshot = await partition.GetSnapshotAsync(current.Version, previousVersion, addedRange).AsTask().WaitAsync(ShutdownToken);
-
-            if (snapshot is null)
+            var waitedForRange = false;
+            foreach (var transferRange in GetSnapshotTransferRanges(previousOwnerRange, addedRange))
             {
-                LogWarningExpectedValidSnapshot(_logger, previousOwner, addedRange);
-                return false;
+                currentTransferRange = transferRange;
+                LogTraceRequestingEntries(_logger, transferRange, previousOwner, previousVersion);
+
+                // Alternatively, the previous owner could push the snapshot. The pull-based approach is used here because it is simpler.
+                var snapshot = await partition.GetSnapshotAsync(current.Version, previousVersion, transferRange).AsTask().WaitAsync(ShutdownToken);
+
+                if (snapshot is null)
+                {
+                    LogWarningExpectedValidSnapshot(_logger, previousOwner, transferRange);
+                    return false;
+                }
+
+                if (!waitedForRange)
+                {
+                    // Wait for previous versions to be unlocked before proceeding.
+                    await WaitForRange(addedRange, previousVersion);
+                    waitedForRange = true;
+                }
+
+                // Incorporate the values into the grain directory.
+                foreach (var entry in snapshot.GrainAddresses)
+                {
+                    DebugAssertOwnership(current, entry.GrainId);
+
+                    LogTraceReceivedEntry(_logger, entry, previousOwner, previousVersion);
+                    _directory[entry.GrainId] = entry;
+                }
+
+                LogDebugTransferredEntries(_logger, snapshot.GrainAddresses.Count, transferRange, previousOwner);
             }
 
             // The acknowledgement step lets the previous owner know that the snapshot has been received so that it can proceed.
@@ -525,20 +555,6 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                 async () => await partition.AcknowledgeSnapshotTransferAsync(_id, _partitionIndex, previousVersion),
                 false,
                 nameof(IGrainDirectoryPartition.AcknowledgeSnapshotTransferAsync)).Ignore();
-
-            // Wait for previous versions to be unlocked before proceeding.
-            await WaitForRange(addedRange, previousVersion);
-
-            // Incorporate the values into the grain directory.
-            foreach (var entry in snapshot.GrainAddresses)
-            {
-                DebugAssertOwnership(current, entry.GrainId);
-
-                LogTraceReceivedEntry(_logger, entry, previousOwner, previousVersion);
-                _directory[entry.GrainId] = entry;
-            }
-
-            LogDebugTransferredEntries(_logger, snapshot.GrainAddresses.Count, addedRange, previousOwner);
 
             DirectoryInstruments.SnapshotTransferCount.Add(1);
             DirectoryInstruments.SnapshotTransferDuration.Record((long)stopwatch.Elapsed.TotalMilliseconds);
@@ -549,11 +565,11 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         {
             if (exception is SiloUnavailableException)
             {
-                LogWarningRemoteHostUnavailable(_logger, addedRange);
+                LogWarningRemoteHostUnavailable(_logger, currentTransferRange);
             }
             else
             {
-                LogWarningErrorTransferringOwnership(_logger, exception, addedRange);
+                LogWarningErrorTransferringOwnership(_logger, exception, currentTransferRange);
             }
 
             return false;
@@ -638,6 +654,11 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
             return result.Value;
         }
+    }
+
+    internal static IEnumerable<RingRange> GetSnapshotTransferRanges(RingRange previousOwnerRange, RingRange addedRange)
+    {
+        return previousOwnerRange.Intersections(addedRange);
     }
 
     private async Task<T> InvokeOnClusterMember<T>(SiloAddress siloAddress, Func<Task<T>> func, T defaultValue, string operationName)
@@ -841,13 +862,13 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
     [LoggerMessage(
         Level = LogLevel.Trace,
-        Message = "Requesting entries for ranges '{Range}' from '{PreviousOwner}' at version '{PreviousVersion}'."
+        Message = "Requesting entries for range '{Range}' from '{PreviousOwner}' at version '{PreviousVersion}'."
     )]
     private static partial void LogTraceRequestingEntries(ILogger logger, RingRange range, SiloAddress previousOwner, MembershipVersion previousVersion);
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "Expected a valid snapshot from previous owner '{PreviousOwner}' for part of ranges '{Range}', but found none."
+        Message = "Expected a valid snapshot from previous owner '{PreviousOwner}' for range '{Range}', but found none."
     )]
     private static partial void LogWarningExpectedValidSnapshot(ILogger logger, SiloAddress previousOwner, RingRange range);
 

--- a/src/Orleans.Runtime/GrainDirectory/RingRange.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RingRange.cs
@@ -191,6 +191,22 @@ internal readonly struct RingRange : IEquatable<RingRange>, ISpanFormattable, IC
         {
             yield return this;
         }
+        else if (IsWrapped && other.IsWrapped)
+        {
+            yield return new RingRange(Math.Max(Start, other.Start), Math.Min(End, other.End));
+
+            if (Start < other.Start)
+            {
+                if (Start < other.End)
+                {
+                    yield return new RingRange(Start, other.End);
+                }
+            }
+            else if (other.Start < Start && other.Start < End)
+            {
+                yield return new RingRange(other.Start, End);
+            }
+        }
         else if (IsWrapped ^ other.IsWrapped)
         {
             var wrapped = IsWrapped ? this : other;
@@ -206,14 +222,14 @@ internal readonly struct RingRange : IEquatable<RingRange>, ISpanFormattable, IC
             if (wrappedEnd > normalStart)
             {
                 // ---NB====WE---
-                yield return new RingRange(normalStart, wrappedEnd);
+                yield return new RingRange(normalStart, Math.Min(normalEnd, wrappedEnd));
             }
 
             // Intersection at the high side.
             if (wrappedStart < normalEnd)
             {
                 // ---WB====NE---
-                yield return new RingRange(wrappedStart, normalEnd);
+                yield return new RingRange(Math.Max(normalStart, wrappedStart), normalEnd);
             }
         }
         else

--- a/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
+++ b/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
@@ -26,14 +26,24 @@ public sealed class DirectoryMembershipSnapshotTests
         return new ClusterMembershipSnapshot(dict.ToImmutable(), new(1));
     });
 
-    private static readonly Gen<DirectoryMembershipSnapshot> GenDirectoryMembershipSnapshot =
+    private sealed record DirectoryMembershipSnapshotTestCase(DirectoryMembershipSnapshot Snapshot, uint[][] HashesByMember);
+
+    private static readonly Gen<DirectoryMembershipSnapshotTestCase> GenDirectoryMembershipSnapshotTestCase =
         GenClusterMembershipSnapshot.SelectMany(snapshot =>
-            Gen.Int[1, DirectoryMembershipSnapshot.PartitionsPerSilo * 2].SelectMany(partitionCount =>
-                Gen.UInt.Array[partitionCount].Array[snapshot.Members.Count].Select(hashes =>
+        {
+            var activeMemberCount = snapshot.Members.Count(static member => member.Value.Status == SiloStatus.Active);
+            return Gen.Int[1, DirectoryMembershipSnapshot.PartitionsPerSilo * 2].SelectMany(partitionCount =>
+                Gen.UInt.Array[partitionCount].Array[activeMemberCount].Select(hashes =>
                 {
                     var i = 0;
-                    return new DirectoryMembershipSnapshot(snapshot, null!, partitionCount, (_, _) => hashes[i++]);
-                })));
+                    return new DirectoryMembershipSnapshotTestCase(
+                        new DirectoryMembershipSnapshot(snapshot, null!, partitionCount, (_, _) => hashes[i++]),
+                        hashes);
+                }));
+        });
+
+    private static readonly Gen<DirectoryMembershipSnapshot> GenDirectoryMembershipSnapshot =
+        GenDirectoryMembershipSnapshotTestCase.Select(static testCase => testCase.Snapshot);
 
     [Fact]
     public void GetOwnerTest()
@@ -68,24 +78,78 @@ public sealed class DirectoryMembershipSnapshotTests
     [Fact]
     public void GetRangeReturnsRangeForRequestedPartition()
     {
-        GenDirectoryMembershipSnapshot.Where(s => s.Members.Length > 0)
-            .Sample(snapshot =>
+        GenDirectoryMembershipSnapshotTestCase.Where(testCase => testCase.Snapshot.Members.Length > 0)
+            .Sample(testCase =>
             {
-                var expectedRanges = new Dictionary<(SiloAddress Member, int PartitionIndex), RingRange>();
-                foreach (var (range, memberIndex, partitionIndex) in snapshot.RangeOwners)
-                {
-                    expectedRanges.Add((snapshot.Members[memberIndex], partitionIndex), range);
-                }
+                var snapshot = testCase.Snapshot;
 
-                foreach (var member in snapshot.Members)
+                for (var memberIndex = 0; memberIndex < snapshot.Members.Length; memberIndex++)
                 {
+                    var member = snapshot.Members[memberIndex];
                     for (var partitionIndex = 0; partitionIndex < snapshot.PartitionCount; partitionIndex++)
                     {
-                        expectedRanges.TryGetValue((member, partitionIndex), out var expectedRange);
+                        var expectedRange = GetExpectedRange(testCase.HashesByMember, memberIndex, partitionIndex);
                         Assert.Equal(expectedRange, snapshot.GetRange(member, partitionIndex));
                     }
                 }
             });
+    }
+
+    private static RingRange GetExpectedRange(uint[][] hashesByMember, int memberIndex, int partitionIndex)
+    {
+        var boundaries = new List<(uint Hash, int MemberIndex, int PartitionIndex)>();
+        for (var i = 0; i < hashesByMember.Length; i++)
+        {
+            var hashes = hashesByMember[i];
+            for (var j = 0; j < hashes.Length; j++)
+            {
+                boundaries.Add((hashes[j], i, j));
+            }
+        }
+
+        boundaries.Sort(static (left, right) =>
+        {
+            var hashCompare = left.Hash.CompareTo(right.Hash);
+            if (hashCompare != 0)
+            {
+                return hashCompare;
+            }
+
+            var partitionCompare = left.PartitionIndex.CompareTo(right.PartitionIndex);
+            if (partitionCompare != 0)
+            {
+                return partitionCompare;
+            }
+
+            return left.MemberIndex.CompareTo(right.MemberIndex);
+        });
+
+        for (var i = 1; i < boundaries.Count;)
+        {
+            if (boundaries[i].Hash == boundaries[i - 1].Hash)
+            {
+                boundaries.RemoveAt(i);
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        var boundaryIndex = boundaries.FindIndex(boundary => boundary.MemberIndex == memberIndex && boundary.PartitionIndex == partitionIndex);
+        if (boundaryIndex < 0)
+        {
+            return RingRange.Empty;
+        }
+
+        if (boundaries.Count == 1)
+        {
+            return RingRange.Full;
+        }
+
+        var current = boundaries[boundaryIndex];
+        var next = boundaries[(boundaryIndex + 1) % boundaries.Count];
+        return RingRange.Create(current.Hash, next.Hash);
     }
 
     [Fact]

--- a/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
+++ b/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
@@ -67,27 +67,24 @@ public sealed class DirectoryMembershipSnapshotTests
     [Fact]
     public void GetRangeReturnsRangeForRequestedPartition()
     {
-        var siloAddress = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 11111), 1);
-        var clusterSnapshot = new ClusterMembershipSnapshot(
-            ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(siloAddress, new ClusterMember(siloAddress, SiloStatus.Active, "Silo_1")),
-            new(1));
-        var hashes = Enumerable
-            .Range(0, ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS)
-            .Select(index => (uint)(ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS - index))
-            .ToArray();
-        var snapshot = new DirectoryMembershipSnapshot(clusterSnapshot, null!, (_, _) => hashes);
-        var expectedRanges = new RingRange[ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS];
+        GenDirectoryMembershipSnapshot.Where(s => s.Members.Length > 0)
+            .Sample(snapshot =>
+            {
+                var expectedRanges = new Dictionary<(SiloAddress Member, int PartitionIndex), RingRange>();
+                foreach (var (range, memberIndex, partitionIndex) in snapshot.RangeOwners)
+                {
+                    expectedRanges.Add((snapshot.Members[memberIndex], partitionIndex), range);
+                }
 
-        foreach (var (range, memberIndex, partitionIndex) in snapshot.RangeOwners)
-        {
-            Assert.Equal(siloAddress, snapshot.Members[memberIndex]);
-            expectedRanges[partitionIndex] = range;
-        }
-
-        for (var partitionIndex = 0; partitionIndex < expectedRanges.Length; partitionIndex++)
-        {
-            Assert.Equal(expectedRanges[partitionIndex], snapshot.GetRange(siloAddress, partitionIndex));
-        }
+                foreach (var member in snapshot.Members)
+                {
+                    for (var partitionIndex = 0; partitionIndex < ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS; partitionIndex++)
+                    {
+                        expectedRanges.TryGetValue((member, partitionIndex), out var expectedRange);
+                        Assert.Equal(expectedRange, snapshot.GetRange(member, partitionIndex));
+                    }
+                }
+            });
     }
 
     [Fact]

--- a/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
+++ b/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Immutable;
 using Orleans.Runtime.GrainDirectory;
 using CsCheck;
 using Xunit;
-using Orleans.Configuration;
 
 namespace NonSilo.Tests.Directory;
 
@@ -28,11 +27,13 @@ public sealed class DirectoryMembershipSnapshotTests
     });
 
     private static readonly Gen<DirectoryMembershipSnapshot> GenDirectoryMembershipSnapshot =
-        GenClusterMembershipSnapshot.SelectMany(snapshot => Gen.UInt.Array[ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS].Array[snapshot.Members.Count].Select(hashes => 
-    {
-        var i = 0;
-        return new DirectoryMembershipSnapshot(snapshot, null!, (_, _) => hashes[i++]);
-    }));
+        GenClusterMembershipSnapshot.SelectMany(snapshot =>
+            Gen.Int[1, DirectoryMembershipSnapshot.PartitionsPerSilo * 2].SelectMany(partitionCount =>
+                Gen.UInt.Array[partitionCount].Array[snapshot.Members.Count].Select(hashes =>
+                {
+                    var i = 0;
+                    return new DirectoryMembershipSnapshot(snapshot, null!, partitionCount, (_, _) => hashes[i++]);
+                })));
 
     [Fact]
     public void GetOwnerTest()
@@ -78,7 +79,7 @@ public sealed class DirectoryMembershipSnapshotTests
 
                 foreach (var member in snapshot.Members)
                 {
-                    for (var partitionIndex = 0; partitionIndex < ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS; partitionIndex++)
+                    for (var partitionIndex = 0; partitionIndex < snapshot.PartitionCount; partitionIndex++)
                     {
                         expectedRanges.TryGetValue((member, partitionIndex), out var expectedRange);
                         Assert.Equal(expectedRange, snapshot.GetRange(member, partitionIndex));

--- a/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
+++ b/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
@@ -65,6 +65,32 @@ public sealed class DirectoryMembershipSnapshotTests
     }
 
     [Fact]
+    public void GetRangeReturnsRangeForRequestedPartition()
+    {
+        var siloAddress = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 11111), 1);
+        var clusterSnapshot = new ClusterMembershipSnapshot(
+            ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(siloAddress, new ClusterMember(siloAddress, SiloStatus.Active, "Silo_1")),
+            new(1));
+        var hashes = Enumerable
+            .Range(0, ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS)
+            .Select(index => (uint)(ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS - index))
+            .ToArray();
+        var snapshot = new DirectoryMembershipSnapshot(clusterSnapshot, null!, (_, _) => hashes);
+        var expectedRanges = new RingRange[ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS];
+
+        foreach (var (range, memberIndex, partitionIndex) in snapshot.RangeOwners)
+        {
+            Assert.Equal(siloAddress, snapshot.Members[memberIndex]);
+            expectedRanges[partitionIndex] = range;
+        }
+
+        for (var partitionIndex = 0; partitionIndex < expectedRanges.Length; partitionIndex++)
+        {
+            Assert.Equal(expectedRanges[partitionIndex], snapshot.GetRange(siloAddress, partitionIndex));
+        }
+    }
+
+    [Fact]
     public void ViewCoversRingTest()
     {
         // The union of all member ranges should cover the entire ring.

--- a/test/Orleans.Core.Tests/Directory/RingRangeTests.cs
+++ b/test/Orleans.Core.Tests/Directory/RingRangeTests.cs
@@ -103,6 +103,35 @@ public sealed class RingRangeTests
     }
 
     [Fact]
+    public void RingRangeIntersectionsMatchIndependentModel()
+    {
+        Gen.Select(GenRingRange, GenRingRange).Sample(AssertIntersectionsMatchIndependentModel);
+    }
+
+    [Fact]
+    public void RingRangeIntersectionsMatchIndependentModel_WhenWrappedRangeContainsNormalRange()
+    {
+        var lowSideCases = Gen.Select(Gen.Int[0, 10_000], Gen.Int[0, 10_000], Gen.Int[0, 10_000], static (wrappedEndSeed, normalStartSeed, normalLengthSeed) =>
+        {
+            var wrappedEnd = (uint)(2 + wrappedEndSeed);
+            var normalStart = (uint)(normalStartSeed % (int)(wrappedEnd - 1));
+            var normalEnd = normalStart + 1 + (uint)(normalLengthSeed % (int)(wrappedEnd - normalStart));
+            return (Wrapped: RingRange.Create(uint.MaxValue - 10_000, wrappedEnd), Normal: RingRange.Create(normalStart, normalEnd));
+        });
+
+        var highSideCases = Gen.Select(Gen.Int[0, 10_000], Gen.Int[0, 10_000], Gen.Int[0, 10_000], static (wrappedStartSeed, normalStartOffsetSeed, normalLengthSeed) =>
+        {
+            var wrappedStart = (uint)(wrappedStartSeed + 1);
+            var normalStart = wrappedStart + 1 + (uint)normalStartOffsetSeed;
+            var normalEnd = normalStart + 1 + (uint)normalLengthSeed;
+            return (Wrapped: RingRange.Create(wrappedStart, 0), Normal: RingRange.Create(normalStart, normalEnd));
+        });
+
+        lowSideCases.Sample(testCase => AssertIntersectionsMatchIndependentModel(testCase.Wrapped, testCase.Normal));
+        highSideCases.Sample(testCase => AssertIntersectionsMatchIndependentModel(testCase.Wrapped, testCase.Normal));
+    }
+
+    [Fact]
     public void RingRangeContains()
     {
         Assert.False(RingRange.Empty.Contains(0));
@@ -182,5 +211,99 @@ public sealed class RingRangeTests
 
             throw new ArgumentException(null, nameof(index));
         }
+    }
+
+    private static void AssertIntersectionsMatchIndependentModel(RingRange left, RingRange right)
+    {
+        var expected = GetExpectedIntersections(left, right).ToArray();
+
+        var actual = left.Intersections(right).ToArray();
+        Assert.Equal(expected, actual);
+        Assert.All(actual, intersection =>
+        {
+            Assert.True(Contains(left, intersection));
+            Assert.True(Contains(right, intersection));
+        });
+
+        var reversed = right.Intersections(left).ToArray();
+        Assert.Equal(expected, reversed);
+        Assert.Equal(expected.Length > 0, left.Intersects(right));
+        Assert.Equal(left.Intersects(right), right.Intersects(left));
+    }
+
+    private static IEnumerable<RingRange> GetExpectedIntersections(RingRange left, RingRange right)
+    {
+        var intervals = new List<(uint Start, uint End)>();
+        foreach (var leftInterval in ToIntervals(left))
+        {
+            foreach (var rightInterval in ToIntervals(right))
+            {
+                var start = Math.Max(leftInterval.Start, rightInterval.Start);
+                var end = Math.Min(leftInterval.End, rightInterval.End);
+                if (start <= end)
+                {
+                    intervals.Add((start, end));
+                }
+            }
+        }
+
+        intervals.Sort(static (left, right) => left.Start.CompareTo(right.Start));
+        if (intervals.Count >= 2 && intervals[0].Start == 0 && intervals[^1].End == uint.MaxValue)
+        {
+            yield return RingRange.Create(unchecked(intervals[^1].Start - 1), intervals[0].End);
+            for (var i = 1; i < intervals.Count - 1; i++)
+            {
+                yield return FromInclusiveInterval(intervals[i].Start, intervals[i].End);
+            }
+
+            yield break;
+        }
+
+        foreach (var interval in intervals)
+        {
+            yield return FromInclusiveInterval(interval.Start, interval.End);
+        }
+    }
+
+    private static bool Contains(RingRange range, RingRange candidate)
+    {
+        return ToIntervals(candidate).All(candidateInterval =>
+            ToIntervals(range).Any(rangeInterval => rangeInterval.Start <= candidateInterval.Start && candidateInterval.End <= rangeInterval.End));
+    }
+
+    private static IEnumerable<(uint Start, uint End)> ToIntervals(RingRange range)
+    {
+        if (range.IsEmpty)
+        {
+            yield break;
+        }
+
+        if (range.IsFull)
+        {
+            yield return (0, uint.MaxValue);
+            yield break;
+        }
+
+        if (range.Start < range.End)
+        {
+            yield return (range.Start + 1, range.End);
+            yield break;
+        }
+
+        yield return (0, range.End);
+        if (range.Start < uint.MaxValue)
+        {
+            yield return (range.Start + 1, uint.MaxValue);
+        }
+    }
+
+    private static RingRange FromInclusiveInterval(uint start, uint end)
+    {
+        if (start == 0 && end == uint.MaxValue)
+        {
+            return RingRange.Full;
+        }
+
+        return RingRange.Create(unchecked(start - 1), end);
     }
 }

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
@@ -1,0 +1,47 @@
+#nullable enable
+using System.Linq;
+using Orleans.Runtime.GrainDirectory;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.GrainDirectory;
+
+[TestCategory("BVT"), TestCategory("Directory")]
+public sealed class GrainDirectoryPartitionTests
+{
+    [Fact]
+    public void GetSnapshotTransferRanges_ReturnsOnlyPreviousOwnerIntersections()
+    {
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(20, 70),
+            addedRange: RingRange.Create(50, 100),
+            RingRange.Create(50, 70));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(10, 40),
+            addedRange: RingRange.Create(30, 20),
+            RingRange.Create(10, 20),
+            RingRange.Create(30, 40));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Full,
+            addedRange: RingRange.Create(5, 15),
+            RingRange.Create(5, 15));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(5, 15),
+            addedRange: RingRange.Full,
+            RingRange.Create(5, 15));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(10, 20),
+            addedRange: RingRange.Create(30, 40));
+    }
+
+    private static void AssertRanges(RingRange previousOwnerRange, RingRange addedRange, params RingRange[] expected)
+    {
+        var actual = GrainDirectoryPartition.GetSnapshotTransferRanges(previousOwnerRange, addedRange).ToArray();
+
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
## Summary

Stabilizes distributed grain directory ownership transfer so this can be the first merge candidate in the directory PR sequence.

This PR is now limited to the foundational ownership-transfer fixes:

- correct snapshot handoff range selection
- stable ownership checks while partition transfers are in flight

## Details

When a partition acquires a range, that range can span multiple previous owners. The acquiring partition now requests snapshots only for the intersection between the acquired range and each previous owner's actual range, instead of asking any previous owner for unrelated parts of the ring.

Directory register/lookup/deregister operations now wait against a stable ownership view before deciding whether the local partition can serve a request. This avoids stale-membership requests racing with a newer in-flight range transfer and being served by a partition that is no longer the correct owner.

## Changes

- Request snapshot transfer only for the intersection of `previousOwnerRange` and `addedRange`.
- Add targeted coverage for snapshot transfer range intersections.
- Wait for stable current ownership before partition `RegisterAsync`, `LookupAsync`, and `DeregisterAsync` responses.

## Stack notes

- #10050 is rebased on top of this branch and contains the `IRemoteGrainDirectory` compatibility implementation.
- #10053 is stacked above #10050 for large transfer payload batching.
- #10049 is stacked above #10053 for the directory migration join regression.

Focused branch ranges:

- #10047: `main..fix/directory-snapshot-transfer-ranges`
- #10050: `fix/directory-snapshot-transfer-ranges..feature/distributed-remote-grain-directory`
- #10053: `feature/distributed-remote-grain-directory..fix/directory-transfer-payload-batching`
- #10049: `fix/directory-transfer-payload-batching..fix/directory-migration-regression-test`

## Validation

Focused validation run locally:

- `dotnet test test\Orleans.GrainDirectory.Tests\Orleans.GrainDirectory.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~GrainDirectoryPartitionTests" -- -parallel none -noshadow`
- `dotnet test test\Orleans.GrainDirectory.Tests\Orleans.GrainDirectory.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~GrainDirectoryRollingUpgradeTests|FullyQualifiedName~GrainDirectoryPartitionBatchingTests|FullyQualifiedName~GrainDirectoryResilienceTests.JoiningSilo_DoesNotLeaveStaleEntriesOnPreviousOwner" -- -parallel none -noshadow`

`GrainDirectoryResilienceTests.ElasticChaos` was also attempted as part of a broader top-stack run and timed out after several minutes; the narrower non-chaos coverage above passed.