### PR TITLE
Add TTL cleanup to grain directory cache

### DIFF
--- a/src/Orleans.Core/Caching/ConcurrentLruCache.cs
+++ b/src/Orleans.Core/Caching/ConcurrentLruCache.cs
@@ -1096,7 +1096,14 @@ internal class ConcurrentLruCache<K, V> : IEnumerable<KeyValuePair<K, V>>, ICach
 
         if (_expirationLoopTask is not null)
         {
-            await _expirationLoopTask.ConfigureAwait(false);
+            try
+            {
+                await _expirationLoopTask.ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                Trace.TraceError($"{nameof(ConcurrentLruCache<K, V>)} background expiration loop failed during disposal: {exception}");
+            }
         }
     }
 

--- a/src/Orleans.Core/Caching/ConcurrentLruCache.cs
+++ b/src/Orleans.Core/Caching/ConcurrentLruCache.cs
@@ -1051,9 +1051,8 @@ internal class ConcurrentLruCache<K, V> : IEnumerable<KeyValuePair<K, V>>, ICach
                 var removedCount = TrimExpiredItems();
                 ConcurrentLruCacheDiagnostics.EmitExpiredItemsRemoved(this, removedCount);
             }
-            catch (Exception exception)
+            catch
             {
-                Trace.TraceError($"{nameof(ConcurrentLruCache<K, V>)} background expiration loop failed: {exception}");
             }
         }
     }

--- a/src/Orleans.Core/Caching/ConcurrentLruCache.cs
+++ b/src/Orleans.Core/Caching/ConcurrentLruCache.cs
@@ -1096,14 +1096,7 @@ internal class ConcurrentLruCache<K, V> : IEnumerable<KeyValuePair<K, V>>, ICach
 
         if (_expirationLoopTask is not null)
         {
-            try
-            {
-                await _expirationLoopTask.ConfigureAwait(false);
-            }
-            catch (Exception exception)
-            {
-                Trace.TraceError($"{nameof(ConcurrentLruCache<K, V>)} background expiration loop failed during disposal: {exception}");
-            }
+            await _expirationLoopTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
         }
     }
 

--- a/src/Orleans.Core/Caching/ConcurrentLruCache.cs
+++ b/src/Orleans.Core/Caching/ConcurrentLruCache.cs
@@ -1046,8 +1046,15 @@ internal class ConcurrentLruCache<K, V> : IEnumerable<KeyValuePair<K, V>>, ICach
 
         while (await _expirationTimer.WaitForNextTickAsync().ConfigureAwait(false))
         {
-            var removedCount = TrimExpiredItems();
-            ConcurrentLruCacheDiagnostics.EmitExpiredItemsRemoved(this, removedCount);
+            try
+            {
+                var removedCount = TrimExpiredItems();
+                ConcurrentLruCacheDiagnostics.EmitExpiredItemsRemoved(this, removedCount);
+            }
+            catch (Exception exception)
+            {
+                Trace.TraceError($"{nameof(ConcurrentLruCache<K, V>)} background expiration loop failed: {exception}");
+            }
         }
     }
 

--- a/src/Orleans.Core/Caching/ConcurrentLruCache.cs
+++ b/src/Orleans.Core/Caching/ConcurrentLruCache.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Orleans.Caching.Internal;
 
 namespace Orleans.Caching;
@@ -18,8 +19,8 @@ namespace Orleans.Caching;
 /// On cache miss, a new item is added. Tail items in each segment are dequeued, examined, and are either enqueued
 /// or discarded.
 /// The TU-Q scheme of hot, warm and cold is similar to that used in MemCached (https://memcached.org/blog/modern-lru/)
-/// and OpenBSD (https://flak.tedunangst.com/post/2Q-buffer-cache-algorithm), but does not use a background thread
-/// to maintain the internal queues.
+/// and OpenBSD (https://flak.tedunangst.com/post/2Q-buffer-cache-algorithm). Capacity maintenance does not use a
+/// background thread, while optional TTL cleanup uses a timer to periodically remove expired items.
 /// </summary>
 /// <remarks>
 /// This implementation is derived from BitFaster.Caching (https://github.com/bitfaster/BitFaster.Caching), removing
@@ -35,26 +36,25 @@ namespace Orleans.Caching;
 ///   <item><description>When cold is full, cold tail is moved to warm head or removed from dictionary on depending on WasAccessed.</description></item>
 ///</list>
 /// </remarks>
