### PR TITLE
Make ITargetHolder methods non-generic

### DIFF
--- a/src/Orleans.Core/Runtime/ClientGrainContext.cs
+++ b/src/Orleans.Core/Runtime/ClientGrainContext.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;

--- a/src/Orleans.Serialization/Invocation/ITargetHolder.cs
+++ b/src/Orleans.Serialization/Invocation/ITargetHolder.cs
@@ -1,3 +1,6 @@
+#nullable enable
+using System;
+
 namespace Orleans.Serialization.Invocation;
 
 /// <summary>

--- a/src/Orleans.Serialization/Invocation/TargetHolderExtensions.cs
+++ b/src/Orleans.Serialization/Invocation/TargetHolderExtensions.cs
@@ -1,4 +1,6 @@
+#nullable enable
 using Orleans.Serialization.Invocation;
+
 namespace Orleans.Runtime;
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Changes `ITargetHolder` to expose non-generic `GetComponent(Type)` to avoid costly generic lookup at runtime.
- Keeps the generic convenience API as an extension method.

## Validation
- `git diff --check HEAD^ HEAD`
- conflict-marker scan
- `dotnet build src\Orleans.Serialization\Orleans.Serialization.csproj -m`
- `dotnet build src\Orleans.Core\Orleans.Core.csproj -m`

## Notes
- No dedicated behavior tests were added; useful follow-up coverage would assert `GetComponent(Type)` and generic extension equivalence across generated/runtime consumers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10060)