### PR TITLE
refactor(runtime): encapsulate ActivationData synchronization

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainContext.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainContext.cs
@@ -125,62 +125,6 @@ namespace Orleans.Runtime
     }
 
     /// <summary>
-    /// Defines functionality required for grains which are subject to activation collection.
-    /// </summary>
-    internal interface ICollectibleGrainContext : IGrainContext
-    {
-        /// <summary>
-        /// Gets a value indicating whether the instance is available to process messages.
-        /// </summary>
-        bool IsValid { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether this instance is exempt from collection.
-        /// </summary>
-        bool IsExemptFromCollection { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether this instance is not currently processing a request.
-        /// </summary>
-        bool IsInactive { get; }
-
-        /// <summary>
-        /// Gets the collection age limit, which defines how long an instance must be inactive before it is eligible for collection.
-        /// </summary>
-        TimeSpan CollectionAgeLimit { get; }
-
-        /// <summary>
-        /// Gets the keep alive override value, which is the earliest time after which this instance will be available for collection.
-        /// </summary>
-        DateTime KeepAliveUntil { get; }
-
-        /// <summary>
-        /// Gets or sets the collection ticket, which is a special value used for tracking this activation's lifetime.
-        /// </summary>
-        DateTime CollectionTicket { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether this activation has been idle longer than its <see cref="CollectionAgeLimit"/>.
-        /// </summary>
-        /// <returns><see langword="true"/> if the activation is stale, otherwise <see langword="false"/>.</returns>
-        bool IsStale();
-
-        /// <summary>
-        /// Gets the duration which this activation has been idle for.
-        /// </summary>
-        /// <returns>
-        /// The duration which this activation has been idle for.
-        /// </returns>
-        TimeSpan GetIdleness();
-
-        /// <summary>
-        /// Delays activation collection until at least until the specified duration has elapsed.
-        /// </summary>
-        /// <param name="timeSpan">The period of time to delay activation collection for.</param>
-        void DelayDeactivation(TimeSpan timeSpan);
-    }
-
-    /// <summary>
     /// Functionality to schedule tasks on a grain.
     /// </summary>
     public interface IWorkItemScheduler

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -249,6 +249,11 @@ namespace Orleans.Runtime
                 for (var i = 0; i < claims.Count; i++)
                 {
                     var claim = claims[i];
+                    if (!claim.Registration.IsClaimed(claim.SourceBucket))
+                    {
+                        continue;
+                    }
+
                     var activation = claim.Registration.Context;
                     var result = activation.TryDeactivateForCollection(
                         reason,

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -21,19 +21,15 @@ namespace Orleans.Runtime
     /// </summary>
     internal partial class ActivationCollector : IActivationWorkingSetObserver, ILifecycleParticipant<ISiloLifecycle>, IDisposable
     {
-#if NET10_0_OR_GREATER
-        private readonly Lock _scheduleLock = new();
-#else
-        private readonly object _scheduleLock = new();
-#endif
         private readonly TimeSpan shortestAgeLimit;
         private readonly ConcurrentDictionary<DateTime, Bucket> buckets = new();
         private readonly ConcurrentDictionary<ICollectibleGrainContext, CollectionRegistration> _registrations = new(ReferenceEqualsComparer.Default);
         private readonly CancellationTokenSource _shutdownCts = new();
         private readonly TimeProvider _timeProvider;
-        private DateTime nextTicket;
+        private long _nextTicketTicks;
         private static readonly List<ICollectibleGrainContext> nothing = [];
         private static readonly IReadOnlyList<CollectionClaim> NoClaims = Array.Empty<CollectionClaim>();
+        private static readonly IEnumerable<CollectionRegistration> NoRegistrations = Array.Empty<CollectionRegistration>();
         private readonly ILogger logger;
         private int collectionNumber;
 
@@ -69,7 +65,7 @@ namespace Orleans.Runtime
             _catalogInstruments = catalogInstruments;
 
             shortestAgeLimit = new(_grainCollectionOptions.ClassSpecificCollectionAge.Values.Aggregate(_grainCollectionOptions.CollectionAge.Ticks, (a, v) => Math.Min(a, v.Ticks)));
-            nextTicket = MakeTicketFromDateTime(timeProvider.GetUtcNow().UtcDateTime);
+            _nextTicketTicks = MakeTicketFromDateTime(timeProvider.GetUtcNow().UtcDateTime).Ticks;
             this.logger = logger;
             _collectionTimer = new PeriodicTimer(_grainCollectionOptions.CollectionQuantum);
 
@@ -94,7 +90,7 @@ namespace Orleans.Runtime
                 var timeSinceLastUsed = shortestAgeLimit - timeTillCollection;
                 if (timeSinceLastUsed <= recencyPeriod)
                 {
-                    sum += bucket.Value.Items.Count;
+                    sum += bucket.Value.Count;
                 }
             }
 
@@ -129,13 +125,9 @@ namespace Orleans.Runtime
             }
 
             var registration = _registrations.GetOrAdd(item, static item => new(item));
-            lock (_scheduleLock)
+            if (!TryScheduleCollection(registration, timeout, now, throwIfExpired: true))
             {
-                var ticket = MakeTicketFromTimeSpan(timeout, now);
-                if (!registration.TrySchedule(GetOrCreateBucket(ticket), ticket))
-                {
-                    throw new InvalidOperationException("Call CancelCollection before calling ScheduleCollection.");
-                }
+                throw new InvalidOperationException("Call CancelCollection before calling ScheduleCollection.");
             }
         }
 
@@ -161,55 +153,74 @@ namespace Orleans.Runtime
         {
             if (item.IsExemptFromCollection) return false;
             var registration = _registrations.GetOrAdd(item, static item => new(item));
-
-            lock (_scheduleLock)
-            {
-                return TryRescheduleCollection(registration, item.CollectionAgeLimit);
-            }
+            return TryRescheduleCollection(registration, item.CollectionAgeLimit);
         }
 
         private bool TryRescheduleCollection(CollectionRegistration registration, TimeSpan timeout)
         {
-            if (registration.TryGetScheduledTicket(out var oldTicket))
+            while (registration.TryGetScheduledTicket(out var oldTicket))
             {
                 ThrowIfTicketIsInvalid(oldTicket);
                 if (!IsExpired(oldTicket))
                 {
-                    var rescheduledTicket = MakeTicketFromTimeSpan(timeout, _timeProvider.GetUtcNow().UtcDateTime);
+                    if (!TryMakeTicketFromTimeSpan(timeout, _timeProvider.GetUtcNow().UtcDateTime, out var rescheduledTicket))
+                    {
+                        break;
+                    }
+
                     if (rescheduledTicket.Equals(oldTicket)) return true;
 
-                    return registration.TryReschedule(GetOrCreateBucket(rescheduledTicket), rescheduledTicket);
+                    var bucket = GetOrCreateBucket(rescheduledTicket);
+                    if (registration.TryReschedule(bucket, rescheduledTicket))
+                    {
+                        if (!IsExpired(rescheduledTicket))
+                        {
+                            return true;
+                        }
+
+                        registration.TryCancel();
+                        bucket.CloseForCleanup();
+                        break;
+                    }
+
+                    continue;
                 }
+
+                break;
             }
 
             registration.TryCancel();
-            var newTicket = MakeTicketFromTimeSpan(timeout, _timeProvider.GetUtcNow().UtcDateTime);
-            return registration.TrySchedule(GetOrCreateBucket(newTicket), newTicket);
+            return TryScheduleCollection(registration, timeout, _timeProvider.GetUtcNow().UtcDateTime, throwIfExpired: false);
         }
 
         private bool DequeueQuantum([NotNullWhen(true)] out IReadOnlyList<CollectionClaim>? items, DateTime now)
         {
-            Bucket? bucket;
-            lock (_scheduleLock)
+            long ticketTicks;
+            while (true)
             {
-                if (nextTicket > now)
+                ticketTicks = Volatile.Read(ref _nextTicketTicks);
+                if (ticketTicks > now.Ticks)
                 {
                     items = null;
                     return false;
                 }
 
-                var key = nextTicket;
-                nextTicket += _grainCollectionOptions.CollectionQuantum;
-                buckets.TryRemove(key, out bucket);
+                var nextTicketTicks = checked(ticketTicks + _grainCollectionOptions.CollectionQuantum.Ticks);
+                if (Interlocked.CompareExchange(ref _nextTicketTicks, nextTicketTicks, ticketTicks) == ticketTicks)
+                {
+                    break;
+                }
             }
 
+            var key = new DateTime(ticketTicks, DateTimeKind.Utc);
+            buckets.TryRemove(key, out var bucket);
             if (bucket is null)
             {
                 items = NoClaims;
                 return true;
             }
 
-            items = bucket.ClaimAll();
+            items = bucket.CloseAndClaimAll();
             return true;
         }
 
@@ -218,8 +229,8 @@ namespace Orleans.Runtime
         {
             var now = _timeProvider.GetUtcNow().UtcDateTime;
             var all = buckets.ToList();
-            var bucketsText = Utils.EnumerableToString(all.OrderBy(bucket => bucket.Key), bucket => $"{Utils.TimeSpanToString(bucket.Key - now)}->{bucket.Value.Items.Count} items");
-            return $"<#Activations={all.Sum(b => b.Value.Items.Count)}, #Buckets={all.Count}, buckets={bucketsText}>";
+            var bucketsText = Utils.EnumerableToString(all.OrderBy(bucket => bucket.Key), bucket => $"{Utils.TimeSpanToString(bucket.Key - now)}->{bucket.Value.Count} items");
+            return $"<#Activations={all.Sum(b => b.Value.Count)}, #Buckets={all.Count}, buckets={bucketsText}>";
         }
 
         private List<ICollectibleGrainContext> ScanStale(DeactivationReason reason, CancellationToken cancellationToken)
@@ -267,7 +278,7 @@ namespace Orleans.Runtime
             foreach (var kv in buckets)
             {
                 var bucket = kv.Value;
-                foreach (var registration in bucket.Items.Keys)
+                foreach (var registration in bucket.Registrations)
                 {
                     if (!registration.IsScheduledIn(bucket))
                     {
@@ -299,10 +310,35 @@ namespace Orleans.Runtime
 
         private void RescheduleClaim(CollectionClaim claim, TimeSpan timeout, DateTime now)
         {
-            lock (_scheduleLock)
+            while (claim.Registration.IsClaimed(claim.Generation))
             {
-                var ticket = MakeTicketFromTimeSpan(timeout, now);
-                claim.Registration.TryRescheduleClaim(claim.Generation, GetOrCreateBucket(ticket), ticket);
+                if (!TryMakeTicketFromTimeSpan(timeout, now, out var ticket))
+                {
+                    claim.Registration.TryCompleteClaim(claim.Generation);
+                    TryScheduleCollection(claim.Registration, timeout, _timeProvider.GetUtcNow().UtcDateTime, throwIfExpired: false);
+                    return;
+                }
+
+                var bucket = GetOrCreateBucket(ticket);
+                if (claim.Registration.TryRescheduleClaim(claim.Generation, bucket, ticket))
+                {
+                    if (IsExpired(ticket))
+                    {
+                        claim.Registration.TryCancel();
+                        bucket.CloseForCleanup();
+                        TryScheduleCollection(claim.Registration, timeout, _timeProvider.GetUtcNow().UtcDateTime, throwIfExpired: false);
+                    }
+
+                    return;
+                }
+
+                if (IsExpired(ticket))
+                {
+                    bucket.CloseForCleanup();
+                    claim.Registration.TryCompleteClaim(claim.Generation);
+                    TryScheduleCollection(claim.Registration, timeout, _timeProvider.GetUtcNow().UtcDateTime, throwIfExpired: false);
+                    return;
+                }
             }
         }
 
@@ -365,7 +401,7 @@ namespace Orleans.Runtime
             Array.Sort(bucketSnapshot, static (left, right) => left.Key.CompareTo(right.Key));
             foreach (var bucket in bucketSnapshot)
             {
-                foreach (var registration in bucket.Value.Items.Keys)
+                foreach (var registration in bucket.Value.Registrations)
                 {
                     if (candidates.Count >= count)
                     {
@@ -442,10 +478,22 @@ namespace Orleans.Runtime
 
         private bool IsExpired(DateTime ticket)
         {
-            return ticket < nextTicket;
+            return ticket.Ticks < Volatile.Read(ref _nextTicketTicks);
         }
 
         public DateTime MakeTicketFromDateTime(DateTime timestamp)
+        {
+            var ticket = CalculateTicket(timestamp);
+            var nextTicketTicks = Volatile.Read(ref _nextTicketTicks);
+            if (ticket.Ticks < nextTicketTicks)
+            {
+                throw new ArgumentException(string.Format("The earliest collection that can be scheduled from now is for {0}", new DateTime(nextTicketTicks - _grainCollectionOptions.CollectionQuantum.Ticks + 1, DateTimeKind.Utc)));
+            }
+
+            return ticket;
+        }
+
+        private DateTime CalculateTicket(DateTime timestamp)
         {
             // Round the timestamp to the next _grainCollectionOptions.CollectionQuantum. e.g. if the _grainCollectionOptions.CollectionQuantum is 1 minute and the timestamp is 3:45:22, then the ticket will be 3:46.
             // Note that TimeStamp.Ticks and DateTime.Ticks both return a long.
@@ -455,26 +503,65 @@ namespace Orleans.Runtime
                 return DateTime.MaxValue;
             }
 
-            var ticket = new DateTime(ticketTicks, DateTimeKind.Utc);
-            if (ticket < nextTicket)
-            {
-                throw new ArgumentException(string.Format("The earliest collection that can be scheduled from now is for {0}", new DateTime(nextTicket.Ticks - _grainCollectionOptions.CollectionQuantum.Ticks + 1, DateTimeKind.Utc)));
-            }
-
-            return ticket;
+            return new DateTime(ticketTicks, DateTimeKind.Utc);
         }
 
-        private DateTime MakeTicketFromTimeSpan(TimeSpan timeout, DateTime now)
+        private bool TryMakeTicketFromTimeSpan(TimeSpan timeout, DateTime now, out DateTime ticket)
         {
             if (timeout < _grainCollectionOptions.CollectionQuantum)
             {
                 throw new ArgumentException(string.Format("timeout must be at least {0}, but it is {1}", _grainCollectionOptions.CollectionQuantum, timeout), nameof(timeout));
             }
 
-            return MakeTicketFromDateTime(now + timeout);
+            ticket = CalculateTicket(now + timeout);
+            return !IsExpired(ticket);
         }
 
-        private Bucket GetOrCreateBucket(DateTime ticket) => buckets.GetOrAdd(ticket, static _ => new());
+        private Bucket GetOrCreateBucket(DateTime ticket)
+            => buckets.GetOrAdd(ticket, static (ticket, owner) => new(owner, ticket), this);
+
+        private void RemoveClosedBucket(DateTime ticket, Bucket bucket)
+            => ((ICollection<KeyValuePair<DateTime, Bucket>>)buckets).Remove(new(ticket, bucket));
+
+        private bool TryScheduleCollection(CollectionRegistration registration, TimeSpan timeout, DateTime now, bool throwIfExpired)
+        {
+            while (!registration.IsScheduled)
+            {
+                if (!TryMakeTicketFromTimeSpan(timeout, now, out var ticket))
+                {
+                    if (throwIfExpired)
+                    {
+                        MakeTicketFromDateTime(now + timeout);
+                    }
+
+                    now = GetInternalScheduleBaseline();
+                    continue;
+                }
+
+                var bucket = GetOrCreateBucket(ticket);
+                if (registration.TrySchedule(bucket, ticket))
+                {
+                    if (!IsExpired(ticket))
+                    {
+                        return true;
+                    }
+
+                    registration.TryCancel();
+                    bucket.CloseForCleanup();
+                }
+
+                now = GetInternalScheduleBaseline();
+            }
+
+            return false;
+        }
+
+        private DateTime GetInternalScheduleBaseline()
+        {
+            var now = _timeProvider.GetUtcNow().UtcDateTime;
+            var nextTicketTicks = Volatile.Read(ref _nextTicketTicks);
+            return now.Ticks >= nextTicketTicks ? now : new DateTime(nextTicketTicks, DateTimeKind.Utc);
+        }
 
         internal DateTime GetCollectionTicketForTesting(ICollectibleGrainContext item)
             => _registrations.TryGetValue(item, out var registration) ? registration.Ticket : default;
@@ -487,18 +574,9 @@ namespace Orleans.Runtime
             }
 
             var registration = _registrations.GetOrAdd(item, static item => new(item));
-            if (registration.IsTracked)
+            if (!registration.IsScheduled)
             {
-                return;
-            }
-
-            lock (_scheduleLock)
-            {
-                if (!registration.IsTracked)
-                {
-                    var ticket = MakeTicketFromTimeSpan(item.CollectionAgeLimit, _timeProvider.GetUtcNow().UtcDateTime);
-                    registration.TrySchedule(GetOrCreateBucket(ticket), ticket);
-                }
+                TryScheduleCollection(registration, item.CollectionAgeLimit, _timeProvider.GetUtcNow().UtcDateTime, throwIfExpired: false);
             }
         }
 
@@ -745,13 +823,13 @@ namespace Orleans.Runtime
 
             public ICollectibleGrainContext Context { get; } = context;
 
-            public bool IsTracked
+            public bool IsScheduled
             {
                 get
                 {
                     lock (_lock)
                     {
-                        return _state is not CollectionRegistrationState.None;
+                        return _state is CollectionRegistrationState.Scheduled;
                     }
                 }
             }
@@ -771,14 +849,14 @@ namespace Orleans.Runtime
             {
                 lock (_lock)
                 {
-                    if (_state is not CollectionRegistrationState.None)
+                    if (_state is CollectionRegistrationState.Scheduled)
                     {
                         return false;
                     }
 
-                    if (!bucket.Items.TryAdd(this, 0))
+                    if (!bucket.TryAdd(this))
                     {
-                        throw new InvalidOperationException("Collection registration is already associated with this bucket.");
+                        return false;
                     }
 
                     _bucket = bucket;
@@ -819,12 +897,12 @@ namespace Orleans.Runtime
                         return true;
                     }
 
-                    _bucket!.Items.TryRemove(this, out _);
-                    if (!bucket.Items.TryAdd(this, 0))
+                    if (!bucket.TryAdd(this))
                     {
-                        throw new InvalidOperationException("Collection registration is already associated with the destination bucket.");
+                        return false;
                     }
 
+                    _bucket!.TryRemove(this);
                     _bucket = bucket;
                     _ticket = ticket;
                     _generation++;
@@ -841,7 +919,7 @@ namespace Orleans.Runtime
                         return false;
                     }
 
-                    _bucket?.Items.TryRemove(this, out _);
+                    _bucket?.TryRemove(this);
                     _bucket = null;
                     _ticket = default;
                     _state = CollectionRegistrationState.None;
@@ -855,6 +933,14 @@ namespace Orleans.Runtime
                 lock (_lock)
                 {
                     return _state is CollectionRegistrationState.Scheduled && ReferenceEquals(_bucket, bucket);
+                }
+            }
+
+            public bool IsClaimed(long generation)
+            {
+                lock (_lock)
+                {
+                    return _state is CollectionRegistrationState.Claimed && _generation == generation;
                 }
             }
 
@@ -901,9 +987,9 @@ namespace Orleans.Runtime
                         return false;
                     }
 
-                    if (!bucket.Items.TryAdd(this, 0))
+                    if (!bucket.TryAdd(this))
                     {
-                        throw new InvalidOperationException("Collection registration is already associated with the destination bucket.");
+                        return false;
                     }
 
                     _bucket = bucket;
@@ -915,14 +1001,78 @@ namespace Orleans.Runtime
             }
         }
 
-        private sealed class Bucket
+        private sealed class Bucket(ActivationCollector owner, DateTime ticket)
         {
-            public ConcurrentDictionary<CollectionRegistration, byte> Items { get; } = new(ReferenceEqualsComparer.Default);
+            private readonly ActivationCollector _owner = owner;
+            private readonly DateTime _ticket = ticket;
+            private ConcurrentDictionary<CollectionRegistration, byte>? _items;
+            private int _activeAdders;
+            private int _closed;
 
-            public IReadOnlyList<CollectionClaim> ClaimAll()
+            public int Count => Volatile.Read(ref _items)?.Count ?? 0;
+
+            public IEnumerable<CollectionRegistration> Registrations
+                => Volatile.Read(ref _items)?.Keys ?? NoRegistrations;
+
+            public bool TryAdd(CollectionRegistration registration)
             {
+                Interlocked.Increment(ref _activeAdders);
+                try
+                {
+                    if (Volatile.Read(ref _closed) != 0)
+                    {
+                        return false;
+                    }
+
+                    var items = LazyInitializer.EnsureInitialized(
+                        ref _items,
+                        static () => new ConcurrentDictionary<CollectionRegistration, byte>(ReferenceEqualsComparer.Default));
+                    if (!items.TryAdd(registration, 0))
+                    {
+                        return false;
+                    }
+
+                    if (Volatile.Read(ref _closed) == 0)
+                    {
+                        return true;
+                    }
+
+                    items.TryRemove(registration, out _);
+                    return false;
+                }
+                finally
+                {
+                    if (Interlocked.Decrement(ref _activeAdders) == 0)
+                    {
+                        RemoveIfClosedAndEmpty();
+                    }
+                }
+            }
+
+            public void TryRemove(CollectionRegistration registration)
+            {
+                Volatile.Read(ref _items)?.TryRemove(registration, out _);
+                RemoveIfClosedAndEmpty();
+            }
+
+            public void CloseForCleanup()
+            {
+                Interlocked.Exchange(ref _closed, 1);
+                RemoveIfClosedAndEmpty();
+            }
+
+            public IReadOnlyList<CollectionClaim> CloseAndClaimAll()
+            {
+                Interlocked.Exchange(ref _closed, 1);
+                WaitForAdders();
+                var items = Volatile.Read(ref _items);
+                if (items is null)
+                {
+                    return NoClaims;
+                }
+
                 List<CollectionClaim>? result = null;
-                foreach (var registration in Items.Keys)
+                foreach (var registration in items.Keys)
                 {
                     if (registration.TryClaim(this, out var claim))
                     {
@@ -931,7 +1081,27 @@ namespace Orleans.Runtime
                     }
                 }
 
+                items.Clear();
                 return result ?? NoClaims;
+            }
+
+            private void RemoveIfClosedAndEmpty()
+            {
+                if (Volatile.Read(ref _closed) != 0
+                    && Volatile.Read(ref _activeAdders) == 0
+                    && Volatile.Read(ref _items) is not { IsEmpty: false })
+                {
+                    _owner.RemoveClosedBucket(_ticket, this);
+                }
+            }
+
+            private void WaitForAdders()
+            {
+                var spinner = new SpinWait();
+                while (Volatile.Read(ref _activeAdders) != 0)
+                {
+                    spinner.SpinOnce();
+                }
             }
         }
 

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,7 +23,6 @@ namespace Orleans.Runtime
     {
         private readonly TimeSpan shortestAgeLimit;
         private readonly ConcurrentDictionary<DateTime, Bucket> buckets = new();
-        private readonly ConditionalWeakTable<ICollectibleGrainContext, CollectionRegistration> _registrations = new();
         private readonly CancellationTokenSource _shutdownCts = new();
         private readonly TimeProvider _timeProvider;
         private long _nextTicketTicks;
@@ -125,7 +123,7 @@ namespace Orleans.Runtime
                 return;
             }
 
-            var registration = _registrations.GetValue(item, static item => new(item));
+            var registration = GetOrCreateCollectionRegistration(item);
             if (!TryScheduleCollection(registration, timeout, now, throwIfExpired: true))
             {
                 throw new InvalidOperationException("Call TryCancelCollection before calling ScheduleCollection.");
@@ -142,7 +140,7 @@ namespace Orleans.Runtime
             if (item is null) return false;
             if (item.IsExemptFromCollection) return false;
 
-            return _registrations.TryGetValue(item, out var registration) && registration.TryCancel();
+            return GetCollectionRegistration(item) is { } registration && registration.TryCancel();
         }
 
         /// <summary>
@@ -153,7 +151,7 @@ namespace Orleans.Runtime
         public bool TryRescheduleCollection(ICollectibleGrainContext item)
         {
             if (item.IsExemptFromCollection) return false;
-            if (!_registrations.TryGetValue(item, out var registration)) return false;
+            if (GetCollectionRegistration(item) is not { } registration) return false;
             return TryRescheduleCollection(registration, item.CollectionAgeLimit);
         }
 
@@ -524,6 +522,20 @@ namespace Orleans.Runtime
         private void RemoveClosedBucket(DateTime ticket, Bucket bucket)
             => ((ICollection<KeyValuePair<DateTime, Bucket>>)buckets).Remove(new(ticket, bucket));
 
+        private static CollectionRegistration? GetCollectionRegistration(ICollectibleGrainContext item)
+            => item.CollectionRegistration as CollectionRegistration;
+
+        private static CollectionRegistration GetOrCreateCollectionRegistration(ICollectibleGrainContext item)
+        {
+            if (GetCollectionRegistration(item) is { } existing)
+            {
+                return existing;
+            }
+
+            var candidate = new CollectionRegistration(item);
+            return (CollectionRegistration)item.GetOrSetCollectionRegistration(candidate);
+        }
+
         private bool TryScheduleCollection(CollectionRegistration registration, TimeSpan timeout, DateTime now, bool throwIfExpired)
         {
             while (!registration.IsScheduled && !registration.IsRetired)
@@ -565,10 +577,10 @@ namespace Orleans.Runtime
         }
 
         internal DateTime GetCollectionTicketForTesting(ICollectibleGrainContext item)
-            => _registrations.TryGetValue(item, out var registration) ? registration.Ticket : default;
+            => GetCollectionRegistration(item) is { } registration ? registration.Ticket : default;
 
         internal bool HasActiveCollectionRegistrationForTesting(ICollectibleGrainContext item)
-            => _registrations.TryGetValue(item, out var registration) && !registration.IsRetired;
+            => GetCollectionRegistration(item) is { IsRetired: false };
 
         private void EnsureCollectionScheduled(ICollectibleGrainContext item)
         {
@@ -577,7 +589,7 @@ namespace Orleans.Runtime
                 return;
             }
 
-            var registration = _registrations.GetValue(item, static item => new(item));
+            var registration = GetOrCreateCollectionRegistration(item);
             if (!registration.IsScheduled)
             {
                 TryScheduleCollection(registration, item.CollectionAgeLimit, _timeProvider.GetUtcNow().UtcDateTime, throwIfExpired: false);
@@ -610,7 +622,7 @@ namespace Orleans.Runtime
         void IActivationWorkingSetObserver.OnDeactivating(IActivationWorkingSetMember member)
         {
             if (member is ICollectibleGrainContext activation
-                && _registrations.TryGetValue(activation, out var registration))
+                && GetCollectionRegistration(activation) is { } registration)
             {
                 registration.Retire();
             }
@@ -621,7 +633,7 @@ namespace Orleans.Runtime
             Interlocked.Decrement(ref _activationCount);
             if (member is ICollectibleGrainContext activation)
             {
-                if (_registrations.TryGetValue(activation, out var registration))
+                if (GetCollectionRegistration(activation) is { } registration)
                 {
                     registration.Retire();
                 }
@@ -817,7 +829,7 @@ namespace Orleans.Runtime
             Retired
         }
 
-        private sealed class CollectionRegistration(ICollectibleGrainContext context)
+        private sealed class CollectionRegistration(ICollectibleGrainContext context) : IActivationCollectionRegistration
         {
 #if NET10_0_OR_GREATER
             private readonly Lock _lock = new();

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -28,7 +28,7 @@ namespace Orleans.Runtime
         private long _nextTicketTicks;
         private static readonly List<ICollectibleGrainContext> nothing = [];
         private static readonly IReadOnlyList<CollectionClaim> NoClaims = Array.Empty<CollectionClaim>();
-        private static readonly IEnumerable<CollectionRegistration> NoRegistrations = Array.Empty<CollectionRegistration>();
+        private static readonly IEnumerable<KeyValuePair<CollectionRegistration, byte>> NoRegistrations = Array.Empty<KeyValuePair<CollectionRegistration, byte>>();
         private readonly ILogger logger;
         private int collectionNumber;
 
@@ -170,7 +170,7 @@ namespace Orleans.Runtime
                     if (rescheduledTicket.Equals(oldTicket)) return true;
 
                     var bucket = GetOrCreateBucket(rescheduledTicket);
-                    if (registration.TryReschedule(bucket, rescheduledTicket))
+                    if (registration.TryReschedule(bucket))
                     {
                         if (!IsExpired(rescheduledTicket))
                         {
@@ -238,8 +238,9 @@ namespace Orleans.Runtime
             List<ICollectibleGrainContext>? condemned = null;
             while (DequeueQuantum(out var claims, now))
             {
-                foreach (var claim in claims)
+                for (var i = 0; i < claims.Count; i++)
                 {
+                    var claim = claims[i];
                     var activation = claim.Registration.Context;
                     var result = activation.TryDeactivateForCollection(
                         reason,
@@ -277,8 +278,9 @@ namespace Orleans.Runtime
             foreach (var kv in buckets)
             {
                 var bucket = kv.Value;
-                foreach (var registration in bucket.Registrations)
+                foreach (var entry in bucket.Registrations)
                 {
+                    var registration = entry.Key;
                     if (!registration.IsScheduledIn(bucket))
                     {
                         continue;
@@ -319,7 +321,7 @@ namespace Orleans.Runtime
                 }
 
                 var bucket = GetOrCreateBucket(ticket);
-                if (claim.Registration.TryRescheduleClaim(claim.Generation, bucket, ticket))
+                if (claim.Registration.TryRescheduleClaim(claim.Generation, bucket))
                 {
                     if (IsExpired(ticket))
                     {
@@ -400,8 +402,9 @@ namespace Orleans.Runtime
             Array.Sort(bucketSnapshot, static (left, right) => left.Key.CompareTo(right.Key));
             foreach (var bucket in bucketSnapshot)
             {
-                foreach (var registration in bucket.Value.Registrations)
+                foreach (var entry in bucket.Value.Registrations)
                 {
+                    var registration = entry.Key;
                     if (candidates.Count >= count)
                     {
                         break;
@@ -552,7 +555,7 @@ namespace Orleans.Runtime
                 }
 
                 var bucket = GetOrCreateBucket(ticket);
-                if (registration.TrySchedule(bucket, ticket))
+                if (registration.TrySchedule(bucket))
                 {
                     if (!IsExpired(ticket))
                     {
@@ -839,7 +842,6 @@ namespace Orleans.Runtime
             private Bucket? _bucket;
             private long _generation;
             private CollectionRegistrationState _state;
-            private DateTime _ticket;
 
             public ICollectibleGrainContext Context { get; } = context;
 
@@ -871,12 +873,12 @@ namespace Orleans.Runtime
                 {
                     lock (_lock)
                     {
-                        return _state is CollectionRegistrationState.Scheduled ? _ticket : default;
+                        return _state is CollectionRegistrationState.Scheduled ? _bucket!.Ticket : default;
                     }
                 }
             }
 
-            public bool TrySchedule(Bucket bucket, DateTime ticket)
+            public bool TrySchedule(Bucket bucket)
             {
                 lock (_lock)
                 {
@@ -891,7 +893,6 @@ namespace Orleans.Runtime
                     }
 
                     _bucket = bucket;
-                    _ticket = ticket;
                     _state = CollectionRegistrationState.Scheduled;
                     _generation++;
                     return true;
@@ -904,7 +905,7 @@ namespace Orleans.Runtime
                 {
                     if (_state is CollectionRegistrationState.Scheduled)
                     {
-                        ticket = _ticket;
+                        ticket = _bucket!.Ticket;
                         return true;
                     }
 
@@ -913,7 +914,7 @@ namespace Orleans.Runtime
                 }
             }
 
-            public bool TryReschedule(Bucket bucket, DateTime ticket)
+            public bool TryReschedule(Bucket bucket)
             {
                 lock (_lock)
                 {
@@ -924,7 +925,6 @@ namespace Orleans.Runtime
 
                     if (ReferenceEquals(_bucket, bucket))
                     {
-                        _ticket = ticket;
                         return true;
                     }
 
@@ -935,7 +935,6 @@ namespace Orleans.Runtime
 
                     _bucket!.TryRemove(this);
                     _bucket = bucket;
-                    _ticket = ticket;
                     _generation++;
                     return true;
                 }
@@ -952,7 +951,6 @@ namespace Orleans.Runtime
 
                     _bucket?.TryRemove(this);
                     _bucket = null;
-                    _ticket = default;
                     _state = CollectionRegistrationState.None;
                     _generation++;
                     return true;
@@ -965,7 +963,6 @@ namespace Orleans.Runtime
                 {
                     _bucket?.TryRemove(this);
                     _bucket = null;
-                    _ticket = default;
                     _state = CollectionRegistrationState.Retired;
                     _generation++;
                 }
@@ -998,7 +995,6 @@ namespace Orleans.Runtime
                     }
 
                     _bucket = null;
-                    _ticket = default;
                     _state = CollectionRegistrationState.Claimed;
                     var generation = ++_generation;
                     claim = new CollectionClaim(this, generation);
@@ -1021,7 +1017,7 @@ namespace Orleans.Runtime
                 }
             }
 
-            public bool TryRescheduleClaim(long generation, Bucket bucket, DateTime ticket)
+            public bool TryRescheduleClaim(long generation, Bucket bucket)
             {
                 lock (_lock)
                 {
@@ -1036,7 +1032,6 @@ namespace Orleans.Runtime
                     }
 
                     _bucket = bucket;
-                    _ticket = ticket;
                     _state = CollectionRegistrationState.Scheduled;
                     _generation++;
                     return true;
@@ -1054,8 +1049,10 @@ namespace Orleans.Runtime
 
             public int Count => Volatile.Read(ref _items)?.Count ?? 0;
 
-            public IEnumerable<CollectionRegistration> Registrations
-                => Volatile.Read(ref _items)?.Keys ?? NoRegistrations;
+            public DateTime Ticket => _ticket;
+
+            public IEnumerable<KeyValuePair<CollectionRegistration, byte>> Registrations
+                => Volatile.Read(ref _items) ?? NoRegistrations;
 
             public bool TryAdd(CollectionRegistration registration)
             {
@@ -1115,8 +1112,10 @@ namespace Orleans.Runtime
                 }
 
                 List<CollectionClaim>? result = null;
-                foreach (var registration in items.Keys)
+                // Closure and the adder drain prevent new entries; removals are validated by TryClaim.
+                foreach (var entry in items)
                 {
+                    var registration = entry.Key;
                     if (registration.TryClaim(this, out var claim))
                     {
                         result ??= [];
@@ -1124,7 +1123,8 @@ namespace Orleans.Runtime
                     }
                 }
 
-                items.Clear();
+                // A closed bucket keeps no dictionary storage after its claims have been extracted.
+                Volatile.Write(ref _items, null);
                 return result ?? NoClaims;
             }
 

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -203,7 +203,10 @@ namespace Orleans.Runtime
                     return false;
                 }
 
-                var nextTicketTicks = checked(ticketTicks + _grainCollectionOptions.CollectionQuantum.Ticks);
+                var remainingTicks = DateTime.MaxValue.Ticks - ticketTicks;
+                var nextTicketTicks = _grainCollectionOptions.CollectionQuantum.Ticks >= remainingTicks
+                    ? DateTime.MaxValue.Ticks
+                    : ticketTicks + _grainCollectionOptions.CollectionQuantum.Ticks;
                 if (Interlocked.CompareExchange(ref _nextTicketTicks, nextTicketTicks, ticketTicks) == ticketTicks)
                 {
                     break;
@@ -214,6 +217,12 @@ namespace Orleans.Runtime
             buckets.TryRemove(key, out var bucket);
             if (bucket is null)
             {
+                if (ticketTicks == DateTime.MaxValue.Ticks)
+                {
+                    items = null;
+                    return false;
+                }
+
                 items = NoClaims;
                 return true;
             }

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -21,7 +21,11 @@ namespace Orleans.Runtime
     /// </summary>
     internal partial class ActivationCollector : IActivationWorkingSetObserver, ILifecycleParticipant<ISiloLifecycle>, IDisposable
     {
+#if NET10_0_OR_GREATER
+        private readonly Lock _scheduleLock = new();
+#else
         private readonly object _scheduleLock = new();
+#endif
         private readonly TimeSpan shortestAgeLimit;
         private readonly ConcurrentDictionary<DateTime, Bucket> buckets = new();
         private readonly ConcurrentDictionary<ICollectibleGrainContext, CollectionRegistration> _registrations = new(ReferenceEqualsComparer.Default);
@@ -729,7 +733,11 @@ namespace Orleans.Runtime
 
         private sealed class CollectionRegistration(ICollectibleGrainContext context)
         {
+#if NET10_0_OR_GREATER
+            private readonly Lock _lock = new();
+#else
             private readonly object _lock = new();
+#endif
             private Bucket? _bucket;
             private long _generation;
             private CollectionRegistrationState _state;

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -28,7 +28,6 @@ namespace Orleans.Runtime
         private long _nextTicketTicks;
         private static readonly List<ICollectibleGrainContext> nothing = [];
         private static readonly IReadOnlyList<CollectionClaim> NoClaims = Array.Empty<CollectionClaim>();
-        private static readonly IEnumerable<KeyValuePair<CollectionRegistration, byte>> NoRegistrations = Array.Empty<KeyValuePair<CollectionRegistration, byte>>();
         private readonly ILogger logger;
         private int collectionNumber;
 
@@ -278,7 +277,12 @@ namespace Orleans.Runtime
             foreach (var kv in buckets)
             {
                 var bucket = kv.Value;
-                foreach (var entry in bucket.Registrations)
+                if (bucket.Registrations is not { } registrations)
+                {
+                    continue;
+                }
+
+                foreach (var entry in registrations)
                 {
                     var registration = entry.Key;
                     if (!registration.IsScheduledIn(bucket))
@@ -403,7 +407,12 @@ namespace Orleans.Runtime
             Array.Sort(bucketSnapshot, static (left, right) => left.Key.CompareTo(right.Key));
             foreach (var bucket in bucketSnapshot)
             {
-                foreach (var entry in bucket.Value.Registrations)
+                if (bucket.Value.Registrations is not { } registrations)
+                {
+                    continue;
+                }
+
+                foreach (var entry in registrations)
                 {
                     var registration = entry.Key;
                     if (candidates.Count >= count)
@@ -1059,8 +1068,7 @@ namespace Orleans.Runtime
 
             public DateTime Ticket => _ticket;
 
-            public IEnumerable<KeyValuePair<CollectionRegistration, byte>> Registrations
-                => Volatile.Read(ref _items) ?? NoRegistrations;
+            public ConcurrentDictionary<CollectionRegistration, byte>? Registrations => Volatile.Read(ref _items);
 
             public bool TryAdd(CollectionRegistration registration)
             {

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -29,6 +29,7 @@ namespace Orleans.Runtime
         private readonly TimeProvider _timeProvider;
         private DateTime nextTicket;
         private static readonly List<ICollectibleGrainContext> nothing = [];
+        private static readonly IReadOnlyList<CollectionClaim> NoClaims = Array.Empty<CollectionClaim>();
         private readonly ILogger logger;
         private int collectionNumber;
 
@@ -182,7 +183,7 @@ namespace Orleans.Runtime
             return registration.TrySchedule(GetOrCreateBucket(newTicket), newTicket);
         }
 
-        private bool DequeueQuantum([NotNullWhen(true)] out List<CollectionClaim>? items, DateTime now)
+        private bool DequeueQuantum([NotNullWhen(true)] out IReadOnlyList<CollectionClaim>? items, DateTime now)
         {
             Bucket? bucket;
             lock (_scheduleLock)
@@ -200,7 +201,7 @@ namespace Orleans.Runtime
 
             if (bucket is null)
             {
-                items = [];
+                items = NoClaims;
                 return true;
             }
 
@@ -910,7 +911,7 @@ namespace Orleans.Runtime
         {
             public ConcurrentDictionary<CollectionRegistration, byte> Items { get; } = new(ReferenceEqualsComparer.Default);
 
-            public List<CollectionClaim> ClaimAll()
+            public IReadOnlyList<CollectionClaim> ClaimAll()
             {
                 List<CollectionClaim>? result = null;
                 foreach (var registration in Items.Keys)
@@ -922,7 +923,7 @@ namespace Orleans.Runtime
                     }
                 }
 
-                return result ?? [];
+                return result ?? NoClaims;
             }
         }
 

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -114,7 +114,7 @@ namespace Orleans.Runtime
         /// <param name="now">The current time, used to calculate when the grain becomes eligible for collection.</param>
         public void ScheduleCollection(ICollectibleGrainContext item, TimeSpan timeout, DateTime now)
         {
-            lock (item)
+            lock (ActivationData.GetSynchronizationLock(item))
             {
                 if (item.IsExemptFromCollection)
                 {
@@ -142,7 +142,7 @@ namespace Orleans.Runtime
             if (item is null) return false;
             if (item.IsExemptFromCollection) return false;
 
-            lock (item)
+            lock (ActivationData.GetSynchronizationLock(item))
             {
                 DateTime ticket = item.CollectionTicket;
                 if (default == ticket) return false;
@@ -165,7 +165,7 @@ namespace Orleans.Runtime
         {
             if (item.IsExemptFromCollection) return false;
 
-            lock (item)
+            lock (ActivationData.GetSynchronizationLock(item))
             {
                 if (TryRescheduleCollection_Impl(item, item.CollectionAgeLimit)) return true;
 
@@ -247,7 +247,7 @@ namespace Orleans.Runtime
                 // If the activation is to be reactivated, it's our job to clear the activation's copy of the ticket.
                 foreach (var activation in activations)
                 {
-                    lock (activation)
+                    lock (ActivationData.GetSynchronizationLock(activation))
                     {
                         activation.CollectionTicket = default;
                         if (!activation.IsValid)
@@ -294,7 +294,7 @@ namespace Orleans.Runtime
                 foreach (var kvp in bucket.Items)
                 {
                     var activation = kvp.Value;
-                    lock (activation)
+                    lock (ActivationData.GetSynchronizationLock(activation))
                     {
                         if (!activation.IsValid)
                         {
@@ -396,7 +396,7 @@ namespace Orleans.Runtime
                     }
 
                     var activation = item.Value;
-                    lock (activation)
+                    lock (ActivationData.GetSynchronizationLock(activation))
                     {
                         if (!activation.IsValid || !activation.IsInactive)
                         {
@@ -736,7 +736,7 @@ namespace Orleans.Runtime
 
             public bool TryRemove(ICollectibleGrainContext item)
             {
-                lock (item)
+                lock (ActivationData.GetSynchronizationLock(item))
                 {
                     if (item.CollectionTicket == default)
                     {
@@ -756,7 +756,7 @@ namespace Orleans.Runtime
                 {
                     // Attempt to cancel the item. if we succeed, it wasn't already cancelled and we can return it. otherwise, we silently ignore it.
                     var item = pair.Value;
-                    lock (item)
+                    lock (ActivationData.GetSynchronizationLock(item))
                     {
                         if (item.CollectionTicket == default)
                         {

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +24,7 @@ namespace Orleans.Runtime
     {
         private readonly TimeSpan shortestAgeLimit;
         private readonly ConcurrentDictionary<DateTime, Bucket> buckets = new();
-        private readonly ConcurrentDictionary<ICollectibleGrainContext, CollectionRegistration> _registrations = new(ReferenceEqualsComparer.Default);
+        private readonly ConditionalWeakTable<ICollectibleGrainContext, CollectionRegistration> _registrations = new();
         private readonly CancellationTokenSource _shutdownCts = new();
         private readonly TimeProvider _timeProvider;
         private long _nextTicketTicks;
@@ -124,7 +125,7 @@ namespace Orleans.Runtime
                 return;
             }
 
-            var registration = _registrations.GetOrAdd(item, static item => new(item));
+            var registration = _registrations.GetValue(item, static item => new(item));
             if (!TryScheduleCollection(registration, timeout, now, throwIfExpired: true))
             {
                 throw new InvalidOperationException("Call CancelCollection before calling ScheduleCollection.");
@@ -152,7 +153,7 @@ namespace Orleans.Runtime
         public bool TryRescheduleCollection(ICollectibleGrainContext item)
         {
             if (item.IsExemptFromCollection) return false;
-            var registration = _registrations.GetOrAdd(item, static item => new(item));
+            if (!_registrations.TryGetValue(item, out var registration)) return false;
             return TryRescheduleCollection(registration, item.CollectionAgeLimit);
         }
 
@@ -525,7 +526,7 @@ namespace Orleans.Runtime
 
         private bool TryScheduleCollection(CollectionRegistration registration, TimeSpan timeout, DateTime now, bool throwIfExpired)
         {
-            while (!registration.IsScheduled)
+            while (!registration.IsScheduled && !registration.IsRetired)
             {
                 if (!TryMakeTicketFromTimeSpan(timeout, now, out var ticket))
                 {
@@ -566,6 +567,9 @@ namespace Orleans.Runtime
         internal DateTime GetCollectionTicketForTesting(ICollectibleGrainContext item)
             => _registrations.TryGetValue(item, out var registration) ? registration.Ticket : default;
 
+        internal bool HasActiveCollectionRegistrationForTesting(ICollectibleGrainContext item)
+            => _registrations.TryGetValue(item, out var registration) && !registration.IsRetired;
+
         private void EnsureCollectionScheduled(ICollectibleGrainContext item)
         {
             if (item.IsExemptFromCollection)
@@ -573,7 +577,7 @@ namespace Orleans.Runtime
                 return;
             }
 
-            var registration = _registrations.GetOrAdd(item, static item => new(item));
+            var registration = _registrations.GetValue(item, static item => new(item));
             if (!registration.IsScheduled)
             {
                 TryScheduleCollection(registration, item.CollectionAgeLimit, _timeProvider.GetUtcNow().UtcDateTime, throwIfExpired: false);
@@ -605,9 +609,10 @@ namespace Orleans.Runtime
 
         void IActivationWorkingSetObserver.OnDeactivating(IActivationWorkingSetMember member)
         {
-            if (member is ICollectibleGrainContext activation)
+            if (member is ICollectibleGrainContext activation
+                && _registrations.TryGetValue(activation, out var registration))
             {
-                TryCancelCollection(activation);
+                registration.Retire();
             }
         }
 
@@ -616,8 +621,10 @@ namespace Orleans.Runtime
             Interlocked.Decrement(ref _activationCount);
             if (member is ICollectibleGrainContext activation)
             {
-                _ = TryCancelCollection(activation);
-                _registrations.TryRemove(activation, out _);
+                if (_registrations.TryGetValue(activation, out var registration))
+                {
+                    registration.Retire();
+                }
             }
         }
 
@@ -806,7 +813,8 @@ namespace Orleans.Runtime
         {
             None,
             Scheduled,
-            Claimed
+            Claimed,
+            Retired
         }
 
         private sealed class CollectionRegistration(ICollectibleGrainContext context)
@@ -834,6 +842,17 @@ namespace Orleans.Runtime
                 }
             }
 
+            public bool IsRetired
+            {
+                get
+                {
+                    lock (_lock)
+                    {
+                        return _state is CollectionRegistrationState.Retired;
+                    }
+                }
+            }
+
             public DateTime Ticket
             {
                 get
@@ -849,7 +868,7 @@ namespace Orleans.Runtime
             {
                 lock (_lock)
                 {
-                    if (_state is CollectionRegistrationState.Scheduled)
+                    if (_state is CollectionRegistrationState.Scheduled or CollectionRegistrationState.Retired)
                     {
                         return false;
                     }
@@ -914,7 +933,7 @@ namespace Orleans.Runtime
             {
                 lock (_lock)
                 {
-                    if (_state is CollectionRegistrationState.None)
+                    if (_state is CollectionRegistrationState.None or CollectionRegistrationState.Retired)
                     {
                         return false;
                     }
@@ -925,6 +944,18 @@ namespace Orleans.Runtime
                     _state = CollectionRegistrationState.None;
                     _generation++;
                     return true;
+                }
+            }
+
+            public void Retire()
+            {
+                lock (_lock)
+                {
+                    _bucket?.TryRemove(this);
+                    _bucket = null;
+                    _ticket = default;
+                    _state = CollectionRegistrationState.Retired;
+                    _generation++;
                 }
             }
 

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -808,10 +808,24 @@ namespace Orleans.Runtime
                 MaxDegreeOfParallelism = Environment.ProcessorCount * 512
             };
 
-            await Parallel.ForEachAsync(list, options, async (activationData, token) =>
+            var deactivationTask = Parallel.ForEachAsync(list, options, async (activationData, token) =>
             {
                 await activationData.Deactivated.ConfigureAwait(false);
-            }).WaitAsync(cancellationToken);
+            });
+
+            try
+            {
+                await deactivationTask.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                _ = deactivationTask.ContinueWith(
+                    static task => _ = task.Exception,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted,
+                    TaskScheduler.Default);
+                throw;
+            }
 
             ActivationCollectionEvents.EmitCollectionCompleted(collectionSource, ageLimit, deactivationReason, list);
         }

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -21,11 +21,14 @@ namespace Orleans.Runtime
     /// </summary>
     internal partial class ActivationCollector : IActivationWorkingSetObserver, ILifecycleParticipant<ISiloLifecycle>, IDisposable
     {
+        private readonly object _scheduleLock = new();
         private readonly TimeSpan shortestAgeLimit;
         private readonly ConcurrentDictionary<DateTime, Bucket> buckets = new();
+        private readonly ConcurrentDictionary<ICollectibleGrainContext, CollectionRegistration> _registrations = new(ReferenceEqualsComparer.Default);
         private readonly CancellationTokenSource _shutdownCts = new();
+        private readonly TimeProvider _timeProvider;
         private DateTime nextTicket;
-        private static readonly List<ICollectibleGrainContext> nothing = new(0);
+        private static readonly List<ICollectibleGrainContext> nothing = [];
         private readonly ILogger logger;
         private int collectionNumber;
 
@@ -56,6 +59,7 @@ namespace Orleans.Runtime
             IEnvironmentStatisticsProvider environmentStatisticsProvider,
             CatalogInstruments catalogInstruments)
         {
+            _timeProvider = timeProvider;
             _grainCollectionOptions = options.Value;
             _catalogInstruments = catalogInstruments;
 
@@ -74,7 +78,7 @@ namespace Orleans.Runtime
         // Return the number of activations that were used (touched) in the last recencyPeriod.
         public int GetNumRecentlyUsed(TimeSpan recencyPeriod)
         {
-            var now = DateTime.UtcNow;
+            var now = _timeProvider.GetUtcNow().UtcDateTime;
             int sum = 0;
             foreach (var bucket in buckets)
             {
@@ -114,21 +118,19 @@ namespace Orleans.Runtime
         /// <param name="now">The current time, used to calculate when the grain becomes eligible for collection.</param>
         public void ScheduleCollection(ICollectibleGrainContext item, TimeSpan timeout, DateTime now)
         {
-            lock (ActivationData.GetSynchronizationLock(item))
+            if (item.IsExemptFromCollection)
             {
-                if (item.IsExemptFromCollection)
-                {
-                    return;
-                }
+                return;
+            }
 
-                DateTime ticket = MakeTicketFromTimeSpan(timeout, now);
-
-                if (default != item.CollectionTicket)
+            var registration = _registrations.GetOrAdd(item, static item => new(item));
+            lock (_scheduleLock)
+            {
+                var ticket = MakeTicketFromTimeSpan(timeout, now);
+                if (!registration.TrySchedule(GetOrCreateBucket(ticket), ticket))
                 {
                     throw new InvalidOperationException("Call CancelCollection before calling ScheduleCollection.");
                 }
-
-                Add(item, ticket);
             }
         }
 
@@ -142,18 +144,7 @@ namespace Orleans.Runtime
             if (item is null) return false;
             if (item.IsExemptFromCollection) return false;
 
-            lock (ActivationData.GetSynchronizationLock(item))
-            {
-                DateTime ticket = item.CollectionTicket;
-                if (default == ticket) return false;
-                if (IsExpired(ticket)) return false;
-
-                // first, we attempt to remove the ticket.
-                Bucket? bucket;
-                if (!buckets.TryGetValue(ticket, out bucket) || !bucket.TryRemove(item)) return false;
-            }
-
-            return true;
+            return _registrations.TryGetValue(item, out var registration) && registration.TryCancel();
         }
 
         /// <summary>
@@ -164,44 +155,37 @@ namespace Orleans.Runtime
         public bool TryRescheduleCollection(ICollectibleGrainContext item)
         {
             if (item.IsExemptFromCollection) return false;
+            var registration = _registrations.GetOrAdd(item, static item => new(item));
 
-            lock (ActivationData.GetSynchronizationLock(item))
+            lock (_scheduleLock)
             {
-                if (TryRescheduleCollection_Impl(item, item.CollectionAgeLimit)) return true;
-
-                item.CollectionTicket = default;
-                return false;
+                return TryRescheduleCollection(registration, item.CollectionAgeLimit);
             }
         }
 
-        private bool TryRescheduleCollection_Impl(ICollectibleGrainContext item, TimeSpan timeout)
+        private bool TryRescheduleCollection(CollectionRegistration registration, TimeSpan timeout)
         {
-            // note: we expect the activation lock to be held.
-            if (default == item.CollectionTicket) return false;
-            ThrowIfTicketIsInvalid(item.CollectionTicket);
-            if (IsExpired(item.CollectionTicket)) return false;
+            if (registration.TryGetScheduledTicket(out var oldTicket))
+            {
+                ThrowIfTicketIsInvalid(oldTicket);
+                if (!IsExpired(oldTicket))
+                {
+                    var newTicket = MakeTicketFromTimeSpan(timeout, _timeProvider.GetUtcNow().UtcDateTime);
+                    if (newTicket.Equals(oldTicket)) return true;
 
-            DateTime oldTicket = item.CollectionTicket;
-            DateTime newTicket = MakeTicketFromTimeSpan(timeout, DateTime.UtcNow);
-            // if the ticket value doesn't change, then the source and destination bucket are the same and there's nothing to do.
-            if (newTicket.Equals(oldTicket)) return true;
+                    return registration.TryReschedule(GetOrCreateBucket(newTicket), newTicket);
+                }
+            }
 
+            registration.TryCancel();
+            var newTicket = MakeTicketFromTimeSpan(timeout, _timeProvider.GetUtcNow().UtcDateTime);
+            return registration.TrySchedule(GetOrCreateBucket(newTicket), newTicket);
+        }
+
+        private bool DequeueQuantum([NotNullWhen(true)] out List<CollectionClaim>? items, DateTime now)
+        {
             Bucket? bucket;
-            if (!buckets.TryGetValue(oldTicket, out bucket) || !bucket.TryRemove(item))
-            {
-                // fail: item is not associated with currentKey.
-                return false;
-            }
-
-            // it shouldn't be possible for Add to throw an exception here, as only one concurrent competitor should be able to reach to this point in the method.
-            Add(item, newTicket);
-            return true;
-        }
-
-        private bool DequeueQuantum([NotNullWhen(true)] out List<ICollectibleGrainContext>? items, DateTime now)
-        {
-            DateTime key;
-            lock (buckets)
+            lock (_scheduleLock)
             {
                 if (nextTicket > now)
                 {
@@ -209,69 +193,58 @@ namespace Orleans.Runtime
                     return false;
                 }
 
-                key = nextTicket;
+                var key = nextTicket;
                 nextTicket += _grainCollectionOptions.CollectionQuantum;
+                buckets.TryRemove(key, out bucket);
             }
 
-            Bucket? bucket;
-            if (!buckets.TryRemove(key, out bucket))
+            if (bucket is null)
             {
-                items = nothing;
+                items = [];
                 return true;
             }
 
-            items = bucket.CancelAll();
+            items = bucket.ClaimAll();
             return true;
         }
 
         /// <inheritdoc/>
         public override string ToString()
         {
-            var now = DateTime.UtcNow;
+            var now = _timeProvider.GetUtcNow().UtcDateTime;
             var all = buckets.ToList();
             var bucketsText = Utils.EnumerableToString(all.OrderBy(bucket => bucket.Key), bucket => $"{Utils.TimeSpanToString(bucket.Key - now)}->{bucket.Value.Items.Count} items");
             return $"<#Activations={all.Sum(b => b.Value.Items.Count)}, #Buckets={all.Count}, buckets={bucketsText}>";
         }
 
-        /// <summary>
-        /// Scans for activations that are due for collection.
-        /// </summary>
-        /// <returns>A list of activations that are due for collection.</returns>
-        public List<ICollectibleGrainContext> ScanStale()
+        private List<ICollectibleGrainContext> ScanStale(DeactivationReason reason, CancellationToken cancellationToken)
         {
-            var now = DateTime.UtcNow;
+            var now = _timeProvider.GetUtcNow().UtcDateTime;
             List<ICollectibleGrainContext>? condemned = null;
-            while (DequeueQuantum(out var activations, now))
+            while (DequeueQuantum(out var claims, now))
             {
-                // At this point, all tickets associated with activations are cancelled and any attempts to reschedule will fail silently.
-                // If the activation is to be reactivated, it's our job to clear the activation's copy of the ticket.
-                foreach (var activation in activations)
+                foreach (var claim in claims)
                 {
-                    lock (ActivationData.GetSynchronizationLock(activation))
+                    var activation = claim.Registration.Context;
+                    var result = activation.TryDeactivateForCollection(
+                        reason,
+                        now,
+                        activation.CollectionAgeLimit,
+                        respectKeepAlive: true,
+                        cancellationToken);
+                    switch (result.Action)
                     {
-                        activation.CollectionTicket = default;
-                        if (!activation.IsValid)
-                        {
-                            // This is not an error scenario because the activation may have become invalid between the time
-                            // we captured a snapshot in 'DequeueQuantum' and now. We are not be able to observe such changes.
-                            // Do nothing: don't collect, don't reschedule.
-                        }
-                        else if (activation.KeepAliveUntil > now)
-                        {
-                            var keepAliveDuration = activation.KeepAliveUntil - now;
-                            var timeout = TimeSpan.FromTicks(Math.Max(keepAliveDuration.Ticks, activation.CollectionAgeLimit.Ticks));
-                            ScheduleCollection(activation, timeout, now);
-                        }
-                        else if (!activation.IsInactive || !activation.IsStale())
-                        {
-                            ScheduleCollection(activation, activation.CollectionAgeLimit, now);
-                        }
-                        else
-                        {
-                            // Atomically set Deactivating state, to disallow any new requests or new timer ticks to be dispatched on this activation.
+                        case ActivationCollectionAction.StartedDeactivation:
+                            claim.Registration.TryCompleteClaim(claim.Generation);
                             condemned ??= [];
                             condemned.Add(activation);
-                        }
+                            break;
+                        case ActivationCollectionAction.Reschedule:
+                            RescheduleClaim(claim, result.RescheduleAfter, now);
+                            break;
+                        default:
+                            claim.Registration.TryCompleteClaim(claim.Generation);
+                            break;
                     }
                 }
             }
@@ -279,57 +252,53 @@ namespace Orleans.Runtime
             return condemned ?? nothing;
         }
 
-        /// <summary>
-        /// Scans for activations that have been idle for the specified age limit.
-        /// </summary>
-        /// <param name="ageLimit">The age limit.</param>
-        /// <returns>The grain activations which have been idle for at least the specified age limit.</returns>
-        public List<ICollectibleGrainContext> ScanAll(TimeSpan ageLimit)
+        private List<ICollectibleGrainContext> ScanAll(
+            TimeSpan ageLimit,
+            DeactivationReason reason,
+            CancellationToken cancellationToken)
         {
             List<ICollectibleGrainContext>? condemned = null;
-            var now = DateTime.UtcNow;
+            var now = _timeProvider.GetUtcNow().UtcDateTime;
             foreach (var kv in buckets)
             {
                 var bucket = kv.Value;
-                foreach (var kvp in bucket.Items)
+                foreach (var registration in bucket.Items.Keys)
                 {
-                    var activation = kvp.Value;
-                    lock (ActivationData.GetSynchronizationLock(activation))
+                    if (!registration.IsScheduledIn(bucket))
                     {
-                        if (!activation.IsValid)
-                        {
-                            // Do nothing: don't collect, don't reschedule.
-                        }
-                        else if (activation.KeepAliveUntil > now)
-                        {
-                            // do nothing
-                        }
-                        else if (!activation.IsInactive)
-                        {
-                            // do nothing
-                        }
-                        else
-                        {
-                            if (activation.GetIdleness() >= ageLimit)
-                            {
-                                if (bucket.TryRemove(activation))
-                                {
-                                    condemned ??= [];
-                                    condemned.Add(activation);
-                                }
+                        continue;
+                    }
 
-                                // someone else has already deactivated the activation, so there's nothing to do.
-                            }
-                            else
-                            {
-                                // activation is not idle long enough for collection. do nothing.
-                            }
-                        }
+                    var activation = registration.Context;
+                    var result = activation.TryDeactivateForCollection(
+                        reason,
+                        now,
+                        ageLimit,
+                        respectKeepAlive: true,
+                        cancellationToken);
+                    if (result.Action is ActivationCollectionAction.StartedDeactivation)
+                    {
+                        registration.TryCancel();
+                        condemned ??= [];
+                        condemned.Add(activation);
+                    }
+                    else if (result.Action is ActivationCollectionAction.Remove)
+                    {
+                        registration.TryCancel();
                     }
                 }
             }
 
             return condemned ?? nothing;
+        }
+
+        private void RescheduleClaim(CollectionClaim claim, TimeSpan timeout, DateTime now)
+        {
+            lock (_scheduleLock)
+            {
+                var ticket = MakeTicketFromTimeSpan(timeout, now);
+                claim.Registration.TryRescheduleClaim(claim.Generation, GetOrCreateBucket(ticket), ticket);
+            }
         }
 
         // Internal for testing. It's expected that when this returns true, activation shedding will occur.
@@ -382,29 +351,43 @@ namespace Orleans.Runtime
             LogBeforeCollection(number, memBefore, _activationCount, this);
 
             var candidates = new List<ICollectibleGrainContext>(count);
+            var reason = new DeactivationReason(
+                DeactivationReasonCode.HighMemoryPressure,
+                $"Process memory utilization exceeded the configured limit of '{_grainCollectionOptions.MemoryUsageLimitPercentage}'. Detected memory usage is {memBefore} MB.");
 
             // snapshot to avoid concurrency collection modification issues
             var bucketSnapshot = buckets.ToArray();
             Array.Sort(bucketSnapshot, static (left, right) => left.Key.CompareTo(right.Key));
             foreach (var bucket in bucketSnapshot)
             {
-                foreach (var item in bucket.Value.Items)
+                foreach (var registration in bucket.Value.Items.Keys)
                 {
                     if (candidates.Count >= count)
                     {
                         break;
                     }
 
-                    var activation = item.Value;
-                    lock (ActivationData.GetSynchronizationLock(activation))
+                    if (!registration.IsScheduledIn(bucket.Value))
                     {
-                        if (!activation.IsValid || !activation.IsInactive)
-                        {
-                            continue;
-                        }
+                        continue;
                     }
 
-                    candidates.Add(activation);
+                    var activation = registration.Context;
+                    var result = activation.TryDeactivateForCollection(
+                        reason,
+                        _timeProvider.GetUtcNow().UtcDateTime,
+                        ageLimit: TimeSpan.Zero,
+                        respectKeepAlive: false,
+                        cancellationToken);
+                    if (result.Action is ActivationCollectionAction.StartedDeactivation)
+                    {
+                        registration.TryCancel();
+                        candidates.Add(activation);
+                    }
+                    else if (result.Action is ActivationCollectionAction.Remove)
+                    {
+                        registration.TryCancel();
+                    }
                 }
 
                 if (candidates.Count >= count)
@@ -418,11 +401,7 @@ namespace Orleans.Runtime
             {
                 LogCollectActivations(new(candidates));
 
-                var reason = new DeactivationReason(
-                    DeactivationReasonCode.HighMemoryPressure,
-                    $"Process memory utilization exceeded the configured limit of '{_grainCollectionOptions.MemoryUsageLimitPercentage}'. Detected memory usage is {memBefore} MB.");
-
-                await DeactivateActivationsFromCollector(
+                await AwaitDeactivatedActivationsFromCollector(
                     candidates,
                     cancellationToken,
                     reason,
@@ -490,12 +469,32 @@ namespace Orleans.Runtime
             return MakeTicketFromDateTime(now + timeout);
         }
 
-        private void Add(ICollectibleGrainContext item, DateTime ticket)
+        private Bucket GetOrCreateBucket(DateTime ticket) => buckets.GetOrAdd(ticket, static _ => new());
+
+        internal DateTime GetCollectionTicketForTesting(ICollectibleGrainContext item)
+            => _registrations.TryGetValue(item, out var registration) ? registration.Ticket : default;
+
+        private void EnsureCollectionScheduled(ICollectibleGrainContext item)
         {
-            // note: we expect the activation lock to be held.
-            item.CollectionTicket = ticket;
-            var bucket = buckets.GetOrAdd(ticket, _ => new Bucket());
-            bucket.Add(item);
+            if (item.IsExemptFromCollection)
+            {
+                return;
+            }
+
+            var registration = _registrations.GetOrAdd(item, static item => new(item));
+            if (registration.IsTracked)
+            {
+                return;
+            }
+
+            lock (_scheduleLock)
+            {
+                if (!registration.IsTracked)
+                {
+                    var ticket = MakeTicketFromTimeSpan(item.CollectionAgeLimit, _timeProvider.GetUtcNow().UtcDateTime);
+                    registration.TrySchedule(GetOrCreateBucket(ticket), ticket);
+                }
+            }
         }
 
         void IActivationWorkingSetObserver.OnAdded(IActivationWorkingSetMember member)
@@ -503,14 +502,7 @@ namespace Orleans.Runtime
             if (member is ICollectibleGrainContext activation)
             {
                 Interlocked.Increment(ref _activationCount);
-                if (activation.CollectionTicket == default)
-                {
-                    ScheduleCollection(activation, activation.CollectionAgeLimit, DateTime.UtcNow);
-                }
-                else
-                {
-                    TryRescheduleCollection(activation);
-                }
+                ScheduleCollection(activation, activation.CollectionAgeLimit, _timeProvider.GetUtcNow().UtcDateTime);
             }
         }
 
@@ -522,9 +514,9 @@ namespace Orleans.Runtime
 
         void IActivationWorkingSetObserver.OnEvicted(IActivationWorkingSetMember member)
         {
-            if (member is ICollectibleGrainContext activation && activation.CollectionTicket == default)
+            if (member is ICollectibleGrainContext activation)
             {
-                TryRescheduleCollection(activation);
+                EnsureCollectionScheduled(activation);
             }
         }
 
@@ -539,7 +531,11 @@ namespace Orleans.Runtime
         void IActivationWorkingSetObserver.OnDeactivated(IActivationWorkingSetMember member)
         {
             Interlocked.Decrement(ref _activationCount);
-            _ = TryCancelCollection(member as ICollectibleGrainContext);
+            if (member is ICollectibleGrainContext activation)
+            {
+                _ = TryCancelCollection(activation);
+                _registrations.TryRemove(activation, out _);
+            }
         }
 
         private Task Start(CancellationToken cancellationToken)
@@ -667,15 +663,18 @@ namespace Orleans.Runtime
 
             LogBeforeCollection(number, memBefore, _activationCount, this);
 
-            List<ICollectibleGrainContext> list = scanStale ? ScanStale() : ScanAll(ageLimit);
+            var deactivationReason = GetDeactivationReason();
+            List<ICollectibleGrainContext> list = scanStale
+                ? ScanStale(deactivationReason, cancellationToken)
+                : ScanAll(ageLimit, deactivationReason, cancellationToken);
             _catalogInstruments.OnActivationCollected();
             if (list is { Count: > 0 })
             {
                 LogCollectActivations(new(list));
-                await DeactivateActivationsFromCollector(
+                await AwaitDeactivatedActivationsFromCollector(
                     list,
                     cancellationToken,
-                    deactivationReason: null,
+                    deactivationReason,
                     collectionSource: scanStale ? ActivationCollectionEvents.CollectionSource.Stale : ActivationCollectionEvents.CollectionSource.AgeLimit,
                     ageLimit: ageLimit);
             }
@@ -686,17 +685,15 @@ namespace Orleans.Runtime
             LogAfterCollection(number, memAfter, _activationCount, list?.Count ?? 0, this, watch.Elapsed);
         }
 
-        private async Task DeactivateActivationsFromCollector(
+        private async Task AwaitDeactivatedActivationsFromCollector(
             List<ICollectibleGrainContext> list,
             CancellationToken cancellationToken,
-            DeactivationReason? deactivationReason,
+            DeactivationReason deactivationReason,
             ActivationCollectionEvents.CollectionSource collectionSource,
             TimeSpan ageLimit)
         {
             LogDeactivateActivationsFromCollector(list.Count);
             _catalogInstruments.ActivationShutdownViaCollection();
-
-            deactivationReason ??= GetDeactivationReason();
 
             var options = new ParallelOptions
             {
@@ -707,12 +704,10 @@ namespace Orleans.Runtime
 
             await Parallel.ForEachAsync(list, options, async (activationData, token) =>
             {
-                // Continue deactivation when ready.
-                activationData.Deactivate(deactivationReason.Value, cancellationToken);
                 await activationData.Deactivated.ConfigureAwait(false);
             }).WaitAsync(cancellationToken);
 
-            ActivationCollectionEvents.EmitCollectionCompleted(collectionSource, ageLimit, deactivationReason.Value, list);
+            ActivationCollectionEvents.EmitCollectionCompleted(collectionSource, ageLimit, deactivationReason, list);
         }
 
         public void Dispose()
@@ -722,55 +717,212 @@ namespace Orleans.Runtime
             _memBasedDeactivationTimer?.Dispose();
         }
 
-        private class Bucket
-        {
-            public ConcurrentDictionary<ICollectibleGrainContext, ICollectibleGrainContext> Items { get; } = new(ReferenceEqualsComparer.Default);
+        private readonly record struct CollectionClaim(CollectionRegistration Registration, long Generation);
 
-            public void Add(ICollectibleGrainContext item)
+        private enum CollectionRegistrationState
+        {
+            None,
+            Scheduled,
+            Claimed
+        }
+
+        private sealed class CollectionRegistration(ICollectibleGrainContext context)
+        {
+            private readonly object _lock = new();
+            private Bucket? _bucket;
+            private long _generation;
+            private CollectionRegistrationState _state;
+            private DateTime _ticket;
+
+            public ICollectibleGrainContext Context { get; } = context;
+
+            public bool IsTracked
             {
-                if (!Items.TryAdd(item, item))
+                get
                 {
-                    throw new InvalidOperationException("item is already associated with this bucket");
+                    lock (_lock)
+                    {
+                        return _state is not CollectionRegistrationState.None;
+                    }
                 }
             }
 
-            public bool TryRemove(ICollectibleGrainContext item)
+            public DateTime Ticket
             {
-                lock (ActivationData.GetSynchronizationLock(item))
+                get
                 {
-                    if (item.CollectionTicket == default)
+                    lock (_lock)
+                    {
+                        return _state is CollectionRegistrationState.Scheduled ? _ticket : default;
+                    }
+                }
+            }
+
+            public bool TrySchedule(Bucket bucket, DateTime ticket)
+            {
+                lock (_lock)
+                {
+                    if (_state is not CollectionRegistrationState.None)
                     {
                         return false;
                     }
 
-                    item.CollectionTicket = default;
-                }
-
-                return Items.TryRemove(item, out _);
-            }
-
-            public List<ICollectibleGrainContext> CancelAll()
-            {
-                List<ICollectibleGrainContext>? result = null;
-                foreach (var pair in Items)
-                {
-                    // Attempt to cancel the item. if we succeed, it wasn't already cancelled and we can return it. otherwise, we silently ignore it.
-                    var item = pair.Value;
-                    lock (ActivationData.GetSynchronizationLock(item))
+                    if (!bucket.Items.TryAdd(this, 0))
                     {
-                        if (item.CollectionTicket == default)
-                        {
-                            continue;
-                        }
-
-                        item.CollectionTicket = default;
+                        throw new InvalidOperationException("Collection registration is already associated with this bucket.");
                     }
 
-                    result ??= [];
-                    result.Add(pair.Value);
+                    _bucket = bucket;
+                    _ticket = ticket;
+                    _state = CollectionRegistrationState.Scheduled;
+                    _generation++;
+                    return true;
+                }
+            }
+
+            public bool TryGetScheduledTicket(out DateTime ticket)
+            {
+                lock (_lock)
+                {
+                    if (_state is CollectionRegistrationState.Scheduled)
+                    {
+                        ticket = _ticket;
+                        return true;
+                    }
+
+                    ticket = default;
+                    return false;
+                }
+            }
+
+            public bool TryReschedule(Bucket bucket, DateTime ticket)
+            {
+                lock (_lock)
+                {
+                    if (_state is not CollectionRegistrationState.Scheduled)
+                    {
+                        return false;
+                    }
+
+                    if (ReferenceEquals(_bucket, bucket))
+                    {
+                        _ticket = ticket;
+                        return true;
+                    }
+
+                    _bucket!.Items.TryRemove(this, out _);
+                    if (!bucket.Items.TryAdd(this, 0))
+                    {
+                        throw new InvalidOperationException("Collection registration is already associated with the destination bucket.");
+                    }
+
+                    _bucket = bucket;
+                    _ticket = ticket;
+                    _generation++;
+                    return true;
+                }
+            }
+
+            public bool TryCancel()
+            {
+                lock (_lock)
+                {
+                    if (_state is CollectionRegistrationState.None)
+                    {
+                        return false;
+                    }
+
+                    _bucket?.Items.TryRemove(this, out _);
+                    _bucket = null;
+                    _ticket = default;
+                    _state = CollectionRegistrationState.None;
+                    _generation++;
+                    return true;
+                }
+            }
+
+            public bool IsScheduledIn(Bucket bucket)
+            {
+                lock (_lock)
+                {
+                    return _state is CollectionRegistrationState.Scheduled && ReferenceEquals(_bucket, bucket);
+                }
+            }
+
+            public bool TryClaim(Bucket bucket, out CollectionClaim claim)
+            {
+                lock (_lock)
+                {
+                    if (_state is not CollectionRegistrationState.Scheduled || !ReferenceEquals(_bucket, bucket))
+                    {
+                        claim = default;
+                        return false;
+                    }
+
+                    _bucket = null;
+                    _ticket = default;
+                    _state = CollectionRegistrationState.Claimed;
+                    var generation = ++_generation;
+                    claim = new CollectionClaim(this, generation);
+                    return true;
+                }
+            }
+
+            public bool TryCompleteClaim(long generation)
+            {
+                lock (_lock)
+                {
+                    if (_state is not CollectionRegistrationState.Claimed || _generation != generation)
+                    {
+                        return false;
+                    }
+
+                    _state = CollectionRegistrationState.None;
+                    _generation++;
+                    return true;
+                }
+            }
+
+            public bool TryRescheduleClaim(long generation, Bucket bucket, DateTime ticket)
+            {
+                lock (_lock)
+                {
+                    if (_state is not CollectionRegistrationState.Claimed || _generation != generation)
+                    {
+                        return false;
+                    }
+
+                    if (!bucket.Items.TryAdd(this, 0))
+                    {
+                        throw new InvalidOperationException("Collection registration is already associated with the destination bucket.");
+                    }
+
+                    _bucket = bucket;
+                    _ticket = ticket;
+                    _state = CollectionRegistrationState.Scheduled;
+                    _generation++;
+                    return true;
+                }
+            }
+        }
+
+        private sealed class Bucket
+        {
+            public ConcurrentDictionary<CollectionRegistration, byte> Items { get; } = new(ReferenceEqualsComparer.Default);
+
+            public List<CollectionClaim> ClaimAll()
+            {
+                List<CollectionClaim>? result = null;
+                foreach (var registration in Items.Keys)
+                {
+                    if (registration.TryClaim(this, out var claim))
+                    {
+                        result ??= [];
+                        result.Add(claim);
+                    }
                 }
 
-                return result ?? nothing;
+                return result ?? [];
             }
         }
 

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -170,10 +170,10 @@ namespace Orleans.Runtime
                 ThrowIfTicketIsInvalid(oldTicket);
                 if (!IsExpired(oldTicket))
                 {
-                    var newTicket = MakeTicketFromTimeSpan(timeout, _timeProvider.GetUtcNow().UtcDateTime);
-                    if (newTicket.Equals(oldTicket)) return true;
+                    var rescheduledTicket = MakeTicketFromTimeSpan(timeout, _timeProvider.GetUtcNow().UtcDateTime);
+                    if (rescheduledTicket.Equals(oldTicket)) return true;
 
-                    return registration.TryReschedule(GetOrCreateBucket(newTicket), newTicket);
+                    return registration.TryReschedule(GetOrCreateBucket(rescheduledTicket), rescheduledTicket);
                 }
             }
 

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -803,7 +803,7 @@ namespace Orleans.Runtime
 
             var options = new ParallelOptions
             {
-                // Avoid passing the cancellation token, since we want all of these activations to be deactivated, even if cancellation is triggered.
+                // Continue observing completion when the caller cancels its WaitAsync below.
                 CancellationToken = CancellationToken.None,
                 MaxDegreeOfParallelism = Environment.ProcessorCount * 512
             };

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -128,7 +128,7 @@ namespace Orleans.Runtime
             var registration = _registrations.GetValue(item, static item => new(item));
             if (!TryScheduleCollection(registration, timeout, now, throwIfExpired: true))
             {
-                throw new InvalidOperationException("Call CancelCollection before calling ScheduleCollection.");
+                throw new InvalidOperationException("Call TryCancelCollection before calling ScheduleCollection.");
             }
         }
 
@@ -149,7 +149,7 @@ namespace Orleans.Runtime
         /// Tries the reschedule collection.
         /// </summary>
         /// <param name="item">The grain context.</param>
-        /// <returns><see langword="true"/> if collection was canceled, <see langword="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if collection was rescheduled, <see langword="false"/> otherwise.</returns>
         public bool TryRescheduleCollection(ICollectibleGrainContext item)
         {
             if (item.IsExemptFromCollection) return false;

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -251,7 +251,7 @@ namespace Orleans.Runtime
                     switch (result.Action)
                     {
                         case ActivationCollectionAction.StartedDeactivation:
-                            claim.Registration.TryCompleteClaim(claim.Generation);
+                            claim.Registration.TryCompleteClaim(claim.SourceBucket);
                             condemned ??= [];
                             condemned.Add(activation);
                             break;
@@ -259,7 +259,7 @@ namespace Orleans.Runtime
                             RescheduleClaim(claim, result.RescheduleAfter, now);
                             break;
                         default:
-                            claim.Registration.TryCompleteClaim(claim.Generation);
+                            claim.Registration.TryCompleteClaim(claim.SourceBucket);
                             break;
                     }
                 }
@@ -311,23 +311,26 @@ namespace Orleans.Runtime
 
         private void RescheduleClaim(CollectionClaim claim, TimeSpan timeout, DateTime now)
         {
-            while (claim.Registration.IsClaimed(claim.Generation))
+            while (claim.Registration.IsClaimed(claim.SourceBucket))
             {
                 if (!TryMakeTicketFromTimeSpan(timeout, now, out var ticket))
                 {
-                    claim.Registration.TryCompleteClaim(claim.Generation);
-                    TryScheduleCollection(claim.Registration, timeout, _timeProvider.GetUtcNow().UtcDateTime, throwIfExpired: false);
-                    return;
+                    now = GetInternalScheduleBaseline();
+                    continue;
                 }
 
                 var bucket = GetOrCreateBucket(ticket);
-                if (claim.Registration.TryRescheduleClaim(claim.Generation, bucket))
+                if (claim.Registration.TryRescheduleClaim(claim.SourceBucket, bucket))
                 {
                     if (IsExpired(ticket))
                     {
-                        claim.Registration.TryCancel();
                         bucket.CloseForCleanup();
-                        TryScheduleCollection(claim.Registration, timeout, _timeProvider.GetUtcNow().UtcDateTime, throwIfExpired: false);
+                        if (claim.Registration.TryClaim(bucket, out var retryClaim))
+                        {
+                            claim = retryClaim;
+                            now = GetInternalScheduleBaseline();
+                            continue;
+                        }
                     }
 
                     return;
@@ -336,9 +339,7 @@ namespace Orleans.Runtime
                 if (IsExpired(ticket))
                 {
                     bucket.CloseForCleanup();
-                    claim.Registration.TryCompleteClaim(claim.Generation);
-                    TryScheduleCollection(claim.Registration, timeout, _timeProvider.GetUtcNow().UtcDateTime, throwIfExpired: false);
-                    return;
+                    now = GetInternalScheduleBaseline();
                 }
             }
         }
@@ -822,7 +823,7 @@ namespace Orleans.Runtime
             _memBasedDeactivationTimer?.Dispose();
         }
 
-        private readonly record struct CollectionClaim(CollectionRegistration Registration, long Generation);
+        private readonly record struct CollectionClaim(CollectionRegistration Registration, Bucket SourceBucket);
 
         private enum CollectionRegistrationState
         {
@@ -840,7 +841,6 @@ namespace Orleans.Runtime
             private readonly object _lock = new();
 #endif
             private Bucket? _bucket;
-            private long _generation;
             private CollectionRegistrationState _state;
 
             public ICollectibleGrainContext Context { get; } = context;
@@ -894,7 +894,6 @@ namespace Orleans.Runtime
 
                     _bucket = bucket;
                     _state = CollectionRegistrationState.Scheduled;
-                    _generation++;
                     return true;
                 }
             }
@@ -935,7 +934,6 @@ namespace Orleans.Runtime
 
                     _bucket!.TryRemove(this);
                     _bucket = bucket;
-                    _generation++;
                     return true;
                 }
             }
@@ -952,7 +950,6 @@ namespace Orleans.Runtime
                     _bucket?.TryRemove(this);
                     _bucket = null;
                     _state = CollectionRegistrationState.None;
-                    _generation++;
                     return true;
                 }
             }
@@ -964,7 +961,6 @@ namespace Orleans.Runtime
                     _bucket?.TryRemove(this);
                     _bucket = null;
                     _state = CollectionRegistrationState.Retired;
-                    _generation++;
                 }
             }
 
@@ -976,11 +972,11 @@ namespace Orleans.Runtime
                 }
             }
 
-            public bool IsClaimed(long generation)
+            public bool IsClaimed(Bucket sourceBucket)
             {
                 lock (_lock)
                 {
-                    return _state is CollectionRegistrationState.Claimed && _generation == generation;
+                    return _state is CollectionRegistrationState.Claimed && ReferenceEquals(_bucket, sourceBucket);
                 }
             }
 
@@ -994,34 +990,33 @@ namespace Orleans.Runtime
                         return false;
                     }
 
-                    _bucket = null;
+                    // Buckets close permanently before claiming, so their identity uniquely identifies this claim.
                     _state = CollectionRegistrationState.Claimed;
-                    var generation = ++_generation;
-                    claim = new CollectionClaim(this, generation);
+                    claim = new CollectionClaim(this, bucket);
                     return true;
                 }
             }
 
-            public bool TryCompleteClaim(long generation)
+            public bool TryCompleteClaim(Bucket sourceBucket)
             {
                 lock (_lock)
                 {
-                    if (_state is not CollectionRegistrationState.Claimed || _generation != generation)
+                    if (_state is not CollectionRegistrationState.Claimed || !ReferenceEquals(_bucket, sourceBucket))
                     {
                         return false;
                     }
 
+                    _bucket = null;
                     _state = CollectionRegistrationState.None;
-                    _generation++;
                     return true;
                 }
             }
 
-            public bool TryRescheduleClaim(long generation, Bucket bucket)
+            public bool TryRescheduleClaim(Bucket sourceBucket, Bucket bucket)
             {
                 lock (_lock)
                 {
-                    if (_state is not CollectionRegistrationState.Claimed || _generation != generation)
+                    if (_state is not CollectionRegistrationState.Claimed || !ReferenceEquals(_bucket, sourceBucket))
                     {
                         return false;
                     }
@@ -1033,7 +1028,6 @@ namespace Orleans.Runtime
 
                     _bucket = bucket;
                     _state = CollectionRegistrationState.Scheduled;
-                    _generation++;
                     return true;
                 }
             }

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -23,8 +23,7 @@ namespace Orleans.Runtime;
 
 /// <summary>
 /// Maintains additional per-activation state that is required for Orleans internal operations.
-/// MUST lock this object for any concurrent access
-/// MUST lock on `this` object because there are locks taken on ActivationData instances in various places in the codebase such as ActivationCollector.ScheduleCollection.
+/// The activation synchronization lock protects concurrent access to mutable activation state.
 /// Consider: compartmentalize by usage, e.g., using separate interfaces for data for catalog, etc.
 /// </summary>
 [DebuggerDisplay("GrainId = {GrainId}, State = {State}, Waiting = {WaitingCount}, Executing = {IsCurrentlyExecuting}")]
@@ -41,6 +40,7 @@ internal sealed partial class ActivationData :
     IDisposable
 {
     private const string GrainAddressMigrationContextKey = "sys.addr";
+    private readonly object _lock = new();
     private readonly GrainTypeSharedContext _shared;
     private readonly IServiceScope _serviceScope;
     private readonly WorkItemGroup _workItemGroup;
@@ -119,8 +119,7 @@ internal sealed partial class ActivationData :
     public void Start(IGrainActivator grainActivator)
     {
         Debug.Assert(Equals(ActivationTaskScheduler, TaskScheduler.Current));
-        // locking on `this` is intentional as there are other places in the codebase taking locks on ActivationData instances
-        lock (this)
+        lock (_lock)
         {
             try
             {
@@ -149,6 +148,7 @@ internal sealed partial class ActivationData :
     public ActivationState State { get; private set; } = ActivationState.Creating;
     public PlacementStrategy PlacementStrategy => _shared.PlacementStrategy;
     public DateTime CollectionTicket { get; set; }
+    internal object SynchronizationLock => _lock;
     public IServiceProvider ActivationServices => _serviceScope.ServiceProvider;
     public ActivationId ActivationId => Address.ActivationId;
     public IGrainLifecycle ObservableLifecycle
@@ -156,11 +156,14 @@ internal sealed partial class ActivationData :
         get
         {
             if (_lifecycle is { } lifecycle) return lifecycle;
-            lock (this) { return _lifecycle ??= new GrainLifecycle(_shared.Logger); }
+            lock (_lock) { return _lifecycle ??= new GrainLifecycle(_shared.Logger); }
         }
     }
 
     internal GrainTypeSharedContext Shared => _shared;
+
+    internal static object GetSynchronizationLock(ICollectibleGrainContext context) =>
+        context is ActivationData activation ? activation._lock : context;
 
     public GrainId GrainId => Address.GrainId;
     public bool IsExemptFromCollection => _shared.CollectionAgeLimit == Timeout.InfiniteTimeSpan;
@@ -217,7 +220,7 @@ internal sealed partial class ActivationData :
         get => _extras?.ForwardingAddress;
         set
         {
-            lock (this)
+            lock (_lock)
             {
                 _extras ??= new();
                 _extras.ForwardingAddress = value;
@@ -234,7 +237,7 @@ internal sealed partial class ActivationData :
         get => _extras?.PreviousRegistration;
         set
         {
-            lock (this)
+            lock (_lock)
             {
                 _extras ??= new();
                 _extras.PreviousRegistration = value;
@@ -249,7 +252,7 @@ internal sealed partial class ActivationData :
         get => _extras?.DeactivationReason ?? default;
         set
         {
-            lock (this)
+            lock (_lock)
             {
                 _extras ??= new();
                 _extras.DeactivationReason = value;
@@ -262,7 +265,7 @@ internal sealed partial class ActivationData :
         get => _extras?.Timers;
         set
         {
-            lock (this)
+            lock (_lock)
             {
                 _extras ??= new();
                 _extras.Timers = value;
@@ -275,7 +278,7 @@ internal sealed partial class ActivationData :
         get => _extras?.DeactivationStartTime;
         set
         {
-            lock (this)
+            lock (_lock)
             {
                 _extras ??= new();
                 _extras.DeactivationStartTime = value;
@@ -288,7 +291,7 @@ internal sealed partial class ActivationData :
         get => _extras?.IsStuckDeactivating ?? false;
         set
         {
-            lock (this)
+            lock (_lock)
             {
                 _extras ??= new();
                 _extras.IsStuckDeactivating = value;
@@ -301,7 +304,7 @@ internal sealed partial class ActivationData :
         get => _extras?.IsStuckProcessingMessage ?? false;
         set
         {
-            lock (this)
+            lock (_lock)
             {
                 _extras ??= new();
                 _extras.IsStuckProcessingMessage = value;
@@ -314,7 +317,7 @@ internal sealed partial class ActivationData :
         get => _extras?.DehydrationContext;
         set
         {
-            lock (this)
+            lock (_lock)
             {
                 _extras ??= new();
                 _extras.DehydrationContext = value;
@@ -391,7 +394,7 @@ internal sealed partial class ActivationData :
             throw new ArgumentException("Cannot override a component which is implemented by this grain context");
         }
 
-        lock (this)
+        lock (_lock)
         {
             if (instance == null)
             {
@@ -408,7 +411,7 @@ internal sealed partial class ActivationData :
     {
         ArgumentNullException.ThrowIfNull(grainInstance);
 
-        lock (this)
+        lock (_lock)
         {
             if (GrainInstance is not null)
             {
@@ -475,7 +478,7 @@ internal sealed partial class ActivationData :
 
     internal int GetRequestCount()
     {
-        lock (this)
+        lock (_lock)
         {
             return _runningRequests.Count + _waitingRequests.Count;
         }
@@ -483,7 +486,7 @@ internal sealed partial class ActivationData :
 
     internal List<Message> DequeueAllWaitingRequests()
     {
-        lock (this)
+        lock (_lock)
         {
             var result = new List<Message>(_waitingRequests.Count);
             foreach (var (message, _) in _waitingRequests)
@@ -541,7 +544,7 @@ internal sealed partial class ActivationData :
 
     private void ScheduleOperation(object operation)
     {
-        lock (this)
+        lock (_lock)
         {
             _pendingOperations ??= new();
             _pendingOperations.Enqueue(operation);
@@ -552,7 +555,7 @@ internal sealed partial class ActivationData :
 
     private void CancelPendingOperations()
     {
-        lock (this)
+        lock (_lock)
         {
             // If the grain is currently activating, cancel that operation.
             if (_pendingOperations is not { Count: > 0 } operations)
@@ -603,7 +606,7 @@ internal sealed partial class ActivationData :
 
     internal bool TryStartMigration(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default)
     {
-        lock (this)
+        lock (_lock)
         {
             if (State is not (ActivationState.Activating or ActivationState.Valid or ActivationState.Deactivating))
             {
@@ -629,8 +632,7 @@ internal sealed partial class ActivationData :
         var deactivateActivity = activityContext is { } parent
             ? ActivitySources.LifecycleGrainSource.StartActivity(ActivityNames.DeactivateGrain, ActivityKind.Internal, parentContext: parent)
             : ActivitySources.LifecycleGrainSource.StartActivity(ActivityNames.DeactivateGrain);
-
-        lock (this)
+        lock (_lock)
         {
             try
             {
@@ -714,7 +716,7 @@ internal sealed partial class ActivationData :
 
     void IGrainTimerRegistry.OnTimerCreated(IGrainTimer timer)
     {
-        lock (this)
+        lock (_lock)
         {
             Timers ??= new HashSet<IGrainTimer>();
             Timers.Add(timer);
@@ -723,7 +725,7 @@ internal sealed partial class ActivationData :
 
     void IGrainTimerRegistry.OnTimerDisposed(IGrainTimer timer)
     {
-        lock (this) // need to lock since dispose can be called on finalizer thread, outside grain context (not single threaded).
+        lock (_lock) // need to lock since dispose can be called on finalizer thread, outside grain context (not single threaded).
         {
             if (Timers is null)
             {
@@ -736,7 +738,7 @@ internal sealed partial class ActivationData :
 
     private void DisposeTimers()
     {
-        lock (this)
+        lock (_lock)
         {
             if (Timers is null)
             {
@@ -761,7 +763,7 @@ internal sealed partial class ActivationData :
         var longQueueTimeDuration = options.RequestQueueDelayWarningTime;
 
         List<string>? diagnostics = null;
-        lock (this)
+        lock (_lock)
         {
             if (State != ActivationState.Valid)
             {
@@ -863,7 +865,7 @@ internal sealed partial class ActivationData :
 
     internal string ToDetailedString(bool includeExtraDetails = false)
     {
-        lock (this)
+        lock (_lock)
         {
             var currentlyExecuting = includeExtraDetails ? _blockingRequest : null;
             return @$"[Activation: {Address.SiloAddress}/{GrainId}{ActivationId} {GetActivationInfoString()} State={State} NonReentrancyQueueSize={WaitingCount} NumRunning={_runningRequests.Count} IdlenessTimeSpan={GetIdleness()} CollectionAgeLimit={_shared.CollectionAgeLimit}{(currentlyExecuting != null ? " CurrentlyExecuting=" : null)}{currentlyExecuting}]";
@@ -901,7 +903,7 @@ internal sealed partial class ActivationData :
 
         CancelPendingOperations();
 
-        lock (this)
+        lock (_lock)
         {
             _shared.InternalRuntime.ActivationWorkingSet.OnDeactivated(this);
             SetState(ActivationState.Invalid);
@@ -1001,7 +1003,7 @@ internal sealed partial class ActivationData :
     bool IActivationWorkingSetMember.IsCandidateForRemoval(bool wouldRemove)
     {
         const int IdlenessLowerBound = 10_000;
-        lock (this)
+        lock (_lock)
         {
             var inactive = IsInactive && _idleDuration.ElapsedMilliseconds > IdlenessLowerBound;
 
@@ -1028,7 +1030,7 @@ internal sealed partial class ActivationData :
                 if (!IsCurrentlyExecuting)
                 {
                     bool hasPendingOperations;
-                    lock (this)
+                    lock (_lock)
                     {
                         hasPendingOperations = _pendingOperations is { Count: > 0 };
                     }
@@ -1056,7 +1058,7 @@ internal sealed partial class ActivationData :
             do
             {
                 Message? message = null;
-                lock (this)
+                lock (_lock)
                 {
                     if (_waitingRequests.Count <= i)
                     {
@@ -1271,7 +1273,7 @@ internal sealed partial class ActivationData :
             object? op = null;
             while (true)
             {
-                lock (this)
+                lock (_lock)
                 {
                     Debug.Assert(_pendingOperations is not null);
 
@@ -1349,7 +1351,7 @@ internal sealed partial class ActivationData :
                 rehydrateSpan?.SetTag(ActivityTagKeys.ActivationId, ActivationId.ToString());
             }
 
-            lock (this)
+            lock (_lock)
             {
                 if (State != ActivationState.Creating)
                 {
@@ -1397,7 +1399,7 @@ internal sealed partial class ActivationData :
     {
         LogDehydratingActivation(_shared.Logger);
 
-        lock (this)
+        lock (_lock)
         {
             Debug.Assert(context is not null);
 
@@ -1510,7 +1512,7 @@ internal sealed partial class ActivationData :
     /// <param name="message">The message that has just completed processing.</param>
     private void OnCompletedRequest(Message message)
     {
-        lock (this)
+        lock (_lock)
         {
             _runningRequests.Remove(message);
 
@@ -1588,7 +1590,7 @@ internal sealed partial class ActivationData :
             return;
         }
 
-        lock (this)
+        lock (_lock)
         {
             _waitingRequests.Add((message, CoarseStopwatch.StartNew()));
         }
@@ -1601,7 +1603,7 @@ internal sealed partial class ActivationData :
     /// </summary>
     private void RejectAllQueuedMessages()
     {
-        lock (this)
+        lock (_lock)
         {
             List<Message> msgs = DequeueAllWaitingRequests();
             if (msgs == null || msgs.Count <= 0) return;
@@ -1620,7 +1622,7 @@ internal sealed partial class ActivationData :
 
     private void RerouteAllQueuedMessages()
     {
-        lock (this)
+        lock (_lock)
         {
             List<Message> msgs = DequeueAllWaitingRequests();
             if (msgs is not { Count: > 0 })
@@ -1795,7 +1797,7 @@ internal sealed partial class ActivationData :
                 }
             }
 
-            lock (this)
+            lock (_lock)
             {
                 SetState(ActivationState.Activating);
             }
@@ -1878,7 +1880,7 @@ internal sealed partial class ActivationData :
                     }
                 }
 
-                lock (this)
+                lock (_lock)
                 {
                     if (State is ActivationState.Activating)
                     {
@@ -2145,7 +2147,7 @@ internal sealed partial class ActivationData :
 
     private TaskCompletionSource<bool> GetDeactivationCompletionSource()
     {
-        lock (this)
+        lock (_lock)
         {
             _extras ??= new();
             return _extras.DeactivationTask ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2295,7 +2297,7 @@ internal sealed partial class ActivationData :
         {
             Message? message = null;
             var wasWaiting = false;
-            lock (this)
+            lock (_lock)
             {
                 // Check the running requests.
                 foreach (var candidate in _runningRequests.Keys)
@@ -2454,12 +2456,13 @@ internal sealed partial class ActivationData :
     private abstract class Command(CancellationTokenSource cts) : IDisposable
     {
         private bool _disposed;
+        private readonly object _lock = new();
         private readonly CancellationTokenSource _cts = cts;
         public CancellationToken CancellationToken => _cts.Token;
 
         public virtual void Cancel()
         {
-            lock (this)
+            lock (_lock)
             {
                 if (_disposed) return;
                 _cts.Cancel();
@@ -2470,7 +2473,7 @@ internal sealed partial class ActivationData :
         {
             try
             {
-                lock (this)
+                lock (_lock)
                 {
                     _disposed = true;
                     _cts.Dispose();

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -191,7 +191,7 @@ internal sealed partial class ActivationData :
     {
         get
         {
-            lock (this)
+            lock (_lock)
             {
                 return _waitingRequests.Count;
             }
@@ -204,7 +204,7 @@ internal sealed partial class ActivationData :
     {
         get
         {
-            lock (this)
+            lock (_lock)
             {
                 return _runningRequests.Count > 0;
             }
@@ -213,7 +213,7 @@ internal sealed partial class ActivationData :
 
     internal (int WaitingCount, bool IsInactive) GetRequestStatus()
     {
-        lock (this)
+        lock (_lock)
         {
             var waitingCount = _waitingRequests.Count;
             return (waitingCount, waitingCount == 0 && _runningRequests.Count == 0);

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -148,7 +148,12 @@ internal sealed partial class ActivationData :
     public ActivationState State { get; private set; } = ActivationState.Creating;
     public PlacementStrategy PlacementStrategy => _shared.PlacementStrategy;
     public DateTime CollectionTicket { get; set; }
+
+    /// <summary>
+    /// Gets the monitor which protects mutable state for this activation.
+    /// </summary>
     internal object SynchronizationLock => _lock;
+
     public IServiceProvider ActivationServices => _serviceScope.ServiceProvider;
     public ActivationId ActivationId => Address.ActivationId;
     public IGrainLifecycle ObservableLifecycle
@@ -162,8 +167,11 @@ internal sealed partial class ActivationData :
 
     internal GrainTypeSharedContext Shared => _shared;
 
-    internal static object GetSynchronizationLock(ICollectibleGrainContext context) =>
-        context is ActivationData activation ? activation._lock : context;
+    /// <summary>
+    /// Gets the monitor which protects collection state for the provided context.
+    /// </summary>
+    internal static object GetSynchronizationLock(ICollectibleGrainContext context)
+        => context is ActivationData activation ? activation._lock : context;
 
     public GrainId GrainId => Address.GrainId;
     public bool IsExemptFromCollection => _shared.CollectionAgeLimit == Timeout.InfiniteTimeSpan;
@@ -2456,13 +2464,12 @@ internal sealed partial class ActivationData :
     private abstract class Command(CancellationTokenSource cts) : IDisposable
     {
         private bool _disposed;
-        private readonly object _lock = new();
         private readonly CancellationTokenSource _cts = cts;
         public CancellationToken CancellationToken => _cts.Token;
 
         public virtual void Cancel()
         {
-            lock (_lock)
+            lock (_cts)
             {
                 if (_disposed) return;
                 _cts.Cancel();
@@ -2473,7 +2480,7 @@ internal sealed partial class ActivationData :
         {
             try
             {
-                lock (_lock)
+                lock (_cts)
                 {
                     _disposed = true;
                     _cts.Dispose();

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -451,7 +451,11 @@ internal sealed partial class ActivationData :
 
     private void SetState(ActivationState state)
     {
+#if NET10_0_OR_GREATER
+        Debug.Assert(_lock.IsHeldByCurrentThread);
+#else
         Debug.Assert(Monitor.IsEntered(_lock));
+#endif
         State = state;
         if (state is ActivationState.Valid or ActivationState.Invalid)
         {

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -39,7 +39,11 @@ internal sealed partial class ActivationData :
     IDisposable
 {
     private const string GrainAddressMigrationContextKey = "sys.addr";
+#if NET10_0_OR_GREATER
+    private readonly Lock _lock = new();
+#else
     private readonly object _lock = new();
+#endif
     private readonly GrainTypeSharedContext _shared;
     private readonly IServiceScope _serviceScope;
     private readonly WorkItemGroup _workItemGroup;
@@ -2521,7 +2525,11 @@ internal sealed partial class ActivationData :
     private abstract class Command(CancellationTokenSource cts) : IDisposable
     {
         private bool _disposed;
+#if NET10_0_OR_GREATER
+        private readonly Lock _lock = new();
+#else
         private readonly object _lock = new();
+#endif
         private readonly CancellationTokenSource _cts = cts;
         public CancellationToken CancellationToken => _cts.Token;
 

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -57,6 +57,7 @@ internal sealed partial class ActivationData :
     private CoarseStopwatch _busyDuration;
     private CoarseStopwatch _idleDuration;
     private GrainReference? _selfReference;
+    private IActivationCollectionRegistration? _collectionRegistration;
 
     // Values which are needed less frequently and do not warrant living directly on activation for object size reasons.
     // The values in this field are typically used to represent termination state of an activation or features which are not
@@ -166,8 +167,15 @@ internal sealed partial class ActivationData :
 
     public GrainId GrainId => Address.GrainId;
     public bool IsExemptFromCollection => _shared.CollectionAgeLimit == Timeout.InfiniteTimeSpan;
+    IActivationCollectionRegistration? ICollectibleGrainContext.CollectionRegistration => Volatile.Read(ref _collectionRegistration);
     private DateTime KeepAliveUntil { get; set; } = DateTime.MinValue;
     public bool IsValid => State is ActivationState.Valid;
+
+    IActivationCollectionRegistration ICollectibleGrainContext.GetOrSetCollectionRegistration(IActivationCollectionRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        return Interlocked.CompareExchange(ref _collectionRegistration, registration, null) ?? registration;
+    }
 
     // Currently, the only supported multi-activation grain is one using the StatelessWorkerPlacement strategy.
     internal bool IsStatelessWorker => PlacementStrategy is StatelessWorkerPlacement;

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -23,8 +23,7 @@ namespace Orleans.Runtime;
 
 /// <summary>
 /// Maintains additional per-activation state that is required for Orleans internal operations.
-/// The activation synchronization lock protects concurrent access to mutable activation state.
-/// Consider: compartmentalize by usage, e.g., using separate interfaces for data for catalog, etc.
+/// Concurrent mutation of activation state is synchronized internally.
 /// </summary>
 [DebuggerDisplay("GrainId = {GrainId}, State = {State}, Waiting = {WaitingCount}, Executing = {IsCurrentlyExecuting}")]
 internal sealed partial class ActivationData :
@@ -147,12 +146,6 @@ internal sealed partial class ActivationData :
     public GrainReference GrainReference => _selfReference ??= _shared.GrainReferenceActivator.CreateReference(GrainId, default);
     public ActivationState State { get; private set; } = ActivationState.Creating;
     public PlacementStrategy PlacementStrategy => _shared.PlacementStrategy;
-    public DateTime CollectionTicket { get; set; }
-
-    /// <summary>
-    /// Gets the monitor which protects mutable state for this activation.
-    /// </summary>
-    internal object SynchronizationLock => _lock;
 
     public IServiceProvider ActivationServices => _serviceScope.ServiceProvider;
     public ActivationId ActivationId => Address.ActivationId;
@@ -167,15 +160,9 @@ internal sealed partial class ActivationData :
 
     internal GrainTypeSharedContext Shared => _shared;
 
-    /// <summary>
-    /// Gets the monitor which protects collection state for the provided context.
-    /// </summary>
-    internal static object GetSynchronizationLock(ICollectibleGrainContext context)
-        => context is ActivationData activation ? activation._lock : context;
-
     public GrainId GrainId => Address.GrainId;
     public bool IsExemptFromCollection => _shared.CollectionAgeLimit == Timeout.InfiniteTimeSpan;
-    public DateTime KeepAliveUntil { get; set; } = DateTime.MinValue;
+    private DateTime KeepAliveUntil { get; set; } = DateTime.MinValue;
     public bool IsValid => State is ActivationState.Valid;
 
     // Currently, the only supported multi-activation grain is one using the StatelessWorkerPlacement strategy.
@@ -217,6 +204,21 @@ internal sealed partial class ActivationData :
         {
             var waitingCount = _waitingRequests.Count;
             return (waitingCount, waitingCount == 0 && _runningRequests.Count == 0);
+        }
+    }
+
+    internal ValueTask WaitForActivationReadyAsync(CancellationToken cancellationToken)
+    {
+        lock (_lock)
+        {
+            if (State is ActivationState.Valid or ActivationState.Invalid)
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            _extras ??= new();
+            var completion = _extras.ActivationReady ??= new(TaskCreationOptions.RunContinuationsAsynchronously);
+            return new ValueTask(completion.Task.WaitAsync(cancellationToken));
         }
     }
 
@@ -443,9 +445,20 @@ internal sealed partial class ActivationData :
         }
     }
 
-    public void SetState(ActivationState state)
+    private void SetState(ActivationState state)
     {
+        Debug.Assert(Monitor.IsEntered(_lock));
         State = state;
+        if (state is ActivationState.Valid or ActivationState.Invalid)
+        {
+            var activationReady = _extras?.ActivationReady;
+            if (_extras is not null)
+            {
+                _extras.ActivationReady = null;
+            }
+
+            activationReady?.TrySetResult();
+        }
     }
 
     /// <summary>
@@ -525,30 +538,72 @@ internal sealed partial class ActivationData :
 
     public void DelayDeactivation(TimeSpan timespan)
     {
-        if (timespan == TimeSpan.MaxValue || timespan == Timeout.InfiniteTimeSpan)
+        var rescheduleCollection = false;
+        lock (_lock)
         {
-            // Adding these values to the current time would overflow, so use DateTime.MaxValue directly.
-            KeepAliveUntil = DateTime.MaxValue;
-        }
-        else if (timespan <= TimeSpan.Zero)
-        {
-            // Cancel the previous DelayDeactivation and revert to normal collection behavior.
-            // If there was an active keep-alive, reschedule collection so the grain can be collected
-            // after CollectionAgeLimit rather than waiting for the previously scheduled far-future time.
-            var hadActiveKeepAlive = KeepAliveUntil > GrainRuntime.TimeProvider.GetUtcNow().UtcDateTime;
-            ResetKeepAliveRequest();
-            if (hadActiveKeepAlive)
+            if (timespan == TimeSpan.MaxValue || timespan == Timeout.InfiniteTimeSpan)
             {
-                _shared.InternalRuntime.ActivationCollector.TryRescheduleCollection(this);
+                // Adding these values to the current time would overflow, so use DateTime.MaxValue directly.
+                KeepAliveUntil = DateTime.MaxValue;
+            }
+            else if (timespan <= TimeSpan.Zero)
+            {
+                // Cancel the previous DelayDeactivation and revert to normal collection behavior.
+                // If there was an active keep-alive, reschedule collection so the grain can be collected
+                // after CollectionAgeLimit rather than waiting for the previously scheduled far-future time.
+                rescheduleCollection = KeepAliveUntil > GrainRuntime.TimeProvider.GetUtcNow().UtcDateTime;
+                KeepAliveUntil = DateTime.MinValue;
+            }
+            else
+            {
+                KeepAliveUntil = GrainRuntime.TimeProvider.GetUtcNow().UtcDateTime + timespan;
             }
         }
-        else
+
+        if (rescheduleCollection)
         {
-            KeepAliveUntil = GrainRuntime.TimeProvider.GetUtcNow().UtcDateTime + timespan;
+            _shared.InternalRuntime.ActivationCollector.TryRescheduleCollection(this);
         }
     }
 
-    public void ResetKeepAliveRequest() => KeepAliveUntil = DateTime.MinValue;
+    public void ResetKeepAliveRequest()
+    {
+        lock (_lock)
+        {
+            KeepAliveUntil = DateTime.MinValue;
+        }
+    }
+
+    ActivationCollectionResult ICollectibleGrainContext.TryDeactivateForCollection(
+        DeactivationReason reason,
+        DateTime now,
+        TimeSpan ageLimit,
+        bool respectKeepAlive,
+        CancellationToken cancellationToken)
+    {
+        lock (_lock)
+        {
+            if (State is not ActivationState.Valid)
+            {
+                return ActivationCollectionResult.Remove;
+            }
+
+            if (respectKeepAlive && KeepAliveUntil > now)
+            {
+                var keepAliveDuration = KeepAliveUntil - now;
+                return ActivationCollectionResult.Reschedule(
+                    TimeSpan.FromTicks(Math.Max(keepAliveDuration.Ticks, CollectionAgeLimit.Ticks)));
+            }
+
+            if (_waitingRequests.Count > 0 || _runningRequests.Count > 0 || _idleDuration.Elapsed < ageLimit)
+            {
+                return ActivationCollectionResult.Reschedule(CollectionAgeLimit);
+            }
+
+            Deactivate(reason, cancellationToken);
+            return ActivationCollectionResult.StartedDeactivation;
+        }
+    }
 
     private void ScheduleOperation(object operation)
     {
@@ -2400,6 +2455,8 @@ internal sealed partial class ActivationData :
         /// A <see cref="TaskCompletionSource{TResult}"/> which completes when a grain has deactivated.
         /// </summary>
         public TaskCompletionSource<bool>? DeactivationTask { get => GetDeactivationInfoOrDefault()?.DeactivationTask; set => EnsureDeactivationInfo().DeactivationTask = value; }
+
+        public TaskCompletionSource? ActivationReady { get => GetValueOrDefault<TaskCompletionSource>(nameof(ActivationReady)); set => SetOrRemoveValue(nameof(ActivationReady), value); }
 
         public DateTime? DeactivationStartTime { get => GetDeactivationInfoOrDefault()?.DeactivationStartTime; set => EnsureDeactivationInfo().DeactivationStartTime = value; }
 

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -2464,12 +2464,13 @@ internal sealed partial class ActivationData :
     private abstract class Command(CancellationTokenSource cts) : IDisposable
     {
         private bool _disposed;
+        private readonly object _lock = new();
         private readonly CancellationTokenSource _cts = cts;
         public CancellationToken CancellationToken => _cts.Token;
 
         public virtual void Cancel()
         {
-            lock (_cts)
+            lock (_lock)
             {
                 if (_disposed) return;
                 _cts.Cancel();
@@ -2480,7 +2481,7 @@ internal sealed partial class ActivationData :
         {
             try
             {
-                lock (_cts)
+                lock (_lock)
                 {
                     _disposed = true;
                     _cts.Dispose();

--- a/src/Orleans.Runtime/Catalog/ActivationMigrationManager.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationMigrationManager.cs
@@ -127,28 +127,9 @@ internal sealed partial class ActivationMigrationManager : SystemTarget, IActiva
         // Otherwise, there could be a race where the original silo removes the activation from its catalog, receives a new message for that activation,
         // and re-activates it before the new activation on this silo has been registered with the directory.
         using var waitActivity = ActivitySources.LifecycleGrainSource.StartActivity(ActivityNames.WaitMigration);
-        while (true)
+        foreach (var activation in activations)
         {
-            var allActiveOrTerminal = true;
-            foreach (var activation in activations)
-            {
-                lock (activation.SynchronizationLock)
-                {
-                    if (activation.State is not (ActivationState.Valid or ActivationState.Invalid))
-                    {
-                        allActiveOrTerminal = false;
-                        break;
-                    }
-                }
-            }
-
-            if (allActiveOrTerminal)
-            {
-                break;
-            }
-
-            // Wait a short amount of time and poll the activations again.
-            await Task.Delay(5, cancellationToken);
+            await activation.WaitForActivationReadyAsync(cancellationToken);
         }
     }
 

--- a/src/Orleans.Runtime/Catalog/ActivationMigrationManager.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationMigrationManager.cs
@@ -132,7 +132,7 @@ internal sealed partial class ActivationMigrationManager : SystemTarget, IActiva
             var allActiveOrTerminal = true;
             foreach (var activation in activations)
             {
-                lock (activation)
+                lock (activation.SynchronizationLock)
                 {
                     if (activation.State is not (ActivationState.Valid or ActivationState.Invalid))
                     {

--- a/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
@@ -60,7 +60,7 @@ namespace Orleans.Runtime
 
         public void OnActivated(IActivationWorkingSetMember member)
         {
-            Debug.Assert(member is not ICollectibleGrainContext collectible || collectible.IsValid);
+            Debug.Assert(member is not ActivationData activation || activation.IsValid);
             if (_members.TryAdd(member, new MemberState()))
             {
                 Interlocked.Increment(ref _activeCount);

--- a/src/Orleans.Runtime/Catalog/ICollectibleGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/ICollectibleGrainContext.cs
@@ -53,7 +53,9 @@ internal interface ICollectibleGrainContext : IGrainContext
 /// <summary>
 /// Represents opaque activation-collector state whose lifetime is anchored by a grain context.
 /// </summary>
-internal interface IActivationCollectionRegistration;
+internal interface IActivationCollectionRegistration
+{
+}
 
 internal enum ActivationCollectionAction
 {

--- a/src/Orleans.Runtime/Catalog/ICollectibleGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/ICollectibleGrainContext.cs
@@ -1,0 +1,55 @@
+namespace Orleans.Runtime;
+
+/// <summary>
+/// Defines functionality required for grain contexts which are subject to activation collection.
+/// </summary>
+internal interface ICollectibleGrainContext : IGrainContext
+{
+    /// <summary>
+    /// Gets a value indicating whether the instance is exempt from collection.
+    /// </summary>
+    bool IsExemptFromCollection { get; }
+
+    /// <summary>
+    /// Gets the collection age limit, which defines how long an instance must be inactive before it is eligible for collection.
+    /// </summary>
+    TimeSpan CollectionAgeLimit { get; }
+
+    /// <summary>
+    /// Atomically evaluates collection eligibility and begins deactivation when the instance is eligible.
+    /// </summary>
+    /// <param name="reason">The reason for deactivation.</param>
+    /// <param name="now">The current time.</param>
+    /// <param name="ageLimit">The minimum idle duration.</param>
+    /// <param name="respectKeepAlive">Whether a keep-alive request delays collection.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The collection action which the collector should perform.</returns>
+    ActivationCollectionResult TryDeactivateForCollection(
+        DeactivationReason reason,
+        DateTime now,
+        TimeSpan ageLimit,
+        bool respectKeepAlive,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Delays activation collection until at least until the specified duration has elapsed.
+    /// </summary>
+    /// <param name="timeSpan">The period to delay activation collection for.</param>
+    void DelayDeactivation(TimeSpan timeSpan);
+}
+
+internal enum ActivationCollectionAction
+{
+    Remove,
+    StartedDeactivation,
+    Reschedule
+}
+
+internal readonly record struct ActivationCollectionResult(ActivationCollectionAction Action, TimeSpan RescheduleAfter)
+{
+    public static ActivationCollectionResult Remove { get; } = new(ActivationCollectionAction.Remove, default);
+
+    public static ActivationCollectionResult StartedDeactivation { get; } = new(ActivationCollectionAction.StartedDeactivation, default);
+
+    public static ActivationCollectionResult Reschedule(TimeSpan delay) => new(ActivationCollectionAction.Reschedule, delay);
+}

--- a/src/Orleans.Runtime/Catalog/ICollectibleGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/ICollectibleGrainContext.cs
@@ -16,6 +16,18 @@ internal interface ICollectibleGrainContext : IGrainContext
     TimeSpan CollectionAgeLimit { get; }
 
     /// <summary>
+    /// Gets the opaque collection registration associated with this context, if one has been assigned.
+    /// </summary>
+    IActivationCollectionRegistration? CollectionRegistration { get; }
+
+    /// <summary>
+    /// Atomically assigns the collection registration if one has not already been assigned.
+    /// </summary>
+    /// <param name="registration">The registration to assign.</param>
+    /// <returns>The assigned registration.</returns>
+    IActivationCollectionRegistration GetOrSetCollectionRegistration(IActivationCollectionRegistration registration);
+
+    /// <summary>
     /// Atomically evaluates collection eligibility and begins deactivation when the instance is eligible.
     /// </summary>
     /// <param name="reason">The reason for deactivation.</param>
@@ -37,6 +49,11 @@ internal interface ICollectibleGrainContext : IGrainContext
     /// <param name="timeSpan">The period to delay activation collection for.</param>
     void DelayDeactivation(TimeSpan timeSpan);
 }
+
+/// <summary>
+/// Represents opaque activation-collector state whose lifetime is anchored by a grain context.
+/// </summary>
+internal interface IActivationCollectionRegistration;
 
 internal enum ActivationCollectionAction
 {

--- a/src/Orleans.Runtime/Catalog/ICollectibleGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/ICollectibleGrainContext.cs
@@ -32,7 +32,7 @@ internal interface ICollectibleGrainContext : IGrainContext
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// Delays activation collection until at least until the specified duration has elapsed.
+    /// Delays activation collection until the specified duration has elapsed.
     /// </summary>
     /// <param name="timeSpan">The period to delay activation collection for.</param>
     void DelayDeactivation(TimeSpan timeSpan);

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -97,7 +97,7 @@ namespace Orleans.Runtime
                 {
                     if (member is ActivationData activation)
                     {
-                        lock (activation)
+                        lock (activation.SynchronizationLock)
                         {
                             activation.AnalyzeWorkload(now, messageCenter, _messageFactory, options);
                         }

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -97,10 +97,7 @@ namespace Orleans.Runtime
                 {
                     if (member is ActivationData activation)
                     {
-                        lock (activation.SynchronizationLock)
-                        {
-                            activation.AnalyzeWorkload(now, messageCenter, _messageFactory, options);
-                        }
+                        activation.AnalyzeWorkload(now, messageCenter, _messageFactory, options);
                     }
 
                     if (++iteration % 100 == 0)

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -103,6 +103,22 @@ namespace UnitTests.Runtime
             Assert.NotEqual(DateTime.MaxValue, activation.CollectionTicket);
         }
 
+        [Fact, TestCategory("Activation")]
+        public void ScheduleCollection_UsesContextMonitor_ForNonActivationData()
+        {
+            var activation = Substitute.For<ICollectibleGrainContext>();
+            activation.IsExemptFromCollection.Returns(_ =>
+            {
+                Assert.True(Monitor.IsEntered(activation));
+                return false;
+            });
+
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+            collector.ScheduleCollection(activation, TimeSpan.FromMinutes(1), now);
+
+            Assert.NotEqual(default, activation.CollectionTicket);
+        }
+
         [Theory, TestCategory("MemoryBasedDeactivations")]
         [InlineData(80.0, 70.0, 1000, 150, 100, true, 82)] // Over threshold, need to deactivate
         [InlineData(80.0, 70.0, 1000, 250, 100, false, 0)] // Below threshold, no deactivation

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -82,6 +82,7 @@ namespace UnitTests.Runtime
             // ActivationData into TryRescheduleCollection, which must be able to move the
             // activation out of the MaxValue bucket without throwing.
             var activation = Substitute.For<ICollectibleGrainContext, IActivationWorkingSetMember>();
+            ConfigureCollectionRegistrationSlot(activation);
             activation.CollectionAgeLimit.Returns(TimeSpan.FromMinutes(5));
             activation.IsExemptFromCollection.Returns(false);
 
@@ -106,6 +107,7 @@ namespace UnitTests.Runtime
         public void ScheduleCollection_DoesNotAcquireContextMonitor()
         {
             var activation = Substitute.For<ICollectibleGrainContext>();
+            ConfigureCollectionRegistrationSlot(activation);
             activation.IsExemptFromCollection.Returns(_ =>
             {
                 Assert.False(Monitor.IsEntered(activation));
@@ -125,6 +127,8 @@ namespace UnitTests.Runtime
             var ageLimit = TimeSpan.FromMinutes(5);
             var first = Substitute.For<ICollectibleGrainContext>();
             var second = Substitute.For<ICollectibleGrainContext>();
+            ConfigureCollectionRegistrationSlot(first);
+            ConfigureCollectionRegistrationSlot(second);
             first.IsExemptFromCollection.Returns(false);
             second.IsExemptFromCollection.Returns(false);
             second.CollectionAgeLimit.Returns(ageLimit);
@@ -169,6 +173,7 @@ namespace UnitTests.Runtime
             var cancellationToken = TestContext.Current.CancellationToken;
             var ageLimit = TimeSpan.FromMinutes(1);
             var activation = Substitute.For<ICollectibleGrainContext>();
+            ConfigureCollectionRegistrationSlot(activation);
             activation.CollectionAgeLimit.Returns(ageLimit);
             activation.IsExemptFromCollection.Returns(false);
             activation.TryDeactivateForCollection(
@@ -201,6 +206,7 @@ namespace UnitTests.Runtime
             var cancellationToken = TestContext.Current.CancellationToken;
             var ageLimit = TimeSpan.FromMinutes(1);
             var activation = Substitute.For<ICollectibleGrainContext>();
+            ConfigureCollectionRegistrationSlot(activation);
             activation.CollectionAgeLimit.Returns(ageLimit);
             activation.IsExemptFromCollection.Returns(false);
             activation.TryDeactivateForCollection(
@@ -617,9 +623,22 @@ namespace UnitTests.Runtime
             return services.BuildServiceProvider().GetRequiredService<CatalogInstruments>();
         }
 
+        private static void ConfigureCollectionRegistrationSlot(ICollectibleGrainContext activation)
+        {
+            IActivationCollectionRegistration? registration = null;
+            activation.CollectionRegistration.Returns(_ => Volatile.Read(ref registration));
+            activation.GetOrSetCollectionRegistration(Arg.Any<IActivationCollectionRegistration>())
+                .Returns(call =>
+                {
+                    var candidate = call.Arg<IActivationCollectionRegistration>();
+                    return Interlocked.CompareExchange(ref registration, candidate, null) ?? candidate;
+                });
+        }
+
         private IActivationWorkingSetMember PrepareActivation(TimeSpan collectionAgeLimit, ActivationCollector collector)
         {
             var activation = Substitute.For<ICollectibleGrainContext, IActivationWorkingSetMember>();
+            ConfigureCollectionRegistrationSlot(activation);
             activation.CollectionAgeLimit.Returns(collectionAgeLimit);
             activation.IsExemptFromCollection.Returns(false);
             activation.TryDeactivateForCollection(

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -72,7 +72,7 @@ namespace UnitTests.Runtime
         [Fact, TestCategory("Activation")]
         public void TryRescheduleCollection_DoesNotThrow_WhenCollectionTicketIsMaxValue()
         {
-            // Simulate an activation whose collection ticket sits in the DateTime.MaxValue bucket.
+            // Simulate an activation whose collector-owned registration sits in the DateTime.MaxValue bucket.
             // That state arises when ScanStale reschedules an activation with
             // KeepAliveUntil = DateTime.MaxValue (from DelayDeactivation(Timeout.InfiniteTimeSpan))
             // and MakeTicketFromDateTime clamps the overflowed timestamp to DateTime.MaxValue
@@ -83,13 +83,12 @@ namespace UnitTests.Runtime
             // activation out of the MaxValue bucket without throwing.
             var activation = Substitute.For<ICollectibleGrainContext, IActivationWorkingSetMember>();
             activation.CollectionAgeLimit.Returns(TimeSpan.FromMinutes(5));
-            activation.IsValid.Returns(true);
             activation.IsExemptFromCollection.Returns(false);
 
             var now = timeProvider.GetUtcNow().UtcDateTime;
             var farFuture = DateTime.MaxValue - now;
             collector.ScheduleCollection(activation, farFuture, now);
-            Assert.Equal(DateTime.MaxValue, activation.CollectionTicket);
+            Assert.Equal(DateTime.MaxValue, collector.GetCollectionTicketForTesting(activation));
 
             var rescheduled = false;
             var exception = Record.Exception(() =>
@@ -99,24 +98,85 @@ namespace UnitTests.Runtime
 
             Assert.Null(exception);
             Assert.True(rescheduled);
-            Assert.NotEqual(default, activation.CollectionTicket);
-            Assert.NotEqual(DateTime.MaxValue, activation.CollectionTicket);
+            Assert.NotEqual(default, collector.GetCollectionTicketForTesting(activation));
+            Assert.NotEqual(DateTime.MaxValue, collector.GetCollectionTicketForTesting(activation));
         }
 
         [Fact, TestCategory("Activation")]
-        public void ScheduleCollection_UsesContextMonitor_ForNonActivationData()
+        public void ScheduleCollection_DoesNotAcquireContextMonitor()
         {
             var activation = Substitute.For<ICollectibleGrainContext>();
             activation.IsExemptFromCollection.Returns(_ =>
             {
-                Assert.True(Monitor.IsEntered(activation));
+                Assert.False(Monitor.IsEntered(activation));
                 return false;
             });
 
             var now = timeProvider.GetUtcNow().UtcDateTime;
             collector.ScheduleCollection(activation, TimeSpan.FromMinutes(1), now);
 
-            Assert.NotEqual(default, activation.CollectionTicket);
+            Assert.NotEqual(default, collector.GetCollectionTicketForTesting(activation));
+        }
+
+        [Fact, TestCategory("Activation")]
+        public async Task CollectStaleActivations_DelegatesAtomicTransitionToContext()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var ageLimit = TimeSpan.FromMinutes(1);
+            var activation = Substitute.For<ICollectibleGrainContext>();
+            activation.CollectionAgeLimit.Returns(ageLimit);
+            activation.IsExemptFromCollection.Returns(false);
+            activation.TryDeactivateForCollection(
+                    Arg.Any<DeactivationReason>(),
+                    Arg.Any<DateTime>(),
+                    Arg.Any<TimeSpan>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(ActivationCollectionResult.StartedDeactivation);
+            activation.Deactivated.Returns(Task.CompletedTask);
+
+            var scheduledAt = timeProvider.GetUtcNow().UtcDateTime;
+            collector.ScheduleCollection(activation, ageLimit, scheduledAt);
+            timeProvider.Advance(ageLimit);
+
+            await collector.CollectStaleActivations(cancellationToken);
+
+            activation.Received(1).TryDeactivateForCollection(
+                Arg.Is<DeactivationReason>(reason => reason.ReasonCode == DeactivationReasonCode.ActivationIdle),
+                timeProvider.GetUtcNow().UtcDateTime,
+                ageLimit,
+                true,
+                cancellationToken);
+            Assert.Equal(default, collector.GetCollectionTicketForTesting(activation));
+        }
+
+        [Fact, TestCategory("Activation")]
+        public async Task CollectStaleActivations_CancellationInvalidatesClaim()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var ageLimit = TimeSpan.FromMinutes(1);
+            var activation = Substitute.For<ICollectibleGrainContext>();
+            activation.CollectionAgeLimit.Returns(ageLimit);
+            activation.IsExemptFromCollection.Returns(false);
+            activation.TryDeactivateForCollection(
+                    Arg.Any<DeactivationReason>(),
+                    Arg.Any<DateTime>(),
+                    Arg.Any<TimeSpan>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    Assert.True(collector.TryCancelCollection(activation));
+                    return ActivationCollectionResult.Reschedule(ageLimit);
+                });
+
+            var scheduledAt = timeProvider.GetUtcNow().UtcDateTime;
+            collector.ScheduleCollection(activation, ageLimit, scheduledAt);
+            timeProvider.Advance(ageLimit);
+
+            await collector.CollectStaleActivations(cancellationToken);
+
+            Assert.Equal(default, collector.GetCollectionTicketForTesting(activation));
         }
 
         [Theory, TestCategory("MemoryBasedDeactivations")]
@@ -384,15 +444,49 @@ namespace UnitTests.Runtime
             workingSet.OnActivated(invalidActivation);
             workingSet.OnActivated(inactiveActivation2);
 
-            ((ICollectibleGrainContext)activeActivation).IsInactive.Returns(false);
-            ((ICollectibleGrainContext)invalidActivation).IsValid.Returns(false);
+            ((ICollectibleGrainContext)activeActivation)
+                .TryDeactivateForCollection(
+                    Arg.Any<DeactivationReason>(),
+                    Arg.Any<DateTime>(),
+                    Arg.Any<TimeSpan>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(ActivationCollectionResult.Reschedule(TimeSpan.FromMinutes(1)));
+            ((ICollectibleGrainContext)invalidActivation)
+                .TryDeactivateForCollection(
+                    Arg.Any<DeactivationReason>(),
+                    Arg.Any<DateTime>(),
+                    Arg.Any<TimeSpan>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(ActivationCollectionResult.Remove);
 
             await collector.DeactivateInDueTimeOrder(4, CancellationToken.None);
 
-            ((ICollectibleGrainContext)inactiveActivation1).Received(1).Deactivate(Arg.Any<DeactivationReason>(), Arg.Any<CancellationToken>());
-            ((ICollectibleGrainContext)inactiveActivation2).Received(1).Deactivate(Arg.Any<DeactivationReason>(), Arg.Any<CancellationToken>());
-            ((ICollectibleGrainContext)activeActivation).DidNotReceive().Deactivate(Arg.Any<DeactivationReason>(), Arg.Any<CancellationToken>());
-            ((ICollectibleGrainContext)invalidActivation).DidNotReceive().Deactivate(Arg.Any<DeactivationReason>(), Arg.Any<CancellationToken>());
+            ((ICollectibleGrainContext)inactiveActivation1).Received(1).TryDeactivateForCollection(
+                Arg.Any<DeactivationReason>(),
+                Arg.Any<DateTime>(),
+                TimeSpan.Zero,
+                false,
+                Arg.Any<CancellationToken>());
+            ((ICollectibleGrainContext)inactiveActivation2).Received(1).TryDeactivateForCollection(
+                Arg.Any<DeactivationReason>(),
+                Arg.Any<DateTime>(),
+                TimeSpan.Zero,
+                false,
+                Arg.Any<CancellationToken>());
+            ((ICollectibleGrainContext)activeActivation).Received(1).TryDeactivateForCollection(
+                Arg.Any<DeactivationReason>(),
+                Arg.Any<DateTime>(),
+                TimeSpan.Zero,
+                false,
+                Arg.Any<CancellationToken>());
+            ((ICollectibleGrainContext)invalidActivation).Received(1).TryDeactivateForCollection(
+                Arg.Any<DeactivationReason>(),
+                Arg.Any<DateTime>(),
+                TimeSpan.Zero,
+                false,
+                Arg.Any<CancellationToken>());
             Assert.Equal(2, collector._activationCount);
         }
 
@@ -412,9 +506,14 @@ namespace UnitTests.Runtime
         {
             var activation = Substitute.For<ICollectibleGrainContext, IActivationWorkingSetMember>();
             activation.CollectionAgeLimit.Returns(collectionAgeLimit);
-            activation.IsValid.Returns(true);
             activation.IsExemptFromCollection.Returns(false);
-            activation.IsInactive.Returns(true);
+            activation.TryDeactivateForCollection(
+                    Arg.Any<DeactivationReason>(),
+                    Arg.Any<DateTime>(),
+                    Arg.Any<TimeSpan>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(ActivationCollectionResult.StartedDeactivation);
             activation.Deactivated.Returns(Task.CompletedTask).AndDoes(_ => { Interlocked.Decrement(ref collector._activationCount); });
 
             return (IActivationWorkingSetMember)activation;

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -168,6 +168,137 @@ namespace UnitTests.Runtime
         [Theory, TestCategory("Activation")]
         [InlineData(false)]
         [InlineData(true)]
+        public async Task CollectStaleActivations_OldClaimCannotModifyNewClaim(bool rescheduleOldClaim)
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var timeout = TimeSpan.FromSeconds(30);
+            var ageLimit = TimeSpan.FromMinutes(1);
+            var activation = Substitute.For<ICollectibleGrainContext>();
+            ConfigureCollectionRegistrationSlot(activation);
+            activation.CollectionAgeLimit.Returns(ageLimit);
+            var firstClaimEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var secondClaimEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var releaseFirstClaim = new ManualResetEventSlim();
+            using var releaseSecondClaim = new ManualResetEventSlim();
+            var claimCount = 0;
+            activation.TryDeactivateForCollection(
+                    Arg.Any<DeactivationReason>(),
+                    Arg.Any<DateTime>(),
+                    Arg.Any<TimeSpan>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    var claimNumber = Interlocked.Increment(ref claimCount);
+                    if (claimNumber == 1)
+                    {
+                        firstClaimEntered.SetResult();
+                        if (!releaseFirstClaim.Wait(timeout, cancellationToken))
+                        {
+                            throw new TimeoutException("Timed out releasing the first collection claim.");
+                        }
+
+                        return rescheduleOldClaim
+                            ? ActivationCollectionResult.Reschedule(ageLimit)
+                            : ActivationCollectionResult.Remove;
+                    }
+
+                    Assert.Equal(2, claimNumber);
+                    secondClaimEntered.SetResult();
+                    if (!releaseSecondClaim.Wait(timeout, cancellationToken))
+                    {
+                        throw new TimeoutException("Timed out releasing the second collection claim.");
+                    }
+
+                    return ActivationCollectionResult.Reschedule(ageLimit);
+                });
+
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+            collector.ScheduleCollection(activation, ageLimit, now);
+            var registration = activation.CollectionRegistration;
+            timeProvider.Advance(ageLimit);
+            var firstScan = Task.Run(() => collector.CollectStaleActivations(cancellationToken), cancellationToken);
+            Task secondScan = Task.CompletedTask;
+            try
+            {
+                await firstClaimEntered.Task.WaitAsync(timeout, cancellationToken);
+                Assert.True(collector.TryCancelCollection(activation));
+                collector.ScheduleCollection(activation, ageLimit, timeProvider.GetUtcNow().UtcDateTime);
+                timeProvider.Advance(ageLimit);
+                secondScan = Task.Run(() => collector.CollectStaleActivations(cancellationToken), cancellationToken);
+                await secondClaimEntered.Task.WaitAsync(timeout, cancellationToken);
+
+                releaseFirstClaim.Set();
+                await firstScan.WaitAsync(timeout, cancellationToken);
+                Assert.Equal(default, collector.GetCollectionTicketForTesting(activation));
+
+                releaseSecondClaim.Set();
+                await secondScan.WaitAsync(timeout, cancellationToken);
+                Assert.Equal(now.AddMinutes(3), collector.GetCollectionTicketForTesting(activation));
+                Assert.Same(registration, activation.CollectionRegistration);
+                Assert.Equal(2, Volatile.Read(ref claimCount));
+            }
+            finally
+            {
+                releaseFirstClaim.Set();
+                releaseSecondClaim.Set();
+                await Task.WhenAll(firstScan, secondScan).WaitAsync(timeout, CancellationToken.None);
+            }
+        }
+
+        [Fact, TestCategory("Activation")]
+        public async Task CollectStaleActivations_ClaimRetriesAfterCursorAdvances()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var timeout = TimeSpan.FromSeconds(30);
+            var ageLimit = TimeSpan.FromMinutes(1);
+            var activation = Substitute.For<ICollectibleGrainContext>();
+            ConfigureCollectionRegistrationSlot(activation);
+            activation.CollectionAgeLimit.Returns(ageLimit);
+            var claimEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var releaseClaim = new ManualResetEventSlim();
+            activation.TryDeactivateForCollection(
+                    Arg.Any<DeactivationReason>(),
+                    Arg.Any<DateTime>(),
+                    Arg.Any<TimeSpan>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    claimEntered.SetResult();
+                    if (!releaseClaim.Wait(timeout, cancellationToken))
+                    {
+                        throw new TimeoutException("Timed out releasing the collection claim after cursor advancement.");
+                    }
+
+                    return ActivationCollectionResult.Reschedule(ageLimit);
+                });
+
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+            collector.ScheduleCollection(activation, ageLimit, now);
+            timeProvider.Advance(ageLimit);
+            var scan = Task.Run(() => collector.CollectStaleActivations(cancellationToken), cancellationToken);
+            try
+            {
+                await claimEntered.Task.WaitAsync(timeout, cancellationToken);
+                timeProvider.Advance(TimeSpan.FromMinutes(2));
+                await collector.CollectStaleActivations(cancellationToken).WaitAsync(timeout, cancellationToken);
+                releaseClaim.Set();
+                await scan.WaitAsync(timeout, cancellationToken);
+                Assert.Equal(now.AddMinutes(5), collector.GetCollectionTicketForTesting(activation));
+                Assert.True(collector.TryCancelCollection(activation));
+                Assert.Equal(default, collector.GetCollectionTicketForTesting(activation));
+            }
+            finally
+            {
+                releaseClaim.Set();
+                await scan.WaitAsync(timeout, CancellationToken.None);
+            }
+        }
+
+        [Theory, TestCategory("Activation")]
+        [InlineData(false)]
+        [InlineData(true)]
         public async Task CollectionScans_VisitEveryRegistrationDuringRemoval(bool scanStale)
         {
             var cancellationToken = TestContext.Current.CancellationToken;

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -224,6 +224,76 @@ namespace UnitTests.Runtime
             Assert.Equal(default, collector.GetCollectionTicketForTesting(activation));
         }
 
+        [Fact, TestCategory("Activation")]
+        public void OnDeactivating_RemovesCollectionRegistration()
+        {
+            var activation = PrepareActivation(1, collector);
+            var observer = (IActivationWorkingSetObserver)collector;
+
+            observer.OnAdded(activation);
+            Assert.True(collector.HasActiveCollectionRegistrationForTesting((ICollectibleGrainContext)activation));
+
+            observer.OnDeactivating(activation);
+
+            Assert.False(collector.HasActiveCollectionRegistrationForTesting((ICollectibleGrainContext)activation));
+            Assert.False(collector.TryRescheduleCollection((ICollectibleGrainContext)activation));
+        }
+
+        [Fact, TestCategory("Activation")]
+        public async Task OnDeactivating_PreventsInFlightReschedule()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var ageLimit = TimeSpan.FromMinutes(1);
+            var activation = PrepareActivation(ageLimit, collector);
+            var collectible = (ICollectibleGrainContext)activation;
+            var observer = (IActivationWorkingSetObserver)collector;
+            observer.OnAdded(activation);
+
+            var metadataRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var releaseMetadata = new ManualResetEventSlim();
+            collectible.CollectionAgeLimit.Returns(_ =>
+            {
+                metadataRequested.TrySetResult();
+                if (!releaseMetadata.Wait(TimeSpan.FromSeconds(10), cancellationToken))
+                {
+                    throw new TimeoutException("Timed out waiting to release collection metadata access.");
+                }
+
+                return ageLimit;
+            });
+
+            var reschedule = Task.Run(() => collector.TryRescheduleCollection(collectible), cancellationToken);
+            await metadataRequested.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            try
+            {
+                observer.OnDeactivating(activation);
+            }
+            finally
+            {
+                releaseMetadata.Set();
+            }
+
+            Assert.False(await reschedule.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken));
+            Assert.False(collector.HasActiveCollectionRegistrationForTesting(collectible));
+            Assert.Equal(default, collector.GetCollectionTicketForTesting(collectible));
+        }
+
+        [Fact, TestCategory("Activation")]
+        public void OnEvicted_DoesNotRecreateRetiredCollectionRegistration()
+        {
+            var activation = PrepareActivation(1, collector);
+            var collectible = (ICollectibleGrainContext)activation;
+            var observer = (IActivationWorkingSetObserver)collector;
+            observer.OnAdded(activation);
+
+            observer.OnDeactivating(activation);
+            observer.OnDeactivated(activation);
+            observer.OnEvicted(activation);
+
+            Assert.False(collector.HasActiveCollectionRegistrationForTesting(collectible));
+            Assert.Equal(default, collector.GetCollectionTicketForTesting(collectible));
+        }
+
         [Theory, TestCategory("MemoryBasedDeactivations")]
         [InlineData(80.0, 70.0, 1000, 150, 100, true, 82)] // Over threshold, need to deactivate
         [InlineData(80.0, 70.0, 1000, 250, 100, false, 0)] // Below threshold, no deactivation

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -119,6 +119,51 @@ namespace UnitTests.Runtime
         }
 
         [Fact, TestCategory("Activation")]
+        public async Task TryRescheduleCollection_DoesNotSerializeIndependentContexts()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var ageLimit = TimeSpan.FromMinutes(5);
+            var first = Substitute.For<ICollectibleGrainContext>();
+            var second = Substitute.For<ICollectibleGrainContext>();
+            first.IsExemptFromCollection.Returns(false);
+            second.IsExemptFromCollection.Returns(false);
+            second.CollectionAgeLimit.Returns(ageLimit);
+
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+            collector.ScheduleCollection(first, ageLimit, now);
+            collector.ScheduleCollection(second, ageLimit, now);
+
+            var metadataRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var releaseMetadata = new ManualResetEventSlim();
+            first.CollectionAgeLimit.Returns(_ =>
+            {
+                metadataRequested.TrySetResult();
+                if (!releaseMetadata.Wait(TimeSpan.FromSeconds(10), cancellationToken))
+                {
+                    throw new TimeoutException("Timed out waiting to release collection metadata access.");
+                }
+
+                return ageLimit;
+            });
+
+            var firstReschedule = Task.Run(() => collector.TryRescheduleCollection(first), cancellationToken);
+            await metadataRequested.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            try
+            {
+                Assert.True(
+                    await Task.Run(
+                        () => collector.TryRescheduleCollection(second),
+                        cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken));
+            }
+            finally
+            {
+                releaseMetadata.Set();
+            }
+
+            Assert.True(await firstReschedule.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken));
+        }
+
+        [Fact, TestCategory("Activation")]
         public async Task CollectStaleActivations_DelegatesAtomicTransitionToContext()
         {
             var cancellationToken = TestContext.Current.CancellationToken;

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -99,8 +99,113 @@ namespace UnitTests.Runtime
 
             Assert.Null(exception);
             Assert.True(rescheduled);
-            Assert.NotEqual(default, collector.GetCollectionTicketForTesting(activation));
-            Assert.NotEqual(DateTime.MaxValue, collector.GetCollectionTicketForTesting(activation));
+            Assert.Equal(now.AddMinutes(5), collector.GetCollectionTicketForTesting(activation));
+        }
+
+        [Fact, TestCategory("Activation")]
+        public void CollectionTicket_FollowsBucketAcrossScheduleCancelAndRetire()
+        {
+            var member = PrepareActivation(5, collector);
+            var activation = (ICollectibleGrainContext)member;
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+            collector.ScheduleCollection(activation, activation.CollectionAgeLimit, now);
+            var registration = activation.CollectionRegistration;
+
+            Assert.Equal(now.AddMinutes(5), collector.GetCollectionTicketForTesting(activation));
+            Assert.True(collector.TryRescheduleCollection(activation));
+            Assert.Equal(now.AddMinutes(5), collector.GetCollectionTicketForTesting(activation));
+
+            timeProvider.Advance(TimeSpan.FromMinutes(1));
+            Assert.True(collector.TryRescheduleCollection(activation));
+            Assert.Equal(now.AddMinutes(6), collector.GetCollectionTicketForTesting(activation));
+
+            Assert.True(collector.TryCancelCollection(activation));
+            Assert.Equal(default, collector.GetCollectionTicketForTesting(activation));
+            collector.ScheduleCollection(activation, activation.CollectionAgeLimit, timeProvider.GetUtcNow().UtcDateTime);
+            Assert.Equal(now.AddMinutes(6), collector.GetCollectionTicketForTesting(activation));
+            Assert.Same(registration, activation.CollectionRegistration);
+
+            ((IActivationWorkingSetObserver)collector).OnDeactivating(member);
+            Assert.Equal(default, collector.GetCollectionTicketForTesting(activation));
+            Assert.False(collector.TryRescheduleCollection(activation));
+        }
+
+        [Fact, TestCategory("Activation")]
+        public async Task CollectStaleActivations_ReschedulesClaimsIntoNextBucket()
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var ageLimit = TimeSpan.FromMinutes(1);
+            var activation = Substitute.For<ICollectibleGrainContext>();
+            ConfigureCollectionRegistrationSlot(activation);
+            activation.CollectionAgeLimit.Returns(ageLimit);
+            activation.TryDeactivateForCollection(
+                    Arg.Any<DeactivationReason>(),
+                    Arg.Any<DateTime>(),
+                    Arg.Any<TimeSpan>(),
+                    Arg.Any<bool>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    Assert.Equal(default, collector.GetCollectionTicketForTesting(activation));
+                    return ActivationCollectionResult.Reschedule(ageLimit);
+                });
+
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+            collector.ScheduleCollection(activation, ageLimit, now);
+            var registration = activation.CollectionRegistration;
+            timeProvider.Advance(ageLimit);
+            await collector.CollectStaleActivations(cancellationToken);
+            Assert.Equal(now.AddMinutes(2), collector.GetCollectionTicketForTesting(activation));
+
+            timeProvider.Advance(ageLimit);
+            await collector.CollectStaleActivations(cancellationToken);
+            Assert.Equal(now.AddMinutes(3), collector.GetCollectionTicketForTesting(activation));
+            Assert.Same(registration, activation.CollectionRegistration);
+            activation.Received(2).TryDeactivateForCollection(
+                Arg.Any<DeactivationReason>(), Arg.Any<DateTime>(), ageLimit, true, cancellationToken);
+        }
+
+        [Theory, TestCategory("Activation")]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task CollectionScans_VisitEveryRegistrationDuringRemoval(bool scanStale)
+        {
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var observer = (IActivationWorkingSetObserver)collector;
+            var activations = new ICollectibleGrainContext[8];
+            for (var i = 0; i < activations.Length; i++)
+            {
+                var member = PrepareActivation(1, collector);
+                var activation = (ICollectibleGrainContext)member;
+                activations[i] = activation;
+                activation.TryDeactivateForCollection(
+                        Arg.Any<DeactivationReason>(),
+                        Arg.Any<DateTime>(),
+                        Arg.Any<TimeSpan>(),
+                        Arg.Any<bool>(),
+                        Arg.Any<CancellationToken>())
+                    .Returns(_ =>
+                    {
+                        observer.OnDeactivating(member);
+                        return ActivationCollectionResult.StartedDeactivation;
+                    });
+                observer.OnAdded(member);
+            }
+
+            timeProvider.Advance(TimeSpan.FromMinutes(1));
+            await (scanStale
+                ? collector.CollectStaleActivations(cancellationToken)
+                : collector.CollectActivations(TimeSpan.FromMinutes(1), cancellationToken));
+
+            foreach (var activation in activations)
+            {
+                activation.Received(1).TryDeactivateForCollection(
+                    Arg.Any<DeactivationReason>(), Arg.Any<DateTime>(), TimeSpan.FromMinutes(1), true, cancellationToken);
+                Assert.False(collector.HasActiveCollectionRegistrationForTesting(activation));
+                Assert.Equal(default, collector.GetCollectionTicketForTesting(activation));
+            }
+
+            Assert.Equal(0, collector._activationCount);
         }
 
         [Fact, TestCategory("Activation")]

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
@@ -43,6 +43,49 @@ public class ActivationDataMigrationTests(ActivationDataMigrationTests.Fixture f
         Assert.False(activation.TryStartMigration(requestContext: null, cancellationToken));
     }
 
+    [Fact]
+    public async Task TryStartMigration_DoesNotAcquireActivationInstanceMonitor()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var activation = await GetActivation(cancellationToken);
+        Assert.NotSame(activation, activation.SynchronizationLock);
+        Assert.Same(activation.SynchronizationLock, activation.SynchronizationLock);
+
+        var lockAcquired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var releaseLock = new ManualResetEventSlim();
+        var lockHolder = Task.Factory.StartNew(
+            () =>
+            {
+                lock (activation)
+                {
+                    lockAcquired.SetResult();
+                    if (!releaseLock.Wait(TimeSpan.FromSeconds(10), cancellationToken))
+                    {
+                        throw new TimeoutException("Timed out waiting to release the activation instance monitor.");
+                    }
+                }
+            },
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+
+        await lockAcquired.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        try
+        {
+            Assert.True(
+                await Task.Run(
+                    () => activation.TryStartMigration(requestContext: null, cancellationToken),
+                    cancellationToken).WaitAsync(TimeSpan.FromSeconds(10), cancellationToken));
+        }
+        finally
+        {
+            releaseLock.Set();
+            await lockHolder.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        }
+
+        await activation.Deactivated.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+    }
+
     private async Task<ActivationData> GetActivation(CancellationToken cancellationToken)
     {
         var grain = _fixture.GrainFactory.GetGrain<IIdleActivationGcTestGrain1>(Guid.NewGuid());

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
@@ -48,6 +48,7 @@ public class ActivationDataMigrationTests(ActivationDataMigrationTests.Fixture f
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var activation = await GetActivation(cancellationToken);
+        var deactivated = activation.Deactivated;
         var reason = new DeactivationReason(DeactivationReasonCode.ActivationIdle, "test");
 
         var result = ((ICollectibleGrainContext)activation).TryDeactivateForCollection(
@@ -58,8 +59,8 @@ public class ActivationDataMigrationTests(ActivationDataMigrationTests.Fixture f
             cancellationToken);
 
         Assert.Equal(ActivationCollectionAction.StartedDeactivation, result.Action);
-        Assert.Equal(ActivationState.Deactivating, activation.State);
-        await activation.Deactivated.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        await deactivated.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+        Assert.Equal(ActivationState.Invalid, activation.State);
     }
 
     [Fact]

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
@@ -44,12 +44,29 @@ public class ActivationDataMigrationTests(ActivationDataMigrationTests.Fixture f
     }
 
     [Fact]
+    public async Task TryDeactivateForCollection_AtomicallyStartsDeactivation()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var activation = await GetActivation(cancellationToken);
+        var reason = new DeactivationReason(DeactivationReasonCode.ActivationIdle, "test");
+
+        var result = ((ICollectibleGrainContext)activation).TryDeactivateForCollection(
+            reason,
+            DateTime.UtcNow,
+            TimeSpan.Zero,
+            respectKeepAlive: true,
+            cancellationToken);
+
+        Assert.Equal(ActivationCollectionAction.StartedDeactivation, result.Action);
+        Assert.Equal(ActivationState.Deactivating, activation.State);
+        await activation.Deactivated.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+    }
+
+    [Fact]
     public async Task TryStartMigration_DoesNotAcquireActivationInstanceMonitor()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var activation = await GetActivation(cancellationToken);
-        Assert.NotSame(activation, activation.SynchronizationLock);
-        Assert.Same(activation.SynchronizationLock, activation.SynchronizationLock);
 
         var lockAcquired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         using var releaseLock = new ManualResetEventSlim();


### PR DESCRIPTION
## Problem

`ActivationData` exposed its synchronization monitor so the collector, migration manager, and request monitor could coordinate with mutable activation state. That made external components participants in activation lock ordering and split collection state between the activation and the collector.

## Solution

- Keep activation lifecycle, request, idleness, and keep-alive invariants behind one private `ActivationData` lock.
- Add `ICollectibleGrainContext.TryDeactivateForCollection` so eligibility checks and the transition to deactivating are atomic and owned by the grain context.
- Move collection membership into collector-owned registrations with source-bucket-validated claims and fine-grained synchronization. Store each collection ticket once in its bucket.
- Anchor each opaque collector registration in an atomic `ICollectibleGrainContext` slot, giving it the context's lifetime.
- Enumerate bucket entries directly during scans and release drained dictionary storage when a bucket closes.
- Replace migration state polling with an awaitable activation-ready completion.
- Let workload analysis synchronize internally.
- Use `System.Threading.Lock` for dedicated synchronization on .NET 10 and object monitors on .NET 8.

## Rationale

Each component owns and synchronizes its mutable state. The context stores only an opaque registration reference; the collector owns the registration type, bucket membership, retirement state, and transition protocol. Retired registrations remain attached to their context so delayed lifecycle callbacks cannot recreate collection state, while abandoned activations remain collectible as an ordinary object cycle.

Claim validity is the combination of the registration's `Claimed` state and its source bucket's identity. A bucket closes permanently before claiming registrations. The registration retains that source reference until completion, cancellation, retirement, or rescheduling; a later claim uses a different bucket. Expiry recovery uses the same identity-checked transitions so older work leaves newer claims intact.

Deriving tickets from immutable buckets and using bucket identity instead of generation counters removes two eight-byte fields from every registration (estimated x64 layout: 64 to 48 bytes, excluding the dedicated lock). Claims retain the same estimated x64 size of 16 bytes. Direct enumeration eliminates scan-sized key snapshots and their all-segment locking. Closed buckets release their dictionary instead of clearing and allocating replacement storage; indexed claim traversal also avoids boxed list enumerators. These are structural allocation reductions, not benchmark measurements.

The collector calls grain-context operations after releasing registration locks. Collection, migration, scheduling, and deactivation coordinate through those operation-based boundaries, preserving per-activation concurrency.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10068)