### PR TITLE
perf(runtime): add safe pooled CallbackData reuse

### DIFF
--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Orleans.Serialization.Invocation;
@@ -20,45 +21,23 @@ namespace Orleans.Runtime
         private StatusResponse? lastKnownStatus;
         private ValueStopwatch stopwatch;
         private CancellationTokenRegistration _cancellationTokenRegistration;
-        private CorrelationId _correlationId;
         private int _refCount;
         private long _generation;
 
-        /// <summary>
-        /// Parameterless constructor for object pooling.
-        /// </summary>
         internal CallbackData()
         {
         }
 
-        public CallbackData(
-            SharedCallbackData shared,
-            IResponseCompletionSource ctx,
-            Message msg,
-            ApplicationRequestInstruments applicationRequestInstruments)
-        {
-            Initialize(shared, ctx, msg, applicationRequestInstruments);
-        }
-
-        /// <summary>
-        /// Initializes the callback data for use. Called after retrieving from the pool.
-        /// Does NOT set ref count - that is done by <see cref="CallbackDataOwner"/> constructor.
-        /// </summary>
-        public void Initialize(SharedCallbackData shared, IResponseCompletionSource ctx, Message msg, ApplicationRequestInstruments applicationRequestInstruments)
+        internal void Initialize(SharedCallbackData shared, IResponseCompletionSource ctx, Message msg, ApplicationRequestInstruments applicationRequestInstruments)
         {
             Debug.Assert(_refCount == 0, "CallbackData ref count should be 0 before initialization");
             this.shared = shared;
             this.context = ctx;
             this.Message = msg;
             _applicationRequestInstruments = applicationRequestInstruments;
-            this._correlationId = msg.Id;
             this.stopwatch = ValueStopwatch.StartNew();
-            _generation++;
         }
 
-        /// <summary>
-        /// Resets the callback data for return to the pool.
-        /// </summary>
         internal void Reset()
         {
             Debug.Assert(_refCount == 0, "CallbackData ref count should be 0 before reset");
@@ -70,29 +49,22 @@ namespace Orleans.Runtime
             stopwatch = default;
             _cancellationTokenRegistration.Dispose();
             _cancellationTokenRegistration = default;
-            _correlationId = default;
             Message = null!;
         }
 
-        /// <summary>
-        /// Acquires the initial owner reference. Must only be called once after initialization.
-        /// </summary>
-        /// <returns>The previous ref count (should be 0).</returns>
-        internal int AcquireOwnerReference()
+        internal long AcquireOwnerReference()
         {
-            return Interlocked.Increment(ref _refCount) - 1;
+            var generation = Interlocked.Increment(ref _generation);
+            if (Interlocked.CompareExchange(ref _refCount, 1, 0) != 0)
+            {
+                throw new InvalidOperationException("CallbackData already has an owner.");
+            }
+
+            return generation;
         }
 
-        internal long Generation => Volatile.Read(ref _generation);
-
-        /// <summary>
-        /// Attempts to acquire a borrowed lease on this callback, incrementing the ref count.
-        /// Returns true only if the ref count is positive (object is still owned).
-        /// </summary>
-        /// <returns>True if the lease was acquired, false if the object is being/has been returned to pool.</returns>
         internal bool TryAcquireLease(long generation)
         {
-            // Spin until we either successfully increment or detect ref count is 0
             while (true)
             {
                 if (generation != Volatile.Read(ref _generation))
@@ -102,13 +74,11 @@ namespace Orleans.Runtime
 
                 var currentRefCount = Volatile.Read(ref _refCount);
 
-                // If ref count is 0 or negative, the object is being returned to pool or already pooled
                 if (currentRefCount <= 0)
                 {
                     return false;
                 }
 
-                // Try to increment the ref count
                 if (Interlocked.CompareExchange(ref _refCount, currentRefCount + 1, currentRefCount) == currentRefCount)
                 {
                     if (generation == Volatile.Read(ref _generation))
@@ -119,15 +89,9 @@ namespace Orleans.Runtime
                     ReleaseReference();
                     return false;
                 }
-
-                // CAS failed, spin and retry
             }
         }
 
-        /// <summary>
-        /// Releases a lease on this callback, decrementing the ref count.
-        /// If the ref count reaches zero, returns the callback to the pool.
-        /// </summary>
         internal void ReleaseLease(long generation)
         {
             if (generation != Volatile.Read(ref _generation))
@@ -147,9 +111,8 @@ namespace Orleans.Runtime
             }
             else if (newRefCount < 0)
             {
-                // This should never happen - indicates a bug
                 Debug.Fail("CallbackData ref count went negative");
-                throw new InvalidOperationException("CallbackData ref count went negative - indicates a double release bug");
+                throw new InvalidOperationException("CallbackData was released more than once.");
             }
         }
 
@@ -199,18 +162,7 @@ namespace Orleans.Runtime
             }
         }
 
-        public void OnStatusUpdate(CorrelationId messageId, StatusResponse status)
-        {
-            // Validate that the status update is for this callback instance.
-            // This is necessary because the callback may have been returned to the pool
-            // and reused for a different message between TryGetValue and OnStatusUpdate.
-            if (_correlationId != messageId)
-            {
-                return;
-            }
-
-            this.lastKnownStatus = status;
-        }
+        public void OnStatusUpdate(StatusResponse status) => this.lastKnownStatus = status;
 
         public bool IsExpired(long currentTimestamp)
         {
@@ -239,6 +191,24 @@ namespace Orleans.Runtime
 
         private void OnCancellation(CancellationToken cancellationToken)
         {
+            var generation = Volatile.Read(ref _generation);
+            if (!TryAcquireLease(generation))
+            {
+                throw new InvalidOperationException("Cancellation ran after CallbackData ownership ended.");
+            }
+
+            try
+            {
+                OnCancellationCore(cancellationToken);
+            }
+            finally
+            {
+                ReleaseLease(generation);
+            }
+        }
+
+        private void OnCancellationCore(CancellationToken cancellationToken)
+        {
             // If waiting for acknowledgement is enabled, simply signal to the remote grain that cancellation
             // is requested and return.
             if (shared.WaitForCancellationAcknowledgement)
@@ -256,21 +226,12 @@ namespace Orleans.Runtime
 
             stopwatch.Stop();
             SignalCancellation();
-            // Capture locals before Unregister, which may return this to the pool
-            var elapsedMs = (long)stopwatch.Elapsed.TotalMilliseconds;
-            var msg = Message;
-            var ctx = context;
-            var instruments = _applicationRequestInstruments;
-            var targetGrainType = GetTargetGrainType();
+            shared.Unregister(Message);
             DisposeCancellationRegistration();
-
-            // Unregister last - this may return the callback to the pool
-            shared.Unregister(msg);
-
-            instruments.OnAppRequestsEnd(elapsedMs);
-            instruments.OnAppRequestsCanceled(targetGrainType);
-            OrleansCallBackDataEvent.Instance.OnCanceled(msg);
-            ctx.Complete(Response.FromException(new OperationCanceledException(cancellationToken)));
+            _applicationRequestInstruments.OnAppRequestsEnd((long)stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsCanceled(GetTargetGrainType());
+            OrleansCallBackDataEvent.Instance.OnCanceled(Message);
+            context.Complete(Response.FromException(new OperationCanceledException(cancellationToken)));
         }
 
         public void OnTimeout()
@@ -286,29 +247,18 @@ namespace Orleans.Runtime
                 SignalCancellation();
             }
 
-            // Capture locals before Unregister, which may return this to the pool
+            this.shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            var elapsedMs = (long)this.stopwatch.Elapsed.TotalMilliseconds;
+            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsTimedOut(GetTargetGrainType());
+
+            OrleansCallBackDataEvent.Instance.OnTimeout(this.Message);
             var msg = this.Message;
             var statusMessage = lastKnownStatus is StatusResponse status ? $"Last known status is {status}. " : string.Empty;
             var timeout = GetResponseTimeout();
-            var logger = this.shared.Logger;
-            var ctx = this.context;
-            var instruments = _applicationRequestInstruments;
-            var targetGrainType = GetTargetGrainType();
-
-            // Unregister last - this may return the callback to the pool
-            this.shared.Unregister(msg);
-
-            instruments.OnAppRequestsEnd(elapsedMs);
-            instruments.OnAppRequestsTimedOut(targetGrainType);
-
-            OrleansCallBackDataEvent.Instance.OnTimeout(msg);
-
-            LogTimeout(logger, timeout, msg, statusMessage);
-
+            LogTimeout(this.shared.Logger, timeout, msg, statusMessage);
             var exception = new TimeoutException($"Response did not arrive on time in {timeout} for message: {msg}. {statusMessage}");
-            ctx.Complete(Response.FromException(exception));
+            context.Complete(Response.FromException(exception));
         }
 
         public void OnTargetSiloFail()
@@ -319,23 +269,16 @@ namespace Orleans.Runtime
             }
 
             this.stopwatch.Stop();
-            // Capture locals before Unregister, which may return this to the pool
+            this.shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            var elapsedMs = (long)this.stopwatch.Elapsed.TotalMilliseconds;
+            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+
+            OrleansCallBackDataEvent.Instance.OnTargetSiloFail(this.Message);
             var msg = this.Message;
             var statusMessage = lastKnownStatus is StatusResponse status ? $"Last known status is {status}. " : string.Empty;
-            var logger = this.shared.Logger;
-            var ctx = this.context;
-            var instruments = _applicationRequestInstruments;
-
-            // Unregister last - this may return the callback to the pool
-            this.shared.Unregister(msg);
-            instruments.OnAppRequestsEnd(elapsedMs);
-
-            OrleansCallBackDataEvent.Instance.OnTargetSiloFail(msg);
-            LogTargetSiloFail(logger, msg, statusMessage, Constants.TroubleshootingHelpLink);
+            LogTargetSiloFail(this.shared.Logger, msg, statusMessage, Constants.TroubleshootingHelpLink);
             var exception = new SiloUnavailableException($"The target silo became unavailable for message: {msg}. {statusMessage}See {Constants.TroubleshootingHelpLink} for troubleshooting help.");
-            ctx.Complete(Response.FromException(exception));
+            this.context.Complete(Response.FromException(exception));
         }
 
         public void OnHostShutdown()
@@ -346,19 +289,13 @@ namespace Orleans.Runtime
             }
 
             this.stopwatch.Stop();
+            this.shared.Unregister(this.Message);
             DisposeCancellationRegistration();
+            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
 
-            var elapsedMs = (long)this.stopwatch.Elapsed.TotalMilliseconds;
             var msg = this.Message;
-            var shared = this.shared;
-            var context = this.context;
-            var instruments = _applicationRequestInstruments;
-
-            shared.Unregister(msg);
-            instruments.OnAppRequestsEnd(elapsedMs);
-
             var exception = new SiloUnavailableException($"The local Orleans host is shutting down and can no longer process the request: {msg}.");
-            context.Complete(Response.FromException(exception));
+            this.context.Complete(Response.FromException(exception));
         }
 
         public void DoCallback(Message response)
@@ -441,57 +378,39 @@ namespace Orleans.Runtime
     }
 
     /// <summary>
-    /// Owns a pooled <see cref="CallbackData"/> instance and manages its lifecycle.
-    /// This represents the "owner" - the code that creates this and stores it in the callbacks dictionary.
-    /// When the owner is done with the callback, it should call <see cref="Release"/> to return it to the pool.
-    /// The owner increments the ref count to 1 on construction.
+    /// Holds the dictionary-owned reference to a pooled <see cref="CallbackData"/> instance.
     /// </summary>
     internal readonly struct CallbackDataOwner
     {
-        private readonly CallbackData _callback;
+        private readonly CallbackData? _callback;
         private readonly long _generation;
 
         public CallbackDataOwner(CallbackData callback)
         {
-            Debug.Assert(callback is not null, "CallbackDataOwner requires a non-null callback");
             _callback = callback;
-            _generation = callback.Generation;
-            var previousRefCount = callback.AcquireOwnerReference();
-            Debug.Assert(previousRefCount == 0, $"CallbackData ref count should have been 0 when creating owner, but was {previousRefCount}");
+            _generation = callback.AcquireOwnerReference();
         }
 
-        /// <summary>
-        /// Attempts to acquire a borrowed lease on the callback.
-        /// The returned lease MUST be disposed when done to release the reference count.
-        /// Use <see cref="CallbackDataLease.TryGetValue"/> to check if the lease is valid and get the callback.
-        /// </summary>
-        /// <returns>A lease that must be disposed. Check <see cref="CallbackDataLease.TryGetValue"/> to see if it's valid.</returns>
         public CallbackDataLease Acquire()
         {
-            Debug.Assert(_callback is not null, "CallbackDataOwner.Acquire called on default struct");
-            if (_callback.TryAcquireLease(_generation))
+            var callback = _callback ?? throw new InvalidOperationException("CallbackDataOwner is not initialized.");
+            if (callback.TryAcquireLease(_generation))
             {
-                return new CallbackDataLease(_callback, _generation);
+                return new CallbackDataLease(callback, _generation);
             }
 
             return default;
         }
 
-        /// <summary>
-        /// Releases the owner's reference to the callback, potentially returning it to the pool.
-        /// This should be called when the callback is removed from the dictionary and is no longer needed.
-        /// </summary>
         public void Release()
         {
-            Debug.Assert(_callback is not null, "CallbackDataOwner.Release called on default struct");
-            _callback.ReleaseLease(_generation);
+            var callback = _callback ?? throw new InvalidOperationException("CallbackDataOwner is not initialized.");
+            callback.ReleaseLease(_generation);
         }
     }
 
     /// <summary>
-    /// A borrowed lease on a <see cref="CallbackData"/> instance.
-    /// This is a ref struct to ensure it cannot escape the current scope without being disposed.
-    /// Disposing the lease releases the reference count, potentially allowing the callback to be returned to the pool.
+    /// Holds a scoped reference to a pooled <see cref="CallbackData"/> instance.
     /// </summary>
     internal ref struct CallbackDataLease
     {
@@ -504,26 +423,15 @@ namespace Orleans.Runtime
             _generation = generation;
         }
 
