### PR TITLE
Fix mixed local-to-distributed directory upgrades

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
@@ -1,7 +1,12 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Orleans.GrainDirectory;
+using Orleans.Internal;
+using Orleans.Runtime.Scheduler;
 
 #nullable enable
 namespace Orleans.Runtime.GrainDirectory;
@@ -11,10 +16,17 @@ namespace Orleans.Runtime.GrainDirectory;
 /// This enables silos running the old <see cref="LocalGrainDirectory"/> to forward directory requests to silos running the
 /// new <see cref="DistributedGrainDirectory"/> during a rolling upgrade.
 /// </summary>
-internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGrainDirectory
+internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGrainDirectory
 {
+    private const int MaxBatchDegreeOfParallelism = 32;
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(250);
+
     private readonly DistributedGrainDirectory _directory;
+    private readonly ILogger<DistributedRemoteGrainDirectory> _logger;
     private readonly DirectoryMembershipService _membershipService;
+    private readonly Queue<(string Name, object State, Func<DistributedRemoteGrainDirectory, object, Task> Action)> _pendingOperations = new();
+    private readonly AsyncLock _executorLock = new();
 
     private DistributedRemoteGrainDirectory(
         DistributedGrainDirectory directory,
@@ -24,6 +36,7 @@ internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGra
         : base(grainType, shared)
     {
         _directory = directory;
+        _logger = shared.LoggerFactory.CreateLogger<DistributedRemoteGrainDirectory>();
         _membershipService = membershipService;
         shared.ActivationDirectory.RecordNewTarget(this);
     }
@@ -54,7 +67,181 @@ internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGra
         }
     }
 
