### PR TITLE
Add fast-path message destination cache

### DIFF
--- a/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/GrainReference.cs
@@ -253,7 +253,7 @@ namespace Orleans.Runtime
     [DefaultInvokableBaseType(typeof(Task), typeof(TaskRequest))]
     [DefaultInvokableBaseType(typeof(void), typeof(VoidRequest))]
     [DefaultInvokableBaseType(typeof(IAsyncEnumerable<>), typeof(AsyncEnumerableRequest<>))]
-    public class GrainReference : IAddressable, IEquatable<GrainReference>, ISpanFormattable
+    public class GrainReference : IAddressable, IEquatable<GrainReference>, ISpanFormattable, IMessageReceiverCache
     {
         /// <summary>
         /// The grain reference functionality which is shared by all grain references of a given type.
@@ -266,6 +266,12 @@ namespace Orleans.Runtime
         /// </summary>
         [NonSerialized]
         private readonly IdSpan _key;
+
+        /// <summary>
+        /// Gets or sets a cached recipient which can be used to handle messages sent to the target represented by this instance.
+        /// </summary>
+        [field: NonSerialized]
+        public object? MessageReceiver { get; set; }
 
         /// <summary>
         /// Gets the grain reference functionality which is shared by all grain references of a given type.

--- a/src/Orleans.Core.Abstractions/Runtime/IMessageReceiverCache.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IMessageReceiverCache.cs
@@ -1,0 +1,12 @@
+namespace Orleans.Runtime;
+
+/// <summary>
+/// Acts as a cache for a message recipient.
+/// </summary>
+public interface IMessageReceiverCache
+{
+    /// <summary>
+    /// Gets or sets a cached recipient which can be used to handle messages sent to the target represented by this instance.
+    /// </summary>
+    object? MessageReceiver { get; set; }
+}

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -239,7 +239,8 @@ namespace Orleans.Messaging
             // If there's a specific gateway specified, use it
             if (msg.TargetSilo != null && gatewayManager.IsGatewayAvailable(msg.TargetSilo))
             {
-                var connectionTask = this.connectionManager.GetConnection(msg.TargetSilo);
+                var siloAddress = SiloAddress.New(msg.TargetSilo.Endpoint, 0);
+                var connectionTask = this.connectionManager.GetConnection(siloAddress);
                 if (connectionTask.IsCompletedSuccessfully) return connectionTask;
 
                 return ConnectAsync(msg.TargetSilo, connectionTask, msg, directGatewayMessage: true);

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -169,11 +169,17 @@ namespace Orleans.Messaging
             static void ThrowNullMessageHandler() => throw new InvalidOperationException("MessageCenter does not have a message handler set");
         }
 
-        public void SendMessage(Message msg)
+        public void SendMessage(Message msg, IMessageReceiverCache receiverCache)
         {
             if (!Running)
             {
                 LogNotRunning(msg);
+                return;
+            }
+
+            if (receiverCache?.MessageReceiver is IMessageReceiver receiver)
+            {
+                receiver.ReceiveMessage(msg, receiverCache);
                 return;
             }
 
@@ -184,13 +190,15 @@ namespace Orleans.Messaging
                 if (connection is null) return;
 
                 connection.Send(msg);
+                receiverCache?.MessageReceiver = connection;
+
                 LogSendingMessage(msg, connection.RemoteEndPoint);
             }
             else
             {
-                _ = SendAsync(connectionTask, msg);
+                _ = SendAsync(connectionTask, msg, receiverCache);
 
-                async Task SendAsync(ValueTask<Connection> task, Message message)
+                async Task SendAsync(ValueTask<Connection> task, Message message, IMessageReceiverCache targetCache)
                 {
                     try
                     {
@@ -200,6 +208,7 @@ namespace Orleans.Messaging
                         if (connection is null) return;
 
                         connection.Send(message);
+                        targetCache?.MessageReceiver = connection;
 
                         LogSendingMessage(message, connection.RemoteEndPoint);
                     }
@@ -210,7 +219,7 @@ namespace Orleans.Messaging
                             ++message.RetryCount;
 
                             _ = Task.Factory.StartNew(
-                                state => this.SendMessage((Message)state),
+                                state => this.SendMessage((Message)state, targetCache),
                                 message,
                                 CancellationToken.None,
                                 TaskCreationOptions.DenyChildAttach,
@@ -230,8 +239,7 @@ namespace Orleans.Messaging
             // If there's a specific gateway specified, use it
             if (msg.TargetSilo != null && gatewayManager.IsGatewayAvailable(msg.TargetSilo))
             {
-                var siloAddress = SiloAddress.New(msg.TargetSilo.Endpoint, 0);
-                var connectionTask = this.connectionManager.GetConnection(siloAddress);
+                var connectionTask = this.connectionManager.GetConnection(msg.TargetSilo);
                 if (connectionTask.IsCompletedSuccessfully) return connectionTask;
 
                 return ConnectAsync(msg.TargetSilo, connectionTask, msg, directGatewayMessage: true);

--- a/src/Orleans.Core/Messaging/IMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/IMessageCenter.cs
@@ -2,7 +2,7 @@ namespace Orleans.Runtime
 {
     internal interface IMessageCenter
     {
-        void SendMessage(Message msg);
+        void SendMessage(Message msg, IMessageReceiverCache? receiverCache);
 
         void DispatchLocalMessage(Message message);
     }

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -7,7 +7,7 @@ using System.Threading;
 namespace Orleans.Runtime
 {
     [Id(101)]
-    internal sealed class Message : ISpanFormattable
+    internal sealed class Message : ISpanFormattable, IMessageReceiverCache
     {
         public const int LENGTH_HEADER_SIZE = 8;
         public const int LENGTH_META_HEADER = 4;
@@ -265,6 +265,10 @@ namespace Orleans.Runtime
                 _headers.SetFlag(MessageFlags.HasInterfaceType, !value.IsDefault);
             }
         }
+
+        // This is the receiver of the REPLY to this message
+        [field: NonSerialized]
+        public object? MessageReceiver { get; set; }
 
         public bool IsExpirableMessage()
         {

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -56,6 +56,7 @@ namespace Orleans.Runtime.Messaging
 
         protected override void OnReceivedMessage(Message message)
         {
+            message.SendingSilo ??= RemoteSiloAddress;
             this.messageCenter.DispatchLocalMessage(message);
         }
 
@@ -105,7 +106,7 @@ namespace Orleans.Runtime.Messaging
             {
                 // Recycle the message we've dequeued. Note that this will recycle messages that were queued up to be sent when the gateway connection is declared dead
                 msg.TargetSilo = null;
-                this.messageCenter.SendMessage(msg);
+                this.messageCenter.SendMessage(msg, receiverCache: null);
                 return false;
             }
 
@@ -123,7 +124,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
                 ++msg.RetryCount;
-                this.messageCenter.SendMessage(msg);
+                this.messageCenter.SendMessage(msg, receiverCache: null);
             }
             else
             {
@@ -166,7 +167,7 @@ namespace Orleans.Runtime.Messaging
         protected override void OnSendMessageFailure(Message message, string error)
         {
             message.TargetSilo = null;
-            this.messageCenter.SendMessage(message);
+            this.messageCenter.SendMessage(message, receiverCache: null);
         }
 
         [LoggerMessage(

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -17,7 +17,7 @@ using Orleans.Serialization.Invocation;
 #nullable disable
 namespace Orleans.Runtime.Messaging
 {
-    internal abstract partial class Connection
+    internal abstract partial class Connection : IMessageReceiver
     {
         private static readonly Func<ConnectionContext, Task> OnConnectedDelegate = context => OnConnectedAsync(context);
         private static readonly Action<object> OnConnectionClosedDelegate = state => ((Connection)state).OnTransportConnectionClosed();
@@ -296,6 +296,7 @@ namespace Orleans.Runtime.Messaging
                                 if (requiredBytes == 0)
                                 {
                                     Debug.Assert(message is not null);
+                                    message.MessageReceiver = this;
                                     RecordMessageReceive(message, bodyLength + headerLength, headerLength);
                                     var handler = MessageHandlerPool.Get();
                                     handler.Set(message, this);
@@ -512,6 +513,18 @@ namespace Orleans.Runtime.Messaging
             }
 
             return true;
+        }
+
+        void IMessageReceiver.ReceiveMessage(Message message, IMessageReceiverCache cache)
+        {
+            if (!IsValid)
+            {
+                cache.MessageReceiver = null;
+                RetryMessage(message);
+                return;
+            }
+
+            Send(message);
         }
 
         private sealed class MessageHandlerPoolPolicy : PooledObjectPolicy<MessageHandler>

--- a/src/Orleans.Core/Networking/ConnectionManager.cs
+++ b/src/Orleans.Core/Networking/ConnectionManager.cs
@@ -49,6 +49,11 @@ namespace Orleans.Runtime.Messaging
 
         public ValueTask<Connection> GetConnection(SiloAddress endpoint)
         {
+            if (endpoint.Generation != 0)
+            {
+                endpoint = SiloAddress.New(endpoint.Endpoint, 0);
+            }
+
             if (this.connections.TryGetValue(endpoint, out var entry) && entry.NextConnection() is { } connection)
             {
                 if (!entry.HasSufficientConnections(connectionOptions) && entry.PendingConnection is null)

--- a/src/Orleans.Core/Runtime/IMessageReceiver.cs
+++ b/src/Orleans.Core/Runtime/IMessageReceiver.cs
@@ -1,0 +1,6 @@
+namespace Orleans.Runtime;
+
+internal interface IMessageReceiver
+{
+    void ReceiveMessage(Message message, IMessageReceiverCache cache);
+}

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -46,6 +46,7 @@ namespace Orleans
 
         private readonly SharedCallbackData sharedCallbackData;
         private readonly PeriodicTimer callbackTimer;
+        private readonly ConcurrentDictionary<GrainId, SiloAddress> _grainMappingCache = new();
         private Task callbackTimerTask;
 
         public GrainAddress CurrentActivationAddress
@@ -252,7 +253,7 @@ namespace Orleans
             OrleansOutsideRuntimeClientEvent.Instance.SendResponse(message);
             message.BodyObject = response;
 
-            MessageCenter.SendMessage(message);
+            MessageCenter.SendMessage(message, receiverCache: request);
         }
 
         public void SendRequest(GrainReference target, IInvokable request, IResponseCompletionSource context, InvokeMethodOptions options)
@@ -275,6 +276,10 @@ namespace Orleans
                 // If the silo isn't be supplied, it will be filled in by the sender to be the gateway silo
                 message.TargetSilo = systemTargetGrainId.GetSiloAddress();
             }
+            else if (_grainMappingCache.TryGetValue(targetGrainId, out var cachedSilo))
+            {
+                message.TargetSilo = cachedSilo;
+            }
 
             if (this.clientMessagingOptions.DropExpiredMessages && message.IsExpirableMessage())
             {
@@ -295,7 +300,7 @@ namespace Orleans
             }
 
             LogSendingMessage(logger, message);
-            MessageCenter.SendMessage(message);
+            MessageCenter.SendMessage(message, receiverCache: target);
         }
 
         public void ReceiveResponse(Message response)
@@ -347,6 +352,7 @@ namespace Orleans
                 // Unfortunately, it is not enough, since CallContext.LogicalGetData will not flow "up" from task completion source into the resolved task.
                 // RequestContextExtensions.Import(response.RequestContextData);
                 callbackData.DoCallback(response);
+                _grainMappingCache[response.SendingGrain] = response.SendingSilo;
             }
             else
             {

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -270,11 +270,13 @@ namespace Orleans
             var oneWay = (options & InvokeMethodOptions.OneWay) != 0;
             message.SendingGrain = CurrentActivationAddress.GrainId;
             message.TargetGrain = targetGrainId;
+            IMessageReceiverCache targetCache = target;
 
             if (SystemTargetGrainId.TryParse(targetGrainId, out var systemTargetGrainId))
             {
                 // If the silo isn't be supplied, it will be filled in by the sender to be the gateway silo
                 message.TargetSilo = systemTargetGrainId.GetSiloAddress();
+                targetCache = null;
             }
             else if (_grainMappingCache.TryGetValue(targetGrainId, out var cachedSilo))
             {
@@ -300,7 +302,7 @@ namespace Orleans
             }
 
             LogSendingMessage(logger, message);
-            MessageCenter.SendMessage(message, receiverCache: target);
+            MessageCenter.SendMessage(message, receiverCache: targetCache);
         }
 
         public void ReceiveResponse(Message response)

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -37,7 +37,8 @@ internal sealed partial class ActivationData :
     IGrainCallCancellationExtension,
     ICallChainReentrantGrainContext,
     IAsyncDisposable,
-    IDisposable
+    IDisposable,
+    IMessageReceiver
 {
     private const string GrainAddressMigrationContextKey = "sys.addr";
     private readonly GrainTypeSharedContext _shared;
@@ -754,7 +755,7 @@ internal sealed partial class ActivationData :
                     }
 
                     var response = messageFactory.CreateDiagnosticResponseMessage(message, isExecuting: true, isWaiting: false, diagnostics);
-                    messageCenter.SendMessage(response);
+                    messageCenter.SendMessage(response, receiverCache: null);
                 }
             }
 
@@ -779,7 +780,7 @@ internal sealed partial class ActivationData :
                     };
 
                     var response = messageFactory.CreateDiagnosticResponseMessage(message, isExecuting: true, isWaiting: false, messageDiagnostics);
-                    messageCenter.SendMessage(response);
+                    messageCenter.SendMessage(response, receiverCache: null);
                 }
             }
 
@@ -803,7 +804,7 @@ internal sealed partial class ActivationData :
                     };
 
                     var response = messageFactory.CreateDiagnosticResponseMessage(message, isExecuting: false, isWaiting: true, messageDiagnostics);
-                    messageCenter.SendMessage(response);
+                    messageCenter.SendMessage(response, receiverCache: null);
                 }
 
                 queueLength++;
@@ -2277,6 +2278,15 @@ internal sealed partial class ActivationData :
     )]
     private static partial void LogErrorCancellationCallbackFailed(ILogger logger, Exception exception);
 
