### PR TITLE
Add AdaptivePing benchmark with hill-climbing concurrency tuning

### DIFF
--- a/test/Benchmarks/Ping/AdaptiveConcurrencyLoadGenerator.cs
+++ b/test/Benchmarks/Ping/AdaptiveConcurrencyLoadGenerator.cs
@@ -1,0 +1,380 @@
+using System.Diagnostics;
+using System.Threading.Channels;
+
+namespace Benchmarks.Ping;
+
+/// <summary>
+/// A load generator that runs indefinitely and uses a hill climbing algorithm
+/// to continuously tune concurrency for maximum throughput.
+/// </summary>
+public sealed class AdaptiveConcurrencyLoadGenerator<TState>
+{
+    private static readonly double StopwatchTickPerSecond = Stopwatch.Frequency;
+
+    private readonly Func<TState, ValueTask> _issueRequest;
+    private readonly Func<int, TState> _getStateForWorker;
+    private readonly int _requestsPerBlock;
+    private readonly TimeSpan _warmupDuration;
+    private readonly TimeSpan _measurementInterval;
+    private readonly int _minConcurrency;
+    private readonly int _maxConcurrency;
+    private readonly int _initialConcurrency;
+    private readonly int _maxStableRounds;
+
+    private Channel<WorkBlock> _completedBlocks;
+    private volatile int _currentConcurrency;
+    private CancellationTokenSource _cts;
+
+    // Hill climbing state
+    private double _bestThroughput;
+    private double _lastThroughput;
+    private int _bestConcurrency;
+    private int _stepSize;
+    private int _direction; // 1 = increasing, -1 = decreasing
+    private int _stableCount;
+    private int _roundsSinceBestChanged;
+    private const int StableThreshold = 3; // Number of consecutive non-improvements before changing direction
+
+    public int CurrentConcurrency => _currentConcurrency;
+    public int BestConcurrency => _bestConcurrency;
+    public double BestThroughput => _bestThroughput;
+    public bool Converged { get; private set; }
+
+    public AdaptiveConcurrencyLoadGenerator(
+        Func<TState, ValueTask> issueRequest,
+        Func<int, TState> getStateForWorker,
+        int requestsPerBlock = 500,
+        TimeSpan? warmupDuration = null,
+        TimeSpan? measurementInterval = null,
+        int minConcurrency = 1,
+        int maxConcurrency = 2000,
+        int initialConcurrency = 100,
+        int maxStableRounds = 0)
+    {
+        _issueRequest = issueRequest;
+        _getStateForWorker = getStateForWorker;
+        _requestsPerBlock = requestsPerBlock;
+        _warmupDuration = warmupDuration ?? TimeSpan.FromSeconds(5);
+        _measurementInterval = measurementInterval ?? TimeSpan.FromSeconds(5);
+        _minConcurrency = minConcurrency;
+        _maxConcurrency = maxConcurrency;
+        _initialConcurrency = initialConcurrency;
+        _currentConcurrency = initialConcurrency;
+        _stepSize = Math.Max(1, initialConcurrency / 10);
+        _direction = 1;
+        _maxStableRounds = maxStableRounds; // 0 = run forever
+    }
+
+    public async Task RunForeverAsync(CancellationToken cancellationToken = default)
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        Console.WriteLine($"Starting adaptive load generator with initial concurrency: {_initialConcurrency}");
+        Console.WriteLine($"Warmup duration: {_warmupDuration.TotalSeconds}s, Measurement interval: {_measurementInterval.TotalSeconds}s");
+        Console.WriteLine($"Concurrency range: [{_minConcurrency}, {_maxConcurrency}]");
+        if (_maxStableRounds > 0)
+            Console.WriteLine($"Will terminate after {_maxStableRounds} rounds with no improvement to best");
+        Console.WriteLine();
+
+        // Warmup phase
+        Console.WriteLine("=== WARMUP PHASE ===");
+        await RunPhaseAsync(_warmupDuration, isWarmup: true);
+        GC.Collect();
+
+        Console.WriteLine();
+        Console.WriteLine("=== TUNING PHASE ===");
+        Console.WriteLine($"{"Time",-12} {"Concurrency",12} {"Throughput",14} {"Best",14} {"BestConc",10} {"Action",-20}");
+        Console.WriteLine(new string('-', 82));
+
+        var startTime = DateTime.UtcNow;
+
+        while (!_cts.Token.IsCancellationRequested)
+        {
+            var throughput = await RunPhaseAsync(_measurementInterval, isWarmup: false);
+            var elapsed = DateTime.UtcNow - startTime;
+
+            var action = ApplyHillClimbing(throughput);
+
+            var elapsedStr = elapsed.ToString(@"hh\:mm\:ss\.f");
+            Console.WriteLine($"{elapsedStr,-12} {_currentConcurrency,12} {throughput,14:N0}/s {_bestThroughput,14:N0}/s {_bestConcurrency,10} {action,-20}");
+
+            // Check for convergence
+            if (_maxStableRounds > 0 && _roundsSinceBestChanged >= _maxStableRounds)
+            {
+                Converged = true;
+                Console.WriteLine();
+                Console.WriteLine($"Converged after {_roundsSinceBestChanged} rounds with no improvement.");
+                break;
+            }
+        }
+    }
+
+    private async Task<double> RunPhaseAsync(TimeSpan duration, bool isWarmup)
+    {
+        _completedBlocks = Channel.CreateUnbounded<WorkBlock>(
+            new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                AllowSynchronousContinuations = false
+            });
+
+        var workerTasks = new List<Task>();
+        // Link to main cancellation token so Ctrl+C stops workers immediately
+        using var workerCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+        var states = new Dictionary<int, TState>();
+
+        // Start initial workers
+        for (int i = 0; i < _currentConcurrency; i++)
+        {
+            var state = _getStateForWorker(i);
+            states[i] = state;
+            workerTasks.Add(RunWorkerAsync(state, i, workerCts.Token));
+        }
+
+        var aggregator = Task.Run(() => AggregateBlocksAsync(duration, isWarmup, workerCts));
+
+        var throughput = await aggregator;
+
+        // Signal workers to stop
+        await workerCts.CancelAsync();
+        _completedBlocks.Writer.Complete();
+
+        // Wait for workers with timeout
+        try
+        {
+            await Task.WhenAll(workerTasks).WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        catch (TimeoutException)
+        {
+            // Workers didn't stop in time, continue anyway
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected
+        }
+
+        return throughput;
+    }
+
+    private async Task<double> AggregateBlocksAsync(TimeSpan duration, bool isWarmup, CancellationTokenSource workerCts)
+    {
+        var reader = _completedBlocks.Reader;
+        var startTime = Stopwatch.GetTimestamp();
+        var endTime = startTime + (long)(duration.TotalSeconds * StopwatchTickPerSecond);
+
+        long totalCompleted = 0;
+        long totalSuccesses = 0;
+        long totalFailures = 0;
+        long minStartTime = long.MaxValue;
+        long maxEndTime = long.MinValue;
+
+        while (Stopwatch.GetTimestamp() < endTime && !_cts.Token.IsCancellationRequested)
+        {
+            try
+            {
+                var readTask = reader.WaitToReadAsync(_cts.Token).AsTask();
+                var completed = await readTask.WaitAsync(TimeSpan.FromMilliseconds(100));
+
+                if (!completed) continue;
+
+                while (reader.TryRead(out var block))
+                {
+                    totalCompleted += block.Completed;
+                    totalSuccesses += block.Successes;
+                    totalFailures += block.Failures;
+                    if (block.StartTimestamp < minStartTime) minStartTime = block.StartTimestamp;
+                    if (block.EndTimestamp > maxEndTime) maxEndTime = block.EndTimestamp;
+                }
+            }
+            catch (TimeoutException)
+            {
+                // Continue waiting
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        // Signal workers to stop
+        workerCts.Cancel();
+
+        // Drain remaining blocks
+        while (reader.TryRead(out var block))
+        {
+            totalCompleted += block.Completed;
+            totalSuccesses += block.Successes;
+            totalFailures += block.Failures;
+            if (block.StartTimestamp < minStartTime) minStartTime = block.StartTimestamp;
+            if (block.EndTimestamp > maxEndTime) maxEndTime = block.EndTimestamp;
+        }
+
+        if (totalCompleted == 0 || maxEndTime <= minStartTime)
+        {
+            return 0;
+        }
+
+        var totalSeconds = (maxEndTime - minStartTime) / StopwatchTickPerSecond;
+        var throughput = totalCompleted / totalSeconds;
+
+        if (isWarmup)
+        {
+            var failureInfo = totalFailures > 0 ? $" ({totalFailures} failures)" : "";
+            Console.WriteLine($"  Warmup: {throughput:N0}/s, {totalCompleted:N0} requests in {totalSeconds:F1}s{failureInfo}");
+        }
+
+        return throughput;
+    }
+
+    private string ApplyHillClimbing(double currentThroughput)
+    {
+        string action;
+        bool isNewBest = currentThroughput > _bestThroughput;
+
+        // Always track the actual best
+        if (isNewBest)
+        {
+            _bestThroughput = currentThroughput;
+            _bestConcurrency = _currentConcurrency;
+            _roundsSinceBestChanged = 0;
+        }
+        else
+        {
+            _roundsSinceBestChanged++;
+        }
+
+        // Determine if this is a meaningful improvement (resets stable count)
+        // or just noise within measurement variance
+        bool meaningfulImprovement = currentThroughput > _lastThroughput * 1.005; // 0.5% threshold
+
+        if (meaningfulImprovement)
+        {
+            _stableCount = 0;
+
+            // Continue in the same direction
+            var newConcurrency = _currentConcurrency + (_direction * _stepSize);
+            newConcurrency = Math.Clamp(newConcurrency, _minConcurrency, _maxConcurrency);
+
+            if (newConcurrency != _currentConcurrency)
+            {
+                _currentConcurrency = newConcurrency;
+                action = isNewBest ? $"New best! {_direction * _stepSize:+#;-#;0}" : $"Improving {_direction * _stepSize:+#;-#;0}";
+            }
+            else
+            {
+                // Hit boundary, reverse direction
+                _direction = -_direction;
+                action = "Hit boundary";
+            }
+        }
+        else
+        {
+            _stableCount++;
+
+            if (_stableCount >= StableThreshold)
+            {
+                // No improvement for a while
+                _stableCount = 0;
+
+                if (_stepSize > 1)
+                {
+                    // Reduce step size for finer tuning
+                    _stepSize = Math.Max(1, _stepSize / 2);
+                    _direction = -_direction; // Try the other direction with smaller steps
+                    action = $"Refine step={_stepSize}";
+                }
+                else
+                {
+                    // At minimum step, jump back toward best and try again
+                    _direction = _bestConcurrency > _currentConcurrency ? 1 : -1;
+                    _stepSize = Math.Max(1, Math.Abs(_currentConcurrency - _bestConcurrency) / 2);
+                    if (_stepSize < 1) _stepSize = Math.Max(1, _bestConcurrency / 10);
+                    action = $"Reset toward best";
+                }
+
+                var newConcurrency = _currentConcurrency + (_direction * _stepSize);
+                newConcurrency = Math.Clamp(newConcurrency, _minConcurrency, _maxConcurrency);
+                _currentConcurrency = newConcurrency;
+            }
+            else
+            {
+                // Continue probing in current direction
+                var newConcurrency = _currentConcurrency + (_direction * _stepSize);
+                newConcurrency = Math.Clamp(newConcurrency, _minConcurrency, _maxConcurrency);
+
+                if (newConcurrency == _currentConcurrency)
+                {
+                    // Hit boundary, reverse
+                    _direction = -_direction;
+                    newConcurrency = _currentConcurrency + (_direction * _stepSize);
+                    newConcurrency = Math.Clamp(newConcurrency, _minConcurrency, _maxConcurrency);
+                    action = "Boundary, reverse";
+                }
+                else
+                {
+                    action = $"Probing ({_stableCount}/{StableThreshold})";
+                }
+
+                _currentConcurrency = newConcurrency;
+            }
+        }
+
+        _lastThroughput = currentThroughput;
+        return action;
+    }
+
+    private async Task RunWorkerAsync(TState state, int workerId, CancellationToken cancellationToken)
+    {
+        var writer = _completedBlocks.Writer;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var workBlock = new WorkBlock { StartTimestamp = Stopwatch.GetTimestamp() };
+
+            while (workBlock.Completed < _requestsPerBlock && !cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await _issueRequest(state).ConfigureAwait(false);
+                    workBlock.Successes++;
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch
+                {
+                    workBlock.Failures++;
+                }
+            }
+
+            workBlock.EndTimestamp = Stopwatch.GetTimestamp();
+
+            if (workBlock.Completed > 0)
+            {
+                try
+                {
+                    await writer.WriteAsync(workBlock, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (ChannelClosedException)
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+    private struct WorkBlock
+    {
+        public long StartTimestamp;
+        public long EndTimestamp;
+        public int Successes;
+        public int Failures;
+        public readonly int Completed => Successes + Failures;
+    }
+}

--- a/test/Benchmarks/Ping/AdaptivePingBenchmark.cs
+++ b/test/Benchmarks/Ping/AdaptivePingBenchmark.cs
@@ -1,0 +1,260 @@
+using System.Net;
+using BenchmarkGrainInterfaces.Ping;
+using BenchmarkGrains.Ping;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.Configuration;
+
+namespace Benchmarks.Ping;
+
+/// <summary>
+/// Benchmark that runs indefinitely and uses hill climbing to tune concurrency
+/// for maximum throughput. Useful for finding optimal concurrency levels and
+/// for long-running performance testing.
+/// </summary>
+public class AdaptivePingBenchmark : IDisposable
+{
+    public enum BenchmarkMode
+    {
+        /// <summary>Client runs inside the silo process (lowest latency)</summary>
+        HostedClient,
+        /// <summary>External client connects to silo(s)</summary>
+        ExternalClient,
+        /// <summary>Calls go from one silo to another (tests cross-silo performance)</summary>
+        SiloToSilo
+    }
+
+    private readonly List<IHost> _hosts = new();
+    private readonly IHost _clientHost;
+    private readonly IClusterClient _client;
+    private readonly BenchmarkMode _mode;
+    private readonly int _numSilos;
+    private readonly CancellationTokenSource _cts = new();
+
+    public string Description { get; }
+    public int BestConcurrency { get; private set; }
+    public double BestThroughput { get; private set; }
+
+    public AdaptivePingBenchmark(BenchmarkMode mode = BenchmarkMode.HostedClient, int numSilos = 1)
+    {
+        _mode = mode;
+        _numSilos = numSilos;
+
+        // Determine configuration based on mode
+        bool startClient = mode == BenchmarkMode.ExternalClient;
+        bool grainsOnSecondariesOnly = mode == BenchmarkMode.SiloToSilo;
+
+        if (mode == BenchmarkMode.SiloToSilo && numSilos < 2)
+        {
+            numSilos = 2;
+            _numSilos = 2;
+        }
+
+        Description = mode switch
+        {
+            BenchmarkMode.HostedClient => "Hosted Client",
+            BenchmarkMode.ExternalClient when numSilos == 1 => "Client to Silo",
+            BenchmarkMode.ExternalClient => $"Client to {numSilos} Silos",
+            BenchmarkMode.SiloToSilo => "Silo to Silo",
+            _ => mode.ToString()
+        };
+
+        // Start silos
+        for (int i = 0; i < numSilos; i++)
+        {
+            var primary = i == 0 ? null : new IPEndPoint(IPAddress.Loopback, 11111);
+            var hostBuilder = new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+            {
+                siloBuilder.UseLocalhostClustering(
+                    siloPort: 11111 + i,
+                    gatewayPort: 30000 + i,
+                    primarySiloEndpoint: primary);
+
+                // For SiloToSilo mode: remove grains from primary silo to force cross-silo calls
+                if (i == 0 && grainsOnSecondariesOnly)
+                {
+                    siloBuilder.Configure<GrainTypeOptions>(options => options.Classes.Remove(typeof(PingGrain)));
+                }
+            });
+
+            var host = hostBuilder.Build();
+            host.StartAsync().GetAwaiter().GetResult();
+            _hosts.Add(host);
+        }
+
+        // Wait for cluster to stabilize in multi-silo mode
+        if (numSilos > 1)
+        {
+            Thread.Sleep(4000);
+        }
+
+        // Start external client if needed
+        if (startClient)
+        {
+            var hostBuilder = new HostBuilder().UseOrleansClient((ctx, clientBuilder) =>
+            {
+                if (numSilos == 1)
+                {
+                    clientBuilder.UseLocalhostClustering();
+                }
+                else
+                {
+                    var gateways = Enumerable.Range(30000, numSilos)
+                        .Select(i => new IPEndPoint(IPAddress.Loopback, i))
+                        .ToArray();
+                    clientBuilder.UseStaticClustering(gateways);
+                }
+            });
+
+            _clientHost = hostBuilder.Build();
+            _clientHost.StartAsync().GetAwaiter().GetResult();
+            _client = _clientHost.Services.GetRequiredService<IClusterClient>();
+
+            // Warm up the client connection
+            var grain = _client.GetGrain<IPingGrain>(0);
+            grain.Run().AsTask().GetAwaiter().GetResult();
+        }
+
+        // Wire up Ctrl+C to cancel
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            Console.WriteLine("\nShutdown requested...");
+            _cts.Cancel();
+        };
+    }
+
+    /// <summary>
+    /// Gets the grain factory based on the current mode.
+    /// </summary>
+    private IGrainFactory GetGrainFactory()
+    {
+        return _mode == BenchmarkMode.ExternalClient
+            ? _client
+            : _hosts[0].Services.GetRequiredService<IGrainFactory>();
+    }
+
+    /// <summary>
+    /// Runs the adaptive benchmark, tuning concurrency via hill climbing.
+    /// Terminates after maxStableRounds without improvement (default 10), or runs forever if 0.
+    /// </summary>
+    public async Task RunAsync(
+        int initialConcurrency = 100,
+        int minConcurrency = 1,
+        int maxConcurrency = 2000,
+        TimeSpan? warmupDuration = null,
+        TimeSpan? measurementInterval = null,
+        int maxStableRounds = 10)
+    {
+        var grainFactory = GetGrainFactory();
+
+        Console.WriteLine($"=== Adaptive Ping Benchmark: {Description} ===");
+        Console.WriteLine();
+
+        var loadGenerator = new AdaptiveConcurrencyLoadGenerator<IPingGrain>(
+            issueRequest: g => g.Run(),
+            getStateForWorker: workerId => grainFactory.GetGrain<IPingGrain>(workerId),
+            requestsPerBlock: 500,
+            warmupDuration: warmupDuration ?? TimeSpan.FromSeconds(5),
+            measurementInterval: measurementInterval ?? TimeSpan.FromSeconds(5),
+            minConcurrency: minConcurrency,
+            maxConcurrency: maxConcurrency,
+            initialConcurrency: initialConcurrency,
+            maxStableRounds: maxStableRounds);
+
+        try
+        {
+            await loadGenerator.RunForeverAsync(_cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on Ctrl+C
+        }
+
+        BestConcurrency = loadGenerator.BestConcurrency;
+        BestThroughput = loadGenerator.BestThroughput;
+
+        Console.WriteLine($"\nFinal best: {BestConcurrency} concurrency @ {BestThroughput:N0}/s");
+    }
+
+    public async Task ShutdownAsync()
+    {
+        if (_clientHost != null)
+        {
+            await _clientHost.StopAsync();
+            if (_clientHost is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync();
+            else
+                _clientHost.Dispose();
+        }
+
+        _hosts.Reverse();
+        foreach (var host in _hosts)
+        {
+            await host.StopAsync();
+            if (host is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync();
+            else
+                host.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Dispose();
+        (_client as IDisposable)?.Dispose();
+        _hosts.ForEach(h => h.Dispose());
+    }
+
+    /// <summary>
+    /// Runs all adaptive ping benchmark scenarios and prints a summary.
+    /// </summary>
+    public static async Task RunAllScenariosAsync(int maxStableRounds = 10)
+    {
+        var results = new List<(string Description, int BestConcurrency, double BestThroughput)>();
+
+        var scenarios = new (BenchmarkMode Mode, int NumSilos)[]
+        {
+            (BenchmarkMode.HostedClient, 1),
+            (BenchmarkMode.ExternalClient, 1),
+            (BenchmarkMode.ExternalClient, 2),
+            (BenchmarkMode.SiloToSilo, 2),
+        };
+
+        foreach (var (mode, numSilos) in scenarios)
+        {
+            var benchmark = new AdaptivePingBenchmark(mode, numSilos);
+            try
+            {
+                await benchmark.RunAsync(maxStableRounds: maxStableRounds);
+                results.Add((benchmark.Description, benchmark.BestConcurrency, benchmark.BestThroughput));
+            }
+            finally
+            {
+                await benchmark.ShutdownAsync();
+                benchmark.Dispose();
+            }
+
+            Console.WriteLine();
+            Console.WriteLine(new string('=', 82));
+            Console.WriteLine();
+
+            GC.Collect();
+            await Task.Delay(1000); // Brief pause between scenarios
+        }
+
+        // Print summary in GitHub-flavored markdown table format
+        Console.WriteLine();
+        Console.WriteLine("## Adaptive Ping Benchmark Results");
+        Console.WriteLine();
+        Console.WriteLine("| Scenario | Best Concurrency | Best Throughput |");
+        Console.WriteLine("|----------|------------------|-----------------|");
+
+        foreach (var (description, bestConcurrency, bestThroughput) in results)
+        {
+            Console.WriteLine($"| {description} | {bestConcurrency} | {bestThroughput:N0}/s |");
+        }
+
+        Console.WriteLine();
+    }
+}

--- a/test/Benchmarks/Ping/PingBenchmark.cs
+++ b/test/Benchmarks/Ping/PingBenchmark.cs
@@ -99,19 +99,19 @@ public class PingBenchmark : IDisposable
         blocksPerWorker: 10);
 
     public Task PingConcurrent() => this.Run(
-        runs: 3,
+        runs: 10,
         grainFactory: this.client,
         blocksPerWorker: 10);
 
     public Task PingConcurrentHostedClient(int blocksPerWorker = 30) => this.Run(
-        runs: 3,
+        runs: 10,
         grainFactory: (IGrainFactory)this.hosts[0].Services.GetService(typeof(IGrainFactory)),
         blocksPerWorker: blocksPerWorker);
 
     private async Task Run(int runs, IGrainFactory grainFactory, int blocksPerWorker)
     {
         var loadGenerator = new ConcurrentLoadGenerator<IPingGrain>(
-            maxConcurrency: 250,
+            maxConcurrency: 100,
             blocksPerWorker: blocksPerWorker,
             requestsPerBlock: 500,
             issueRequest: g => g.Run(),

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -190,6 +190,41 @@ internal class Program
         {
             new PingBenchmark(numSilos: 2, startClient: false, grainsOnSecondariesOnly: true).PingConcurrentHostedClient(blocksPerWorker: 1000).GetAwaiter().GetResult();
         },
+        ["AdaptivePing"] = _ =>
+        {
+            // Default: HostedClient mode with hill climbing concurrency tuning
+            var benchmark = new AdaptivePingBenchmark(AdaptivePingBenchmark.BenchmarkMode.HostedClient);
+            benchmark.RunAsync().GetAwaiter().GetResult();
+            benchmark.ShutdownAsync().GetAwaiter().GetResult();
+        },
+        ["AdaptivePing_HostedClient"] = _ =>
+        {
+            var benchmark = new AdaptivePingBenchmark(AdaptivePingBenchmark.BenchmarkMode.HostedClient);
+            benchmark.RunAsync().GetAwaiter().GetResult();
+            benchmark.ShutdownAsync().GetAwaiter().GetResult();
+        },
+        ["AdaptivePing_ClientToOneSilo"] = _ =>
+        {
+            var benchmark = new AdaptivePingBenchmark(AdaptivePingBenchmark.BenchmarkMode.ExternalClient, numSilos: 1);
+            benchmark.RunAsync().GetAwaiter().GetResult();
+            benchmark.ShutdownAsync().GetAwaiter().GetResult();
+        },
+        ["AdaptivePing_ClientToTwoSilos"] = _ =>
+        {
+            var benchmark = new AdaptivePingBenchmark(AdaptivePingBenchmark.BenchmarkMode.ExternalClient, numSilos: 2);
+            benchmark.RunAsync().GetAwaiter().GetResult();
+            benchmark.ShutdownAsync().GetAwaiter().GetResult();
+        },
+        ["AdaptivePing_SiloToSilo"] = _ =>
+        {
+            var benchmark = new AdaptivePingBenchmark(AdaptivePingBenchmark.BenchmarkMode.SiloToSilo, numSilos: 2);
+            benchmark.RunAsync().GetAwaiter().GetResult();
+            benchmark.ShutdownAsync().GetAwaiter().GetResult();
+        },
+        ["AdaptivePing_All"] = _ =>
+        {
+            AdaptivePingBenchmark.RunAllScenariosAsync().GetAwaiter().GetResult();
+        },
         ["ConcurrentPing_OneSilo_Forever"] = _ =>
         {
             new PingBenchmark(numSilos: 1, startClient: true).PingConcurrentForever().GetAwaiter().GetResult();


### PR DESCRIPTION
## Summary
- Adds the AdaptivePing benchmark and hill-climbing concurrency load generator.
- Adds AdaptivePing command entries for hosted-client, external-client, silo-to-silo, and all-scenario runs.
- Adjusts the existing concurrent ping benchmark to run 10 iterations with a max concurrency of 100.

## Validation
- `git diff --check HEAD~1 HEAD`
- conflict-marker scan
- `dotnet build test\Benchmarks\Benchmarks.csproj -m --no-restore --tl:off -v:minimal`
- Smoke-tested `AdaptivePing` HostedClient successfully

## Notes
- Multi-silo/all scenarios were not smoke-tested.
- Benchmark results can be noisy because the hill-climbing algorithm is timing-sensitive.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10069)