-    private CancellationTokenSource CreateTimeoutCts() => new(TimeSpan.FromSeconds(30));
+    private static ParallelOptions CreateParallelOptions(CancellationToken cancellationToken) => new()
+    {
+        CancellationToken = cancellationToken,
+        MaxDegreeOfParallelism = MaxBatchDegreeOfParallelism,
+        TaskScheduler = TaskScheduler.Current,
+    };
+
+    private CancellationTokenSource CreateTimeoutCts() => new(OperationTimeout);
+
+    private CancellationTokenSource CreateTimeoutCts(CancellationToken cancellationToken)
+    {
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _directory.OnStoppedToken);
+        cts.CancelAfter(OperationTimeout);
+        return cts;
+    }
+
+    private async Task RunBatchOperationAsync<T>(List<T> values, Func<T, CancellationToken, Task> operation)
+    {
+        using (var cts = CreateTimeoutCts(_directory.OnStoppedToken))
+        {
+            await EnsureDirectoryInitializedAsync(cts.Token);
+        }
+
+        var options = CreateParallelOptions(_directory.OnStoppedToken);
+        await Parallel.ForEachAsync(values, options, async (value, cancellationToken) =>
+        {
+            using var cts = CreateTimeoutCts(cancellationToken);
+            await operation(value, cts.Token);
+        });
+    }
+
+    private IInternalGrainFactory GrainFactory => ActivationServices.GetRequiredService<IInternalGrainFactory>();
+
+    private ISiloStatusOracle SiloStatusOracle => ActivationServices.GetRequiredService<ISiloStatusOracle>();
+
+    private void EnqueueOperation(string name, object state, Func<DistributedRemoteGrainDirectory, object, Task> action)
+    {
+        lock (_pendingOperations)
+        {
+            _pendingOperations.Enqueue((name, state, action));
+            if (_pendingOperations.Count <= 2)
+            {
+                WorkItemGroup.QueueTask(ExecutePendingOperations, this);
+            }
+        }
+    }
+
+    private async Task ExecutePendingOperations()
+    {
+        using (await _executorLock.LockAsync())
+        {
+            while (!_directory.OnStoppedToken.IsCancellationRequested)
+            {
+                (string Name, object State, Func<DistributedRemoteGrainDirectory, object, Task> Action) op;
+                lock (_pendingOperations)
+                {
+                    if (_pendingOperations.Count == 0)
+                    {
+                        break;
+                    }
+
+                    op = _pendingOperations.Peek();
+                }
+
+                try
+                {
+                    await op.Action(this, op.State);
+                    lock (_pendingOperations)
+                    {
+                        _pendingOperations.Dequeue();
+                    }
+                }
+                catch (Exception exception) when (!_directory.OnStoppedToken.IsCancellationRequested)
+                {
+                    LogWarningOperationFailedRetry(_logger, exception, op.Name);
+                    await Task.Delay(RetryDelay, _directory.OnStoppedToken).SuppressThrowing();
+                }
+            }
+        }
+    }
+
+    private void DestroyDuplicateActivations(Dictionary<SiloAddress, List<GrainAddress>>? duplicates)
+    {
+        if (duplicates is null || duplicates.Count == 0)
+        {
+            return;
+        }
+
+        EnqueueOperation(
+            nameof(DestroyDuplicateActivations),
+            duplicates,
+            static (self, state) => self.DestroyDuplicateActivationsAsync((Dictionary<SiloAddress, List<GrainAddress>>)state));
+    }
+
+    private async Task DestroyDuplicateActivationsAsync(Dictionary<SiloAddress, List<GrainAddress>> duplicates)
+    {
+        while (duplicates.Count > 0)
+        {
+            var pair = duplicates.First();
+            if (SiloStatusOracle.GetApproximateSiloStatus(pair.Key) == SiloStatus.Active)
+            {
+                var remoteCatalog = GrainFactory.GetSystemTarget<ICatalog>(Constants.CatalogType, pair.Key);
+                await remoteCatalog.DeleteActivations(
+                    pair.Value,
+                    DeactivationReasonCode.DuplicateActivation,
+                    "This grain has been activated elsewhere");
+            }
+
+            duplicates.Remove(pair.Key);
+        }
+    }
+
+    private async Task ProcessSplitPartitionRegistrationsAsync(SplitPartitionRegistrationBatch batch)
+    {
+        using (var cts = CreateTimeoutCts(_directory.OnStoppedToken))
+        {
+            await EnsureDirectoryInitializedAsync(cts.Token);
+        }
+
+        var pendingRegistrations = batch.PendingRegistrations;
+        var winners = new GrainAddress?[pendingRegistrations.Count];
+        var failures = new Exception?[pendingRegistrations.Count];
+        var options = CreateParallelOptions(_directory.OnStoppedToken);
+        await Parallel.ForEachAsync(Enumerable.Range(0, pendingRegistrations.Count), options, async (index, cancellationToken) =>
+        {
+            try
+            {
+                using var cts = CreateTimeoutCts(cancellationToken);
+                winners[index] = await _directory.RegisterAsync(pendingRegistrations[index], null, cts.Token);
+            }
+            catch (Exception exception)
+            {
+                failures[index] = exception;
+            }
+        });
+
+        Dictionary<SiloAddress, List<GrainAddress>>? duplicates = null;
+        Exception? failure = null;
+        for (var i = pendingRegistrations.Count - 1; i >= 0; i--)
+        {
+            if (failures[i] is not null)
+            {
+                failure ??= failures[i];
+                continue;
+            }
+
+            var registration = pendingRegistrations[i];
+            var winner = winners[i];
+            if (winner is null || !winner.Equals(registration))
+            {
+                if (registration.SiloAddress is { } siloAddress)
+                {
+                    if (duplicates is null || !duplicates.TryGetValue(siloAddress, out var activations))
+                    {
+                        activations = [];
+                        (duplicates ??= []).Add(siloAddress, activations);
+                    }
+
+                    activations.Add(registration);
+                }
+            }
+
+            pendingRegistrations.RemoveAt(i);
+        }
+
+        DestroyDuplicateActivations(duplicates);
+
+        if (failure is not null)
+        {
+            LogWarningAcceptSplitPartitionFailed(_logger, failure, Silo, pendingRegistrations.Count);
+            throw failure;
+        }
+
+        LogInformationAcceptSplitPartitionCompleted(_logger, Silo, batch.InitialCount);
+    }
 
     public async Task<AddressAndTag> RegisterAsync(GrainAddress address, int hopCount)
     {
@@ -89,12 +276,7 @@ internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGra
 
     public async Task UnregisterManyAsync(List<GrainAddress> addresses, UnregistrationCause cause, int hopCount)
     {
-        using var cts = CreateTimeoutCts();
-        await EnsureDirectoryInitializedAsync(cts.Token);
-        foreach (var address in addresses)
-        {
-            await _directory.UnregisterAsync(address, cts.Token);
-        }
+        await RunBatchOperationAsync(addresses, (address, cancellationToken) => _directory.UnregisterAsync(address, cancellationToken));
     }
 
     public async Task DeleteGrainAsync(GrainId grainId, int hopCount)
@@ -110,35 +292,77 @@ internal sealed class DistributedRemoteGrainDirectory : SystemTarget, IRemoteGra
 
     public async Task RegisterMany(List<GrainAddress> addresses)
     {
-        using var cts = CreateTimeoutCts();
-        await EnsureDirectoryInitializedAsync(cts.Token);
-        foreach (var address in addresses)
-        {
-            await _directory.RegisterAsync(address, null, cts.Token);
-        }
+        await RunBatchOperationAsync(addresses, (address, cancellationToken) => _directory.RegisterAsync(address, null, cancellationToken));
     }
 
     public async Task<List<AddressAndTag>> LookUpMany(List<(GrainId GrainId, int Version)> grainAndETagList)
     {
-        using var cts = CreateTimeoutCts();
-        await EnsureDirectoryInitializedAsync(cts.Token);
-        var result = new List<AddressAndTag>(grainAndETagList.Count);
-        foreach (var (grainId, _) in grainAndETagList)
+        LogInformationLookUpManyReceived(_logger, Silo, grainAndETagList.Count);
+
+        using (var cts = CreateTimeoutCts(_directory.OnStoppedToken))
         {
-            var address = await _directory.LookupAsync(grainId, cts.Token);
-            result.Add(new(address, 0));
+            await EnsureDirectoryInitializedAsync(cts.Token);
         }
 
-        return result;
+        var result = new AddressAndTag[grainAndETagList.Count];
+        var options = CreateParallelOptions(_directory.OnStoppedToken);
+        await Parallel.ForEachAsync(Enumerable.Range(0, grainAndETagList.Count), options, async (index, cancellationToken) =>
+        {
+            using var cts = CreateTimeoutCts(cancellationToken);
+            var address = await _directory.LookupAsync(grainAndETagList[index].GrainId, cts.Token);
+            result[index] = new(address, 0);
+        });
+
+        return [.. result];
     }
 
-    public async Task AcceptSplitPartition(List<GrainAddress> singleActivations)
+    public Task AcceptSplitPartition(List<GrainAddress> singleActivations)
     {
-        using var cts = CreateTimeoutCts();
-        await EnsureDirectoryInitializedAsync(cts.Token);
-        foreach (var address in singleActivations)
+        LogInformationAcceptSplitPartitionStarted(_logger, Silo, singleActivations.Count);
+        if (singleActivations.Count > 0)
         {
-            await _directory.RegisterAsync(address, null, cts.Token);
+            EnqueueOperation(
+                nameof(AcceptSplitPartition),
+                new SplitPartitionRegistrationBatch([.. singleActivations]),
+                static (self, state) => self.ProcessSplitPartitionRegistrationsAsync((SplitPartitionRegistrationBatch)state));
         }
+
+        return Task.CompletedTask;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Rolling upgrade diagnostic: silo {Silo} received LookUpMany for {Count} entries."
+    )]
+    private static partial void LogInformationLookUpManyReceived(ILogger logger, SiloAddress silo, int count);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Rolling upgrade diagnostic: silo {Silo} accepted split-partition handoff for {Count} registrations."
+    )]
+    private static partial void LogInformationAcceptSplitPartitionStarted(ILogger logger, SiloAddress silo, int count);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Rolling upgrade diagnostic: silo {Silo} completed split-partition handoff for {Count} registrations."
+    )]
+    private static partial void LogInformationAcceptSplitPartitionCompleted(ILogger logger, SiloAddress silo, int count);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Rolling upgrade diagnostic: silo {Silo} failed split-partition handoff for {Count} registrations."
+    )]
+    private static partial void LogWarningAcceptSplitPartitionFailed(ILogger logger, Exception exception, SiloAddress silo, int count);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Rolling upgrade compatibility operation {Operation} failed and will be retried."
+    )]
+    private static partial void LogWarningOperationFailedRetry(ILogger logger, Exception exception, string operation);
+
+    private sealed class SplitPartitionRegistrationBatch(List<GrainAddress> pendingRegistrations)
+    {
+        public int InitialCount { get; } = pendingRegistrations.Count;
+        public List<GrainAddress> PendingRegistrations { get; } = pendingRegistrations;
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -77,9 +77,22 @@ namespace Orleans.Runtime.GrainDirectory
                 if (splitPartListSingle.Count > 0)
                 {
                     LogDebugSendingEntries(logger, splitPartListSingle.Count, addedSilo);
+                    LogInformationSendingSplitPartition(logger, splitPartListSingle.Count, addedSilo);
                 }
 
-                await localDirectory.GetDirectoryReference(addedSilo).AcceptSplitPartition(splitPartListSingle);
+                try
+                {
+                    await localDirectory.GetDirectoryReference(addedSilo).AcceptSplitPartition(splitPartListSingle);
+                    if (splitPartListSingle.Count > 0)
+                    {
+                        LogInformationCompletedSplitPartition(logger, splitPartListSingle.Count, addedSilo);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    LogWarningSplitPartitionFailed(logger, exception, splitPartListSingle.Count, addedSilo);
+                    throw;
+                }
             }
             else
             {
@@ -95,6 +108,8 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     localDirectory.DirectoryPartition.RemoveGrain(activationAddress.GrainId);
                 }
+
+                LogInformationRemovedTransferredEntries(logger, splitPartListSingle.Count, addedSilo);
             }
         }
 
