### PR TITLE
Fix persistent stream pulling agent shutdown

### DIFF
--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -43,8 +43,7 @@ namespace Orleans.Streams
 
         private Task receiverInitTask;
         private Task _activePumpTask = Task.CompletedTask;
-        private bool _isStopping;
-        private bool IsShutdown => _isStopping;
+        private bool IsShutdown => timer is null;
         private string StatisticUniquePostfix => $"{streamProviderName}.{QueueId}";
 
         internal interface ITestAccessor
@@ -132,7 +131,6 @@ namespace Orleans.Streams
         {
             LogInfoInit(GetType().Name, GrainId, Silo, new(QueueId));
 
-            _isStopping = false;
             _activePumpTask = Task.CompletedTask;
             lastTimeCleanedPubSubCache = _timeProvider.GetUtcNow().UtcDateTime;
 
@@ -192,7 +190,6 @@ namespace Orleans.Streams
             // Stop pulling from queues that are not in my range anymore.
             LogInfoShutdown(GetType().Name, new(QueueId));
 
-            _isStopping = true;
             var asyncTimer = timer;
             timer = null;
             asyncTimer?.Dispose();
@@ -227,7 +224,7 @@ namespace Orleans.Streams
             }
 
             // Drain any in-progress background registration tasks before proceeding.
-            // Setting _isStopping = true above makes IsShutdown = true, which causes registrations
+            // Setting timer = null above makes IsShutdown = true, which causes registrations
             // to stop retrying, so these tasks will complete quickly.
             var inFlightRegistrations = pubSubCache.Values
                 .Select(v => v.RegistrationTask)

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -42,7 +42,9 @@ namespace Orleans.Streams
         private IGrainTimer timer;
 
         private Task receiverInitTask;
-        private bool IsShutdown => timer == null;
+        private Task _activePumpTask = Task.CompletedTask;
+        private bool _isStopping;
+        private bool IsShutdown => _isStopping;
         private string StatisticUniquePostfix => $"{streamProviderName}.{QueueId}";
 
         internal interface ITestAccessor
@@ -50,6 +52,8 @@ namespace Orleans.Streams
             Task<bool> ReadFromQueue(QueueId myQueueId, IQueueAdapterReceiver receiver, int maxCacheAddCount);
             Task RegisterStream(QualifiedStreamId streamId, StreamSequenceToken firstToken, DateTime now);
             Task<IReadOnlyDictionary<QualifiedStreamId, StreamConsumerCollection>> GetPubSubCache();
+            Task PumpQueue(QueueId myQueueId, IQueueAdapterReceiver receiver, CancellationToken cancellationToken);
+            Task Shutdown();
         }
 
         internal PersistentStreamPullingAgent(
@@ -90,7 +94,7 @@ namespace Orleans.Streams
         }
 
         Task<bool> ITestAccessor.ReadFromQueue(QueueId myQueueId, IQueueAdapterReceiver receiver, int maxCacheAddCount)
