### PR TITLE
Add ArcBuffer support to Orleans serialization

### DIFF
--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -971,27 +971,28 @@ namespace Orleans.Serialization.TestKit
         protected object RoundTripThroughUntypedSerializer(object original, out string formattedBitStream)
         {
             object result;
-            using (var readerSession = SessionPool.GetSession())
-            using (var writeSession = SessionPool.GetSession())
+            using var readerSession = SessionPool.GetSession();
+            using var writeSession = SessionPool.GetSession();
+
+            using var bufferWriter = new ArcBufferWriter();
+            var writer = Writer.Create(bufferWriter, writeSession);
+            try
             {
-                var writer = Writer.CreatePooled(writeSession);
-                try
-                {
-                    var serializer = ServiceProvider.GetService<Serializer<object>>();
-                    serializer.Serialize(original, ref writer);
+                var serializer = ServiceProvider.GetService<Serializer<object>>();
+                serializer.Serialize(original, ref writer);
 
-                    using var analyzerSession = SessionPool.GetSession();
-                    var output = writer.Output.Slice();
-                    formattedBitStream = BitStreamFormatter.Format(output, analyzerSession);
+                using var analyzerSession = SessionPool.GetSession();
+                using var output = bufferWriter.ConsumeSlice(bufferWriter.Length);
+                var analyzerReader = Reader.Create(output, analyzerSession);
+                formattedBitStream = BitStreamFormatter.Format(ref analyzerReader);
 
-                    var reader = Reader.Create(output, readerSession);
+                var reader = Reader.Create(output, readerSession);
 
-                    result = serializer.Deserialize(ref reader);
-                }
-                finally
-                {
-                    writer.Dispose();
-                }
+                result = serializer.Deserialize(ref reader);
+            }
+            finally
+            {
+                writer.Dispose();
             }
 
             return result;

--- a/src/Orleans.Serialization/Buffers/Adaptors/BufferSliceReaderInput.cs
+++ b/src/Orleans.Serialization/Buffers/Adaptors/BufferSliceReaderInput.cs
@@ -110,3 +110,63 @@ public struct BufferSliceReaderInput
     [DoesNotReturn]
     private static void ThrowInsufficientData() => throw new InvalidOperationException("Insufficient data present in buffer.");
 }
+
+/// <summary>
+/// Input type for <see cref="Reader{TInput}"/> to support <see cref="ArcBuffer"/> buffers.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="ArcBufferReaderInput"/> type.
+/// </remarks>
+/// <param name="slice">The underlying buffer.</param>
+public struct ArcBufferReaderInput(in ArcBuffer slice)
+{
+    private readonly ArcBuffer _slice = slice;
+    private ArcBufferPage _page = slice.First;
+    private int _position;
+
+    internal readonly ArcBufferPage First => _slice.First;
+    internal readonly int Position => _position;
+    internal readonly int Offset => _slice.Offset;
+    internal readonly int Length => _slice.Length;
+    internal long PreviousBuffersSize;
+
+    internal readonly ArcBufferReaderInput ForkFrom(int position)
+    {
+        // Rely on the outer buffer being pinned.
+        var sliced = _slice.UnsafeSlice(position, Length - position);
+        return new ArcBufferReaderInput(in sliced);
+    }
+
+    internal ReadOnlySpan<byte> GetNext()
+    {
+        Debug.Assert(_position <= Length);
+        if (_page is not null)
+        {
+            if (_page == First)
+            {
+                Debug.Assert(_position == 0);
+                var offset = Offset;
+                var length = Math.Min(Length, _page.Length - offset);
+                _position += length;
+                var result = _page.AsSpan(offset, length);
+                _page = _page.Next;
+                return result;
+            }
+
+            if (_position != Length)
+            {
+                var length = Math.Min(Length - _position, _page.Length);
+                _position += length;
+                var result = _page.AsSpan(0, length);
+                _page = _page.Next;
+                return result;
+            }
+        }
+
+        ThrowInsufficientData();
+        return default;
+    }
+
+    [DoesNotReturn]
+    private static void ThrowInsufficientData() => throw new InvalidOperationException("Insufficient data present in buffer.");
+}

