### PR TITLE
Add distributed remote grain directory compatibility

### DIFF
--- a/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs
@@ -47,6 +47,19 @@ namespace Orleans.Configuration
         public const int DEFAULT_CACHE_SIZE = 1_000_000;
 
         /// <summary>
+        /// Gets or sets the number of directory partitions per silo.
+        /// </summary>
+        /// <remarks>
+        /// This option only applies when using the <see cref="DistributedGrainDirectory"/>.
+        /// </remarks>
+        public int PartitionsPerSilo { get; set; } = DEFAULT_PARTITIONS_PER_SILO;
+
+        /// <summary>
+        /// The default value for <see cref="PartitionsPerSilo"/>.
+        /// </summary>
+        public const int DEFAULT_PARTITIONS_PER_SILO = ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS;
+
+        /// <summary>
         /// Gets or sets the initial (minimum) time, in seconds, to keep a cache entry before revalidating.
         /// </summary>
         [Obsolete("InitialCacheTTL is deprecated and will be removed in a future version.")]

--- a/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs
@@ -57,7 +57,7 @@ namespace Orleans.Configuration
         /// <summary>
         /// The default value for <see cref="PartitionsPerSilo"/>.
         /// </summary>
-        public const int DEFAULT_PARTITIONS_PER_SILO = ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS;
+        public const int DEFAULT_PARTITIONS_PER_SILO = 1;
 
         /// <summary>
         /// Gets or sets the initial (minimum) time, in seconds, to keep a cache entry before revalidating.

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
@@ -17,8 +17,12 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
     private readonly CancellationTokenSource _shutdownCts = new();
     private readonly Task _runTask;
     private readonly AsyncEnumerable<DirectoryMembershipSnapshot> _viewUpdates;
+    private readonly int _partitionsPerSilo;
+    private readonly Func<SiloAddress, int, uint[]> _getRingBoundaries;
 
     public DirectoryMembershipSnapshot CurrentView { get; private set; } = DirectoryMembershipSnapshot.Default;
+
+    public int PartitionsPerSilo => _partitionsPerSilo;
 
     public IAsyncEnumerable<DirectoryMembershipSnapshot> ViewUpdates => _viewUpdates;
 
@@ -41,8 +45,15 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
         return CurrentView;
     }
 
-    public DirectoryMembershipService(ClusterMembershipService clusterMembershipService, IInternalGrainFactory grainFactory, ILogger<DirectoryMembershipService> logger)
+    public DirectoryMembershipService(
+        ClusterMembershipService clusterMembershipService,
+        IInternalGrainFactory grainFactory,
+        ILogger<DirectoryMembershipService> logger,
+        int partitionsPerSilo = 1,
+        Func<SiloAddress, int, uint[]>? getRingBoundaries = null)
     {
+        _partitionsPerSilo = partitionsPerSilo;
+        _getRingBoundaries = getRingBoundaries ?? DirectoryMembershipSnapshot.DefaultGetRingBoundaries;
         _viewUpdates = new(
             DirectoryMembershipSnapshot.Default,
             (previous, proposed) => proposed.Version >= previous.Version,
@@ -64,7 +75,7 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
                 {
                     await foreach (var update in ClusterMembershipService.MembershipUpdates.WithCancellation(_shutdownCts.Token))
                     {
-                        var view = new DirectoryMembershipSnapshot(update, _grainFactory);
+                        var view = new DirectoryMembershipSnapshot(update, _grainFactory, _partitionsPerSilo, _getRingBoundaries);
                         _viewUpdates.Publish(view);
                     }
                 }

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
@@ -49,11 +49,11 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
         ClusterMembershipService clusterMembershipService,
         IInternalGrainFactory grainFactory,
         ILogger<DirectoryMembershipService> logger,
-        int partitionsPerSilo = 1,
-        Func<SiloAddress, int, uint[]>? getRingBoundaries = null)
+        int partitionsPerSilo,
+        Func<SiloAddress, int, uint[]> getRingBoundaries)
     {
         _partitionsPerSilo = partitionsPerSilo;
-        _getRingBoundaries = getRingBoundaries ?? DirectoryMembershipSnapshot.DefaultGetRingBoundaries;
+        _getRingBoundaries = getRingBoundaries;
         _viewUpdates = new(
             DirectoryMembershipSnapshot.Default,
             (previous, proposed) => proposed.Version >= previous.Version,

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipService.cs
@@ -52,6 +52,7 @@ internal sealed partial class DirectoryMembershipService : IAsyncDisposable
         int partitionsPerSilo,
         Func<SiloAddress, int, uint[]> getRingBoundaries)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(partitionsPerSilo, 1);
         _partitionsPerSilo = partitionsPerSilo;
         _getRingBoundaries = getRingBoundaries;
         _viewUpdates = new(

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
@@ -8,25 +8,37 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
-using Orleans.Configuration;
 using Orleans.Runtime.Utilities;
 
 namespace Orleans.Runtime.GrainDirectory;
 
 internal sealed class DirectoryMembershipSnapshot
 {
-    internal const int PartitionsPerSilo = ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS;
+    /// <summary>
+    /// The default hash function for directory ring boundaries, matching the <see cref="LocalGrainDirectory"/> partitioning scheme.
+    /// </summary>
+    internal static readonly Func<SiloAddress, int, uint[]> DefaultGetRingBoundaries = static (silo, count) =>
+    {
+        if (count == 1)
+        {
+            return [unchecked((uint)silo.GetConsistentHashCode())];
+        }
+
+        return silo.GetUniformHashCodes(count);
+    };
+
     private readonly ImmutableArray<(uint Start, int MemberIndex, int PartitionIndex)> _ringBoundaries;
     private readonly RingRangeCollection[] _rangesByMember;
     private readonly ImmutableArray<ImmutableArray<IGrainDirectoryPartition>> _partitionsByMember;
     private readonly ImmutableArray<ImmutableArray<RingRange>> _rangesByMemberPartition;
 
-    public DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory) : this(snapshot, grainFactory, static (silo, count) => silo.GetUniformHashCodes(count))
+    public DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory, int partitionsPerSilo = 1) : this(snapshot, grainFactory, partitionsPerSilo, DefaultGetRingBoundaries)
     {
     }
 
-    internal DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory, Func<SiloAddress, int, uint[]> getRingBoundaries)
+    internal DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory, int partitionsPerSilo, Func<SiloAddress, int, uint[]> getRingBoundaries)
     {
+        PartitionsPerSilo = partitionsPerSilo;
         var sortedActiveMembers = ImmutableArray.CreateBuilder<SiloAddress>(snapshot.Members.Count(static m => m.Value.Status == SiloStatus.Active));
         foreach (var member in snapshot.Members)
         {
@@ -38,15 +50,15 @@ internal sealed class DirectoryMembershipSnapshot
         }
 
         sortedActiveMembers.Sort(static (left, right) => left.CompareTo(right));
-        var hashIndexPairs = ImmutableArray.CreateBuilder<(uint Hash, int MemberIndex, int PartitionIndex)>(PartitionsPerSilo * sortedActiveMembers.Count);
+        var hashIndexPairs = ImmutableArray.CreateBuilder<(uint Hash, int MemberIndex, int PartitionIndex)>(partitionsPerSilo * sortedActiveMembers.Count);
         var memberPartitions = ImmutableArray.CreateBuilder<ImmutableArray<IGrainDirectoryPartition>>();
         for (var memberIndex = 0; memberIndex < sortedActiveMembers.Count; memberIndex++)
         {
             var activeMember = sortedActiveMembers[memberIndex];
-            var hashCodes = getRingBoundaries(activeMember, PartitionsPerSilo).ToList();
+            var hashCodes = getRingBoundaries(activeMember, partitionsPerSilo).ToList();
             hashCodes.Sort();
-            Debug.Assert(hashCodes.Count == PartitionsPerSilo);
-            var partitionReferences = ImmutableArray.CreateBuilder<IGrainDirectoryPartition>(PartitionsPerSilo);
+            Debug.Assert(hashCodes.Count == partitionsPerSilo);
+            var partitionReferences = ImmutableArray.CreateBuilder<IGrainDirectoryPartition>(partitionsPerSilo);
             for (var partitionIndex = 0; partitionIndex < hashCodes.Count; partitionIndex++)
             {
                 var hashCode = hashCodes[partitionIndex];
@@ -81,7 +93,7 @@ internal sealed class DirectoryMembershipSnapshot
         {
             var (_, memberIndex, _) = hashIndexPairs[i];
             ref var builder = ref CollectionsMarshal.GetValueRefOrAddDefault(rangesByMemberPartitionBuilders, memberIndex, out _);
-            builder ??= ImmutableArray.CreateBuilder<RingRange>(PartitionsPerSilo);
+            builder ??= ImmutableArray.CreateBuilder<RingRange>(partitionsPerSilo);
             var (entryStart, _, _) = hashIndexPairs[i];
             var (nextStart, _, _) = hashIndexPairs[(i + 1) % hashIndexPairs.Count];
             var range = (entryStart == nextStart) switch
@@ -126,9 +138,14 @@ internal sealed class DirectoryMembershipSnapshot
     }
 
     public static DirectoryMembershipSnapshot Default { get; } = new DirectoryMembershipSnapshot(
-        new ClusterMembershipSnapshot(ImmutableDictionary<SiloAddress, ClusterMember>.Empty, MembershipVersion.MinValue), null!);
+        new ClusterMembershipSnapshot(ImmutableDictionary<SiloAddress, ClusterMember>.Empty, MembershipVersion.MinValue), null!, partitionsPerSilo: 1);
 
     public MembershipVersion Version => ClusterMembershipSnapshot.Version;
+
+    /// <summary>
+    /// The number of directory partitions per silo in this snapshot.
+    /// </summary>
+    public int PartitionsPerSilo { get; }
 
     public ImmutableArray<SiloAddress> Members { get; }
 

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
@@ -14,7 +14,7 @@ namespace Orleans.Runtime.GrainDirectory;
 
 internal sealed class DirectoryMembershipSnapshot
 {
-    internal const int PartitionsPerSilo = ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS;
+    internal const int PartitionsPerSilo = GrainDirectoryOptions.DEFAULT_PARTITIONS_PER_SILO;
 
     /// <summary>
     /// The default hash function for directory ring boundaries, matching the <see cref="LocalGrainDirectory"/> partitioning scheme.

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
@@ -7,15 +7,12 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
-using Orleans.Configuration;
 using Orleans.Runtime.Utilities;
 
 namespace Orleans.Runtime.GrainDirectory;
 
 internal sealed class DirectoryMembershipSnapshot
 {
-    internal const int PartitionsPerSilo = GrainDirectoryOptions.DEFAULT_PARTITIONS_PER_SILO;
-
     /// <summary>
     /// The default hash function for directory ring boundaries, matching the <see cref="LocalGrainDirectory"/> partitioning scheme.
     /// </summary>
@@ -33,16 +30,6 @@ internal sealed class DirectoryMembershipSnapshot
     private readonly RingRangeCollection[] _rangesByMember;
     private readonly ImmutableArray<ImmutableArray<IGrainDirectoryPartition>> _partitionsByMember;
     private readonly ImmutableArray<ImmutableArray<RingRange>> _rangesByMemberPartition;
-
-    public DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory)
-        : this(snapshot, grainFactory, PartitionsPerSilo, DefaultGetRingBoundaries)
-    {
-    }
-
-    internal DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory, Func<SiloAddress, int, uint[]> getRingBoundaries)
-        : this(snapshot, grainFactory, PartitionsPerSilo, getRingBoundaries)
-    {
-    }
 
     internal DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory, int partitionCount, Func<SiloAddress, int, uint[]> getRingBoundaries)
     {
@@ -159,7 +146,10 @@ internal sealed class DirectoryMembershipSnapshot
     public RingRange GetRange(SiloAddress address, int partitionIndex)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(partitionIndex, 0);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(partitionIndex, PartitionCount - 1);
+        if (partitionIndex >= PartitionCount)
+        {
+            return RingRange.Empty;
+        }
 
         var memberIndex = TryGetMemberIndex(address);
         if (memberIndex < 0)

--- a/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DirectoryMembershipSnapshot.cs
@@ -15,13 +15,27 @@ namespace Orleans.Runtime.GrainDirectory;
 internal sealed class DirectoryMembershipSnapshot
 {
     internal const int PartitionsPerSilo = ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS;
+
+    /// <summary>
+    /// The default hash function for directory ring boundaries, matching the <see cref="LocalGrainDirectory"/> partitioning scheme.
+    /// </summary>
+    internal static readonly Func<SiloAddress, int, uint[]> DefaultGetRingBoundaries = static (silo, count) =>
+    {
+        if (count == 1)
+        {
+            return [unchecked((uint)silo.GetConsistentHashCode())];
+        }
+
+        return silo.GetUniformHashCodes(count);
+    };
+
     private readonly ImmutableArray<(uint Start, int MemberIndex, int PartitionIndex)> _ringBoundaries;
     private readonly RingRangeCollection[] _rangesByMember;
     private readonly ImmutableArray<ImmutableArray<IGrainDirectoryPartition>> _partitionsByMember;
     private readonly ImmutableArray<ImmutableArray<RingRange>> _rangesByMemberPartition;
 
     public DirectoryMembershipSnapshot(ClusterMembershipSnapshot snapshot, IInternalGrainFactory grainFactory)
-        : this(snapshot, grainFactory, PartitionsPerSilo, static (silo, count) => silo.GetUniformHashCodes(count))
+        : this(snapshot, grainFactory, PartitionsPerSilo, DefaultGetRingBoundaries)
     {
     }
 
@@ -134,7 +148,7 @@ internal sealed class DirectoryMembershipSnapshot
     }
 
     public static DirectoryMembershipSnapshot Default { get; } = new DirectoryMembershipSnapshot(
-        new ClusterMembershipSnapshot(ImmutableDictionary<SiloAddress, ClusterMember>.Empty, MembershipVersion.MinValue), null!);
+        new ClusterMembershipSnapshot(ImmutableDictionary<SiloAddress, ClusterMember>.Empty, MembershipVersion.MinValue), null!, partitionCount: 1, DefaultGetRingBoundaries);
 
     public MembershipVersion Version => ClusterMembershipSnapshot.Version;
 

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -90,14 +90,19 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         _serviceProvider = serviceProvider;
         _membershipService = membershipService;
         _logger = logger;
-        var partitions = ImmutableArray.CreateBuilder<GrainDirectoryPartition>(DirectoryMembershipSnapshot.PartitionsPerSilo);
-        for (var i = 0; i < DirectoryMembershipSnapshot.PartitionsPerSilo; i++)
+        var partitionsPerSilo = membershipService.PartitionsPerSilo;
+        var partitions = ImmutableArray.CreateBuilder<GrainDirectoryPartition>(partitionsPerSilo);
+        for (var i = 0; i < partitionsPerSilo; i++)
         {
             partitions.Add(new GrainDirectoryPartition(i, this, grainFactory, shared));
         }
 
         _partitions = partitions.ToImmutable();
         shared.ActivationDirectory.RecordNewTarget(this);
+
+        // Register IRemoteGrainDirectory system targets so that silos running LocalGrainDirectory
+        // can forward directory requests to this silo during a rolling upgrade.
+        DistributedRemoteGrainDirectory.Create(this, shared);
     }
 
     public async Task<GrainAddress?> Lookup(GrainId grainId) => await InvokeAsync(

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -103,20 +103,12 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
 
         // Register IRemoteGrainDirectory system targets so that silos running LocalGrainDirectory
         // can forward directory requests to this silo during a rolling upgrade.
-        DistributedRemoteGrainDirectory.Create(this, shared);
+        DistributedRemoteGrainDirectory.Create(this, membershipService, shared);
     }
 
-    public async Task<GrainAddress?> Lookup(GrainId grainId) => await InvokeAsync(
-        grainId,
-        static (partition, version, grainId, cancellationToken) => partition.LookupAsync(version, grainId),
-        grainId,
-        CancellationToken.None);
+    public async Task<GrainAddress?> Lookup(GrainId grainId) => await LookupAsync(grainId, CancellationToken.None);
 
-    public async Task<GrainAddress?> Register(GrainAddress address) => await InvokeAsync(
-        address.GrainId,
-        static (partition, version, address, cancellationToken) => partition.RegisterAsync(version, address, null),
-        address,
-        CancellationToken.None);
+    public async Task<GrainAddress?> Register(GrainAddress address) => await RegisterAsync(address, null, CancellationToken.None);
 
     public async Task Unregister(GrainAddress address) => await InvokeAsync(
         address.GrainId,
@@ -124,13 +116,27 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         address,
         CancellationToken.None);
 
-    public async Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress) => await InvokeAsync(
+    public async Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress) => await RegisterAsync(address, previousAddress, CancellationToken.None);
+
+    public Task UnregisterSilos(List<SiloAddress> siloAddresses) => Task.CompletedTask;
+
+    internal Task<GrainAddress?> LookupAsync(GrainId grainId, CancellationToken cancellationToken) => InvokeAsync(
+        grainId,
+        static (partition, version, grainId, cancellationToken) => partition.LookupAsync(version, grainId),
+        grainId,
+        cancellationToken);
+
+    internal async Task<GrainAddress?> RegisterAsync(GrainAddress address, GrainAddress? previousAddress, CancellationToken cancellationToken) => await InvokeAsync(
         address.GrainId,
         static (partition, version, state, cancellationToken) => partition.RegisterAsync(version, state.Address, state.PreviousAddress),
         (Address: address, PreviousAddress: previousAddress),
-        CancellationToken.None);
+        cancellationToken);
 
-    public Task UnregisterSilos(List<SiloAddress> siloAddresses) => Task.CompletedTask;
+    internal Task UnregisterAsync(GrainAddress address, CancellationToken cancellationToken) => InvokeAsync(
+        address.GrainId,
+        static (partition, version, address, cancellationToken) => partition.DeregisterAsync(version, address),
+        address,
+        cancellationToken);
 
     private async Task<TResult> InvokeAsync<TState, TResult>(
         GrainId grainId,

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -91,14 +91,19 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         _serviceProvider = serviceProvider;
         _membershipService = membershipService;
         _logger = logger;
-        var partitions = ImmutableArray.CreateBuilder<GrainDirectoryPartition>(DirectoryMembershipSnapshot.PartitionsPerSilo);
-        for (var i = 0; i < DirectoryMembershipSnapshot.PartitionsPerSilo; i++)
+        var partitionsPerSilo = membershipService.PartitionsPerSilo;
+        var partitions = ImmutableArray.CreateBuilder<GrainDirectoryPartition>(partitionsPerSilo);
+        for (var i = 0; i < partitionsPerSilo; i++)
         {
             partitions.Add(new GrainDirectoryPartition(i, this, grainFactory, shared));
         }
 
         _partitions = partitions.ToImmutable();
         shared.ActivationDirectory.RecordNewTarget(this);
+
+        // Register IRemoteGrainDirectory system targets so that silos running LocalGrainDirectory
+        // can forward directory requests to this silo during a rolling upgrade.
+        DistributedRemoteGrainDirectory.Create(this, shared);
     }
 
     public async Task<GrainAddress?> Lookup(GrainId grainId) => await InvokeAsync(

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -355,7 +355,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
                         {
                             foreach (var partition in _partitions)
                             {
-                                tasks.Add(partition.OnSiloRemovedFromClusterAsync(change));
+                                tasks.Add(ObserveMembershipUpdateTask(partition.OnSiloRemovedFromClusterAsync(change)));
                             }
                         }
                     }
