### PR TITLE
Stabilize directory ownership checks

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
@@ -13,26 +13,24 @@ internal sealed partial class GrainDirectoryPartition
         ArgumentNullException.ThrowIfNull(address);
         LogRegisterAsync(version, address, currentRegistration);
 
-        // Ensure that the current membership version is new enough.
-        await WaitForRange(address.GrainId, version);
-        if (!IsOwner(CurrentView, address.GrainId))
+        var currentView = await WaitForOwnershipViewAsync(address.GrainId, version);
+        if (!IsOwner(currentView, address.GrainId))
         {
-            return DirectoryResult.RefreshRequired<GrainAddress>(CurrentView.Version);
+            return DirectoryResult.RefreshRequired<GrainAddress>(currentView.Version);
         }
 
-        DebugAssertOwnership(address.GrainId);
-        return DirectoryResult.FromResult(RegisterCore(address, currentRegistration), version);
+        DebugAssertOwnership(currentView, address.GrainId);
+        return DirectoryResult.FromResult(RegisterCore(address, currentRegistration, currentView.Version), version);
     }
 
     async ValueTask<DirectoryResult<GrainAddress?>> IGrainDirectoryPartition.LookupAsync(MembershipVersion version, GrainId grainId)
     {
         LogLookupAsync(version, grainId);
 
-        // Ensure we can serve the request.
-        await WaitForRange(grainId, version);
-        if (!IsOwner(CurrentView, grainId))
+        var currentView = await WaitForOwnershipViewAsync(grainId, version);
+        if (!IsOwner(currentView, grainId))
         {
-            return DirectoryResult.RefreshRequired<GrainAddress?>(CurrentView.Version);
+            return DirectoryResult.RefreshRequired<GrainAddress?>(currentView.Version);
         }
 
         return DirectoryResult.FromResult(LookupCore(grainId), version);
@@ -43,13 +41,13 @@ internal sealed partial class GrainDirectoryPartition
         ArgumentNullException.ThrowIfNull(address);
         LogDeregisterAsync(version, address);
 
-        await WaitForRange(address.GrainId, version);
-        if (!IsOwner(CurrentView, address.GrainId))
+        var currentView = await WaitForOwnershipViewAsync(address.GrainId, version);
+        if (!IsOwner(currentView, address.GrainId))
         {
-            return DirectoryResult.RefreshRequired<bool>(CurrentView.Version);
+            return DirectoryResult.RefreshRequired<bool>(currentView.Version);
         }
 
-        DebugAssertOwnership(address.GrainId);
+        DebugAssertOwnership(currentView, address.GrainId);
         return DirectoryResult.FromResult(DeregisterCore(address), version);
     }
 
@@ -73,13 +71,29 @@ internal sealed partial class GrainDirectoryPartition
         return null;
     }
 