+    public void ReceiveMessage(Message message, IMessageReceiverCache cache)
+    {
+        if (!IsValid)
+        {
+            cache.MessageReceiver = null;
+        }
+
+        ReceiveMessage(message);
+    }
     #endregion
 
     /// <summary>

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -18,7 +18,7 @@ namespace Orleans.Runtime
     /// <summary>
     /// A client which is hosted within a silo.
     /// </summary>
-    internal sealed partial class HostedClient : IGrainContext, IGrainExtensionBinder, IDisposable, ILifecycleParticipant<ISiloLifecycle>
+    internal sealed partial class HostedClient : IGrainContext, IGrainExtensionBinder, IDisposable, ILifecycleParticipant<ISiloLifecycle>, IMessageReceiver
     {
 #if NET9_0_OR_GREATER
         private readonly Lock lockObj = new();
@@ -215,6 +215,16 @@ namespace Orleans.Runtime
                 // Requests against client objects are scheduled for execution on the client.
                 this.incomingMessages.Writer.TryWrite(msg);
             }
+        }
+
+        public void ReceiveMessage(Message message, IMessageReceiverCache cache)
+        {
+            if (this.disposing)
+            {
+                cache.MessageReceiver = null;
+            }
+
+            ReceiveMessage(message);
         }
 
         /// <inheritdoc />

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -140,6 +140,7 @@ namespace Orleans.Runtime
                 message.SendingSilo = MySilo;
 
             IGrainContext sendingActivation = RuntimeContext.Current;
