### PR TITLE
Add Benchmarks.Scenarios project for throughput testing

### DIFF
--- a/Orleans.slnx
+++ b/Orleans.slnx
@@ -135,6 +135,7 @@
   </Folder>
   <Folder Name="/test/Benchmarks/">
     <Project Path="test/Benchmarks.AdoNet/Benchmarks.AdoNet.csproj" />
+    <Project Path="test/Benchmarks.Scenarios/Benchmarks.Scenarios.csproj" />
     <Project Path="test/Benchmarks/Benchmarks.csproj" />
     <Project Path="test/Grains/BenchmarkGrainInterfaces/BenchmarkGrainInterfaces.csproj" />
     <Project Path="test/Grains/BenchmarkGrains/BenchmarkGrains.csproj" />

--- a/test/Benchmarks.Scenarios/Benchmarks.Scenarios.csproj
+++ b/test/Benchmarks.Scenarios/Benchmarks.Scenarios.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Benchmarks.Scenarios</RootNamespace>
+    <AssemblyName>Benchmarks.Scenarios</AssemblyName>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <DebugSymbols>true</DebugSymbols>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(SourceRoot)src\Azure\Orleans.Persistence.AzureStorage\Orleans.Persistence.AzureStorage.csproj" />
+    <ProjectReference Include="$(SourceRoot)src\Azure\Orleans.Transactions.AzureStorage\Orleans.Transactions.AzureStorage.csproj" />
+    <ProjectReference Include="$(SourceRoot)src\AdoNet\Orleans.Persistence.AdoNet\Orleans.Persistence.AdoNet.csproj" />
+    <ProjectReference Include="..\Grains\TestGrainInterfaces\TestGrainInterfaces.csproj" />
+    <ProjectReference Include="..\Grains\BenchmarkGrainInterfaces\BenchmarkGrainInterfaces.csproj" />
+    <ProjectReference Include="..\Grains\BenchmarkGrains\BenchmarkGrains.csproj" />
+    <ProjectReference Include="..\TestInfrastructure\TestExtensions\TestExtensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Benchmarks.Scenarios/GrainStorage/GrainStorageScenario.cs
+++ b/test/Benchmarks.Scenarios/GrainStorage/GrainStorageScenario.cs
@@ -1,0 +1,148 @@
+using System.Diagnostics;
+using Orleans.TestingHost;
+using TestExtensions;
+using BenchmarkGrainInterfaces.GrainStorage;
+
+namespace Benchmarks.Scenarios.GrainStorage;
+
+/// <summary>
+/// Scenario for grain storage providers by measuring read/write operations against different storage backends.
+/// </summary>
+public class GrainStorageScenario : IDisposable
+{
+    private TestCluster host;
+    private readonly int concurrent;
+    private readonly int payloadSize;
+    private readonly TimeSpan duration;
+
+    public GrainStorageScenario(int concurrent, int payloadSize, TimeSpan duration)
+    {
+        this.concurrent = concurrent;
+        this.payloadSize = payloadSize;
+        this.duration = duration;
+    }
+
+    public void MemorySetup()
+    {
+        var builder = new TestClusterBuilder();
+        builder.AddSiloBuilderConfigurator<SiloMemoryStorageConfigurator>();
+        this.host = builder.Build();
+        this.host.Deploy();
+    }
+
+    public void AzureTableSetup()
+    {
+        var builder = new TestClusterBuilder();
+        builder.AddSiloBuilderConfigurator<SiloAzureTableStorageConfigurator>();
+        this.host = builder.Build();
+        this.host.Deploy();
+    }
+
+    public void AzureBlobSetup()
+    {
+        var builder = new TestClusterBuilder();
+        builder.AddSiloBuilderConfigurator<SiloAzureBlobStorageConfigurator>();
+        this.host = builder.Build();
+        this.host.Deploy();
+    }
+
+    public void AdoNetSetup()
+    {
+        var builder = new TestClusterBuilder();
+        builder.AddSiloBuilderConfigurator<SiloAdoNetStorageConfigurator>();
+        this.host = builder.Build();
+        this.host.Deploy();
+    }
+
+    public class SiloMemoryStorageConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder hostBuilder)
+        {
+            hostBuilder.AddMemoryGrainStorageAsDefault();
+        }
+    }
+
+    public class SiloAzureTableStorageConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder hostBuilder)
+        {
+            hostBuilder.AddAzureTableGrainStorageAsDefault(options =>
+            {
+                options.TableServiceClient = new(TestDefaultConfiguration.DataConnectionString);
+            });
+        }
+    }
+
+    public class SiloAzureBlobStorageConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder hostBuilder)
+        {
+            hostBuilder.AddAzureBlobGrainStorageAsDefault(options =>
+            {
+                options.BlobServiceClient = new(TestDefaultConfiguration.DataConnectionString);
+            });
+        }
+    }
+
+    public class SiloAdoNetStorageConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder hostBuilder)
+        {
+            hostBuilder.AddAdoNetGrainStorageAsDefault(options =>
+            {
+                options.ConnectionString = TestDefaultConfiguration.DataConnectionString;
+            });
+        }
+    }
+
+    public async Task RunAsync()
+    {
+        Stopwatch sw = Stopwatch.StartNew();
+        bool running = true;
+        bool isRunning() => running;
+        var runTask = Task.WhenAll(Enumerable.Range(0, concurrent).Select(i => RunAsync(i, isRunning)).ToList());
+        Task[] waitTasks = { runTask, Task.Delay(duration) };
+        await Task.WhenAny(waitTasks);
+        running = false;
+        var runResults = await runTask;
+        sw.Stop();
+        var reports = runResults.SelectMany(r => r).ToList();
+
+        var stored = reports.Count(r => r.Success);
+        var failed = reports.Count(r => !r.Success);
+        var calltimes = reports.Select(r => r.Elapsed.TotalMilliseconds);
+        var calltime = calltimes.Sum();
+        var maxCalltime = calltimes.Max();
+        var averageCalltime = calltimes.Average();
+        Console.WriteLine($"Performed {stored} persist (read & write) operations with {failed} failures in {sw.ElapsedMilliseconds}ms.");
+        Console.WriteLine($"Average time in ms per call was {averageCalltime}, with longest call taking {maxCalltime}ms.");
+        Console.WriteLine($"Total time waiting for the persistent store was {calltime}ms.");
+    }
+
+    public async Task<List<Report>> RunAsync(int instance, Func<bool> running)
+    {
+        var persistentGrain = this.host.Client.GetGrain<IPersistentGrain>(Guid.NewGuid());
+        // activate grain
+        await persistentGrain.Init(payloadSize);
+        var iteration = instance % payloadSize;
+        var reports = new List<Report>(5000);
+        while (running())
+        {
+            var report = await persistentGrain.TrySet(iteration);
+            reports.Add(report);
+            iteration = (iteration + 1) % payloadSize;
+        }
+
+        return reports;
+    }
+
+    public void Teardown()
+    {
+        host.StopAllSilos();
+    }
+
+    public void Dispose()
+    {
+        host?.Dispose();
+    }
+}