-    private GrainAddress RegisterCore(GrainAddress newAddress, GrainAddress? existingAddress)
+    private async ValueTask<DirectoryMembershipSnapshot> WaitForOwnershipViewAsync(GrainId grainId, MembershipVersion version)
+    {
+        while (true)
+        {
+            // Requests which arrive with a stale membership version must still wait for any in-flight ownership
+            // transition in the current view before deciding whether this partition can serve them.
+            var currentView = CurrentView;
+            var waitVersion = currentView.Version > version ? currentView.Version : version;
+            await WaitForRange(grainId, waitVersion);
+            if (ReferenceEquals(currentView, CurrentView))
+            {
+                return currentView;
+            }
+        }
+    }
+
+    private GrainAddress RegisterCore(GrainAddress newAddress, GrainAddress? existingAddress, MembershipVersion currentVersion)
     {
         ref var existing = ref CollectionsMarshal.GetValueRefOrAddDefault(_directory, newAddress.GrainId, out _);
 
         if (existing is null || existing.Matches(existingAddress) || IsSiloDead(existing))
         {
-            if (newAddress.MembershipVersion != CurrentView.Version)
+            if (newAddress.MembershipVersion != currentVersion)
             {
                 // Set the membership version to match the view number in which it was registered.
                 newAddress = new()
@@ -87,7 +101,7 @@ internal sealed partial class GrainDirectoryPartition
                     GrainId = newAddress.GrainId,
                     SiloAddress = newAddress.SiloAddress,
                     ActivationId = newAddress.ActivationId,
-                    MembershipVersion = CurrentView.Version
+                    MembershipVersion = currentVersion
                 };
             }
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -326,7 +326,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         Debug.Assert(!addedRange.Intersects(removedRange));
         Debug.Assert(addedRange.IsEmpty || addedRange.Intersects(_currentRange));
         Debug.Assert(!addedRange.Intersects(previousRange));
-        Debug.Assert(previousRange.IsEmpty || _currentRange.IsEmpty || previousRange.Start == _currentRange.Start);
+        Debug.Assert(previousRange.IsEmpty || previousRange.IsFull || _currentRange.IsEmpty || _currentRange.IsFull || previousRange.Start == _currentRange.Start);
 #endif
 
         if (!removedRange.IsEmpty)
@@ -440,7 +440,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                         var previousOwnerRange = previousOwnerRanges[partitionIndex];
                         if (previousOwnerRange.Intersects(addedRange))
                         {
-                            tasks.Add(TransferSnapshotAsync(current, addedRange, previousOwner, partitionIndex, previous.Version));
+                            tasks.Add(TransferSnapshotAsync(current, previousOwnerRange, addedRange, previousOwner, partitionIndex, previous.Version));
                         }
                     }
                 }
@@ -501,22 +501,52 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         }
     }
 