+            message.MessageReceiver = sendingActivation ?? HostedClient;
 
             if (sendingActivation == null)
             {
@@ -187,7 +188,15 @@ namespace Orleans.Runtime
             }
 
             this.messagingTrace.OnSendRequest(message);
-            this.MessageCenter.AddressAndSendMessage(message);
+
+            if (target.MessageReceiver is IMessageReceiver receiver)
+            {
+                receiver.ReceiveMessage(message, target);
+            }
+            else
+            {
+                this.MessageCenter.AddressAndSendMessage(message, targetCache: target);
+            }
         }
 
         public void SendResponse(Message request, Response response)
@@ -390,7 +399,7 @@ namespace Orleans.Runtime
                 {
                     // gatewayed message - gateway back to sender
                     LogTraceNoCallbackForRejection(this.logger, message);
-                    this.MessageCenter.AddressAndSendMessage(message);
+                    this.MessageCenter.AddressAndSendMessage(message, targetCache: null);
                     return;
                 }
 

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -156,11 +156,13 @@ namespace Orleans.Runtime
             var targetGrainId = target.GrainId;
             message.TargetGrain = targetGrainId;
             SharedCallbackData sharedData;
+            IMessageReceiverCache targetCache = target;
             if (SystemTargetGrainId.TryParse(targetGrainId, out var systemTargetGrainId))
             {
                 message.TargetSilo = systemTargetGrainId.GetSiloAddress();
                 message.IsSystemMessage = true;
                 sharedData = this.systemSharedCallbackData;
+                targetCache = null;
             }
             else
             {
@@ -189,13 +191,13 @@ namespace Orleans.Runtime
 
             this.messagingTrace.OnSendRequest(message);
 
-            if (target.MessageReceiver is IMessageReceiver receiver)
+            if (targetCache?.MessageReceiver is IMessageReceiver receiver)
             {
-                receiver.ReceiveMessage(message, target);
+                receiver.ReceiveMessage(message, targetCache);
             }
             else
             {
-                this.MessageCenter.AddressAndSendMessage(message, targetCache: target);
+                this.MessageCenter.AddressAndSendMessage(message, targetCache);
             }
         }
 

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -248,7 +248,7 @@ namespace Orleans.Runtime.Messaging
         /// </summary>
         /// <param name="msg"></param>
         /// <returns>true if the message should be delivered to a proxied grain, false if not.</returns>