-        /// <summary>
-        /// Gets whether this lease is valid (successfully acquired a reference).
-        /// </summary>
-        public readonly bool IsValid => _callback is not null;
+        public readonly CallbackData Value =>
+            _callback ?? throw new InvalidOperationException("CallbackDataLease is not initialized.");
 
-        /// <summary>
-        /// Attempts to get the callback data if the lease is valid.
-        /// </summary>
-        /// <param name="callback">The callback data if valid, otherwise null.</param>
-        /// <returns>True if the lease is valid and the callback was returned.</returns>
-        public readonly bool TryGetValue([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out CallbackData? callback)
+        public readonly bool TryGetValue([NotNullWhen(true)] out CallbackData? callback)
         {
             callback = _callback;
             return callback is not null;
         }
 
-        /// <summary>
-        /// Releases the lease, decrementing the reference count.
-        /// If this was the last reference, the callback will be returned to the pool.
-        /// </summary>
         public void Dispose()
         {
             if (_callback is { } callback)

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -26,6 +26,7 @@ namespace Orleans.Runtime
         private StatusResponse? lastKnownStatus;
         private ValueStopwatch stopwatch;
         private CancellationTokenRegistration _cancellationTokenRegistration;
+        private long _cancellationGeneration;
         private long _referenceState;
 
         internal CallbackData()
@@ -53,6 +54,7 @@ namespace Orleans.Runtime
             stopwatch = default;
             _cancellationTokenRegistration.Dispose();
             _cancellationTokenRegistration = default;
+            Volatile.Write(ref _cancellationGeneration, 0);
             Message = null!;
         }
 
@@ -179,7 +181,7 @@ namespace Orleans.Runtime
 
         public bool IsCompleted => (Volatile.Read(ref _state) & StateCompleted) != 0;
 
-        public void SubscribeForCancellation(CancellationToken cancellationToken, CallbackDataOwner owner)
+        public void SubscribeForCancellation(CancellationToken cancellationToken)
         {
             if (!cancellationToken.CanBeCanceled)
             {
@@ -194,14 +196,19 @@ namespace Orleans.Runtime
                 return;
             }
 
+            Volatile.Write(ref _cancellationGeneration, GetGeneration(Volatile.Read(ref _referenceState)));
             var registration = cancellationToken.UnsafeRegister(static (arg, token) =>
             {
-                using var lease = ((CallbackDataOwner)arg!).Acquire();
+                var callback = (CallbackData)arg!;
+                var generation = Volatile.Read(ref callback._cancellationGeneration);
+                using var lease = callback.TryAcquireLease(generation)
+                    ? new CallbackDataLease(callback, generation)
+                    : default;
                 if (lease.TryGetValue(out var callbackData))
                 {
                     callbackData.OnCancellation(token);
                 }
-            }, owner);
+            }, this);
 
             _cancellationTokenRegistration = registration;
             if (Interlocked.CompareExchange(
@@ -364,6 +371,8 @@ namespace Orleans.Runtime
         private void DisposeCancellationRegistration()
         {
             // If registration is still pending, its publisher observes completion and disposes it.
+            // Dispose waits for a concurrently executing callback, so its captured generation remains
+            // stable until that callback releases its lease and this instance can return to the pool.
             if ((Volatile.Read(ref _state) & StateCancellationRegistrationPublished) != 0)
             {
                 _cancellationTokenRegistration.Dispose();

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -179,7 +179,7 @@ namespace Orleans.Runtime
 
         public bool IsCompleted => (Volatile.Read(ref _state) & StateCompleted) != 0;
 
-        public void SubscribeForCancellation(CancellationToken cancellationToken)
+        public void SubscribeForCancellation(CancellationToken cancellationToken, CallbackDataOwner owner)
         {
             if (!cancellationToken.CanBeCanceled)
             {
@@ -196,9 +196,12 @@ namespace Orleans.Runtime
 
             var registration = cancellationToken.UnsafeRegister(static (arg, token) =>
             {
-                var callbackData = (CallbackData)arg!;
-                callbackData.OnCancellation(token);
-            }, this);
+                using var lease = ((CallbackDataOwner)arg!).Acquire();
+                if (lease.TryGetValue(out var callbackData))
+                {
+                    callbackData.OnCancellation(token);
+                }
+            }, owner);
 
             _cancellationTokenRegistration = registration;
             if (Interlocked.CompareExchange(
@@ -249,24 +252,6 @@ namespace Orleans.Runtime
         }
 
         private void OnCancellation(CancellationToken cancellationToken)
-        {
-            var generation = GetGeneration(Volatile.Read(ref _referenceState));
-            if (!TryAcquireLease(generation))
-            {
-                return;
-            }
-
-            try
-            {
-                OnCancellationCore(cancellationToken);
-            }
-            finally
-            {
-                ReleaseLease(generation);
-            }
-        }
-
-        private void OnCancellationCore(CancellationToken cancellationToken)
         {
             // If waiting for acknowledgement is enabled, simply signal to the remote grain that cancellation
             // is requested and return.

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -13,13 +13,23 @@ namespace Orleans.Runtime
         private const int StateCancellationRegistrationPending = 2;
         private const int StateCancellationRegistrationPublished = 4;
 
-        private readonly SharedCallbackData shared;
-        private readonly IResponseCompletionSource context;
-        private readonly ApplicationRequestInstruments _applicationRequestInstruments;
+        private SharedCallbackData shared = null!;
+        private IResponseCompletionSource context = null!;
+        private ApplicationRequestInstruments _applicationRequestInstruments = null!;
         private int _state;
         private StatusResponse? lastKnownStatus;
         private ValueStopwatch stopwatch;
         private CancellationTokenRegistration _cancellationTokenRegistration;
+        private CorrelationId _correlationId;
+        private int _refCount;
+        private long _generation;
+
+        /// <summary>
+        /// Parameterless constructor for object pooling.
+        /// </summary>
+        internal CallbackData()
+        {
+        }
 
         public CallbackData(
             SharedCallbackData shared,
@@ -27,14 +37,123 @@ namespace Orleans.Runtime
             Message msg,
             ApplicationRequestInstruments applicationRequestInstruments)
         {
+            Initialize(shared, ctx, msg, applicationRequestInstruments);
+        }
+
+        /// <summary>
+        /// Initializes the callback data for use. Called after retrieving from the pool.
+        /// Does NOT set ref count - that is done by <see cref="CallbackDataOwner"/> constructor.
+        /// </summary>
+        public void Initialize(SharedCallbackData shared, IResponseCompletionSource ctx, Message msg, ApplicationRequestInstruments applicationRequestInstruments)
+        {
+            Debug.Assert(_refCount == 0, "CallbackData ref count should be 0 before initialization");
             this.shared = shared;
             this.context = ctx;
             this.Message = msg;
             _applicationRequestInstruments = applicationRequestInstruments;
+            this._correlationId = msg.Id;
             this.stopwatch = ValueStopwatch.StartNew();
+            _generation++;
         }
 
-        public Message Message { get; } // might hold metadata used by response pipeline
+        /// <summary>
+        /// Resets the callback data for return to the pool.
+        /// </summary>
+        internal void Reset()
+        {
+            Debug.Assert(_refCount == 0, "CallbackData ref count should be 0 before reset");
+            shared = null!;
+            context = null!;
+            _applicationRequestInstruments = null!;
+            _state = StateNone;
+            lastKnownStatus = null;
+            stopwatch = default;
+            _cancellationTokenRegistration.Dispose();
+            _cancellationTokenRegistration = default;
+            _correlationId = default;
+            Message = null!;
+        }
+
+        /// <summary>
+        /// Acquires the initial owner reference. Must only be called once after initialization.
+        /// </summary>
+        /// <returns>The previous ref count (should be 0).</returns>
+        internal int AcquireOwnerReference()
+        {
+            return Interlocked.Increment(ref _refCount) - 1;
+        }
+
+        internal long Generation => Volatile.Read(ref _generation);
+
+        /// <summary>
+        /// Attempts to acquire a borrowed lease on this callback, incrementing the ref count.
+        /// Returns true only if the ref count is positive (object is still owned).
+        /// </summary>
+        /// <returns>True if the lease was acquired, false if the object is being/has been returned to pool.</returns>
+        internal bool TryAcquireLease(long generation)
+        {
+            // Spin until we either successfully increment or detect ref count is 0
+            while (true)
+            {
+                if (generation != Volatile.Read(ref _generation))
+                {
+                    return false;
+                }
+
+                var currentRefCount = Volatile.Read(ref _refCount);
+
+                // If ref count is 0 or negative, the object is being returned to pool or already pooled
+                if (currentRefCount <= 0)
+                {
+                    return false;
+                }
+
+                // Try to increment the ref count
+                if (Interlocked.CompareExchange(ref _refCount, currentRefCount + 1, currentRefCount) == currentRefCount)
+                {
+                    if (generation == Volatile.Read(ref _generation))
+                    {
+                        return true;
+                    }
+
+                    ReleaseReference();
+                    return false;
+                }
+
+                // CAS failed, spin and retry
+            }
+        }
+
+        /// <summary>
+        /// Releases a lease on this callback, decrementing the ref count.
+        /// If the ref count reaches zero, returns the callback to the pool.
+        /// </summary>
+        internal void ReleaseLease(long generation)
+        {
+            if (generation != Volatile.Read(ref _generation))
+            {
+                throw new InvalidOperationException("Cannot release a stale CallbackData reference.");
+            }
+
+            ReleaseReference();
+        }
+
+        private void ReleaseReference()
+        {
+            var newRefCount = Interlocked.Decrement(ref _refCount);
+            if (newRefCount == 0)
+            {
+                CallbackDataPool.ReturnCore(this);
+            }
+            else if (newRefCount < 0)
+            {
+                // This should never happen - indicates a bug
+                Debug.Fail("CallbackData ref count went negative");
+                throw new InvalidOperationException("CallbackData ref count went negative - indicates a double release bug");
+            }
+        }
+
+        public Message Message { get; private set; } = null!; // might hold metadata used by response pipeline
 
         public bool IsCompleted => (Volatile.Read(ref _state) & StateCompleted) != 0;
 
@@ -80,8 +199,16 @@ namespace Orleans.Runtime
             }
         }
 
-        public void OnStatusUpdate(StatusResponse status)
+        public void OnStatusUpdate(CorrelationId messageId, StatusResponse status)
         {
+            // Validate that the status update is for this callback instance.
+            // This is necessary because the callback may have been returned to the pool
+            // and reused for a different message between TryGetValue and OnStatusUpdate.
+            if (_correlationId != messageId)
+            {
+                return;
+            }
+
             this.lastKnownStatus = status;
         }
 
@@ -129,12 +256,21 @@ namespace Orleans.Runtime
 
             stopwatch.Stop();
             SignalCancellation();
-            shared.Unregister(Message);
-            _applicationRequestInstruments.OnAppRequestsEnd((long)stopwatch.Elapsed.TotalMilliseconds);
-            _applicationRequestInstruments.OnAppRequestsCanceled(GetTargetGrainType());
-            OrleansCallBackDataEvent.Instance.OnCanceled(Message);
-            context.Complete(Response.FromException(new OperationCanceledException(cancellationToken)));
+            // Capture locals before Unregister, which may return this to the pool
+            var elapsedMs = (long)stopwatch.Elapsed.TotalMilliseconds;
+            var msg = Message;
+            var ctx = context;
+            var instruments = _applicationRequestInstruments;
+            var targetGrainType = GetTargetGrainType();
             DisposeCancellationRegistration();
+
+            // Unregister last - this may return the callback to the pool
+            shared.Unregister(msg);
+
+            instruments.OnAppRequestsEnd(elapsedMs);
+            instruments.OnAppRequestsCanceled(targetGrainType);
+            OrleansCallBackDataEvent.Instance.OnCanceled(msg);
+            ctx.Complete(Response.FromException(new OperationCanceledException(cancellationToken)));
         }
 
         public void OnTimeout()
@@ -150,21 +286,29 @@ namespace Orleans.Runtime
                 SignalCancellation();
             }
 
-            this.shared.Unregister(this.Message);
+            // Capture locals before Unregister, which may return this to the pool
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
-            _applicationRequestInstruments.OnAppRequestsTimedOut(GetTargetGrainType());
-
-            OrleansCallBackDataEvent.Instance.OnTimeout(this.Message);
-
-            var msg = this.Message; // Local working copy
-
+            var elapsedMs = (long)this.stopwatch.Elapsed.TotalMilliseconds;
+            var msg = this.Message;
             var statusMessage = lastKnownStatus is StatusResponse status ? $"Last known status is {status}. " : string.Empty;
             var timeout = GetResponseTimeout();
-            LogTimeout(this.shared.Logger, timeout, msg, statusMessage);
+            var logger = this.shared.Logger;
+            var ctx = this.context;
+            var instruments = _applicationRequestInstruments;
+            var targetGrainType = GetTargetGrainType();
+
+            // Unregister last - this may return the callback to the pool
+            this.shared.Unregister(msg);
+
+            instruments.OnAppRequestsEnd(elapsedMs);
+            instruments.OnAppRequestsTimedOut(targetGrainType);
+
+            OrleansCallBackDataEvent.Instance.OnTimeout(msg);
+
+            LogTimeout(logger, timeout, msg, statusMessage);
 
             var exception = new TimeoutException($"Response did not arrive on time in {timeout} for message: {msg}. {statusMessage}");
-            context.Complete(Response.FromException(exception));
+            ctx.Complete(Response.FromException(exception));
         }
 
         public void OnTargetSiloFail()
@@ -175,16 +319,23 @@ namespace Orleans.Runtime
             }
 
             this.stopwatch.Stop();