@@ -256,6 +271,24 @@ namespace Orleans.Runtime.GrainDirectory
         private static partial void LogDebugSendingEntries(ILogger logger, int count, SiloAddress addedSilo);
 
         [LoggerMessage(
+            Level = LogLevel.Information,
+            Message = "Rolling upgrade diagnostic: sending {Count} split-partition registrations to {AddedSilo}."
+        )]
+        private static partial void LogInformationSendingSplitPartition(ILogger logger, int count, SiloAddress addedSilo);
+
+        [LoggerMessage(
+            Level = LogLevel.Information,
+            Message = "Rolling upgrade diagnostic: completed split-partition transfer of {Count} registrations to {AddedSilo}."
+        )]
+        private static partial void LogInformationCompletedSplitPartition(ILogger logger, int count, SiloAddress addedSilo);
+
+        [LoggerMessage(
+            Level = LogLevel.Warning,
+            Message = "Rolling upgrade diagnostic: split-partition transfer of {Count} registrations to {AddedSilo} failed."
+        )]
+        private static partial void LogWarningSplitPartitionFailed(ILogger logger, Exception exception, int count, SiloAddress addedSilo);
+
+        [LoggerMessage(
             Level = LogLevel.Warning,
             Message = "Silo {AddedSilo} is no longer active and therefore cannot receive this partition split"
         )]