@@ -365,7 +365,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
 
                     foreach (var partition in _partitions)
                     {
-                        tasks.Add(partition.ProcessMembershipUpdateAsync(current));
+                        tasks.Add(ObserveMembershipUpdateTask(partition.ProcessMembershipUpdateAsync(current)));
                     }
 
                     var deltaSize = currentRanges.SizePercent - previousRanges.SizePercent;
@@ -388,6 +388,18 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         }
 
         await Task.WhenAll(tasks).SuppressThrowing();
+    }
+
+    private async Task ObserveMembershipUpdateTask(Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch (Exception exception) when (!_stoppedCts.IsCancellationRequested)
+        {
+            LogErrorProcessingMembershipUpdates(exception);
+        }
     }
 
     SiloAddress? ITestHooks.GetPrimaryForGrain(GrainId grainId)

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -272,24 +272,24 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         }
 
         return new(result.AsImmutable());
+    }
 
-        static IGrainDirectory? GetGrainDirectory(IGrainContext grainContext, GrainDirectoryResolver grainDirectoryResolver)
+    internal static IGrainDirectory? GetGrainDirectory(IGrainContext grainContext, GrainDirectoryResolver grainDirectoryResolver)
+    {
+        if (grainContext is ActivationData activationData)
         {
-            if (grainContext is ActivationData activationData)
-            {
-                return activationData.Shared.GrainDirectory;
-            }
-            else if (grainContext is SystemTarget systemTarget)
-            {
-                return null;
-            }
-            else if (grainContext.GetComponent<PlacementStrategy>() is { IsUsingGrainDirectory: true })
-            {
-                return grainDirectoryResolver.Resolve(grainContext.GrainId.Type);
-            }
-
+            return activationData.Shared.GrainDirectory;
+        }
+        else if (grainContext is SystemTarget)
+        {
             return null;
         }
+        else if (grainContext.GetComponent<PlacementStrategy>() is { IsUsingGrainDirectory: true })
+        {
+            return grainDirectoryResolver.Resolve(grainContext.GrainId.Type);
+        }
+
+        return null;
     }
 
     internal ValueTask<DirectoryMembershipSnapshot> RefreshViewAsync(MembershipVersion version, CancellationToken cancellationToken) => _membershipService.RefreshViewAsync(version, cancellationToken);

--- a/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
@@ -271,12 +271,27 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
     {
         using var cts = CreateTimeoutCts();
         await EnsureDirectoryInitializedAsync(cts.Token);
-        await _directory.UnregisterAsync(address, cts.Token);
+        await UnregisterAsync(address, cause, cts.Token);
     }
 
     public async Task UnregisterManyAsync(List<GrainAddress> addresses, UnregistrationCause cause, int hopCount)
     {
-        await RunBatchOperationAsync(addresses, (address, cancellationToken) => _directory.UnregisterAsync(address, cancellationToken));
+        await RunBatchOperationAsync(addresses, (address, cancellationToken) => UnregisterAsync(address, cause, cancellationToken));
+    }
+
+    private Task UnregisterAsync(GrainAddress address, UnregistrationCause cause, CancellationToken cancellationToken)
+    {
+        switch (cause)
+        {
+            case UnregistrationCause.Force:
+                return _directory.UnregisterAsync(address, cancellationToken);
+            case UnregistrationCause.NonexistentActivation:
+                // LocalGrainDirectory only removes these entries after LazyDeregistrationDelay.
+                // This compatibility path does not track entry age, so preserve the conditional semantics by not force-removing the entry.
+                return Task.CompletedTask;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(cause), cause, $"Deregistration cause {cause} is unknown and is not supported. This is a bug.");
+        }
     }
 
     public async Task DeleteGrainAsync(GrainId grainId, int hopCount)

--- a/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans.GrainDirectory;
+
+#nullable enable
+namespace Orleans.Runtime.GrainDirectory;
+
+/// <summary>
+/// A system target that implements <see cref="IRemoteGrainDirectory"/> by delegating to <see cref="DistributedGrainDirectory"/>.
+/// This enables silos running the old <see cref="LocalGrainDirectory"/> to forward directory requests to silos running the
+/// new <see cref="DistributedGrainDirectory"/> during a rolling upgrade.
+/// </summary>
+internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGrainDirectory
+{
+    private readonly DistributedGrainDirectory _directory;
+
+    private DistributedRemoteGrainDirectory(
+        DistributedGrainDirectory directory,
+        GrainType grainType,
+        SystemTargetShared shared)
+        : base(grainType, shared)
+    {
+        _directory = directory;
+        shared.ActivationDirectory.RecordNewTarget(this);
+    }
+
+    /// <summary>
+    /// Creates the pair of system targets that replace <see cref="RemoteGrainDirectory"/> when
+    /// <see cref="DistributedGrainDirectory"/> is active: one for <see cref="Constants.DirectoryServiceType"/>
+    /// and one for <see cref="Constants.DirectoryCacheValidatorType"/>.
+    /// </summary>
+    internal static (DistributedRemoteGrainDirectory DirectoryService, DistributedRemoteGrainDirectory CacheValidator)
+        Create(DistributedGrainDirectory directory, SystemTargetShared shared)
+    {
+        var directoryService = new DistributedRemoteGrainDirectory(directory, Constants.DirectoryServiceType, shared);
+        var cacheValidator = new DistributedRemoteGrainDirectory(directory, Constants.DirectoryCacheValidatorType, shared);
+        return (directoryService, cacheValidator);
+    }
+
+    public async Task<AddressAndTag> RegisterAsync(GrainAddress address, int hopCount)
+    {
+        var result = await _directory.Register(address);
+        return new(result, 0);
+    }
+
+    public async Task<AddressAndTag> RegisterAsync(GrainAddress address, GrainAddress? previousAddress, int hopCount)
+    {
+        var result = await _directory.Register(address, previousAddress);
+        return new(result, 0);
+    }
+
+    public async Task<AddressAndTag> LookupAsync(GrainId grainId, int hopCount)
+    {
+        var result = await _directory.Lookup(grainId);
+        return new(result, 0);
+    }
+
+    public async Task UnregisterAsync(GrainAddress address, UnregistrationCause cause, int hopCount)
+    {
+        await _directory.Unregister(address);
+    }
+
+    public async Task UnregisterManyAsync(List<GrainAddress> addresses, UnregistrationCause cause, int hopCount)
+    {
+        foreach (var address in addresses)
+        {
+            await _directory.Unregister(address);
+        }
+    }
+
+    public async Task DeleteGrainAsync(GrainId grainId, int hopCount)
+    {
+        var existing = await _directory.Lookup(grainId);
+        if (existing is not null)
+        {
+            await _directory.Unregister(existing);
+        }
+    }
+
+    public async Task RegisterMany(List<GrainAddress> addresses)
+    {
+        foreach (var address in addresses)
+        {
+            await _directory.Register(address);
+        }
+    }
+
+    public async Task<List<AddressAndTag>> LookUpMany(List<(GrainId GrainId, int Version)> grainAndETagList)
+    {
+        var result = new List<AddressAndTag>(grainAndETagList.Count);
+        foreach (var (grainId, _) in grainAndETagList)
+        {
+            var address = await _directory.Lookup(grainId);
+            result.Add(new(address, 0));
+        }
+
+        return result;
+    }
+
+    public async Task AcceptSplitPartition(List<GrainAddress> singleActivations)
+    {
+        foreach (var address in singleActivations)
+        {
+            await _directory.Register(address);
+        }
+    }
+}

--- a/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
@@ -1,7 +1,12 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Orleans.GrainDirectory;
+using Orleans.Internal;
+using Orleans.Runtime.Scheduler;
 
 #nullable enable
 namespace Orleans.Runtime.GrainDirectory;
@@ -11,10 +16,17 @@ namespace Orleans.Runtime.GrainDirectory;
 /// This enables silos running the old <see cref="LocalGrainDirectory"/> to forward directory requests to silos running the
 /// new <see cref="DistributedGrainDirectory"/> during a rolling upgrade.
 /// </summary>
-internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGrainDirectory
+internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGrainDirectory
 {
+    private const int MaxBatchDegreeOfParallelism = 32;
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(250);
+
     private readonly DistributedGrainDirectory _directory;
+    private readonly ILogger<DistributedRemoteGrainDirectory> _logger;
     private readonly DirectoryMembershipService _membershipService;
+    private readonly Queue<(string Name, object State, Func<DistributedRemoteGrainDirectory, object, Task> Action)> _pendingOperations = new();
+    private readonly AsyncLock _executorLock = new();
 
     private DistributedRemoteGrainDirectory(
         DistributedGrainDirectory directory,
@@ -24,6 +36,7 @@ internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGra
         : base(grainType, shared)
     {
         _directory = directory;
+        _logger = shared.LoggerFactory.CreateLogger<DistributedRemoteGrainDirectory>();
         _membershipService = membershipService;
         shared.ActivationDirectory.RecordNewTarget(this);
     }
@@ -54,7 +67,181 @@ internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGra
         }
     }
 