-        internal bool TryDeliverToProxy(Message msg)
+        internal bool TryDeliverToProxy(Message msg, IMessageReceiverCache targetCache)
         {
             // See if it's a grain we're proxying.
             var targetGrain = msg.TargetGrain;
@@ -262,22 +262,13 @@ namespace Orleans.Runtime.Messaging
                 return false;
             }
 
-            // when this Gateway receives a message from client X to client addressable object Y
-            // it needs to record the original Gateway address through which this message came from (the address of the Gateway that X is connected to)
-            // it will use this Gateway to re-route the REPLY from Y back to X.
-            if (msg.SendingGrain.IsClient())
-            {
-                clientsReplyRoutingCache.RecordClientRoute(msg.SendingGrain, msg.SendingSilo);
-            }
+            client.ReceiveMessage(msg);
+            targetCache?.MessageReceiver = client;
 
-            msg.TargetSilo = null;
-            msg.SendingSilo ??= gatewayAddress;
-
-            client.Send(msg);
             return true;
         }
 
-        private class ClientState
+        private class ClientState : IMessageReceiver
         {
             private readonly Gateway _gateway;
             private readonly Task _messageLoop;
@@ -354,11 +345,46 @@ namespace Orleans.Runtime.Messaging
                 _signal.Signal();
             }
 