-/// <remarks>
-/// Initializes a new instance of the ConcurrentLruCore class with the specified concurrencyLevel, capacity, equality comparer, item policy and telemetry policy.
-/// </remarks>
-/// <param name="capacity">The capacity.</param>
-/// <param name="comparer">The equality comparer.</param>
-internal class ConcurrentLruCache<K, V>(
-    int capacity,
-    IEqualityComparer<K>? comparer) : IEnumerable<KeyValuePair<K, V>>, ICacheMetrics, ConcurrentLruCache<K, V>.ITestAccessor
+internal class ConcurrentLruCache<K, V> : IEnumerable<KeyValuePair<K, V>>, ICacheMetrics, IAsyncDisposable, ConcurrentLruCache<K, V>.ITestAccessor
     where K : notnull
 {
-    private readonly ConcurrentDictionary<K, LruItem> _dictionary = new(concurrencyLevel: -1, capacity: capacity, comparer: comparer);
+    private readonly ConcurrentDictionary<K, LruItem> _dictionary;
     private readonly ConcurrentQueue<LruItem> _hotQueue = new();
     private readonly ConcurrentQueue<LruItem> _warmQueue = new();
     private readonly ConcurrentQueue<LruItem> _coldQueue = new();
-    private readonly CapacityPartition _capacity = new(capacity);
+    private readonly CapacityPartition _capacity;
     private readonly TelemetryPolicy _telemetryPolicy = new();
+    private readonly bool _expiresAfterAccess;
+    private readonly TimeSpan _timeToLive;
+    private readonly TimeProvider _timeProvider;
+    private readonly PeriodicTimer? _expirationTimer;
+    private readonly Task? _expirationLoopTask;
 
     // maintain count outside ConcurrentQueue, since ConcurrentQueue.Count holds a global lock
     private PaddedQueueCount _counter;
     private bool _isWarm;
+    private int _disposed;
 
     /// <summary>
     /// Initializes a new instance of the ConcurrentLruCore class with the specified capacity.
@@ -62,6 +62,43 @@ internal class ConcurrentLruCache<K, V>(
     /// <param name="capacity">The capacity.</param>
     public ConcurrentLruCache(int capacity) : this(capacity, comparer: null)
     {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the ConcurrentLruCore class with the specified capacity and expire-after-access time to live.
+    /// </summary>
+    /// <param name="capacity">The capacity.</param>
+    /// <param name="timeToLive">The time after which inactive items expire.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    public ConcurrentLruCache(int capacity, TimeSpan timeToLive, TimeProvider? timeProvider = null)
+        : this(capacity, comparer: null, timeToLive: timeToLive, timeProvider: timeProvider)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the ConcurrentLruCore class with the specified concurrencyLevel, capacity, equality comparer, item policy and telemetry policy.
+    /// </summary>
+    /// <param name="capacity">The capacity.</param>
+    /// <param name="comparer">The equality comparer.</param>
+    /// <param name="timeToLive">The time after which inactive items expire.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    public ConcurrentLruCache(
+        int capacity,
+        IEqualityComparer<K>? comparer,
+        TimeSpan? timeToLive = null,
+        TimeProvider? timeProvider = null)
+    {
+        _capacity = new CapacityPartition(capacity);
+        _dictionary = new ConcurrentDictionary<K, LruItem>(concurrencyLevel: -1, capacity: capacity, comparer: comparer);
+        _expiresAfterAccess = timeToLive.HasValue;
+        _timeToLive = ValidateTimeToLive(timeToLive);
+        _timeProvider = timeProvider ?? TimeProvider.System;
+
+        if (_expiresAfterAccess)
+        {
+            _expirationTimer = new PeriodicTimer(_timeToLive, _timeProvider);
+            _expirationLoopTask = RunExpirationLoop();
+        }
     }
 
     // No lock count: https://arbel.net/2013/02/03/best-practices-for-using-concurrentdictionary/
@@ -127,7 +164,7 @@ internal class ConcurrentLruCache<K, V>(
         if (_dictionary.TryGetValue(key, out var item))
         {
             value = item.Value;
-            item.MarkAccessed();
+            Touch(item);
             _telemetryPolicy.IncrementHit();
             return true;
         }
@@ -139,7 +176,7 @@ internal class ConcurrentLruCache<K, V>(
 
     public bool TryAdd(K key, V value)
     {
-        var newItem = new LruItem(key, value);
+        var newItem = CreateItem(key, value);
 
         if (_dictionary.TryAdd(key, newItem))
         {
@@ -315,6 +352,7 @@ internal class ConcurrentLruCache<K, V>(
                     var oldValue = existing.Value;
 
                     existing.Value = value;
+                    UpdateTimestamp(existing);
 
                     _telemetryPolicy.IncrementUpdated();
                     DisposeValue(oldValue);
@@ -340,7 +378,7 @@ internal class ConcurrentLruCache<K, V>(
             }
 
             // then try add
-            var newItem = new LruItem(key, value);
+            var newItem = CreateItem(key, value);
 
             if (_dictionary.TryAdd(key, newItem))
             {
@@ -356,14 +394,10 @@ internal class ConcurrentLruCache<K, V>(
     ///<inheritdoc/>
     public void Clear()
     {
-        // don't overlap Clear/Trim/TrimExpired
-        lock (_dictionary)
-        {
-            // evaluate queue count, remove everything including items removed from the dictionary but
-            // not the queues. This also avoids the expensive o(n) no lock count, or locking the dictionary.
-            var queueCount = HotCount + WarmCount + ColdCount;
-            TrimLiveItems(queueCount, ItemRemovedReason.Cleared);
-        }
+        // evaluate queue count, remove everything including items removed from the dictionary but
+        // not the queues. This also avoids the expensive o(n) no lock count, or locking the dictionary.
+        var queueCount = HotCount + WarmCount + ColdCount;
+        TrimLiveItems(queueCount, ItemRemovedReason.Cleared);
     }
 
     /// <summary>
@@ -385,11 +419,57 @@ internal class ConcurrentLruCache<K, V>(
         // clamp itemCount to number of items actually in the cache
         itemCount = Math.Min(itemCount, HotCount + WarmCount + ColdCount);
 
-        // don't overlap Clear/Trim/TrimExpired
-        lock (_dictionary)
+        TrimLiveItems(itemCount, ItemRemovedReason.Trimmed);
+    }
+
+    private int TrimExpiredItems()
+    {
+        if (!_expiresAfterAccess)
         {
-            TrimLiveItems(itemCount, ItemRemovedReason.Trimmed);
+            return 0;
         }
+
+        var timestamp = _timeProvider.GetTimestamp();
+
+        int RemoveExpiredItems(ConcurrentQueue<LruItem> queue, ref int queueCounter)
+        {
+            var itemsRemoved = 0;
+            var localCount = Volatile.Read(ref queueCounter);
+
+            for (var i = 0; i < localCount; i++)
+            {
+                if (queue.TryDequeue(out var item))
+                {
+                    if (item.WasRemoved)
+                    {
+                        Interlocked.Decrement(ref queueCounter);
+                    }
+                    else if (IsExpired(item, timestamp))
+                    {
+                        Interlocked.Decrement(ref queueCounter);
+                        Move(item, ItemDestination.Remove, ItemRemovedReason.Trimmed);
+                        itemsRemoved++;
+                    }
+                    else
+                    {
+                        queue.Enqueue(item);
+                    }
+                }
+            }
+
+            return itemsRemoved;
+        }
+
+        var coldRemoved = RemoveExpiredItems(_coldQueue, ref _counter.Cold);
+        var warmRemoved = RemoveExpiredItems(_warmQueue, ref _counter.Warm);
+        var hotRemoved = RemoveExpiredItems(_hotQueue, ref _counter.Hot);
+
+        if (warmRemoved > 0)
+        {
+            Volatile.Write(ref _isWarm, false);
+        }
+
+        return coldRemoved + warmRemoved + hotRemoved;
     }
 
     private void TrimLiveItems(int itemCount, ItemRemovedReason reason)
@@ -773,12 +853,13 @@ internal class ConcurrentLruCache<K, V>(
     /// <param name="value">The value.</param>
     // NOTE: Internal for testing
     [DebuggerDisplay("[{Key}] = {Value}")]
-    internal sealed class LruItem(K key, V value)
+    internal sealed class LruItem(K key, V value, long timestamp = 0)
     {
         private V _data = value;
 
         // only used when V is a non-atomic value type to prevent torn reads
         private int _sequence;
+        private long _timestamp = timestamp;
 
         /// <summary>
         /// Gets the key.
@@ -825,6 +906,14 @@ internal class ConcurrentLruCache<K, V>(
         /// Gets or sets a value indicating whether the item was removed.
         /// </summary>
         public bool WasRemoved { get; set; }
+
+        public long Timestamp
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => Volatile.Read(ref _timestamp);
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set => Volatile.Write(ref _timestamp, value);
+        }
 
         /// <summary>
         /// Marks the item as accessed, if it was not already accessed.
@@ -949,5 +1038,71 @@ internal class ConcurrentLruCache<K, V>(
         {
             d.Dispose();
         }
+    }
+
+    private async Task RunExpirationLoop()
+    {
+        Debug.Assert(_expirationTimer is not null);
+
+        while (await _expirationTimer.WaitForNextTickAsync().ConfigureAwait(false))
+        {
+            var removedCount = TrimExpiredItems();
+            ConcurrentLruCacheDiagnostics.EmitExpiredItemsRemoved(this, removedCount);
+        }
+    }
+
+    private LruItem CreateItem(K key, V value) =>
+        new(key, value, _expiresAfterAccess ? _timeProvider.GetTimestamp() : 0);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void Touch(LruItem item)
+    {
+        if (_expiresAfterAccess)
+        {
+            item.Timestamp = _timeProvider.GetTimestamp();
+        }
+
+        item.MarkAccessed();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void UpdateTimestamp(LruItem item)
+    {
+        if (_expiresAfterAccess)
+        {
+            item.Timestamp = _timeProvider.GetTimestamp();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsExpired(LruItem item, long timestamp) =>
+        _expiresAfterAccess && _timeProvider.GetElapsedTime(item.Timestamp, timestamp) > _timeToLive;
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        _expirationTimer?.Dispose();
+
+        if (_expirationLoopTask is not null)
+        {
+            await _expirationLoopTask.ConfigureAwait(false);
+        }
+    }
+
+    private static TimeSpan ValidateTimeToLive(TimeSpan? timeToLive)
+    {
+        if (!timeToLive.HasValue)
+        {
+            return default;
+        }
+
+        var value = timeToLive.GetValueOrDefault();
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, TimeSpan.Zero, nameof(timeToLive));
+
+        return value;
     }
 }

--- a/src/Orleans.Core/Caching/ConcurrentLruCacheDiagnostics.cs
+++ b/src/Orleans.Core/Caching/ConcurrentLruCacheDiagnostics.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Orleans.Caching;
+
+internal static class ConcurrentLruCacheDiagnostics
+{
+    internal const string ListenerName = "Orleans.Caching.ConcurrentLruCache";
+    internal const string ExpiredItemsRemovedEventName = nameof(ExpiredItemsRemoved);
+
+    private static readonly DiagnosticListener Listener = new(ListenerName);
+
+    internal static IObservable<ExpiredItemsRemoved> ExpiredItemsRemovedEvents { get; } = new Observable();
+
+    internal sealed class ExpiredItemsRemoved(object cache, int removedCount)
+    {
+        public object Cache { get; } = cache;
+
+        public int RemovedCount { get; } = removedCount;
+    }
+
+    internal static void EmitExpiredItemsRemoved(object cache, int removedCount)
+    {
+        if (!Listener.IsEnabled(ExpiredItemsRemovedEventName))
+        {
+            return;
+        }
+
+        Emit(cache, removedCount);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(object cache, int removedCount)
+        {
+            Listener.Write(ExpiredItemsRemovedEventName, new ExpiredItemsRemoved(cache, removedCount));
+        }
+    }
+
+    private sealed class Observable : IObservable<ExpiredItemsRemoved>
+    {
+        public IDisposable Subscribe(IObserver<ExpiredItemsRemoved> observer) => Listener.Subscribe(new Observer(observer));
+
+        private sealed class Observer(IObserver<ExpiredItemsRemoved> observer) : IObserver<KeyValuePair<string, object?>>
+        {
+            public void OnCompleted() => observer.OnCompleted();
+
+            public void OnError(Exception error) => observer.OnError(error);
+
+            public void OnNext(KeyValuePair<string, object?> value)
+            {
+                if (value.Value is ExpiredItemsRemoved evt)
+                {
+                    observer.OnNext(evt);
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs
@@ -61,13 +61,11 @@ namespace Orleans.Configuration
         /// <summary>
         /// Gets or sets the maximum time, in seconds, to keep a cache entry before revalidating.
         /// </summary>
-        [Obsolete("MaximumCacheTTL is deprecated and will be removed in a future version.")]
         public TimeSpan MaximumCacheTTL { get; set; } = DEFAULT_MAXIMUM_CACHE_TTL;
 
         /// <summary>
         /// The default value for <see cref="MaximumCacheTTL"/>.
         /// </summary>
-        [Obsolete("DEFAULT_MAXIMUM_CACHE_TTL is deprecated and will be removed in a future version.")]
         public static readonly TimeSpan DEFAULT_MAXIMUM_CACHE_TTL = TimeSpan.FromSeconds(240);
 
         /// <summary>

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -18,6 +18,7 @@ namespace Orleans.Runtime.GrainDirectory
     {
         private readonly GrainDirectoryResolver grainDirectoryResolver;
         private readonly IGrainDirectoryCache cache;
+        private readonly bool disposeCache;
 
         private readonly CancellationTokenSource shutdownToken = new CancellationTokenSource();
         private readonly IClusterMembershipService clusterMembershipService;
@@ -39,7 +40,7 @@ namespace Orleans.Runtime.GrainDirectory
         {
             this.grainDirectoryResolver = grainDirectoryResolver;
             this.clusterMembershipService = clusterMembershipService;
-            this.cache = GrainDirectoryCacheFactory.CreateCustomGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value);
+            this.cache = GrainDirectoryCacheFactory.CreateCustomGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value, out this.disposeCache);
         }
 
         public async ValueTask<GrainAddress> Lookup(GrainId grainId)
@@ -149,9 +150,9 @@ namespace Orleans.Runtime.GrainDirectory
                     await listenToClusterChangeTask.WaitAsync(ct).SuppressThrowing();
                 }
 
-                if (this.cache is LruGrainDirectoryCache lruCache)
+                if (this.disposeCache)
                 {
-                    await lruCache.DisposeAsync();
+                    await GrainDirectoryCacheFactory.DisposeGrainDirectoryCacheAsync(this.cache);
                 }
             };
             lifecycle.Subscribe(nameof(CachedGrainLocator), ServiceLifecycleStage.RuntimeGrainServices, OnStart, OnStop);

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -148,6 +148,11 @@ namespace Orleans.Runtime.GrainDirectory
                 {
                     await listenToClusterChangeTask.WaitAsync(ct).SuppressThrowing();
                 }
+
+                if (this.cache is LruGrainDirectoryCache lruCache)
+                {
+                    await lruCache.DisposeAsync();
+                }
             };
             lifecycle.Subscribe(nameof(CachedGrainLocator), ServiceLifecycleStage.RuntimeGrainServices, OnStart, OnStop);
         }

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
@@ -80,9 +80,7 @@ namespace Orleans.Runtime.GrainDirectory
         private static IGrainDirectoryCache CreateLruGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options)
         {
             var timeProvider = services?.GetService<TimeProvider>() ?? TimeProvider.System;
-#pragma warning disable CS0618 // Type or member is obsolete
             return new LruGrainDirectoryCache(options.CacheSize, options.MaximumCacheTTL, timeProvider);
-#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime.GrainDirectory
 #pragma warning disable CS0618 // Type or member is obsolete
                 case GrainDirectoryOptions.CachingStrategyType.Adaptive:
 #pragma warning restore CS0618 // Type or member is obsolete
-                    return new LruGrainDirectoryCache(options.CacheSize);
+                    return CreateLruGrainDirectoryCache(services, options);
                 case GrainDirectoryOptions.CachingStrategyType.Custom:
                 default:
                     return services.GetRequiredService<IGrainDirectoryCache>();
@@ -47,8 +47,16 @@ namespace Orleans.Runtime.GrainDirectory
             }
             else
             {
-                return new LruGrainDirectoryCache(options.CacheSize);
+                return CreateLruGrainDirectoryCache(services, options);
             }
+        }
+
+        private static IGrainDirectoryCache CreateLruGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options)
+        {
+            var timeProvider = services?.GetService<TimeProvider>() ?? TimeProvider.System;
+#pragma warning disable CS0618 // Type or member is obsolete
+            return new LruGrainDirectoryCache(options.CacheSize, options.MaximumCacheTTL, timeProvider);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
@@ -19,36 +19,62 @@ namespace Orleans.Runtime.GrainDirectory
         /// <param name="options">The options.</param>
         /// <returns>The newly created <see cref="IGrainDirectoryCache"/> instance.</returns>
         public static IGrainDirectoryCache CreateGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options)
+            => CreateGrainDirectoryCache(services, options, out _);
+
+        internal static IGrainDirectoryCache CreateGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options, out bool disposeCache)
         {
             if (options.CacheSize <= 0)
+            {
+                disposeCache = true;
                 return new NullGrainDirectoryCache();
+            }
 
             switch (options.CachingStrategy)
             {
                 case GrainDirectoryOptions.CachingStrategyType.None:
+                    disposeCache = true;
                     return new NullGrainDirectoryCache();
                 case GrainDirectoryOptions.CachingStrategyType.LRU:
 #pragma warning disable CS0618 // Type or member is obsolete
                 case GrainDirectoryOptions.CachingStrategyType.Adaptive:
 #pragma warning restore CS0618 // Type or member is obsolete
+                    disposeCache = true;
                     return CreateLruGrainDirectoryCache(services, options);
                 case GrainDirectoryOptions.CachingStrategyType.Custom:
                 default:
+                    disposeCache = false;
                     return services.GetRequiredService<IGrainDirectoryCache>();
             }
         }
 
         internal static IGrainDirectoryCache CreateCustomGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options)
+            => CreateCustomGrainDirectoryCache(services, options, out _);
+
+        internal static IGrainDirectoryCache CreateCustomGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options, out bool disposeCache)
         {
             var grainDirectoryCache = services.GetService<IGrainDirectoryCache>();
-            if (grainDirectoryCache != null)
+            if (grainDirectoryCache is not null)
             {
+                disposeCache = false;
                 return grainDirectoryCache;
             }
-            else
+
+            disposeCache = true;
+            return CreateLruGrainDirectoryCache(services, options);
+        }
+
+        internal static ValueTask DisposeGrainDirectoryCacheAsync(IGrainDirectoryCache cache)
+        {
+            switch (cache)
             {
-                return CreateLruGrainDirectoryCache(services, options);
+                case IAsyncDisposable asyncDisposable:
+                    return asyncDisposable.DisposeAsync();
+                case IDisposable disposable:
+                    disposable.Dispose();
+                    break;
             }
+
+            return default;
         }
 
         private static IGrainDirectoryCache CreateLruGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -106,7 +106,7 @@ namespace Orleans.Runtime.GrainDirectory
         // The alternative would be to allow the silo to process requests after it has handed off its partition, in which case those changes
         // would receive successful responses but would not be reflected in the eventual state of the directory.
         // It's easy to change this, if we think the trade-off is better the other way.
-        public Task StopAsync()
+        public async Task StopAsync()
         {
             // This will cause remote write requests to be forwarded to the silo that will become the new owner.
             // Requests might bounce back and forth for a while as membership stabilizes, but they will either be served by the
@@ -116,9 +116,13 @@ namespace Orleans.Runtime.GrainDirectory
             //mark Running as false will exclude myself from CalculateGrainDirectoryPartition(grainId)
             Running = false;
 
+            if (DirectoryCache is LruGrainDirectoryCache lruCache)
+            {
+                await lruCache.DisposeAsync();
+            }
+
             DirectoryPartition.Clear();
             DirectoryCache.Clear();
-            return Task.CompletedTask;
         }
 
         private void AddServer(SiloAddress silo)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -37,6 +37,7 @@ namespace Orleans.Runtime.GrainDirectory
         internal SiloAddress MyAddress { get; }
 
         internal IGrainDirectoryCache DirectoryCache { get; }
+        private readonly bool disposeDirectoryCache;
         internal LocalGrainDirectoryPartition DirectoryPartition { get; }
 
         public RemoteGrainDirectory RemoteGrainDirectory { get; }
@@ -62,7 +63,7 @@ namespace Orleans.Runtime.GrainDirectory
             this.siloStatusOracle = siloStatusOracle;
             this.grainFactory = grainFactory;
 
-            DirectoryCache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value);
+            DirectoryCache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value, out this.disposeDirectoryCache);
 
             var primarySiloEndPoint = developmentClusterMembershipOptions.Value.PrimarySiloEndpoint;
             if (primarySiloEndPoint != null)
@@ -116,9 +117,9 @@ namespace Orleans.Runtime.GrainDirectory
             //mark Running as false will exclude myself from CalculateGrainDirectoryPartition(grainId)
             Running = false;
 
-            if (DirectoryCache is LruGrainDirectoryCache lruCache)
+            if (this.disposeDirectoryCache)
             {
-                await lruCache.DisposeAsync();
+                await GrainDirectoryCacheFactory.DisposeGrainDirectoryCacheAsync(DirectoryCache);
             }
 
             DirectoryPartition.Clear();

--- a/src/Orleans.Runtime/GrainDirectory/LruGrainDirectoryCache.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LruGrainDirectoryCache.cs
@@ -5,7 +5,14 @@ using Orleans.Caching;
 #nullable disable
 namespace Orleans.Runtime.GrainDirectory;
 
-internal sealed class LruGrainDirectoryCache(int maxCacheSize) : ConcurrentLruCache<GrainId, (GrainAddress ActivationAddress, int Version)>(capacity: maxCacheSize), IGrainDirectoryCache
+internal sealed class LruGrainDirectoryCache(
+    int maxCacheSize,
+    TimeSpan maxCacheTTL,
+    TimeProvider timeProvider) : ConcurrentLruCache<GrainId, (GrainAddress ActivationAddress, int Version)>(
+        capacity: maxCacheSize,
+        comparer: null,
+        timeToLive: maxCacheTTL,
+        timeProvider: timeProvider), IGrainDirectoryCache
 {
     private static readonly Func<(GrainAddress Address, int Version), GrainAddress, bool> ActivationAddressesMatch = (value, state) => GrainAddress.MatchesGrainIdAndSilo(state, value.Address);
 

--- a/src/Orleans.Runtime/Orleans.Runtime.csproj
+++ b/src/Orleans.Runtime/Orleans.Runtime.csproj
@@ -29,6 +29,7 @@
     <InternalsVisibleTo Include="Orleans.GrainDirectory.Tests" />
     <InternalsVisibleTo Include="Orleans.Journaling" />
     <InternalsVisibleTo Include="Orleans.Placement.Tests" />
+    <InternalsVisibleTo Include="Orleans.Runtime.Tests" />
     <InternalsVisibleTo Include="Orleans.Reminders" />
     <InternalsVisibleTo Include="Orleans.Runtime.Internal.Tests" />
     <InternalsVisibleTo Include="Orleans.Streaming" />

--- a/src/api/Orleans.Runtime/Orleans.Runtime.cs
+++ b/src/api/Orleans.Runtime/Orleans.Runtime.cs
@@ -189,7 +189,6 @@ namespace Orleans.Configuration
 
         public System.TimeSpan LazyDeregistrationDelay { get { throw null; } set { } }
 
-        [System.Obsolete("MaximumCacheTTL is deprecated and will be removed in a future version.")]
         public System.TimeSpan MaximumCacheTTL { get { throw null; } set { } }
 
         public enum CachingStrategyType

--- a/test/Orleans.Core.Tests/Caching/ConcurrentLruTests.cs
+++ b/test/Orleans.Core.Tests/Caching/ConcurrentLruTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Orleans.Caching;
 using Orleans.Caching.Internal;
+using TestExtensions;
 
 namespace NonSilo.Tests.Caching;
 
@@ -752,13 +753,13 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
     {
         var timeProvider = new FakeTimeProvider();
         await using var lru = CreateExpiringLru(timeProvider);
-        using var listener = new ExpirationCleanupListener(lru);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(lru);
 
         lru.AddOrUpdate(1, "1");
         timeProvider.Advance(TimeSpan.FromMinutes(2));
 
         var cleanup = await listener.WaitForCleanupAsync();
-        cleanup.RemovedCount.Should().Be(1);
+        cleanup.Should().Be(1);
         lru.TryGet(1, out var value).Should().BeFalse();
         value.Should().BeNull();
         lru.Count.Should().Be(0);
@@ -770,7 +771,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
     {
         var timeProvider = new FakeTimeProvider();
         await using var lru = CreateExpiringLru(timeProvider);
-        using var listener = new ExpirationCleanupListener(lru);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(lru);
 
         lru.AddOrUpdate(1, "1");
         timeProvider.Advance(TimeSpan.FromSeconds(45));
@@ -781,14 +782,14 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
         timeProvider.Advance(TimeSpan.FromSeconds(45));
 
         var firstCleanup = await listener.WaitForCleanupAsync();
-        firstCleanup.RemovedCount.Should().Be(0);
+        firstCleanup.Should().Be(0);
         lru.TryGet(1, out value).Should().BeTrue();
         value.Should().Be("1");
 
         timeProvider.Advance(TimeSpan.FromSeconds(61));
 
         var secondCleanup = await listener.WaitForCleanupAsync();
-        secondCleanup.RemovedCount.Should().Be(1);
+        secondCleanup.Should().Be(1);
         lru.TryGet(1, out _).Should().BeFalse();
     }
 
@@ -797,7 +798,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
     {
         var timeProvider = new FakeTimeProvider();
         await using var lru = CreateExpiringLru(timeProvider);
-        using var listener = new ExpirationCleanupListener(lru);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(lru);
 
         lru.AddOrUpdate(1, "1");
         timeProvider.Advance(TimeSpan.FromSeconds(45));
@@ -806,7 +807,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
         timeProvider.Advance(TimeSpan.FromSeconds(45));
 
         var firstCleanup = await listener.WaitForCleanupAsync();
-        firstCleanup.RemovedCount.Should().Be(0);
+        firstCleanup.Should().Be(0);
 
         lru.TryGet(1, out var value).Should().BeTrue();
         value.Should().Be("2");
@@ -821,7 +822,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
             comparer: EqualityComparer<int>.Default,
             timeToLive: TimeSpan.FromMinutes(1),
             timeProvider: timeProvider);
-        using var listener = new ExpirationCleanupListener(lru);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(lru);
         var items = Enumerable.Range(1, 2).Select(_ => new DisposableItem()).ToArray();
 
         lru.AddOrUpdate(1, items[0]);
@@ -830,9 +831,39 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
 
         var cleanup = await listener.WaitForCleanupAsync();
 
-        cleanup.RemovedCount.Should().Be(2);
+        cleanup.Should().Be(2);
         items.All(item => item.IsDisposed).Should().BeTrue();
         lru.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task WhenExpiredItemDisposalThrowsExpirationLoopContinues()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var lru = new ConcurrentLruCache<int, ThrowingDisposableItem>(
+            capacity: 6,
+            comparer: EqualityComparer<int>.Default,
+            timeToLive: TimeSpan.FromMinutes(1),
+            timeProvider: timeProvider);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(lru);
+        var item = new ThrowingDisposableItem();
+
+        try
+        {
+            lru.AddOrUpdate(1, item);
+            timeProvider.Advance(TimeSpan.FromMinutes(2));
+
+            await item.Disposed.WaitAsync(TimeSpan.FromSeconds(10));
+
+            timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+            var cleanup = await listener.WaitForCleanupAsync();
+            cleanup.Should().Be(0);
+        }
+        finally
+        {
+            await lru.DisposeAsync();
+        }
     }
 
     [Fact]
@@ -840,7 +871,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
     {
         var timeProvider = new FakeTimeProvider();
         await using var lru = CreateExpiringLru(timeProvider, capacity: 9);
-        using var listener = new ExpirationCleanupListener(lru);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(lru);
 
         lru.AddOrUpdate(1, "1");
         lru.AddOrUpdate(2, "2");
@@ -864,7 +895,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
         timeProvider.Advance(TimeSpan.FromMinutes(2));
 
         var cleanup = await listener.WaitForCleanupAsync();
-        cleanup.RemovedCount.Should().Be(9);
+        cleanup.Should().Be(9);
         lru.Count.Should().Be(0);
         lru.HotCount.Should().Be(0);
         lru.WarmCount.Should().Be(0);
@@ -876,7 +907,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
     {
         var timeProvider = new FakeTimeProvider();
         await using var lru = CreateExpiringLru(timeProvider, capacity: 9);
-        using var listener = new ExpirationCleanupListener(lru);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(lru);
 
         lru.AddOrUpdate(1, "1");
         lru.AddOrUpdate(2, "2");
@@ -895,7 +926,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
         timeProvider.Advance(TimeSpan.FromSeconds(2));
 
         var cleanup = await listener.WaitForCleanupAsync();
-        cleanup.RemovedCount.Should().Be(3);
+        cleanup.Should().Be(3);
         lru.Count.Should().Be(3);
         lru.Keys.Should().BeEquivalentTo([1, 2, 3]);
 
@@ -908,7 +939,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
     {
         var timeProvider = new FakeTimeProvider();
         await using var lru = CreateExpiringLru(timeProvider, capacity: 9);
-        using var listener = new ExpirationCleanupListener(lru);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(lru);
         var testAccessor = GetTestAccessor(lru);
 
         lru.AddOrUpdate(1, "1");
@@ -931,7 +962,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
         timeProvider.Advance(TimeSpan.FromMinutes(2));
 
         var cleanup = await listener.WaitForCleanupAsync();
-        cleanup.RemovedCount.Should().Be(9);
+        cleanup.Should().Be(9);
         testAccessor.IsWarm.Should().BeFalse();
 
         for (var i = 0; i < lru.Capacity; i++)
@@ -950,7 +981,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
     {
         var timeProvider = new FakeTimeProvider();
         await using var lru = CreateExpiringLru(timeProvider, capacity: 9);
-        using var listener = new ExpirationCleanupListener(lru);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(lru);
         var testAccessor = GetTestAccessor(lru);
 
         for (var i = 0; i < lru.Capacity; i++)
@@ -976,7 +1007,7 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
         timeProvider.Advance(TimeSpan.FromMinutes(1));
 
         var cleanup = await listener.WaitForCleanupAsync();
-        cleanup.RemovedCount.Should().Be(0);
+        cleanup.Should().Be(0);
         lru.Count.Should().Be(6);
         lru.HotCount.Should().Be(hotCount - 1);
         lru.WarmCount.Should().Be(warmCount - 1);
@@ -1469,65 +1500,6 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
 #endif
     }
 
-    private sealed class ExpirationCleanupListener : IObserver<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>, IDisposable
-    {
-        private readonly object _targetCache;
-        private readonly IDisposable _subscription;
-        private readonly Queue<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> _events = [];
-        private readonly Queue<TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>> _waiters = [];
-
-        public ExpirationCleanupListener(object targetCache)
-        {
-            _targetCache = targetCache;
-            _subscription = ConcurrentLruCacheDiagnostics.ExpiredItemsRemovedEvents.Subscribe(this);
-        }
-
-        public Task<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> WaitForCleanupAsync()
-        {
-            lock (_events)
-            {
-                if (_events.TryDequeue(out var evt))
-                {
-                    return Task.FromResult(evt);
-                }
-
-                var waiter = new TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>(TaskCreationOptions.RunContinuationsAsynchronously);
-                _waiters.Enqueue(waiter);
-                return waiter.Task.WaitAsync(TimeSpan.FromSeconds(10));
-            }
-        }
-
-        public void OnCompleted()
-        {
-        }
-
-        public void OnError(Exception error)
-        {
-        }
-
-        public void OnNext(ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved value)
-        {
-            if (!ReferenceEquals(value.Cache, _targetCache))
-            {
-                return;
-            }
-
-            TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> waiter;
-            lock (_events)
-            {
-                if (!_waiters.TryDequeue(out waiter))
-                {
-                    _events.Enqueue(value);
-                    return;
-                }
-            }
-
-            waiter.SetResult(value);
-        }
-
-        public void Dispose() => _subscription.Dispose();
-    }
-
     private class ValueFactory
     {
         public int TimesCalled;
@@ -1564,6 +1536,19 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
         public void Dispose()
         {
             IsDisposed = true;
+        }
+    }
+
+    private sealed class ThrowingDisposableItem : IDisposable
+    {
+        private readonly TaskCompletionSource _disposed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Disposed => _disposed.Task;
+
+        public void Dispose()
+        {
+            _disposed.TrySetResult();
+            throw new InvalidOperationException("Dispose failed");
         }
     }
 

--- a/test/Orleans.Core.Tests/Caching/ConcurrentLruTests.cs
+++ b/test/Orleans.Core.Tests/Caching/ConcurrentLruTests.cs
@@ -767,6 +767,29 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task WhenItemAgeEqualsTimeToLivePeriodicCleanupKeepsItemUntilLaterTick()
+    {
+        var timeProvider = new FakeTimeProvider();
+        await using var lru = CreateExpiringLru(timeProvider);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(lru);
+
+        lru.AddOrUpdate(1, "1");
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+        var firstCleanup = await listener.WaitForCleanupAsync();
+        firstCleanup.Should().Be(0);
+        lru.Count.Should().Be(1);
+        lru.Keys.Should().BeEquivalentTo([1]);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+        var secondCleanup = await listener.WaitForCleanupAsync();
+        secondCleanup.Should().Be(1);
+        lru.TryGet(1, out _).Should().BeFalse();
+        lru.Count.Should().Be(0);
+    }
+
+    [Fact]
     public async Task WhenItemIsReadTimeToLiveIsExtended()
     {
         var timeProvider = new FakeTimeProvider();
@@ -859,11 +882,41 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
 
             var cleanup = await listener.WaitForCleanupAsync();
             cleanup.Should().Be(0);
+
+            Func<Task> dispose = async () => await lru.DisposeAsync();
+            await dispose.Should().NotThrowAsync();
         }
         finally
         {
             await lru.DisposeAsync();
         }
+    }
+
+    [Fact]
+    public async Task WhenOtherCacheExpiresCleanupListenerWithShortTimeoutDoesNotCompleteForNonTargetCache()
+    {
+        var targetTimeProvider = new FakeTimeProvider();
+        var otherTimeProvider = new FakeTimeProvider();
+        await using var targetLru = CreateExpiringLru(targetTimeProvider);
+        await using var otherLru = CreateExpiringLru(otherTimeProvider);
+        using var targetListener = new ConcurrentLruCacheExpirationCleanupListener(targetLru);
+        using var otherListener = new ConcurrentLruCacheExpirationCleanupListener(otherLru);
+
+        targetLru.AddOrUpdate(1, "target");
+        otherLru.AddOrUpdate(1, "other");
+        otherTimeProvider.Advance(TimeSpan.FromMinutes(2));
+
+        var otherCleanup = await otherListener.WaitForCleanupAsync();
+        otherCleanup.Should().Be(1);
+
+        Func<Task> waitForTargetCleanup = () => targetListener.WaitForCleanupAsync(TimeSpan.FromMilliseconds(10));
+        await waitForTargetCleanup.Should().ThrowAsync<TimeoutException>();
+
+        using var targetListenerAfterNegativeAssertion = new ConcurrentLruCacheExpirationCleanupListener(targetLru);
+        targetTimeProvider.Advance(TimeSpan.FromMinutes(2));
+
+        var targetCleanup = await targetListenerAfterNegativeAssertion.WaitForCleanupAsync();
+        targetCleanup.Should().Be(1);
     }
 
     [Fact]

--- a/test/Orleans.Core.Tests/Caching/ConcurrentLruTests.cs
+++ b/test/Orleans.Core.Tests/Caching/ConcurrentLruTests.cs
@@ -935,6 +935,25 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task WhenItemIsInsertedBeforePeriodicCleanupRunsItIsNotRemoved()
+    {
+        var timeProvider = new FakeTimeProvider();
+        timeProvider.Advance(TimeSpan.FromHours(1));
+        await using var lru = CreateExpiringLru(timeProvider);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(lru);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(50));
+        lru.AddOrUpdate(1, "1");
+        timeProvider.Advance(TimeSpan.FromSeconds(10));
+
+        var cleanup = await listener.WaitForCleanupAsync();
+        cleanup.Should().Be(0);
+        lru.TryGet(1, out var value).Should().BeTrue();
+        value.Should().Be("1");
+        lru.Count.Should().Be(1);
+    }
+
+    [Fact]
     public async Task WhenExpiredItemsAreCleanedUpCacheIsMarkedCold()
     {
         var timeProvider = new FakeTimeProvider();

--- a/test/Orleans.Core.Tests/Caching/ConcurrentLruTests.cs
+++ b/test/Orleans.Core.Tests/Caching/ConcurrentLruTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using System.Collections;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 using Xunit.Abstractions;
 using Orleans.Caching;
@@ -747,6 +748,266 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task WhenItemExceedsTimeToLivePeriodicCleanupRemovesIt()
+    {
+        var timeProvider = new FakeTimeProvider();
+        await using var lru = CreateExpiringLru(timeProvider);
+        using var listener = new ExpirationCleanupListener(lru);
+
+        lru.AddOrUpdate(1, "1");
+        timeProvider.Advance(TimeSpan.FromMinutes(2));
+
+        var cleanup = await listener.WaitForCleanupAsync();
+        cleanup.RemovedCount.Should().Be(1);
+        lru.TryGet(1, out var value).Should().BeFalse();
+        value.Should().BeNull();
+        lru.Count.Should().Be(0);
+        lru.Keys.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenItemIsReadTimeToLiveIsExtended()
+    {
+        var timeProvider = new FakeTimeProvider();
+        await using var lru = CreateExpiringLru(timeProvider);
+        using var listener = new ExpirationCleanupListener(lru);
+
+        lru.AddOrUpdate(1, "1");
+        timeProvider.Advance(TimeSpan.FromSeconds(45));
+
+        lru.TryGet(1, out var value).Should().BeTrue();
+        value.Should().Be("1");
+
+        timeProvider.Advance(TimeSpan.FromSeconds(45));
+
+        var firstCleanup = await listener.WaitForCleanupAsync();
+        firstCleanup.RemovedCount.Should().Be(0);
+        lru.TryGet(1, out value).Should().BeTrue();
+        value.Should().Be("1");
+
+        timeProvider.Advance(TimeSpan.FromSeconds(61));
+
+        var secondCleanup = await listener.WaitForCleanupAsync();
+        secondCleanup.RemovedCount.Should().Be(1);
+        lru.TryGet(1, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task WhenItemIsUpdatedTimeToLiveIsExtended()
+    {
+        var timeProvider = new FakeTimeProvider();
+        await using var lru = CreateExpiringLru(timeProvider);
+        using var listener = new ExpirationCleanupListener(lru);
+
+        lru.AddOrUpdate(1, "1");
+        timeProvider.Advance(TimeSpan.FromSeconds(45));
+
+        lru.TryUpdate(1, "2").Should().BeTrue();
+        timeProvider.Advance(TimeSpan.FromSeconds(45));
+
+        var firstCleanup = await listener.WaitForCleanupAsync();
+        firstCleanup.RemovedCount.Should().Be(0);
+
+        lru.TryGet(1, out var value).Should().BeTrue();
+        value.Should().Be("2");
+    }
+
+    [Fact]
+    public async Task WhenExpiredItemsAreCleanedUpTheyAreDisposed()
+    {
+        var timeProvider = new FakeTimeProvider();
+        await using var lru = new ConcurrentLruCache<int, DisposableItem>(
+            capacity: 6,
+            comparer: EqualityComparer<int>.Default,
+            timeToLive: TimeSpan.FromMinutes(1),
+            timeProvider: timeProvider);
+        using var listener = new ExpirationCleanupListener(lru);
+        var items = Enumerable.Range(1, 2).Select(_ => new DisposableItem()).ToArray();
+
+        lru.AddOrUpdate(1, items[0]);
+        lru.AddOrUpdate(2, items[1]);
+        timeProvider.Advance(TimeSpan.FromMinutes(2));
+
+        var cleanup = await listener.WaitForCleanupAsync();
+
+        cleanup.RemovedCount.Should().Be(2);
+        items.All(item => item.IsDisposed).Should().BeTrue();
+        lru.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task WhenItemsExceedTimeToLivePeriodicCleanupRemovesExpiredItemsFromAllQueues()
+    {
+        var timeProvider = new FakeTimeProvider();
+        await using var lru = CreateExpiringLru(timeProvider, capacity: 9);
+        using var listener = new ExpirationCleanupListener(lru);
+
+        lru.AddOrUpdate(1, "1");
+        lru.AddOrUpdate(2, "2");
+        lru.AddOrUpdate(3, "3");
+        lru.GetOrAdd(1, _valueFactory.Create);
+        lru.GetOrAdd(2, _valueFactory.Create);
+        lru.GetOrAdd(3, _valueFactory.Create);
+
+        lru.AddOrUpdate(4, "4");
+        lru.AddOrUpdate(5, "5");
+        lru.AddOrUpdate(6, "6");
+
+        lru.AddOrUpdate(7, "7");
+        lru.AddOrUpdate(8, "8");
+        lru.AddOrUpdate(9, "9");
+
+        lru.HotCount.Should().BeGreaterThan(0);
+        lru.WarmCount.Should().BeGreaterThan(0);
+        lru.ColdCount.Should().BeGreaterThan(0);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(2));
+
+        var cleanup = await listener.WaitForCleanupAsync();
+        cleanup.RemovedCount.Should().Be(9);
+        lru.Count.Should().Be(0);
+        lru.HotCount.Should().Be(0);
+        lru.WarmCount.Should().Be(0);
+        lru.ColdCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task WhenCacheHasExpiredAndFreshItemsPeriodicCleanupRemovesOnlyExpiredItems()
+    {
+        var timeProvider = new FakeTimeProvider();
+        await using var lru = CreateExpiringLru(timeProvider, capacity: 9);
+        using var listener = new ExpirationCleanupListener(lru);
+
+        lru.AddOrUpdate(1, "1");
+        lru.AddOrUpdate(2, "2");
+        lru.AddOrUpdate(3, "3");
+
+        lru.AddOrUpdate(4, "4");
+        lru.AddOrUpdate(5, "5");
+        lru.AddOrUpdate(6, "6");
+
+        timeProvider.Advance(TimeSpan.FromSeconds(59));
+
+        lru.GetOrAdd(1, _valueFactory.Create);
+        lru.GetOrAdd(2, _valueFactory.Create);
+        lru.GetOrAdd(3, _valueFactory.Create);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(2));
+
+        var cleanup = await listener.WaitForCleanupAsync();
+        cleanup.RemovedCount.Should().Be(3);
+        lru.Count.Should().Be(3);
+        lru.Keys.Should().BeEquivalentTo([1, 2, 3]);
+
+        var total = lru.HotCount + lru.WarmCount + lru.ColdCount;
+        total.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task WhenExpiredItemsAreCleanedUpCacheIsMarkedCold()
+    {
+        var timeProvider = new FakeTimeProvider();
+        await using var lru = CreateExpiringLru(timeProvider, capacity: 9);
+        using var listener = new ExpirationCleanupListener(lru);
+        var testAccessor = GetTestAccessor(lru);
+
+        lru.AddOrUpdate(1, "1");
+        lru.AddOrUpdate(2, "2");
+        lru.AddOrUpdate(3, "3");
+        lru.GetOrAdd(1, _valueFactory.Create);
+        lru.GetOrAdd(2, _valueFactory.Create);
+        lru.GetOrAdd(3, _valueFactory.Create);
+
+        lru.AddOrUpdate(4, "4");
+        lru.AddOrUpdate(5, "5");
+        lru.AddOrUpdate(6, "6");
+
+        lru.AddOrUpdate(7, "7");
+        lru.AddOrUpdate(8, "8");
+        lru.AddOrUpdate(9, "9");
+
+        testAccessor.IsWarm.Should().BeTrue();
+
+        timeProvider.Advance(TimeSpan.FromMinutes(2));
+
+        var cleanup = await listener.WaitForCleanupAsync();
+        cleanup.RemovedCount.Should().Be(9);
+        testAccessor.IsWarm.Should().BeFalse();
+
+        for (var i = 0; i < lru.Capacity; i++)
+        {
+            lru.GetOrAdd(i, _valueFactory.Create);
+        }
+
+        lru.Count.Should().Be(lru.Capacity);
+
+        var total = lru.HotCount + lru.WarmCount + lru.ColdCount;
+        total.Should().Be(lru.Capacity);
+    }
+
+    [Fact]
+    public async Task WhenItemsAreRemovedPeriodicCleanupRemovesDeletedItemsFromQueues()
+    {
+        var timeProvider = new FakeTimeProvider();
+        await using var lru = CreateExpiringLru(timeProvider, capacity: 9);
+        using var listener = new ExpirationCleanupListener(lru);
+        var testAccessor = GetTestAccessor(lru);
+
+        for (var i = 0; i < lru.Capacity; i++)
+        {
+            lru.GetOrAdd(i, _valueFactory.Create);
+        }
+
+        var hotCount = lru.HotCount;
+        var warmCount = lru.WarmCount;
+        var coldCount = lru.ColdCount;
+        var hotKey = testAccessor.HotQueue.First().Key;
+        var warmKey = testAccessor.WarmQueue.First().Key;
+        var coldKey = testAccessor.ColdQueue.First().Key;
+
+        lru.TryRemove(hotKey).Should().BeTrue();
+        lru.TryRemove(warmKey).Should().BeTrue();
+        lru.TryRemove(coldKey).Should().BeTrue();
+
+        lru.HotCount.Should().Be(hotCount);
+        lru.WarmCount.Should().Be(warmCount);
+        lru.ColdCount.Should().Be(coldCount);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+        var cleanup = await listener.WaitForCleanupAsync();
+        cleanup.RemovedCount.Should().Be(0);
+        lru.Count.Should().Be(6);
+        lru.HotCount.Should().Be(hotCount - 1);
+        lru.WarmCount.Should().Be(warmCount - 1);
+        lru.ColdCount.Should().Be(coldCount - 1);
+    }
+
+    [Fact]
+    public void WhenTimeToLiveIsNotConfiguredItemsDoNotExpire()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var lru = new ConcurrentLruCache<int, string>(
+            capacity: 6,
+            comparer: EqualityComparer<int>.Default,
+            timeProvider: timeProvider);
+
+        lru.AddOrUpdate(1, "1");
+        timeProvider.Advance(TimeSpan.FromDays(1));
+
+        lru.TryGet(1, out var value).Should().BeTrue();
+        value.Should().Be("1");
+    }
+
+    [Fact]
+    public void WhenTimeToLiveIsNotPositiveCtorThrows()
+    {
+        Action constructor = () => new ConcurrentLruCache<int, string>(6, TimeSpan.Zero);
+
+        constructor.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
     public void WhenKeyExistsAddOrUpdateGuidUpdatesExistingItem()
     {
         var lru2 = new ConcurrentLruCache<int, Guid>(Capacity, EqualityComparer<int>.Default);
@@ -1194,11 +1455,77 @@ public class ConcurrentLruTests(ITestOutputHelper testOutputHelper)
 
     private void FillCache() => GetOrAddRangeInclusive(-1, -Capacity);
 
+    private static ConcurrentLruCache<int, string> CreateExpiringLru(TimeProvider timeProvider, int capacity = 6) =>
+        new(
+            capacity: capacity,
+            comparer: EqualityComparer<int>.Default,
+            timeToLive: TimeSpan.FromMinutes(1),
+            timeProvider: timeProvider);
+
     private void Print()
     {
 #if DEBUG
         _testOutputHelper.WriteLine(_lru.FormatLruString());
 #endif
+    }
+
+    private sealed class ExpirationCleanupListener : IObserver<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>, IDisposable
+    {
+        private readonly object _targetCache;
+        private readonly IDisposable _subscription;
+        private readonly Queue<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> _events = [];
+        private readonly Queue<TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>> _waiters = [];
+
+        public ExpirationCleanupListener(object targetCache)
+        {
+            _targetCache = targetCache;
+            _subscription = ConcurrentLruCacheDiagnostics.ExpiredItemsRemovedEvents.Subscribe(this);
+        }
+
+        public Task<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> WaitForCleanupAsync()
+        {
+            lock (_events)
+            {
+                if (_events.TryDequeue(out var evt))
+                {
+                    return Task.FromResult(evt);
+                }
+
+                var waiter = new TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _waiters.Enqueue(waiter);
+                return waiter.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            }
+        }
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved value)
+        {
+            if (!ReferenceEquals(value.Cache, _targetCache))
+            {
+                return;
+            }
+
+            TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> waiter;
+            lock (_events)
+            {
+                if (!_waiters.TryDequeue(out waiter))
+                {
+                    _events.Enqueue(value);
+                    return;
+                }
+            }
+
+            waiter.SetResult(value);
+        }
+
+        public void Dispose() => _subscription.Dispose();
     }
 
     private class ValueFactory

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -99,6 +99,82 @@ namespace UnitTests.Directory
         }
 
         [Fact]
+        public async Task StopDoesNotDisposeRegisteredCustomCache()
+        {
+            var cache = new DisposableGrainDirectoryCache();
+            var grainDirectory = Substitute.For<IGrainDirectory>();
+            var services = new ServiceCollection()
+                .AddSingleton<IGrainDirectoryCache>(cache)
+                .AddGrainDirectory(GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY, (sp, name) => grainDirectory)
+                .BuildServiceProvider();
+            var grainDirectoryResolver = new GrainDirectoryResolver(
+                services,
+                new GrainPropertiesResolver(new NoOpClusterManifestProvider()),
+                Array.Empty<IGrainDirectoryResolver>());
+            var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
+            var membershipService = new MockClusterMembershipService();
+            var grainLocator = new CachedGrainLocator(
+                services,
+                grainDirectoryResolver,
+                membershipService.Target,
+                Options.Create(new GrainDirectoryOptions()));
+
+            grainLocator.Participate(lifecycle);
+
+            await lifecycle.OnStart();
+            await lifecycle.OnStop();
+
+            Assert.False(cache.Disposed);
+            Assert.False(cache.AsyncDisposed);
+        }
+
+        [Fact]
+        public async Task LocalGrainDirectoryStopDoesNotDisposeRegisteredCustomCache()
+        {
+            var cache = new DisposableGrainDirectoryCache();
+            var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+            var localSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 11111), 123);
+            localSiloDetails.SiloAddress.Returns(localSilo);
+            localSiloDetails.GatewayAddress.Returns(localSilo);
+            localSiloDetails.DnsHostName.Returns("localhost");
+            localSiloDetails.Name.Returns("TestSilo");
+            localSiloDetails.ClusterId.Returns("TestCluster");
+            var siloStatusOracle = Substitute.For<ISiloStatusOracle>();
+            var grainFactory = Substitute.For<IInternalGrainFactory>();
+            var services = new ServiceCollection()
+                .AddSingleton<IGrainDirectoryCache>(cache)
+                .BuildServiceProvider();
+            Factory<LocalGrainDirectoryPartition> partitionFactory = () => new LocalGrainDirectoryPartition(
+                siloStatusOracle,
+                Options.Create(new GrainDirectoryOptions()),
+                this.loggerFactory);
+            var systemTargetShared = new SystemTargetShared(
+                runtimeClient: null!,
+                localSiloDetails: localSiloDetails,
+                loggerFactory: this.loggerFactory,
+                schedulingOptions: Options.Create(new SchedulingOptions()),
+                grainReferenceActivator: null,
+                timerRegistry: null,
+                activations: new ActivationDirectory());
+            var localGrainDirectory = new LocalGrainDirectory(
+                serviceProvider: services,
+                siloDetails: localSiloDetails,
+                siloStatusOracle: siloStatusOracle,
+                grainFactory: grainFactory,
+                grainDirectoryPartitionFactory: partitionFactory,
+                developmentClusterMembershipOptions: Options.Create(new DevelopmentClusterMembershipOptions()),
+                grainDirectoryOptions: Options.Create(new GrainDirectoryOptions { CachingStrategy = GrainDirectoryOptions.CachingStrategyType.Custom }),
+                loggerFactory: this.loggerFactory,
+                systemTargetShared: systemTargetShared);
+
+            await localGrainDirectory.StopAsync();
+
+            Assert.False(cache.Disposed);
+            Assert.False(cache.AsyncDisposed);
+            Assert.Equal(1, cache.ClearCount);
+        }
+
+        [Fact]
         public async Task RegisterWhenOtherEntryExists()
         {
             var expectedSilo = GenerateSiloAddress();
@@ -530,6 +606,53 @@ namespace UnitTests.Directory
                 yield return this.Current;
                 await Task.Delay(100);
                 yield break;
+            }
+        }
+
+        private sealed class DisposableGrainDirectoryCache : IGrainDirectoryCache, IDisposable, IAsyncDisposable
+        {
+            private readonly Dictionary<GrainId, (GrainAddress Address, int Version)> entries = new();
+
+            public bool Disposed { get; private set; }
+
+            public bool AsyncDisposed { get; private set; }
+
+            public int ClearCount { get; private set; }
+
+            public IEnumerable<(GrainAddress ActivationAddress, int Version)> KeyValues => this.entries.Values.Select(entry => (entry.Address, entry.Version));
+
+            public void AddOrUpdate(GrainAddress value, int version) => this.entries[value.GrainId] = (value, version);
+
+            public bool Remove(GrainId key) => this.entries.Remove(key);
+
+            public bool Remove(GrainAddress key) => this.entries.Remove(key.GrainId);
+
+            public void Clear()
+            {
+                ++this.ClearCount;
+                this.entries.Clear();
+            }
+
+            public bool LookUp(GrainId key, out GrainAddress result, out int version)
+            {
+                if (this.entries.TryGetValue(key, out var entry))
+                {
+                    result = entry.Address;
+                    version = entry.Version;
+                    return true;
+                }
+
+                result = default;
+                version = default;
+                return false;
+            }
+
+            public void Dispose() => this.Disposed = true;
+
+            public ValueTask DisposeAsync()
+            {
+                this.AsyncDisposed = true;
+                return default;
             }
         }
     }

--- a/test/Orleans.Runtime.Tests/Directories/GrainDirectoryCacheFactoryTests.cs
+++ b/test/Orleans.Runtime.Tests/Directories/GrainDirectoryCacheFactoryTests.cs
@@ -1,0 +1,160 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using Orleans.Caching;
+using Orleans.Configuration;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Xunit;
+
+namespace Tester.Directories;
+
+[TestCategory("BVT"), TestCategory("Directory")]
+public class GrainDirectoryCacheFactoryTests
+{
+    [Fact]
+    public async Task CreateGrainDirectoryCache_LruHonorsMaximumCacheTtl()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var services = new ServiceCollection()
+            .AddSingleton<TimeProvider>(timeProvider)
+            .BuildServiceProvider();
+#pragma warning disable CS0618 // Type or member is obsolete
+        var options = new GrainDirectoryOptions
+        {
+            CacheSize = 10,
+            MaximumCacheTTL = TimeSpan.FromMinutes(1)
+        };
+#pragma warning restore CS0618 // Type or member is obsolete
+        var cache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(services, options);
+        var disposableCache = Assert.IsAssignableFrom<IAsyncDisposable>(cache);
+        using var listener = new ExpirationCleanupListener(cache);
+        var address = CreateGrainAddress();
+
+        try
+        {
+            cache.AddOrUpdate(address, version: 1);
+            Assert.True(cache.LookUp(address.GrainId, out var result, out var version));
+            Assert.Equal(address, result);
+            Assert.Equal(1, version);
+
+            timeProvider.Advance(TimeSpan.FromMinutes(2));
+            var cleanup = await listener.WaitForCleanupAsync();
+
+            Assert.Equal(1, cleanup.RemovedCount);
+            Assert.False(cache.LookUp(address.GrainId, out _, out _));
+            Assert.Empty(cache.KeyValues);
+        }
+        finally
+        {
+            await disposableCache.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public void CreateGrainDirectoryCache_CustomDoesNotWrapRegisteredCache()
+    {
+        var expected = new TestGrainDirectoryCache();
+        var services = new ServiceCollection()
+            .AddSingleton<IGrainDirectoryCache>(expected)
+            .BuildServiceProvider();
+        var options = new GrainDirectoryOptions
+        {
+            CachingStrategy = GrainDirectoryOptions.CachingStrategyType.Custom
+        };
+
+        var actual = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(services, options);
+
+        Assert.Same(expected, actual);
+    }
+
+    private static GrainAddress CreateGrainAddress() => new()
+    {
+        ActivationId = ActivationId.NewId(),
+        GrainId = GrainId.Parse($"user/{Guid.NewGuid():N}"),
+        SiloAddress = SiloAddress.FromParsableString("127.0.0.1:11111@1"),
+        MembershipVersion = new MembershipVersion(1)
+    };
+
+    private sealed class ExpirationCleanupListener : IObserver<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>, IDisposable
+    {
+        private readonly object _targetCache;
+        private readonly IDisposable _subscription;
+        private readonly Queue<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> _events = [];
+        private readonly Queue<TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>> _waiters = [];
+
+        public ExpirationCleanupListener(object targetCache)
+        {
+            _targetCache = targetCache;
+            _subscription = ConcurrentLruCacheDiagnostics.ExpiredItemsRemovedEvents.Subscribe(this);
+        }
+
+        public Task<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> WaitForCleanupAsync()
+        {
+            lock (_events)
+            {
+                if (_events.TryDequeue(out var evt))
+                {
+                    return Task.FromResult(evt);
+                }
+
+                var waiter = new TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _waiters.Enqueue(waiter);
+                return waiter.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            }
+        }
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved value)
+        {
+            if (!ReferenceEquals(value.Cache, _targetCache))
+            {
+                return;
+            }
+
+            TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> waiter;
+            lock (_events)
+            {
+                if (!_waiters.TryDequeue(out waiter))
+                {
+                    _events.Enqueue(value);
+                    return;
+                }
+            }
+
+            waiter.SetResult(value);
+        }
+
+        public void Dispose() => _subscription.Dispose();
+    }
+
+    private sealed class TestGrainDirectoryCache : IGrainDirectoryCache
+    {
+        public IEnumerable<(GrainAddress ActivationAddress, int Version)> KeyValues => [];
+
+        public void AddOrUpdate(GrainAddress value, int version)
+        {
+        }
+
+        public void Clear()
+        {
+        }
+
+        public bool LookUp(GrainId key, out GrainAddress result, out int version)
+        {
+            result = default;
+            version = default;
+            return false;
+        }
+
+        public bool Remove(GrainId key) => false;
+
+        public bool Remove(GrainAddress key) => false;
+    }
+}

--- a/test/Orleans.Runtime.Tests/Directories/GrainDirectoryCacheFactoryTests.cs
+++ b/test/Orleans.Runtime.Tests/Directories/GrainDirectoryCacheFactoryTests.cs
@@ -18,13 +18,11 @@ public class GrainDirectoryCacheFactoryTests
         var services = new ServiceCollection()
             .AddSingleton<TimeProvider>(timeProvider)
             .BuildServiceProvider();
-#pragma warning disable CS0618 // Type or member is obsolete
         var options = new GrainDirectoryOptions
         {
             CacheSize = 10,
             MaximumCacheTTL = TimeSpan.FromMinutes(1)
         };
-#pragma warning restore CS0618 // Type or member is obsolete
         var cache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(services, options);
         var disposableCache = Assert.IsAssignableFrom<IAsyncDisposable>(cache);
         using var listener = new ConcurrentLruCacheExpirationCleanupListener(cache);

--- a/test/Orleans.Runtime.Tests/Directories/GrainDirectoryCacheFactoryTests.cs
+++ b/test/Orleans.Runtime.Tests/Directories/GrainDirectoryCacheFactoryTests.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
-using Orleans.Caching;
 using Orleans.Configuration;
 using Orleans.Runtime;
 using Orleans.Runtime.GrainDirectory;
+using TestExtensions;
 using Xunit;
 
 namespace Tester.Directories;
@@ -27,7 +27,7 @@ public class GrainDirectoryCacheFactoryTests
 #pragma warning restore CS0618 // Type or member is obsolete
         var cache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(services, options);
         var disposableCache = Assert.IsAssignableFrom<IAsyncDisposable>(cache);
-        using var listener = new ExpirationCleanupListener(cache);
+        using var listener = new ConcurrentLruCacheExpirationCleanupListener(cache);
         var address = CreateGrainAddress();
 
         try
@@ -40,7 +40,7 @@ public class GrainDirectoryCacheFactoryTests
             timeProvider.Advance(TimeSpan.FromMinutes(2));
             var cleanup = await listener.WaitForCleanupAsync();
 
-            Assert.Equal(1, cleanup.RemovedCount);
+            Assert.Equal(1, cleanup);
             Assert.False(cache.LookUp(address.GrainId, out _, out _));
             Assert.Empty(cache.KeyValues);
         }
@@ -74,65 +74,6 @@ public class GrainDirectoryCacheFactoryTests
         SiloAddress = SiloAddress.FromParsableString("127.0.0.1:11111@1"),
         MembershipVersion = new MembershipVersion(1)
     };
-
-    private sealed class ExpirationCleanupListener : IObserver<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>, IDisposable
-    {
-        private readonly object _targetCache;
-        private readonly IDisposable _subscription;
-        private readonly Queue<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> _events = [];
-        private readonly Queue<TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>> _waiters = [];
-
-        public ExpirationCleanupListener(object targetCache)
-        {
-            _targetCache = targetCache;
-            _subscription = ConcurrentLruCacheDiagnostics.ExpiredItemsRemovedEvents.Subscribe(this);
-        }
-
-        public Task<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> WaitForCleanupAsync()
-        {
-            lock (_events)
-            {
-                if (_events.TryDequeue(out var evt))
-                {
-                    return Task.FromResult(evt);
-                }
-
-                var waiter = new TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>(TaskCreationOptions.RunContinuationsAsynchronously);
-                _waiters.Enqueue(waiter);
-                return waiter.Task.WaitAsync(TimeSpan.FromSeconds(10));
-            }
-        }
-
-        public void OnCompleted()
-        {
-        }
-
-        public void OnError(Exception error)
-        {
-        }
-
-        public void OnNext(ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved value)
-        {
-            if (!ReferenceEquals(value.Cache, _targetCache))
-            {
-                return;
-            }
-
-            TaskCompletionSource<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved> waiter;
-            lock (_events)
-            {
-                if (!_waiters.TryDequeue(out waiter))
-                {
-                    _events.Enqueue(value);
-                    return;
-                }
-            }
-
-            waiter.SetResult(value);
-        }
-
-        public void Dispose() => _subscription.Dispose();
-    }
 
     private sealed class TestGrainDirectoryCache : IGrainDirectoryCache
     {

--- a/test/Orleans.Runtime.Tests/Directories/GrainDirectoryCacheFactoryTests.cs
+++ b/test/Orleans.Runtime.Tests/Directories/GrainDirectoryCacheFactoryTests.cs
@@ -65,6 +65,146 @@ public class GrainDirectoryCacheFactoryTests
         Assert.Same(expected, actual);
     }
 
+    [Fact]
+    public async Task CreateGrainDirectoryCache_LruReturnsOwnedCache()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var options = new GrainDirectoryOptions
+        {
+            CachingStrategy = GrainDirectoryOptions.CachingStrategyType.LRU,
+            CacheSize = 10
+        };
+
+        var cache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(services, options, out var disposeCache);
+        var disposableCache = Assert.IsAssignableFrom<IAsyncDisposable>(cache);
+
+        try
+        {
+            Assert.True(disposeCache);
+            Assert.IsAssignableFrom<IGrainDirectoryCache>(cache);
+        }
+        finally
+        {
+            await disposableCache.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public void CreateGrainDirectoryCache_NoneReturnsOwnedCache()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var options = new GrainDirectoryOptions
+        {
+            CachingStrategy = GrainDirectoryOptions.CachingStrategyType.None,
+            CacheSize = 10
+        };
+
+        var cache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(services, options, out var disposeCache);
+
+        Assert.True(disposeCache);
+        Assert.IsAssignableFrom<IGrainDirectoryCache>(cache);
+    }
+
+    [Fact]
+    public void CreateGrainDirectoryCache_NonPositiveCacheSizeReturnsOwnedCache()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var options = new GrainDirectoryOptions
+        {
+            CachingStrategy = GrainDirectoryOptions.CachingStrategyType.LRU,
+            CacheSize = 0
+        };
+
+        var cache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(services, options, out var disposeCache);
+
+        Assert.True(disposeCache);
+        Assert.IsAssignableFrom<IGrainDirectoryCache>(cache);
+    }
+
+    [Fact]
+    public void CreateGrainDirectoryCache_CustomReturnsUnownedRegisteredCache()
+    {
+        var expected = new TestGrainDirectoryCache();
+        var services = new ServiceCollection()
+            .AddSingleton<IGrainDirectoryCache>(expected)
+            .BuildServiceProvider();
+        var options = new GrainDirectoryOptions
+        {
+            CachingStrategy = GrainDirectoryOptions.CachingStrategyType.Custom
+        };
+
+        var actual = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(services, options, out var disposeCache);
+
+        Assert.False(disposeCache);
+        Assert.Same(expected, actual);
+    }
+
+    [Fact]
+    public void CreateCustomGrainDirectoryCache_ReturnsUnownedRegisteredCache()
+    {
+        var expected = new TestGrainDirectoryCache();
+        var services = new ServiceCollection()
+            .AddSingleton<IGrainDirectoryCache>(expected)
+            .BuildServiceProvider();
+        var options = new GrainDirectoryOptions();
+
+        var actual = GrainDirectoryCacheFactory.CreateCustomGrainDirectoryCache(services, options, out var disposeCache);
+
+        Assert.False(disposeCache);
+        Assert.Same(expected, actual);
+    }
+
+    [Fact]
+    public async Task CreateCustomGrainDirectoryCache_FallbackReturnsOwnedLruCache()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var options = new GrainDirectoryOptions
+        {
+            CacheSize = 10
+        };
+
+        var cache = GrainDirectoryCacheFactory.CreateCustomGrainDirectoryCache(services, options, out var disposeCache);
+        var disposableCache = Assert.IsAssignableFrom<IAsyncDisposable>(cache);
+
+        try
+        {
+            Assert.True(disposeCache);
+            Assert.IsAssignableFrom<IGrainDirectoryCache>(cache);
+        }
+        finally
+        {
+            await disposableCache.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task DisposeGrainDirectoryCacheAsync_AsyncDisposableCacheCallsDisposeAsync()
+    {
+        var cache = new AsyncDisposableGrainDirectoryCache();
+
+        await GrainDirectoryCacheFactory.DisposeGrainDirectoryCacheAsync(cache);
+
+        Assert.True(cache.DisposeAsyncCalled);
+    }
+
+    [Fact]
+    public async Task DisposeGrainDirectoryCacheAsync_DisposableOnlyCacheCallsDispose()
+    {
+        var cache = new DisposableGrainDirectoryCache();
+
+        await GrainDirectoryCacheFactory.DisposeGrainDirectoryCacheAsync(cache);
+
+        Assert.True(cache.DisposeCalled);
+    }
+
+    [Fact]
+    public async Task DisposeGrainDirectoryCacheAsync_NonDisposableCacheCompletes()
+    {
+        var cache = new TestGrainDirectoryCache();
+
+        await GrainDirectoryCacheFactory.DisposeGrainDirectoryCacheAsync(cache);
+    }
+
     private static GrainAddress CreateGrainAddress() => new()
     {
         ActivationId = ActivationId.NewId(),
@@ -73,7 +213,7 @@ public class GrainDirectoryCacheFactoryTests
         MembershipVersion = new MembershipVersion(1)
     };
 
-    private sealed class TestGrainDirectoryCache : IGrainDirectoryCache
+    private class TestGrainDirectoryCache : IGrainDirectoryCache
     {
         public IEnumerable<(GrainAddress ActivationAddress, int Version)> KeyValues => [];
 
@@ -95,5 +235,23 @@ public class GrainDirectoryCacheFactoryTests
         public bool Remove(GrainId key) => false;
 
         public bool Remove(GrainAddress key) => false;
+    }
+
+    private sealed class AsyncDisposableGrainDirectoryCache : TestGrainDirectoryCache, IAsyncDisposable
+    {
+        public bool DisposeAsyncCalled { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeAsyncCalled = true;
+            return default;
+        }
+    }
+
+    private sealed class DisposableGrainDirectoryCache : TestGrainDirectoryCache, IDisposable
+    {
+        public bool DisposeCalled { get; private set; }
+
+        public void Dispose() => DisposeCalled = true;
     }
 }

--- a/test/Orleans.Runtime.Tests/Orleans.Runtime.Tests.csproj
+++ b/test/Orleans.Runtime.Tests/Orleans.Runtime.Tests.csproj
@@ -15,6 +15,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/ConcurrentLruCacheExpirationCleanupListener.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/ConcurrentLruCacheExpirationCleanupListener.cs
@@ -1,0 +1,85 @@
+#nullable enable
+using Orleans.Caching;
+
+namespace TestExtensions;
+
+/// <summary>
+/// A test helper that subscribes to <see cref="ConcurrentLruCache{K, V}"/> expiration cleanup events.
+/// </summary>
+public sealed class ConcurrentLruCacheExpirationCleanupListener : IDisposable
+{
+    private readonly object _targetCache;
+    private readonly IDisposable _subscription;
+    private readonly Queue<int> _events = [];
+    private readonly Queue<TaskCompletionSource<int>> _waiters = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConcurrentLruCacheExpirationCleanupListener"/> class.
+    /// </summary>
+    /// <param name="targetCache">The cache to listen for.</param>
+    public ConcurrentLruCacheExpirationCleanupListener(object targetCache)
+    {
+        _targetCache = targetCache;
+        _subscription = ConcurrentLruCacheDiagnostics.ExpiredItemsRemovedEvents.Subscribe(new Observer(this));
+    }
+
+    /// <summary>
+    /// Waits for the next expiration cleanup event.
+    /// </summary>
+    /// <param name="timeout">The maximum time to wait. Defaults to 10 seconds.</param>
+    /// <returns>The number of items removed by the cleanup.</returns>
+    public Task<int> WaitForCleanupAsync(TimeSpan? timeout = null)
+    {
+        lock (_events)
+        {
+            if (_events.TryDequeue(out var removedCount))
+            {
+                return Task.FromResult(removedCount);
+            }
+
+            var waiter = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _waiters.Enqueue(waiter);
+            return waiter.Task.WaitAsync(timeout ?? TimeSpan.FromSeconds(10));
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => _subscription.Dispose();
+
+    private void OnNext(ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved value)
+    {
+        if (!ReferenceEquals(value.Cache, _targetCache))
+        {
+            return;
+        }
+
+        TaskCompletionSource<int> waiter;
+        lock (_events)
+        {
+            if (_waiters.TryDequeue(out var existingWaiter))
+            {
+                waiter = existingWaiter;
+            }
+            else
+            {
+                _events.Enqueue(value.RemovedCount);
+                return;
+            }
+        }
+
+        waiter.SetResult(value.RemovedCount);
+    }
+
+    private sealed class Observer(ConcurrentLruCacheExpirationCleanupListener listener) : IObserver<ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved>
+    {
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(ConcurrentLruCacheDiagnostics.ExpiredItemsRemoved value) => listener.OnNext(value);
+    }
+}


### PR DESCRIPTION
## Summary
- Wire GrainDirectoryOptions.MaximumCacheTTL into the built-in LRU grain directory cache.
- Add non-strict timer-driven expiration cleanup to the extracted ConcurrentLru cache.
- Add DiagnosticListener observability and port compatible BitFaster.
- Caching TTL cleanup test scenarios.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10055)