-    private async Task<bool> TransferSnapshotAsync(DirectoryMembershipSnapshot current, RingRange addedRange, SiloAddress previousOwner, int partitionIndex, MembershipVersion previousVersion)
+    private async Task<bool> TransferSnapshotAsync(
+        DirectoryMembershipSnapshot current,
+        RingRange previousOwnerRange,
+        RingRange addedRange,
+        SiloAddress previousOwner,
+        int partitionIndex,
+        MembershipVersion previousVersion)
     {
+        var currentTransferRange = addedRange;
         try
         {
             var stopwatch = ValueStopwatch.StartNew();
-            LogTraceRequestingEntries(_logger, addedRange, previousOwner, previousVersion);
 
             var partition = GetPartitionReference(previousOwner, partitionIndex);
-
-            // Alternatively, the previous owner could push the snapshot. The pull-based approach is used here because it is simpler.
-            var snapshot = await partition.GetSnapshotAsync(current.Version, previousVersion, addedRange).AsTask().WaitAsync(ShutdownToken);
-
-            if (snapshot is null)
+            var waitedForRange = false;
+            foreach (var transferRange in GetSnapshotTransferRanges(previousOwnerRange, addedRange))
             {
-                LogWarningExpectedValidSnapshot(_logger, previousOwner, addedRange);
-                return false;
+                currentTransferRange = transferRange;
+                LogTraceRequestingEntries(_logger, transferRange, previousOwner, previousVersion);
+
+                // Alternatively, the previous owner could push the snapshot. The pull-based approach is used here because it is simpler.
+                var snapshot = await partition.GetSnapshotAsync(current.Version, previousVersion, transferRange).AsTask().WaitAsync(ShutdownToken);
+
+                if (snapshot is null)
+                {
+                    LogWarningExpectedValidSnapshot(_logger, previousOwner, transferRange);
+                    return false;
+                }
+
+                if (!waitedForRange)
+                {
+                    // Wait for previous versions to be unlocked before proceeding.
+                    await WaitForRange(addedRange, previousVersion);
+                    waitedForRange = true;
+                }
+
+                // Incorporate the values into the grain directory.
+                foreach (var entry in snapshot.GrainAddresses)
+                {
+                    DebugAssertOwnership(current, entry.GrainId);
+
+                    LogTraceReceivedEntry(_logger, entry, previousOwner, previousVersion);
+                    _directory[entry.GrainId] = entry;
+                }
+
+                LogDebugTransferredEntries(_logger, snapshot.GrainAddresses.Count, transferRange, previousOwner);
             }
 
             // The acknowledgement step lets the previous owner know that the snapshot has been received so that it can proceed.
@@ -525,20 +555,6 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                 async () => await partition.AcknowledgeSnapshotTransferAsync(_id, _partitionIndex, previousVersion),
                 false,
                 nameof(IGrainDirectoryPartition.AcknowledgeSnapshotTransferAsync)).Ignore();
-
-            // Wait for previous versions to be unlocked before proceeding.
-            await WaitForRange(addedRange, previousVersion);
-
-            // Incorporate the values into the grain directory.
-            foreach (var entry in snapshot.GrainAddresses)
-            {
-                DebugAssertOwnership(current, entry.GrainId);
-
-                LogTraceReceivedEntry(_logger, entry, previousOwner, previousVersion);
-                _directory[entry.GrainId] = entry;
-            }
-
-            LogDebugTransferredEntries(_logger, snapshot.GrainAddresses.Count, addedRange, previousOwner);
 
             DirectoryInstruments.SnapshotTransferCount.Add(1);
             DirectoryInstruments.SnapshotTransferDuration.Record((long)stopwatch.Elapsed.TotalMilliseconds);
@@ -549,11 +565,11 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         {
             if (exception is SiloUnavailableException)
             {
-                LogWarningRemoteHostUnavailable(_logger, addedRange);
+                LogWarningRemoteHostUnavailable(_logger, currentTransferRange);
             }
             else
             {
-                LogWarningErrorTransferringOwnership(_logger, exception, addedRange);
+                LogWarningErrorTransferringOwnership(_logger, exception, currentTransferRange);
             }
 
             return false;
@@ -638,6 +654,11 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
             return result.Value;
         }
+    }
+
+    internal static IEnumerable<RingRange> GetSnapshotTransferRanges(RingRange previousOwnerRange, RingRange addedRange)
+    {
+        return previousOwnerRange.Intersections(addedRange);
     }
 
     private async Task<T> InvokeOnClusterMember<T>(SiloAddress siloAddress, Func<Task<T>> func, T defaultValue, string operationName)
