### PR TITLE
Optimize RPC response hot paths

### DIFF
--- a/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
+++ b/src/Orleans.Core/Runtime/OutgoingCallInvoker.cs
@@ -115,7 +115,7 @@ namespace Orleans.Runtime
                     stage++;
                     var responseCompletionSource = ResponseCompletionSourcePool.Get();
                     this.sendRequest(this.grainReference, responseCompletionSource, this.request, this.options);
-                    this.Response = await responseCompletionSource.AsValueTask();
+                    this.Response = await responseCompletionSource.AsValueTask().ConfigureAwait(false);
 
                     return;
                 }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -395,7 +396,15 @@ namespace Orleans.Runtime
         public void ReceiveResponse(Message message)
         {
             OrleansInsideRuntimeClientEvent.Instance.ReceiveResponse(message);
-            if (message.Result is Message.ResponseTypes.Rejection)
+
+            var result = message.Result;
+            if (result != Message.ResponseTypes.Rejection && result != Message.ResponseTypes.Status)
+            {
+                ProcessResponseCallback(message);
+                return;
+            }
+
+            if (result is Message.ResponseTypes.Rejection)
             {
                 if (!message.TargetSilo.Matches(this.MySilo))
                 {
@@ -429,46 +438,19 @@ namespace Orleans.Runtime
                         LogErrorUnsupportedRejectionType(this.logger, rejection.RejectionType);
                         break;
                 }
+
+                ProcessResponseCallback(message);
             }
-            else if (message.Result == Message.ResponseTypes.Status)
+            else
             {
-                var status = (StatusResponse)message.BodyObject;
-                callbacks.TryGetValue((message.TargetGrain, message.Id), out var callback);
-                var request = callback?.Message;
-                if (request is not null)
-                {
-                    callback.OnStatusUpdate(status);
-                    if (status.Diagnostics != null && status.Diagnostics.Count > 0)
-                    {
-                        LogInformationReceivedStatusUpdate(this.logger, request, status.Diagnostics);
-                    }
-                }
-                else
-                {
-                    if (messagingOptions.CancelUnknownRequestOnStatusUpdate)
-                    {
-                        // Cancel the call since the caller has abandoned it.
-                        // Note that the target and sender arguments are swapped because this is a response to the original request.
-                        _cancellationManager.SignalCancellation(
-                            message.SendingSilo,
-                            targetGrainId: message.SendingGrain,
-                            sendingGrainId: message.TargetGrain,
-                            messageId: message.Id);
-                    }
-
-                    if (status.Diagnostics != null && status.Diagnostics.Count > 0 && logger.IsEnabled(LogLevel.Debug))
-                    {
-                        var diagnosticsString = string.Join("\n", status.Diagnostics);
-                        LogDebugReceivedStatusUpdateUnknownRequest(this.logger, message, diagnosticsString);
-                    }
-                }
-
-                return;
+                ProcessStatusResponse(message);
             }
+        }
 