-            this.shared.Unregister(this.Message);
+            // Capture locals before Unregister, which may return this to the pool
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
-
-            OrleansCallBackDataEvent.Instance.OnTargetSiloFail(this.Message);
+            var elapsedMs = (long)this.stopwatch.Elapsed.TotalMilliseconds;
             var msg = this.Message;
             var statusMessage = lastKnownStatus is StatusResponse status ? $"Last known status is {status}. " : string.Empty;
-            LogTargetSiloFail(this.shared.Logger, msg, statusMessage, Constants.TroubleshootingHelpLink);
+            var logger = this.shared.Logger;
+            var ctx = this.context;
+            var instruments = _applicationRequestInstruments;
+
+            // Unregister last - this may return the callback to the pool
+            this.shared.Unregister(msg);
+            instruments.OnAppRequestsEnd(elapsedMs);
+
+            OrleansCallBackDataEvent.Instance.OnTargetSiloFail(msg);
+            LogTargetSiloFail(logger, msg, statusMessage, Constants.TroubleshootingHelpLink);
             var exception = new SiloUnavailableException($"The target silo became unavailable for message: {msg}. {statusMessage}See {Constants.TroubleshootingHelpLink} for troubleshooting help.");
-            this.context.Complete(Response.FromException(exception));
+            ctx.Complete(Response.FromException(exception));
         }
 
         public void OnHostShutdown()
@@ -195,13 +346,19 @@ namespace Orleans.Runtime
             }
 
             this.stopwatch.Stop();
-            this.shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
 
+            var elapsedMs = (long)this.stopwatch.Elapsed.TotalMilliseconds;
             var msg = this.Message;
+            var shared = this.shared;
+            var context = this.context;
+            var instruments = _applicationRequestInstruments;
+
+            shared.Unregister(msg);
+            instruments.OnAppRequestsEnd(elapsedMs);
+
             var exception = new SiloUnavailableException($"The local Orleans host is shutting down and can no longer process the request: {msg}.");
-            this.context.Complete(Response.FromException(exception));
+            context.Complete(Response.FromException(exception));
         }
 
         public void DoCallback(Message response)
@@ -281,5 +438,99 @@ namespace Orleans.Runtime
             Message = "The target silo became unavailable for message: '{Message}'. {StatusMessage}See {TroubleshootingHelpLink} for troubleshooting help. About to break its promise."
         )]
         private static partial void LogTargetSiloFail(ILogger logger, Message message, string statusMessage, string troubleshootingHelpLink);
+    }
+
+    /// <summary>
+    /// Owns a pooled <see cref="CallbackData"/> instance and manages its lifecycle.
+    /// This represents the "owner" - the code that creates this and stores it in the callbacks dictionary.
+    /// When the owner is done with the callback, it should call <see cref="Release"/> to return it to the pool.
+    /// The owner increments the ref count to 1 on construction.
+    /// </summary>
+    internal readonly struct CallbackDataOwner
+    {
+        private readonly CallbackData _callback;
+        private readonly long _generation;
+
+        public CallbackDataOwner(CallbackData callback)
+        {
+            Debug.Assert(callback is not null, "CallbackDataOwner requires a non-null callback");
+            _callback = callback;
+            _generation = callback.Generation;
+            var previousRefCount = callback.AcquireOwnerReference();
+            Debug.Assert(previousRefCount == 0, $"CallbackData ref count should have been 0 when creating owner, but was {previousRefCount}");
+        }
+
+        /// <summary>
+        /// Attempts to acquire a borrowed lease on the callback.
+        /// The returned lease MUST be disposed when done to release the reference count.
+        /// Use <see cref="CallbackDataLease.TryGetValue"/> to check if the lease is valid and get the callback.
+        /// </summary>
+        /// <returns>A lease that must be disposed. Check <see cref="CallbackDataLease.TryGetValue"/> to see if it's valid.</returns>
+        public CallbackDataLease Acquire()
+        {
+            Debug.Assert(_callback is not null, "CallbackDataOwner.Acquire called on default struct");
+            if (_callback.TryAcquireLease(_generation))
+            {
+                return new CallbackDataLease(_callback, _generation);
+            }
+
+            return default;
+        }
+
+        /// <summary>
+        /// Releases the owner's reference to the callback, potentially returning it to the pool.
+        /// This should be called when the callback is removed from the dictionary and is no longer needed.
+        /// </summary>
+        public void Release()
+        {
+            Debug.Assert(_callback is not null, "CallbackDataOwner.Release called on default struct");
+            _callback.ReleaseLease(_generation);
+        }
+    }
+
+    /// <summary>
+    /// A borrowed lease on a <see cref="CallbackData"/> instance.
+    /// This is a ref struct to ensure it cannot escape the current scope without being disposed.
+    /// Disposing the lease releases the reference count, potentially allowing the callback to be returned to the pool.
+    /// </summary>
+    internal ref struct CallbackDataLease
+    {
+        private CallbackData? _callback;
+        private readonly long _generation;
+
+        internal CallbackDataLease(CallbackData callback, long generation)
+        {
+            _callback = callback;
+            _generation = generation;
+        }
+
+        /// <summary>
+        /// Gets whether this lease is valid (successfully acquired a reference).
+        /// </summary>
+        public readonly bool IsValid => _callback is not null;
+
+        /// <summary>
+        /// Attempts to get the callback data if the lease is valid.
+        /// </summary>
+        /// <param name="callback">The callback data if valid, otherwise null.</param>
+        /// <returns>True if the lease is valid and the callback was returned.</returns>
+        public readonly bool TryGetValue([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out CallbackData? callback)
+        {
+            callback = _callback;
+            return callback is not null;
+        }
+
+        /// <summary>
+        /// Releases the lease, decrementing the reference count.
+        /// If this was the last reference, the callback will be returned to the pool.
+        /// </summary>
+        public void Dispose()
+        {
+            if (_callback is { } callback)
+            {
+                _callback = null;
+                callback.ReleaseLease(_generation);
+            }
+        }
     }
 }

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -13,6 +13,11 @@ namespace Orleans.Runtime
         private const int StateCompleted = 1;
         private const int StateCancellationRegistrationPending = 2;
         private const int StateCancellationRegistrationPublished = 4;
+        private const long OwnerReference = 1;
+        private const long LeaseReference = 2;
+        private const int ReferenceBits = 16;
+        private const long ReferenceMask = (1L << ReferenceBits) - 1;
+        private const long GenerationIncrement = 1L << ReferenceBits;
 
         private SharedCallbackData shared = null!;
         private IResponseCompletionSource context = null!;
@@ -21,8 +26,7 @@ namespace Orleans.Runtime
         private StatusResponse? lastKnownStatus;
         private ValueStopwatch stopwatch;
         private CancellationTokenRegistration _cancellationTokenRegistration;
-        private int _refCount;
-        private long _generation;
+        private long _referenceState;
 
         internal CallbackData()
         {
@@ -30,7 +34,7 @@ namespace Orleans.Runtime
 
         internal void Initialize(SharedCallbackData shared, IResponseCompletionSource ctx, Message msg, ApplicationRequestInstruments applicationRequestInstruments)
         {
-            Debug.Assert(_refCount == 0, "CallbackData ref count should be 0 before initialization");
+            Debug.Assert(GetReferences(Volatile.Read(ref _referenceState)) == 0, "CallbackData should have no references before initialization");
             this.shared = shared;
             this.context = ctx;
             this.Message = msg;
@@ -40,7 +44,7 @@ namespace Orleans.Runtime
 
         internal void Reset()
         {
-            Debug.Assert(_refCount == 0, "CallbackData ref count should be 0 before reset");
+            Debug.Assert(GetReferences(Volatile.Read(ref _referenceState)) == 0, "CallbackData should have no references before reset");
             shared = null!;
             context = null!;
             _applicationRequestInstruments = null!;
@@ -52,67 +56,122 @@ namespace Orleans.Runtime
             Message = null!;
         }
 
-        internal long AcquireOwnerReference()
+        internal long AcquireOwnerReference(bool acquireLease)
         {
-            var generation = Interlocked.Increment(ref _generation);
-            if (Interlocked.CompareExchange(ref _refCount, 1, 0) != 0)
+            while (true)
             {
-                throw new InvalidOperationException("CallbackData already has an owner.");
-            }
+                var state = Volatile.Read(ref _referenceState);
+                if (GetReferences(state) != 0)
+                {
+                    throw new InvalidOperationException("CallbackData already has an owner.");
+                }
 
-            return generation;
+                var generation = unchecked((state & ~ReferenceMask) + GenerationIncrement);
+                var nextState = generation | OwnerReference | (acquireLease ? LeaseReference : 0);
+                if (Interlocked.CompareExchange(ref _referenceState, nextState, state) == state)
+                {
+                    return generation;
+                }
+            }
+        }
+
+        internal bool TryTransferOwnerToLease(long generation)
+        {
+            while (true)
+            {
+                var state = Volatile.Read(ref _referenceState);
+                if (GetGeneration(state) != generation || (state & OwnerReference) == 0)
+                {
+                    return false;
+                }
+
+                if (GetReferences(state) > ReferenceMask - LeaseReference)
+                {
+                    throw new InvalidOperationException("CallbackData has too many active leases.");
+                }
+
+                // Replace the owner reference with one lease.
+                if (Interlocked.CompareExchange(ref _referenceState, state + LeaseReference - OwnerReference, state) == state)
+                {
+                    return true;
+                }
+            }
+        }
+
+        internal void ReleaseOwnerReference(long generation)
+        {
+            while (true)
+            {
+                var state = Volatile.Read(ref _referenceState);
+                if (GetGeneration(state) != generation || (state & OwnerReference) == 0)
+                {
+                    return;
+                }
+
+                var nextState = state - OwnerReference;
+                if (Interlocked.CompareExchange(ref _referenceState, nextState, state) == state)
+                {
+                    ReturnIfUnreferenced(nextState);
+                    return;
+                }
+            }
         }
 
         internal bool TryAcquireLease(long generation)
         {
             while (true)
             {
-                if (generation != Volatile.Read(ref _generation))
+                var state = Volatile.Read(ref _referenceState);
+                if (GetGeneration(state) != generation || (state & OwnerReference) == 0)
                 {
                     return false;
                 }
 
-                var currentRefCount = Volatile.Read(ref _refCount);
-
-                if (currentRefCount <= 0)
+                if (GetReferences(state) > ReferenceMask - LeaseReference)
                 {
-                    return false;
+                    throw new InvalidOperationException("CallbackData has too many active leases.");
                 }
 
-                if (Interlocked.CompareExchange(ref _refCount, currentRefCount + 1, currentRefCount) == currentRefCount)
+                if (Interlocked.CompareExchange(ref _referenceState, state + LeaseReference, state) == state)
                 {
-                    if (generation == Volatile.Read(ref _generation))
-                    {
-                        return true;
-                    }
-
-                    ReleaseReference();
-                    return false;
+                    return true;
                 }
             }
         }
 
         internal void ReleaseLease(long generation)
         {
-            if (generation != Volatile.Read(ref _generation))
+            while (true)
             {
-                throw new InvalidOperationException("Cannot release a stale CallbackData reference.");
-            }
+                var state = Volatile.Read(ref _referenceState);
+                if (GetGeneration(state) != generation)
+                {
+                    throw new InvalidOperationException("Cannot release a stale CallbackData lease.");
+                }
 
-            ReleaseReference();
+                if (GetReferences(state) < LeaseReference)
+                {
+                    throw new InvalidOperationException("CallbackData lease was released more than once.");
+                }
+
+                var nextState = state - LeaseReference;
+                if (Interlocked.CompareExchange(ref _referenceState, nextState, state) == state)
+                {
+                    ReturnIfUnreferenced(nextState);
+                    return;
+                }
+            }
         }
 
-        private void ReleaseReference()
+        private static long GetGeneration(long state) => state & ~ReferenceMask;
+
+        private static long GetReferences(long state) => state & ReferenceMask;
+
+        private void ReturnIfUnreferenced(long state)
         {
-            var newRefCount = Interlocked.Decrement(ref _refCount);
-            if (newRefCount == 0)
+            if (GetReferences(state) == 0)
             {
                 CallbackDataPool.ReturnCore(this);
-            }
-            else if (newRefCount < 0)
-            {
-                Debug.Fail("CallbackData ref count went negative");
-                throw new InvalidOperationException("CallbackData was released more than once.");
             }
         }
 