@@ -841,13 +862,13 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
     [LoggerMessage(
         Level = LogLevel.Trace,
-        Message = "Requesting entries for ranges '{Range}' from '{PreviousOwner}' at version '{PreviousVersion}'."
+        Message = "Requesting entries for range '{Range}' from '{PreviousOwner}' at version '{PreviousVersion}'."
     )]
     private static partial void LogTraceRequestingEntries(ILogger logger, RingRange range, SiloAddress previousOwner, MembershipVersion previousVersion);
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "Expected a valid snapshot from previous owner '{PreviousOwner}' for part of ranges '{Range}', but found none."
+        Message = "Expected a valid snapshot from previous owner '{PreviousOwner}' for range '{Range}', but found none."
     )]
     private static partial void LogWarningExpectedValidSnapshot(ILogger logger, SiloAddress previousOwner, RingRange range);
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -20,6 +20,9 @@ namespace Orleans.Runtime.GrainDirectory;
 /// </summary>
 internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDirectoryPartition, IGrainDirectoryTestHooks
 {
+    private const float MaxActivationQueryRangePercent = 5f;
+    private const int MaxActivationQueryRangeCount = 32;
+
     internal static SystemTargetGrainId CreateGrainId(SiloAddress siloAddress, int partitionIndex) => SystemTargetGrainId.Create(Constants.GrainDirectoryPartitionType, siloAddress, partitionIndex.ToString(CultureInfo.InvariantCulture));
     private readonly Dictionary<GrainId, GrainAddress> _directory = [];
     private readonly int _partitionIndex;
@@ -515,18 +518,29 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
             var stopwatch = ValueStopwatch.StartNew();
 
             var partition = GetPartitionReference(previousOwner, partitionIndex);
+            var transferredEntries = 0;
             var waitedForRange = false;
-            foreach (var transferRange in GetSnapshotTransferRanges(previousOwnerRange, addedRange))
+            var previousTransferRange = RingRange.Empty;
+            foreach (var (transferRange, queryRange) in GetSnapshotTransferQueryRanges(previousOwnerRange, addedRange))
             {
-                currentTransferRange = transferRange;
-                LogTraceRequestingEntries(_logger, transferRange, previousOwner, previousVersion);
+                if (transferRange != previousTransferRange)
+                {
+                    if (!previousTransferRange.IsEmpty)
+                    {
+                        LogDebugTransferredEntries(_logger, transferredEntries, previousTransferRange, previousOwner);
+                        transferredEntries = 0;
+                    }
+
+                    currentTransferRange = previousTransferRange = transferRange;
+                    LogTraceRequestingEntries(_logger, transferRange, previousOwner, previousVersion);
+                }
 
                 // Alternatively, the previous owner could push the snapshot. The pull-based approach is used here because it is simpler.
-                var snapshot = await partition.GetSnapshotAsync(current.Version, previousVersion, transferRange).AsTask().WaitAsync(ShutdownToken);
+                var snapshot = await partition.GetSnapshotAsync(current.Version, previousVersion, queryRange).AsTask().WaitAsync(ShutdownToken);
 
                 if (snapshot is null)
                 {
-                    LogWarningExpectedValidSnapshot(_logger, previousOwner, transferRange);
+                    LogWarningExpectedValidSnapshot(_logger, previousOwner, queryRange);
                     return false;
                 }
 
@@ -546,7 +560,12 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                     _directory[entry.GrainId] = entry;
                 }
 
-                LogDebugTransferredEntries(_logger, snapshot.GrainAddresses.Count, transferRange, previousOwner);
+                transferredEntries += snapshot.GrainAddresses.Count;
+            }
+
+            if (!previousTransferRange.IsEmpty)
+            {
+                LogDebugTransferredEntries(_logger, transferredEntries, previousTransferRange, previousOwner);
             }
 
             // The acknowledgement step lets the previous owner know that the snapshot has been received so that it can proceed.
@@ -604,26 +623,29 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         var clusterMembershipSnapshot = _owner.ClusterMembershipSnapshot;
         Debug.Assert(clusterMembershipSnapshot.Version >= current.Version);
 
-        var tasks = new List<Task<List<GrainAddress>>>();
-        foreach (var member in clusterMembershipSnapshot.Members.Values)
+        foreach (var queryRange in GetActivationQueryRanges(range))
         {
-            if (member.Status is not (SiloStatus.Active or SiloStatus.Joining or SiloStatus.ShuttingDown))
+            var tasks = new List<Task<List<GrainAddress>>>();
+            foreach (var member in clusterMembershipSnapshot.Members.Values)
             {
-                continue;
+                if (member.Status is not (SiloStatus.Active or SiloStatus.Joining or SiloStatus.ShuttingDown))
+                {
+                    continue;
+                }
+
+                tasks.Add(GetRegisteredActivationsFromClusterMember(current.Version, queryRange, member.SiloAddress, isValidation));
             }
 
-            tasks.Add(GetRegisteredActivationsFromClusterMember(current.Version, range, member.SiloAddress, isValidation));
-        }
+            await Task.WhenAll(tasks).WaitAsync(ShutdownToken).SuppressThrowing();
+            if (ShutdownToken.IsCancellationRequested)
+            {
+                yield break;
+            }
 