-            public void Send(Message msg)
+            public void ReceiveMessage(Message msg, IMessageReceiverCache cache)
             {
-                _pendingToSend.Enqueue(msg);
-                _signal.Signal();
-                LogTraceQueuedMessage(_gateway.logger, msg, msg.TargetGrain);
+                if (IsDropped)
+                {
+                    // Invalidate the cache.
+                    // The message will be handled by the message loop.
+                    cache.MessageReceiver = null;
+                }
+
+                ReceiveMessage(msg);
+            }
+
+            public void ReceiveMessage(Message msg)
+            {
+                // When this Gateway receives a message from client X to client addressable object Y
+                // it needs to record the original Gateway address through which this message came from (the address of the Gateway that X is connected to)
+                // it will use this Gateway to re-route the REPLY from Y back to X.
+                if (msg.SendingGrain.IsClient())
+                {
+                    _gateway.clientsReplyRoutingCache.RecordClientRoute(msg.SendingGrain, msg.SendingSilo);
+                }
+
+                msg.TargetSilo = null;
+
+                // Override the SendingSilo only if the sending grain is not
+                // a system target
+                if (!msg.SendingGrain.IsSystemTarget())
+                {
+                    msg.SendingSilo = _gateway.gatewayAddress;
+                }
+
+                var connection = Volatile.Read(ref _connection);
+                if (connection is null || !TrySend(connection, msg))
+                {
+                    _pendingToSend.Enqueue(msg);
+                    _signal.Signal();
+                    LogTraceQueuedMessage(_gateway.logger, msg, msg.TargetGrain);
+                    return;
+                }
+                LogTraceSentQueuedMessage(_gateway.logger, msg, Id);
             }
 
             private async Task RunMessageLoop()

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -23,11 +23,11 @@ namespace Orleans.Runtime.Messaging
         private readonly SiloMessagingOptions messagingOptions;
         private readonly PlacementService placementService;
         private readonly GrainLocator _grainLocator;
-        private readonly Action<Message>? _messageObserver;
         private readonly ILogger log;
         private readonly Catalog catalog;
         private bool stopped;
         private HostedClient? hostedClient;