@@ -191,7 +250,7 @@ namespace Orleans.Runtime
 
         private void OnCancellation(CancellationToken cancellationToken)
         {
-            var generation = Volatile.Read(ref _generation);
+            var generation = GetGeneration(Volatile.Read(ref _referenceState));
             if (!TryAcquireLease(generation))
             {
                 return;
@@ -379,6 +438,9 @@ namespace Orleans.Runtime
 
     /// <summary>
     /// Holds the dictionary-owned reference to a pooled <see cref="CallbackData"/> instance.
+    /// Copies share one idempotent owner release. Callers acquire a lease before accessing the
+    /// callback, and the callback returns to the pool after the owner and every lease are released.
+    /// The generation prevents stale handles from accessing or releasing a reused callback.
     /// </summary>
     internal readonly struct CallbackDataOwner
     {
@@ -388,7 +450,14 @@ namespace Orleans.Runtime
         public CallbackDataOwner(CallbackData callback)
         {
             _callback = callback;
-            _generation = callback.AcquireOwnerReference();
+            _generation = callback.AcquireOwnerReference(acquireLease: false);
+        }
+
+        internal CallbackDataOwner(CallbackData callback, out CallbackDataLease lease)
+        {
+            _callback = callback;
+            _generation = callback.AcquireOwnerReference(acquireLease: true);
+            lease = new CallbackDataLease(callback, _generation);
         }
 
         public CallbackDataLease Acquire()
@@ -402,10 +471,21 @@ namespace Orleans.Runtime
             return default;
         }
 
+        public CallbackDataLease TransferToLease()
+        {
+            var callback = _callback ?? throw new InvalidOperationException("CallbackDataOwner is not initialized.");
+            if (callback.TryTransferOwnerToLease(_generation))
+            {
+                return new CallbackDataLease(callback, _generation);
+            }
+
+            return default;
+        }
+
         public void Release()
         {
             var callback = _callback ?? throw new InvalidOperationException("CallbackDataOwner is not initialized.");
-            callback.ReleaseLease(_generation);
+            callback.ReleaseOwnerReference(_generation);
         }
     }
 

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -194,7 +194,7 @@ namespace Orleans.Runtime
             var generation = Volatile.Read(ref _generation);
             if (!TryAcquireLease(generation))
             {
-                throw new InvalidOperationException("Cancellation ran after CallbackData ownership ended.");
+                return;
             }
 
             try

--- a/src/Orleans.Core/Runtime/CallbackDataPool.cs
+++ b/src/Orleans.Core/Runtime/CallbackDataPool.cs
@@ -1,0 +1,59 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// A thread-local object pool for <see cref="CallbackData"/> instances.
+    /// </summary>
+    internal static class CallbackDataPool
+    {
+        private static readonly ThreadLocal<Stack<CallbackData>> _callbacks = new(() => new());
+
+        /// <summary>
+        /// The maximum number of callbacks to keep per thread.
+        /// </summary>
+        public static int MaxPoolSizePerThread { get; set; } = 128;
+
+        /// <summary>
+        /// Gets a callback from the pool, or creates a new one if the pool is empty.
+        /// </summary>
+        public static CallbackData Get()
+        {
+            var stack = _callbacks.Value!;
+            if (stack.TryPop(out var callback))
+            {
+                return callback;
+            }
+
+            return new CallbackData();
+        }
+
+        /// <summary>
+        /// Returns a callback to the pool via the reference counting system.
+        /// This decrements the owner's reference count. The callback will be returned
+        /// to the pool when all leases have been released.
+        /// </summary>
+        /// <param name="owner">The owner of the callback.</param>
+        public static void Return(CallbackDataOwner owner)
+        {
+            owner.Release();
+        }
+
+        /// <summary>
+        /// Internal method called by <see cref="CallbackData.ReleaseLease"/> when ref count reaches zero.
+        /// Actually returns the callback to the pool after resetting it.
+        /// </summary>
+        internal static void ReturnCore(CallbackData callback)
+        {
+            callback.Reset();
+
+            var stack = _callbacks.Value!;
+            if (stack.Count < MaxPoolSizePerThread)
+            {
+                stack.Push(callback);
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/Runtime/CallbackDataPool.cs
+++ b/src/Orleans.Core/Runtime/CallbackDataPool.cs
@@ -20,16 +20,38 @@ internal static class CallbackDataPool
         Message message,
         ApplicationRequestInstruments applicationRequestInstruments)
     {
+        var callback = RentCore(shared, context, message, applicationRequestInstruments);
+        return new(callback);
+    }
+
+    public static CallbackDataOwner Rent(
+        SharedCallbackData shared,
+        IResponseCompletionSource context,
+        Message message,
+        ApplicationRequestInstruments applicationRequestInstruments,
+        out CallbackDataLease lease)
+    {
+        var callback = RentCore(shared, context, message, applicationRequestInstruments);
+        return new(callback, out lease);
+    }
+
+    private static CallbackData RentCore(
+        SharedCallbackData shared,
+        IResponseCompletionSource context,
+        Message message,
+        ApplicationRequestInstruments applicationRequestInstruments)
+    {
         var callbacks = _callbacks ??= new();
         var callback = callbacks.TryPop(out var pooled) ? pooled : new CallbackData();
         callback.Initialize(shared, context, message, applicationRequestInstruments);
-        return new(callback);
+        return callback;
     }
 
     public static void Return(CallbackDataOwner owner) => owner.Release();
 
     internal static void ReturnCore(CallbackData callback)
     {
+        // Clear request-scoped references before the callback becomes available to another renter.
         callback.Reset();
 
         var callbacks = _callbacks ??= new();

--- a/src/Orleans.Core/Runtime/CallbackDataPool.cs
+++ b/src/Orleans.Core/Runtime/CallbackDataPool.cs
@@ -1,59 +1,41 @@
-#nullable enable
+using System;
 using System.Collections.Generic;
-using System.Threading;
+using Orleans.Serialization.Invocation;
 
-namespace Orleans.Runtime
+namespace Orleans.Runtime;
+
+/// <summary>
+/// Provides thread-local pooling for <see cref="CallbackData"/> instances.
+/// </summary>
+internal static class CallbackDataPool
 {
-    /// <summary>
-    /// A thread-local object pool for <see cref="CallbackData"/> instances.
-    /// </summary>
-    internal static class CallbackDataPool
+    private const int MaxPoolSizePerThread = 128;
+
+    [ThreadStatic]
+    private static Stack<CallbackData>? _callbacks;
+
+    public static CallbackDataOwner Rent(
+        SharedCallbackData shared,
+        IResponseCompletionSource context,
+        Message message,
+        ApplicationRequestInstruments applicationRequestInstruments)
     {
-        private static readonly ThreadLocal<Stack<CallbackData>> _callbacks = new(() => new());
+        var callbacks = _callbacks ??= new();
+        var callback = callbacks.TryPop(out var pooled) ? pooled : new CallbackData();
+        callback.Initialize(shared, context, message, applicationRequestInstruments);
+        return new(callback);
+    }
 
-        /// <summary>
-        /// The maximum number of callbacks to keep per thread.
-        /// </summary>
-        public static int MaxPoolSizePerThread { get; set; } = 128;
+    public static void Return(CallbackDataOwner owner) => owner.Release();
 
-        /// <summary>
-        /// Gets a callback from the pool, or creates a new one if the pool is empty.
-        /// </summary>
-        public static CallbackData Get()
+    internal static void ReturnCore(CallbackData callback)
+    {
+        callback.Reset();
+
+        var callbacks = _callbacks ??= new();
+        if (callbacks.Count < MaxPoolSizePerThread)
         {
-            var stack = _callbacks.Value!;
-            if (stack.TryPop(out var callback))
-            {
-                return callback;
-            }
-
-            return new CallbackData();
-        }
-
-        /// <summary>
-        /// Returns a callback to the pool via the reference counting system.
-        /// This decrements the owner's reference count. The callback will be returned
-        /// to the pool when all leases have been released.
-        /// </summary>
-        /// <param name="owner">The owner of the callback.</param>
-        public static void Return(CallbackDataOwner owner)
-        {
-            owner.Release();
-        }
-
-        /// <summary>
-        /// Internal method called by <see cref="CallbackData.ReleaseLease"/> when ref count reaches zero.
-        /// Actually returns the callback to the pool after resetting it.
-        /// </summary>
-        internal static void ReturnCore(CallbackData callback)
-        {
-            callback.Reset();
-
-            var stack = _callbacks.Value!;
-            if (stack.Count < MaxPoolSizePerThread)
-            {
-                stack.Push(callback);
-            }
+            callbacks.Push(callback);
         }
     }
 }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -309,7 +309,7 @@ namespace Orleans
 
                     try
                     {
-                        callbackData.SubscribeForCancellation(cancellationToken);
+                        callbackData.SubscribeForCancellation(cancellationToken, owner);
                     }
                     catch
                     {

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -290,36 +290,42 @@ namespace Orleans
 
             if (!oneWay)
             {
-                var owner = CallbackDataPool.Rent(this.sharedCallbackData, context!, message, _applicationRequestInstruments);
-                using var lease = owner.Acquire();
-                var callbackData = lease.Value;
-                if (!callbacks.TryAdd(message.Id, owner))
-                {
-                    CallbackDataPool.Return(owner);
-                    throw new InvalidOperationException($"Duplicate callback registration for message {message}.");
-                }
-
-                // Cancellation can run synchronously during registration.
-                if (Volatile.Read(ref _isStopping) != 0)
-                {
-                    callbackData.OnHostShutdown();
-                    return;
-                }
-
+                var owner = CallbackDataPool.Rent(this.sharedCallbackData, context!, message, _applicationRequestInstruments, out var lease);
                 try
                 {
-                    callbackData.SubscribeForCancellation(cancellationToken);
-                }
-                catch
-                {
-                    UnregisterCallback(message.Id);
-                    throw;
-                }
+                    var callbackData = lease.Value;
+                    if (!callbacks.TryAdd(message.Id, owner))
+                    {
+                        CallbackDataPool.Return(owner);
+                        throw new InvalidOperationException($"Duplicate callback registration for message {message}.");
+                    }
 
-                if (Volatile.Read(ref _isStopping) != 0)
+                    // Cancellation can run synchronously during registration.
+                    if (Volatile.Read(ref _isStopping) != 0)
+                    {
+                        callbackData.OnHostShutdown();
+                        return;
+                    }
+
+                    try
+                    {
+                        callbackData.SubscribeForCancellation(cancellationToken);
+                    }
+                    catch
+                    {
+                        UnregisterCallback(message.Id);
+                        throw;
+                    }
+
+                    if (Volatile.Read(ref _isStopping) != 0)
+                    {
+                        callbackData.OnHostShutdown();
+                        return;
+                    }
+                }
+                finally
                 {
-                    callbackData.OnHostShutdown();
-                    return;
+                    lease.Dispose();
                 }
             }
             else
@@ -382,14 +388,14 @@ namespace Orleans
             var found = callbacks.TryRemove(response.Id, out var removedOwner);
             if (found)
             {
-                using var removedLease = removedOwner.Acquire();
-                try
+                using var removedLease = removedOwner.TransferToLease();
+                if (removedLease.TryGetValue(out var callbackData))
                 {
-                    removedLease.Value.DoCallback(response);
+                    callbackData.DoCallback(response);
                 }
-                finally
+                else
                 {
-                    CallbackDataPool.Return(removedOwner);
+                    LogDebugNoCallbackForResponseMessage(logger, response);
                 }
             }
             else

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -290,9 +290,9 @@ namespace Orleans
 
             if (!oneWay)
             {
-                var callbackData = CallbackDataPool.Get();
-                callbackData.Initialize(this.sharedCallbackData, context!, message, _applicationRequestInstruments);
-                var owner = new CallbackDataOwner(callbackData);
+                var owner = CallbackDataPool.Rent(this.sharedCallbackData, context!, message, _applicationRequestInstruments);
+                using var lease = owner.Acquire();
+                var callbackData = lease.Value;
                 if (!callbacks.TryAdd(message.Id, owner))
                 {
                     CallbackDataPool.Return(owner);
@@ -300,12 +300,6 @@ namespace Orleans
                 }
 
                 // Cancellation can run synchronously during registration.
-                using var lease = owner.Acquire();
-                if (!lease.TryGetValue(out callbackData))
-                {
-                    return;
-                }
-
                 if (Volatile.Read(ref _isStopping) != 0)
                 {
                     callbackData.OnHostShutdown();
@@ -356,7 +350,7 @@ namespace Orleans
                     if (lease.TryGetValue(out var callback))
                     {
                         var request = callback.Message;
-                        callback.OnStatusUpdate(response.Id, status);
+                        callback.OnStatusUpdate(status);
                         if (status.Diagnostics != null && status.Diagnostics.Count > 0)
                         {
                             LogReceivedStatusUpdateForPendingRequest(logger, request, new(status.Diagnostics));
@@ -389,17 +383,14 @@ namespace Orleans
             if (found)
             {
                 using var removedLease = removedOwner.Acquire();
-                if (removedLease.TryGetValue(out var callbackData))
+                try
                 {
-                    callbackData.DoCallback(response);
+                    removedLease.Value.DoCallback(response);
                 }
-                else
+                finally
                 {
-                    LogDebugNoCallbackForResponseMessage(logger, response);
+                    CallbackDataPool.Return(removedOwner);
                 }
-
-                // Release the owner's reference - this will return to pool when all leases are released
-                CallbackDataPool.Return(removedOwner);
             }
             else
             {
@@ -411,7 +402,6 @@ namespace Orleans
         {
             if (callbacks.TryRemove(id, out var owner))
             {
-                // Release the owner's reference - this will return to pool when all leases are released
                 CallbackDataPool.Return(owner);
             }
         }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -25,7 +25,7 @@ namespace Orleans
         private readonly ILogger logger;
         private readonly ClientMessagingOptions clientMessagingOptions;
 
-        private readonly ConcurrentDictionary<CorrelationId, CallbackData> callbacks;
+        private readonly ConcurrentDictionary<CorrelationId, CallbackDataOwner> callbacks;
         private InvokableObjectManager? localObjects;
         private int _isStopping;
         private bool disposing;
@@ -84,7 +84,7 @@ namespace Orleans
             this.loggerFactory = loggerFactory;
             this.messagingTrace = messagingTrace;
             this.logger = loggerFactory.CreateLogger<OutsideRuntimeClient>();
-            callbacks = new ConcurrentDictionary<CorrelationId, CallbackData>();
+            callbacks = new ConcurrentDictionary<CorrelationId, CallbackDataOwner>();
             this.clientMessagingOptions = clientMessagingOptions.Value;
             var period = Max(
                 TimeSpan.FromMilliseconds(1),
@@ -290,15 +290,37 @@ namespace Orleans
 
             if (!oneWay)
             {
-                var callbackData = new CallbackData(this.sharedCallbackData, context!, message, _applicationRequestInstruments);
+                var callbackData = CallbackDataPool.Get();
+                callbackData.Initialize(this.sharedCallbackData, context!, message, _applicationRequestInstruments);
+                var owner = new CallbackDataOwner(callbackData);
+                if (!callbacks.TryAdd(message.Id, owner))
+                {
+                    CallbackDataPool.Return(owner);
+                    throw new InvalidOperationException($"Duplicate callback registration for message {message}.");
+                }
+
+                // Cancellation can run synchronously during registration.
+                using var lease = owner.Acquire();
+                if (!lease.TryGetValue(out callbackData))
+                {
+                    return;
+                }
+
                 if (Volatile.Read(ref _isStopping) != 0)
                 {
                     callbackData.OnHostShutdown();
                     return;
                 }
 
-                callbacks.TryAdd(message.Id, callbackData);
-                callbackData.SubscribeForCancellation(cancellationToken);
+                try
+                {
+                    callbackData.SubscribeForCancellation(cancellationToken);
+                }
+                catch
+                {
+                    UnregisterCallback(message.Id);
+                    throw;
+                }
 
                 if (Volatile.Read(ref _isStopping) != 0)
                 {
@@ -328,46 +350,56 @@ namespace Orleans
             if (response.Result is Message.ResponseTypes.Status)
             {
                 var status = (StatusResponse)response.BodyObject!;
-                callbacks.TryGetValue(response.Id, out var callback);
-                var request = callback?.Message;
-                if (request is not null)
+                if (callbacks.TryGetValue(response.Id, out var owner))
                 {
-                    callback!.OnStatusUpdate(status);
-                    if (status.Diagnostics != null && status.Diagnostics.Count > 0)
+                    using var lease = owner.Acquire();
+                    if (lease.TryGetValue(out var callback))
                     {
-                        LogReceivedStatusUpdateForPendingRequest(logger, request, new(status.Diagnostics));
+                        var request = callback.Message;
+                        callback.OnStatusUpdate(response.Id, status);
+                        if (status.Diagnostics != null && status.Diagnostics.Count > 0)
+                        {
+                            LogReceivedStatusUpdateForPendingRequest(logger, request, new(status.Diagnostics));
+                        }
+
+                        return;
                     }
                 }
-                else
-                {
-                    if (clientMessagingOptions.CancelUnknownRequestOnStatusUpdate)
-                    {
-                        // Cancel the call since the caller has abandoned it.
-                        // Note that the target and sender arguments are swapped because this is a response to the original request.
-                        _cancellationManager?.SignalCancellation(
-                            response.SendingSilo,
-                            targetGrainId: response.SendingGrain,
-                            sendingGrainId: response.TargetGrain,
-                            messageId: response.Id);
-                    }
 
-                    if (status.Diagnostics != null && status.Diagnostics.Count > 0)
-                    {
-                        LogReceivedStatusUpdateForUnknownRequest(logger, response, new(status.Diagnostics));
-                    }
+                if (clientMessagingOptions.CancelUnknownRequestOnStatusUpdate)
+                {
+                    // Cancel the call since the caller has abandoned it.
+                    // Note that the target and sender arguments are swapped because this is a response to the original request.
+                    _cancellationManager?.SignalCancellation(
+                        response.SendingSilo,
+                        targetGrainId: response.SendingGrain,
+                        sendingGrainId: response.TargetGrain,
+                        messageId: response.Id);
+                }
+
+                if (status.Diagnostics != null && status.Diagnostics.Count > 0)
+                {
+                    LogReceivedStatusUpdateForUnknownRequest(logger, response, new(status.Diagnostics));
                 }
 
                 return;
             }
 
-            CallbackData? callbackData;
-            var found = callbacks.TryRemove(response.Id, out callbackData);
+            var found = callbacks.TryRemove(response.Id, out var removedOwner);
             if (found)
             {
-                // We need to import the RequestContext here as well.
-                // Unfortunately, it is not enough, since CallContext.LogicalGetData will not flow "up" from task completion source into the resolved task.
-                // RequestContextExtensions.Import(response.RequestContextData);
-                callbackData!.DoCallback(response);
+                using var removedLease = removedOwner.Acquire();
+                if (removedLease.TryGetValue(out var callbackData))
+                {
+                    callbackData.DoCallback(response);
+                }
+                else
+                {
+                    LogDebugNoCallbackForResponseMessage(logger, response);
+                }
+
+                // Release the owner's reference - this will return to pool when all leases are released
+                CallbackDataPool.Return(removedOwner);
             }
             else
             {
@@ -377,7 +409,11 @@ namespace Orleans
 
         private void UnregisterCallback(CorrelationId id)
         {
-            callbacks.TryRemove(id, out _);
+            if (callbacks.TryRemove(id, out var owner))
+            {
+                // Release the owner's reference - this will return to pool when all leases are released
+                CallbackDataPool.Return(owner);
+            }
         }
 
         private void ConstructorReset()
@@ -447,22 +483,27 @@ namespace Orleans
 
         public void BreakOutstandingMessagesToSilo(SiloAddress deadSilo)
         {
-            foreach (var callback in callbacks)
+            foreach (var (_, owner) in callbacks)
             {
-                if (deadSilo.Equals(callback.Value.Message.TargetSilo))
+                using var lease = owner.Acquire();
+                if (lease.TryGetValue(out var callback) && deadSilo.Equals(callback.Message.TargetSilo))
                 {
-                    callback.Value.OnTargetSiloFail();
+                    callback.OnTargetSiloFail();
                 }
             }
         }
 
         private void BreakOutstandingMessages()
         {
-            foreach (var (_, callback) in callbacks)
+            foreach (var (_, owner) in callbacks)
             {
                 try
                 {
-                    callback.OnHostShutdown();
+                    using var lease = owner.Acquire();
+                    if (lease.TryGetValue(out var callback))
+                    {
+                        callback.OnHostShutdown();
+                    }
                 }
                 catch (Exception exception)
                 {
@@ -472,7 +513,18 @@ namespace Orleans
         }
 
         public int GetRunningRequestsCount(GrainInterfaceType grainInterfaceType)
-            => this.callbacks.Count(c => c.Value.Message.InterfaceType == grainInterfaceType);
+        {
+            var count = 0;
+            foreach (var (_, owner) in callbacks)
+            {
+                using var lease = owner.Acquire();
+                if (lease.TryGetValue(out var callback) && callback.Message.InterfaceType == grainInterfaceType)
+                {
+                    count++;
+                }
+            }
+            return count;
+        }
 
         /// <inheritdoc />
         public void NotifyClusterConnectionLost()
@@ -516,8 +568,14 @@ namespace Orleans
                 try
                 {
                     var currentStopwatchTicks = ValueStopwatch.GetTimestamp();
-                    foreach (var (_, callback) in callbacks)
+                    foreach (var (_, owner) in callbacks)
                     {
+                        using var lease = owner.Acquire();
+                        if (!lease.TryGetValue(out var callback))
+                        {
+                            continue;
+                        }
+
                         if (callback.IsCompleted)
                         {
                             continue;

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -309,7 +309,7 @@ namespace Orleans
 
                     try
                     {
-                        callbackData.SubscribeForCancellation(cancellationToken, owner);
+                        callbackData.SubscribeForCancellation(cancellationToken);
                     }
                     catch
                     {

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -31,7 +31,7 @@ namespace Orleans.Runtime
         private readonly ILogger invokeExceptionLogger;
         private readonly ILoggerFactory loggerFactory;
         private readonly SiloMessagingOptions messagingOptions;
-        private readonly ConcurrentDictionary<(GrainId, CorrelationId), CallbackData> callbacks;
+        private readonly ConcurrentDictionary<(GrainId, CorrelationId), CallbackDataOwner> callbacks;
         private readonly InterfaceToImplementationMappingCache interfaceToImplementationMapping;
         private readonly SharedCallbackData sharedCallbackData;
         private readonly SharedCallbackData systemSharedCallbackData;
@@ -74,7 +74,7 @@ namespace Orleans.Runtime
             this._applicationRequestInstruments = new(orleansInstruments);
             this.ServiceProvider = serviceProvider;
             this.MySilo = siloDetails.SiloAddress;
-            this.callbacks = new ConcurrentDictionary<(GrainId, CorrelationId), CallbackData>();
+            this.callbacks = new ConcurrentDictionary<(GrainId, CorrelationId), CallbackDataOwner>();
             this.messageFactory = messageFactory;
             this.ConcreteGrainFactory = new GrainFactory(this, referenceActivator, interfaceIdResolver, interfaceToTypeResolver);
             this.logger = loggerFactory.CreateLogger<InsideRuntimeClient>();
@@ -188,15 +188,44 @@ namespace Orleans.Runtime
                 Debug.Assert(context is not null);
 
                 // Register a callback for the request.
-                callbackData = new CallbackData(sharedData, context, message, _applicationRequestInstruments);
+                callbackData = CallbackDataPool.Get();
+                callbackData.Initialize(sharedData, context!, message, _applicationRequestInstruments);
+                var owner = new CallbackDataOwner(callbackData);
+                var callbackKey = (message.SendingGrain, message.Id);
+                if (!callbacks.TryAdd(callbackKey, owner))
+                {
+                    CallbackDataPool.Return(owner);
+                    throw new InvalidOperationException($"Duplicate callback registration for message {message}.");
+                }
+
+                // Cancellation can run synchronously during registration.
+                using var lease = owner.Acquire();
+                if (!lease.TryGetValue(out callbackData))
+                {
+                    return;
+                }
+
                 if (Volatile.Read(ref _isStopping) != 0)
                 {
                     callbackData.OnHostShutdown();
                     return;
                 }
 
-                callbacks.TryAdd((message.SendingGrain, message.Id), callbackData);
-                callbackData.SubscribeForCancellation(cancellationToken);
+                try
+                {
+                    callbackData.SubscribeForCancellation(cancellationToken);
+                }
+                catch
+                {
+                    UnregisterCallback(message.SendingGrain, message.Id);
+                    throw;
+                }
+
+                if (Volatile.Read(ref _isStopping) != 0)
+                {
+                    callbackData.OnHostShutdown();
+                    return;
+                }
             }
             else
             {
@@ -205,14 +234,6 @@ namespace Orleans.Runtime
                 {
                     return;
                 }
-            }
-
-            // Completing callbacks during shutdown can resume application code which issues follow-up
-            // calls. Reject those calls so that they cannot outlive the shutdown callback sweep.
-            if (Volatile.Read(ref _isStopping) != 0)
-            {
-                callbackData?.OnHostShutdown();
-                return;
             }
 
             this.messagingTrace.OnSendRequest(message);
@@ -238,7 +259,11 @@ namespace Orleans.Runtime
         /// </summary>
         private void UnregisterCallback(GrainId grainId, CorrelationId correlationId)
         {
-            callbacks.TryRemove((grainId, correlationId), out _);
+            if (callbacks.TryRemove((grainId, correlationId), out var owner))
+            {
+                // Release the owner's reference - this will return to pool when all leases are released
+                CallbackDataPool.Return(owner);
+            }
         }
 
         public void SniffIncomingMessage(Message message)
@@ -324,7 +349,7 @@ namespace Orleans.Runtime
                                     response = this.responseCopier.Copy(response)!;
                                 }
 
-                                invokable.Dispose();
+                                // Note: invokable disposal happens at the end of Invoke to return it to its pool
                                 break;
                             }
                         default:
@@ -468,11 +493,23 @@ namespace Orleans.Runtime
 
         private void ProcessResponseCallback(Message message)
         {
-            if (callbacks.TryRemove((message.TargetGrain, message.Id), out var callbackData))
+            bool found = callbacks.TryRemove((message.TargetGrain, message.Id), out var removedOwner);
+            if (found)
             {
-                // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
-                // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
-                callbackData.DoCallback(message);
+                using var removedLease = removedOwner.Acquire();
+                if (removedLease.TryGetValue(out var callbackData))
+                {
+                    // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
+                    // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
+                    callbackData.DoCallback(message);
+                }
+                else
+                {
+                    LogDebugNoCallbackForResponse(this.logger, message);
+                }
+
+                // Release the owner's reference - this will return to pool when all leases are released
+                CallbackDataPool.Return(removedOwner);
             }
             else
             {
@@ -483,17 +520,20 @@ namespace Orleans.Runtime
         private void ProcessStatusResponse(Message message)
         {
             var status = (StatusResponse)message.BodyObject!;
-            callbacks.TryGetValue((message.TargetGrain, message.Id), out var callback);
-            var request = callback?.Message;
-            if (request is not null)
+            if (callbacks.TryGetValue((message.TargetGrain, message.Id), out var owner))
             {
-                callback!.OnStatusUpdate(status);
-                if (status.Diagnostics is { Count: > 0 })
+                using var lease = owner.Acquire();
+                if (lease.TryGetValue(out var callback))
                 {
-                    LogInformationReceivedStatusUpdate(this.logger, request, status.Diagnostics);
-                }
+                    var request = callback.Message;
+                    callback.OnStatusUpdate(message.Id, status);
+                    if (status.Diagnostics is { Count: > 0 })
+                    {
+                        LogInformationReceivedStatusUpdate(this.logger, request, status.Diagnostics);
+                    }
 
-                return;
+                    return;
+                }
             }
 
             HandleUnknownStatusUpdate(message, status);
@@ -566,11 +606,15 @@ namespace Orleans.Runtime
 
         private void BreakOutstandingMessages()
         {
-            foreach (var (_, callback) in callbacks)
+            foreach (var (_, owner) in callbacks)
             {
                 try
                 {
-                    callback.OnHostShutdown();
+                    using var lease = owner.Acquire();
+                    if (lease.TryGetValue(out var callback))
+                    {
+                        callback.OnHostShutdown();
+                    }
                 }
                 catch (Exception exception)
                 {
@@ -600,11 +644,12 @@ namespace Orleans.Runtime
 
         public void BreakOutstandingMessagesToSilo(SiloAddress deadSilo)
         {
-            foreach (var callback in callbacks)
+            foreach (var (_, owner) in callbacks)
             {
-                if (deadSilo.Equals(callback.Value.Message.TargetSilo))
+                using var lease = owner.Acquire();
+                if (lease.TryGetValue(out var callback) && deadSilo.Equals(callback.Message.TargetSilo))
                 {
-                    callback.Value.OnTargetSiloFail();
+                    callback.OnTargetSiloFail();
                 }
             }
         }
@@ -616,7 +661,18 @@ namespace Orleans.Runtime
         }
 
         public int GetRunningRequestsCount(GrainInterfaceType grainInterfaceType)
-            => this.callbacks.Count(c => c.Value.Message.InterfaceType == grainInterfaceType);
+        {
+            var count = 0;
+            foreach (var (_, owner) in callbacks)
+            {
+                using var lease = owner.Acquire();
+                if (lease.TryGetValue(out var callback) && callback.Message.InterfaceType == grainInterfaceType)
+                {
+                    count++;
+                }
+            }
+            return count;
+        }
 
         private async Task MonitorCallbackExpiry()
         {
@@ -625,8 +681,14 @@ namespace Orleans.Runtime
                 try
                 {
                     var currentStopwatchTicks = ValueStopwatch.GetTimestamp();
-                    foreach (var (_, callback) in callbacks)
+                    foreach (var (_, owner) in callbacks)
                     {
+                        using var lease = owner.Acquire();
+                        if (!lease.TryGetValue(out var callback))
+                        {
+                            continue;
+                        }
+
                         if (callback.IsCompleted)
                         {
                             continue;

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -183,61 +183,71 @@ namespace Orleans.Runtime
 
             var oneWay = (options & InvokeMethodOptions.OneWay) != 0;
             CallbackData? callbackData = null;
-            if (!oneWay)
+            CallbackDataLease callbackLease = default;
+            try
             {
-                Debug.Assert(context is not null);
-
-                // Register a callback for the request.
-                callbackData = CallbackDataPool.Get();
-                callbackData.Initialize(sharedData, context!, message, _applicationRequestInstruments);
-                var owner = new CallbackDataOwner(callbackData);
-                var callbackKey = (message.SendingGrain, message.Id);
-                if (!callbacks.TryAdd(callbackKey, owner))
+                if (!oneWay)
                 {
-                    CallbackDataPool.Return(owner);
-                    throw new InvalidOperationException($"Duplicate callback registration for message {message}.");
+                    Debug.Assert(context is not null);
+
+                    // Register a callback for the request.
+                    var owner = CallbackDataPool.Rent(sharedData, context!, message, _applicationRequestInstruments);
+                    callbackLease = owner.Acquire();
+                    callbackData = callbackLease.Value;
+                    var callbackKey = (message.SendingGrain, message.Id);
+                    if (!callbacks.TryAdd(callbackKey, owner))
+                    {
+                        CallbackDataPool.Return(owner);
+                        throw new InvalidOperationException($"Duplicate callback registration for message {message}.");
+                    }
+
+                    // Cancellation can run synchronously during registration.
+                    if (Volatile.Read(ref _isStopping) != 0)
+                    {
+                        callbackData.OnHostShutdown();
+                        return;
+                    }
+
+                    try
+                    {
+                        callbackData.SubscribeForCancellation(cancellationToken);
+                    }
+                    catch
+                    {
+                        UnregisterCallback(message.SendingGrain, message.Id);
+                        throw;
+                    }
+
+                    if (Volatile.Read(ref _isStopping) != 0)
+                    {
+                        callbackData.OnHostShutdown();
+                        return;
+                    }
+                }
+                else
+                {
+                    context?.Complete();
+                    if (Volatile.Read(ref _isStopping) != 0)
+                    {
+                        return;
+                    }
                 }
 
-                // Cancellation can run synchronously during registration.
-                using var lease = owner.Acquire();
-                if (!lease.TryGetValue(out callbackData))
-                {
-                    return;
-                }
-
+                // Completing callbacks during shutdown can resume application code which issues follow-up
+                // calls. Reject those calls so that they cannot outlive the shutdown callback sweep.
                 if (Volatile.Read(ref _isStopping) != 0)
                 {
-                    callbackData.OnHostShutdown();
+                    callbackData?.OnHostShutdown();
                     return;
                 }
 
-                try
-                {
-                    callbackData.SubscribeForCancellation(cancellationToken);
-                }
-                catch
-                {
-                    UnregisterCallback(message.SendingGrain, message.Id);
-                    throw;
-                }
-
-                if (Volatile.Read(ref _isStopping) != 0)
-                {
-                    callbackData.OnHostShutdown();
-                    return;
-                }
+                this.messagingTrace.OnSendRequest(message);
+                this.MessageCenter.AddressAndSendMessage(message);
             }
-            else
+            finally
             {
-                context?.Complete();
-                if (Volatile.Read(ref _isStopping) != 0)
-                {
-                    return;
-                }
+                callbackLease.Dispose();
             }
-
-            this.messagingTrace.OnSendRequest(message);
-            this.MessageCenter.AddressAndSendMessage(message);
         }
 
         public void SendResponse(Message request, Response response)
@@ -261,7 +271,6 @@ namespace Orleans.Runtime
         {
             if (callbacks.TryRemove((grainId, correlationId), out var owner))
             {
-                // Release the owner's reference - this will return to pool when all leases are released
                 CallbackDataPool.Return(owner);
             }
         }
@@ -349,7 +358,7 @@ namespace Orleans.Runtime
                                     response = this.responseCopier.Copy(response)!;
                                 }
 
-                                // Note: invokable disposal happens at the end of Invoke to return it to its pool
+                                invokable.Dispose();
                                 break;
                             }
                         default:
@@ -493,23 +502,19 @@ namespace Orleans.Runtime
 
         private void ProcessResponseCallback(Message message)
         {
-            bool found = callbacks.TryRemove((message.TargetGrain, message.Id), out var removedOwner);
-            if (found)
+            if (callbacks.TryRemove((message.TargetGrain, message.Id), out var removedOwner))
             {
                 using var removedLease = removedOwner.Acquire();
-                if (removedLease.TryGetValue(out var callbackData))
+                try
                 {
                     // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
                     // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
-                    callbackData.DoCallback(message);
+                    removedLease.Value.DoCallback(message);
                 }
-                else
+                finally
                 {
-                    LogDebugNoCallbackForResponse(this.logger, message);
+                    CallbackDataPool.Return(removedOwner);
                 }
-
-                // Release the owner's reference - this will return to pool when all leases are released
-                CallbackDataPool.Return(removedOwner);
             }
             else
             {
@@ -526,7 +531,7 @@ namespace Orleans.Runtime
                 if (lease.TryGetValue(out var callback))
                 {
                     var request = callback.Message;
-                    callback.OnStatusUpdate(message.Id, status);
+                    callback.OnStatusUpdate(status);
                     if (status.Diagnostics is { Count: > 0 })
                     {
                         LogInformationReceivedStatusUpdate(this.logger, request, status.Diagnostics);

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -209,7 +209,7 @@ namespace Orleans.Runtime
 
                     try
                     {
-                        callbackData.SubscribeForCancellation(cancellationToken, owner);
+                        callbackData.SubscribeForCancellation(cancellationToken);
                     }
                     catch
                     {

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -191,8 +191,7 @@ namespace Orleans.Runtime
                     Debug.Assert(context is not null);
 
                     // Register a callback for the request.
-                    var owner = CallbackDataPool.Rent(sharedData, context!, message, _applicationRequestInstruments);
-                    callbackLease = owner.Acquire();
+                    var owner = CallbackDataPool.Rent(sharedData, context!, message, _applicationRequestInstruments, out callbackLease);
                     callbackData = callbackLease.Value;
                     var callbackKey = (message.SendingGrain, message.Id);
                     if (!callbacks.TryAdd(callbackKey, owner))
@@ -504,16 +503,16 @@ namespace Orleans.Runtime
         {
             if (callbacks.TryRemove((message.TargetGrain, message.Id), out var removedOwner))
             {
-                using var removedLease = removedOwner.Acquire();
-                try
+                using var removedLease = removedOwner.TransferToLease();
+                if (removedLease.TryGetValue(out var callbackData))
                 {
                     // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
                     // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
-                    removedLease.Value.DoCallback(message);
+                    callbackData.DoCallback(message);
                 }
-                finally
+                else
                 {
-                    CallbackDataPool.Return(removedOwner);
+                    LogDebugNoCallbackForResponse(this.logger, message);
                 }
             }
             else

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -209,7 +209,7 @@ namespace Orleans.Runtime
 
                     try
                     {
-                        callbackData.SubscribeForCancellation(cancellationToken);
+                        callbackData.SubscribeForCancellation(cancellationToken, owner);
                     }
                     catch
                     {

--- a/test/Benchmarks/Runtime/CallbackDataPoolingBenchmark.cs
+++ b/test/Benchmarks/Runtime/CallbackDataPoolingBenchmark.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics.Metrics;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Runtime;
+using Orleans.Serialization.Invocation;
+
+namespace Benchmarks.Runtime;
+
+[MemoryDiagnoser]
+public class CallbackDataPoolingBenchmark
+{
+    private readonly Consumer _consumer = new();
+    private ServiceProvider _serviceProvider = null!;
+    private SharedCallbackData _shared = null!;
+    private ApplicationRequestInstruments _instruments = null!;
+    private IResponseCompletionSource _completion = null!;
+    private Message _message = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        _serviceProvider = services.BuildServiceProvider();
+        _shared = new SharedCallbackData(
+            unregister: _ => { },
+            logger: NullLogger<CallbackData>.Instance,
+            responseTimeout: TimeSpan.FromMinutes(1),
+            cancelOnTimeout: false,
+            waitForCancellationAcknowledgement: false,
+            cancellationManager: null);
+        _instruments = new(new OrleansInstruments(_serviceProvider.GetRequiredService<IMeterFactory>()));
+        _completion = new NoOpResponseCompletionSource();
+        _message = new Message();
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup() => _serviceProvider.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public void AllocateAndInitialize()
+    {
+        var callback = new CallbackData();
+        callback.Initialize(_shared, _completion, _message, _instruments);
+        _consumer.Consume(callback);
+    }
+
+    [Benchmark]
+    public void RentLeaseAndReturn()
+    {
+        var owner = CallbackDataPool.Rent(_shared, _completion, _message, _instruments, out var lease);
+        _consumer.Consume(lease.Value);
+        CallbackDataPool.Return(owner);
+        lease.Dispose();
+    }
+
+    private sealed class NoOpResponseCompletionSource : IResponseCompletionSource
+    {
+        public void Complete(Response value)
+        {
+        }
+
+        public void Complete()
+        {
+        }
+    }
+}

--- a/test/Benchmarks/Runtime/CallbackDataPoolingBenchmark.cs
+++ b/test/Benchmarks/Runtime/CallbackDataPoolingBenchmark.cs
@@ -40,20 +40,23 @@ public class CallbackDataPoolingBenchmark
     public void GlobalCleanup() => _serviceProvider.Dispose();
 
     [Benchmark(Baseline = true)]
-    public void AllocateAndInitialize()
+    public void AllocatedRequestLifecycle()
     {
         var callback = new CallbackData();
         callback.Initialize(_shared, _completion, _message, _instruments);
         _consumer.Consume(callback);
+        _consumer.Consume(callback);
     }
 
     [Benchmark]
-    public void RentLeaseAndReturn()
+    public void PooledRequestLifecycle()
     {
-        var owner = CallbackDataPool.Rent(_shared, _completion, _message, _instruments, out var lease);
-        _consumer.Consume(lease.Value);
-        CallbackDataPool.Return(owner);
-        lease.Dispose();
+        var owner = CallbackDataPool.Rent(_shared, _completion, _message, _instruments, out var senderLease);
+        _consumer.Consume(senderLease.Value);
+        senderLease.Dispose();
+
+        using var responseLease = owner.TransferToLease();
+        _consumer.Consume(responseLease.Value);
     }
 
     private sealed class NoOpResponseCompletionSource : IResponseCompletionSource

--- a/test/Benchmarks/Runtime/CallbackDataPoolingBenchmark.cs
+++ b/test/Benchmarks/Runtime/CallbackDataPoolingBenchmark.cs
@@ -17,6 +17,7 @@ public class CallbackDataPoolingBenchmark
     private ApplicationRequestInstruments _instruments = null!;
     private IResponseCompletionSource _completion = null!;
     private Message _message = null!;
+    private CancellationTokenSource _cancellation = null!;
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -34,24 +35,32 @@ public class CallbackDataPoolingBenchmark
         _instruments = new(new OrleansInstruments(_serviceProvider.GetRequiredService<IMeterFactory>()));
         _completion = new NoOpResponseCompletionSource();
         _message = new Message();
+        _cancellation = new CancellationTokenSource();
     }
 
     [GlobalCleanup]
-    public void GlobalCleanup() => _serviceProvider.Dispose();
+    public void GlobalCleanup()
+    {
+        _cancellation.Dispose();
+        _serviceProvider.Dispose();
+    }
 
     [Benchmark(Baseline = true)]
     public void AllocatedRequestLifecycle()
     {
         var callback = new CallbackData();
         callback.Initialize(_shared, _completion, _message, _instruments);
+        callback.SubscribeForCancellation(_cancellation.Token);
         _consumer.Consume(callback);
         _consumer.Consume(callback);
+        callback.Reset();
     }
 
     [Benchmark]
     public void PooledRequestLifecycle()
     {
         var owner = CallbackDataPool.Rent(_shared, _completion, _message, _instruments, out var senderLease);
+        senderLease.Value.SubscribeForCancellation(_cancellation.Token);
         _consumer.Consume(senderLease.Value);
         senderLease.Dispose();
 

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -55,6 +55,30 @@ public class CallbackDataTests
         GC.KeepAlive(cancellation);
     }
 
+    [Fact, TestCategory("BVT")]
+    public void StaleOwnerCannotLeaseReusedCallback()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var instruments = CreateInstruments(serviceProvider);
+        var callback = CallbackDataPool.Get();
+        callback.Initialize(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        var staleOwner = new CallbackDataOwner(callback);
+        CallbackDataPool.Return(staleOwner);
+
+        var reusedCallback = CallbackDataPool.Get();
+        Assert.Same(callback, reusedCallback);
+        reusedCallback.Initialize(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        var currentOwner = new CallbackDataOwner(reusedCallback);
+
+        using var staleLease = staleOwner.Acquire();
+        Assert.False(staleLease.TryGetValue(out _));
+        using var currentLease = currentOwner.Acquire();
+        Assert.True(currentLease.TryGetValue(out var currentCallback));
+        Assert.Same(reusedCallback, currentCallback);
+
+        CallbackDataPool.Return(currentOwner);
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference CreateCompletedCallback(CancellationToken cancellationToken, ApplicationRequestInstruments instruments)
     {
@@ -71,15 +95,18 @@ public class CallbackDataTests
         Action<Message> unregister,
         ApplicationRequestInstruments instruments)
     {
-        var shared = new SharedCallbackData(
-            unregister,
+        var shared = CreateSharedData(unregister);
+        return new CallbackData(shared, completion, new Message(), instruments);
+    }
+
+    private static SharedCallbackData CreateSharedData(Action<Message>? unregister = null) =>
+        new(
+            unregister ?? (_ => { }),
             logger: NullLogger<CallbackData>.Instance,
             responseTimeout: TimeSpan.FromMinutes(1),
             cancelOnTimeout: false,
             waitForCancellationAcknowledgement: false,
             cancellationManager: null);
-        return new CallbackData(shared, completion, new Message(), instruments);
-    }
 
     private static ServiceProvider CreateServiceProvider()
     {

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -311,8 +311,8 @@ public class CallbackDataTests
                 start.SignalAndWait();
                 if (Interlocked.Exchange(ref registered, 0) == 1)
                 {
-                    CallbackDataPool.Return(owner);
-                    callback.DoCallback(response);
+                    using var responseLease = owner.TransferToLease();
+                    responseLease.Value.DoCallback(response);
                 }
             });
 

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -93,6 +93,46 @@ public class CallbackDataTests
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
+    public void WrongCorrelationStatusUpdateDoesNotAffectReusedCallback()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var instruments = CreateInstruments(serviceProvider);
+        var staleOwner = CallbackDataPool.Rent(
+            CreateSharedData(),
+            new TestResponseCompletionSource(),
+            new Message { Id = new CorrelationId(1) },
+            instruments);
+        using (var lease = staleOwner.Acquire())
+        {
+            Assert.Equal(new CorrelationId(1), lease.Value.Message.Id);
+        }
+        CallbackDataPool.Return(staleOwner);
+
+        var completion = new TestResponseCompletionSource();
+        CallbackDataOwner currentOwner = default;
+        currentOwner = CallbackDataPool.Rent(
+            CreateSharedData(_ => CallbackDataPool.Return(currentOwner)),
+            completion,
+            new Message { Id = new CorrelationId(2) },
+            instruments);
+        using var currentLease = currentOwner.Acquire();
+        Assert.Equal(new CorrelationId(2), currentLease.Value.Message.Id);
+
+        using var staleLease = staleOwner.Acquire();
+        if (staleLease.TryGetValue(out var staleCallback))
+        {
+            staleCallback.OnStatusUpdate(new StatusResponse(isExecuting: true, isWaiting: false, diagnostics: ["stale"]));
+        }
+
+        currentLease.Value.OnTimeout();
+
+        var exception = Assert.IsType<TimeoutException>(completion.Response!.Exception);
+        Assert.DoesNotContain("stale", exception.Message);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
     public void ActiveLeaseDelaysCallbackReuse()
     {
         using var serviceProvider = CreateServiceProvider();
@@ -118,7 +158,148 @@ public class CallbackDataTests
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
-    public void CancellationAfterCompletionDoesNotAffectReusedCallback()
+    public void CopiedLeaseDoubleReleaseThrows()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var owner = CallbackDataPool.Rent(
+            CreateSharedData(),
+            new TestResponseCompletionSource(),
+            new Message(),
+            CreateInstruments(serviceProvider));
+        var lease = owner.Acquire();
+        var callback = lease.Value;
+        var copiedLease = lease;
+        lease.Dispose();
+
+        var threw = false;
+        try
+        {
+            copiedLease.Dispose();
+        }
+        catch (InvalidOperationException)
+        {
+            threw = true;
+        }
+
+        Assert.True(threw);
+        CallbackDataPool.Return(owner);
+
+        var reusedOwner = CallbackDataPool.Rent(
+            CreateSharedData(),
+            new TestResponseCompletionSource(),
+            new Message(),
+            CreateInstruments(serviceProvider));
+        using var reusedLease = reusedOwner.Acquire();
+        Assert.Same(callback, reusedLease.Value);
+
+        var concurrentOwner = CallbackDataPool.Rent(
+            CreateSharedData(),
+            new TestResponseCompletionSource(),
+            new Message(),
+            CreateInstruments(serviceProvider));
+        using var concurrentLease = concurrentOwner.Acquire();
+        Assert.NotSame(callback, concurrentLease.Value);
+
+        CallbackDataPool.Return(concurrentOwner);
+        CallbackDataPool.Return(reusedOwner);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void StatusLeaseDelaysReuseAfterResponseTransfer()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var instruments = CreateInstruments(serviceProvider);
+        var owner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        var senderLease = owner.Acquire();
+        var callback = senderLease.Value;
+        senderLease.Dispose();
+        var statusLease = owner.Acquire();
+
+        using (var responseLease = owner.TransferToLease())
+        {
+            responseLease.Value.DoCallback(new Message { BodyObject = Response.Completed });
+        }
+
+        var concurrentOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        using (var concurrentLease = concurrentOwner.Acquire())
+        {
+            Assert.NotSame(callback, concurrentLease.Value);
+        }
+        CallbackDataPool.Return(concurrentOwner);
+
+        var localOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        using var localLease = localOwner.Acquire();
+        statusLease.Value.OnStatusUpdate(new StatusResponse(isExecuting: true, isWaiting: false, diagnostics: []));
+        statusLease.Dispose();
+
+        var reusedOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        using var reusedLease = reusedOwner.Acquire();
+        Assert.Same(callback, reusedLease.Value);
+        CallbackDataPool.Return(reusedOwner);
+        CallbackDataPool.Return(localOwner);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public async Task InFlightCancellationDelaysReuseUntilCallbackReturns()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        using var cancellation = new CancellationTokenSource();
+        var instruments = CreateInstruments(serviceProvider);
+        using var completion = new BlockingResponseCompletionSource();
+        CallbackDataOwner owner = default;
+        owner = CallbackDataPool.Rent(
+            CreateSharedData(_ => CallbackDataPool.Return(owner)),
+            completion,
+            new Message(),
+            instruments);
+        var senderLease = owner.Acquire();
+        var callback = senderLease.Value;
+        callback.SubscribeForCancellation(cancellation.Token);
+        senderLease.Dispose();
+
+        var prematurelyReused = false;
+        completion.SetProbe(() =>
+        {
+            var probeOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+            using var probeLease = probeOwner.Acquire();
+            prematurelyReused = ReferenceEquals(callback, probeLease.Value);
+            CallbackDataPool.Return(probeOwner);
+        });
+
+        var cancellationTask = Task.Run(() =>
+        {
+            var localOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+            using var localLease = localOwner.Acquire();
+            cancellation.Cancel();
+            var reusedOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+            using var reusedLease = reusedOwner.Acquire();
+            var reusedCallback = reusedLease.Value;
+            CallbackDataPool.Return(reusedOwner);
+            CallbackDataPool.Return(localOwner);
+            return reusedCallback;
+        });
+
+        completion.WaitUntilProbed();
+        try
+        {
+            Assert.False(prematurelyReused);
+        }
+        finally
+        {
+            completion.Release();
+        }
+
+        Assert.Same(callback, await cancellationTask.WaitAsync(TimeSpan.FromSeconds(10)));
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void StaleCancellationCallbackDoesNotAffectReusedCallback()
     {
         using var serviceProvider = CreateServiceProvider();
         using var cancellation = new CancellationTokenSource();
@@ -367,5 +548,46 @@ public class CallbackDataTests
         public void Complete(Response value) => throw new InvalidOperationException("Test completion failure.");
 
         public void Complete() => throw new InvalidOperationException("Test completion failure.");
+    }
+
+    private sealed class BlockingResponseCompletionSource : IResponseCompletionSource, IDisposable
+    {
+        private readonly ManualResetEventSlim _probed = new();
+        private readonly ManualResetEventSlim _release = new();
+        private Action? _probe;
+
+        public void Complete(Response value)
+        {
+            try
+            {
+                _probe!();
+            }
+            finally
+            {
+                _probed.Set();
+            }
+
+            _release.Wait();
+        }
+
+        public void Complete() => Complete(Response.Completed);
+
+        public void SetProbe(Action probe) => _probe = probe;
+
+        public void WaitUntilProbed()
+        {
+            if (!_probed.Wait(TimeSpan.FromSeconds(10)))
+            {
+                throw new TimeoutException("Cancellation callback did not probe the callback pool.");
+            }
+        }
+
+        public void Release() => _release.Set();
+
+        public void Dispose()
+        {
+            _probed.Dispose();
+            _release.Dispose();
+        }
     }
 }

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -293,7 +293,7 @@ public class CallbackDataTests
             completion.Release();
         }
 
-        Assert.Same(callback, await cancellationTask.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.Same(callback, await cancellationTask.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
     }
 
     [TestSuite("BVT")]

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -36,7 +36,7 @@ public class CallbackDataTests
         using var lease = owner.Acquire();
         var callback = lease.Value;
 
-        callback.SubscribeForCancellation(cancellation.Token, owner);
+        callback.SubscribeForCancellation(cancellation.Token);
 
         Assert.True(callback.IsCompleted);
         Assert.Equal(1, unregisterCount);
@@ -131,7 +131,7 @@ public class CallbackDataTests
             instruments);
         var completedLease = completedOwner.Acquire();
         var completedCallback = completedLease.Value;
-        completedCallback.SubscribeForCancellation(cancellation.Token, completedOwner);
+        completedCallback.SubscribeForCancellation(cancellation.Token);
         completedCallback.OnHostShutdown();
         completedLease.Dispose();
 
@@ -183,9 +183,9 @@ public class CallbackDataTests
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
     public void CancellationAndResponseRaceCompletesExactlyOnce() =>
-        RunTerminalRace(static (callback, owner, cancellation) =>
+        RunTerminalRace(static (callback, _, cancellation) =>
         {
-            callback.SubscribeForCancellation(cancellation.Token, owner);
+            callback.SubscribeForCancellation(cancellation.Token);
             cancellation.Cancel();
         });
 
@@ -269,7 +269,7 @@ public class CallbackDataTests
         var callback = lease.Value;
 
         callback.OnHostShutdown();
-        callback.SubscribeForCancellation(cancellationToken, owner);
+        callback.SubscribeForCancellation(cancellationToken);
 
         return new WeakReference(completion);
     }

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -36,7 +36,7 @@ public class CallbackDataTests
         using var lease = owner.Acquire();
         var callback = lease.Value;
 
-        callback.SubscribeForCancellation(cancellation.Token);
+        callback.SubscribeForCancellation(cancellation.Token, owner);
 
         Assert.True(callback.IsCompleted);
         Assert.Equal(1, unregisterCount);
@@ -131,7 +131,7 @@ public class CallbackDataTests
             instruments);
         var completedLease = completedOwner.Acquire();
         var completedCallback = completedLease.Value;
-        completedCallback.SubscribeForCancellation(cancellation.Token);
+        completedCallback.SubscribeForCancellation(cancellation.Token, completedOwner);
         completedCallback.OnHostShutdown();
         completedLease.Dispose();
 
@@ -183,9 +183,9 @@ public class CallbackDataTests
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
     public void CancellationAndResponseRaceCompletesExactlyOnce() =>
-        RunTerminalRace(static (callback, cancellation) =>
+        RunTerminalRace(static (callback, owner, cancellation) =>
         {
-            callback.SubscribeForCancellation(cancellation.Token);
+            callback.SubscribeForCancellation(cancellation.Token, owner);
             cancellation.Cancel();
         });
 
@@ -193,13 +193,13 @@ public class CallbackDataTests
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
     public void TimeoutAndResponseRaceCompletesExactlyOnce() =>
-        RunTerminalRace(static (callback, _) => callback.OnTimeout());
+        RunTerminalRace(static (callback, _, _) => callback.OnTimeout());
 
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
     public void ShutdownAndResponseRaceCompletesExactlyOnce() =>
-        RunTerminalRace(static (callback, _) => callback.OnHostShutdown());
+        RunTerminalRace(static (callback, _, _) => callback.OnHostShutdown());
 
     [TestSuite("BVT")]
     [TestProvider("None")]
@@ -269,12 +269,12 @@ public class CallbackDataTests
         var callback = lease.Value;
 
         callback.OnHostShutdown();
-        callback.SubscribeForCancellation(cancellationToken);
+        callback.SubscribeForCancellation(cancellationToken, owner);
 
         return new WeakReference(completion);
     }
 
-    private static void RunTerminalRace(Action<CallbackData, CancellationTokenSource> complete)
+    private static void RunTerminalRace(Action<CallbackData, CallbackDataOwner, CancellationTokenSource> complete)
     {
         using var serviceProvider = CreateServiceProvider();
         var instruments = CreateInstruments(serviceProvider);
@@ -304,7 +304,7 @@ public class CallbackDataTests
             var completionTask = Task.Run(() =>
             {
                 start.SignalAndWait();
-                complete(callback, cancellation);
+                complete(callback, owner, cancellation);
             });
             var responseTask = Task.Run(() =>
             {

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -22,10 +22,18 @@ public class CallbackDataTests
         cancellation.Cancel();
         var completion = new TestResponseCompletionSource();
         var unregisterCount = 0;
-        var callback = CreateCallback(
+        CallbackDataOwner owner = default;
+        owner = CallbackDataPool.Rent(
+            CreateSharedData(_ =>
+            {
+                Interlocked.Increment(ref unregisterCount);
+                CallbackDataPool.Return(owner);
+            }),
             completion,
-            _ => Interlocked.Increment(ref unregisterCount),
+            new Message(),
             CreateInstruments(serviceProvider));
+        using var lease = owner.Acquire();
+        var callback = lease.Value;
 
         callback.SubscribeForCancellation(cancellation.Token);
 
@@ -38,65 +46,89 @@ public class CallbackDataTests
     [TestSuite("BVT")]
     [TestProvider("None")]
     [Fact, TestCategory("BVT")]
-    public void CancellationSubscriptionAfterCompletionDoesNotRetainCallback()
+    public void CancellationSubscriptionAfterCompletionDoesNotRetainCompletionSource()
     {
         using var serviceProvider = CreateServiceProvider();
         using var cancellation = new CancellationTokenSource();
 
-        var callbackReference = CreateCompletedCallback(cancellation.Token, CreateInstruments(serviceProvider));
+        var completionReference = CreateCompletedCallback(cancellation.Token, CreateInstruments(serviceProvider));
 
-        for (var attempt = 0; attempt < 10 && callbackReference.IsAlive; attempt++)
+        for (var attempt = 0; attempt < 10 && completionReference.IsAlive; attempt++)
         {
             GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
             GC.WaitForPendingFinalizers();
         }
 
-        Assert.False(callbackReference.IsAlive);
+        Assert.False(completionReference.IsAlive);
         GC.KeepAlive(cancellation);
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
     [Fact, TestCategory("BVT")]
     public void StaleOwnerCannotLeaseReusedCallback()
     {
         using var serviceProvider = CreateServiceProvider();
         var instruments = CreateInstruments(serviceProvider);
-        var callback = CallbackDataPool.Get();
-        callback.Initialize(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
-        var staleOwner = new CallbackDataOwner(callback);
+        var staleOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        var lease = staleOwner.Acquire();
+        var callback = lease.Value;
+        lease.Dispose();
         CallbackDataPool.Return(staleOwner);
 
-        var reusedCallback = CallbackDataPool.Get();
+        var currentOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        using var currentLease = currentOwner.Acquire();
+        var reusedCallback = currentLease.Value;
         Assert.Same(callback, reusedCallback);
-        reusedCallback.Initialize(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
-        var currentOwner = new CallbackDataOwner(reusedCallback);
 
         using var staleLease = staleOwner.Acquire();
         Assert.False(staleLease.TryGetValue(out _));
-        using var currentLease = currentOwner.Acquire();
-        Assert.True(currentLease.TryGetValue(out var currentCallback));
-        Assert.Same(reusedCallback, currentCallback);
 
         CallbackDataPool.Return(currentOwner);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void ActiveLeaseDelaysCallbackReuse()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var instruments = CreateInstruments(serviceProvider);
+        var firstOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        var firstLease = firstOwner.Acquire();
+        var firstCallback = firstLease.Value;
+        CallbackDataPool.Return(firstOwner);
+
+        var secondOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        using var secondLease = secondOwner.Acquire();
+        Assert.NotSame(firstCallback, secondLease.Value);
+        CallbackDataPool.Return(secondOwner);
+
+        firstLease.Dispose();
+
+        var reusedOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        using var reusedLease = reusedOwner.Acquire();
+        Assert.Same(firstCallback, reusedLease.Value);
+        CallbackDataPool.Return(reusedOwner);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference CreateCompletedCallback(CancellationToken cancellationToken, ApplicationRequestInstruments instruments)
     {
-        var callback = CreateCallback(new TestResponseCompletionSource(), _ => { }, instruments);
+        var completion = new TestResponseCompletionSource();
+        CallbackDataOwner owner = default;
+        owner = CallbackDataPool.Rent(
+            CreateSharedData(_ => CallbackDataPool.Return(owner)),
+            completion,
+            new Message(),
+            instruments);
+        using var lease = owner.Acquire();
+        var callback = lease.Value;
 
         callback.OnHostShutdown();
         callback.SubscribeForCancellation(cancellationToken);
 
-        return new WeakReference(callback);
-    }
-
-    private static CallbackData CreateCallback(
-        IResponseCompletionSource completion,
-        Action<Message> unregister,
-        ApplicationRequestInstruments instruments)
-    {
-        var shared = CreateSharedData(unregister);
-        return new CallbackData(shared, completion, new Message(), instruments);
+        return new WeakReference(completion);
     }
 
     private static SharedCallbackData CreateSharedData(Action<Message>? unregister = null) =>

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Runtime;
@@ -83,6 +84,8 @@ public class CallbackDataTests
 
         using var staleLease = staleOwner.Acquire();
         Assert.False(staleLease.TryGetValue(out _));
+        CallbackDataPool.Return(staleOwner);
+        Assert.Same(reusedCallback, currentLease.Value);
 
         CallbackDataPool.Return(currentOwner);
     }
@@ -144,6 +147,114 @@ public class CallbackDataTests
         CallbackDataPool.Return(currentOwner);
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void ConcurrentOwnerReturnsAreIdempotent()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var instruments = CreateInstruments(serviceProvider);
+
+        for (var iteration = 0; iteration < 1_000; iteration++)
+        {
+            var owner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+            var lease = owner.Acquire();
+            var callback = lease.Value;
+
+            Parallel.Invoke(
+                () => CallbackDataPool.Return(owner),
+                () => CallbackDataPool.Return(owner));
+            lease.Dispose();
+
+            var reusedOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+            using var reusedLease = reusedOwner.Acquire();
+            Assert.Same(callback, reusedLease.Value);
+
+            var concurrentOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+            using var concurrentLease = concurrentOwner.Acquire();
+            Assert.NotSame(callback, concurrentLease.Value);
+
+            CallbackDataPool.Return(concurrentOwner);
+            CallbackDataPool.Return(reusedOwner);
+        }
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void CancellationAndResponseRaceCompletesExactlyOnce() =>
+        RunTerminalRace(static (callback, cancellation) =>
+        {
+            callback.SubscribeForCancellation(cancellation.Token);
+            cancellation.Cancel();
+        });
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void TimeoutAndResponseRaceCompletesExactlyOnce() =>
+        RunTerminalRace(static (callback, _) => callback.OnTimeout());
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void ShutdownAndResponseRaceCompletesExactlyOnce() =>
+        RunTerminalRace(static (callback, _) => callback.OnHostShutdown());
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void CompletionExceptionDoesNotPreventCallbackReuse()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var instruments = CreateInstruments(serviceProvider);
+        var owner = CallbackDataPool.Rent(
+            CreateSharedData(),
+            new ThrowingResponseCompletionSource(),
+            new Message(),
+            instruments);
+        var lease = owner.TransferToLease();
+        var callback = lease.Value;
+
+        try
+        {
+            var response = new Message { BodyObject = Response.Completed };
+            Assert.Throws<InvalidOperationException>(() => callback.DoCallback(response));
+        }
+        finally
+        {
+            lease.Dispose();
+        }
+
+        var reusedOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        using var reusedLease = reusedOwner.Acquire();
+        Assert.Same(callback, reusedLease.Value);
+        CallbackDataPool.Return(reusedOwner);
+    }
+
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void OwnerTransferPreventsNewLeasesAndReturnsAfterLeaseDisposal()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var instruments = CreateInstruments(serviceProvider);
+        var owner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        var transferLease = owner.TransferToLease();
+        var callback = transferLease.Value;
+
+        using var staleLease = owner.Acquire();
+        Assert.False(staleLease.TryGetValue(out _));
+        CallbackDataPool.Return(owner);
+
+        transferLease.Dispose();
+
+        var reusedOwner = CallbackDataPool.Rent(CreateSharedData(), new TestResponseCompletionSource(), new Message(), instruments);
+        using var reusedLease = reusedOwner.Acquire();
+        Assert.Same(callback, reusedLease.Value);
+        CallbackDataPool.Return(reusedOwner);
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference CreateCompletedCallback(CancellationToken cancellationToken, ApplicationRequestInstruments instruments)
     {
@@ -161,6 +272,57 @@ public class CallbackDataTests
         callback.SubscribeForCancellation(cancellationToken);
 
         return new WeakReference(completion);
+    }
+
+    private static void RunTerminalRace(Action<CallbackData, CancellationTokenSource> complete)
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var instruments = CreateInstruments(serviceProvider);
+
+        for (var iteration = 0; iteration < 1_000; iteration++)
+        {
+            using var cancellation = new CancellationTokenSource();
+            using var start = new Barrier(3);
+            var completion = new TestResponseCompletionSource();
+            var registered = 1;
+            CallbackDataOwner owner = default;
+            owner = CallbackDataPool.Rent(
+                CreateSharedData(_ =>
+                {
+                    if (Interlocked.Exchange(ref registered, 0) == 1)
+                    {
+                        CallbackDataPool.Return(owner);
+                    }
+                }),
+                completion,
+                new Message(),
+                instruments);
+            using var lease = owner.Acquire();
+            var callback = lease.Value;
+            var response = new Message { BodyObject = Response.Completed };
+
+            var completionTask = Task.Run(() =>
+            {
+                start.SignalAndWait();
+                complete(callback, cancellation);
+            });
+            var responseTask = Task.Run(() =>
+            {
+                start.SignalAndWait();
+                if (Interlocked.Exchange(ref registered, 0) == 1)
+                {
+                    CallbackDataPool.Return(owner);
+                    callback.DoCallback(response);
+                }
+            });
+
+            start.SignalAndWait();
+            Task.WaitAll(completionTask, responseTask);
+
+            Assert.Equal(1, completion.CompletionCount);
+            Assert.NotNull(completion.Response);
+            Assert.Equal(0, Volatile.Read(ref registered));
+        }
     }
 
     private static SharedCallbackData CreateSharedData(Action<Message>? unregister = null) =>
@@ -184,10 +346,26 @@ public class CallbackDataTests
 
     private sealed class TestResponseCompletionSource : IResponseCompletionSource
     {
-        public Response? Response { get; private set; }
+        private int _completionCount;
+        private Response? _response;
 
-        public void Complete(Response value) => Response = value;
+        public int CompletionCount => Volatile.Read(ref _completionCount);
 
-        public void Complete() => Response = Orleans.Serialization.Invocation.Response.Completed;
+        public Response? Response => Volatile.Read(ref _response);
+
+        public void Complete(Response value)
+        {
+            Interlocked.Increment(ref _completionCount);
+            Interlocked.CompareExchange(ref _response, value, null);
+        }
+
+        public void Complete() => Complete(Orleans.Serialization.Invocation.Response.Completed);
+    }
+
+    private sealed class ThrowingResponseCompletionSource : IResponseCompletionSource
+    {
+        public void Complete(Response value) => throw new InvalidOperationException("Test completion failure.");
+
+        public void Complete() => throw new InvalidOperationException("Test completion failure.");
     }
 }

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -39,7 +39,7 @@ public class CallbackDataTests
 
         Assert.True(callback.IsCompleted);
         Assert.Equal(1, unregisterCount);
-        var exception = Assert.IsType<OperationCanceledException>(completion.Response.Exception);
+        var exception = Assert.IsType<OperationCanceledException>(completion.Response!.Exception);
         Assert.Equal(cancellation.Token, exception.CancellationToken);
     }
 
@@ -112,6 +112,38 @@ public class CallbackDataTests
         CallbackDataPool.Return(reusedOwner);
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void CancellationAfterCompletionDoesNotAffectReusedCallback()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        using var cancellation = new CancellationTokenSource();
+        var instruments = CreateInstruments(serviceProvider);
+        CallbackDataOwner completedOwner = default;
+        completedOwner = CallbackDataPool.Rent(
+            CreateSharedData(_ => CallbackDataPool.Return(completedOwner)),
+            new TestResponseCompletionSource(),
+            new Message(),
+            instruments);
+        var completedLease = completedOwner.Acquire();
+        var completedCallback = completedLease.Value;
+        completedCallback.SubscribeForCancellation(cancellation.Token);
+        completedCallback.OnHostShutdown();
+        completedLease.Dispose();
+
+        var currentCompletion = new TestResponseCompletionSource();
+        var currentOwner = CallbackDataPool.Rent(CreateSharedData(), currentCompletion, new Message(), instruments);
+        using var currentLease = currentOwner.Acquire();
+        Assert.Same(completedCallback, currentLease.Value);
+
+        cancellation.Cancel();
+
+        Assert.False(currentLease.Value.IsCompleted);
+        Assert.Null(currentCompletion.Response);
+        CallbackDataPool.Return(currentOwner);
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference CreateCompletedCallback(CancellationToken cancellationToken, ApplicationRequestInstruments instruments)
     {
@@ -152,7 +184,7 @@ public class CallbackDataTests
 
     private sealed class TestResponseCompletionSource : IResponseCompletionSource
     {
-        public Response Response { get; private set; } = null!;
+        public Response? Response { get; private set; }
 
         public void Complete(Response value) => Response = value;
 


### PR DESCRIPTION
## Summary
- Adds pooled `CallbackData` reuse via `CallbackDataPool`, `CallbackDataOwner`, and lease-based lifetime management.
- Updates outside and inside runtime client callback registration, response completion, cancellation, unregister, failover, and timeout paths to return callbacks to the pool safely.

## Validation
- `git diff --check`
- conflict-marker scan
- `dotnet build src\Orleans.Core\Orleans.Core.csproj -m`
- `dotnet build src\Orleans.Runtime\Orleans.Runtime.csproj -m`
- `gh pr checks 10067 --repo dotnet/orleans` (62 checks passing)

## Notes
- This branch was adapted to current dictionaries and does not require the striped callback dictionary PR.
- No focused pooling/concurrency tests were added. Follow-up coverage should include response/status/cancel/unregister races, reuse-after-return, wrong-correlation status updates, double-release/ref-count underflow, and cancellation registration disposal ordering.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10067)