-        await Task.WhenAll(tasks).WaitAsync(ShutdownToken).SuppressThrowing();
-        if (ShutdownToken.IsCancellationRequested)
-        {
-            yield break;
-        }
-
-        foreach (var task in tasks)
-        {
-            yield return await task;
+            foreach (var task in tasks)
+            {
+                yield return await task;
+            }
         }
 
         async Task<List<GrainAddress>> GetRegisteredActivationsFromClusterMember(MembershipVersion version, RingRange range, SiloAddress siloAddress, bool isValidation)
@@ -659,6 +681,67 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
     internal static IEnumerable<RingRange> GetSnapshotTransferRanges(RingRange previousOwnerRange, RingRange addedRange)
     {
         return previousOwnerRange.Intersections(addedRange);
+    }
+
+    // Directory recovery and validation can temporarily involve very large ranges.
+    // Split those requests so the returned GrainAddress list stays comfortably under MaxMessageBodySize.
+    internal static IEnumerable<(RingRange TransferRange, RingRange QueryRange)> GetSnapshotTransferQueryRanges(RingRange previousOwnerRange, RingRange addedRange)
+    {
+        foreach (var transferRange in GetSnapshotTransferRanges(previousOwnerRange, addedRange))
+        {
+            foreach (var queryRange in GetActivationQueryRanges(transferRange))
+            {
+                yield return (transferRange, queryRange);
+            }
+        }
+    }
+
+    internal static IEnumerable<RingRange> GetActivationQueryRanges(RingRange range)
+    {
+        if (range.IsEmpty)
+        {
+            yield break;
+        }
+
+        var queryRangeCount = Math.Clamp(
+            (int)Math.Ceiling(range.SizePercent / MaxActivationQueryRangePercent),
+            1,
+            MaxActivationQueryRangeCount);
+        if (queryRangeCount == 1)
+        {
+            yield return range;
+            yield break;
+        }
+
+        var totalSize = GetRangeCoverageSize(range);
+        queryRangeCount = (int)Math.Min((ulong)queryRangeCount, totalSize);
+        if (queryRangeCount == 1)
+        {
+            yield return range;
+            yield break;
+        }
+
+        var (baseSize, remainder) = Math.DivRem(totalSize, (ulong)queryRangeCount);
+        var start = range.Start;
+        for (var i = 0; i < queryRangeCount; i++)
+        {
+            var size = baseSize + ((ulong)i < remainder ? 1UL : 0UL);
+            var end = unchecked((uint)((ulong)start + size));
+            yield return RingRange.Create(start, end);
+            start = end;
+        }
+
+        static ulong GetRangeCoverageSize(RingRange range)
+        {
+            if (range.IsFull)
+            {
+                return (ulong)uint.MaxValue + 1;
+            }
+
+            return range.IsWrapped
+                ? (ulong)uint.MaxValue - range.Start + range.End + 1
+                : range.Size;
+        }
     }
 
     private async Task<T> InvokeOnClusterMember<T>(SiloAddress siloAddress, Func<Task<T>> func, T defaultValue, string operationName)

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionBatchingTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionBatchingTests.cs
@@ -1,0 +1,97 @@
+#nullable enable
+using System.Linq;
+using Orleans.Runtime.GrainDirectory;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.GrainDirectory;
+
+[TestCategory("BVT"), TestCategory("Directory")]
+public sealed class GrainDirectoryPartitionBatchingTests
+{
+    [Fact]
+    public void GetActivationQueryRanges_ReturnsNoRangesForEmptyRange()
+    {
+        var ranges = GrainDirectoryPartition.GetActivationQueryRanges(RingRange.Empty).ToArray();
+
+        Assert.Empty(ranges);
+    }
+
+    [Fact]
+    public void GetActivationQueryRanges_ReturnsOriginalRangeForSmallRange()
+    {
+        var range = RingRange.Create(100, 200);
+
+        var ranges = GrainDirectoryPartition.GetActivationQueryRanges(range).ToArray();
+
+        var result = Assert.Single(ranges);
+        Assert.Equal(range, result);
+    }
+
+    [Fact]
+    public void GetActivationQueryRanges_SplitsLargeRangeIntoContiguousBalancedRanges()
+    {
+        var range = RingRange.Create(0x1000, 0x30001000);
+
+        var ranges = GrainDirectoryPartition.GetActivationQueryRanges(range).ToArray();
+
+        Assert.True(ranges.Length > 1);
+        AssertRangePartition(range, ranges);
+        AssertBalancedRanges(ranges);
+    }
+
+    [Fact]
+    public void GetActivationQueryRanges_SplitsWrappedRangeIntoContiguousBalancedRanges()
+    {
+        var range = RingRange.Create(0xD0000000, 0x20000000);
+
+        var ranges = GrainDirectoryPartition.GetActivationQueryRanges(range).ToArray();
+
+        Assert.True(ranges.Length > 1);
+        AssertRangePartition(range, ranges);
+        AssertBalancedRanges(ranges);
+    }
+
+    [Fact]
+    public void GetActivationQueryRanges_SplitsFullRangeAcrossEntireRing()
+    {
+        var ranges = GrainDirectoryPartition.GetActivationQueryRanges(RingRange.Full).ToArray();
+
+        Assert.True(ranges.Length > 1);
+        AssertRangePartition(RingRange.Full, ranges);
+        AssertBalancedRanges(ranges);
+    }
+
+    private static void AssertRangePartition(RingRange range, RingRange[] ranges)
+    {
+        Assert.NotEmpty(ranges);
+        Assert.All(ranges, static candidate => Assert.False(candidate.IsEmpty));
+        Assert.Equal(range.Start, ranges[0].Start);
+        Assert.Equal(range.End, ranges[^1].End);
+        Assert.Equal(GetRangeSize(range), ranges.Aggregate(0UL, static (sum, range) => sum + GetRangeSize(range)));
+
+        for (var i = 1; i < ranges.Length; i++)
+        {
+            Assert.Equal(ranges[i - 1].End, ranges[i].Start);
+        }
+    }
+
+    private static void AssertBalancedRanges(RingRange[] ranges)
+    {
+        var sizes = ranges.Select(GetRangeSize).ToArray();
+
+        Assert.True(sizes.Max() - sizes.Min() <= 1);
+    }
+
+    private static ulong GetRangeSize(RingRange range)
+    {
+        if (range.IsFull)
+        {
+            return (ulong)uint.MaxValue + 1;
+        }
+
+        return range.IsWrapped
+            ? (ulong)uint.MaxValue - range.Start + range.End + 1
+            : range.Size;
+    }
+}

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
@@ -1,0 +1,47 @@
+#nullable enable
+using System.Linq;
+using Orleans.Runtime.GrainDirectory;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.GrainDirectory;
+
+[TestCategory("BVT"), TestCategory("Directory")]
+public sealed class GrainDirectoryPartitionTests
+{
+    [Fact]
+    public void GetSnapshotTransferRanges_ReturnsOnlyPreviousOwnerIntersections()
+    {
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(20, 70),
+            addedRange: RingRange.Create(50, 100),
+            RingRange.Create(50, 70));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(10, 40),
+            addedRange: RingRange.Create(30, 20),
+            RingRange.Create(10, 20),
+            RingRange.Create(30, 40));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Full,
+            addedRange: RingRange.Create(5, 15),
+            RingRange.Create(5, 15));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(5, 15),
+            addedRange: RingRange.Full,
+            RingRange.Create(5, 15));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(10, 20),
+            addedRange: RingRange.Create(30, 40));
+    }
+
+    private static void AssertRanges(RingRange previousOwnerRange, RingRange addedRange, params RingRange[] expected)
+    {
+        var actual = GrainDirectoryPartition.GetSnapshotTransferRanges(previousOwnerRange, addedRange).ToArray();
+
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
Stack 2/3, based on: https://github.com/dotnet/orleans/pull/10047

This waits for a stable directory ownership view before serving register, lookup, and deregister operations, then stamps registrations with the captured membership version used for ownership validation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10048)