-    private CancellationTokenSource CreateTimeoutCts() => new(TimeSpan.FromSeconds(30));
+    private static ParallelOptions CreateParallelOptions(CancellationToken cancellationToken) => new()
+    {
+        CancellationToken = cancellationToken,
+        MaxDegreeOfParallelism = MaxBatchDegreeOfParallelism,
+        TaskScheduler = TaskScheduler.Current,
+    };
+
+    private CancellationTokenSource CreateTimeoutCts() => new(OperationTimeout);
+
+    private CancellationTokenSource CreateTimeoutCts(CancellationToken cancellationToken)
+    {
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _directory.OnStoppedToken);
+        cts.CancelAfter(OperationTimeout);
+        return cts;
+    }
+
+    private async Task RunBatchOperationAsync<T>(List<T> values, Func<T, CancellationToken, Task> operation)
+    {
+        using (var cts = CreateTimeoutCts(_directory.OnStoppedToken))
+        {
+            await EnsureDirectoryInitializedAsync(cts.Token);
+        }
+
+        var options = CreateParallelOptions(_directory.OnStoppedToken);
+        await Parallel.ForEachAsync(values, options, async (value, cancellationToken) =>
+        {
+            using var cts = CreateTimeoutCts(cancellationToken);
+            await operation(value, cts.Token);
+        });
+    }
+
+    private IInternalGrainFactory GrainFactory => ActivationServices.GetRequiredService<IInternalGrainFactory>();
+
+    private ISiloStatusOracle SiloStatusOracle => ActivationServices.GetRequiredService<ISiloStatusOracle>();
+
+    private void EnqueueOperation(string name, object state, Func<DistributedRemoteGrainDirectory, object, Task> action)
+    {
+        lock (_pendingOperations)
+        {
+            _pendingOperations.Enqueue((name, state, action));
+            if (_pendingOperations.Count <= 2)
+            {
+                WorkItemGroup.QueueTask(ExecutePendingOperations, this);
+            }
+        }
+    }
+
+    private async Task ExecutePendingOperations()
+    {
+        using (await _executorLock.LockAsync())
+        {
+            while (!_directory.OnStoppedToken.IsCancellationRequested)
+            {
+                (string Name, object State, Func<DistributedRemoteGrainDirectory, object, Task> Action) op;
+                lock (_pendingOperations)
+                {
+                    if (_pendingOperations.Count == 0)
+                    {
+                        break;
+                    }
+
+                    op = _pendingOperations.Peek();
+                }
+
+                try
+                {
+                    await op.Action(this, op.State);
+                    lock (_pendingOperations)
+                    {
+                        _pendingOperations.Dequeue();
+                    }
+                }
+                catch (Exception exception) when (!_directory.OnStoppedToken.IsCancellationRequested)
+                {
+                    LogWarningOperationFailedRetry(_logger, exception, op.Name);
+                    await Task.Delay(RetryDelay, _directory.OnStoppedToken).SuppressThrowing();
+                }
+            }
+        }
+    }
+
+    private void DestroyDuplicateActivations(Dictionary<SiloAddress, List<GrainAddress>>? duplicates)
+    {
+        if (duplicates is null || duplicates.Count == 0)
+        {
+            return;
+        }
+
+        EnqueueOperation(
+            nameof(DestroyDuplicateActivations),
+            duplicates,
+            static (self, state) => self.DestroyDuplicateActivationsAsync((Dictionary<SiloAddress, List<GrainAddress>>)state));
+    }
+
+    private async Task DestroyDuplicateActivationsAsync(Dictionary<SiloAddress, List<GrainAddress>> duplicates)
+    {
+        while (duplicates.Count > 0)
+        {
+            var pair = duplicates.First();
+            if (SiloStatusOracle.GetApproximateSiloStatus(pair.Key) == SiloStatus.Active)
+            {
+                var remoteCatalog = GrainFactory.GetSystemTarget<ICatalog>(Constants.CatalogType, pair.Key);
+                await remoteCatalog.DeleteActivations(
+                    pair.Value,
+                    DeactivationReasonCode.DuplicateActivation,
+                    "This grain has been activated elsewhere");
+            }
+
+            duplicates.Remove(pair.Key);
+        }
+    }
+
+    private async Task ProcessSplitPartitionRegistrationsAsync(SplitPartitionRegistrationBatch batch)
+    {
+        using (var cts = CreateTimeoutCts(_directory.OnStoppedToken))
+        {
+            await EnsureDirectoryInitializedAsync(cts.Token);
+        }
+
+        var pendingRegistrations = batch.PendingRegistrations;
+        var winners = new GrainAddress?[pendingRegistrations.Count];
+        var failures = new Exception?[pendingRegistrations.Count];
+        var options = CreateParallelOptions(_directory.OnStoppedToken);
+        await Parallel.ForEachAsync(Enumerable.Range(0, pendingRegistrations.Count), options, async (index, cancellationToken) =>
+        {
+            try
+            {
+                using var cts = CreateTimeoutCts(cancellationToken);
+                winners[index] = await _directory.RegisterAsync(pendingRegistrations[index], null, cts.Token);
+            }
+            catch (Exception exception)
+            {
+                failures[index] = exception;
+            }
+        });
+
+        Dictionary<SiloAddress, List<GrainAddress>>? duplicates = null;
+        Exception? failure = null;
+        for (var i = pendingRegistrations.Count - 1; i >= 0; i--)
+        {
+            if (failures[i] is not null)
+            {
+                failure ??= failures[i];
+                continue;
+            }
+
+            var registration = pendingRegistrations[i];
+            var winner = winners[i];
+            if (winner is null || !winner.Equals(registration))
+            {
+                if (registration.SiloAddress is { } siloAddress)
+                {
+                    if (duplicates is null || !duplicates.TryGetValue(siloAddress, out var activations))
+                    {
+                        activations = [];
+                        (duplicates ??= []).Add(siloAddress, activations);
+                    }
+
+                    activations.Add(registration);
+                }
+            }
+
+            pendingRegistrations.RemoveAt(i);
+        }
+
+        DestroyDuplicateActivations(duplicates);
+
+        if (failure is not null)
+        {
+            LogWarningAcceptSplitPartitionFailed(_logger, failure, Silo, pendingRegistrations.Count);
+            throw failure;
+        }
+
+        LogInformationAcceptSplitPartitionCompleted(_logger, Silo, batch.InitialCount);
+    }
 
     public async Task<AddressAndTag> RegisterAsync(GrainAddress address, int hopCount)
     {
@@ -89,12 +276,7 @@ internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGra
 
     public async Task UnregisterManyAsync(List<GrainAddress> addresses, UnregistrationCause cause, int hopCount)
     {
-        using var cts = CreateTimeoutCts();
-        await EnsureDirectoryInitializedAsync(cts.Token);
-        foreach (var address in addresses)
-        {
-            await _directory.UnregisterAsync(address, cts.Token);
-        }
+        await RunBatchOperationAsync(addresses, (address, cancellationToken) => _directory.UnregisterAsync(address, cancellationToken));
     }
 
     public async Task DeleteGrainAsync(GrainId grainId, int hopCount)
@@ -110,35 +292,77 @@ internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGra
 
     public async Task RegisterMany(List<GrainAddress> addresses)
     {
-        using var cts = CreateTimeoutCts();
-        await EnsureDirectoryInitializedAsync(cts.Token);
-        foreach (var address in addresses)
-        {
-            await _directory.RegisterAsync(address, null, cts.Token);
-        }
+        await RunBatchOperationAsync(addresses, (address, cancellationToken) => _directory.RegisterAsync(address, null, cancellationToken));
     }
 
     public async Task<List<AddressAndTag>> LookUpMany(List<(GrainId GrainId, int Version)> grainAndETagList)
     {
-        using var cts = CreateTimeoutCts();
-        await EnsureDirectoryInitializedAsync(cts.Token);
-        var result = new List<AddressAndTag>(grainAndETagList.Count);
-        foreach (var (grainId, _) in grainAndETagList)
+        LogInformationLookUpManyReceived(_logger, Silo, grainAndETagList.Count);
+
+        using (var cts = CreateTimeoutCts(_directory.OnStoppedToken))
         {
-            var address = await _directory.LookupAsync(grainId, cts.Token);
-            result.Add(new(address, 0));
+            await EnsureDirectoryInitializedAsync(cts.Token);
         }
 
-        return result;
+        var result = new AddressAndTag[grainAndETagList.Count];
+        var options = CreateParallelOptions(_directory.OnStoppedToken);
+        await Parallel.ForEachAsync(Enumerable.Range(0, grainAndETagList.Count), options, async (index, cancellationToken) =>
+        {
+            using var cts = CreateTimeoutCts(cancellationToken);
+            var address = await _directory.LookupAsync(grainAndETagList[index].GrainId, cts.Token);
+            result[index] = new(address, 0);
+        });
+
+        return [.. result];
     }
 
-    public async Task AcceptSplitPartition(List<GrainAddress> singleActivations)
+    public Task AcceptSplitPartition(List<GrainAddress> singleActivations)
     {
-        using var cts = CreateTimeoutCts();
-        await EnsureDirectoryInitializedAsync(cts.Token);
-        foreach (var address in singleActivations)
+        LogInformationAcceptSplitPartitionStarted(_logger, Silo, singleActivations.Count);
+        if (singleActivations.Count > 0)
         {
-            await _directory.RegisterAsync(address, null, cts.Token);
+            EnqueueOperation(
+                nameof(AcceptSplitPartition),
+                new SplitPartitionRegistrationBatch([.. singleActivations]),
+                static (self, state) => self.ProcessSplitPartitionRegistrationsAsync((SplitPartitionRegistrationBatch)state));
         }
+
+        return Task.CompletedTask;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Rolling upgrade diagnostic: silo {Silo} received LookUpMany for {Count} entries."
+    )]
+    private static partial void LogInformationLookUpManyReceived(ILogger logger, SiloAddress silo, int count);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Rolling upgrade diagnostic: silo {Silo} accepted split-partition handoff for {Count} registrations."
+    )]
+    private static partial void LogInformationAcceptSplitPartitionStarted(ILogger logger, SiloAddress silo, int count);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Rolling upgrade diagnostic: silo {Silo} completed split-partition handoff for {Count} registrations."
+    )]
+    private static partial void LogInformationAcceptSplitPartitionCompleted(ILogger logger, SiloAddress silo, int count);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Rolling upgrade diagnostic: silo {Silo} failed split-partition handoff for {Count} registrations."
+    )]
+    private static partial void LogWarningAcceptSplitPartitionFailed(ILogger logger, Exception exception, SiloAddress silo, int count);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Rolling upgrade compatibility operation {Operation} failed and will be retried."
+    )]
+    private static partial void LogWarningOperationFailedRetry(ILogger logger, Exception exception, string operation);
+
+    private sealed class SplitPartitionRegistrationBatch(List<GrainAddress> pendingRegistrations)
+    {
+        public int InitialCount { get; } = pendingRegistrations.Count;
+        public List<GrainAddress> PendingRegistrations { get; } = pendingRegistrations;
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.GrainDirectory;
 
@@ -13,14 +14,17 @@ namespace Orleans.Runtime.GrainDirectory;
 internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGrainDirectory
 {
     private readonly DistributedGrainDirectory _directory;
+    private readonly DirectoryMembershipService _membershipService;
 
     private DistributedRemoteGrainDirectory(
         DistributedGrainDirectory directory,
+        DirectoryMembershipService membershipService,
         GrainType grainType,
         SystemTargetShared shared)
         : base(grainType, shared)
     {
         _directory = directory;
+        _membershipService = membershipService;
         shared.ActivationDirectory.RecordNewTarget(this);
     }
 
@@ -30,67 +34,98 @@ internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGra
     /// and one for <see cref="Constants.DirectoryCacheValidatorType"/>.
     /// </summary>
     internal static (DistributedRemoteGrainDirectory DirectoryService, DistributedRemoteGrainDirectory CacheValidator)
-        Create(DistributedGrainDirectory directory, SystemTargetShared shared)
+        Create(DistributedGrainDirectory directory, DirectoryMembershipService membershipService, SystemTargetShared shared)
     {
-        var directoryService = new DistributedRemoteGrainDirectory(directory, Constants.DirectoryServiceType, shared);
-        var cacheValidator = new DistributedRemoteGrainDirectory(directory, Constants.DirectoryCacheValidatorType, shared);
+        var directoryService = new DistributedRemoteGrainDirectory(directory, membershipService, Constants.DirectoryServiceType, shared);
+        var cacheValidator = new DistributedRemoteGrainDirectory(directory, membershipService, Constants.DirectoryCacheValidatorType, shared);
         return (directoryService, cacheValidator);
     }
 
+    /// <summary>
+    /// Ensures the directory has an initialized membership view before processing requests.
+    /// Without this, calls arriving before the directory processes its first membership update
+    /// would block indefinitely in <see cref="DistributedGrainDirectory"/>'s internal retry loop.
+    /// </summary>
+    private async Task EnsureDirectoryInitializedAsync(CancellationToken cancellationToken)
+    {
+        if (_membershipService.CurrentView.Version == MembershipVersion.MinValue)
+        {
+            await _membershipService.RefreshViewAsync(new MembershipVersion(1), cancellationToken);
+        }
+    }
+
+    private CancellationTokenSource CreateTimeoutCts() => new(TimeSpan.FromSeconds(30));
+
     public async Task<AddressAndTag> RegisterAsync(GrainAddress address, int hopCount)
     {
-        var result = await _directory.Register(address);
+        using var cts = CreateTimeoutCts();
+        await EnsureDirectoryInitializedAsync(cts.Token);
+        var result = await _directory.RegisterAsync(address, null, cts.Token);
         return new(result, 0);
     }
 
     public async Task<AddressAndTag> RegisterAsync(GrainAddress address, GrainAddress? previousAddress, int hopCount)
     {
-        var result = await _directory.Register(address, previousAddress);
+        using var cts = CreateTimeoutCts();
+        await EnsureDirectoryInitializedAsync(cts.Token);
+        var result = await _directory.RegisterAsync(address, previousAddress, cts.Token);
         return new(result, 0);
     }
 
     public async Task<AddressAndTag> LookupAsync(GrainId grainId, int hopCount)
     {
-        var result = await _directory.Lookup(grainId);
+        using var cts = CreateTimeoutCts();
+        await EnsureDirectoryInitializedAsync(cts.Token);
+        var result = await _directory.LookupAsync(grainId, cts.Token);
         return new(result, 0);
     }
 
     public async Task UnregisterAsync(GrainAddress address, UnregistrationCause cause, int hopCount)
     {
-        await _directory.Unregister(address);
+        using var cts = CreateTimeoutCts();
+        await EnsureDirectoryInitializedAsync(cts.Token);
+        await _directory.UnregisterAsync(address, cts.Token);
     }
 
     public async Task UnregisterManyAsync(List<GrainAddress> addresses, UnregistrationCause cause, int hopCount)
     {
+        using var cts = CreateTimeoutCts();
+        await EnsureDirectoryInitializedAsync(cts.Token);
         foreach (var address in addresses)
         {
-            await _directory.Unregister(address);
+            await _directory.UnregisterAsync(address, cts.Token);
         }
     }
 
     public async Task DeleteGrainAsync(GrainId grainId, int hopCount)
     {
-        var existing = await _directory.Lookup(grainId);
+        using var cts = CreateTimeoutCts();
+        await EnsureDirectoryInitializedAsync(cts.Token);
+        var existing = await _directory.LookupAsync(grainId, cts.Token);
         if (existing is not null)
         {
-            await _directory.Unregister(existing);
+            await _directory.UnregisterAsync(existing, cts.Token);
         }
     }
 
     public async Task RegisterMany(List<GrainAddress> addresses)
     {
+        using var cts = CreateTimeoutCts();
+        await EnsureDirectoryInitializedAsync(cts.Token);
         foreach (var address in addresses)
         {
-            await _directory.Register(address);
+            await _directory.RegisterAsync(address, null, cts.Token);
         }
     }
 
     public async Task<List<AddressAndTag>> LookUpMany(List<(GrainId GrainId, int Version)> grainAndETagList)
     {
+        using var cts = CreateTimeoutCts();
+        await EnsureDirectoryInitializedAsync(cts.Token);
         var result = new List<AddressAndTag>(grainAndETagList.Count);
         foreach (var (grainId, _) in grainAndETagList)
         {
-            var address = await _directory.Lookup(grainId);
+            var address = await _directory.LookupAsync(grainId, cts.Token);
             result.Add(new(address, 0));
         }
 
@@ -99,9 +134,11 @@ internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGra
 
     public async Task AcceptSplitPartition(List<GrainAddress> singleActivations)
     {
+        using var cts = CreateTimeoutCts();
+        await EnsureDirectoryInitializedAsync(cts.Token);
         foreach (var address in singleActivations)
         {
-            await _directory.Register(address);
+            await _directory.RegisterAsync(address, null, cts.Token);
         }
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -77,9 +77,22 @@ namespace Orleans.Runtime.GrainDirectory
                 if (splitPartListSingle.Count > 0)
                 {
                     LogDebugSendingEntries(logger, splitPartListSingle.Count, addedSilo);
+                    LogInformationSendingSplitPartition(logger, splitPartListSingle.Count, addedSilo);
                 }
 
-                await localDirectory.GetDirectoryReference(addedSilo).AcceptSplitPartition(splitPartListSingle);
+                try
+                {
+                    await localDirectory.GetDirectoryReference(addedSilo).AcceptSplitPartition(splitPartListSingle);
+                    if (splitPartListSingle.Count > 0)
+                    {
+                        LogInformationCompletedSplitPartition(logger, splitPartListSingle.Count, addedSilo);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    LogWarningSplitPartitionFailed(logger, exception, splitPartListSingle.Count, addedSilo);
+                    throw;
+                }
             }
             else
             {
@@ -95,6 +108,8 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     localDirectory.DirectoryPartition.RemoveGrain(activationAddress.GrainId);
                 }
+
+                LogInformationRemovedTransferredEntries(logger, splitPartListSingle.Count, addedSilo);
             }
         }
 
@@ -256,6 +271,24 @@ namespace Orleans.Runtime.GrainDirectory
         private static partial void LogDebugSendingEntries(ILogger logger, int count, SiloAddress addedSilo);
 
         [LoggerMessage(
+            Level = LogLevel.Information,
+            Message = "Rolling upgrade diagnostic: sending {Count} split-partition registrations to {AddedSilo}."
+        )]
+        private static partial void LogInformationSendingSplitPartition(ILogger logger, int count, SiloAddress addedSilo);
+
+        [LoggerMessage(
+            Level = LogLevel.Information,
+            Message = "Rolling upgrade diagnostic: completed split-partition transfer of {Count} registrations to {AddedSilo}."
+        )]
+        private static partial void LogInformationCompletedSplitPartition(ILogger logger, int count, SiloAddress addedSilo);
+
+        [LoggerMessage(
+            Level = LogLevel.Warning,
+            Message = "Rolling upgrade diagnostic: split-partition transfer of {Count} registrations to {AddedSilo} failed."
+        )]
+        private static partial void LogWarningSplitPartitionFailed(ILogger logger, Exception exception, int count, SiloAddress addedSilo);
+
+        [LoggerMessage(
             Level = LogLevel.Warning,
             Message = "Silo {AddedSilo} is no longer active and therefore cannot receive this partition split"
         )]
@@ -266,6 +299,12 @@ namespace Orleans.Runtime.GrainDirectory
             Message = "Removing {Count} single activation after partition split"
         )]
         private static partial void LogDebugRemovingEntries(ILogger logger, int count);
+
+        [LoggerMessage(
+            Level = LogLevel.Information,
+            Message = "Rolling upgrade diagnostic: removed {Count} transferred registrations after handoff to {AddedSilo}."
+        )]
+        private static partial void LogInformationRemovedTransferredEntries(ILogger logger, int count, SiloAddress addedSilo);
 
         [LoggerMessage(
             Level = LogLevel.Debug,

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
@@ -13,26 +13,24 @@ internal sealed partial class GrainDirectoryPartition
         ArgumentNullException.ThrowIfNull(address);
         LogRegisterAsync(version, address, currentRegistration);
 
-        // Ensure that the current membership version is new enough.
-        await WaitForRange(address.GrainId, version);
-        if (!IsOwner(CurrentView, address.GrainId))
+        var currentView = await WaitForOwnershipViewAsync(address.GrainId, version);
+        if (!IsOwner(currentView, address.GrainId))
         {
-            return DirectoryResult.RefreshRequired<GrainAddress>(CurrentView.Version);
+            return DirectoryResult.RefreshRequired<GrainAddress>(currentView.Version);
         }
 
-        DebugAssertOwnership(address.GrainId);
-        return DirectoryResult.FromResult(RegisterCore(address, currentRegistration), version);
+        DebugAssertOwnership(currentView, address.GrainId);
+        return DirectoryResult.FromResult(RegisterCore(address, currentRegistration, currentView.Version), version);
     }
 
     async ValueTask<DirectoryResult<GrainAddress?>> IGrainDirectoryPartition.LookupAsync(MembershipVersion version, GrainId grainId)
     {
         LogLookupAsync(version, grainId);
 
-        // Ensure we can serve the request.
-        await WaitForRange(grainId, version);
-        if (!IsOwner(CurrentView, grainId))
+        var currentView = await WaitForOwnershipViewAsync(grainId, version);
+        if (!IsOwner(currentView, grainId))
         {
-            return DirectoryResult.RefreshRequired<GrainAddress?>(CurrentView.Version);
+            return DirectoryResult.RefreshRequired<GrainAddress?>(currentView.Version);
         }
 
         return DirectoryResult.FromResult(LookupCore(grainId), version);
@@ -43,13 +41,13 @@ internal sealed partial class GrainDirectoryPartition
         ArgumentNullException.ThrowIfNull(address);
         LogDeregisterAsync(version, address);
 
-        await WaitForRange(address.GrainId, version);
-        if (!IsOwner(CurrentView, address.GrainId))
+        var currentView = await WaitForOwnershipViewAsync(address.GrainId, version);
+        if (!IsOwner(currentView, address.GrainId))
         {
-            return DirectoryResult.RefreshRequired<bool>(CurrentView.Version);
+            return DirectoryResult.RefreshRequired<bool>(currentView.Version);
         }
 
-        DebugAssertOwnership(address.GrainId);
+        DebugAssertOwnership(currentView, address.GrainId);
         return DirectoryResult.FromResult(DeregisterCore(address), version);
     }
 
@@ -73,13 +71,29 @@ internal sealed partial class GrainDirectoryPartition
         return null;
     }
 
-    private GrainAddress RegisterCore(GrainAddress newAddress, GrainAddress? existingAddress)
+    private async ValueTask<DirectoryMembershipSnapshot> WaitForOwnershipViewAsync(GrainId grainId, MembershipVersion version)
+    {
+        while (true)
+        {
+            // Requests which arrive with a stale membership version must still wait for any in-flight ownership
+            // transition in the current view before deciding whether this partition can serve them.
+            var currentView = CurrentView;
+            var waitVersion = currentView.Version > version ? currentView.Version : version;
+            await WaitForRange(grainId, waitVersion);
+            if (ReferenceEquals(currentView, CurrentView))
+            {
+                return currentView;
+            }
+        }
+    }
+
+    private GrainAddress RegisterCore(GrainAddress newAddress, GrainAddress? existingAddress, MembershipVersion currentVersion)
     {
         ref var existing = ref CollectionsMarshal.GetValueRefOrAddDefault(_directory, newAddress.GrainId, out _);
 
         if (existing is null || existing.Matches(existingAddress) || IsSiloDead(existing))
         {
-            if (newAddress.MembershipVersion != CurrentView.Version)
+            if (newAddress.MembershipVersion != currentVersion)
             {
                 // Set the membership version to match the view number in which it was registered.
                 newAddress = new()
@@ -87,7 +101,7 @@ internal sealed partial class GrainDirectoryPartition
                     GrainId = newAddress.GrainId,
                     SiloAddress = newAddress.SiloAddress,
                     ActivationId = newAddress.ActivationId,
-                    MembershipVersion = CurrentView.Version
+                    MembershipVersion = currentVersion
                 };
             }
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -326,7 +326,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         Debug.Assert(!addedRange.Intersects(removedRange));
         Debug.Assert(addedRange.IsEmpty || addedRange.Intersects(_currentRange));
         Debug.Assert(!addedRange.Intersects(previousRange));
-        Debug.Assert(previousRange.IsEmpty || _currentRange.IsEmpty || previousRange.Start == _currentRange.Start);
+        Debug.Assert(previousRange.IsEmpty || previousRange.IsFull || _currentRange.IsEmpty || _currentRange.IsFull || previousRange.Start == _currentRange.Start);
 #endif
 
         if (!removedRange.IsEmpty)
@@ -440,7 +440,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                         var previousOwnerRange = previousOwnerRanges[partitionIndex];
                         if (previousOwnerRange.Intersects(addedRange))
                         {
-                            tasks.Add(TransferSnapshotAsync(current, addedRange, previousOwner, partitionIndex, previous.Version));
+                            tasks.Add(TransferSnapshotAsync(current, previousOwnerRange, addedRange, previousOwner, partitionIndex, previous.Version));
                         }
                     }
                 }
@@ -501,22 +501,52 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         }
     }
 
-    private async Task<bool> TransferSnapshotAsync(DirectoryMembershipSnapshot current, RingRange addedRange, SiloAddress previousOwner, int partitionIndex, MembershipVersion previousVersion)
+    private async Task<bool> TransferSnapshotAsync(
+        DirectoryMembershipSnapshot current,
+        RingRange previousOwnerRange,
+        RingRange addedRange,
+        SiloAddress previousOwner,
+        int partitionIndex,
+        MembershipVersion previousVersion)
     {
+        var currentTransferRange = addedRange;
         try
         {
             var stopwatch = ValueStopwatch.StartNew();
-            LogTraceRequestingEntries(_logger, addedRange, previousOwner, previousVersion);
 
             var partition = GetPartitionReference(previousOwner, partitionIndex);
-
-            // Alternatively, the previous owner could push the snapshot. The pull-based approach is used here because it is simpler.
-            var snapshot = await partition.GetSnapshotAsync(current.Version, previousVersion, addedRange).AsTask().WaitAsync(ShutdownToken);
-
-            if (snapshot is null)
+            var waitedForRange = false;
+            foreach (var transferRange in GetSnapshotTransferRanges(previousOwnerRange, addedRange))
             {
-                LogWarningExpectedValidSnapshot(_logger, previousOwner, addedRange);
-                return false;
+                currentTransferRange = transferRange;
+                LogTraceRequestingEntries(_logger, transferRange, previousOwner, previousVersion);
+
+                // Alternatively, the previous owner could push the snapshot. The pull-based approach is used here because it is simpler.
+                var snapshot = await partition.GetSnapshotAsync(current.Version, previousVersion, transferRange).AsTask().WaitAsync(ShutdownToken);
+
+                if (snapshot is null)
+                {
+                    LogWarningExpectedValidSnapshot(_logger, previousOwner, transferRange);
+                    return false;
+                }
+
+                if (!waitedForRange)
+                {
+                    // Wait for previous versions to be unlocked before proceeding.
+                    await WaitForRange(addedRange, previousVersion);
+                    waitedForRange = true;
+                }
+
+                // Incorporate the values into the grain directory.
+                foreach (var entry in snapshot.GrainAddresses)
+                {
+                    DebugAssertOwnership(current, entry.GrainId);
+
+                    LogTraceReceivedEntry(_logger, entry, previousOwner, previousVersion);
+                    _directory[entry.GrainId] = entry;
+                }
+
+                LogDebugTransferredEntries(_logger, snapshot.GrainAddresses.Count, transferRange, previousOwner);
             }
 
             // The acknowledgement step lets the previous owner know that the snapshot has been received so that it can proceed.
@@ -525,20 +555,6 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                 async () => await partition.AcknowledgeSnapshotTransferAsync(_id, _partitionIndex, previousVersion),
                 false,
                 nameof(IGrainDirectoryPartition.AcknowledgeSnapshotTransferAsync)).Ignore();
-
-            // Wait for previous versions to be unlocked before proceeding.
-            await WaitForRange(addedRange, previousVersion);
-
-            // Incorporate the values into the grain directory.
-            foreach (var entry in snapshot.GrainAddresses)
-            {
-                DebugAssertOwnership(current, entry.GrainId);
-
-                LogTraceReceivedEntry(_logger, entry, previousOwner, previousVersion);
-                _directory[entry.GrainId] = entry;
-            }
-
-            LogDebugTransferredEntries(_logger, snapshot.GrainAddresses.Count, addedRange, previousOwner);
 
             DirectoryInstruments.SnapshotTransferCount.Add(1);
             DirectoryInstruments.SnapshotTransferDuration.Record((long)stopwatch.Elapsed.TotalMilliseconds);
@@ -549,11 +565,11 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         {
             if (exception is SiloUnavailableException)
             {
-                LogWarningRemoteHostUnavailable(_logger, addedRange);
+                LogWarningRemoteHostUnavailable(_logger, currentTransferRange);
             }
             else
             {
-                LogWarningErrorTransferringOwnership(_logger, exception, addedRange);
+                LogWarningErrorTransferringOwnership(_logger, exception, currentTransferRange);
             }
 
             return false;
@@ -638,6 +654,11 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
             return result.Value;
         }
+    }
+
+    internal static IEnumerable<RingRange> GetSnapshotTransferRanges(RingRange previousOwnerRange, RingRange addedRange)
+    {
+        return previousOwnerRange.Intersections(addedRange);
     }
 
     private async Task<T> InvokeOnClusterMember<T>(SiloAddress siloAddress, Func<Task<T>> func, T defaultValue, string operationName)