--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -195,6 +195,15 @@ namespace Orleans.Serialization.Buffers
         public static Reader<BufferSliceReaderInput> Create(BufferSlice input, SerializerSession session) => new(new BufferSliceReaderInput(in input), session, 0);
 
         /// <summary>
+        /// Creates a reader for the provided buffer.
+        /// </summary>
+        /// <param name="input">The input.</param>
+        /// <param name="session">The session.</param>
+        /// <returns>A new <see cref="Reader{TInput}"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Reader<ArcBufferReaderInput> Create(ArcBuffer input, SerializerSession session) => new(new ArcBufferReaderInput(in input), session, 0);
+
+        /// <summary>
         /// Creates a reader for the provided input stream.
         /// </summary>
         /// <param name="stream">The stream.</param>
@@ -267,6 +276,7 @@ namespace Orleans.Serialization.Buffers
         private readonly static bool IsReadOnlySequenceInput = typeof(TInput) == typeof(ReadOnlySequenceInput);
         private readonly static bool IsReaderInput = typeof(ReaderInput).IsAssignableFrom(typeof(TInput));
         private readonly static bool IsBufferSliceInput = typeof(TInput) == typeof(BufferSliceReaderInput);
+        private readonly static bool IsArcBufferInput = typeof(TInput) == typeof(ArcBufferReaderInput);
 
         private ReadOnlySpan<byte> _currentSpan;
         private int _bufferPos;
@@ -292,6 +302,15 @@ namespace Orleans.Serialization.Buffers
             {
                 _input = input;
                 ref var slice = ref Unsafe.As<TInput, BufferSliceReaderInput>(ref _input);
+                _currentSpan = slice.GetNext();
+                _bufferPos = 0;
+                _bufferSize = _currentSpan.Length;
+                _sequenceOffset = globalOffset;
+            }
+            else if (IsArcBufferInput)
+            {
+                _input = input;
+                ref var slice = ref Unsafe.As<TInput, ArcBufferReaderInput>(ref _input);
                 _currentSpan = slice.GetNext();
                 _bufferPos = 0;
                 _bufferSize = _currentSpan.Length;
@@ -357,6 +376,11 @@ namespace Orleans.Serialization.Buffers
                     var previousBuffersSize = Unsafe.As<TInput, BufferSliceReaderInput>(ref _input).PreviousBuffersSize;
                     return _sequenceOffset + previousBuffersSize + _bufferPos;
                 }