-            CallbackData callbackData;
-            bool found = callbacks.TryRemove((message.TargetGrain, message.Id), out callbackData);
-            if (found)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ProcessResponseCallback(Message message)
+        {
+            if (callbacks.TryRemove((message.TargetGrain, message.Id), out var callbackData))
             {
                 // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
                 // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
@@ -477,6 +459,45 @@ namespace Orleans.Runtime
             else
             {
                 LogDebugNoCallbackForResponse(this.logger, message);
+            }
+        }
+
+        private void ProcessStatusResponse(Message message)
+        {
+            var status = (StatusResponse)message.BodyObject;
+            callbacks.TryGetValue((message.TargetGrain, message.Id), out var callback);
+            var request = callback?.Message;
+            if (request is not null)
+            {
+                callback.OnStatusUpdate(status);
+                if (status.Diagnostics is { Count: > 0 })
+                {
+                    LogInformationReceivedStatusUpdate(this.logger, request, status.Diagnostics);
+                }
+
+                return;
+            }
+
+            HandleUnknownStatusUpdate(message, status);
+        }
+
+        private void HandleUnknownStatusUpdate(Message message, StatusResponse status)
+        {
+            if (messagingOptions.CancelUnknownRequestOnStatusUpdate)
+            {
+                // Cancel the call since the caller has abandoned it.
+                // Note that the target and sender arguments are swapped because this is a response to the original request.
+                _cancellationManager.SignalCancellation(
+                    message.SendingSilo,
+                    targetGrainId: message.SendingGrain,
+                    sendingGrainId: message.TargetGrain,
+                    messageId: message.Id);
+            }
+
+            if (status.Diagnostics is { Count: > 0 } && logger.IsEnabled(LogLevel.Debug))
+            {
+                var diagnosticsString = string.Join("\n", status.Diagnostics);
+                LogDebugReceivedStatusUpdateUnknownRequest(this.logger, message, diagnosticsString);
             }
         }
 

--- a/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
+++ b/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
@@ -156,31 +156,36 @@ namespace Orleans.Serialization.Invocation
         public void SetResult(TResult result) => _core.SetResult(result);
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Complete(Response value)
         {
-            if (value is Response<TResult> typed)
-            {
-                Complete(typed);
-            }
-            else if (value.Exception is { } exception)
+            // Fast path: check exception first since it's a simple null check
+            if (value.Exception is { } exception)
             {
                 SetException(exception);
+                return;
+            }
+
+            // Check for typed response (common for void returns)
+            if (value is Response<TResult> typed)
+            {
+                SetResult(typed.TypedResult);
+                return;
+            }
+
+            // Handle untyped successful response
+            var result = value.Result;
+            if (result is null)
+            {
+                SetResult(default);
+            }
+            else if (result is TResult typedResult)
+            {
+                SetResult(typedResult);
             }
             else
             {
-                var result = value.Result;
-                if (result is null)
-                {
-                    SetResult(default);
-                }
-                else if (result is TResult typedResult)
-                {
-                    SetResult(typedResult);
-                }
-                else
-                {
-                    SetInvalidCastException(result);
-                }
+                SetInvalidCastException(result);
             }
         }
 

--- a/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
+++ b/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
@@ -11,6 +11,8 @@ namespace Orleans.Serialization.Invocation
     /// </summary>
     public sealed class ResponseCompletionSource : IResponseCompletionSource, IValueTaskSource<Response>, IValueTaskSource
     {
+        // This source is pooled and GetResult returns it to the pool. Continuations must not run inline from SetResult/SetException,
+        // or they can reset/reuse this instance before completion unwinds.
         private ManualResetValueTaskSourceCore<Response> _core = new() { RunContinuationsAsynchronously = true };
 
         /// <summary>
@@ -114,6 +116,8 @@ namespace Orleans.Serialization.Invocation
     /// <typeparam name="TResult">The underlying result type.</typeparam>
     public sealed class ResponseCompletionSource<TResult> : IResponseCompletionSource, IValueTaskSource<TResult>, IValueTaskSource
     {
+        // This source is pooled and GetResult returns it to the pool. Continuations must not run inline from SetResult/SetException,
+        // or they can reset/reuse this instance before completion unwinds.
         private ManualResetValueTaskSourceCore<TResult> _core = new() { RunContinuationsAsynchronously = true };
 
         /// <summary>

--- a/test/Orleans.Serialization.UnitTests/ResponseCompletionSourceTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ResponseCompletionSourceTests.cs
@@ -1,0 +1,90 @@
+#nullable enable
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Serialization.Invocation;
+using Xunit;
+
+#pragma warning disable xUnit1031 // These tests manually complete ValueTaskSource awaiters and must call GetResult.
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+public class ResponseCompletionSourceTests
+{
+    [Fact]
+    public async Task TypedCompletionRunsContinuationsAsynchronously()
+    {
+        var source = ResponseCompletionSourcePool.Get<int>();
+        var awaiter = source.AsValueTask().GetAwaiter();
+        var continuation = RegisterContinuation(awaiter);
+
+        using var response = Response.FromResult(42);
+        continuation.CompletionThreadId = Thread.CurrentThread.ManagedThreadId;
+        source.Complete(response);
+
+        Assert.NotEqual(continuation.CompletionThreadId, Volatile.Read(ref continuation.ContinuationThreadId));
+
+        await WaitForContinuation(continuation.Task);
+        Assert.Equal(42, awaiter.GetResult());
+    }
+
+    [Fact]
+    public async Task UntypedCompletionRunsContinuationsAsynchronously()
+    {
+        var source = ResponseCompletionSourcePool.Get();
+        var awaiter = source.AsValueTask().GetAwaiter();
+        var continuation = RegisterContinuation(awaiter);
+        var response = Response.FromResult(42);
+        Response? result = null;
+
+        try
+        {
+            continuation.CompletionThreadId = Thread.CurrentThread.ManagedThreadId;
+            source.Complete(response);
+
+            Assert.NotEqual(continuation.CompletionThreadId, Volatile.Read(ref continuation.ContinuationThreadId));
+
+            await WaitForContinuation(continuation.Task);
+            result = awaiter.GetResult();
+            Assert.Same(response, result);
+            Assert.Equal(42, result.GetResult<int>());
+        }
+        finally
+        {
+            (result ?? response).Dispose();
+        }
+    }
+
+    private static ContinuationProbe RegisterContinuation<T>(ValueTaskAwaiter<T> awaiter)
+    {
+        var continuation = new ContinuationProbe();
+
+        awaiter.OnCompleted(() =>
+        {
+            Volatile.Write(ref continuation.ContinuationThreadId, Thread.CurrentThread.ManagedThreadId);
+            continuation.SetResult();
+        });
+
+        return continuation;
+    }
+
+    private static async Task WaitForContinuation(Task continuation)
+    {
+        var completed = await Task.WhenAny(continuation, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(continuation, completed);
+        await continuation;
+    }
+
+    private sealed class ContinuationProbe
+    {
+        private readonly TaskCompletionSource<bool> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int CompletionThreadId = -1;
+        public int ContinuationThreadId = -1;
+        public Task Task => _completion.Task;
+
+        public void SetResult() => _completion.SetResult(true);
+    }
+}


### PR DESCRIPTION
## Summary
- Fast-paths normal RPC responses in `InsideRuntimeClient.ReceiveResponse` by avoiding rejection/status handling on the common path and factoring callback completion.
- Keeps rejection and status handling semantics intact while moving status diagnostics/cancellation handling into helper methods.
- Optimizes `ResponseCompletionSource<TResult>.Complete` for common exception, typed, and untyped result paths, and adds `ConfigureAwait(false)` in the outgoing call await path.

## Notes
- Additional coverage would be useful for response callback cleanup, rejection/status response handling, typed/untyped response completion, and exception propagation.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10065)