@@ -266,6 +299,12 @@ namespace Orleans.Runtime.GrainDirectory
             Message = "Removing {Count} single activation after partition split"
         )]
         private static partial void LogDebugRemovingEntries(ILogger logger, int count);
+
+        [LoggerMessage(
+            Level = LogLevel.Information,
+            Message = "Rolling upgrade diagnostic: removed {Count} transferred registrations after handoff to {AddedSilo}."
+        )]
+        private static partial void LogInformationRemovedTransferredEntries(ILogger logger, int count, SiloAddress addedSilo);
 
         [LoggerMessage(
             Level = LogLevel.Debug,

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -41,6 +41,8 @@ namespace Orleans.Runtime.GrainDirectory
 
         public RemoteGrainDirectory RemoteGrainDirectory { get; }
         public RemoteGrainDirectory CacheValidator { get; }
+        internal LocalGrainDirectoryClientCompatibility? DistributedGrainDirectoryClientCompatibility { get; }
+        internal LocalGrainDirectoryPartitionCompatibility? DistributedGrainDirectoryPartitionCompatibility { get; }
 
         internal GrainDirectoryHandoffManager HandoffManager { get; }
 
@@ -79,6 +81,8 @@ namespace Orleans.Runtime.GrainDirectory
             var distributedDirectoryActive = serviceProvider.GetService<DistributedGrainDirectory>() is not null;
             RemoteGrainDirectory = new RemoteGrainDirectory(this, Constants.DirectoryServiceType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
             CacheValidator = new RemoteGrainDirectory(this, Constants.DirectoryCacheValidatorType, systemTargetShared, registerAsSystemTarget: !distributedDirectoryActive);
+            DistributedGrainDirectoryClientCompatibility = distributedDirectoryActive ? null : new LocalGrainDirectoryClientCompatibility(this, systemTargetShared);
+            DistributedGrainDirectoryPartitionCompatibility = distributedDirectoryActive ? null : new LocalGrainDirectoryPartitionCompatibility(this, systemTargetShared);
 
             // add myself to the list of members
             AddServer(MyAddress);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Orleans.Concurrency;
+using Orleans.GrainDirectory;
+
+namespace Orleans.Runtime.GrainDirectory;
+
+/// <summary>
+/// Compatibility system targets which allow distributed-directory silos to interact with local-directory silos
+/// during rolling upgrades.
+/// </summary>
+internal sealed class LocalGrainDirectoryClientCompatibility : SystemTarget, IGrainDirectoryClient
+{
+    private readonly LocalGrainDirectory _directory;
+
+    internal LocalGrainDirectoryClientCompatibility(LocalGrainDirectory directory, SystemTargetShared shared)
+        : base(Constants.GrainDirectoryType, shared)
+    {
+        _directory = directory;
+        shared.ActivationDirectory.RecordNewTarget(this);
+    }
+
+    public ValueTask<Immutable<List<GrainAddress>>> GetRegisteredActivations(MembershipVersion membershipVersion, RingRange range, bool isValidation)
+        => new(_directory.DirectoryPartition.Split(range.Contains).AsImmutable());
+
+    public ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(MembershipVersion membershipVersion, RingRange range, SiloAddress siloAddress, int partitionId)
+        => GetRegisteredActivations(membershipVersion, range, isValidation: false);
+}
+
+internal sealed class LocalGrainDirectoryPartitionCompatibility : SystemTarget, IGrainDirectoryPartition
+{
+    private readonly LocalGrainDirectory _directory;
+
+    internal LocalGrainDirectoryPartitionCompatibility(LocalGrainDirectory directory, SystemTargetShared shared)
+        : base(GrainDirectoryPartition.CreateGrainId(shared.SiloAddress, 0), shared)
+    {
+        _directory = directory;
+        shared.ActivationDirectory.RecordNewTarget(this);
+    }
+
+    public async ValueTask<DirectoryResult<GrainAddress>> RegisterAsync(MembershipVersion version, GrainAddress address, GrainAddress? currentRegistration)
+    {
+        var result = await _directory.RegisterAsync(address, currentRegistration, hopCount: 1);
+        return DirectoryResult.FromResult(result.Address!, version);
+    }
+
+    public async ValueTask<DirectoryResult<GrainAddress?>> LookupAsync(MembershipVersion version, GrainId grainId)
+    {
+        var result = await _directory.LookupAsync(grainId, hopCount: 1);
+        return DirectoryResult.FromResult(result.Address, version);
+    }
+
+    public async ValueTask<DirectoryResult<bool>> DeregisterAsync(MembershipVersion version, GrainAddress address)
+    {
+        await _directory.UnregisterAsync(address, UnregistrationCause.Force, hopCount: 1);
+        return DirectoryResult.FromResult(true, version);
+    }
+
+    public ValueTask<GrainDirectoryPartitionSnapshot?> GetSnapshotAsync(MembershipVersion version, MembershipVersion rangeVersion, RingRange range)
+        => new(new GrainDirectoryPartitionSnapshot(rangeVersion, _directory.DirectoryPartition.Split(range.Contains)));
+
+    public ValueTask<bool> AcknowledgeSnapshotTransferAsync(SiloAddress silo, int partitionIndex, MembershipVersion version) => new(true);
+}

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -707,14 +707,22 @@ namespace Orleans.TestingHost
             }
             if (options.UseTestClusterMembership)
             {
-                var gateways = new List<IPEndPoint>();
-                if (options.GatewayPerSilo)
+                var gateways = Silos
+                    .Where(silo => silo.IsActive && silo.GatewayAddress?.Endpoint is { Port: > 0 } )
+                    .Select(silo => new IPEndPoint(silo.GatewayAddress.Endpoint.Address, silo.GatewayAddress.Endpoint.Port))
+                    .Distinct()
+                    .ToList();
+
+                if (gateways.Count == 0)
                 {
-                    gateways.AddRange(Enumerable.Range(options.BaseGatewayPort, options.InitialSilosCount).Select(port => new IPEndPoint(IPAddress.Loopback, port)));
-                }
-                else
-                {
-                    gateways.Add(new IPEndPoint(IPAddress.Loopback, options.BaseGatewayPort));
+                    if (options.GatewayPerSilo)
+                    {
+                        gateways.AddRange(Enumerable.Range(options.BaseGatewayPort, options.InitialSilosCount).Select(port => new IPEndPoint(IPAddress.Loopback, port)));
+                    }
+                    else
+                    {
+                        gateways.Add(new IPEndPoint(IPAddress.Loopback, options.BaseGatewayPort));
+                    }
                 }
 
                 var clustering = new Dictionary<string, string?>();

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -1,9 +1,13 @@
 #nullable enable
 using System.Collections.Concurrent;
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Orleans;
 using Orleans.GrainDirectory;
+using Orleans.Hosting;
 using Orleans.Runtime;
 using Orleans.Runtime.GrainDirectory;
 using Orleans.TestingHost;
@@ -37,67 +41,92 @@ internal class RollingUpgradeTestGrain : Grain, IRollingUpgradeTestGrain
 [TestCategory("Directory"), TestCategory("Functional")]
 public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 {
-    /// <summary>
-    /// Controls whether newly started silos enable the <see cref="DistributedGrainDirectory"/>.
-    /// </summary>
-    internal static volatile bool UseDistributedDirectory;
-
     [Fact]
     public async Task RollingUpgrade_LocalToDistributed_NoErrors()
     {
-        UseDistributedDirectory = false;
-        var errorLogs = new ConcurrentBag<string>();
-        ErrorLogCaptureSiloConfigurator.Errors = errorLogs;
-
         var builder = new TestClusterBuilder(3);
         // Remove the default DistributedGrainDirectory configurator — initial silos use LocalGrainDirectory only.
         builder.Options.SiloBuilderConfiguratorTypes.RemoveAll(
             t => t.Contains(nameof(ConfigureDistributedGrainDirectory), StringComparison.Ordinal));
         builder.AddSiloBuilderConfigurator<RollingUpgradeSiloConfigurator>();
         builder.AddSiloBuilderConfigurator<ErrorLogCaptureSiloConfigurator>();
+        builder.AddSiloBuilderConfigurator<RollingUpgradeDiagnosticCaptureSiloConfigurator>();
 
         var cluster = builder.Build();
-        await cluster.DeployAsync();
-        output.WriteLine($"Cluster deployed with {cluster.Silos.Count} silos (LocalGrainDirectory only).");
+        var errorLogs = ErrorLogCaptureRegistry.Get(cluster.Options.ClusterId);
+        var diagnosticLogs = DiagnosticLogCaptureRegistry.Get(cluster.Options.ClusterId);
+        long? failingGrainKey = null;
 
-        var client = cluster.Client;
-        var grainId = 0L;
-        var nextGrainId = () => Interlocked.Increment(ref grainId);
-
-        // Phase 1: Drive load on the LocalGrainDirectory cluster.
-        output.WriteLine("Phase 1: Driving load on LocalGrainDirectory cluster...");
-        await DriveLoad(client, nextGrainId, count: 100);
-
-        // Phase 2: Add DistributedGrainDirectory silos one at a time.
-        output.WriteLine("Phase 2: Rolling upgrade — adding DistributedGrainDirectory silos...");
-        UseDistributedDirectory = true;
-
-        var oldSilos = cluster.Silos.ToList();
-
-        for (var i = 0; i < oldSilos.Count; i++)
+        try
         {
-            var newSilo = await cluster.StartAdditionalSiloAsync();
-            output.WriteLine($"  Started new silo: {newSilo.SiloAddress}");
-            await cluster.WaitForLivenessToStabilizeAsync();
-            await DriveLoad(client, nextGrainId, count: 100);
-        }
+            await cluster.DeployAsync();
+            output.WriteLine($"Cluster deployed with {cluster.Silos.Count} silos (LocalGrainDirectory only).");
 
-        // Phase 3: Stop old silos one at a time, non-primary first.
-        output.WriteLine($"Phase 3: Removing {oldSilos.Count} old LocalGrainDirectory silos...");
-        foreach (var oldSilo in oldSilos.OrderBy(s => s == cluster.Primary ? 1 : 0))
+            IGrainFactory client = cluster.Client;
+            var grainId = 0L;
+            var nextGrainId = () => Interlocked.Increment(ref grainId);
+
+            try
+            {
+                // Phase 1: Drive load on the LocalGrainDirectory cluster.
+                output.WriteLine("Phase 1: Driving load on LocalGrainDirectory cluster...");
+                await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
+
+                // Phase 2: Add DistributedGrainDirectory silos one at a time.
+                output.WriteLine("Phase 2: Rolling upgrade — adding DistributedGrainDirectory silos...");
+
+                var oldSilos = cluster.Silos.ToList();
+
+                for (var i = 0; i < oldSilos.Count; i++)
+                {
+                    var newSilo = await cluster.StartAdditionalSiloAsync();
+                    output.WriteLine($"  Started new silo: {newSilo.SiloAddress}");
+                    await cluster.WaitForLivenessToStabilizeAsync();
+                    await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
+                }
+
+                await cluster.InitializeClientAsync();
+                client = cluster.Client;
+
+                // Phase 3: Stop old silos one at a time, non-primary first.
+                output.WriteLine($"Phase 3: Removing {oldSilos.Count} old LocalGrainDirectory silos...");
+                foreach (var oldSilo in oldSilos.OrderBy(s => s == cluster.Primary ? 1 : 0))
+                {
+                    await cluster.StopSiloAsync(oldSilo);
+                    output.WriteLine($"  Stopped old silo: {oldSilo.SiloAddress}");
+                    await cluster.WaitForLivenessToStabilizeAsync();
+                    await DriveLoad(client, nextGrainId, count: 100, id => failingGrainKey = id);
+                }
+
+                // Phase 4: Final verification on the fully-upgraded cluster — must succeed without retries.
+                output.WriteLine("Phase 4: Verifying fully-upgraded DistributedGrainDirectory cluster...");
+                await DriveLoad(client, nextGrainId, count: 200, id => failingGrainKey = id);
+            }
+            catch
+            {
+                await DumpFailureDiagnosticsAsync(cluster, errorLogs, diagnosticLogs, failingGrainKey);
+                throw;
+            }
+        }
+        finally
         {
-            await cluster.StopSiloAsync(oldSilo);
-            output.WriteLine($"  Stopped old silo: {oldSilo.SiloAddress}");
-            await cluster.WaitForLivenessToStabilizeAsync();
-            await DriveLoad(client, nextGrainId, count: 100);
+            try
+            {
+                await cluster.StopAllSilosAsync();
+                await cluster.DisposeAsync();
+            }
+            finally
+            {
+                ErrorLogCaptureRegistry.Remove(cluster.Options.ClusterId);
+                DiagnosticLogCaptureRegistry.Remove(cluster.Options.ClusterId);
+            }
         }
-
-        // Phase 4: Final verification on the fully-upgraded cluster — must succeed without retries.
-        output.WriteLine("Phase 4: Verifying fully-upgraded DistributedGrainDirectory cluster...");
-        await DriveLoad(client, nextGrainId, count: 200);
 
         // Assert no error-level logs occurred.
-        var errors = errorLogs.ToArray();
+        var errors = errorLogs
+            .ToArray()
+            .Where(static error => !IsExpectedClientRoutingTableCancellation(error))
+            .ToArray();
         if (errors.Length > 0)
         {
             output.WriteLine($"ERROR LOGS ({errors.Length}):");
@@ -107,17 +136,18 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             }
         }
 
-        await cluster.StopAllSilosAsync();
-        await cluster.DisposeAsync();
-
         Assert.Empty(errors);
     }
+
+    private static bool IsExpectedClientRoutingTableCancellation(string error) =>
+        error.StartsWith("[Orleans.Runtime.GrainDirectory.ClientDirectory] Exception publishing client routing table", StringComparison.Ordinal)
+        && error.Contains("TaskCanceledException: A task was canceled.", StringComparison.Ordinal);
 
     /// <summary>
     /// Activates grains by calling each one. Retries individual calls that fail with transient
     /// exceptions expected during directory ownership transitions in a rolling upgrade.
     /// </summary>
-    private async Task DriveLoad(IGrainFactory client, Func<long> nextGrainId, int count)
+    private async Task DriveLoad(IGrainFactory client, Func<long> nextGrainId, int count, Action<long>? onPersistentFailure = null)
     {
         var ids = new long[count];
         for (var i = 0; i < count; i++)
@@ -151,45 +181,151 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         // Retry failed calls one at a time.
         foreach (var id in failedIds)
         {
-            await client.GetGrain<IRollingUpgradeTestGrain>(id).GetHost();
-        }
-    }
-
-    private class RollingUpgradeSiloConfigurator : ISiloConfigurator
-    {
-        public void Configure(ISiloBuilder siloBuilder)
-        {
-            if (UseDistributedDirectory)
+            try
             {
-#pragma warning disable ORLEANSEXP003
-                siloBuilder.AddDistributedGrainDirectory();
-#pragma warning restore ORLEANSEXP003
+                await client.GetGrain<IRollingUpgradeTestGrain>(id).GetHost();
+            }
+            catch
+            {
+                onPersistentFailure?.Invoke(id);
+                throw;
             }
         }
     }
 
-    private class ErrorLogCaptureSiloConfigurator : IHostConfigurator
+    private async Task DumpFailureDiagnosticsAsync(TestCluster cluster, ErrorLogCapture errorLogs, DiagnosticLogCapture diagnosticLogs, long? failingGrainKey)
     {
-        internal static ConcurrentBag<string>? Errors;
+        DumpCapturedMessages("ERROR LOGS", errorLogs.ToArray());
+        DumpCapturedMessages("ROLLING UPGRADE DIAGNOSTICS", diagnosticLogs.ToArray(), limit: 200);
 
+        if (failingGrainKey is not long grainKey)
+        {
+            return;
+        }
+
+        var grain = cluster.Client.GetGrain<IRollingUpgradeTestGrain>(grainKey);
+        var grainId = grain.GetGrainId();
+        output.WriteLine($"DETAILED GRAIN REPORTS for failing grain key {grainKey} ({grainId}):");
+        foreach (var silo in cluster.Silos)
+        {
+            try
+            {
+                var siloControl = cluster.InternalGrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlType, silo.SiloAddress);
+                var report = await siloControl.GetDetailedGrainReport(grainId);
+                output.WriteLine(report.ToString());
+            }
+            catch (Exception exception)
+            {
+                output.WriteLine($"Failed to get detailed grain report from silo {silo.SiloAddress}: {exception}");
+            }
+        }
+
+        output.WriteLine("LIKELY RESOLUTION PLAN:");
+        output.WriteLine("  1. Preserve RemoteGrainDirectory.AcceptSplitPartition semantics in DistributedRemoteGrainDirectory.");
+        output.WriteLine("  2. Queue split-partition registration work instead of awaiting the full transfer inline.");
+        output.WriteLine("  3. Retry failed registrations and handle duplicate activations before removing sender-side entries.");
+    }
+
+    private void DumpCapturedMessages(string title, string[] messages, int limit = 50)
+    {
+        if (messages.Length == 0)
+        {
+            return;
+        }
+
+        output.WriteLine($"{title} ({messages.Length}):");
+        foreach (var message in messages.Take(limit))
+        {
+            output.WriteLine($"  {message}");
+        }
+
+        if (messages.Length > limit)
+        {
+            output.WriteLine($"  ... truncated to first {limit} entries.");
+        }
+    }
+
+    private static bool ShouldUseDistributedDirectory(IConfiguration configuration)
+    {
+        var initialSiloCountText = configuration[nameof(TestClusterOptions.InitialSilosCount)]
+            ?? throw new InvalidOperationException($"Missing {nameof(TestClusterOptions.InitialSilosCount)} configuration.");
+        var initialSiloCount = int.Parse(initialSiloCountText, CultureInfo.InvariantCulture);
+        return GetSiloInstanceNumber(configuration) >= initialSiloCount;
+    }
+
+    private static int GetSiloInstanceNumber(IConfiguration configuration)
+    {
+        var siloName = configuration["Orleans:Name"]
+            ?? throw new InvalidOperationException("Missing Orleans:Name configuration.");
+        if (string.Equals(siloName, Silo.PrimarySiloName, StringComparison.Ordinal))
+        {
+            return 0;
+        }
+
+        const string secondaryPrefix = "Secondary_";
+        if (siloName.StartsWith(secondaryPrefix, StringComparison.Ordinal)
+            && int.TryParse(siloName.AsSpan(secondaryPrefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out var instanceNumber))
+        {
+            return instanceNumber;
+        }
+
+        throw new InvalidOperationException($"Unexpected silo name '{siloName}'.");
+    }
+
+    private sealed class RollingUpgradeSiloConfigurator : IHostConfigurator
+    {
         public void Configure(IHostBuilder hostBuilder)
         {
+            if (!ShouldUseDistributedDirectory(hostBuilder.GetConfiguration()))
+            {
+                return;
+            }
+
+#pragma warning disable ORLEANSEXP003
+            hostBuilder.UseOrleans(static (_, siloBuilder) => siloBuilder.AddDistributedGrainDirectory());
+#pragma warning restore ORLEANSEXP003
+        }
+    }
+
+    private sealed class ErrorLogCaptureSiloConfigurator : IHostConfigurator
+    {
+        public void Configure(IHostBuilder hostBuilder)
+        {
+            var clusterId = hostBuilder.GetConfiguration()["Orleans:ClusterId"]
+                ?? throw new InvalidOperationException("Missing Orleans:ClusterId configuration.");
             hostBuilder.ConfigureServices(services =>
             {
-                if (Errors is { } errors)
-                {
-                    services.AddSingleton<ILoggerProvider>(new ErrorCapturingLoggerProvider(errors));
-                }
+                services.AddSingleton(ErrorLogCaptureRegistry.Get(clusterId));
+                services.AddSingleton<ILoggerProvider, ErrorCapturingLoggerProvider>();
             });
         }
     }
 
-    private sealed class ErrorCapturingLoggerProvider(ConcurrentBag<string> errors) : ILoggerProvider
+    private sealed class RollingUpgradeDiagnosticCaptureSiloConfigurator : IHostConfigurator
     {
-        public ILogger CreateLogger(string categoryName) => new ErrorCapturingLogger(categoryName, errors);
+        public void Configure(IHostBuilder hostBuilder)
+        {
+            var clusterId = hostBuilder.GetConfiguration()["Orleans:ClusterId"]
+                ?? throw new InvalidOperationException("Missing Orleans:ClusterId configuration.");
+            hostBuilder.ConfigureLogging(logging =>
+            {
+                logging.AddFilter(typeof(DistributedRemoteGrainDirectory).FullName, LogLevel.Information);
+                logging.AddFilter(typeof(GrainDirectoryHandoffManager).FullName, LogLevel.Information);
+            });
+            hostBuilder.ConfigureServices(services =>
+            {
+                services.AddSingleton(DiagnosticLogCaptureRegistry.Get(clusterId));
+                services.AddSingleton<ILoggerProvider, DiagnosticCapturingLoggerProvider>();
+            });
+        }
+    }
+
+    private sealed class ErrorCapturingLoggerProvider(ErrorLogCapture errorLogs) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new ErrorCapturingLogger(categoryName, errorLogs);
         public void Dispose() { }
 
-        private sealed class ErrorCapturingLogger(string category, ConcurrentBag<string> errors) : ILogger
+        private sealed class ErrorCapturingLogger(string category, ErrorLogCapture errorLogs) : ILogger
         {
             public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
             public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
@@ -210,9 +346,77 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                         message += $"\n  Exception: {exception.GetType().Name}: {exception.Message}";
                     }
 
-                    errors.Add(message);
+                    errorLogs.Add(message);
                 }
             }
         }