+        private readonly Action<Message>? _messageObserver;
         private Action<Message>? sniffIncomingMessageHandler;
 
         public MessageCenter(
@@ -68,13 +68,20 @@ namespace Orleans.Runtime.Messaging
 
         public void SetHostedClient(HostedClient? client) => this.hostedClient = client;
 
-        public bool TryDeliverToProxy(Message msg)
+        public bool TryDeliverToProxy(Message msg, IMessageReceiverCache? targetCache)
         {
             if (!msg.TargetGrain.IsClient()) return false;
-            if (this.Gateway is Gateway gateway && gateway.TryDeliverToProxy(msg)
-                || this.hostedClient is HostedClient client && client.TryDispatchToClient(msg))
+            if (this.Gateway is Gateway gateway && gateway.TryDeliverToProxy(msg, targetCache))
             {
                 _messageObserver?.Invoke(msg);
+                return true;
+            }
+
+            if (this.hostedClient is HostedClient hostedClient && hostedClient.TryDispatchToClient(msg))
+            {
+                targetCache?.MessageReceiver = hostedClient;
+                _messageObserver?.Invoke(msg);
+
                 return true;
             }
 
@@ -134,7 +141,7 @@ namespace Orleans.Runtime.Messaging
             get => this.sniffIncomingMessageHandler;
         }
 
-        public void SendMessage(Message msg)
+        public void SendMessage(Message msg, IMessageReceiverCache? receiverCache)
         {
             Debug.Assert(!msg.IsLocalOnly);
 
@@ -147,6 +154,11 @@ namespace Orleans.Runtime.Messaging
             else
             {
                 msg.SendingSilo ??= _siloAddress;
+                if (receiverCache?.MessageReceiver is IMessageReceiver receiver)
+                {
+                    receiver.ReceiveMessage(msg, receiverCache);
+                    return;
+                }
 
                 if (stopped)
                 {
@@ -163,7 +175,7 @@ namespace Orleans.Runtime.Messaging
                 }
 
                 // First check to see if it's really destined for a proxied client, instead of a local grain.
-                if (TryDeliverToProxy(msg))
+                if (TryDeliverToProxy(msg, receiverCache))
                 {
                     // Message was successfully delivered to the proxy.
                     return;
@@ -184,13 +196,15 @@ namespace Orleans.Runtime.Messaging
 
                     MessagingInstruments.LocalMessagesSentCounterAggregator.Add(1);
 
-                    this.ReceiveMessage(msg);
+                    this.ReceiveMessage(msg, receiverCache);
                 }
                 else
                 {
                     if (this.connectionManager.TryGetConnection(targetSilo, out var existingConnection))
                     {
                         existingConnection.Send(msg);
+                        receiverCache?.MessageReceiver = existingConnection;
+
                         return;
                     }
                     else if (this.siloStatusOracle.IsDeadSilo(targetSilo))
@@ -209,19 +223,23 @@ namespace Orleans.Runtime.Messaging
                         var connectionTask = this.connectionManager.GetConnection(targetSilo);
                         if (connectionTask.IsCompletedSuccessfully)
                         {
-                            var sender = connectionTask.Result;
-                            sender.Send(msg);
+                            var connection = connectionTask.Result;
+                            receiverCache?.MessageReceiver = connection;
+
+                            connection.Send(msg);
                         }
                         else
                         {
-                            _ = SendAsync(this, connectionTask, msg);
+                            _ = SendAsync(this, connectionTask, msg, receiverCache);
 
-                            static async Task SendAsync(MessageCenter messageCenter, ValueTask<Connection> connectionTask, Message msg)
+                            static async Task SendAsync(MessageCenter messageCenter, ValueTask<Connection> connectionTask, Message msg, IMessageReceiverCache? targetCache)
                             {
                                 try
                                 {
-                                    var sender = await connectionTask;
-                                    sender.Send(msg);
+                                    var connection = await connectionTask;
+                                    targetCache?.MessageReceiver = connection;
+
+                                    connection.Send(msg);
                                 }
                                 catch (Exception exception)
                                 {
@@ -234,7 +252,7 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
-        public void DispatchLocalMessage(Message message) => ReceiveMessage(message);
+        public void DispatchLocalMessage(Message message) => ReceiveMessage(message, targetCache: null);
 
         public void RejectMessage(
             Message message,
@@ -249,7 +267,7 @@ namespace Orleans.Runtime.Messaging
 
                 var str = $"{rejectInfo} {exc}";
                 var rejection = this.messageFactory.CreateRejectionResponse(message, rejectionType, str, exc);
-                SendMessage(rejection);
+                SendMessage(rejection, receiverCache: null);
             }
             else
             {
@@ -422,17 +440,17 @@ namespace Orleans.Runtime.Messaging
             if (message.TargetGrain.IsSystemTarget())
             {
                 message.IsSystemMessage = true;
-                SendMessage(message);
+                SendMessage(message, receiverCache: null);
             }
             else if (forwardingAddress != null)
             {
                 message.TargetSilo = forwardingAddress;
-                SendMessage(message);
+                SendMessage(message, receiverCache: null);
             }
             else
             {
                 message.TargetSilo = null;
-                _ = AddressAndSendMessage(message);
+                _ = AddressAndSendMessage(message, targetCache: null);
             }
         }
 
@@ -450,17 +468,17 @@ namespace Orleans.Runtime.Messaging
         /// - add ordering info and maintain send order
         ///
         /// </summary>
-        internal Task AddressAndSendMessage(Message message)
+        internal Task AddressAndSendMessage(Message message, IMessageReceiverCache? targetCache)
         {
             try
             {
                 var messageAddressingTask = placementService.AddressMessage(message);
                 if (messageAddressingTask.Status != TaskStatus.RanToCompletion)
                 {
-                    return SendMessageAsync(messageAddressingTask, message);
+                    return SendMessageAsync(messageAddressingTask, message, targetCache);
                 }
 
-                SendMessage(message);
+                SendMessage(message, receiverCache: targetCache);
             }
             catch (Exception ex)
             {
@@ -469,7 +487,7 @@ namespace Orleans.Runtime.Messaging
 
             return Task.CompletedTask;
 
-            async Task SendMessageAsync(Task addressMessageTask, Message m)
+            async Task SendMessageAsync(Task addressMessageTask, Message message, IMessageReceiverCache? targetCache)
             {
                 try
                 {
@@ -477,11 +495,11 @@ namespace Orleans.Runtime.Messaging
                 }
                 catch (Exception ex)
                 {
-                    OnAddressingFailure(m, ex);
+                    OnAddressingFailure(message, ex);
                     return;
                 }
 
-                SendMessage(m);
+                SendMessage(message, receiverCache: targetCache);
             }
 
             void OnAddressingFailure(Message m, Exception ex)
@@ -496,22 +514,18 @@ namespace Orleans.Runtime.Messaging
             // create the response
             var message = this.messageFactory.CreateResponseMessage(request);
             message.BodyObject = response;
+            message.IsSystemMessage |= message.TargetGrain.IsSystemTarget();
 
-            if (message.TargetGrain.IsSystemTarget())
-            {
-                message.IsSystemMessage = true;
-            }
-
-            SendMessage(message);
+            SendMessage(message, receiverCache: request);
         }
 
-        public void ReceiveMessage(Message msg)
+        public void ReceiveMessage(Message msg, IMessageReceiverCache? targetCache)
         {
             Debug.Assert(!msg.IsLocalOnly);
             try
             {
                 this.messagingTrace.OnIncomingMessageAgentReceiveMessage(msg);
-                if (TryDeliverToProxy(msg))
+                if (TryDeliverToProxy(msg, targetCache: null))
                 {
                     return;
                 }
@@ -532,8 +546,9 @@ namespace Orleans.Runtime.Messaging
                         return;
                     }
 
-                    targetActivation.ReceiveMessage(msg);
                     _messageObserver?.Invoke(msg);
+                    targetActivation.ReceiveMessage(msg);
+                    targetCache?.MessageReceiver = targetActivation;
                 }
             }
             catch (Exception ex)
@@ -566,7 +581,7 @@ namespace Orleans.Runtime.Messaging
                         Message.RejectionTypes.Unrecoverable,
                         $"SystemTarget {msg.TargetGrain} not active on this silo. Msg={msg}");
 
-                    SendMessage(response);
+                    SendMessage(response, receiverCache: null);
                 }
             }
             else
@@ -594,7 +609,7 @@ namespace Orleans.Runtime.Messaging
                 if (string.IsNullOrEmpty(reason)) reason = $"Rejection from silo {this._siloAddress} - Unknown reason.";
                 var error = this.messageFactory.CreateRejectionResponse(msg, rejectionType, reason, exception);
                 // rejection msgs are always originated in the local silo, they are never remote.
-                this.ReceiveMessage(error);
+                this.ReceiveMessage(error, targetCache: null);
             }
         }
 

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -70,7 +70,7 @@ namespace Orleans.Runtime.Messaging
             {
                 MessagingInstruments.OnRejectedMessage(msg);
                 Message rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.GatewayTooBusy, "Shedding load");
-                this.messageCenter.TryDeliverToProxy(rejection);
+                this.messageCenter.TryDeliverToProxy(rejection, targetCache: null);
                 LogRejectingRequestDueToOverloading(this.Log, msg);
                 GatewayInstruments.GatewayLoadShedding.Add(1);
                 return;
@@ -102,7 +102,7 @@ namespace Orleans.Runtime.Messaging
                     msg.TargetGrain = systemTargetId.WithSiloAddress(targetAddress).GrainId;
                 }
 
-                this.messageCenter.SendMessage(msg);
+                this.messageCenter.SendMessage(msg, receiverCache: null);
             }
         }
 