@@ -841,13 +862,13 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
     [LoggerMessage(
         Level = LogLevel.Trace,
-        Message = "Requesting entries for ranges '{Range}' from '{PreviousOwner}' at version '{PreviousVersion}'."
+        Message = "Requesting entries for range '{Range}' from '{PreviousOwner}' at version '{PreviousVersion}'."
     )]
     private static partial void LogTraceRequestingEntries(ILogger logger, RingRange range, SiloAddress previousOwner, MembershipVersion previousVersion);
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "Expected a valid snapshot from previous owner '{PreviousOwner}' for part of ranges '{Range}', but found none."
+        Message = "Expected a valid snapshot from previous owner '{PreviousOwner}' for range '{Range}', but found none."
     )]
     private static partial void LogWarningExpectedValidSnapshot(ILogger logger, SiloAddress previousOwner, RingRange range);
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -771,6 +771,26 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         }
     }
 
+    async ValueTask IGrainDirectoryTestHooks.RecoverAndCheckIntegrityAsync()
+    {
+        GrainRuntime.CheckRuntimeContext(this);
+
+        while (true)
+        {
+            var current = CurrentView;
+            await WaitForRange(RingRange.Full, current.Version);
+            if (!ReferenceEquals(current, CurrentView))
+            {
+                continue;
+            }
+
+            await RecoverPartitionRange(current, _currentRange);
+            break;
+        }
+
+        await ((IGrainDirectoryTestHooks)this).CheckIntegrityAsync();
+    }
+
     private sealed record class PartitionSnapshotState(
         MembershipVersion DirectoryMembershipVersion,
         List<GrainAddress> GrainAddresses,

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -791,6 +791,57 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         await ((IGrainDirectoryTestHooks)this).CheckIntegrityAsync();
     }
 
+    async ValueTask<Immutable<List<GrainId>>> IGrainDirectoryTestHooks.CheckActivationsAsync(Immutable<List<GrainAddress>> activations)
+    {
+        GrainRuntime.CheckRuntimeContext(this);
+        var current = CurrentView;
+
+        await WaitForRange(RingRange.Full, current.Version);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _rangeLocks.Add((RingRange.Full, current.Version, tcs));
+        try
+        {
+            List<GrainId> checkedGrains = [];
+            foreach (var activation in activations.Value)
+            {
+                if (!IsOwner(current, activation.GrainId))
+                {
+                    continue;
+                }
+
+                checkedGrains.Add(activation.GrainId);
+                if (_directory.TryGetValue(activation.GrainId, out var existingEntry))
+                {
+                    if (!existingEntry.Equals(activation))
+                    {
+                        LogErrorIntegrityViolation(_logger, activation, existingEntry);
+                        Debug.Fail($"Integrity violation: activation '{activation}' does not match existing directory entry '{existingEntry}'.");
+                    }
+                }
+                else
+                {
+                    LogErrorIntegrityViolation(_logger, activation);
+                    Debug.Fail($"Integrity violation: activation '{activation}' not found in directory.");
+                }
+            }
+
+            return checkedGrains.AsImmutable();
+        }
+        finally
+        {
+            if (ShutdownToken.IsCancellationRequested)
+            {
+                tcs.SetCanceled(ShutdownToken);
+            }
+            else
+            {
+                tcs.SetResult();
+            }
+
+            _rangeLocks.Remove((RingRange.Full, current.Version, tcs));
+        }
+    }
+
     private sealed record class PartitionSnapshotState(
         MembershipVersion DirectoryMembershipVersion,
         List<GrainAddress> GrainAddresses,

--- a/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
@@ -41,4 +41,7 @@ internal interface IGrainDirectoryTestHooks : ISystemTarget
 
     [Alias("RecoverAndCheckIntegrityAsync")]
     ValueTask RecoverAndCheckIntegrityAsync();
+
+    [Alias("CheckActivationsAsync")]
+    ValueTask<Immutable<List<GrainId>>> CheckActivationsAsync(Immutable<List<GrainAddress>> activations);
 }

--- a/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
@@ -38,4 +38,7 @@ internal interface IGrainDirectoryTestHooks : ISystemTarget
 {
     [Alias("CheckIntegrityAsync")]
     ValueTask CheckIntegrityAsync();
+
+    [Alias("RecoverAndCheckIntegrityAsync")]
+    ValueTask RecoverAndCheckIntegrityAsync();
 }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -73,8 +73,12 @@ namespace Orleans.Runtime.GrainDirectory
             DirectoryPartition = grainDirectoryPartitionFactory();
             HandoffManager = new GrainDirectoryHandoffManager(this, siloStatusOracle, grainFactory, grainDirectoryPartitionFactory, loggerFactory);
 