-            => this.RunOrQueueTaskResult(() => ReadFromQueue(myQueueId, receiver, maxCacheAddCount)).Unwrap();
+            => this.RunOrQueueTaskResult(() => ReadFromQueue(myQueueId, receiver, maxCacheAddCount, CancellationToken.None)).Unwrap();
 
         Task ITestAccessor.RegisterStream(QualifiedStreamId streamId, StreamSequenceToken firstToken, DateTime now)
             => this.RunOrQueueTaskResult(() =>
@@ -108,6 +112,15 @@ namespace Orleans.Streams
         Task<IReadOnlyDictionary<QualifiedStreamId, StreamConsumerCollection>> ITestAccessor.GetPubSubCache()
             => this.RunOrQueueTaskResult(() => (IReadOnlyDictionary<QualifiedStreamId, StreamConsumerCollection>)new Dictionary<QualifiedStreamId, StreamConsumerCollection>(pubSubCache));
 
+        Task ITestAccessor.PumpQueue(QueueId myQueueId, IQueueAdapterReceiver receiver, CancellationToken cancellationToken)
+            => this.RunOrQueueTask(() =>
+            {
+                this.receiver = receiver;
+                return _activePumpTask = PumpQueue(myQueueId, cancellationToken);
+            });
+
+        Task ITestAccessor.Shutdown() => this.RunOrQueueTask(() => Shutdown());
+
         /// <summary>
         /// Take responsibility for a new queues that was assigned to me via a new range.
         /// We first store the new queue in our internal data structure, try to initialize it and start a pumping timer.
@@ -123,6 +136,8 @@ namespace Orleans.Streams
         {
             LogInfoInit(GetType().Name, GrainId, Silo, new(QueueId));
 
+            _isStopping = false;
+            _activePumpTask = Task.CompletedTask;
             lastTimeCleanedPubSubCache = _timeProvider.GetUtcNow().UtcDateTime;
 
             try
@@ -181,11 +196,10 @@ namespace Orleans.Streams
             // Stop pulling from queues that are not in my range anymore.
             LogInfoShutdown(GetType().Name, new(QueueId));
 
+            _isStopping = true;
             var asyncTimer = timer;
             timer = null;
-            asyncTimer.Dispose();
-
-            this.queueCache = null;
+            asyncTimer?.Dispose();
 
             Task localReceiverInitTask = receiverInitTask;
             if (localReceiverInitTask != null)
@@ -193,6 +207,10 @@ namespace Orleans.Streams
                 await localReceiverInitTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
                 receiverInitTask = null;
             }
+
+            await _activePumpTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+
+            this.queueCache = null;
 
             try
             {
@@ -213,7 +231,7 @@ namespace Orleans.Streams
             }
 
             // Drain any in-progress background registration tasks before proceeding.
-            // Setting timer = null above makes IsShutdown = true, which causes registrations
+            // Setting _isStopping = true above makes IsShutdown = true, which causes registrations
             // to stop retrying, so these tasks will complete quickly.
             var inFlightRegistrations = pubSubCache.Values
                 .Select(v => v.RegistrationTask)
@@ -301,6 +319,8 @@ namespace Orleans.Streams
             StreamConsumerData consumerData,
             StreamSequenceToken cacheToken)
         {
+            if (IsShutdown) return false;
+
             StreamHandshakeToken requestedHandshakeToken = null;
             // if not cache, then we can't get cursor and there is no reason to ask consumer for token.
             if (queueCache != null)
@@ -388,7 +408,17 @@ namespace Orleans.Streams
         private Task AsyncTimerCallback(QueueId queueId, CancellationToken cancellationToken)
         {
             using var _ = new ExecutionContextSuppressor();
-            return PumpQueue(queueId, cancellationToken);
+            if (IsShutdown)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (!_activePumpTask.IsCompleted)
+            {
+                return _activePumpTask;
+            }
+
+            return _activePumpTask = PumpQueue(queueId, cancellationToken);
         }
 
         private async Task PumpQueue(QueueId queueId, CancellationToken cancellationToken)
@@ -405,7 +435,7 @@ namespace Orleans.Streams
                 if (IsShutdown || cancellationToken.IsCancellationRequested) return; // timer was already removed, last tick
 
                 // loop through the queue until it is empty.
-                while (!IsShutdown && !cancellationToken.IsCancellationRequested) // timer will be set to null when we are asked to shutdown.
+                while (!IsShutdown && !cancellationToken.IsCancellationRequested) // shutdown sets IsShutdown and cancels the timer token.
                 {
                     int maxCacheAddCount = queueCache?.GetMaxAddCount() ?? QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG;
                     if (maxCacheAddCount != QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG && maxCacheAddCount <= 0)
@@ -416,7 +446,7 @@ namespace Orleans.Streams
                     // If read fails, we retry 6 more times, with backoff policy.
                     //    we log each failure as warnings. After 6 times retry if still fail, we break out of loop and log an error
                     bool moreData = await AsyncExecutorWithRetries.ExecuteWithRetries(
-                        i => ReadFromQueue(queueId, receiver, maxCacheAddCount),
+                        i => ReadFromQueue(queueId, receiver, maxCacheAddCount, cancellationToken),
                         ReadLoopRetryMax,
                         ReadLoopRetryExceptionFilter,
                         Timeout.InfiniteTimeSpan,
@@ -447,9 +477,9 @@ namespace Orleans.Streams
         /// <param name="rcvr"></param>
         /// <param name="maxCacheAddCount"></param>
         /// <returns></returns>
-        private async Task<bool> ReadFromQueue(QueueId myQueueId, IQueueAdapterReceiver rcvr, int maxCacheAddCount)
+        private async Task<bool> ReadFromQueue(QueueId myQueueId, IQueueAdapterReceiver rcvr, int maxCacheAddCount, CancellationToken cancellationToken)
         {
-            if (rcvr == null)
+            if (rcvr == null || IsShutdown || cancellationToken.IsCancellationRequested)
             {
                 return false;
             }
@@ -460,6 +490,11 @@ namespace Orleans.Streams
             {
                 lastTimeCleanedPubSubCache = now;
                 CleanupPubSubCache(now);
+            }
+
+            if (IsShutdown || cancellationToken.IsCancellationRequested)
+            {
+                return false;
             }
 
             if (queueCache != null)
@@ -478,6 +513,11 @@ namespace Orleans.Streams
                 }
             }
 
+            if (IsShutdown || cancellationToken.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (queueCache != null && queueCache.IsUnderPressure())
             {
                 // Under back pressure. Exit the loop. Will attempt again in the next timer callback.
@@ -487,6 +527,11 @@ namespace Orleans.Streams
 
             // Retrieve one multiBatch from the queue. Every multiBatch has an IEnumerable of IBatchContainers, each IBatchContainer may have multiple events.
             IList<IBatchContainer> multiBatch = await rcvr.GetQueueMessagesAsync(maxCacheAddCount);
+
+            if (IsShutdown || cancellationToken.IsCancellationRequested)
+            {
+                return false;
+            }
 
             if (multiBatch == null || multiBatch.Count == 0) return false; // queue is empty. Exit the loop. Will attempt again in the next timer callback.
 
@@ -501,6 +546,11 @@ namespace Orleans.Streams
                 .Where(m => m != null)
                 .GroupBy(container => container.StreamId))
             {
+                if (IsShutdown || cancellationToken.IsCancellationRequested)
+                {
+                    return false;
+                }
+
                 var streamId = new QualifiedStreamId(queueAdapter.Name, group.Key);
                 StreamSequenceToken startToken = group.First().SequenceToken;
                 StreamConsumerCollection streamData;
@@ -535,6 +585,11 @@ namespace Orleans.Streams
 
         private void RegisterStream(QualifiedStreamId streamId, StreamSequenceToken firstToken, DateTime now)
         {
+            if (IsShutdown)
+            {
+                return;
+            }
+
             var streamData = new StreamConsumerCollection(now);
 
             // Create a fake cursor to point into a cache.
@@ -549,9 +604,19 @@ namespace Orleans.Streams
             {
                 await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext | ConfigureAwaitOptions.ForceYielding);
 
+                if (IsShutdown)
+                {
+                    return;
+                }
+
                 try
                 {
                     var subscribers = await RegisterAsStreamProducer(streamId);
+
+                    if (IsShutdown)
+                    {
+                        return;
+                    }
 
                     // Producer registration succeeded; the stream entry is now established.
                     // Subscriber-handshake failures must not tear down the entry from here on.
@@ -603,6 +668,11 @@ namespace Orleans.Streams
 
             async Task SubscribeWithIsolation(PubSubSubscriptionState item)
             {
+                if (IsShutdown)
+                {
+                    return;
+                }
+
                 try
                 {
                     await AddSubscriber_Impl(item.SubscriptionId, item.Stream, item.Consumer, item.FilterData, firstToken);
@@ -618,6 +688,11 @@ namespace Orleans.Streams
         {
             foreach (StreamConsumerData consumerData in streamData.AllConsumers())
             {
+                if (IsShutdown)
+                {
+                    return;
+                }
+
                 // Some consumer might not be fully registered yet
                 if (consumerData.IsRegistered)
                 {
@@ -649,7 +724,7 @@ namespace Orleans.Streams
 
                 consumerData.State = StreamConsumerDataState.Active;
                 var deliveredAny = false;
-                while (consumerData.Cursor != null)
+                while (!IsShutdown && consumerData.Cursor != null)
                 {
                     IBatchContainer batch = null;
                     Exception exceptionOccured = null;
@@ -682,6 +757,11 @@ namespace Orleans.Streams
                     try
                     {
                         StreamInstruments.PersistentStreamSentMessages.Add(1);
+                        if (IsShutdown)
+                        {
+                            break;
+                        }
+
                         if (batch != null)
                         {
                             StreamHandshakeToken newToken = await AsyncExecutorWithRetries.ExecuteWithRetries(
@@ -893,6 +973,10 @@ namespace Orleans.Streams
         private async Task<ISet<PubSubSubscriptionState>> RegisterAsStreamProducer(QualifiedStreamId streamId)
         {
             if (pubSub == null) throw new NullReferenceException("Found pubSub reference not set up correctly in RetrieveNewStream");
+            if (IsShutdown)
+            {
+                return new HashSet<PubSubSubscriptionState>();
+            }
 
             ISet<PubSubSubscriptionState> subscribers = null;
             await AsyncExecutorWithRetries.ExecuteWithRetries(

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -52,7 +52,7 @@ namespace Orleans.Streams
             Task<bool> ReadFromQueue(QueueId myQueueId, IQueueAdapterReceiver receiver, int maxCacheAddCount);
             Task RegisterStream(QualifiedStreamId streamId, StreamSequenceToken firstToken, DateTime now);
             Task<IReadOnlyDictionary<QualifiedStreamId, StreamConsumerCollection>> GetPubSubCache();
-            Task PumpQueue(QueueId myQueueId, IQueueAdapterReceiver receiver, CancellationToken cancellationToken);
+            Task PumpQueue(QueueId myQueueId, CancellationToken cancellationToken);
             Task Shutdown();
         }
 
@@ -112,12 +112,8 @@ namespace Orleans.Streams
         Task<IReadOnlyDictionary<QualifiedStreamId, StreamConsumerCollection>> ITestAccessor.GetPubSubCache()
             => this.RunOrQueueTaskResult(() => (IReadOnlyDictionary<QualifiedStreamId, StreamConsumerCollection>)new Dictionary<QualifiedStreamId, StreamConsumerCollection>(pubSubCache));
 
-        Task ITestAccessor.PumpQueue(QueueId myQueueId, IQueueAdapterReceiver receiver, CancellationToken cancellationToken)
-            => this.RunOrQueueTask(() =>
-            {
-                this.receiver = receiver;
-                return _activePumpTask = PumpQueue(myQueueId, cancellationToken);
-            });
+        Task ITestAccessor.PumpQueue(QueueId myQueueId, CancellationToken cancellationToken)
+            => this.RunOrQueueTask(() => _activePumpTask = PumpQueue(myQueueId, cancellationToken));
 
         Task ITestAccessor.Shutdown() => this.RunOrQueueTask(() => Shutdown());
 

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -52,7 +52,7 @@ namespace Orleans.Streams
             Task<bool> ReadFromQueue(QueueId myQueueId, IQueueAdapterReceiver receiver, int maxCacheAddCount);
             Task RegisterStream(QualifiedStreamId streamId, StreamSequenceToken firstToken, DateTime now);
             Task<IReadOnlyDictionary<QualifiedStreamId, StreamConsumerCollection>> GetPubSubCache();
-            Task PumpQueue(QueueId myQueueId, CancellationToken cancellationToken);
+            Task RunQueuePump(QueueId myQueueId, CancellationToken cancellationToken);
             Task Shutdown();
         }
 
@@ -112,8 +112,8 @@ namespace Orleans.Streams
         Task<IReadOnlyDictionary<QualifiedStreamId, StreamConsumerCollection>> ITestAccessor.GetPubSubCache()
             => this.RunOrQueueTaskResult(() => (IReadOnlyDictionary<QualifiedStreamId, StreamConsumerCollection>)new Dictionary<QualifiedStreamId, StreamConsumerCollection>(pubSubCache));
 
-        Task ITestAccessor.PumpQueue(QueueId myQueueId, CancellationToken cancellationToken)
-            => this.RunOrQueueTask(() => _activePumpTask = PumpQueue(myQueueId, cancellationToken));
+        Task ITestAccessor.RunQueuePump(QueueId myQueueId, CancellationToken cancellationToken)
+            => this.RunOrQueueTask(() => RunQueuePump(myQueueId, cancellationToken));
 
         Task ITestAccessor.Shutdown() => this.RunOrQueueTask(() => Shutdown());
 
@@ -179,7 +179,7 @@ namespace Orleans.Streams
             // Setup a reader for a new receiver.
             // Even if the receiver failed to initialize, treat it as OK and start pumping it. It's receiver responsibility to retry initialization.
             var randomTimerOffset = RandomTimeSpan.Next(this.options.GetQueueMsgsTimerPeriod);
-            timer = RegisterGrainTimer(AsyncTimerCallback, QueueId, randomTimerOffset, this.options.GetQueueMsgsTimerPeriod);
+            timer = RegisterGrainTimer(RunQueuePump, QueueId, randomTimerOffset, this.options.GetQueueMsgsTimerPeriod);
 
             StreamInstruments.RegisterPersistentStreamPubSubCacheSizeObserve(() => new Measurement<int>(pubSubCache.Count, new KeyValuePair<string, object>("name", StatisticUniquePostfix)));
 
@@ -401,7 +401,7 @@ namespace Orleans.Streams
                 pubSubCache.Remove(streamId);
         }
 
-        private Task AsyncTimerCallback(QueueId queueId, CancellationToken cancellationToken)
+        private Task RunQueuePump(QueueId queueId, CancellationToken cancellationToken)
         {
             using var _ = new ExecutionContextSuppressor();
             if (IsShutdown)

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -238,7 +238,7 @@ namespace UnitTests.StreamingTests
 
             await InitializeAgent(agent);
 
-            var pumpTask = testAccessor.PumpQueue(queueId, CancellationToken.None);
+            var pumpTask = testAccessor.RunQueuePump(queueId, CancellationToken.None);
             await queueReadStarted.Task;
 
             var shutdownTask = testAccessor.Shutdown();

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -8,8 +8,10 @@ using Orleans.Internal;
 using Orleans.Providers.Streams.Common;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
+using Orleans.Runtime.Scheduler;
 using Orleans.Streams;
 using Orleans.Streams.Filtering;
+using Orleans.Timers;
 using TestExtensions;
 using Xunit;
 
@@ -139,11 +141,18 @@ namespace UnitTests.StreamingTests
             Assert.Empty(pubSub.ReceivedCalls());
         }
 
-        private static PersistentStreamPullingAgent CreateAgent(IStreamPubSub pubSub, QueueId queueId)
+        private static PersistentStreamPullingAgent CreateAgent(IStreamPubSub pubSub, QueueId queueId, IQueueAdapterReceiver receiver = null)
         {
             var siloAddress = SiloAddress.New(IPAddress.Loopback, 11111, 1);
             var localSiloDetails = Substitute.For<ILocalSiloDetails>();
             localSiloDetails.SiloAddress.Returns(siloAddress);
+            var timerRegistry = Substitute.For<ITimerRegistry>();
+            timerRegistry.RegisterGrainTimer(
+                    Arg.Any<IGrainContext>(),
+                    Arg.Any<Func<QueueId, CancellationToken, Task>>(),
+                    Arg.Any<QueueId>(),
+                    Arg.Any<GrainTimerCreationOptions>())
+                .Returns(Substitute.For<IGrainTimer>());
 
             var shared = new SystemTargetShared(
                 runtimeClient: null!,
@@ -151,11 +160,15 @@ namespace UnitTests.StreamingTests
                 NullLoggerFactory.Instance,
                 Options.Create(new SchedulingOptions()),
                 grainReferenceActivator: null!,
-                timerRegistry: null!,
+                timerRegistry,
                 activations: new ActivationDirectory());
+
+            receiver ??= Substitute.For<IQueueAdapterReceiver>();
+            receiver.Initialize(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
             var queueAdapter = Substitute.For<IQueueAdapter>();
             queueAdapter.Name.Returns("provider");
+            queueAdapter.CreateReceiver(Arg.Any<QueueId>()).Returns(receiver);
 
             return new PersistentStreamPullingAgent(
                 SystemTargetGrainId.Create(SystemTargetGrainId.CreateGrainType("persistent-stream-pulling-agent-test"), siloAddress),
@@ -172,6 +185,8 @@ namespace UnitTests.StreamingTests
                 TimeProvider.System,
                 shared);
         }
+
+        private static Task InitializeAgent(PersistentStreamPullingAgent agent) => agent.RunOrQueueTask(() => agent.Initialize());
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task RegisterStream_KeepsCacheEntryWhenSubscriberHandshakeFails()
@@ -218,10 +233,12 @@ namespace UnitTests.StreamingTests
                 });
             receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
-            var agent = CreateAgent(pubSub: null, queueId);
+            var agent = CreateAgent(pubSub: null, queueId, receiver);
             var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
 
-            var pumpTask = testAccessor.PumpQueue(queueId, receiver, CancellationToken.None);
+            await InitializeAgent(agent);
+
+            var pumpTask = testAccessor.PumpQueue(queueId, CancellationToken.None);
             await queueReadStarted.Task;
 
             var shutdownTask = testAccessor.Shutdown();

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -39,6 +39,7 @@ namespace UnitTests.StreamingTests
 
             var agent = CreateAgent(pubSub, queueId);
             var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
 
             var readTask = testAccessor.ReadFromQueue(queueId, receiver, 1);
 
@@ -78,6 +79,7 @@ namespace UnitTests.StreamingTests
 
             var agent = CreateAgent(pubSub, queueId);
             var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
 
             var readResult = await testAccessor.ReadFromQueue(queueId, receiver, 1);
             Assert.True(readResult, "ReadFromQueue should return true indicating data was read");
@@ -103,6 +105,7 @@ namespace UnitTests.StreamingTests
             var receiver = Substitute.For<IQueueAdapterReceiver>();
             var agent = CreateAgent(pubSub: null, queueId);
             var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
 
             await testAccessor.Shutdown();
 
@@ -119,6 +122,7 @@ namespace UnitTests.StreamingTests
             var streamId = new QualifiedStreamId("provider", StreamId.Create("namespace", Guid.NewGuid()));
             var agent = CreateAgent(pubSub: null, queueId);
             var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
 
             await testAccessor.RegisterStream(streamId, new EventSequenceTokenV2(1), DateTime.UtcNow);
 
@@ -133,6 +137,7 @@ namespace UnitTests.StreamingTests
             var streamId = new QualifiedStreamId("provider", StreamId.Create("namespace", Guid.NewGuid()));
             var agent = CreateAgent(pubSub, queueId);
             var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
 
             await testAccessor.Shutdown();
             await testAccessor.RegisterStream(streamId, new EventSequenceTokenV2(1), DateTime.UtcNow);
@@ -208,6 +213,7 @@ namespace UnitTests.StreamingTests
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);
             var agent = CreateAgent(pubSub, queueId);
             var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
 
             // RegisterStream should complete without throwing even though the subscriber
             // handshake will fault (NullReferenceException from the null RuntimeClient).
@@ -248,6 +254,27 @@ namespace UnitTests.StreamingTests
 
             await shutdownTask;
             await pumpTask;
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task RunQueuePump_ReadsAfterReinitialize()
+        {
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+                .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+            receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
+
+            var agent = CreateAgent(pubSub: null, queueId, receiver);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+
+            await InitializeAgent(agent);
+            await testAccessor.Shutdown();
+            await InitializeAgent(agent);
+
+            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+
+            await receiver.Received(1).GetQueueMessagesAsync(Arg.Any<int>());
         }
     }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -95,6 +95,22 @@ namespace UnitTests.StreamingTests
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task ReadFromQueue_DoesNotStartQueueReadAfterShutdownStarts()
+        {
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            var agent = CreateAgent(pubSub: null, queueId);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+
+            await testAccessor.Shutdown();
+
+            var readResult = await testAccessor.ReadFromQueue(queueId, receiver, 1);
+
+            Assert.False(readResult);
+            Assert.Empty(receiver.ReceivedCalls());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task RegisterStream_RemovesCacheEntryWhenProducerRegistrationTerminates()
         {
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);
@@ -105,6 +121,22 @@ namespace UnitTests.StreamingTests
             await testAccessor.RegisterStream(streamId, new EventSequenceTokenV2(1), DateTime.UtcNow);
 
             Assert.Empty(await testAccessor.GetPubSubCache());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task RegisterStream_DoesNotRegisterProducerAfterShutdownStarts()
+        {
+            var pubSub = Substitute.For<IStreamPubSub>();
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var streamId = new QualifiedStreamId("provider", StreamId.Create("namespace", Guid.NewGuid()));
+            var agent = CreateAgent(pubSub, queueId);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+
+            await testAccessor.Shutdown();
+            await testAccessor.RegisterStream(streamId, new EventSequenceTokenV2(1), DateTime.UtcNow);
+
+            Assert.Empty(await testAccessor.GetPubSubCache());
+            Assert.Empty(pubSub.ReceivedCalls());
         }
 
         private static PersistentStreamPullingAgent CreateAgent(IStreamPubSub pubSub, QueueId queueId)
@@ -169,6 +201,36 @@ namespace UnitTests.StreamingTests
             var cache = await testAccessor.GetPubSubCache();
             Assert.True(cache.ContainsKey(streamId), "Stream entry must remain in pubsub cache after a subscriber-handshake failure.");
             Assert.True(cache[streamId].StreamRegistered, "StreamRegistered must be true once producer registration succeeds.");
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task Shutdown_WaitsForInFlightPumpWork()
+        {
+            var queueReadStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var queueReadReleased = new TaskCompletionSource<IList<IBatchContainer>>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+                .Returns(async _ =>
+                {
+                    queueReadStarted.TrySetResult(true);
+                    return await queueReadReleased.Task;
+                });
+            receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
+
+            var agent = CreateAgent(pubSub: null, queueId);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+
+            var pumpTask = testAccessor.PumpQueue(queueId, receiver, CancellationToken.None);
+            await queueReadStarted.Task;
+
+            var shutdownTask = testAccessor.Shutdown();
+            Assert.False(shutdownTask.IsCompleted);
+
+            queueReadReleased.SetResult(new List<IBatchContainer>());
+
+            await shutdownTask;
+            await pumpTask;
         }
     }
 }


### PR DESCRIPTION
Splits the persistent stream pulling agent shutdown changes out of #10055
- Prevents post-shutdown calls from the stream pulling agent.
- Updates PersistentStreamPullingAgentTests coverage for the shutdown behavior.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10057)