@@ -184,7 +184,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
                 msg.RetryCount++;
-                this.messageCenter.SendMessage(msg);
+                this.messageCenter.SendMessage(msg, receiverCache: null);
             }
             else
             {

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -105,7 +105,7 @@ namespace Orleans.Runtime.Messaging
             // information, so a null target silo is OK.
             if (msg.TargetSilo == null || msg.TargetSilo.Matches(this.LocalSiloAddress))
             {
-                messageCenter.ReceiveMessage(msg);
+                messageCenter.ReceiveMessage(msg, targetCache: null);
                 return;
             }
 
@@ -113,7 +113,7 @@ namespace Orleans.Runtime.Messaging
             {
                 // If the message is for some other silo altogether, then we need to forward it.
                 LogTraceForwardingMessage(this.Log, msg.Id, msg.SendingSilo!, msg.TargetSilo);
-                messageCenter.SendMessage(msg);
+                messageCenter.SendMessage(msg, receiverCache: null);
                 return;
             }
 
@@ -294,7 +294,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
                 ++msg.RetryCount;
-                this.messageCenter.SendMessage(msg);
+                this.messageCenter.SendMessage(msg, receiverCache: null);
             }
             else
             {

--- a/test/Benchmarks/Ping/AdaptivePingBenchmark.cs
+++ b/test/Benchmarks/Ping/AdaptivePingBenchmark.cs
@@ -136,7 +136,7 @@ public class AdaptivePingBenchmark : IDisposable
 
     /// <summary>
     /// Runs the adaptive benchmark, tuning concurrency via hill climbing.
-    /// Terminates after maxStableRounds without improvement (default 10), or runs forever if 0.
+    /// Terminates after maxStableRounds without improvement (default 3), or runs forever if 0.
     /// </summary>
     public async Task RunAsync(
         int initialConcurrency = 100,
@@ -144,7 +144,7 @@ public class AdaptivePingBenchmark : IDisposable
         int maxConcurrency = 2000,
         TimeSpan? warmupDuration = null,
         TimeSpan? measurementInterval = null,
-        int maxStableRounds = 10)
+        int maxStableRounds = 3)
     {
         var grainFactory = GetGrainFactory();
 
@@ -209,7 +209,7 @@ public class AdaptivePingBenchmark : IDisposable
     /// <summary>
     /// Runs all adaptive ping benchmark scenarios and prints a summary.
     /// </summary>
-    public static async Task RunAllScenariosAsync(int maxStableRounds = 10)
+    public static async Task RunAllScenariosAsync(int maxStableRounds = 3)
     {
         var results = new List<(string Description, int BestConcurrency, double BestThroughput)>();
 


### PR DESCRIPTION
## Summary
- Adds a fast-path message destination cache for client/runtime message routing, caching resolved receivers on grain references/messages and reusing valid activation, connection, gateway, and hosted-client receivers.
- Invalidates stale cached receivers and falls back to normal addressing when connections, activations, or client gateway state are no longer valid.
- Avoids caching system target destinations so gateway/liveness changes are re-evaluated; keeps direct gateway connections normalized and updates client grain-to-silo mappings from responses.

## Validation
- `git diff --check`
- conflict-marker scan
- `dotnet build src\Orleans.Core\Orleans.Core.csproj -m`
- `dotnet build src\Orleans.Runtime\Orleans.Runtime.csproj -m`

## Dependencies / notes
- This PR targets `main`, but is logically related to the message-oriented networking work and may need review/merge coordination with that PR.
- Additional coverage should exercise cache hit/miss, invalidation on disconnect/reconnect, stale receiver invalidation, gateway/loopback routing, system target routing, and retry behavior.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10064)