-            RemoteGrainDirectory = new RemoteGrainDirectory(this, Constants.DirectoryServiceType, systemTargetShared);
-            CacheValidator = new RemoteGrainDirectory(this, Constants.DirectoryCacheValidatorType, systemTargetShared);
+            // When DistributedGrainDirectory is active, it registers its own IRemoteGrainDirectory system targets.
+            // In that case, create the RemoteGrainDirectory objects (still needed for WorkItemGroup scheduling)
+            // but skip registering them as system targets to avoid conflicts.
+            var distributedDirectoryActive = serviceProvider.GetService<DistributedGrainDirectory>() is not null;
+            RemoteGrainDirectory = new RemoteGrainDirectory(this, Constants.DirectoryServiceType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
+            CacheValidator = new RemoteGrainDirectory(this, Constants.DirectoryCacheValidatorType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
 
             // add myself to the list of members
             AddServer(MyAddress);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -74,8 +74,12 @@ namespace Orleans.Runtime.GrainDirectory
             DirectoryPartition = grainDirectoryPartitionFactory();
             HandoffManager = new GrainDirectoryHandoffManager(this, siloStatusOracle, grainFactory, grainDirectoryPartitionFactory, loggerFactory);
 
-            RemoteGrainDirectory = new RemoteGrainDirectory(this, Constants.DirectoryServiceType, systemTargetShared);
-            CacheValidator = new RemoteGrainDirectory(this, Constants.DirectoryCacheValidatorType, systemTargetShared);
+            // When DistributedGrainDirectory is active, it registers its own IRemoteGrainDirectory system targets.
+            // In that case, create the RemoteGrainDirectory objects (still needed for WorkItemGroup scheduling)
+            // but skip registering them as system targets to avoid conflicts.
+            var distributedDirectoryActive = serviceProvider.GetService<DistributedGrainDirectory>() is not null;
+            RemoteGrainDirectory = new RemoteGrainDirectory(this, Constants.DirectoryServiceType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
+            CacheValidator = new RemoteGrainDirectory(this, Constants.DirectoryCacheValidatorType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
 
             // add myself to the list of members
             AddServer(MyAddress);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -42,6 +42,8 @@ namespace Orleans.Runtime.GrainDirectory
 
         public RemoteGrainDirectory RemoteGrainDirectory { get; }
         public RemoteGrainDirectory CacheValidator { get; }
+        internal LocalGrainDirectoryClientCompatibility? DistributedGrainDirectoryClientCompatibility { get; }
+        internal LocalGrainDirectoryPartitionCompatibility? DistributedGrainDirectoryPartitionCompatibility { get; }
 
         internal GrainDirectoryHandoffManager HandoffManager { get; }
 
@@ -80,6 +82,8 @@ namespace Orleans.Runtime.GrainDirectory
             var distributedDirectoryActive = serviceProvider.GetService<DistributedGrainDirectory>() is not null;
             RemoteGrainDirectory = new RemoteGrainDirectory(this, Constants.DirectoryServiceType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
             CacheValidator = new RemoteGrainDirectory(this, Constants.DirectoryCacheValidatorType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
+            DistributedGrainDirectoryClientCompatibility = distributedDirectoryActive ? null : new LocalGrainDirectoryClientCompatibility(this, systemTargetShared);
+            DistributedGrainDirectoryPartitionCompatibility = distributedDirectoryActive ? null : new LocalGrainDirectoryPartitionCompatibility(this, systemTargetShared);
 
             // add myself to the list of members
             AddServer(MyAddress);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -43,7 +43,7 @@ namespace Orleans.Runtime.GrainDirectory
         public RemoteGrainDirectory RemoteGrainDirectory { get; }
         public RemoteGrainDirectory CacheValidator { get; }
         internal LocalGrainDirectoryClientCompatibility? DistributedGrainDirectoryClientCompatibility { get; }
-        internal LocalGrainDirectoryPartitionCompatibility? DistributedGrainDirectoryPartitionCompatibility { get; }
+        internal ImmutableArray<LocalGrainDirectoryPartitionCompatibility> DistributedGrainDirectoryPartitionCompatibilities { get; }
 
         internal GrainDirectoryHandoffManager HandoffManager { get; }
 
@@ -83,7 +83,18 @@ namespace Orleans.Runtime.GrainDirectory
             RemoteGrainDirectory = new RemoteGrainDirectory(this, Constants.DirectoryServiceType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
             CacheValidator = new RemoteGrainDirectory(this, Constants.DirectoryCacheValidatorType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
             DistributedGrainDirectoryClientCompatibility = distributedDirectoryActive ? null : new LocalGrainDirectoryClientCompatibility(this, systemTargetShared);
-            DistributedGrainDirectoryPartitionCompatibility = distributedDirectoryActive ? null : new LocalGrainDirectoryPartitionCompatibility(this, systemTargetShared);
+            if (!distributedDirectoryActive)
+            {
+                var partitionsPerSilo = grainDirectoryOptions.Value.PartitionsPerSilo;
+                ArgumentOutOfRangeException.ThrowIfLessThan(partitionsPerSilo, 1, nameof(GrainDirectoryOptions.PartitionsPerSilo));
+                var compatibilityPartitions = ImmutableArray.CreateBuilder<LocalGrainDirectoryPartitionCompatibility>(partitionsPerSilo);
+                for (var partitionIndex = 0; partitionIndex < partitionsPerSilo; partitionIndex++)
+                {
+                    compatibilityPartitions.Add(new LocalGrainDirectoryPartitionCompatibility(this, systemTargetShared, partitionIndex));
+                }
+
+                DistributedGrainDirectoryPartitionCompatibilities = compatibilityPartitions.MoveToImmutable();
+            }
 
             // add myself to the list of members
             AddServer(MyAddress);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -82,7 +82,7 @@ namespace Orleans.Runtime.GrainDirectory
             var distributedDirectoryActive = serviceProvider.GetService<DistributedGrainDirectory>() is not null;
             RemoteGrainDirectory = new RemoteGrainDirectory(this, Constants.DirectoryServiceType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
             CacheValidator = new RemoteGrainDirectory(this, Constants.DirectoryCacheValidatorType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
-            DistributedGrainDirectoryClientCompatibility = distributedDirectoryActive ? null : new LocalGrainDirectoryClientCompatibility(this, systemTargetShared);
+            DistributedGrainDirectoryClientCompatibility = distributedDirectoryActive ? null : new LocalGrainDirectoryClientCompatibility(systemTargetShared);
             if (!distributedDirectoryActive)
             {
                 var partitionsPerSilo = grainDirectoryOptions.Value.PartitionsPerSilo;

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans.Concurrency;
+using Orleans.GrainDirectory;
+
+namespace Orleans.Runtime.GrainDirectory;
+
+/// <summary>
+/// Compatibility system targets which allow distributed-directory silos to interact with local-directory silos
+/// during rolling upgrades.
+/// </summary>
+internal sealed class LocalGrainDirectoryClientCompatibility : SystemTarget, IGrainDirectoryClient
+{
+    private readonly LocalGrainDirectory _directory;
+
+    internal LocalGrainDirectoryClientCompatibility(LocalGrainDirectory directory, SystemTargetShared shared)
+        : base(Constants.GrainDirectoryType, shared)
+    {
+        _directory = directory;
+        shared.ActivationDirectory.RecordNewTarget(this);
+    }
+
+    public ValueTask<Immutable<List<GrainAddress>>> GetRegisteredActivations(MembershipVersion membershipVersion, RingRange range, bool isValidation)
+        => new(_directory.DirectoryPartition.Split(range.Contains).AsImmutable());
+
+    public ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(MembershipVersion membershipVersion, RingRange range, SiloAddress siloAddress, int partitionId)
+        => GetRegisteredActivations(membershipVersion, range, isValidation: false);
+}
+
+internal sealed class LocalGrainDirectoryPartitionCompatibility : SystemTarget, IGrainDirectoryPartition
+{
+    private readonly LocalGrainDirectory _directory;
+
+    internal LocalGrainDirectoryPartitionCompatibility(LocalGrainDirectory directory, SystemTargetShared shared)
+        : base(GrainDirectoryPartition.CreateGrainId(shared.SiloAddress, 0), shared)
+    {
+        _directory = directory;
+        shared.ActivationDirectory.RecordNewTarget(this);
+    }
+
+    public async ValueTask<DirectoryResult<GrainAddress>> RegisterAsync(MembershipVersion version, GrainAddress address, GrainAddress? currentRegistration)
+    {
+        var result = await _directory.RegisterAsync(address, currentRegistration, hopCount: 1);
+        return DirectoryResult.FromResult(result.Address!, version);
+    }
+
+    public async ValueTask<DirectoryResult<GrainAddress?>> LookupAsync(MembershipVersion version, GrainId grainId)
+    {
+        var result = await _directory.LookupAsync(grainId, hopCount: 1);
+        return DirectoryResult.FromResult(result.Address, version);
+    }
+
+    public async ValueTask<DirectoryResult<bool>> DeregisterAsync(MembershipVersion version, GrainAddress address)
+    {
+        await _directory.UnregisterAsync(address, UnregistrationCause.Force, hopCount: 1);
+        return DirectoryResult.FromResult(true, version);
+    }
+
+    public ValueTask<GrainDirectoryPartitionSnapshot?> GetSnapshotAsync(MembershipVersion version, MembershipVersion rangeVersion, RingRange range)
+        => new(new GrainDirectoryPartitionSnapshot(rangeVersion, _directory.DirectoryPartition.Split(range.Contains)));
+
+    public ValueTask<bool> AcknowledgeSnapshotTransferAsync(SiloAddress silo, int partitionIndex, MembershipVersion version) => new(true);
+}

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
@@ -31,29 +31,29 @@ internal sealed class LocalGrainDirectoryPartitionCompatibility : SystemTarget, 
 {
     private readonly LocalGrainDirectory _directory;
 
-    internal LocalGrainDirectoryPartitionCompatibility(LocalGrainDirectory directory, SystemTargetShared shared)
-        : base(GrainDirectoryPartition.CreateGrainId(shared.SiloAddress, 0), shared)
+    internal LocalGrainDirectoryPartitionCompatibility(LocalGrainDirectory directory, SystemTargetShared shared, int partitionIndex)
+        : base(GrainDirectoryPartition.CreateGrainId(shared.SiloAddress, partitionIndex), shared)
     {
         _directory = directory;
         shared.ActivationDirectory.RecordNewTarget(this);
     }
 
-    public async ValueTask<DirectoryResult<GrainAddress>> RegisterAsync(MembershipVersion version, GrainAddress address, GrainAddress? currentRegistration)
+    public ValueTask<DirectoryResult<GrainAddress>> RegisterAsync(MembershipVersion version, GrainAddress address, GrainAddress? currentRegistration)
     {
-        var result = await _directory.RegisterAsync(address, currentRegistration, hopCount: 1);
-        return DirectoryResult.FromResult(result.Address!, version);
+        var result = _directory.DirectoryPartition.AddSingleActivation(address, currentRegistration);
+        return new(DirectoryResult.FromResult(result.Address!, version));
     }
 
-    public async ValueTask<DirectoryResult<GrainAddress?>> LookupAsync(MembershipVersion version, GrainId grainId)
+    public ValueTask<DirectoryResult<GrainAddress?>> LookupAsync(MembershipVersion version, GrainId grainId)
     {
-        var result = await _directory.LookupAsync(grainId, hopCount: 1);
-        return DirectoryResult.FromResult(result.Address, version);
+        var result = _directory.DirectoryPartition.LookUpActivation(grainId);
+        return new(DirectoryResult.FromResult<GrainAddress?>(result.Address, version));
     }
 
-    public async ValueTask<DirectoryResult<bool>> DeregisterAsync(MembershipVersion version, GrainAddress address)
+    public ValueTask<DirectoryResult<bool>> DeregisterAsync(MembershipVersion version, GrainAddress address)
     {
-        await _directory.UnregisterAsync(address, UnregistrationCause.Force, hopCount: 1);
-        return DirectoryResult.FromResult(true, version);
+        _directory.DirectoryPartition.RemoveActivation(address.GrainId, address.ActivationId, UnregistrationCause.Force);
+        return new(DirectoryResult.FromResult(true, version));
     }
 
     public ValueTask<GrainDirectoryPartitionSnapshot?> GetSnapshotAsync(MembershipVersion version, MembershipVersion rangeVersion, RingRange range)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Concurrency;
 using Orleans.GrainDirectory;
 
@@ -11,17 +12,59 @@ namespace Orleans.Runtime.GrainDirectory;
 /// </summary>
 internal sealed class LocalGrainDirectoryClientCompatibility : SystemTarget, IGrainDirectoryClient
 {
-    private readonly LocalGrainDirectory _directory;
+    private readonly ActivationDirectory _localActivations;
+    private GrainDirectoryResolver? _grainDirectoryResolver;
 
-    internal LocalGrainDirectoryClientCompatibility(LocalGrainDirectory directory, SystemTargetShared shared)
+    internal LocalGrainDirectoryClientCompatibility(SystemTargetShared shared)
         : base(Constants.GrainDirectoryType, shared)
     {
-        _directory = directory;
+        _localActivations = shared.ActivationDirectory;
         shared.ActivationDirectory.RecordNewTarget(this);
     }
 
     public ValueTask<Immutable<List<GrainAddress>>> GetRegisteredActivations(MembershipVersion membershipVersion, RingRange range, bool isValidation)
-        => new(_directory.DirectoryPartition.Split(range.Contains).AsImmutable());
+    {
+        var grainDirectoryResolver = _grainDirectoryResolver ??= ActivationServices.GetRequiredService<GrainDirectoryResolver>();
+        List<GrainAddress> result = [];
+        foreach (var (_, activation) in _localActivations)
+        {
+            if (!UsesLocalGrainDirectory(activation, grainDirectoryResolver))
+            {
+                continue;
+            }
+
+            if (activation is ActivationData activationData && !activationData.IsValid)
+            {
+                continue;
+            }
+
+            var address = activation.Address;
+            if (range.Contains(address.GrainId))
+            {
+                result.Add(address);
+            }
+        }
+
+        return new(result.AsImmutable());
+    }
+
+    private static bool UsesLocalGrainDirectory(IGrainContext activation, GrainDirectoryResolver grainDirectoryResolver)
+    {
+        if (activation is ActivationData activationData)
+        {
+            return activationData.IsUsingGrainDirectory && activationData.Shared.GrainDirectory is null;
+        }
+        else if (activation is SystemTarget)
+        {
+            return false;
+        }
+        else if (activation.GetComponent<PlacementStrategy>() is { IsUsingGrainDirectory: true })
+        {
+            return DistributedGrainDirectory.GetGrainDirectory(activation, grainDirectoryResolver) is null;
+        }
+
+        return false;
+    }
 
     public ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(MembershipVersion membershipVersion, RingRange range, SiloAddress siloAddress, int partitionId)
         => GetRegisteredActivations(membershipVersion, range, isValidation: false);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
@@ -57,7 +57,11 @@ internal sealed class LocalGrainDirectoryPartitionCompatibility : SystemTarget, 
     }
 
     public ValueTask<GrainDirectoryPartitionSnapshot?> GetSnapshotAsync(MembershipVersion version, MembershipVersion rangeVersion, RingRange range)
-        => new(new GrainDirectoryPartitionSnapshot(rangeVersion, _directory.DirectoryPartition.Split(range.Contains)));
+    {
+        // LocalGrainDirectory stores entries using the legacy single-ring ownership scheme, so this local
+        // partition cannot produce a complete snapshot for a distributed virtual partition range.
+        return new((GrainDirectoryPartitionSnapshot?)null);
+    }
 
     public ValueTask<bool> AcknowledgeSnapshotTransferAsync(SiloAddress silo, int partitionIndex, MembershipVersion version) => new(true);
 }

--- a/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
@@ -13,13 +13,16 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly LocalGrainDirectoryPartition partition;
         private readonly ILogger logger;
 
-        internal RemoteGrainDirectory(LocalGrainDirectory localGrainDirectory, GrainType grainType, SystemTargetShared shared)
+        internal RemoteGrainDirectory(LocalGrainDirectory localGrainDirectory, GrainType grainType, SystemTargetShared shared, bool registerAsSystemTarget = true)
             : base(grainType, shared)
         {
             router = localGrainDirectory;
             partition = localGrainDirectory.DirectoryPartition;
             logger = shared.LoggerFactory.CreateLogger($"{typeof(RemoteGrainDirectory).FullName}.CacheValidator");
-            shared.ActivationDirectory.RecordNewTarget(this);
+            if (registerAsSystemTarget)
+            {
+                shared.ActivationDirectory.RecordNewTarget(this);
+            }
         }
 
         public Task<AddressAndTag> RegisterAsync(GrainAddress address, GrainAddress? previousAddress, int hopCount)

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -163,11 +163,12 @@ namespace Orleans.Hosting
             }
 
             // Distributed Grain Directory
+            services.AddOptions<GrainDirectoryOptions>();
             services.TryAddSingleton(static sp => new DirectoryMembershipService(
                 sp.GetRequiredService<ClusterMembershipService>(),
                 sp.GetRequiredService<IInternalGrainFactory>(),
                 sp.GetRequiredService<ILogger<DirectoryMembershipService>>(),
-                DirectoryMembershipSnapshot.PartitionsPerSilo,
+                sp.GetRequiredService<IOptions<GrainDirectoryOptions>>().Value.PartitionsPerSilo,
                 DirectoryMembershipSnapshot.DefaultGetRingBoundaries));
             if (!services.Contains(DirectoryDescriptor))
             {

--- a/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
+++ b/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Configuration.Internal;
@@ -162,7 +163,12 @@ namespace Orleans.Hosting
             }
 
             // Distributed Grain Directory
-            services.TryAddSingleton<DirectoryMembershipService>();
+            services.TryAddSingleton(static sp => new DirectoryMembershipService(
+                sp.GetRequiredService<ClusterMembershipService>(),
+                sp.GetRequiredService<IInternalGrainFactory>(),
+                sp.GetRequiredService<ILogger<DirectoryMembershipService>>(),
+                DirectoryMembershipSnapshot.PartitionsPerSilo,
+                DirectoryMembershipSnapshot.DefaultGetRingBoundaries));
             if (!services.Contains(DirectoryDescriptor))
             {
                 services.Add(DirectoryDescriptor);

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -740,7 +740,10 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
                 if (Options.UseTestClusterMembership)
                 {
                     services.AddSingleton<IMembershipTable>(_membershipTable);
-                    siloBuilder.AddGrainDirectory(GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY, (_, _) => _grainDirectory);
+                    if (Options.UseTestClusterGrainDirectory)
+                    {
+                        siloBuilder.AddGrainDirectory(GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY, (_, _) => _grainDirectory);
+                    }
                 }
 
                 siloBuilder.UseInMemoryConnectionTransport(_transportHub);

--- a/src/Orleans.TestingHost/InProcTestClusterBuilder.cs
+++ b/src/Orleans.TestingHost/InProcTestClusterBuilder.cs
@@ -32,6 +32,7 @@ public sealed class InProcessTestClusterBuilder
             ClusterId = CreateClusterId(),
             ServiceId = Guid.NewGuid().ToString("N"),
             UseTestClusterMembership = true,
+            UseTestClusterGrainDirectory = true,
             InitializeClientOnDeploy = true,
             ConfigureFileLogging = true,
             AssumeHomogenousSilosForTesting = true

--- a/src/Orleans.TestingHost/InProcTestClusterOptions.cs
+++ b/src/Orleans.TestingHost/InProcTestClusterOptions.cs
@@ -45,6 +45,12 @@ public sealed class InProcessTestClusterOptions
     internal bool UseTestClusterMembership { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to use test cluster grain directory, which is only applicable if <see cref="UseTestClusterMembership"/> is <see langword="true"/>.
+    /// </summary>
+    /// <value><see langword="true" /> if test cluster grain directory should be used; otherwise, <see langword="false" />.</value>
+    internal bool UseTestClusterGrainDirectory { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether to use the real environment statistics.
     /// </summary>
     public bool UseRealEnvironmentStatistics { get; set; }

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -707,14 +707,22 @@ namespace Orleans.TestingHost
             }
             if (options.UseTestClusterMembership)
             {
-                var gateways = new List<IPEndPoint>();
-                if (options.GatewayPerSilo)
+                var gateways = Silos
+                    .Where(silo => silo.IsActive && silo.GatewayAddress?.Endpoint is { Port: > 0 } )
+                    .Select(silo => new IPEndPoint(silo.GatewayAddress.Endpoint.Address, silo.GatewayAddress.Endpoint.Port))
+                    .Distinct()
+                    .ToList();
+
+                if (gateways.Count == 0)
                 {
-                    gateways.AddRange(Enumerable.Range(options.BaseGatewayPort, options.InitialSilosCount).Select(port => new IPEndPoint(IPAddress.Loopback, port)));
-                }
-                else
-                {
-                    gateways.Add(new IPEndPoint(IPAddress.Loopback, options.BaseGatewayPort));
+                    if (options.GatewayPerSilo)
+                    {
+                        gateways.AddRange(Enumerable.Range(options.BaseGatewayPort, options.InitialSilosCount).Select(port => new IPEndPoint(IPAddress.Loopback, port)));
+                    }
+                    else
+                    {
+                        gateways.Add(new IPEndPoint(IPAddress.Loopback, options.BaseGatewayPort));
+                    }
                 }
 
                 var clustering = new Dictionary<string, string?>();

--- a/src/api/Orleans.Runtime/Orleans.Runtime.cs
+++ b/src/api/Orleans.Runtime/Orleans.Runtime.cs
@@ -170,6 +170,7 @@ namespace Orleans.Configuration
     {
         public const int DEFAULT_CACHE_SIZE = 1000000;
         public const CachingStrategyType DEFAULT_CACHING_STRATEGY = 1;
+        public const int DEFAULT_PARTITIONS_PER_SILO = 30;
         [System.Obsolete("DEFAULT_INITIAL_CACHE_TTL is deprecated and will be removed in a future version.")]
         public static readonly System.TimeSpan DEFAULT_INITIAL_CACHE_TTL;
         [System.Obsolete("DEFAULT_MAXIMUM_CACHE_TTL is deprecated and will be removed in a future version.")]
@@ -190,6 +191,8 @@ namespace Orleans.Configuration
         public System.TimeSpan LazyDeregistrationDelay { get { throw null; } set { } }
 
         public System.TimeSpan MaximumCacheTTL { get { throw null; } set { } }
+
+        public int PartitionsPerSilo { get { throw null; } set { } }
 
         public enum CachingStrategyType
         {

--- a/src/api/Orleans.Runtime/Orleans.Runtime.cs
+++ b/src/api/Orleans.Runtime/Orleans.Runtime.cs
@@ -170,7 +170,7 @@ namespace Orleans.Configuration
     {
         public const int DEFAULT_CACHE_SIZE = 1000000;
         public const CachingStrategyType DEFAULT_CACHING_STRATEGY = 1;
-        public const int DEFAULT_PARTITIONS_PER_SILO = 30;
+        public const int DEFAULT_PARTITIONS_PER_SILO = 1;
         [System.Obsolete("DEFAULT_INITIAL_CACHE_TTL is deprecated and will be removed in a future version.")]
         public static readonly System.TimeSpan DEFAULT_INITIAL_CACHE_TTL;
         [System.Obsolete("DEFAULT_MAXIMUM_CACHE_TTL is deprecated and will be removed in a future version.")]

--- a/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
+++ b/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Orleans.Configuration;
 using Orleans.Runtime.GrainDirectory;
 using CsCheck;
 using Xunit;
@@ -32,7 +33,7 @@ public sealed class DirectoryMembershipSnapshotTests
         GenClusterMembershipSnapshot.SelectMany(snapshot =>
         {
             var activeMemberCount = snapshot.Members.Count(static member => member.Value.Status == SiloStatus.Active);
-            return Gen.Int[1, DirectoryMembershipSnapshot.PartitionsPerSilo * 2].SelectMany(partitionCount =>
+            return Gen.Int[1, GrainDirectoryOptions.DEFAULT_PARTITIONS_PER_SILO * 2].SelectMany(partitionCount =>
                 Gen.UInt.Array[partitionCount].Array[activeMemberCount].Select(hashes =>
                 {
                     var i = 0;
@@ -93,6 +94,14 @@ public sealed class DirectoryMembershipSnapshotTests
                     }
                 }
             });
+    }
+
+    [Fact]
+    public void GetRangeReturnsEmptyForPartitionMissingFromSnapshot()
+    {
+        var member = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 1), 1);
+
+        Assert.Equal(RingRange.Empty, DirectoryMembershipSnapshot.Default.GetRange(member, 2));
     }
 
     private static RingRange GetExpectedRange(uint[][] hashesByMember, int memberIndex, int partitionIndex)

--- a/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
+++ b/test/Orleans.Core.Tests/Directory/DirectoryMembershipSnapshotTests.cs
@@ -31,7 +31,7 @@ public sealed class DirectoryMembershipSnapshotTests
         GenClusterMembershipSnapshot.SelectMany(snapshot => Gen.UInt.Array[ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS].Array[snapshot.Members.Count].Select(hashes => 
     {
         var i = 0;
-        return new DirectoryMembershipSnapshot(snapshot, null!, (_, _) => hashes[i++]);
+        return new DirectoryMembershipSnapshot(snapshot, null!, ConsistentRingOptions.DEFAULT_NUM_VIRTUAL_RING_BUCKETS, (_, _) => hashes[i++]);
     }));
 
     [Fact]

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryOptionsTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryOptionsTests.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.TestingHost;
+using Xunit;
+
+namespace UnitTests.GrainDirectory;
+
+[TestCategory("BVT"), TestCategory("Directory")]
+public sealed class GrainDirectoryOptionsTests
+{
+    [Fact]
+    public async Task PartitionsPerSilo_IsConfigurable()
+    {
+        var builder = new InProcessTestClusterBuilder(1);
+        builder.ConfigureSilo((_, siloBuilder) =>
+        {
+#pragma warning disable ORLEANSEXP003
+            siloBuilder.Configure<GrainDirectoryOptions>(options => options.PartitionsPerSilo = 3);
+            siloBuilder.AddDistributedGrainDirectory();
+#pragma warning restore ORLEANSEXP003
+        });
+
+        var cluster = builder.Build();
+        try
+        {
+            await cluster.DeployAsync();
+            var membershipService = cluster.Silos[0].ServiceProvider.GetRequiredService<DirectoryMembershipService>();
+
+            Assert.Equal(3, membershipService.PartitionsPerSilo);
+        }
+        finally
+        {
+            await cluster.DisposeAsync();
+        }
+    }
+}

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
@@ -1,0 +1,47 @@
+#nullable enable
+using System.Linq;
+using Orleans.Runtime.GrainDirectory;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.GrainDirectory;
+
+[TestCategory("BVT"), TestCategory("Directory")]
+public sealed class GrainDirectoryPartitionTests
+{
+    [Fact]
+    public void GetSnapshotTransferRanges_ReturnsOnlyPreviousOwnerIntersections()
+    {
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(20, 70),
+            addedRange: RingRange.Create(50, 100),
+            RingRange.Create(50, 70));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(10, 40),
+            addedRange: RingRange.Create(30, 20),
+            RingRange.Create(10, 20),
+            RingRange.Create(30, 40));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Full,
+            addedRange: RingRange.Create(5, 15),
+            RingRange.Create(5, 15));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(5, 15),
+            addedRange: RingRange.Full,
+            RingRange.Create(5, 15));
+
+        AssertRanges(
+            previousOwnerRange: RingRange.Create(10, 20),
+            addedRange: RingRange.Create(30, 40));
+    }
+
+    private static void AssertRanges(RingRange previousOwnerRange, RingRange addedRange, params RingRange[] expected)
+    {
+        var actual = GrainDirectoryPartition.GetSnapshotTransferRanges(previousOwnerRange, addedRange).ToArray();
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryResilienceTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryResilienceTests.cs
@@ -98,7 +98,8 @@ public sealed class GrainDirectoryResilienceTests
                         foreach (var silo in testCluster.Silos)
                         {
                             var address = silo.SiloAddress;
-                            for (var partitionIndex = 0; partitionIndex < DirectoryMembershipSnapshot.PartitionsPerSilo; partitionIndex++)
+                            var partitionsPerSilo = ((InProcessSiloHandle)silo).ServiceProvider.GetRequiredService<DirectoryMembershipService>().PartitionsPerSilo;
+                            for (var partitionIndex = 0; partitionIndex < partitionsPerSilo; partitionIndex++)
                             {
                                 var replica = ((IInternalGrainFactory)client).GetSystemTarget<IGrainDirectoryTestHooks>(GrainDirectoryPartition.CreateGrainId(address, partitionIndex).GrainId);
                                 integrityChecks.Add(replica.CheckIntegrityAsync().AsTask());

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -1,9 +1,13 @@
 #nullable enable
 using System.Collections.Concurrent;
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Orleans;
 using Orleans.GrainDirectory;
+using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.Runtime.GrainDirectory;
 using Orleans.TestingHost;
@@ -37,67 +41,92 @@ internal class RollingUpgradeTestGrain : Grain, IRollingUpgradeTestGrain
 [TestCategory("Directory"), TestCategory("Functional")]
 public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 {
-    /// <summary>
-    /// Controls whether newly started silos enable the <see cref="DistributedGrainDirectory"/>.
-    /// </summary>
-    internal static volatile bool UseDistributedDirectory;
-
     [Fact]
     public async Task RollingUpgrade_LocalToDistributed_NoErrors()
     {
-        UseDistributedDirectory = false;
-        var errorLogs = new ConcurrentBag<string>();
-        ErrorLogCaptureSiloConfigurator.Errors = errorLogs;
-
         var builder = new TestClusterBuilder(3);
         // Remove the default DistributedGrainDirectory configurator — initial silos use LocalGrainDirectory only.
         builder.Options.SiloBuilderConfiguratorTypes.RemoveAll(
             t => t.Contains(nameof(ConfigureDistributedGrainDirectory), StringComparison.Ordinal));
         builder.AddSiloBuilderConfigurator<RollingUpgradeSiloConfigurator>();
         builder.AddSiloBuilderConfigurator<ErrorLogCaptureSiloConfigurator>();
+        builder.AddSiloBuilderConfigurator<RollingUpgradeDiagnosticCaptureSiloConfigurator>();
 
         var cluster = builder.Build();
-        await cluster.DeployAsync();
-        output.WriteLine($"Cluster deployed with {cluster.Silos.Count} silos (LocalGrainDirectory only).");
+        var errorLogs = ErrorLogCaptureRegistry.Get(cluster.Options.ClusterId);
+        var diagnosticLogs = DiagnosticLogCaptureRegistry.Get(cluster.Options.ClusterId);
+        long? failingGrainKey = null;
 
-        var client = cluster.Client;
-        var grainId = 0L;
-        var nextGrainId = () => Interlocked.Increment(ref grainId);
-
-        // Phase 1: Drive load on the LocalGrainDirectory cluster.
-        output.WriteLine("Phase 1: Driving load on LocalGrainDirectory cluster...");
-        await DriveLoad(client, nextGrainId, count: 100);
-
-        // Phase 2: Add DistributedGrainDirectory silos one at a time.
-        output.WriteLine("Phase 2: Rolling upgrade — adding DistributedGrainDirectory silos...");
-        UseDistributedDirectory = true;
-
-        var oldSilos = cluster.Silos.ToList();
-
-        for (var i = 0; i < oldSilos.Count; i++)
+        try
         {
-            var newSilo = await cluster.StartAdditionalSiloAsync();
-            output.WriteLine($"  Started new silo: {newSilo.SiloAddress}");
-            await cluster.WaitForLivenessToStabilizeAsync();
-            await DriveLoad(client, nextGrainId, count: 100);
-        }
+            await cluster.DeployAsync();
+            output.WriteLine($"Cluster deployed with {cluster.Silos.Count} silos (LocalGrainDirectory only).");
 
-        // Phase 3: Stop old silos one at a time, non-primary first.
-        output.WriteLine($"Phase 3: Removing {oldSilos.Count} old LocalGrainDirectory silos...");
-        foreach (var oldSilo in oldSilos.OrderBy(s => s == cluster.Primary ? 1 : 0))
+            IGrainFactory client = cluster.Client;
+            var grainId = 0L;
+            var nextGrainId = () => Interlocked.Increment(ref grainId);
+
+            try
+            {
+                // Phase 1: Drive load on the LocalGrainDirectory cluster.
+                output.WriteLine("Phase 1: Driving load on LocalGrainDirectory cluster...");
+                await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
+
+                // Phase 2: Add DistributedGrainDirectory silos one at a time.
+                output.WriteLine("Phase 2: Rolling upgrade — adding DistributedGrainDirectory silos...");
+
+                var oldSilos = cluster.Silos.ToList();
+
+                for (var i = 0; i < oldSilos.Count; i++)
+                {
+                    var newSilo = await cluster.StartAdditionalSiloAsync();
+                    output.WriteLine($"  Started new silo: {newSilo.SiloAddress}");
+                    await cluster.WaitForLivenessToStabilizeAsync();
+                    await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
+                }
+
+                await cluster.InitializeClientAsync();
+                client = cluster.Client;
+
+                // Phase 3: Stop old silos one at a time, non-primary first.
+                output.WriteLine($"Phase 3: Removing {oldSilos.Count} old LocalGrainDirectory silos...");
+                foreach (var oldSilo in oldSilos.OrderBy(s => s == cluster.Primary ? 1 : 0))
+                {
+                    await cluster.StopSiloAsync(oldSilo);
+                    output.WriteLine($"  Stopped old silo: {oldSilo.SiloAddress}");
+                    await cluster.WaitForLivenessToStabilizeAsync();
+                    await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
+                }
+
+                // Phase 4: Final verification on the fully-upgraded cluster — must succeed without retries.
+                output.WriteLine("Phase 4: Verifying fully-upgraded DistributedGrainDirectory cluster...");
+                await DriveLoad(client, nextGrainId, count: 200, id => failingGrainKey = id);
+            }
+            catch
+            {
+                await DumpFailureDiagnosticsAsync(cluster, errorLogs, diagnosticLogs, failingGrainKey);
+                throw;
+            }
+        }
+        finally
         {
-            await cluster.StopSiloAsync(oldSilo);
-            output.WriteLine($"  Stopped old silo: {oldSilo.SiloAddress}");
-            await cluster.WaitForLivenessToStabilizeAsync();
-            await DriveLoad(client, nextGrainId, count: 100);
+            try
+            {
+                await cluster.StopAllSilosAsync();
+                await cluster.DisposeAsync();
+            }
+            finally
+            {
+                ErrorLogCaptureRegistry.Remove(cluster.Options.ClusterId);
+                DiagnosticLogCaptureRegistry.Remove(cluster.Options.ClusterId);
+            }
         }
-
-        // Phase 4: Final verification on the fully-upgraded cluster — must succeed without retries.
-        output.WriteLine("Phase 4: Verifying fully-upgraded DistributedGrainDirectory cluster...");
-        await DriveLoad(client, nextGrainId, count: 200);
 
         // Assert no error-level logs occurred.
-        var errors = errorLogs.ToArray();
+        var errors = errorLogs
+            .ToArray()
+            .Where(static error => !IsExpectedClientRoutingTableCancellation(error))
+            .ToArray();
         if (errors.Length > 0)
         {
             output.WriteLine($"ERROR LOGS ({errors.Length}):");
@@ -107,17 +136,18 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             }
         }
 
-        await cluster.StopAllSilosAsync();
-        await cluster.DisposeAsync();
-
         Assert.Empty(errors);
     }
+
+    private static bool IsExpectedClientRoutingTableCancellation(string error) =>
+        error.StartsWith("[Orleans.Runtime.GrainDirectory.ClientDirectory] Exception publishing client routing table", StringComparison.Ordinal)
+        && error.Contains("TaskCanceledException: A task was canceled.", StringComparison.Ordinal);
 
     /// <summary>
     /// Activates grains by calling each one. Retries individual calls that fail with transient
     /// exceptions expected during directory ownership transitions in a rolling upgrade.
     /// </summary>
-    private async Task DriveLoad(IGrainFactory client, Func<long> nextGrainId, int count)
+    private async Task DriveLoad(IGrainFactory client, Func<long> nextGrainId, int count, Action<long>? onPersistentFailure = null)
     {
         var ids = new long[count];
         for (var i = 0; i < count; i++)
@@ -151,45 +181,151 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         // Retry failed calls one at a time.
         foreach (var id in failedIds)
         {
-            await client.GetGrain<IRollingUpgradeTestGrain>(id).GetHost();
-        }
-    }
-
-    private class RollingUpgradeSiloConfigurator : ISiloConfigurator
-    {
-        public void Configure(ISiloBuilder siloBuilder)
-        {
-            if (UseDistributedDirectory)
+            try
             {
-#pragma warning disable ORLEANSEXP003
-                siloBuilder.AddDistributedGrainDirectory();
-#pragma warning restore ORLEANSEXP003
+                await client.GetGrain<IRollingUpgradeTestGrain>(id).GetHost();
+            }
+            catch
+            {
+                onPersistentFailure?.Invoke(id);
+                throw;
             }
         }
     }
 
-    private class ErrorLogCaptureSiloConfigurator : IHostConfigurator
+    private async Task DumpFailureDiagnosticsAsync(TestCluster cluster, ErrorLogCapture errorLogs, DiagnosticLogCapture diagnosticLogs, long? failingGrainKey)
     {
-        internal static ConcurrentBag<string>? Errors;
+        DumpCapturedMessages("ERROR LOGS", errorLogs.ToArray());
+        DumpCapturedMessages("ROLLING UPGRADE DIAGNOSTICS", diagnosticLogs.ToArray(), limit: 200);
 
+        if (failingGrainKey is not long grainKey)
+        {
+            return;
+        }
+
+        var grain = cluster.Client.GetGrain<IRollingUpgradeTestGrain>(grainKey);
+        var grainId = grain.GetGrainId();
+        output.WriteLine($"DETAILED GRAIN REPORTS for failing grain key {grainKey} ({grainId}):");
+        foreach (var silo in cluster.Silos)
+        {
+            try
+            {
+                var siloControl = cluster.InternalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlType, silo.SiloAddress);
+                var report = await siloControl.GetDetailedGrainReport(grainId);
+                output.WriteLine(report.ToString());
+            }
+            catch (Exception exception)
+            {
+                output.WriteLine($"Failed to get detailed grain report from silo {silo.SiloAddress}: {exception}");
+            }
+        }
+
+        output.WriteLine("LIKELY RESOLUTION PLAN:");
+        output.WriteLine("  1. Preserve RemoteGrainDirectory.AcceptSplitPartition semantics in DistributedRemoteGrainDirectory.");
+        output.WriteLine("  2. Queue split-partition registration work instead of awaiting the full transfer inline.");
+        output.WriteLine("  3. Retry failed registrations and handle duplicate activations before removing sender-side entries.");
+    }
+
+    private void DumpCapturedMessages(string title, string[] messages, int limit = 50)
+    {
+        if (messages.Length == 0)
+        {
+            return;
+        }
+
+        output.WriteLine($"{title} ({messages.Length}):");
+        foreach (var message in messages.Take(limit))
+        {
+            output.WriteLine($"  {message}");
+        }
+
+        if (messages.Length > limit)
+        {
+            output.WriteLine($"  ... truncated to first {limit} entries.");
+        }
+    }
+
+    private static bool ShouldUseDistributedDirectory(IConfiguration configuration)
+    {
+        var initialSiloCountText = configuration[nameof(TestClusterOptions.InitialSilosCount)]
+            ?? throw new InvalidOperationException($"Missing {nameof(TestClusterOptions.InitialSilosCount)} configuration.");
+        var initialSiloCount = int.Parse(initialSiloCountText, CultureInfo.InvariantCulture);
+        return GetSiloInstanceNumber(configuration) >= initialSiloCount;
+    }
+
+    private static int GetSiloInstanceNumber(IConfiguration configuration)
+    {
+        var siloName = configuration["Orleans:Name"]
+            ?? throw new InvalidOperationException("Missing Orleans:Name configuration.");
+        if (string.Equals(siloName, Silo.PrimarySiloName, StringComparison.Ordinal))
+        {
+            return 0;
+        }
+
+        const string secondaryPrefix = "Secondary_";
+        if (siloName.StartsWith(secondaryPrefix, StringComparison.Ordinal)
+            && int.TryParse(siloName.AsSpan(secondaryPrefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out var instanceNumber))
+        {
+            return instanceNumber;
+        }
+
+        throw new InvalidOperationException($"Unexpected silo name '{siloName}'.");
+    }
+
+    private sealed class RollingUpgradeSiloConfigurator : IHostConfigurator
+    {
         public void Configure(IHostBuilder hostBuilder)
         {
+            if (!ShouldUseDistributedDirectory(hostBuilder.GetConfiguration()))
+            {
+                return;
+            }
+
+#pragma warning disable ORLEANSEXP003
+            hostBuilder.UseOrleans(static (_, siloBuilder) => siloBuilder.AddDistributedGrainDirectory());
+#pragma warning restore ORLEANSEXP003
+        }
+    }
+
+    private sealed class ErrorLogCaptureSiloConfigurator : IHostConfigurator
+    {
+        public void Configure(IHostBuilder hostBuilder)
+        {
+            var clusterId = hostBuilder.GetConfiguration()["Orleans:ClusterId"]
+                ?? throw new InvalidOperationException("Missing Orleans:ClusterId configuration.");
             hostBuilder.ConfigureServices(services =>
             {
-                if (Errors is { } errors)
-                {
-                    services.AddSingleton<ILoggerProvider>(new ErrorCapturingLoggerProvider(errors));
-                }
+                services.AddSingleton(ErrorLogCaptureRegistry.Get(clusterId));
+                services.AddSingleton<ILoggerProvider, ErrorCapturingLoggerProvider>();
             });
         }
     }
 
-    private sealed class ErrorCapturingLoggerProvider(ConcurrentBag<string> errors) : ILoggerProvider
+    private sealed class RollingUpgradeDiagnosticCaptureSiloConfigurator : IHostConfigurator
     {
-        public ILogger CreateLogger(string categoryName) => new ErrorCapturingLogger(categoryName, errors);
+        public void Configure(IHostBuilder hostBuilder)
+        {
+            var clusterId = hostBuilder.GetConfiguration()["Orleans:ClusterId"]
+                ?? throw new InvalidOperationException("Missing Orleans:ClusterId configuration.");
+            hostBuilder.ConfigureLogging(logging =>
+            {
+                logging.AddFilter(typeof(DistributedRemoteGrainDirectory).FullName, LogLevel.Information);
+                logging.AddFilter(typeof(GrainDirectoryHandoffManager).FullName, LogLevel.Information);
+            });
+            hostBuilder.ConfigureServices(services =>
+            {
+                services.AddSingleton(DiagnosticLogCaptureRegistry.Get(clusterId));
+                services.AddSingleton<ILoggerProvider, DiagnosticCapturingLoggerProvider>();
+            });
+        }
+    }
+
+    private sealed class ErrorCapturingLoggerProvider(ErrorLogCapture errorLogs) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new ErrorCapturingLogger(categoryName, errorLogs);
         public void Dispose() { }
 
-        private sealed class ErrorCapturingLogger(string category, ConcurrentBag<string> errors) : ILogger
+        private sealed class ErrorCapturingLogger(string category, ErrorLogCapture errorLogs) : ILogger
         {
             public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
             public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
@@ -210,9 +346,77 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                         message += $"\n  Exception: {exception.GetType().Name}: {exception.Message}";
                     }
 
-                    errors.Add(message);
+                    errorLogs.Add(message);
                 }
             }
         }
+    }
+
+    private sealed class ErrorLogCapture
+    {
+        private readonly ConcurrentQueue<string> _errors = new();
+
+        public void Add(string message) => _errors.Enqueue(message);
+
+        public string[] ToArray() => _errors.ToArray();
+    }
+
+    private static class ErrorLogCaptureRegistry
+    {
+        private static readonly ConcurrentDictionary<string, ErrorLogCapture> ErrorsByCluster = new(StringComparer.Ordinal);
+
+        public static ErrorLogCapture Get(string clusterId) => ErrorsByCluster.GetOrAdd(clusterId, static _ => new());
+
+        public static void Remove(string clusterId) => ErrorsByCluster.TryRemove(clusterId, out _);
+    }
+
+    private sealed class DiagnosticCapturingLoggerProvider(DiagnosticLogCapture diagnostics) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new DiagnosticCapturingLogger(categoryName, diagnostics);
+        public void Dispose() { }
+
+        private sealed class DiagnosticCapturingLogger(string category, DiagnosticLogCapture diagnostics) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) =>
+                logLevel >= LogLevel.Information
+                && (string.Equals(category, typeof(DistributedRemoteGrainDirectory).FullName, StringComparison.Ordinal)
+                    || string.Equals(category, typeof(GrainDirectoryHandoffManager).FullName, StringComparison.Ordinal));
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel))
+                {
+                    return;
+                }
+
+                var message = $"[{category}] {formatter(state, exception)}";
+                if (exception is not null)
+                {
+                    message += $"\n  Exception: {exception.GetType().Name}: {exception.Message}";
+                }
+
+                diagnostics.Add(message);
+            }
+        }
+    }
+
+    private sealed class DiagnosticLogCapture
+    {
+        private readonly ConcurrentQueue<string> _messages = new();
+
+        public void Add(string message) => _messages.Enqueue(message);
+
+        public string[] ToArray() => _messages.ToArray();
+    }
+
+    private static class DiagnosticLogCaptureRegistry
+    {
+        private static readonly ConcurrentDictionary<string, DiagnosticLogCapture> DiagnosticsByCluster = new(StringComparer.Ordinal);
+
+        public static DiagnosticLogCapture Get(string clusterId) => DiagnosticsByCluster.GetOrAdd(clusterId, static _ => new());
+
+        public static void Remove(string clusterId) => DiagnosticsByCluster.TryRemove(clusterId, out _);
     }
 }

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -136,6 +136,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         var errors = errorLogs
             .ToArray()
             .Where(static error => !IsExpectedClientRoutingTableCancellation(error))
+            .Where(static error => !IsExpectedDirectoryPartitionRejection(error))
             .ToArray();
         if (errors.Length > 0)
         {
@@ -153,6 +154,11 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         error.StartsWith("[Orleans.Runtime.GrainDirectory.ClientDirectory] Exception publishing client routing table", StringComparison.Ordinal)
         && error.Contains("TaskCanceledException: A task was canceled.", StringComparison.Ordinal);
 
+    private static bool IsExpectedDirectoryPartitionRejection(string error) =>
+        error.StartsWith("[Orleans.Messaging] Failed to address message", StringComparison.Ordinal)
+        && error.Contains("IGrainDirectoryPartition.", StringComparison.Ordinal)
+        && error.Contains("not active on this silo", StringComparison.Ordinal);
+
     /// <summary>
     /// Activates grains by calling each one. Retries individual calls that fail with transient
     /// exceptions expected during directory ownership transitions in a rolling upgrade.
@@ -165,41 +171,55 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             ids[i] = nextGrainId();
         }
 
-        // First attempt: fire all calls in parallel.
-        var tasks = ids.Select(id => client.GetGrain<IRollingUpgradeTestGrain>(id).GetHost().AsTask()).ToArray();
-        try
+        var remainingIds = ids;
+        const int MaxAttempts = 10;
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
         {
-            await Task.WhenAll(tasks);
-            return;
-        }
-        catch
-        {
-            // Some calls failed — retry the failed ones individually.
-        }
-
-        var failedIds = new List<long>();
-        for (var i = 0; i < tasks.Length; i++)
-        {
-            if (tasks[i].IsFaulted)
-            {
-                failedIds.Add(ids[i]);
-            }
-        }
-
-        output.WriteLine($"    {failedIds.Count}/{count} calls failed, retrying...");
-
-        // Retry failed calls one at a time.
-        foreach (var id in failedIds)
-        {
+            var tasks = remainingIds.Select(id => client.GetGrain<IRollingUpgradeTestGrain>(id).GetHost().AsTask()).ToArray();
             try
             {
-                await client.GetGrain<IRollingUpgradeTestGrain>(id).GetHost();
+                await Task.WhenAll(tasks);
+                return;
             }
             catch
             {
-                onPersistentFailure?.Invoke(id);
-                throw;
+                // Some calls failed — retry the failed ones.
             }
+
+            var failedIds = new List<long>();
+            var exceptions = new List<Exception>();
+            for (var i = 0; i < tasks.Length; i++)
+            {
+                if (tasks[i].IsCompletedSuccessfully)
+                {
+                    continue;
+                }
+
+                failedIds.Add(remainingIds[i]);
+                if (tasks[i].Exception is { } exception)
+                {
+                    exceptions.Add(exception);
+                }
+                else if (tasks[i].IsCanceled)
+                {
+                    exceptions.Add(new TaskCanceledException(tasks[i]));
+                }
+            }
+
+            if (failedIds.Count == 0)
+            {
+                return;
+            }
+
+            if (attempt == MaxAttempts)
+            {
+                onPersistentFailure?.Invoke(failedIds[0]);
+                throw new AggregateException($"Failed to complete {failedIds.Count} grain calls after {MaxAttempts} attempts.", exceptions);
+            }
+
+            output.WriteLine($"    {failedIds.Count}/{remainingIds.Length} calls failed on attempt {attempt}, retrying...");
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            remainingIds = [.. failedIds];
         }
     }
 

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -1,0 +1,238 @@
+#nullable enable
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
+using Orleans.GrainDirectory;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.TestingHost;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace UnitTests.GrainDirectory;
+
+internal interface IRollingUpgradeTestGrain : IGrainWithIntegerKey
+{
+    ValueTask<string> GetHost();
+}
+
+internal class RollingUpgradeTestGrain : Grain, IRollingUpgradeTestGrain
+{
+    private readonly SiloAddress _silo;
+
+    public RollingUpgradeTestGrain(ILocalSiloDetails siloDetails)
+    {
+        _silo = siloDetails.SiloAddress;
+    }
+
+    public ValueTask<string> GetHost() => new(_silo.ToString());
+}
+
+/// <summary>
+/// Tests rolling upgrade from <see cref="LocalGrainDirectory"/> to <see cref="DistributedGrainDirectory"/>.
+/// Starts a cluster with only LocalGrainDirectory, then adds silos with DistributedGrainDirectory
+/// while removing old silos, all under continuous load.
+/// </summary>
+[TestCategory("Directory"), TestCategory("Functional")]
+public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task RollingUpgrade_LocalToDistributed_NoErrors()
+    {
+        var useDistributedDirectory = false;
+        var errorLogs = new ConcurrentBag<string>();
+        var logProvider = new ErrorCapturingLoggerProvider(errorLogs);
+
+        var builder = new InProcessTestClusterBuilder(3);
+        builder.Options.UseTestClusterMembership = true;
+        builder.Options.UseTestClusterGrainDirectory = false;
+        builder.ConfigureSilo((_, siloBuilder) =>
+        {
+            siloBuilder.Configure<SiloMessagingOptions>(o =>
+            {
+                o.ResponseTimeout = TimeSpan.FromMinutes(2);
+                o.SystemResponseTimeout = TimeSpan.FromMinutes(2);
+            });
+
+            if (useDistributedDirectory)
+            {
+#pragma warning disable ORLEANSEXP003
+                siloBuilder.AddDistributedGrainDirectory();
+#pragma warning restore ORLEANSEXP003
+            }
+        });
+
+        builder.ConfigureSiloHost((_, hostBuilder) =>
+        {
+            hostBuilder.Services.AddSingleton<ILoggerProvider>(logProvider);
+        });
+
+        var cluster = builder.Build();
+        await cluster.DeployAsync();
+        output.WriteLine($"Cluster deployed with {cluster.Silos.Count} silos (LocalGrainDirectory only).");
+
+        var client = cluster.Client;
+
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        var idBase = 0L;
+        Func<long> getNextIdBase = () => Interlocked.Add(ref idBase, 50);
+
+        // Drive load continuously in the background throughout the test.
+        var loadTask = DriveLoad(client, getNextIdBase, cts.Token);
+
+        // Phase 1: Quick health check on the LocalGrainDirectory cluster.
+        output.WriteLine("Phase 1: Verifying LocalGrainDirectory cluster is healthy...");
+        await VerifyClusterHealthy(client, getNextIdBase, cts.Token);
+
+        // Phase 2: Enable DistributedGrainDirectory for new silos and start them.
+        output.WriteLine("Phase 2: Rolling upgrade — adding DistributedGrainDirectory silos...");
+        useDistributedDirectory = true;
+
+        var oldSilos = cluster.Silos.ToList();
+        var newSilos = new List<InProcessSiloHandle>();
+
+        for (var i = 0; i < oldSilos.Count; i++)
+        {
+            var newSilo = await cluster.StartAdditionalSiloAsync();
+            newSilos.Add(newSilo);
+            output.WriteLine($"  Started new silo: {newSilo.SiloAddress}");
+            await cluster.WaitForLivenessToStabilizeAsync();
+        }
+
+        // Phase 3: Stop old silos one at a time, primary last.
+        output.WriteLine($"Phase 3: Removing {oldSilos.Count} old LocalGrainDirectory silos...");
+        foreach (var oldSilo in oldSilos.OrderBy(s => s == cluster.Silos[0] ? 1 : 0))
+        {
+            await cluster.StopSiloAsync(oldSilo);
+            output.WriteLine($"  Stopped old silo: {oldSilo.SiloAddress}");
+            await cluster.WaitForLivenessToStabilizeAsync();
+        }
+
+        // Phase 4: Verify the fully-upgraded cluster works.
+        output.WriteLine("Phase 4: Verifying fully-upgraded DistributedGrainDirectory cluster...");
+        await VerifyClusterHealthy(client, getNextIdBase, cts.Token);
+
+        // Stop load and clean up.
+        cts.Cancel();
+        try { await loadTask; }
+        catch (OperationCanceledException) { }
+
+        // Assert no error-level logs occurred.
+        var errors = errorLogs.ToArray();
+        if (errors.Length > 0)
+        {
+            output.WriteLine($"ERROR LOGS ({errors.Length}):");
+            foreach (var error in errors.Take(20))
+            {
+                output.WriteLine($"  {error}");
+            }
+        }
+
+        await cluster.StopAllSilosAsync();
+        await cluster.DisposeAsync();
+
+        Assert.Empty(errors);
+    }
+
+    /// <summary>
+    /// Verifies cluster health by completing a batch of grain calls successfully.
+    /// Retries on transient errors to allow membership to settle.
+    /// </summary>
+    private static async Task VerifyClusterHealthy(IGrainFactory client, Func<long> getNextIdBase, CancellationToken ct)
+    {
+        const int BatchSize = 10;
+        const int MaxAttempts = 60;
+        for (var attempt = 0; attempt < MaxAttempts; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var batch = getNextIdBase();
+                var tasks = Enumerable.Range(0, BatchSize)
+                    .Select(i => client.GetGrain<IRollingUpgradeTestGrain>(batch + i).GetHost().AsTask())
+                    .ToList();
+                await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(10), ct);
+                return;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch
+            {
+                await Task.Delay(500, ct);
+            }
+        }
+
+        throw new TimeoutException($"Cluster did not become healthy after {MaxAttempts} attempts.");
+    }
+
+    private static async Task DriveLoad(IGrainFactory client, Func<long> getNextIdBase, CancellationToken ct)
+    {
+        const int CallsPerIteration = 50;
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var idBase = getNextIdBase();
+                var tasks = Enumerable.Range(0, CallsPerIteration)
+                    .Select(i => client.GetGrain<IRollingUpgradeTestGrain>(idBase + i).GetHost().AsTask())
+                    .ToList();
+
+                await Task.WhenAll(tasks).WaitAsync(ct);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (SiloUnavailableException)
+            {
+                // Expected during membership changes.
+            }
+            catch (OrleansMessageRejectionException)
+            {
+                // Expected during membership changes.
+            }
+            catch (TimeoutException)
+            {
+                // Expected during membership changes when directory ownership is shifting.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Logger provider that captures Error-level log messages.
+    /// </summary>
+    private sealed class ErrorCapturingLoggerProvider(ConcurrentBag<string> errors) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new ErrorCapturingLogger(categoryName, errors);
+        public void Dispose() { }
+
+        private sealed class ErrorCapturingLogger(string category, ConcurrentBag<string> errors) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel >= LogLevel.Error)
+                {
+                    // SiloUnavailableException errors in the messaging layer are expected
+                    // when silos are stopped under load during a rolling upgrade.
+                    if (exception is SiloUnavailableException)
+                    {
+                        return;
+                    }
+
+                    var message = $"[{category}] {formatter(state, exception)}";
+                    if (exception is not null)
+                    {
+                        message += $"\n  Exception: {exception.GetType().Name}: {exception.Message}";
+                    }
+
+                    errors.Add(message);
+                }
+            }
+        }
+    }
+}

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using System.Collections.Concurrent;
 using System.Globalization;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -44,13 +43,24 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
     [Fact]
     public async Task RollingUpgrade_LocalToDistributed_NoErrors()
     {
-        var builder = new TestClusterBuilder(3);
-        // Remove the default DistributedGrainDirectory configurator — initial silos use LocalGrainDirectory only.
-        builder.Options.SiloBuilderConfiguratorTypes.RemoveAll(
-            t => t.Contains(nameof(ConfigureDistributedGrainDirectory), StringComparison.Ordinal));
-        builder.AddSiloBuilderConfigurator<RollingUpgradeSiloConfigurator>();
-        builder.AddSiloBuilderConfigurator<ErrorLogCaptureSiloConfigurator>();
-        builder.AddSiloBuilderConfigurator<RollingUpgradeDiagnosticCaptureSiloConfigurator>();
+        var builder = new InProcessTestClusterBuilder(3);
+        // Initial silos use LocalGrainDirectory only; later silos opt into DistributedGrainDirectory.
+        builder.Options.UseTestClusterGrainDirectory = false;
+        var initialSiloCount = builder.Options.InitialSilosCount;
+        var clusterId = builder.Options.ClusterId;
+        builder.ConfigureSilo((siloOptions, siloBuilder) =>
+        {
+            if (!ShouldUseDistributedDirectory(siloOptions.SiloName, initialSiloCount))
+            {
+                return;
+            }
+
+#pragma warning disable ORLEANSEXP003
+            siloBuilder.AddDistributedGrainDirectory();
+#pragma warning restore ORLEANSEXP003
+        });
+        builder.ConfigureSiloHost((_, hostBuilder) => ConfigureErrorLogCapture(hostBuilder, clusterId));
+        builder.ConfigureSiloHost((_, hostBuilder) => ConfigureRollingUpgradeDiagnosticCapture(hostBuilder, clusterId));
 
         var cluster = builder.Build();
         var errorLogs = ErrorLogCaptureRegistry.Get(cluster.Options.ClusterId);
@@ -90,7 +100,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 
                 // Phase 3: Stop old silos one at a time, non-primary first.
                 output.WriteLine($"Phase 3: Removing {oldSilos.Count} old LocalGrainDirectory silos...");
-                foreach (var oldSilo in oldSilos.OrderBy(s => s == cluster.Primary ? 1 : 0))
+                foreach (var oldSilo in oldSilos.OrderBy(static s => s.InstanceNumber == 0 ? 1 : 0))
                 {
                     await cluster.StopSiloAsync(oldSilo);
                     output.WriteLine($"  Stopped old silo: {oldSilo.SiloAddress}");
@@ -193,7 +203,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         }
     }
 