+    }
+
+    private sealed class ErrorLogCapture
+    {
+        private readonly ConcurrentQueue<string> _errors = new();
+
+        public void Add(string message) => _errors.Enqueue(message);
+
+        public string[] ToArray() => _errors.ToArray();
+    }
+
+    private static class ErrorLogCaptureRegistry
+    {
+        private static readonly ConcurrentDictionary<string, ErrorLogCapture> ErrorsByCluster = new(StringComparer.Ordinal);
+
+        public static ErrorLogCapture Get(string clusterId) => ErrorsByCluster.GetOrAdd(clusterId, static _ => new());
+
+        public static void Remove(string clusterId) => ErrorsByCluster.TryRemove(clusterId, out _);
+    }
+
+    private sealed class DiagnosticCapturingLoggerProvider(DiagnosticLogCapture diagnostics) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new DiagnosticCapturingLogger(categoryName, diagnostics);
+        public void Dispose() { }
+
+        private sealed class DiagnosticCapturingLogger(string category, DiagnosticLogCapture diagnostics) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) =>
+                logLevel >= LogLevel.Information
+                && (string.Equals(category, typeof(DistributedRemoteGrainDirectory).FullName, StringComparison.Ordinal)
+                    || string.Equals(category, typeof(GrainDirectoryHandoffManager).FullName, StringComparison.Ordinal));
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel))
+                {
+                    return;
+                }
+
+                var message = $"[{category}] {formatter(state, exception)}";
+                if (exception is not null)
+                {
+                    message += $"\n  Exception: {exception.GetType().Name}: {exception.Message}";
+                }
+
+                diagnostics.Add(message);
+            }
+        }
+    }
+
+    private sealed class DiagnosticLogCapture
+    {
+        private readonly ConcurrentQueue<string> _messages = new();
+
+        public void Add(string message) => _messages.Enqueue(message);
+
+        public string[] ToArray() => _messages.ToArray();
+    }
+
+    private static class DiagnosticLogCaptureRegistry
+    {
+        private static readonly ConcurrentDictionary<string, DiagnosticLogCapture> DiagnosticsByCluster = new(StringComparer.Ordinal);
+
+        public static DiagnosticLogCapture Get(string clusterId) => DiagnosticsByCluster.GetOrAdd(clusterId, static _ => new());
+
+        public static void Remove(string clusterId) => DiagnosticsByCluster.TryRemove(clusterId, out _);
     }
 }


### PR DESCRIPTION
## Summary

Restores mixed local-to-distributed grain directory rolling upgrade behavior.

## Changes

- Restore queued split-partition handoff behavior for local-to-distributed upgrades.
- Add compatibility targets on local silos for distributed recovery APIs.
- Refresh test-cluster gateways from active silos during rolling-upgrade tests.
- Improve rolling-upgrade regression diagnostics and client refresh behavior.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10052)