+                else if (IsArcBufferInput)
+                {
+                    var previousBuffersSize = Unsafe.As<TInput, ArcBufferReaderInput>(ref _input).PreviousBuffersSize;
+                    return _sequenceOffset + previousBuffersSize + _bufferPos;
+                }
                 else if (IsSpanInput)
                 {
                     return _sequenceOffset + _bufferPos;
@@ -387,6 +411,10 @@ namespace Orleans.Serialization.Buffers
                 else if (IsBufferSliceInput)
                 {
                     return Unsafe.As<TInput, BufferSliceReaderInput>(ref _input).Length;
+                }
+                else if (IsArcBufferInput)
+                {
+                    return Unsafe.As<TInput, ArcBufferReaderInput>(ref _input).Length;
                 }
                 else if (IsSpanInput)
                 {
@@ -431,6 +459,22 @@ namespace Orleans.Serialization.Buffers
                 while (Position < end)
                 {
                     var previousBuffersSize = Unsafe.As<TInput, BufferSliceReaderInput>(ref _input).PreviousBuffersSize;
+                    if (end - previousBuffersSize <= _bufferSize)
+                    {
+                        _bufferPos = (int)(end - previousBuffersSize);
+                    }
+                    else
+                    {
+                        MoveNext();
+                    }
+                }
+            }
+            else if (IsArcBufferInput)
+            {
+                var end = Position + count;
+                while (Position < end)
+                {
+                    var previousBuffersSize = Unsafe.As<TInput, ArcBufferReaderInput>(ref _input).PreviousBuffersSize;
                     if (end - previousBuffersSize <= _bufferSize)
                     {
                         _bufferPos = (int)(end - previousBuffersSize);
@@ -496,6 +540,17 @@ namespace Orleans.Serialization.Buffers
                     ThrowInvalidPosition(position, forked.Position);
                 }
             }
+            else if (IsArcBufferInput)
+            {
+                ref var input = ref Unsafe.As<TInput, ArcBufferReaderInput>(ref _input);
+                var newInput = input.ForkFrom(checked((int)position));
+                forked = new Reader<TInput>(Unsafe.As<ArcBufferReaderInput, TInput>(ref newInput), Session, position);
+
+                if (forked.Position != position)
+                {
+                    ThrowInvalidPosition(position, forked.Position);
+                }
+            }
             else if (IsSpanInput)
             {
                 forked = new Reader<TInput>(_currentSpan[(int)position..], Session, position);
@@ -538,6 +593,10 @@ namespace Orleans.Serialization.Buffers
                 // Nothing is required.
             }
             else if (IsBufferSliceInput)
+            {
+                // Nothing is required.
+            }
+            else if (IsArcBufferInput)
             {
                 // Nothing is required.
             }
@@ -598,6 +657,14 @@ namespace Orleans.Serialization.Buffers
                 _bufferPos = 0;
                 _bufferSize = _currentSpan.Length;
             }
+            else if (IsArcBufferInput)
+            {
+                ref var slice = ref Unsafe.As<TInput, ArcBufferReaderInput>(ref _input);
+                slice.PreviousBuffersSize += _bufferSize;
+                _currentSpan = slice.GetNext();
+                _bufferPos = 0;
+                _bufferSize = _currentSpan.Length;
+            }
             else if (IsSpanInput)
             {
                 ThrowInsufficientData();
@@ -615,7 +682,7 @@ namespace Orleans.Serialization.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public byte ReadByte()
         {
-            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput || IsArcBufferInput)
             {
                 var pos = _bufferPos;
                 if ((uint)pos < (uint)_currentSpan.Length)
@@ -657,7 +724,7 @@ namespace Orleans.Serialization.Buffers
         /// <returns>The <see cref="uint"/> which was read.</returns>
         public uint ReadUInt32()
         {
-            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput || IsArcBufferInput)
             {
                 const int width = 4;
                 if (_bufferPos + width > _bufferSize)
@@ -701,7 +768,7 @@ namespace Orleans.Serialization.Buffers
         /// <returns>The <see cref="ulong"/> which was read.</returns>
         public ulong ReadUInt64()
         {
-            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput || IsArcBufferInput)
             {
                 const int width = 8;
                 if (_bufferPos + width > _bufferSize)
@@ -779,7 +846,7 @@ namespace Orleans.Serialization.Buffers
             }
 
             var bytes = new byte[count];
-            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput || IsArcBufferInput)
             {
                 var destination = new Span<byte>(bytes);
                 ReadBytes(destination);
@@ -798,7 +865,7 @@ namespace Orleans.Serialization.Buffers
         /// <param name="destination">The destination.</param>
         public void ReadBytes(scoped Span<byte> destination)
         {
-            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput || IsArcBufferInput)
             {
                 if (_bufferPos + destination.Length <= _bufferSize)
                 {
@@ -846,7 +913,7 @@ namespace Orleans.Serialization.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryReadBytes(int length, out ReadOnlySpan<byte> bytes)
         {
-            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput || IsArcBufferInput)
             {
                 if (_bufferPos + length <= _bufferSize)
                 {
@@ -879,7 +946,7 @@ namespace Orleans.Serialization.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe uint ReadVarUInt32()
         {
-            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput || IsArcBufferInput)
             {
                 var pos = _bufferPos;
 
@@ -937,7 +1004,7 @@ namespace Orleans.Serialization.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ulong ReadVarUInt64()
         {
-            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput)
+            if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput || IsArcBufferInput)
             {
                 var pos = _bufferPos;
 

--- a/src/Orleans.Serialization/Buffers/Writer.cs
+++ b/src/Orleans.Serialization/Buffers/Writer.cs
@@ -37,6 +37,15 @@ namespace Orleans.Serialization.Buffers
         /// <param name="session">The session.</param>
         /// <returns>A new <see cref="Writer{TBufferWriter}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Writer<ArcBufferWriterWrapper> Create(ArcBufferWriter destination, SerializerSession session) => new(new(destination), session);
+
+        /// <summary>
+        /// Creates a writer which writes to the specified destination.
+        /// </summary>
+        /// <param name="destination">The destination.</param>
+        /// <param name="session">The session.</param>
+        /// <returns>A new <see cref="Writer{TBufferWriter}"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Writer<MemoryStreamBufferWriter> Create(MemoryStream destination, SerializerSession session) => new(new MemoryStreamBufferWriter(destination), session);
 
         /// <summary>
@@ -93,6 +102,25 @@ namespace Orleans.Serialization.Buffers
         /// <returns>A new <see cref="Writer{TBufferWriter}"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Writer<PooledBuffer> CreatePooled(SerializerSession session) => new(new PooledBuffer(), session);
+    }
+
+    /// <summary>
+    /// Wraps an <see cref="ArcBufferWriter"/> for use as a serialization writer target.
+    /// </summary>
+    /// <remarks>
+    /// Disposing a <see cref="Writer{TBufferWriter}"/> over this wrapper does not dispose the underlying <see cref="ArcBufferWriter"/>.
+    /// </remarks>
+    /// <param name="bufferWriter">The wrapped buffer writer.</param>
+    public readonly struct ArcBufferWriterWrapper(ArcBufferWriter bufferWriter) : IBufferWriter<byte>
+    {
+        /// <inheritdoc/>
+        public void Advance(int count) => ((IBufferWriter<byte>)bufferWriter).Advance(count);
+
+        /// <inheritdoc/>
+        public Memory<byte> GetMemory(int sizeHint = 0) => bufferWriter.GetMemory(sizeHint);
+
+        /// <inheritdoc/>
+        public Span<byte> GetSpan(int sizeHint = 0) => bufferWriter.GetSpan(sizeHint);
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Serializer.cs
+++ b/src/Orleans.Serialization/Serializer.cs
@@ -414,6 +414,36 @@ namespace Orleans.Serialization
         /// <typeparam name="T">The serialized type.</typeparam>
         /// <param name="source">The source buffer.</param>
         /// <returns>The deserialized value.</returns>
+        public T Deserialize<T>(ArcBuffer source)
+        {
+            using var session = _sessionPool.GetSession();
+            var reader = Reader.Create(source, session);
+            var codec = session.CodecProvider.GetCodec<T>();
+            var field = reader.ReadFieldHeader();
+            return codec.ReadValue(ref reader, field);
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <typeparam name="T">The serialized type.</typeparam>
+        /// <param name="source">The source buffer.</param>
+        /// <param name="session">The serializer session.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize<T>(ArcBuffer source, SerializerSession session)
+        {
+            var reader = Reader.Create(source, session);
+            var codec = session.CodecProvider.GetCodec<T>();
+            var field = reader.ReadFieldHeader();
+            return codec.ReadValue(ref reader, field);
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <typeparam name="T">The serialized type.</typeparam>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
         public T Deserialize<T>(ReadOnlySpan<byte> source)
         {
             using var session = _sessionPool.GetSession();
@@ -839,6 +869,32 @@ namespace Orleans.Serialization
         /// <param name="session">The serializer session.</param>
         /// <returns>The deserialized value.</returns>
         public T Deserialize(PooledBuffer.BufferSlice source, SerializerSession session)
+        {
+            var reader = Reader.Create(source, session);
+            var field = reader.ReadFieldHeader();
+            return _codec.ReadValue(ref reader, field);
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize(ArcBuffer source)
+        {
+            using var session = _sessionPool.GetSession();
+            var reader = Reader.Create(source, session);
+            var field = reader.ReadFieldHeader();
+            return _codec.ReadValue(ref reader, field);
+        }
+
+        /// <summary>
+        /// Deserialize a value of type <typeparamref name="T"/> from <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <param name="session">The serializer session.</param>
+        /// <returns>The deserialized value.</returns>
+        public T Deserialize(ArcBuffer source, SerializerSession session)
         {
             var reader = Reader.Create(source, session);
             var field = reader.ReadFieldHeader();

--- a/test/Orleans.Serialization.UnitTests/Buffers/ArcBufferWriterSerializationTests.cs
+++ b/test/Orleans.Serialization.UnitTests/Buffers/ArcBufferWriterSerializationTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Session;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests.Buffers;
+
+[Trait("Category", "BVT")]
+public sealed class ArcBufferWriterSerializationTests
+{
+    [Fact]
+    public void ArcBufferWriter_RoundTripsReaderWriterAcrossPages()
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddSerializer()
+            .BuildServiceProvider();
+        var sessionPool = serviceProvider.GetRequiredService<SerializerSessionPool>();
+        var payload = new byte[ArcBufferWriter.MinimumPageSize + 17];
+        for (var i = 0; i < payload.Length; i++)
+        {
+            payload[i] = (byte)i;
+        }
+
+        using var bufferWriter = new ArcBufferWriter();
+        using (var writerSession = sessionPool.GetSession())
+        {
+            var writer = Writer.Create(bufferWriter, writerSession);
+            writer.WriteVarUInt32((uint)payload.Length);
+            writer.Write(payload);
+            writer.WriteUInt64(0xDEADBEEFUL);
+            writer.Commit();
+        }
+
+        using var buffer = bufferWriter.PeekSlice(bufferWriter.Length);
+        using var readerSession = sessionPool.GetSession();
+        var reader = Reader.Create(buffer, readerSession);
+        Assert.Equal((uint)payload.Length, reader.ReadVarUInt32());
+        Assert.Equal(payload, reader.ReadBytes((uint)payload.Length));
+        Assert.Equal(0xDEADBEEFUL, reader.ReadUInt64());
+        Assert.Equal(reader.Length, reader.Position);
+    }
+
+    [Fact]
+    public void ArcBufferWriter_DeserializesThroughSerializer()
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddSerializer()
+            .BuildServiceProvider();
+        var sessionPool = serviceProvider.GetRequiredService<SerializerSessionPool>();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var typedSerializer = serviceProvider.GetRequiredService<Serializer<string>>();
+        var expected = new string('x', ArcBufferWriter.MinimumPageSize + 17);
+
+        using var bufferWriter = new ArcBufferWriter();
+        using (var writerSession = sessionPool.GetSession())
+        {
+            var writer = Writer.Create(bufferWriter, writerSession);
+            serializer.Serialize(expected, ref writer);
+            writer.Commit();
+        }
+
+        using var buffer = bufferWriter.PeekSlice(bufferWriter.Length);
+        Assert.Equal(expected, serializer.Deserialize<string>(buffer));
+        Assert.Equal(expected, typedSerializer.Deserialize(buffer));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ArcBuffer` input support for serialization readers, including multi-page reads, position/length tracking, skip, and fork/resume behavior.
- Adds `Serializer` and `Serializer<T>` overloads for deserializing directly from `ArcBuffer`.
- Adds `Writer.Create(ArcBufferWriter, ...)` via a wrapper which does not dispose the underlying `ArcBufferWriter`.
- Updates serialization test helpers and adds focused `ArcBufferWriter` serialization tests for multi-page payloads and serializer round-trips.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10066)