-    private async Task DumpFailureDiagnosticsAsync(TestCluster cluster, ErrorLogCapture errorLogs, DiagnosticLogCapture diagnosticLogs, long? failingGrainKey)
+    private async Task DumpFailureDiagnosticsAsync(InProcessTestCluster cluster, ErrorLogCapture errorLogs, DiagnosticLogCapture diagnosticLogs, long? failingGrainKey)
     {
         DumpCapturedMessages("ERROR LOGS", errorLogs.ToArray());
         DumpCapturedMessages("ROLLING UPGRADE DIAGNOSTICS", diagnosticLogs.ToArray(), limit: 200);
@@ -210,7 +220,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         {
             try
             {
-                var siloControl = cluster.InternalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlType, silo.SiloAddress);
+                var siloControl = cluster.InternalClient.GetSystemTarget<ISiloControl>(Constants.SiloControlType, silo.SiloAddress);
                 var report = await siloControl.GetDetailedGrainReport(grainId);
                 output.WriteLine(report.ToString());
             }
@@ -245,18 +255,11 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         }
     }
 
-    private static bool ShouldUseDistributedDirectory(IConfiguration configuration)
-    {
-        var initialSiloCountText = configuration[nameof(TestClusterOptions.InitialSilosCount)]
-            ?? throw new InvalidOperationException($"Missing {nameof(TestClusterOptions.InitialSilosCount)} configuration.");
-        var initialSiloCount = int.Parse(initialSiloCountText, CultureInfo.InvariantCulture);
-        return GetSiloInstanceNumber(configuration) >= initialSiloCount;
-    }
+    private static bool ShouldUseDistributedDirectory(string siloName, int initialSiloCount) =>
+        GetSiloInstanceNumber(siloName) >= initialSiloCount;
 