--- a/test/Benchmarks.Scenarios/MapReduce/MapReduceScenario.cs
+++ b/test/Benchmarks.Scenarios/MapReduce/MapReduceScenario.cs
@@ -1,0 +1,123 @@
+using BenchmarkGrainInterfaces.MapReduce;
+using BenchmarkGrains.MapReduce;
+using Orleans.TestingHost;
+
+namespace Benchmarks.Scenarios.MapReduce;
+
+/// <summary>
+/// Scenario for Orleans' capability to perform map-reduce operations with complex processing pipelines.
+/// </summary>
+public class MapReduceScenario : IDisposable
+{
+    private static TestCluster _host;
+    private readonly int _intermediateStagesCount = 15;
+    private readonly int _pipelineParallelization = 4;
+    private readonly int _repeats = 50000;
+    private int _currentRepeat = 0;
+
+    public void Setup()
+    {
+        var builder = new TestClusterBuilder(1);
+        _host = builder.Build();
+        _host.Deploy();
+    }
+
+    public async Task RunAsync()
+    {
+        var pipelines = Enumerable
+            .Range(0, this._pipelineParallelization)
+            .AsParallel()
+            .WithDegreeOfParallelism(4)
+            .Select(async i =>
+            {
+                await RunCore();
+            });
+
+        await Task.WhenAll(pipelines);
+    }
+
+    public void Teardown()
+    {
+        _host.StopAllSilos();
+    }
+
+    private async Task RunCore()
+    {
+        List<Task> initializationTasks = new List<Task>();
+        var mapper = _host.GrainFactory.GetGrain<ITransformGrain<string, List<string>>>(Guid.NewGuid());
+        initializationTasks.Add(mapper.Initialize(new MapProcessor()));
+        var reducer =
+            _host.GrainFactory.GetGrain<ITransformGrain<List<string>, Dictionary<string, int>>>(Guid.NewGuid());
+        initializationTasks.Add(reducer.Initialize(new ReduceProcessor()));
+
+        // used for imitation of complex processing pipelines
+        var intermediateGrains = Enumerable
+            .Range(0, this._intermediateStagesCount)
+            .Select(i =>
+            {
+                var intermediateProcessor =
+                    _host.GrainFactory.GetGrain<ITransformGrain<Dictionary<string, int>, Dictionary<string, int>>>
+                        (Guid.NewGuid());
+                initializationTasks.Add(intermediateProcessor.Initialize(new EmptyProcessor()));
+                return intermediateProcessor;
+            });
+
+        initializationTasks.Add(mapper.LinkTo(reducer));
+        var collector = _host.GrainFactory.GetGrain<IBufferGrain<Dictionary<string, int>>>(Guid.NewGuid());
+        using (var e = intermediateGrains.GetEnumerator())
+        {
+            ITransformGrain<Dictionary<string, int>, Dictionary<string, int>> previous = null;
+            if (e.MoveNext())
+            {
+                initializationTasks.Add(reducer.LinkTo(e.Current));
+                previous = e.Current;
+            }
+
+            while (e.MoveNext())
+            {
+                initializationTasks.Add(previous.LinkTo(e.Current));
+                previous = e.Current;
+            }
+
+            initializationTasks.Add(previous.LinkTo(collector));
+        }
+
+        await Task.WhenAll(initializationTasks);
+
+        List<Dictionary<string, int>> resultList = new List<Dictionary<string, int>>();
+
+        while (Interlocked.Increment(ref this._currentRepeat) < this._repeats)
+        {
+            await mapper.SendAsync(this._text);
+            while (!resultList.Any() || resultList.First().Count < 84) // rough way of checking of pipeline completition.
+            {
+                resultList = await collector.ReceiveAll();
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _host?.Dispose();
+    }
+
+    private readonly string _text = @"Historically, the world of data and the world of objects" +
+      @" have not been well integrated. Programmers work in C# or Visual Basic" +
+      @" and also in SQL or XQuery. On the one side are concepts such as classes," +
+      @" objects, fields, inheritance, and .NET Framework APIs. On the other side" +
+      @" are tables, columns, rows, nodes, and separate languages for dealing with" +
+      @" them. Data types often require translation between the two worlds; there are" +
+      @" different standard functions. Because the object world has no notion of query, a" +
+      @" query can only be represented as a string without compile-time type checking or" +
+      @" IntelliSense support in the IDE. Transferring data from SQL tables or XML trees to" +
+      @" objects in memory is often tedious and error-prone. Historically, the world of data and the world of objects" +
+      @" have not been well integrated. Programmers work in C# or Visual Basic" +
+      @" and also in SQL or XQuery. On the one side are concepts such as classes," +
+      @" objects, fields, inheritance, and .NET Framework APIs. On the other side" +
+      @" are tables, columns, rows, nodes, and separate languages for dealing with" +
+      @" them. Data types often require translation between the two worlds; there are" +
+      @" different standard functions. Because the object world has no notion of query, a" +
+      @" query can only be represented as a string without compile-time type checking or" +
+      @" IntelliSense support in the IDE. Transferring data from SQL tables or XML trees to" +
+      @" objects in memory is often tedious and error-prone.";
+}

--- a/test/Benchmarks.Scenarios/Ping/AdaptiveConcurrencyLoadGenerator.cs
+++ b/test/Benchmarks.Scenarios/Ping/AdaptiveConcurrencyLoadGenerator.cs
@@ -1,0 +1,380 @@
+using System.Diagnostics;
+using System.Threading.Channels;
+
+namespace Benchmarks.Scenarios.Ping;
+
+/// <summary>
+/// A load generator that runs indefinitely and uses a hill climbing algorithm
+/// to continuously tune concurrency for maximum throughput.
+/// </summary>
+public sealed class AdaptiveConcurrencyLoadGenerator<TState>
+{
+    private static readonly double StopwatchTickPerSecond = Stopwatch.Frequency;
+
+    private readonly Func<TState, ValueTask> _issueRequest;
+    private readonly Func<int, TState> _getStateForWorker;
+    private readonly int _requestsPerBlock;
+    private readonly TimeSpan _warmupDuration;
+    private readonly TimeSpan _measurementInterval;
+    private readonly int _minConcurrency;
+    private readonly int _maxConcurrency;
+    private readonly int _initialConcurrency;
+    private readonly int _maxStableRounds;
+
+    private Channel<WorkBlock> _completedBlocks;
+    private volatile int _currentConcurrency;
+    private CancellationTokenSource _cts;
+
+    // Hill climbing state
+    private double _bestThroughput;
+    private double _lastThroughput;
+    private int _bestConcurrency;
+    private int _stepSize;
+    private int _direction; // 1 = increasing, -1 = decreasing
+    private int _stableCount;
+    private int _roundsSinceBestChanged;
+    private const int StableThreshold = 3; // Number of consecutive non-improvements before changing direction
+
+    public int CurrentConcurrency => _currentConcurrency;
+    public int BestConcurrency => _bestConcurrency;
+    public double BestThroughput => _bestThroughput;
+    public bool Converged { get; private set; }
+
+    public AdaptiveConcurrencyLoadGenerator(
+        Func<TState, ValueTask> issueRequest,
+        Func<int, TState> getStateForWorker,
+        int requestsPerBlock = 500,
+        TimeSpan? warmupDuration = null,
+        TimeSpan? measurementInterval = null,
+        int minConcurrency = 1,
+        int maxConcurrency = 2000,
+        int initialConcurrency = 100,
+        int maxStableRounds = 0)
+    {
+        _issueRequest = issueRequest;
+        _getStateForWorker = getStateForWorker;
+        _requestsPerBlock = requestsPerBlock;
+        _warmupDuration = warmupDuration ?? TimeSpan.FromSeconds(5);
+        _measurementInterval = measurementInterval ?? TimeSpan.FromSeconds(5);
+        _minConcurrency = minConcurrency;
+        _maxConcurrency = maxConcurrency;
+        _initialConcurrency = initialConcurrency;
+        _currentConcurrency = initialConcurrency;
+        _stepSize = Math.Max(1, initialConcurrency / 10);
+        _direction = 1;
+        _maxStableRounds = maxStableRounds; // 0 = run forever
+    }
+
+    public async Task RunForeverAsync(CancellationToken cancellationToken = default)
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        Console.WriteLine($"Starting adaptive load generator with initial concurrency: {_initialConcurrency}");
+        Console.WriteLine($"Warmup duration: {_warmupDuration.TotalSeconds}s, Measurement interval: {_measurementInterval.TotalSeconds}s");
+        Console.WriteLine($"Concurrency range: [{_minConcurrency}, {_maxConcurrency}]");
+        if (_maxStableRounds > 0)
+            Console.WriteLine($"Will terminate after {_maxStableRounds} rounds with no improvement to best");
+        Console.WriteLine();
+
+        // Warmup phase
+        Console.WriteLine("=== WARMUP PHASE ===");
+        await RunPhaseAsync(_warmupDuration, isWarmup: true);
+        GC.Collect();
+
+        Console.WriteLine();
+        Console.WriteLine("=== TUNING PHASE ===");
+        Console.WriteLine($"{"Time",-12} {"Concurrency",12} {"Throughput",14} {"Best",14} {"BestConc",10} {"Action",-20}");
+        Console.WriteLine(new string('-', 82));
+
+        var startTime = DateTime.UtcNow;
+
+        while (!_cts.Token.IsCancellationRequested)
+        {
+            var throughput = await RunPhaseAsync(_measurementInterval, isWarmup: false);
+            var elapsed = DateTime.UtcNow - startTime;
+
+            var action = ApplyHillClimbing(throughput);
+
+            var elapsedStr = elapsed.ToString(@"hh\:mm\:ss\.f");
+            Console.WriteLine($"{elapsedStr,-12} {_currentConcurrency,12} {throughput,14:N0}/s {_bestThroughput,14:N0}/s {_bestConcurrency,10} {action,-20}");
+
+            // Check for convergence
+            if (_maxStableRounds > 0 && _roundsSinceBestChanged >= _maxStableRounds)
+            {
+                Converged = true;
+                Console.WriteLine();
+                Console.WriteLine($"Converged after {_roundsSinceBestChanged} rounds with no improvement.");
+                break;
+            }
+        }
+    }
+
+    private async Task<double> RunPhaseAsync(TimeSpan duration, bool isWarmup)
+    {
+        _completedBlocks = Channel.CreateUnbounded<WorkBlock>(
+            new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                AllowSynchronousContinuations = false
+            });
+
+        var workerTasks = new List<Task>();
+        // Link to main cancellation token so Ctrl+C stops workers immediately
+        using var workerCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+        var states = new Dictionary<int, TState>();
+
+        // Start initial workers
+        for (int i = 0; i < _currentConcurrency; i++)
+        {
+            var state = _getStateForWorker(i);
+            states[i] = state;
+            workerTasks.Add(RunWorkerAsync(state, i, workerCts.Token));
+        }
+
+        var aggregator = Task.Run(() => AggregateBlocksAsync(duration, isWarmup, workerCts));
+
+        var throughput = await aggregator;
+
+        // Signal workers to stop
+        await workerCts.CancelAsync();
+        _completedBlocks.Writer.Complete();
+
+        // Wait for workers with timeout
+        try
+        {
+            await Task.WhenAll(workerTasks).WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        catch (TimeoutException)
+        {
+            // Workers didn't stop in time, continue anyway
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected
+        }
+
+        return throughput;
+    }
+
+    private async Task<double> AggregateBlocksAsync(TimeSpan duration, bool isWarmup, CancellationTokenSource workerCts)
+    {
+        var reader = _completedBlocks.Reader;
+        var startTime = Stopwatch.GetTimestamp();
+        var endTime = startTime + (long)(duration.TotalSeconds * StopwatchTickPerSecond);
+
+        long totalCompleted = 0;
+        long totalSuccesses = 0;
+        long totalFailures = 0;
+        long minStartTime = long.MaxValue;
+        long maxEndTime = long.MinValue;
+
+        while (Stopwatch.GetTimestamp() < endTime && !_cts.Token.IsCancellationRequested)
+        {
+            try
+            {
+                var readTask = reader.WaitToReadAsync(_cts.Token).AsTask();
+                var completed = await readTask.WaitAsync(TimeSpan.FromMilliseconds(100));
+
+                if (!completed) continue;
+
+                while (reader.TryRead(out var block))
+                {
+                    totalCompleted += block.Completed;
+                    totalSuccesses += block.Successes;
+                    totalFailures += block.Failures;
+                    if (block.StartTimestamp < minStartTime) minStartTime = block.StartTimestamp;
+                    if (block.EndTimestamp > maxEndTime) maxEndTime = block.EndTimestamp;
+                }
+            }
+            catch (TimeoutException)
+            {
+                // Continue waiting
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        // Signal workers to stop
+        workerCts.Cancel();
+
+        // Drain remaining blocks
+        while (reader.TryRead(out var block))
+        {
+            totalCompleted += block.Completed;
+            totalSuccesses += block.Successes;
+            totalFailures += block.Failures;
+            if (block.StartTimestamp < minStartTime) minStartTime = block.StartTimestamp;
+            if (block.EndTimestamp > maxEndTime) maxEndTime = block.EndTimestamp;
+        }
+
+        if (totalCompleted == 0 || maxEndTime <= minStartTime)
+        {
+            return 0;
+        }
+
+        var totalSeconds = (maxEndTime - minStartTime) / StopwatchTickPerSecond;
+        var throughput = totalCompleted / totalSeconds;
+
+        if (isWarmup)
+        {
+            var failureInfo = totalFailures > 0 ? $" ({totalFailures} failures)" : "";
+            Console.WriteLine($"  Warmup: {throughput:N0}/s, {totalCompleted:N0} requests in {totalSeconds:F1}s{failureInfo}");
+        }
+
+        return throughput;
+    }
+
+    private string ApplyHillClimbing(double currentThroughput)
+    {
+        string action;
+        bool isNewBest = currentThroughput > _bestThroughput;
+
+        // Always track the actual best
+        if (isNewBest)
+        {
+            _bestThroughput = currentThroughput;
+            _bestConcurrency = _currentConcurrency;
+            _roundsSinceBestChanged = 0;
+        }
+        else
+        {
+            _roundsSinceBestChanged++;
+        }
+
+        // Determine if this is a meaningful improvement (resets stable count)
+        // or just noise within measurement variance
+        bool meaningfulImprovement = currentThroughput > _lastThroughput * 1.005; // 0.5% threshold
+
+        if (meaningfulImprovement)
+        {
+            _stableCount = 0;
+
+            // Continue in the same direction
+            var newConcurrency = _currentConcurrency + (_direction * _stepSize);
+            newConcurrency = Math.Clamp(newConcurrency, _minConcurrency, _maxConcurrency);
+
+            if (newConcurrency != _currentConcurrency)
+            {
+                _currentConcurrency = newConcurrency;
+                action = isNewBest ? $"New best! {_direction * _stepSize:+#;-#;0}" : $"Improving {_direction * _stepSize:+#;-#;0}";
+            }
+            else
+            {
+                // Hit boundary, reverse direction
+                _direction = -_direction;
+                action = "Hit boundary";
+            }
+        }
+        else
+        {
+            _stableCount++;
+
+            if (_stableCount >= StableThreshold)
+            {
+                // No improvement for a while
+                _stableCount = 0;
+
+                if (_stepSize > 1)
+                {
+                    // Reduce step size for finer tuning
+                    _stepSize = Math.Max(1, _stepSize / 2);
+                    _direction = -_direction; // Try the other direction with smaller steps
+                    action = $"Refine step={_stepSize}";
+                }
+                else
+                {
+                    // At minimum step, jump back toward best and try again
+                    _direction = _bestConcurrency > _currentConcurrency ? 1 : -1;
+                    _stepSize = Math.Max(1, Math.Abs(_currentConcurrency - _bestConcurrency) / 2);
+                    if (_stepSize < 1) _stepSize = Math.Max(1, _bestConcurrency / 10);
+                    action = $"Reset toward best";
+                }
+
+                var newConcurrency = _currentConcurrency + (_direction * _stepSize);
+                newConcurrency = Math.Clamp(newConcurrency, _minConcurrency, _maxConcurrency);
+                _currentConcurrency = newConcurrency;
+            }
+            else
+            {
+                // Continue probing in current direction
+                var newConcurrency = _currentConcurrency + (_direction * _stepSize);
+                newConcurrency = Math.Clamp(newConcurrency, _minConcurrency, _maxConcurrency);
+
+                if (newConcurrency == _currentConcurrency)
+                {
+                    // Hit boundary, reverse
+                    _direction = -_direction;
+                    newConcurrency = _currentConcurrency + (_direction * _stepSize);
+                    newConcurrency = Math.Clamp(newConcurrency, _minConcurrency, _maxConcurrency);
+                    action = "Boundary, reverse";
+                }
+                else
+                {
+                    action = $"Probing ({_stableCount}/{StableThreshold})";
+                }
+
+                _currentConcurrency = newConcurrency;
+            }
+        }
+
+        _lastThroughput = currentThroughput;
+        return action;
+    }
+
+    private async Task RunWorkerAsync(TState state, int workerId, CancellationToken cancellationToken)
+    {
+        var writer = _completedBlocks.Writer;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var workBlock = new WorkBlock { StartTimestamp = Stopwatch.GetTimestamp() };
+
+            while (workBlock.Completed < _requestsPerBlock && !cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await _issueRequest(state).ConfigureAwait(false);
+                    workBlock.Successes++;
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch
+                {
+                    workBlock.Failures++;
+                }
+            }
+
+            workBlock.EndTimestamp = Stopwatch.GetTimestamp();
+
+            if (workBlock.Completed > 0)
+            {
+                try
+                {
+                    await writer.WriteAsync(workBlock, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (ChannelClosedException)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    private struct WorkBlock
+    {
+        public long StartTimestamp;
+        public long EndTimestamp;
+        public int Successes;
+        public int Failures;
+        public readonly int Completed => Successes + Failures;
+    }
+}

--- a/test/Benchmarks.Scenarios/Ping/AdaptivePingScenario.cs
+++ b/test/Benchmarks.Scenarios/Ping/AdaptivePingScenario.cs
@@ -1,0 +1,260 @@
+using System.Net;
+using BenchmarkGrainInterfaces.Ping;
+using BenchmarkGrains.Ping;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.Configuration;
+
+namespace Benchmarks.Scenarios.Ping;
+
+/// <summary>
+/// Scenario that runs indefinitely and uses hill climbing to tune concurrency
+/// for maximum throughput. Useful for finding optimal concurrency levels and
+/// for long-running performance testing.
+/// </summary>
+public class AdaptivePingScenario : IDisposable
+{
+    public enum ScenarioMode
+    {
+        /// <summary>Client runs inside the silo process (lowest latency)</summary>
+        HostedClient,
+        /// <summary>External client connects to silo(s)</summary>
+        ExternalClient,
+        /// <summary>Calls go from one silo to another (tests cross-silo performance)</summary>
+        SiloToSilo
+    }
+
+    private readonly List<IHost> _hosts = new();
+    private readonly IHost _clientHost;
+    private readonly IClusterClient _client;
+    private readonly ScenarioMode _mode;
+    private readonly int _numSilos;
+    private readonly CancellationTokenSource _cts = new();
+
+    public string Description { get; }
+    public int BestConcurrency { get; private set; }
+    public double BestThroughput { get; private set; }
+
+    public AdaptivePingScenario(ScenarioMode mode = ScenarioMode.HostedClient, int numSilos = 1)
+    {
+        _mode = mode;
+        _numSilos = numSilos;
+
+        // Determine configuration based on mode
+        bool startClient = mode == ScenarioMode.ExternalClient;
+        bool grainsOnSecondariesOnly = mode == ScenarioMode.SiloToSilo;
+
+        if (mode == ScenarioMode.SiloToSilo && numSilos < 2)
+        {
+            numSilos = 2;
+            _numSilos = 2;
+        }
+
+        Description = mode switch
+        {
+            ScenarioMode.HostedClient => "Hosted Client",
+            ScenarioMode.ExternalClient when numSilos == 1 => "Client to Silo",
+            ScenarioMode.ExternalClient => $"Client to {numSilos} Silos",
+            ScenarioMode.SiloToSilo => "Silo to Silo",
+            _ => mode.ToString()
+        };
+
+        // Start silos
+        for (int i = 0; i < numSilos; i++)
+        {
+            var primary = i == 0 ? null : new IPEndPoint(IPAddress.Loopback, 11111);
+            var hostBuilder = new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+            {
+                siloBuilder.UseLocalhostClustering(
+                    siloPort: 11111 + i,
+                    gatewayPort: 30000 + i,
+                    primarySiloEndpoint: primary);
+
+                // For SiloToSilo mode: remove grains from primary silo to force cross-silo calls
+                if (i == 0 && grainsOnSecondariesOnly)
+                {
+                    siloBuilder.Configure<GrainTypeOptions>(options => options.Classes.Remove(typeof(PingGrain)));
+                }
+            });
+
+            var host = hostBuilder.Build();
+            host.StartAsync().GetAwaiter().GetResult();
+            _hosts.Add(host);
+        }
+
+        // Wait for cluster to stabilize in multi-silo mode
+        if (numSilos > 1)
+        {
+            Thread.Sleep(4000);
+        }
+
+        // Start external client if needed
+        if (startClient)
+        {
+            var hostBuilder = new HostBuilder().UseOrleansClient((ctx, clientBuilder) =>
+            {
+                if (numSilos == 1)
+                {
+                    clientBuilder.UseLocalhostClustering();
+                }
+                else
+                {
+                    var gateways = Enumerable.Range(30000, numSilos)
+                        .Select(i => new IPEndPoint(IPAddress.Loopback, i))
+                        .ToArray();
+                    clientBuilder.UseStaticClustering(gateways);
+                }
+            });
+
+            _clientHost = hostBuilder.Build();
+            _clientHost.StartAsync().GetAwaiter().GetResult();
+            _client = _clientHost.Services.GetRequiredService<IClusterClient>();
+
+            // Warm up the client connection
+            var grain = _client.GetGrain<IPingGrain>(0);
+            grain.Run().AsTask().GetAwaiter().GetResult();
+        }
+
+        // Wire up Ctrl+C to cancel
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            Console.WriteLine("\nShutdown requested...");
+            _cts.Cancel();
+        };
+    }
+
+    /// <summary>
+    /// Gets the grain factory based on the current mode.
+    /// </summary>
+    private IGrainFactory GetGrainFactory()
+    {
+        return _mode == ScenarioMode.ExternalClient
+            ? _client
+            : _hosts[0].Services.GetRequiredService<IGrainFactory>();
+    }
+
+    /// <summary>
+    /// Runs the adaptive scenario, tuning concurrency via hill climbing.
+    /// Terminates after maxStableRounds without improvement (default 10), or runs forever if 0.
+    /// </summary>
+    public async Task RunAsync(
+        int initialConcurrency = 100,
+        int minConcurrency = 1,
+        int maxConcurrency = 2000,
+        TimeSpan? warmupDuration = null,
+        TimeSpan? measurementInterval = null,
+        int maxStableRounds = 10)
+    {
+        var grainFactory = GetGrainFactory();
+
+        Console.WriteLine($"=== Adaptive Ping Scenario: {Description} ===");
+        Console.WriteLine();
+
+        var loadGenerator = new AdaptiveConcurrencyLoadGenerator<IPingGrain>(
+            issueRequest: g => g.Run(),
+            getStateForWorker: workerId => grainFactory.GetGrain<IPingGrain>(workerId),
+            requestsPerBlock: 500,
+            warmupDuration: warmupDuration ?? TimeSpan.FromSeconds(5),
+            measurementInterval: measurementInterval ?? TimeSpan.FromSeconds(5),
+            minConcurrency: minConcurrency,
+            maxConcurrency: maxConcurrency,
+            initialConcurrency: initialConcurrency,
+            maxStableRounds: maxStableRounds);
+
+        try
+        {
+            await loadGenerator.RunForeverAsync(_cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on Ctrl+C
+        }
+
+        BestConcurrency = loadGenerator.BestConcurrency;
+        BestThroughput = loadGenerator.BestThroughput;
+
+        Console.WriteLine($"\nFinal best: {BestConcurrency} concurrency @ {BestThroughput:N0}/s");
+    }
+
+    public async Task ShutdownAsync()
+    {
+        if (_clientHost != null)
+        {
+            await _clientHost.StopAsync();
+            if (_clientHost is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync();
+            else
+                _clientHost.Dispose();
+        }
+
+        _hosts.Reverse();
+        foreach (var host in _hosts)
+        {
+            await host.StopAsync();
+            if (host is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync();
+            else
+                host.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Dispose();
+        (_client as IDisposable)?.Dispose();
+        _hosts.ForEach(h => h.Dispose());
+    }
+
+    /// <summary>
+    /// Runs all adaptive ping scenarios and prints a summary.
+    /// </summary>
+    public static async Task RunAllScenariosAsync(int maxStableRounds = 10)
+    {
+        var results = new List<(string Description, int BestConcurrency, double BestThroughput)>();
+
+        var scenarios = new (ScenarioMode Mode, int NumSilos)[]
+        {
+            (ScenarioMode.HostedClient, 1),
+            (ScenarioMode.ExternalClient, 1),
+            (ScenarioMode.ExternalClient, 2),
+            (ScenarioMode.SiloToSilo, 2),
+        };
+
+        foreach (var (mode, numSilos) in scenarios)
+        {
+            var scenario = new AdaptivePingScenario(mode, numSilos);
+            try
+            {
+                await scenario.RunAsync(maxStableRounds: maxStableRounds);
+                results.Add((scenario.Description, scenario.BestConcurrency, scenario.BestThroughput));
+            }
+            finally
+            {
+                await scenario.ShutdownAsync();
+                scenario.Dispose();
+            }
+
+            Console.WriteLine();
+            Console.WriteLine(new string('=', 82));
+            Console.WriteLine();
+
+            GC.Collect();
+            await Task.Delay(1000); // Brief pause between scenarios
+        }
+
+        // Print summary in GitHub-flavored markdown table format
+        Console.WriteLine();
+        Console.WriteLine("## Adaptive Ping Scenario Results");
+        Console.WriteLine();
+        Console.WriteLine("| Scenario | Best Concurrency | Best Throughput |");
+        Console.WriteLine("|----------|------------------|-----------------|");
+
+        foreach (var (description, bestConcurrency, bestThroughput) in results)
+        {
+            Console.WriteLine($"| {description} | {bestConcurrency} | {bestThroughput:N0}/s |");
+        }
+
+        Console.WriteLine();
+    }
+}

--- a/test/Benchmarks.Scenarios/Ping/ConcurrentLoadGenerator.cs
+++ b/test/Benchmarks.Scenarios/Ping/ConcurrentLoadGenerator.cs
@@ -1,0 +1,179 @@
+using System.Threading.Channels;
+using System.Diagnostics;
+
+namespace Benchmarks.Scenarios.Ping;
+
+public sealed class ConcurrentLoadGenerator<TState>
+{
+    private static readonly double StopwatchTickPerSecond = Stopwatch.Frequency;
+    private struct WorkBlock
+    {
+        public long StartTimestamp { get; set; }
+        public long EndTimestamp { get; set; }
+        public int Successes { get; set; }
+        public int Failures { get; set; }
+        public readonly int Completed => this.Successes + this.Failures;
+        public readonly double ElapsedSeconds => (this.EndTimestamp - this.StartTimestamp) / StopwatchTickPerSecond;
+        public readonly double RequestsPerSecond => this.Completed / this.ElapsedSeconds;
+    }
+
+    private Channel<WorkBlock> _completedBlocks;
+    private readonly Func<TState, ValueTask> _issueRequest;
+    private readonly Func<int, TState> _getStateForWorker;
+    private readonly bool _logIntermediateResults;
+    private readonly Task[] _tasks;
+    private readonly TState[] _states;
+    private readonly int _numWorkers;
+    private readonly int _blocksPerWorker;
+    private readonly int _requestsPerBlock;
+
+    public ConcurrentLoadGenerator(
+        int maxConcurrency,
+        int blocksPerWorker,
+        int requestsPerBlock,
+        Func<TState, ValueTask> issueRequest,
+        Func<int, TState> getStateForWorker,
+        bool logIntermediateResults = false)
+    {
+        this._numWorkers = maxConcurrency;
+        this._blocksPerWorker = blocksPerWorker;
+        this._requestsPerBlock = requestsPerBlock;
+        this._issueRequest = issueRequest;
+        this._getStateForWorker = getStateForWorker;
+        this._logIntermediateResults = logIntermediateResults;
+        this._tasks = new Task[maxConcurrency];
+        this._states = new TState[maxConcurrency];
+    }
+
+    public async Task Warmup()
+    {
+        this.ResetBetweenRuns();
+        var completedBlockReader = this._completedBlocks.Reader;
+
+        for (var ree = 0; ree < this._numWorkers; ree++)
+        {
+            this._states[ree] = _getStateForWorker(ree);
+            this._tasks[ree] = this.RunWorker(this._states[ree], this._requestsPerBlock, 3);
+        }
+
+        // Wait for warmup to complete.
+        await Task.WhenAll(this._tasks).ConfigureAwait(false);
+
+        // Ignore warmup blocks.
+        while (completedBlockReader.TryRead(out _)) ;
+        GC.Collect();
+    }
+
+    private void ResetBetweenRuns()
+    {
+        this._completedBlocks = Channel.CreateUnbounded<WorkBlock>(
+            new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                AllowSynchronousContinuations = false
+            });
+    }
+
+    public async Task Run()
+    {
+        this.ResetBetweenRuns();
+        var completedBlockReader = this._completedBlocks.Reader;
+
+        // Start the run.
+        for (var i = 0; i < this._numWorkers; i++)
+        {
+            this._tasks[i] = this.RunWorker(this._states[i], this._requestsPerBlock, this._blocksPerWorker);
+        }
+
+        _ = Task.Run(async () => { try { await Task.WhenAll(this._tasks).ConfigureAwait(false); } catch { } finally { this._completedBlocks.Writer.Complete(); } });
+        var blocks = new List<WorkBlock>(this._numWorkers * this._blocksPerWorker);
+        var blocksPerReport = this._numWorkers * this._blocksPerWorker / 5;
+        var nextReportBlockCount = blocksPerReport;
+        while (true)
+        {
+            var more = await completedBlockReader.WaitToReadAsync().ConfigureAwait(false);
+            if (!more) break;
+            while (completedBlockReader.TryRead(out var block))
+            {
+                blocks.Add(block);
+            }
+
+            if (this._logIntermediateResults && blocks.Count >= nextReportBlockCount)
+            {
+                nextReportBlockCount += blocksPerReport;
+                Console.WriteLine("    " + PrintReport(0));
+            }
+        }
+
+        if (this._logIntermediateResults) Console.WriteLine("  Total: " + PrintReport(0));
+        else Console.WriteLine(PrintReport(0));
+
+        string PrintReport(int statingBlockIndex)
+        {
+            if (blocks.Count == 0) return "No blocks completed";
+            var successes = 0;
+            var failures = 0;
+            long completed = 0;
+            var reportBlocks = 0;
+            long minStartTime = long.MaxValue;
+            long maxEndTime = long.MinValue;
+            for (var i = statingBlockIndex; i < blocks.Count; i++)
+            {
+                var b = blocks[i];
+                ++reportBlocks;
+                successes += b.Successes;
+                failures += b.Failures;
+                completed += b.Completed;
+                if (b.StartTimestamp < minStartTime) minStartTime = b.StartTimestamp;
+                if (b.EndTimestamp > maxEndTime) maxEndTime = b.EndTimestamp;
+            }
+
+            var totalSeconds = (maxEndTime - minStartTime) / StopwatchTickPerSecond;
+            var ratePerSecond = (long)(completed / totalSeconds);
+            var failureString = failures == 0 ? string.Empty : $" with {failures,7:N0} failures";
+            return $"{ratePerSecond,8:N0}/s {successes,8:N0} reqs in {totalSeconds,6:0.000}s{failureString}";
+        }
+    }
+
+    private Task RunWorker(TState state, int requestsPerBlock, int numBlocks)
+    {
+        // Suppress ExecutionContext flow before starting the async work
+        // This avoids EC capture/restore overhead in the hot loop
+        if (ExecutionContext.IsFlowSuppressed())
+        {
+            return RunWorkerCore(state, requestsPerBlock, numBlocks);
+        }
+
+        using var asyncFlowControl = ExecutionContext.SuppressFlow();
+        return RunWorkerCore(state, requestsPerBlock, numBlocks);
+    }
+
+    private async Task RunWorkerCore(TState state, int requestsPerBlock, int numBlocks)
+    {
+        await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
+        var completedBlockWriter = this._completedBlocks.Writer;
+        var issueRequest = this._issueRequest; // Cache delegate to avoid field access in hot loop
+        while (numBlocks > 0)
+        {
+            var workBlock = new WorkBlock();
+            workBlock.StartTimestamp = Stopwatch.GetTimestamp();
+            while (workBlock.Completed < requestsPerBlock)
+            {
+                try
+                {
+                    await this._issueRequest(state).ConfigureAwait(false);
+                    ++workBlock.Successes;
+                }
+                catch
+                {
+                    ++workBlock.Failures;
+                }
+            }
+
+            workBlock.EndTimestamp = Stopwatch.GetTimestamp();
+            await completedBlockWriter.WriteAsync(workBlock).ConfigureAwait(false);
+            --numBlocks;
+        }
+    }
+}

--- a/test/Benchmarks.Scenarios/Ping/FanoutScenario.cs
+++ b/test/Benchmarks.Scenarios/Ping/FanoutScenario.cs
@@ -1,0 +1,150 @@
+using System.Net;
+using BenchmarkGrainInterfaces.Ping;
+using BenchmarkGrains.Ping;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using Orleans.Configuration;
+
+namespace Benchmarks.Scenarios.Ping;
+
+/// <summary>
+/// Scenario for grain communication with fanout patterns across multiple silos.
+/// </summary>
+public class FanoutScenario : IDisposable
+{
+    private readonly ConsoleCancelEventHandler _onCancelEvent;
+    private readonly List<IHost> hosts = new();
+    private readonly ITreeGrain grain;
+    private readonly IClusterClient client;
+    private readonly IHost clientHost;
+
+    public FanoutScenario() : this(2, true) { }
+
+    public FanoutScenario(int numSilos, bool startClient, bool grainsOnSecondariesOnly = false)
+    {
+        for (var i = 0; i < numSilos; ++i)
+        {
+            var primary = i == 0 ? null : new IPEndPoint(IPAddress.Loopback, 11111);
+            var hostBuilder = new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+            {
+#pragma warning disable ORLEANSEXP001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                siloBuilder.AddActivationRepartitioner();
+#pragma warning restore ORLEANSEXP001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                siloBuilder.ConfigureLogging(l =>
+                {
+                    l.AddSimpleConsole(o =>
+                    {
+                        o.UseUtcTimestamp = true;
+                        o.TimestampFormat = "HH:mm:ss ";
+                        o.ColorBehavior = LoggerColorBehavior.Enabled;
+                    });
+                    l.AddFilter("Orleans.Runtime.Placement.Repartitioning", LogLevel.Debug);
+                });
+                siloBuilder.Configure<ActivationRepartitionerOptions>(o =>
+                {
+                });
+                siloBuilder.UseLocalhostClustering(
+                    siloPort: 11111 + i,
+                    gatewayPort: 30000 + i,
+                    primarySiloEndpoint: primary);
+
+                if (i == 0 && grainsOnSecondariesOnly)
+                {
+                    siloBuilder.Configure<GrainTypeOptions>(options => options.Classes.Remove(typeof(PingGrain)));
+                }
+            });
+
+            var host = hostBuilder.Build();
+
+            host.StartAsync().GetAwaiter().GetResult();
+            this.hosts.Add(host);
+        }
+
+        if (grainsOnSecondariesOnly) Thread.Sleep(4000);
+
+        if (startClient)
+        {
+            var hostBuilder = new HostBuilder().UseOrleansClient((ctx, clientBuilder) =>
+            {
+                if (numSilos == 1)
+                {
+                    clientBuilder.UseLocalhostClustering();
+                }
+                else
+                {
+                    var gateways = Enumerable.Range(30000, numSilos).Select(i => new IPEndPoint(IPAddress.Loopback, i)).ToArray();
+                    clientBuilder.UseStaticClustering(gateways);
+                }
+            });
+
+            this.clientHost = hostBuilder.Build();
+            this.clientHost.StartAsync().GetAwaiter().GetResult();
+
+            this.client = this.clientHost.Services.GetRequiredService<IClusterClient>();
+            var grainFactory = this.client;
+
+            this.grain = grainFactory.GetGrain<ITreeGrain>(0, keyExtension: "0");
+            this.grain.Ping().AsTask().GetAwaiter().GetResult();
+        }
+
+        _onCancelEvent = CancelPressed;
+        Console.CancelKeyPress += _onCancelEvent;
+        AppDomain.CurrentDomain.FirstChanceException += (object sender, System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs e) => Console.WriteLine("FIRST CHANCE EXCEPTION: " + LogFormatter.PrintException(e.Exception));
+        AppDomain.CurrentDomain.UnhandledException += (object sender, UnhandledExceptionEventArgs e) => Console.WriteLine("UNHANDLED EXCEPTION: " + LogFormatter.PrintException((Exception)e.ExceptionObject));
+    }
+
+    private void CancelPressed(object sender, ConsoleCancelEventArgs e)
+    {
+        Environment.Exit(0);
+    }
+
+    public ValueTask Ping() => grain.Ping();
+
+    public async Task PingForever()
+    {
+        while (true)
+        {
+            await grain.Ping();
+        }
+    }
+
+    public async Task Shutdown()
+    {
+        if (clientHost is { } client)
+        {
+            await client.StopAsync();
+            if (client is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else
+            {
+                client.Dispose();
+            }
+        }
+
+        this.hosts.Reverse();
+        foreach (var host in this.hosts)
+        {
+            await host.StopAsync();
+            if (host is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else
+            {
+                host.Dispose();
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        (this.client as IDisposable)?.Dispose();
+        this.hosts.ForEach(h => h.Dispose());
+
+        Console.CancelKeyPress -= _onCancelEvent;
+    }
+}

--- a/test/Benchmarks.Scenarios/Ping/PingScenario.cs
+++ b/test/Benchmarks.Scenarios/Ping/PingScenario.cs
@@ -1,0 +1,184 @@
+#nullable enable
+using System.Net;
+using BenchmarkGrainInterfaces.Ping;
+using BenchmarkGrains.Ping;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.Configuration;
+
+namespace Benchmarks.Scenarios.Ping;
+
+/// <summary>
+/// Scenario for grain-to-grain communication latency and throughput using simple ping operations.
+/// </summary>
+public class PingScenario : IAsyncDisposable, IDisposable
+{
+    private readonly ConsoleCancelEventHandler? _onCancelEvent;
+    private readonly List<IHost> hosts = new List<IHost>();
+    private readonly IPingGrain grain;
+    private readonly IClusterClient client;
+    private readonly IHost? clientHost;
+
+    public PingScenario() : this(1, false) { }
+
+    public PingScenario(int numSilos, bool startClient, bool grainsOnSecondariesOnly = false)
+    {
+        for (var i = 0; i < numSilos; ++i)
+        {
+            var primary = i == 0 ? null : new IPEndPoint(IPAddress.Loopback, 11111);
+            var hostBuilder = new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+            {
+                siloBuilder.UseLocalhostClustering(
+                    siloPort: 11111 + i,
+                    gatewayPort: 30000 + i,
+                    primarySiloEndpoint: primary);
+
+                if (i == 0 && grainsOnSecondariesOnly)
+                {
+                    siloBuilder.Configure<GrainTypeOptions>(options => options.Classes.Remove(typeof(PingGrain)));
+                }
+            });
+
+            var host = hostBuilder.Build();
+
+            host.StartAsync().GetAwaiter().GetResult();
+            this.hosts.Add(host);
+        }
+
+        if (grainsOnSecondariesOnly) Thread.Sleep(4000);
+
+        if (startClient)
+        {
+            var hostBuilder = new HostBuilder().UseOrleansClient((ctx, clientBuilder) =>
+            {
+                if (numSilos == 1)
+                {
+                    clientBuilder.UseLocalhostClustering();
+                }
+                else
+                {
+                    var gateways = Enumerable.Range(30000, numSilos).Select(i => new IPEndPoint(IPAddress.Loopback, i)).ToArray();
+                    clientBuilder.UseStaticClustering(gateways);
+                }
+            });
+
+            this.clientHost = hostBuilder.Build();
+            this.clientHost.StartAsync().GetAwaiter().GetResult();
+
+            this.client = this.clientHost.Services.GetRequiredService<IClusterClient>();
+            var grainFactory = this.client;
+
+            this.grain = grainFactory.GetGrain<IPingGrain>(Guid.NewGuid().GetHashCode());
+            this.grain.Run().AsTask().GetAwaiter().GetResult();
+        }
+        else
+        {
+            var host = hosts[0];
+            this.client = host.Services.GetRequiredService<IClusterClient>();
+            this.grain = client.GetGrain<IPingGrain>(Guid.NewGuid().GetHashCode());
+            this.grain.Run().AsTask().GetAwaiter().GetResult();
+        }
+
+        _onCancelEvent = CancelPressed;
+        Console.CancelKeyPress += _onCancelEvent;
+    }
+
+    private void CancelPressed(object? sender, ConsoleCancelEventArgs e)
+    {
+        Environment.Exit(0);
+    }
+
+    public ValueTask Ping() => grain.Run();
+
+    public async Task PingForever()
+    {
+        while (true)
+        {
+            await grain.Run();
+        }
+    }
+
+    public Task PingConcurrentForever() => this.Run(
+        runs: int.MaxValue,
+        grainFactory: this.client,
+        blocksPerWorker: 10);
+
+    public Task PingConcurrent() => this.Run(
+        runs: 10,
+        grainFactory: this.client,
+        blocksPerWorker: 10);
+
+    public Task PingConcurrentHostedClient(int blocksPerWorker = 30) => this.Run(
+        runs: 10,
+        grainFactory: this.hosts[0].Services.GetRequiredService<IGrainFactory>(),
+        blocksPerWorker: blocksPerWorker);
+
+    private async Task Run(int runs, IGrainFactory grainFactory, int blocksPerWorker)
+    {
+        var loadGenerator = new ConcurrentLoadGenerator<IPingGrain>(
+            maxConcurrency: 100,
+            blocksPerWorker: blocksPerWorker,
+            requestsPerBlock: 500,
+            issueRequest: g => g.Run(),
+            getStateForWorker: workerId => grainFactory.GetGrain<IPingGrain>(workerId));
+        await loadGenerator.Warmup();
+        while (runs-- > 0) await loadGenerator.Run();
+    }
+
+    public async Task PingPongForever()
+    {
+        var other = this.client.GetGrain<IPingGrain>(Guid.NewGuid().GetHashCode());
+        while (true)
+        {
+            await grain.PingPongInterleave(other, 100);
+        }
+    }
+
+    public async Task Shutdown()
+    {
+        if (clientHost is { } client)
+        {
+            await client.StopAsync();
+            await DisposeAsync(client);
+        }
+
+        this.hosts.Reverse();
+        foreach (var host in this.hosts)
+        {
+            await host.StopAsync();
+            await DisposeAsync(host);
+        }
+    }
+
+    public void Dispose()
+    {
+        (this.client as IDisposable)?.Dispose();
+        this.hosts.ForEach(h => h.Dispose());
+
+        Console.CancelKeyPress -= _onCancelEvent;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeAsync(this.client);
+        var allHosts = ((IEnumerable<IHost>)this.hosts).Reverse().ToList();
+        foreach (var host in hosts)
+        {
+            await DisposeAsync(host);
+        }
+
+        Console.CancelKeyPress -= _onCancelEvent;
+    }
+
+    private static async ValueTask DisposeAsync(object? obj)
+    {
+        if (obj is IAsyncDisposable iad)
+        {
+            await iad.DisposeAsync();
+        }
+        else if (obj is IDisposable id)
+        {
+            id.Dispose();
+        }
+    }
+}

--- a/test/Benchmarks.Scenarios/Ping/StatelessWorkerScenario.cs
+++ b/test/Benchmarks.Scenarios/Ping/StatelessWorkerScenario.cs
@@ -1,0 +1,211 @@
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.Concurrency;
+
+namespace Benchmarks.Scenarios.Ping;
+
+/// <summary>
+/// Scenario for stateless worker grain performance and adaptive worker pool management.
+/// </summary>
+public class StatelessWorkerScenario : IDisposable
+{
+    private readonly IHost _host;
+    private readonly IGrainFactory _grainFactory;
+
+    public StatelessWorkerScenario()
+    {
+        _host = new HostBuilder()
+            .UseOrleans((_, siloBuilder) => siloBuilder
+            .UseLocalhostClustering())
+            .Build();
+
+        _host.StartAsync().GetAwaiter().GetResult();
+        _grainFactory = _host.Services.GetRequiredService<IGrainFactory>();
+    }
+
+    public void Dispose()
+    {
+        _host.StopAsync().GetAwaiter().GetResult();
+        _host.Dispose();
+    }
+
+    public async Task RunAsync()
+    {
+        await Run<IMonotonicGrain, SWMonotonicGrain>(_grainFactory.GetGrain<IMonotonicGrain>(0));
+        await Run<IAdaptiveGrain, SWAdaptiveGrain>(_grainFactory.GetGrain<IAdaptiveGrain>(0));
+    }
+
+    private async static Task Run<T, H>(T grain)
+        where T : IProcessorGrain
+        where H : BaseGrain<H>
+    {
+        Console.WriteLine($"Executing scenario for {typeof(H).Name}");
+
+        using var cts = new CancellationTokenSource();
+
+        var statsCollector = Task.Run(async () =>
+        {
+            while (!cts.Token.IsCancellationRequested)
+            {
+                await Task.Delay(1, cts.Token);
+                BaseGrain<H>.UpdateStats();
+            }
+        }, cts.Token);
+
+        var tasks = new List<Task>();
+
+        const int ConcurrencyLevel = 100;
+        const double Lambda = 10.0d;
+
+        for (var i = 0; i < ConcurrencyLevel; i++)
+        {
+            // For a Poisson process with rate λ (tasks / sec in our case), the time between arrivals is
+            // exponentially distributed with density: f(t) = λe^(-λt), t >= 0; and the interarrival
+            // time can be generated as: Δt = -ln(U) / λ, where U is uniformly distributed on (0, 1)
+
+            var u = Random.Shared.NextDouble();
+            var delaySec = -Math.Log(u > 0 ? u : double.Epsilon) / Lambda;
+            var delayMs = (int)(1000 * delaySec);
+
+            await Task.Delay(delayMs);
+            tasks.Add(grain.Process());
+        }
+
+        await Task.WhenAll(tasks);
+
+        const int CooldownCycles = 10;
+
+        for (var i = 1; i <= CooldownCycles; i++)
+        {
+            var cooldownCycle = $"({i}/{CooldownCycles})";
+
+            Console.WriteLine($"\nWaiting for cooldown {cooldownCycle}\n");
+
+            var cooldownMs = (int)(0.1 * Math.Ceiling(ScenarioConstants.ProcessDelayMs *
+               ((double)ConcurrencyLevel / ScenarioConstants.MaxWorkersLimit)));
+
+            await Task.Delay(cooldownMs);
+
+            Console.WriteLine($"Stats {cooldownCycle}:");
+            Console.WriteLine($" Active Workers:  {BaseGrain<H>.GetActiveWorkers()}");
+            Console.WriteLine($" Average Workers: {BaseGrain<H>.GetAverageActiveWorkers()}");
+            Console.WriteLine($" Maximum Workers: {BaseGrain<H>.GetMaxActiveWorkers()}");
+            Console.Write("\n---------------------------------------------------------------------\n");
+        }
+
+        cts.Cancel();
+
+        try
+        {
+            await statsCollector;
+        }
+        catch (OperationCanceledException)
+        {
+
+        }
+
+        BaseGrain<H>.Stop();
+    }
+
+    public static class ScenarioConstants
+    {
+        public const int MaxWorkersLimit = 10;
+        public const int ProcessDelayMs = 1000;
+    }
+
+    public interface IProcessorGrain : IGrainWithIntegerKey
+    {
+        Task Process();
+    }
+
+    public interface IAdaptiveGrain : IProcessorGrain { }
+    public interface IMonotonicGrain : IProcessorGrain { }
+
+    [StatelessWorker(ScenarioConstants.MaxWorkersLimit, removeIdleWorkers: false)]
+    public class SWMonotonicGrain : BaseGrain<SWMonotonicGrain>, IMonotonicGrain { }
+
+    [StatelessWorker(ScenarioConstants.MaxWorkersLimit, removeIdleWorkers: true)]
+    public class SWAdaptiveGrain : BaseGrain<SWAdaptiveGrain>, IAdaptiveGrain { }
+
+    public abstract class BaseGrain<T> : Grain, IProcessorGrain where T : BaseGrain<T>
+    {
+        private static int _activeWorkers = 0;
+        private static int _maxActiveWorkers = 0;
+        private static long _totalWorkerTicks = 0;
+        private static long _lastUpdateTicks = 0;
+
+        private static int _watchStarted = 0;
+        private static int _watchStopped = 0;
+
+        private static readonly Stopwatch Watch = new();
+
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.CompareExchange(ref _watchStarted, 1, 0) == 0)
+            {
+                Watch.Start();
+            }
+
+            Interlocked.Increment(ref _activeWorkers);
+            UpdateStats();
+
+            return Task.CompletedTask;
+        }
+
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+        {
+            Interlocked.Decrement(ref _activeWorkers);
+            UpdateStats();
+
+            if (Volatile.Read(ref _activeWorkers) == 0 &&
+                Interlocked.CompareExchange(ref _watchStopped, 1, 0) == 0)
+            {
+                Watch.Stop();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task Process() => Task.Delay(ScenarioConstants.ProcessDelayMs);
+
+        public static void UpdateStats()
+        {
+            var currentWorkers = Volatile.Read(ref _activeWorkers);
+
+            int oldMax;
+            do
+            {
+                oldMax = Volatile.Read(ref _maxActiveWorkers);
+                if (currentWorkers <= oldMax)
+                {
+                    break;
+                }
+            } while (Interlocked.CompareExchange(ref _maxActiveWorkers, currentWorkers, oldMax) != oldMax);
+
+            var elapsedTicks = Watch.Elapsed.Ticks;
+            var previousUpdate = Interlocked.Exchange(ref _lastUpdateTicks, elapsedTicks);
+            var elapsedSinceLastUpdate = elapsedTicks - previousUpdate;
+
+            Interlocked.Add(ref _totalWorkerTicks, currentWorkers * elapsedSinceLastUpdate);
+        }
+
+        public static void Stop()
+        {
+            UpdateStats();
+            Watch.Stop();
+        }
+
+        public static int GetActiveWorkers() => Volatile.Read(ref _activeWorkers);
+        public static int GetMaxActiveWorkers() => Volatile.Read(ref _maxActiveWorkers);
+
+        public static double GetAverageActiveWorkers()
+        {
+            var totalTicks = Volatile.Read(ref _totalWorkerTicks);
+            var elapsedTicks = Watch.Elapsed.Ticks;
+            var result = elapsedTicks == 0 ? 0 : (double)totalTicks / elapsedTicks;
+
+            return Math.Round(result, MidpointRounding.ToEven);
+        }
+    }
+}

--- a/test/Benchmarks.Scenarios/Program.cs
+++ b/test/Benchmarks.Scenarios/Program.cs
@@ -1,0 +1,355 @@
+using System.Diagnostics;
+using Benchmarks.Scenarios.MapReduce;
+using Benchmarks.Scenarios.Ping;
+using Benchmarks.Scenarios.Transactions;
+using Benchmarks.Scenarios.GrainStorage;
+
+namespace Benchmarks.Scenarios;
+
+internal class Program
+{
+    private static readonly Dictionary<string, Action<string[]>> _scenarios = new Dictionary<string, Action<string[]>>
+    {
+        ["MapReduce"] = _ =>
+        {
+            RunScenario(
+            "Running MapReduce scenario",
+            () =>
+            {
+                var scenario = new MapReduceScenario();
+                scenario.Setup();
+                return scenario;
+            },
+            scenario => scenario.RunAsync().GetAwaiter().GetResult(),
+            scenario => scenario.Teardown());
+        },
+        ["Transactions.Memory"] = _ =>
+        {
+            RunScenario(
+            "Running Transactions scenario",
+            () =>
+            {
+                var scenario = new TransactionScenario(2, 20000, 5000);
+                scenario.MemorySetup();
+                return scenario;
+            },
+            scenario => scenario.RunAsync().GetAwaiter().GetResult(),
+            scenario => scenario.Teardown());
+        },
+        ["Transactions.Memory.Throttled"] = _ =>
+        {
+            RunScenario(
+            "Running Transactions scenario",
+            () =>
+            {
+                var scenario = new TransactionScenario(2, 200000, 15000);
+                scenario.MemoryThrottledSetup();
+                return scenario;
+            },
+            scenario => scenario.RunAsync().GetAwaiter().GetResult(),
+            scenario => scenario.Teardown());
+        },
+        ["Transactions.Azure"] = _ =>
+        {
+            RunScenario(
+            "Running Transactions scenario",
+            () =>
+            {
+                var scenario = new TransactionScenario(2, 20000, 5000);
+                scenario.AzureSetup();
+                return scenario;
+            },
+            scenario => scenario.RunAsync().GetAwaiter().GetResult(),
+            scenario => scenario.Teardown());
+        },
+        ["Transactions.Azure.Throttled"] = _ =>
+        {
+            RunScenario(
+            "Running Transactions scenario",
+            () =>
+            {
+                var scenario = new TransactionScenario(2, 200000, 15000);
+                scenario.AzureThrottledSetup();
+                return scenario;
+            },
+            scenario => scenario.RunAsync().GetAwaiter().GetResult(),
+            scenario => scenario.Teardown());
+        },
+        ["Transactions.Azure.Overloaded"] = _ =>
+        {
+            RunScenario(
+            "Running Transactions scenario",
+            () =>
+            {
+                var scenario = new TransactionScenario(2, 200000, 15000);
+                scenario.AzureSetup();
+                return scenario;
+            },
+            scenario => scenario.RunAsync().GetAwaiter().GetResult(),
+            scenario => scenario.Teardown());
+        },
+        ["ConcurrentPing"] = _ =>
+        {
+            {
+                Console.WriteLine("## Client to Silo ##");
+                using var test = new PingScenario(numSilos: 1, startClient: true);
+                test.PingConcurrent().GetAwaiter().GetResult();
+                test.Shutdown().GetAwaiter().GetResult();
+            }
+            {
+                Console.WriteLine("## Client to 2 Silos ##");
+                using var test = new PingScenario(numSilos: 2, startClient: true);
+                test.PingConcurrent().GetAwaiter().GetResult();
+                test.Shutdown().GetAwaiter().GetResult();
+            }
+            {
+                Console.WriteLine("## Hosted Client ##");
+                using var test = new PingScenario(numSilos: 1, startClient: false);
+                test.PingConcurrentHostedClient().GetAwaiter().GetResult();
+                test.Shutdown().GetAwaiter().GetResult();
+            }
+            {
+                // All calls are cross-silo because the calling silo doesn't have any grain classes.
+                Console.WriteLine("## Silo to Silo ##");
+                using var test = new PingScenario(numSilos: 2, startClient: false, grainsOnSecondariesOnly: true);
+                test.PingConcurrentHostedClient(blocksPerWorker: 10).GetAwaiter().GetResult();
+                test.Shutdown().GetAwaiter().GetResult();
+            }
+            {
+                Console.WriteLine("## Hosted Client ##");
+                using var test = new PingScenario(numSilos: 1, startClient: false);
+                test.PingConcurrentHostedClient().GetAwaiter().GetResult();
+                test.Shutdown().GetAwaiter().GetResult();
+            }
+        },
+        ["ConcurrentPing_OneSilo"] = _ =>
+        {
+            using var test = new PingScenario(numSilos: 1, startClient: true);
+            test.PingConcurrent().GetAwaiter().GetResult();
+            test.Shutdown().GetAwaiter().GetResult();
+        },
+        ["ConcurrentPing_TwoSilos"] = _ =>
+        {
+            using var test = new PingScenario(numSilos: 2, startClient: true);
+            test.PingConcurrent().GetAwaiter().GetResult();
+            test.Shutdown().GetAwaiter().GetResult();
+        },
+        ["ConcurrentPing_TwoSilos_Forever"] = _ =>
+        {
+            Console.WriteLine("## Client to 2 Silos ##");
+            using var test = new PingScenario(numSilos: 2, startClient: true);
+            test.PingConcurrentForever().GetAwaiter().GetResult();
+        },
+        ["ConcurrentPing_HostedClient"] = _ =>
+        {
+            using var test = new PingScenario(numSilos: 1, startClient: false);
+            test.PingConcurrentHostedClient().GetAwaiter().GetResult();
+            test.Shutdown().GetAwaiter().GetResult();
+        },
+        ["ConcurrentPing_HostedClient_Forever"] = _ =>
+        {
+            using var scenario = new PingScenario(numSilos: 1, startClient: false);
+            Console.WriteLine("Press any key to end.");
+            Console.WriteLine("## Hosted Client ##");
+            using var cts = new CancellationTokenSource();
+            Console.CancelKeyPress += (_, e) =>
+            {
+                e.Cancel = true;
+                cts.Cancel();
+            };
+            while (!cts.IsCancellationRequested)
+            {
+                scenario.PingConcurrentHostedClient().GetAwaiter().GetResult();
+            }
+
+            scenario.Shutdown().GetAwaiter().GetResult();
+            Console.WriteLine("Interrupted by user");
+        },
+        ["ConcurrentPing_SiloToSilo"] = _ =>
+        {
+            using var test = new PingScenario(numSilos: 2, startClient: false, grainsOnSecondariesOnly: true);
+            test.PingConcurrentHostedClient(blocksPerWorker: 10).GetAwaiter().GetResult();
+            test.Shutdown().GetAwaiter().GetResult();
+        },
+        ["ConcurrentPing_SiloToSilo_Forever"] = _ =>
+        {
+            //Console.WriteLine("Press any key to begin.");
+            //Console.ReadKey();
+            Console.WriteLine("Press any key to end.");
+            Console.WriteLine("## Silo to Silo ##");
+            while (!Console.KeyAvailable)
+            {
+                Console.WriteLine("Initializing");
+                using var test = new PingScenario(numSilos: 2, startClient: false, grainsOnSecondariesOnly: true);
+                Console.WriteLine("Starting");
+                test.PingConcurrentHostedClient(blocksPerWorker: 100).GetAwaiter().GetResult();
+                Console.WriteLine("Stopping");
+                test.Shutdown().GetAwaiter().GetResult();
+                Console.WriteLine("Stopped");
+            }
+
+            Console.WriteLine("Interrupted by user");
+        },
+        ["ConcurrentPing_SiloToSilo_Long"] = _ =>
+        {
+            using var test = new PingScenario(numSilos: 2, startClient: false, grainsOnSecondariesOnly: true);
+            test.PingConcurrentHostedClient(blocksPerWorker: 1000).GetAwaiter().GetResult();
+            test.Shutdown().GetAwaiter().GetResult();
+        },
+        ["AdaptivePing"] = _ =>
+        {
+            // Default: HostedClient mode with hill climbing concurrency tuning
+            var scenario = new AdaptivePingScenario(AdaptivePingScenario.ScenarioMode.HostedClient);
+            scenario.RunAsync().GetAwaiter().GetResult();
+            scenario.ShutdownAsync().GetAwaiter().GetResult();
+        },
+        ["AdaptivePing_HostedClient"] = _ =>
+        {
+            var scenario = new AdaptivePingScenario(AdaptivePingScenario.ScenarioMode.HostedClient);
+            scenario.RunAsync().GetAwaiter().GetResult();
+            scenario.ShutdownAsync().GetAwaiter().GetResult();
+        },
+        ["AdaptivePing_ClientToOneSilo"] = _ =>
+        {
+            var scenario = new AdaptivePingScenario(AdaptivePingScenario.ScenarioMode.ExternalClient, numSilos: 1);
+            scenario.RunAsync().GetAwaiter().GetResult();
+            scenario.ShutdownAsync().GetAwaiter().GetResult();
+        },
+        ["AdaptivePing_ClientToTwoSilos"] = _ =>
+        {
+            var scenario = new AdaptivePingScenario(AdaptivePingScenario.ScenarioMode.ExternalClient, numSilos: 2);
+            scenario.RunAsync().GetAwaiter().GetResult();
+            scenario.ShutdownAsync().GetAwaiter().GetResult();
+        },
+        ["AdaptivePing_SiloToSilo"] = _ =>
+        {
+            var scenario = new AdaptivePingScenario(AdaptivePingScenario.ScenarioMode.SiloToSilo, numSilos: 2);
+            scenario.RunAsync().GetAwaiter().GetResult();
+            scenario.ShutdownAsync().GetAwaiter().GetResult();
+        },
+        ["AdaptivePing_All"] = _ =>
+        {
+            AdaptivePingScenario.RunAllScenariosAsync().GetAwaiter().GetResult();
+        },
+        ["ConcurrentPing_OneSilo_Forever"] = _ =>
+        {
+            new PingScenario(numSilos: 1, startClient: true).PingConcurrentForever().GetAwaiter().GetResult();
+        },
+        ["PingOnce"] = _ =>
+        {
+            new PingScenario().Ping().GetAwaiter().GetResult();
+        },
+        ["PingForever"] = _ =>
+        {
+            new PingScenario().PingForever().GetAwaiter().GetResult();
+        },
+        ["PingPongForever"] = _ =>
+        {
+            new PingScenario().PingPongForever().GetAwaiter().GetResult();
+        },
+        ["PingForever_Min_Threads"] = _ =>
+        {
+            ThreadPool.SetMaxThreads(1, 1);
+            new PingScenario().PingForever().GetAwaiter().GetResult();
+        },
+        ["FanoutForever"] = _ =>
+        {
+            new FanoutScenario().PingForever().GetAwaiter().GetResult();
+        },
+        ["StatelessWorker"] = _ =>
+        {
+            RunScenario("", () => new StatelessWorkerScenario(),
+            scenario => scenario.RunAsync().GetAwaiter().GetResult(),
+            scenario => scenario.Dispose());
+        },
+        ["GrainStorage.Memory"] = _ =>
+        {
+            RunScenario(
+            "Running grain storage scenario against memory",
+            () =>
+            {
+                var scenario = new GrainStorageScenario(10, 10000, TimeSpan.FromSeconds( 30 ));
+                scenario.MemorySetup();
+                return scenario;
+            },
+            scenario => scenario.RunAsync().GetAwaiter().GetResult(),
+            scenario => scenario.Teardown());
+        },
+        ["GrainStorage.AzureTable"] = _ =>
+        {
+            RunScenario(
+            "Running grain storage scenario against Azure Table",
+            () =>
+            {
+                var scenario = new GrainStorageScenario(100, 10000, TimeSpan.FromSeconds( 30 ));
+                scenario.AzureTableSetup();
+                return scenario;
+            },
+            scenario => scenario.RunAsync().GetAwaiter().GetResult(),
+            scenario => scenario.Teardown());
+        },
+        ["GrainStorage.AzureBlob"] = _ =>
+        {
+            RunScenario(
+            "Running grain storage scenario against Azure Blob",
+            () =>
+            {
+                var scenario = new GrainStorageScenario(10, 10000, TimeSpan.FromSeconds( 30 ));
+                scenario.AzureBlobSetup();
+                return scenario;
+            },
+            scenario => scenario.RunAsync().GetAwaiter().GetResult(),
+            scenario => scenario.Teardown());
+        },
+        ["GrainStorage.AdoNet"] = _ =>
+        {
+            RunScenario(
+            "Running grain storage scenario against AdoNet",
+            () =>
+            {
+                var scenario = new GrainStorageScenario(100, 10000, TimeSpan.FromSeconds( 30 ));
+                scenario.AdoNetSetup();
+                return scenario;
+            },
+            scenario => scenario.RunAsync().GetAwaiter().GetResult(),
+            scenario => scenario.Teardown());
+        },
+    };
+
+    // requires scenario name or 'All' word as first parameter
+    public static void Main(string[] args)
+    {
+        var slicedArgs = args.Skip(1).ToArray();
+        if (args.Length > 0 && args[0].Equals("all", StringComparison.InvariantCultureIgnoreCase))
+        {
+            Console.WriteLine("Running full scenarios suite");
+            _scenarios.Select(pair => pair.Value).ToList().ForEach(action => action(slicedArgs));
+            return;
+        }
+
+        if (args.Length == 0 || !_scenarios.ContainsKey(args[0]))
+        {
+            Console.WriteLine("Please, select scenario, list of available:");
+            _scenarios
+                .Select(pair => pair.Key)
+                .ToList()
+                .ForEach(Console.WriteLine);
+            Console.WriteLine("All");
+            return;
+        }
+
+        _scenarios[args[0]](slicedArgs);
+    }
+
+    private static void RunScenario<T>(string name, Func<T> init, Action<T> scenarioAction, Action<T> tearDown)
+    {
+        Console.WriteLine(name);
+        var scenario = init();
+        var stopWatch = Stopwatch.StartNew();
+        scenarioAction(scenario);
+        Console.WriteLine($"Elapsed milliseconds: {stopWatch.ElapsedMilliseconds}");
+        Console.WriteLine("Press any key to continue ...");
+        tearDown(scenario);
+        Console.ReadLine();
+    }
+}

--- a/test/Benchmarks.Scenarios/Transactions/TransactionScenario.cs
+++ b/test/Benchmarks.Scenarios/Transactions/TransactionScenario.cs
@@ -1,0 +1,151 @@
+using Orleans.TestingHost;
+using BenchmarkGrainInterfaces.Transaction;
+using TestExtensions;
+using Orleans.Transactions;
+
+namespace Benchmarks.Scenarios.Transactions;
+
+public class TransactionScenario : IDisposable
+{
+    private TestCluster host;
+    private readonly int runs;
+    private readonly int transactionsPerRun;
+    private readonly int concurrent;
+
+    public TransactionScenario(int runs, int transactionsPerRun, int concurrent)
+    {
+        this.runs = runs;
+        this.transactionsPerRun = transactionsPerRun;
+        this.concurrent = concurrent;
+    }
+
+    public void MemorySetup()
+    {
+        var builder = new TestClusterBuilder(4);
+        builder.AddSiloBuilderConfigurator<SiloMemoryStorageConfigurator>();
+        builder.AddSiloBuilderConfigurator<SiloTransactionConfigurator>();
+        this.host = builder.Build();
+        this.host.Deploy();
+    }
+
+    public void MemoryThrottledSetup()
+    {
+        var builder = new TestClusterBuilder(4);
+        builder.AddSiloBuilderConfigurator<SiloMemoryStorageConfigurator>();
+        builder.AddSiloBuilderConfigurator<SiloTransactionConfigurator>();
+        builder.AddSiloBuilderConfigurator<SiloTransactionThrottlingConfigurator>();
+        this.host = builder.Build();
+        this.host.Deploy();
+    }
+
+    public void AzureSetup()
+    {
+        var builder = new TestClusterBuilder(4);
+        builder.AddSiloBuilderConfigurator<SiloAzureStorageConfigurator>();
+        builder.AddSiloBuilderConfigurator<SiloTransactionConfigurator>();
+        this.host = builder.Build();
+        this.host.Deploy();
+    }
+
+    public void AzureThrottledSetup()
+    {
+        var builder = new TestClusterBuilder(4);
+        builder.AddSiloBuilderConfigurator<SiloAzureStorageConfigurator>();
+        builder.AddSiloBuilderConfigurator<SiloTransactionConfigurator>();
+        builder.AddSiloBuilderConfigurator<SiloTransactionThrottlingConfigurator>();
+        this.host = builder.Build();
+        this.host.Deploy();
+    }
+
+    public class SiloMemoryStorageConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder hostBuilder)
+        {
+            hostBuilder.AddMemoryGrainStorageAsDefault();
+        }
+    }
+
+    public class SiloAzureStorageConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder hostBuilder)
+        {
+            hostBuilder.AddAzureTableTransactionalStateStorageAsDefault(options =>
+            {
+                options.TableServiceClient = new(TestDefaultConfiguration.DataConnectionString);
+            });
+        }
+    }
+
+    public class SiloTransactionThrottlingConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder hostBuilder)
+        {
+            hostBuilder.Configure<TransactionRateLoadSheddingOptions>(options =>
+            {
+                options.Enabled = true;
+                options.Limit = 50;
+            });
+        }
+    }
+
+    public async Task RunAsync()
+    {
+        Console.WriteLine($"Cold Run.");
+        await FullRunAsync();
+        for(int i=0; i<runs; i++)
+        {
+            Console.WriteLine($"Warm Run {i+1}.");
+            await FullRunAsync();
+        }
+    }
+
+    private async Task FullRunAsync()
+    {
+        int runners = Math.Max(1,(int)Math.Sqrt(concurrent));
+        int transactionsPerRunner = Math.Max(1, this.transactionsPerRun / runners);
+        Report[] reports = await Task.WhenAll(Enumerable.Range(0, runners).Select(i => RunAsync(i, transactionsPerRunner, runners)));
+        Report finalReport = new Report();
+        foreach (Report report in reports)
+        {
+            finalReport.Succeeded += report.Succeeded;
+            finalReport.Failed += report.Failed;
+            finalReport.Throttled += report.Throttled;
+            finalReport.Elapsed = TimeSpan.FromMilliseconds(Math.Max(finalReport.Elapsed.TotalMilliseconds, report.Elapsed.TotalMilliseconds));
+        }
+        Console.WriteLine($"{finalReport.Succeeded} transactions in {finalReport.Elapsed.TotalMilliseconds}ms.");
+        Console.WriteLine($"{(int)(finalReport.Succeeded * 1000 / finalReport.Elapsed.TotalMilliseconds)} transactions per second.");
+        Console.WriteLine($"{finalReport.Failed} transactions failed.");
+        Console.WriteLine($"{finalReport.Throttled} transactions were throttled.");
+    }
+
+    public async Task<Report> RunAsync(int run, int transactiosPerRun, int concurrentPerRun)
+    {
+        ILoadGrain load = this.host.Client.GetGrain<ILoadGrain>(Guid.NewGuid());
+        await load.Generate(run, transactiosPerRun, concurrentPerRun);
+        Report report = null;
+        while (report == null)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(10));
+            report = await load.TryGetReport();
+        }
+        return report;
+    }
+
+    public void Teardown()
+    {
+        host.StopAllSilos();
+    }
+
+    public void Dispose()
+    {
+        host?.Dispose();
+    }
+
+    public sealed class SiloTransactionConfigurator : ISiloConfigurator
+    {
+        public void Configure(ISiloBuilder hostBuilder)
+        {
+            hostBuilder.UseTransactions();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a standalone `Benchmarks.Scenarios` executable project for Orleans throughput and latency scenarios.
- Wires the project into the solution and references the required benchmark/test/provider projects.
- Adds runnable scenarios for concurrent/adaptive ping, fanout, stateless workers, map-reduce, grain storage, and transactions.

## Validation
- `git diff --check HEAD~1..HEAD`
- conflict-marker scan
- SEDA search in changed paths
- `dotnet build test\Benchmarks.Scenarios\Benchmarks.Scenarios.csproj -m`

## Notes
- Scenario execution still requires provider setup/config for Azure Storage, ADO.NET/SQL, and transactions where applicable.

###### Microsoft Reviewers: Open in CodeFlow https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10063