-    private static int GetSiloInstanceNumber(IConfiguration configuration)
+    private static int GetSiloInstanceNumber(string siloName)
     {
-        var siloName = configuration["Orleans:Name"]
-            ?? throw new InvalidOperationException("Missing Orleans:Name configuration.");
         if (string.Equals(siloName, Silo.PrimarySiloName, StringComparison.Ordinal))
         {
             return 0;
@@ -269,55 +272,28 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             return instanceNumber;
         }
 
+        const string inProcessSiloPrefix = "Silo_";
+        if (siloName.StartsWith(inProcessSiloPrefix, StringComparison.Ordinal)
+            && int.TryParse(siloName.AsSpan(inProcessSiloPrefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out instanceNumber))
+        {
+            return instanceNumber;
+        }
+
         throw new InvalidOperationException($"Unexpected silo name '{siloName}'.");
     }
 
-    private sealed class RollingUpgradeSiloConfigurator : IHostConfigurator
+    private static void ConfigureErrorLogCapture(IHostApplicationBuilder hostBuilder, string clusterId)
     {
-        public void Configure(IHostBuilder hostBuilder)
-        {
-            if (!ShouldUseDistributedDirectory(hostBuilder.GetConfiguration()))
-            {
-                return;
-            }
-
-#pragma warning disable ORLEANSEXP003
-            hostBuilder.UseOrleans(static (_, siloBuilder) => siloBuilder.AddDistributedGrainDirectory());
-#pragma warning restore ORLEANSEXP003
-        }
+        hostBuilder.Services.AddSingleton(ErrorLogCaptureRegistry.Get(clusterId));
+        hostBuilder.Services.AddSingleton<ILoggerProvider, ErrorCapturingLoggerProvider>();
     }
 
-    private sealed class ErrorLogCaptureSiloConfigurator : IHostConfigurator
+    private static void ConfigureRollingUpgradeDiagnosticCapture(IHostApplicationBuilder hostBuilder, string clusterId)
     {
-        public void Configure(IHostBuilder hostBuilder)
-        {
-            var clusterId = hostBuilder.GetConfiguration()["Orleans:ClusterId"]
-                ?? throw new InvalidOperationException("Missing Orleans:ClusterId configuration.");
-            hostBuilder.ConfigureServices(services =>
-            {
-                services.AddSingleton(ErrorLogCaptureRegistry.Get(clusterId));
-                services.AddSingleton<ILoggerProvider, ErrorCapturingLoggerProvider>();
-            });
-        }
-    }
-
-    private sealed class RollingUpgradeDiagnosticCaptureSiloConfigurator : IHostConfigurator
-    {
-        public void Configure(IHostBuilder hostBuilder)
-        {
-            var clusterId = hostBuilder.GetConfiguration()["Orleans:ClusterId"]
-                ?? throw new InvalidOperationException("Missing Orleans:ClusterId configuration.");
-            hostBuilder.ConfigureLogging(logging =>
-            {
-                logging.AddFilter(typeof(DistributedRemoteGrainDirectory).FullName, LogLevel.Information);
-                logging.AddFilter(typeof(GrainDirectoryHandoffManager).FullName, LogLevel.Information);
-            });
-            hostBuilder.ConfigureServices(services =>
-            {
-                services.AddSingleton(DiagnosticLogCaptureRegistry.Get(clusterId));
-                services.AddSingleton<ILoggerProvider, DiagnosticCapturingLoggerProvider>();
-            });
-        }
+        hostBuilder.Logging.AddFilter(typeof(DistributedRemoteGrainDirectory).FullName, LogLevel.Information);
+        hostBuilder.Logging.AddFilter(typeof(GrainDirectoryHandoffManager).FullName, LogLevel.Information);
+        hostBuilder.Services.AddSingleton(DiagnosticLogCaptureRegistry.Get(clusterId));
+        hostBuilder.Services.AddSingleton<ILoggerProvider, DiagnosticCapturingLoggerProvider>();
     }
 
     private sealed class ErrorCapturingLoggerProvider(ErrorLogCapture errorLogs) : ILoggerProvider

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -1,8 +1,8 @@
 #nullable enable
 using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Orleans.Configuration;
 using Orleans.GrainDirectory;
 using Orleans.Runtime;
 using Orleans.Runtime.GrainDirectory;
@@ -32,91 +32,69 @@ internal class RollingUpgradeTestGrain : Grain, IRollingUpgradeTestGrain
 /// <summary>
 /// Tests rolling upgrade from <see cref="LocalGrainDirectory"/> to <see cref="DistributedGrainDirectory"/>.
 /// Starts a cluster with only LocalGrainDirectory, then adds silos with DistributedGrainDirectory
-/// while removing old silos, all under continuous load.
+/// while removing old silos, verifying grain calls succeed after each step.
 /// </summary>
 [TestCategory("Directory"), TestCategory("Functional")]
 public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 {
+    /// <summary>
+    /// Controls whether newly started silos enable the <see cref="DistributedGrainDirectory"/>.
+    /// </summary>
+    internal static volatile bool UseDistributedDirectory;
+
     [Fact]
     public async Task RollingUpgrade_LocalToDistributed_NoErrors()
     {
-        var useDistributedDirectory = false;
+        UseDistributedDirectory = false;
         var errorLogs = new ConcurrentBag<string>();
-        var logProvider = new ErrorCapturingLoggerProvider(errorLogs);
+        ErrorLogCaptureSiloConfigurator.Errors = errorLogs;
 
-        var builder = new InProcessTestClusterBuilder(3);
-        builder.Options.UseTestClusterMembership = true;
-        builder.Options.UseTestClusterGrainDirectory = false;
-        builder.ConfigureSilo((_, siloBuilder) =>
-        {
-            siloBuilder.Configure<SiloMessagingOptions>(o =>
-            {
-                o.ResponseTimeout = TimeSpan.FromMinutes(2);
-                o.SystemResponseTimeout = TimeSpan.FromMinutes(2);
-            });
-
-            if (useDistributedDirectory)
-            {
-#pragma warning disable ORLEANSEXP003
-                siloBuilder.AddDistributedGrainDirectory();
-#pragma warning restore ORLEANSEXP003
-            }
-        });
-
-        builder.ConfigureSiloHost((_, hostBuilder) =>
-        {
-            hostBuilder.Services.AddSingleton<ILoggerProvider>(logProvider);
-        });
+        var builder = new TestClusterBuilder(3);
+        // Remove the default DistributedGrainDirectory configurator — initial silos use LocalGrainDirectory only.
+        builder.Options.SiloBuilderConfiguratorTypes.RemoveAll(
+            t => t.Contains(nameof(ConfigureDistributedGrainDirectory), StringComparison.Ordinal));
+        builder.AddSiloBuilderConfigurator<RollingUpgradeSiloConfigurator>();
+        builder.AddSiloBuilderConfigurator<ErrorLogCaptureSiloConfigurator>();
 
         var cluster = builder.Build();
         await cluster.DeployAsync();
         output.WriteLine($"Cluster deployed with {cluster.Silos.Count} silos (LocalGrainDirectory only).");
 
         var client = cluster.Client;
+        var grainId = 0L;
+        var nextGrainId = () => Interlocked.Increment(ref grainId);
 
-        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
-        var idBase = 0L;
-        Func<long> getNextIdBase = () => Interlocked.Add(ref idBase, 50);
+        // Phase 1: Drive load on the LocalGrainDirectory cluster.
+        output.WriteLine("Phase 1: Driving load on LocalGrainDirectory cluster...");
+        await DriveLoad(client, nextGrainId, count: 100);
 
-        // Drive load continuously in the background throughout the test.
-        var loadTask = DriveLoad(client, getNextIdBase, cts.Token);
-
-        // Phase 1: Quick health check on the LocalGrainDirectory cluster.
-        output.WriteLine("Phase 1: Verifying LocalGrainDirectory cluster is healthy...");
-        await VerifyClusterHealthy(client, getNextIdBase, cts.Token);
-
-        // Phase 2: Enable DistributedGrainDirectory for new silos and start them.
+        // Phase 2: Add DistributedGrainDirectory silos one at a time.
         output.WriteLine("Phase 2: Rolling upgrade — adding DistributedGrainDirectory silos...");
-        useDistributedDirectory = true;
+        UseDistributedDirectory = true;
 
         var oldSilos = cluster.Silos.ToList();
-        var newSilos = new List<InProcessSiloHandle>();
 
         for (var i = 0; i < oldSilos.Count; i++)
         {
             var newSilo = await cluster.StartAdditionalSiloAsync();
-            newSilos.Add(newSilo);
             output.WriteLine($"  Started new silo: {newSilo.SiloAddress}");
             await cluster.WaitForLivenessToStabilizeAsync();
+            await DriveLoad(client, nextGrainId, count: 100);
         }
 
-        // Phase 3: Stop old silos one at a time, primary last.
+        // Phase 3: Stop old silos one at a time, non-primary first.
         output.WriteLine($"Phase 3: Removing {oldSilos.Count} old LocalGrainDirectory silos...");
-        foreach (var oldSilo in oldSilos.OrderBy(s => s == cluster.Silos[0] ? 1 : 0))
+        foreach (var oldSilo in oldSilos.OrderBy(s => s == cluster.Primary ? 1 : 0))
         {
             await cluster.StopSiloAsync(oldSilo);
             output.WriteLine($"  Stopped old silo: {oldSilo.SiloAddress}");
             await cluster.WaitForLivenessToStabilizeAsync();
+            await DriveLoad(client, nextGrainId, count: 100);
         }
 
-        // Phase 4: Verify the fully-upgraded cluster works.
+        // Phase 4: Final verification on the fully-upgraded cluster — must succeed without retries.
         output.WriteLine("Phase 4: Verifying fully-upgraded DistributedGrainDirectory cluster...");
-        await VerifyClusterHealthy(client, getNextIdBase, cts.Token);
-
-        // Stop load and clean up.
-        cts.Cancel();
-        try { await loadTask; }
-        catch (OperationCanceledException) { }
+        await DriveLoad(client, nextGrainId, count: 200);
 
         // Assert no error-level logs occurred.
         var errors = errorLogs.ToArray();
@@ -136,74 +114,76 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// Verifies cluster health by completing a batch of grain calls successfully.
-    /// Retries on transient errors to allow membership to settle.
+    /// Activates grains by calling each one. Retries individual calls that fail with transient
+    /// exceptions expected during directory ownership transitions in a rolling upgrade.
     /// </summary>
-    private static async Task VerifyClusterHealthy(IGrainFactory client, Func<long> getNextIdBase, CancellationToken ct)
+    private async Task DriveLoad(IGrainFactory client, Func<long> nextGrainId, int count)
     {
-        const int BatchSize = 10;
-        const int MaxAttempts = 60;
-        for (var attempt = 0; attempt < MaxAttempts; attempt++)
+        var ids = new long[count];
+        for (var i = 0; i < count; i++)
         {
-            ct.ThrowIfCancellationRequested();
-            try
+            ids[i] = nextGrainId();
+        }
+
+        // First attempt: fire all calls in parallel.
+        var tasks = ids.Select(id => client.GetGrain<IRollingUpgradeTestGrain>(id).GetHost().AsTask()).ToArray();
+        try
+        {
+            await Task.WhenAll(tasks);
+            return;
+        }
+        catch
+        {
+            // Some calls failed — retry the failed ones individually.
+        }
+
+        var failedIds = new List<long>();
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            if (tasks[i].IsFaulted)
             {
-                var batch = getNextIdBase();
-                var tasks = Enumerable.Range(0, BatchSize)
-                    .Select(i => client.GetGrain<IRollingUpgradeTestGrain>(batch + i).GetHost().AsTask())
-                    .ToList();
-                await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(10), ct);
-                return;
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch
-            {
-                await Task.Delay(500, ct);
+                failedIds.Add(ids[i]);
             }
         }
 
-        throw new TimeoutException($"Cluster did not become healthy after {MaxAttempts} attempts.");
+        output.WriteLine($"    {failedIds.Count}/{count} calls failed, retrying...");
+
+        // Retry failed calls one at a time.
+        foreach (var id in failedIds)
+        {
+            await client.GetGrain<IRollingUpgradeTestGrain>(id).GetHost();
+        }
     }
 
-    private static async Task DriveLoad(IGrainFactory client, Func<long> getNextIdBase, CancellationToken ct)
+    private class RollingUpgradeSiloConfigurator : ISiloConfigurator
     {
-        const int CallsPerIteration = 50;
-        while (!ct.IsCancellationRequested)
+        public void Configure(ISiloBuilder siloBuilder)
         {
-            try
+            if (UseDistributedDirectory)
             {
-                var idBase = getNextIdBase();
-                var tasks = Enumerable.Range(0, CallsPerIteration)
-                    .Select(i => client.GetGrain<IRollingUpgradeTestGrain>(idBase + i).GetHost().AsTask())
-                    .ToList();
-
-                await Task.WhenAll(tasks).WaitAsync(ct);
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                break;
-            }
-            catch (SiloUnavailableException)
-            {
-                // Expected during membership changes.
-            }
-            catch (OrleansMessageRejectionException)
-            {
-                // Expected during membership changes.
-            }
-            catch (TimeoutException)
-            {
-                // Expected during membership changes when directory ownership is shifting.
+#pragma warning disable ORLEANSEXP003
+                siloBuilder.AddDistributedGrainDirectory();
+#pragma warning restore ORLEANSEXP003
             }
         }
     }
 
-    /// <summary>
-    /// Logger provider that captures Error-level log messages.
-    /// </summary>
+    private class ErrorLogCaptureSiloConfigurator : IHostConfigurator
+    {
+        internal static ConcurrentBag<string>? Errors;
+
+        public void Configure(IHostBuilder hostBuilder)
+        {
+            hostBuilder.ConfigureServices(services =>
+            {
+                if (Errors is { } errors)
+                {
+                    services.AddSingleton<ILoggerProvider>(new ErrorCapturingLoggerProvider(errors));
+                }
+            });
+        }
+    }
+
     private sealed class ErrorCapturingLoggerProvider(ConcurrentBag<string> errors) : ILoggerProvider
     {
         public ILogger CreateLogger(string categoryName) => new ErrorCapturingLogger(categoryName, errors);
@@ -217,8 +197,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             {
                 if (logLevel >= LogLevel.Error)
                 {
-                    // SiloUnavailableException errors in the messaging layer are expected
-                    // when silos are stopped under load during a rolling upgrade.
+                    // SiloUnavailableException errors from the messaging layer are expected
+                    // when silos are removed during a rolling upgrade.
                     if (exception is SiloUnavailableException)
                     {
                         return;

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Orleans;
+using Orleans.Concurrency;
 using Orleans.GrainDirectory;
 using Orleans.Hosting;
 using Orleans.Runtime;
@@ -161,7 +162,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
     {
         output.WriteLine($"  Validating grain directory integrity {stage}...");
 
-        var integrityChecks = new List<Task>();
+        var activations = GetDirectoryActivations(cluster);
+        var distributedPartitions = new List<IGrainDirectoryTestHooks>();
         foreach (var silo in cluster.Silos)
         {
             var membershipService = silo.ServiceProvider.GetService<DirectoryMembershipService>();
@@ -174,17 +176,108 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             {
                 var replica = cluster.InternalClient.GetSystemTarget<IGrainDirectoryTestHooks>(
                     GrainDirectoryPartition.CreateGrainId(silo.SiloAddress, partitionIndex).GrainId);
-                integrityChecks.Add(replica.RecoverAndCheckIntegrityAsync().AsTask());
+                distributedPartitions.Add(replica);
             }
         }
 
-        await Task.WhenAll(integrityChecks);
-        foreach (var task in integrityChecks)
+        if (distributedPartitions.Count == 0)
+        {
+            await CheckActivationRegistrationsWithLocalDirectoryAsync(activations, stage);
+        }
+        else
+        {
+            var integrityChecks = distributedPartitions.Select(static partition => partition.RecoverAndCheckIntegrityAsync().AsTask()).ToArray();
+            await Task.WhenAll(integrityChecks);
+            foreach (var task in integrityChecks)
+            {
+                await task;
+            }
+
+            var activationAddresses = activations.Select(static activation => activation.Address).ToList().AsImmutable();
+            var activationChecks = distributedPartitions.Select(partition => partition.CheckActivationsAsync(activationAddresses).AsTask()).ToArray();
+            await Task.WhenAll(activationChecks);
+            var distributedCheckedGrains = new HashSet<GrainId>();
+            foreach (var task in activationChecks)
+            {
+                foreach (var grainId in (await task).Value)
+                {
+                    Assert.True(distributedCheckedGrains.Add(grainId), $"Grain '{grainId}' was checked by multiple distributed directory partitions during '{stage}'.");
+                }
+            }
+
+            var localActivationChecks = new List<Task>();
+            foreach (var activation in activations)
+            {
+                if (distributedCheckedGrains.Contains(activation.Address.GrainId))
+                {
+                    continue;
+                }
+
+                var grainLocator = activation.Silo.ServiceProvider.GetRequiredService<GrainLocator>();
+                localActivationChecks.Add(CheckActivationRegistrationAsync(grainLocator, activation.Address, activation.Silo.SiloAddress, stage));
+            }
+
+            await Task.WhenAll(localActivationChecks);
+            foreach (var task in localActivationChecks)
+            {
+                await task;
+            }
+        }
+
+        output.WriteLine($"  Validated {activations.Count} activations and {distributedPartitions.Count} DistributedGrainDirectory partitions {stage}.");
+    }
+
+    private static List<(InProcessSiloHandle Silo, GrainAddress Address)> GetDirectoryActivations(InProcessTestCluster cluster)
+    {
+        var result = new List<(InProcessSiloHandle Silo, GrainAddress Address)>();
+        foreach (var silo in cluster.Silos)
+        {
+            var activations = silo.ServiceProvider.GetRequiredService<ActivationDirectory>();
+            foreach (var (_, activation) in activations)
+            {
+                if (activation is ActivationData { IsValid: false } || !UsesGrainDirectory(activation))
+                {
+                    continue;
+                }
+
+                result.Add((silo, activation.Address));
+            }
+        }
+
+        return result;
+    }
+
+    private static bool UsesGrainDirectory(IGrainContext activation)
+    {
+        if (activation is ActivationData activationData)
+        {
+            return activationData.IsUsingGrainDirectory;
+        }
+
+        return activation is not SystemTarget && activation.GetComponent<PlacementStrategy>() is { IsUsingGrainDirectory: true };
+    }
+
+    private static async Task CheckActivationRegistrationsWithLocalDirectoryAsync(List<(InProcessSiloHandle Silo, GrainAddress Address)> activations, string stage)
+    {
+        var activationChecks = activations.Select(activation =>
+        {
+            var grainLocator = activation.Silo.ServiceProvider.GetRequiredService<GrainLocator>();
+            return CheckActivationRegistrationAsync(grainLocator, activation.Address, activation.Silo.SiloAddress, stage);
+        }).ToArray();
+
+        await Task.WhenAll(activationChecks);
+        foreach (var task in activationChecks)
         {
             await task;
         }
+    }
 
-        output.WriteLine($"  Validated {integrityChecks.Count} DistributedGrainDirectory partitions against ActivationDirectory {stage}.");
+    private static async Task CheckActivationRegistrationAsync(GrainLocator grainLocator, GrainAddress activationAddress, SiloAddress siloAddress, string stage)
+    {
+        var registeredAddress = await grainLocator.Lookup(activationAddress.GrainId);
+        Assert.True(
+            activationAddress.Matches(registeredAddress),
+            $"Activation '{activationAddress.ToFullString()}' on silo '{siloAddress}' did not have a matching directory registration during '{stage}'. Registered address: '{registeredAddress?.ToFullString() ?? "<null>"}'.");
     }
 
     private static bool IsExpectedClientRoutingTableCancellation(string error) =>

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -89,11 +89,11 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 
                 for (var i = 0; i < oldSilos.Count; i++)
                 {
-                    await ValidateDistributedDirectoryIntegrityAsync(cluster, $"before adding distributed silo {i + 1}/{oldSilos.Count}");
+                    await ValidateDirectoryIntegrityAsync(cluster, $"before adding distributed silo {i + 1}/{oldSilos.Count}");
                     var newSilo = await cluster.StartAdditionalSiloAsync();
                     output.WriteLine($"  Started new silo: {newSilo.SiloAddress}");
                     await cluster.WaitForLivenessToStabilizeAsync();
-                    await ValidateDistributedDirectoryIntegrityAsync(cluster, $"after adding distributed silo {i + 1}/{oldSilos.Count}");
+                    await ValidateDirectoryIntegrityAsync(cluster, $"after adding distributed silo {i + 1}/{oldSilos.Count}");
                     await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
                 }
 
@@ -106,18 +106,18 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 foreach (var oldSilo in oldSilos.OrderBy(static s => s.InstanceNumber == 0 ? 1 : 0))
                 {
                     transitionIndex++;
-                    await ValidateDistributedDirectoryIntegrityAsync(cluster, $"before removing local silo {transitionIndex}/{oldSilos.Count}");
+                    await ValidateDirectoryIntegrityAsync(cluster, $"before removing local silo {transitionIndex}/{oldSilos.Count}");
                     await cluster.StopSiloAsync(oldSilo);
                     output.WriteLine($"  Stopped old silo: {oldSilo.SiloAddress}");
                     await cluster.WaitForLivenessToStabilizeAsync();
-                    await ValidateDistributedDirectoryIntegrityAsync(cluster, $"after removing local silo {transitionIndex}/{oldSilos.Count}");
+                    await ValidateDirectoryIntegrityAsync(cluster, $"after removing local silo {transitionIndex}/{oldSilos.Count}");
                     await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
                 }
 
                 // Phase 4: Final verification on the fully-upgraded cluster — must succeed without retries.
                 output.WriteLine("Phase 4: Verifying fully-upgraded DistributedGrainDirectory cluster...");
                 await DriveLoad(client, nextGrainId, count: 200, id => failingGrainKey = id);
-                await ValidateDistributedDirectoryIntegrityAsync(cluster, "after final verification");
+                await ValidateDirectoryIntegrityAsync(cluster, "after final verification");
             }
             catch
             {
@@ -157,9 +157,9 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         Assert.Empty(errors);
     }
 
-    private async Task ValidateDistributedDirectoryIntegrityAsync(InProcessTestCluster cluster, string stage)
+    private async Task ValidateDirectoryIntegrityAsync(InProcessTestCluster cluster, string stage)
     {
-        output.WriteLine($"  Validating DistributedGrainDirectory integrity {stage}...");
+        output.WriteLine($"  Validating grain directory integrity {stage}...");
 
         var integrityChecks = new List<Task>();
         foreach (var silo in cluster.Silos)
@@ -184,7 +184,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             await task;
         }
 
-        output.WriteLine($"  Validated {integrityChecks.Count} DistributedGrainDirectory partitions {stage}.");
+        output.WriteLine($"  Validated {integrityChecks.Count} DistributedGrainDirectory partitions against ActivationDirectory {stage}.");
     }
 
     private static bool IsExpectedClientRoutingTableCancellation(string error) =>

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -89,9 +89,11 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 
                 for (var i = 0; i < oldSilos.Count; i++)
                 {
+                    await ValidateDistributedDirectoryIntegrityAsync(cluster, $"before adding distributed silo {i + 1}/{oldSilos.Count}");
                     var newSilo = await cluster.StartAdditionalSiloAsync();
                     output.WriteLine($"  Started new silo: {newSilo.SiloAddress}");
                     await cluster.WaitForLivenessToStabilizeAsync();
+                    await ValidateDistributedDirectoryIntegrityAsync(cluster, $"after adding distributed silo {i + 1}/{oldSilos.Count}");
                     await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
                 }
 
@@ -100,17 +102,22 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 
                 // Phase 3: Stop old silos one at a time, non-primary first.
                 output.WriteLine($"Phase 3: Removing {oldSilos.Count} old LocalGrainDirectory silos...");
+                var transitionIndex = 0;
                 foreach (var oldSilo in oldSilos.OrderBy(static s => s.InstanceNumber == 0 ? 1 : 0))
                 {
+                    transitionIndex++;
+                    await ValidateDistributedDirectoryIntegrityAsync(cluster, $"before removing local silo {transitionIndex}/{oldSilos.Count}");
                     await cluster.StopSiloAsync(oldSilo);
                     output.WriteLine($"  Stopped old silo: {oldSilo.SiloAddress}");
                     await cluster.WaitForLivenessToStabilizeAsync();
+                    await ValidateDistributedDirectoryIntegrityAsync(cluster, $"after removing local silo {transitionIndex}/{oldSilos.Count}");
                     await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
                 }
 
                 // Phase 4: Final verification on the fully-upgraded cluster — must succeed without retries.
                 output.WriteLine("Phase 4: Verifying fully-upgraded DistributedGrainDirectory cluster...");
                 await DriveLoad(client, nextGrainId, count: 200, id => failingGrainKey = id);
+                await ValidateDistributedDirectoryIntegrityAsync(cluster, "after final verification");
             }
             catch
             {
@@ -148,6 +155,36 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         }
 
         Assert.Empty(errors);
+    }
+
+    private async Task ValidateDistributedDirectoryIntegrityAsync(InProcessTestCluster cluster, string stage)
+    {
+        output.WriteLine($"  Validating DistributedGrainDirectory integrity {stage}...");
+
+        var integrityChecks = new List<Task>();
+        foreach (var silo in cluster.Silos)
+        {
+            var membershipService = silo.ServiceProvider.GetService<DirectoryMembershipService>();
+            if (membershipService is null)
+            {
+                continue;
+            }
+
+            for (var partitionIndex = 0; partitionIndex < membershipService.PartitionsPerSilo; partitionIndex++)
+            {
+                var replica = cluster.InternalClient.GetSystemTarget<IGrainDirectoryTestHooks>(
+                    GrainDirectoryPartition.CreateGrainId(silo.SiloAddress, partitionIndex).GrainId);
+                integrityChecks.Add(replica.RecoverAndCheckIntegrityAsync().AsTask());
+            }
+        }
+
+        await Task.WhenAll(integrityChecks);
+        foreach (var task in integrityChecks)
+        {
+            await task;
+        }
+
+        output.WriteLine($"  Validated {integrityChecks.Count} DistributedGrainDirectory partitions {stage}.");
     }
 
     private static bool IsExpectedClientRoutingTableCancellation(string error) =>


### PR DESCRIPTION
## Summary

Adds the distributed remote grain directory compatibility path on top of #10047 so distributed-directory silos can serve legacy `IRemoteGrainDirectory` requests during rolling upgrades from the local grain directory.

## Changes

- Add `DistributedRemoteGrainDirectory` backed by `DistributedGrainDirectory`.
- Register compatibility system targets for the directory service and cache validator types.
- Route remote register, lookup, and unregister calls through the distributed directory implementation.
- Add mixed local/distributed rolling-upgrade compatibility coverage and resilience fixes.

## Stack notes

This branch is rebased on top of #10047. The focused review range is:

`fix/directory-snapshot-transfer-ranges..feature/distributed-remote-grain-directory`

Follow-on PRs:

- #10053 stacks above this branch for large transfer payload batching.
- #10049 stacks above #10053 for the directory migration join regression.

## Validation

Focused validation run locally:

- `dotnet test test\Orleans.GrainDirectory.Tests\Orleans.GrainDirectory.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~GrainDirectoryRollingUpgradeTests|FullyQualifiedName~GrainDirectoryPartitionBatchingTests|FullyQualifiedName~GrainDirectoryResilienceTests.JoiningSilo_DoesNotLeaveStaleEntriesOnPreviousOwner" -- -parallel none -noshadow`

`GrainDirectoryResilienceTests.ElasticChaos` was also attempted in a broader run and timed out; the deterministic non-chaos coverage above passed.