### PR TITLE
perf(messaging): add ref-counted message pooling

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/MessagingInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/MessagingInstruments.cs
@@ -91,20 +91,20 @@ namespace Orleans.Runtime
 
         internal void OnFailedSentMessage(Message? msg)
         {
-            if (msg == null || !msg.HasDirection) return;
-            FailedSentMessagesCounter.Add(1, new KeyValuePair<string, object?>("Direction", msg.Direction.ToString()));
+            if (msg is not { } message || !message.HasDirection) return;
+            FailedSentMessagesCounter.Add(1, new KeyValuePair<string, object?>("Direction", message.Direction.ToString()));
         }
 
         internal void OnDroppedSentMessage(Message? msg)
         {
-            if (msg == null || !msg.HasDirection) return;
-            DroppedSentMessagesCounter.Add(1, new KeyValuePair<string, object?>("Direction", msg.Direction.ToString()));
+            if (msg is not { } message || !message.HasDirection) return;
+            DroppedSentMessagesCounter.Add(1, new KeyValuePair<string, object?>("Direction", message.Direction.ToString()));
         }
 
         internal void OnRejectedMessage(Message? msg)
         {
-            if (msg == null || !msg.HasDirection) return;
-            RejectedMessagesCounter.Add(1, new KeyValuePair<string, object?>("Direction", msg.Direction.ToString()));
+            if (msg is not { } message || !message.HasDirection) return;
+            RejectedMessagesCounter.Add(1, new KeyValuePair<string, object?>("Direction", message.Direction.ToString()));
         }
 
         internal void OnMessageReRoute(Message msg)

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -370,6 +370,7 @@ namespace Orleans.Messaging
             if (msg.Direction != Message.Directions.Request)
             {
                 LogDroppingMessage(msg, reason);
+                msg.ReleaseDropped("DroppedNonRequest");
             }
             else
             {
@@ -377,6 +378,7 @@ namespace Orleans.Messaging
                 MessagingInstruments.OnRejectedMessage(msg);
                 var error = this.messageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable, reason, exc);
                 DispatchLocalMessage(error);
+                msg.ReleaseDropped("RejectedRequest");
             }
         }
 

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -177,6 +177,7 @@ namespace Orleans.Messaging
             if (!Running)
             {
                 LogNotRunning(msg);
+                msg.ReleaseDropped("ClientMessageCenterNotRunning");
                 return;
             }
 
@@ -368,11 +369,16 @@ namespace Orleans.Messaging
 
         public void RejectMessage(Message msg, string reason, Exception? exc = null)
         {
-            if (!Running) return;
+            if (!Running)
+            {
+                msg.ReleaseDropped("ClientMessageCenterNotRunning");
+                return;
+            }
 
             if (msg.Direction != Message.Directions.Request)
             {
                 LogDroppingMessage(msg, reason);
+                msg.ReleaseDropped("DroppedNonRequest");
             }
             else
             {
@@ -380,6 +386,7 @@ namespace Orleans.Messaging
                 _messagingInstruments.OnRejectedMessage(msg);
                 var error = this.messageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable, reason, exc);
                 DispatchLocalMessage(error);
+                msg.ReleaseDropped("RejectedRequest");
             }
         }
 

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -255,8 +255,8 @@ namespace Orleans.Messaging
                 int numGateways = gatewayAddresses.Count;
                 if (numGateways == 0)
                 {
-                    RejectMessage(msg, "No gateways available");
                     LogSendFailed(msg, gatewayManager);
+                    RejectMessage(msg, "No gateways available");
                     return new ValueTask<Connection?>(default(Connection));
                 }
 
@@ -289,8 +289,8 @@ namespace Orleans.Messaging
             var addr = gatewayManager.GetLiveGateway();
             if (addr == null)
             {
-                RejectMessage(msg, "No gateways available");
                 LogNoGatewayAvailableForMessage(msg, gatewayManager);
+                RejectMessage(msg, "No gateways available");
                 return new ValueTask<Connection?>(default(Connection));
             }
 

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -187,8 +187,8 @@ namespace Orleans.Messaging
                 var connection = connectionTask.Result;
                 if (connection is null) return;
 
-                connection.Send(msg);
                 LogSendingMessage(msg, connection.RemoteEndPoint);
+                connection.Send(msg);
             }
             else
             {
@@ -203,9 +203,8 @@ namespace Orleans.Messaging
                         // If the connection returned is null then the message was already rejected due to a failure.
                         if (connection is null) return;
 
-                        connection.Send(message);
-
                         LogSendingMessage(message, connection.RemoteEndPoint);
+                        connection.Send(message);
                     }
                     catch (Exception exception)
                     {

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -424,7 +424,7 @@ namespace Orleans.Messaging
             Level = LogLevel.Trace,
             Message = "Sending message {Message} via gateway '{Gateway}'."
         )]
-        private partial void LogSendingMessage(Message message, EndPoint gateway);
+        private partial void LogSendingMessage(Message message, EndPoint? gateway);
 
         [LoggerMessage(
             Level = LogLevel.Trace,

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -14,6 +15,14 @@ namespace Orleans.Runtime
 
         [NonSerialized]
         private short _retryCount;
+
+        [NonSerialized]
+        private int _refCount;
+
+#if DEBUG
+        [NonSerialized]
+        private string? _lastTransferTag;
+#endif
 
         public CoarseStopwatch _timeToExpiry;
 
@@ -303,6 +312,73 @@ namespace Orleans.Runtime
             }
         }
 
+        internal void InitializeRefCount()
+        {
+            // Messages are acquired once when checked out from the pool.
+            // Additional owners must call Acquire() and Release().
+            _refCount = 1;
+#if DEBUG
+            _lastTransferTag = null;
+#endif
+        }
+
+        internal void Acquire()
+        {
+            var newRefCount = Interlocked.Increment(ref _refCount);
+            Debug.Assert(newRefCount > 1);
+        }
+
+        internal void Release()
+        {
+            var newRefCount = Interlocked.Decrement(ref _refCount);
+            if (newRefCount == 0)
+            {
+                MessagePool.ReturnCore(this);
+            }
+            else if (newRefCount < 0)
+            {
+                // Ref count should never go negative - indicates a double release.
+#if DEBUG
+                Debug.Fail($"Message ref count went negative. Last transfer tag: '{_lastTransferTag}'");
+#else
+                Debug.Fail("Message ref count went negative.");
+#endif
+            }
+        }
+
+        [Conditional("DEBUG")]
+        internal void MarkTransferred(string tag)
+        {
+#if DEBUG
+            _lastTransferTag = tag;
+#endif
+        }
+
+        /// <summary>
+        /// Releases this message after it has been dropped (expired, rejected, blocked, etc).
+        /// Marks the transfer for debugging and releases the reference.
+        /// </summary>
+        /// <param name="reason">A short description of why the message was dropped.</param>
+        internal void ReleaseDropped(string reason)
+        {
+            MarkTransferred($"Dropped:{reason}");
+            Release();
+        }
+
+        /// <summary>
+        /// Asserts that this message has not been released (refcount > 0).
+        /// Only executes in DEBUG builds.
+        /// </summary>
+        [Conditional("DEBUG")]
+        internal void AssertNotReleased([System.Runtime.CompilerServices.CallerMemberName] string? caller = null)
+        {
+#if DEBUG
+            var currentRefCount = Volatile.Read(ref _refCount);
+            Debug.Assert(currentRefCount > 0,
+                $"Message used after release. Caller: {caller}, RefCount: {currentRefCount}, LastTransfer: {_lastTransferTag}");
+#endif
+        }
+
         public override string ToString() => $"{this}";
 
         string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => ToString();
@@ -371,6 +447,31 @@ grow:
 
         internal bool IsPing() => _requestContextData?.TryGetValue(RequestContext.PING_APPLICATION_HEADER, out var value) == true && value is bool isPing && isPing;
 
+        /// <summary>
+        /// Resets the message to its default state for reuse.
+        /// </summary>
+        internal void Reset()
+        {
+            _retryCount = 0;
+            _timeToExpiry = default;
+            BodyObject = null;
+            _headers = default;
+            _id = default;
+            _refCount = 0;
+#if DEBUG
+            _lastTransferTag = null;
+#endif
+
+            _requestContextData = null;
+            _targetSilo = null;
+            _targetGrain = default;
+            _sendingSilo = null;
+            _sendingGrain = default;
+            _interfaceVersion = 0;
+            _interfaceType = default;
+            _cacheInvalidationHeader = null;
+        }
+
         [Flags]
         internal enum MessageFlags : ushort
         {
@@ -386,10 +487,10 @@ grow:
             HasTimeToLive = 1 << 8,
 
             // Message cannot be forwarded to another activation.
-            IsLocalOnly = 1 << 9, 
+            IsLocalOnly = 1 << 9,
 
             // Message must not trigger grain activation or extend an activation's lifetime.
-            SuppressKeepAlive = 1 << 10,  
+            SuppressKeepAlive = 1 << 10,
 
             // The most significant bit is reserved, possibly for use to indicate more data follows.
             Reserved = 1 << 15,

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -574,6 +574,30 @@ grow:
         internal object StateIdentity => GetState();
         internal ulong GenerationForTesting => _generation;
 
+        internal MessageSnapshot CaptureSnapshot()
+        {
+            using var scope = EnterMutation();
+            var state = scope.State;
+            return new(
+                state.Id,
+                state.Headers.Direction,
+                state.Headers.ResponseType,
+                state.SendingSilo,
+                state.SendingGrain,
+                state.TargetSilo,
+                state.TargetGrain,
+                state.InterfaceType,
+                state.InterfaceVersion,
+                state.Headers.ForwardCount,
+                state.RetryCount,
+                state.Headers.HasFlag(MessageFlags.SystemMessage),
+                state.Headers.HasFlag(MessageFlags.ReadOnly),
+                state.Headers.HasFlag(MessageFlags.AlwaysInterleave),
+                state.Headers.HasFlag(MessageFlags.Unordered),
+                state.Headers.HasFlag(MessageFlags.IsLocalOnly),
+                !state.Headers.HasFlag(MessageFlags.SuppressKeepAlive));
+        }
+
         private readonly ref struct MutationScope
         {
             public MutationScope(MessageState state, ulong generation)
@@ -864,4 +888,23 @@ grow:
             };
         }
     }
+
+    internal readonly record struct MessageSnapshot(
+        CorrelationId Id,
+        Message.Directions Direction,
+        Message.ResponseTypes Result,
+        SiloAddress? SendingSilo,
+        GrainId SendingGrain,
+        SiloAddress? TargetSilo,
+        GrainId TargetGrain,
+        GrainInterfaceType InterfaceType,
+        ushort InterfaceVersion,
+        int ForwardCount,
+        short RetryCount,
+        bool IsSystemMessage,
+        bool IsReadOnly,
+        bool IsAlwaysInterleave,
+        bool IsUnordered,
+        bool IsLocalOnly,
+        bool IsKeepAlive);
 }

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -15,6 +16,14 @@ namespace Orleans.Runtime
 
         [NonSerialized]
         private short _retryCount;
+
+        [NonSerialized]
+        private int _refCount;
+
+#if DEBUG
+        [NonSerialized]
+        private string? _lastTransferTag;
+#endif
 
         public CoarseStopwatch _timeToExpiry;
 
@@ -328,6 +337,73 @@ namespace Orleans.Runtime
             return false;
         }
 
+        internal void InitializeRefCount()
+        {
+            // Messages are acquired once when checked out from the pool.
+            // Additional owners must call Acquire() and Release().
+            _refCount = 1;
+#if DEBUG
+            _lastTransferTag = null;
+#endif
+        }
+
+        internal void Acquire()
+        {
+            var newRefCount = Interlocked.Increment(ref _refCount);
+            Debug.Assert(newRefCount > 1);
+        }
+
+        internal void Release()
+        {
+            var newRefCount = Interlocked.Decrement(ref _refCount);
+            if (newRefCount == 0)
+            {
+                MessagePool.ReturnCore(this);
+            }
+            else if (newRefCount < 0)
+            {
+                // Ref count should never go negative - indicates a double release.
+#if DEBUG
+                Debug.Fail($"Message ref count went negative. Last transfer tag: '{_lastTransferTag}'");
+#else
+                Debug.Fail("Message ref count went negative.");
+#endif
+            }
+        }
+
+        [Conditional("DEBUG")]
+        internal void MarkTransferred(string tag)
+        {
+#if DEBUG
+            _lastTransferTag = tag;
+#endif
+        }
+
+        /// <summary>
+        /// Releases this message after it has been dropped (expired, rejected, blocked, etc).
+        /// Marks the transfer for debugging and releases the reference.
+        /// </summary>
+        /// <param name="reason">A short description of why the message was dropped.</param>
+        internal void ReleaseDropped(string reason)
+        {
+            MarkTransferred($"Dropped:{reason}");
+            Release();
+        }
+
+        /// <summary>
+        /// Asserts that this message has not been released (refcount > 0).
+        /// Only executes in DEBUG builds.
+        /// </summary>
+        [Conditional("DEBUG")]
+        internal void AssertNotReleased([System.Runtime.CompilerServices.CallerMemberName] string? caller = null)
+        {
+#if DEBUG
+            var currentRefCount = Volatile.Read(ref _refCount);
+            Debug.Assert(currentRefCount > 0,
+                $"Message used after release. Caller: {caller}, RefCount: {currentRefCount}, LastTransfer: {_lastTransferTag}");
+#endif
+        }
+
         public override string ToString() => $"{this}";
 
         string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => ToString();
@@ -395,6 +471,31 @@ grow:
         }
 
         internal bool IsPing() => _requestContextData?.TryGetValue(RequestContext.PING_APPLICATION_HEADER, out var value) == true && value is bool isPing && isPing;
+
+        /// <summary>
+        /// Resets the message to its default state for reuse.
+        /// </summary>
+        internal void Reset()
+        {
+            _retryCount = 0;
+            _timeToExpiry = default;
+            BodyObject = null;
+            _headers = default;
+            _id = default;
+            _refCount = 0;
+#if DEBUG
+            _lastTransferTag = null;
+#endif
+
+            _requestContextData = null;
+            _targetSilo = null;
+            _targetGrain = default;
+            _sendingSilo = null;
+            _sendingGrain = default;
+            _interfaceVersion = 0;
+            _interfaceType = default;
+            _cacheInvalidationHeader = null;
+        }
 
         [Flags]
         internal enum MessageFlags : ushort

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -7,6 +7,14 @@ using System.Threading;
 
 namespace Orleans.Runtime
 {
+    /// <summary>
+    /// Represents an ownership-counted pooled message.
+    /// </summary>
+    /// <remarks>
+    /// A pooled message begins with one owner. Each additional concurrent owner calls <see cref="Acquire"/>
+    /// and every owner calls <see cref="Release"/> exactly once. The final release resets the instance before
+    /// returning it to the current thread's pool. Owners relinquish their aliases before the final release.
+    /// </remarks>
     [Id(101)]
     internal sealed class Message : ISpanFormattable
     {
@@ -350,7 +358,11 @@ namespace Orleans.Runtime
         internal void Acquire()
         {
             var newRefCount = Interlocked.Increment(ref _refCount);
-            Debug.Assert(newRefCount > 1);
+            if (newRefCount <= 1)
+            {
+                Interlocked.Decrement(ref _refCount);
+                ThrowInvalidOwnershipOperation("Cannot acquire a released message.");
+            }
         }
 
         internal void Release()
@@ -362,12 +374,8 @@ namespace Orleans.Runtime
             }
             else if (newRefCount < 0)
             {
-                // Ref count should never go negative - indicates a double release.
-#if DEBUG
-                Debug.Fail($"Message ref count went negative. Last transfer tag: '{_lastTransferTag}'");
-#else
-                Debug.Fail("Message ref count went negative.");
-#endif
+                Interlocked.Increment(ref _refCount);
+                ThrowInvalidOwnershipOperation("Cannot release a message which has no owner.");
             }
         }
 
@@ -496,6 +504,8 @@ grow:
             _interfaceType = default;
             _cacheInvalidationHeader = null;
         }
+
+        private static void ThrowInvalidOwnershipOperation(string message) => throw new InvalidOperationException(message);
 
         [Flags]
         internal enum MessageFlags : ushort

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -301,6 +301,8 @@ namespace Orleans.Runtime
 
         internal long GetTimeToLiveMilliseconds() => -Read(static state => state.TimeToExpiry).ElapsedMilliseconds;
 
+        internal long GetTimeToExpiryTimestamp() => Read(static state => state.TimeToExpiry).GetRawTimestamp();
+
         internal void SetTimeToLiveMilliseconds(long milliseconds)
         {
             using var mutation = EnterMutation();

--- a/src/Orleans.Core/Messaging/Message.cs
+++ b/src/Orleans.Core/Messaging/Message.cs
@@ -11,49 +11,55 @@ namespace Orleans.Runtime
     /// Represents an ownership-counted pooled message.
     /// </summary>
     /// <remarks>
-    /// A pooled message begins with one owner. Each additional concurrent owner calls <see cref="Acquire"/>
-    /// and every owner calls <see cref="Release"/> exactly once. The final release resets the instance before
-    /// returning it to the current thread's pool. Owners relinquish their aliases before the final release.
+    /// Each checkout carries the backing state's generation. Every access validates that generation, so a handle
+    /// from an earlier checkout cannot observe, mutate, acquire, or release a later checkout. A pooled message begins
+    /// with one owner. Each additional concurrent owner calls <see cref="Acquire"/> and every owner calls
+    /// <see cref="Release"/> exactly once. The final release resets the backing state before returning it to the pool.
     /// </remarks>
     [Id(101)]
-    internal sealed class Message : ISpanFormattable
+    internal readonly struct Message : ISpanFormattable, IEquatable<Message>
     {
         public const int LENGTH_HEADER_SIZE = 8;
         public const int LENGTH_META_HEADER = 4;
         internal const int MaxCacheInvalidationHeaderEntries = 16;
 
-        [NonSerialized]
-        private short _retryCount;
+        private readonly MessageState? _state;
+        private readonly ulong _generation;
 
-        [NonSerialized]
-        private int _refCount;
+        public Message()
+        {
+            _state = new MessageState(isPoolable: false);
+            if (!_state.TryActivate(out _generation))
+            {
+                throw new InvalidOperationException("A newly-created message state could not be activated.");
+            }
+        }
 
-#if DEBUG
-        [NonSerialized]
-        private string? _lastTransferTag;
-#endif
+        internal Message(MessageState state, ulong generation)
+        {
+            _state = state;
+            _generation = generation;
+        }
 
-        public CoarseStopwatch _timeToExpiry;
+        public object? BodyObject
+        {
+            get => Read(static state => state.BodyObject);
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.BodyObject = value;
+            }
+        }
 
-        public object? BodyObject { get; set; }
-
-        public PackedHeaders _headers;
-        public CorrelationId _id;
-
-        public Dictionary<string, object>? _requestContextData;
-
-        public SiloAddress? _targetSilo;
-        public GrainId _targetGrain;
-
-        public SiloAddress? _sendingSilo;
-        public GrainId _sendingGrain;
-
-        public ushort _interfaceVersion;
-        public GrainInterfaceType _interfaceType;
-
-        public List<GrainAddressCacheUpdate>? _cacheInvalidationHeader;
-
-        public PackedHeaders Headers { get => _headers; set => _headers = value; }
+        public PackedHeaders Headers
+        {
+            get => Read(static state => state.Headers);
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.Headers = value;
+            }
+        }
 
         [GenerateSerializer]
         public enum Directions : byte
@@ -87,29 +93,41 @@ namespace Orleans.Runtime
 
         public Directions Direction
         {
-            get => _headers.Direction;
-            set => _headers.Direction = value;
+            get => Read(static state => state.Headers.Direction);
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.Headers.Direction = value;
+            }
         }
 
-        public bool HasDirection => _headers.Direction != Directions.None;
+        public bool HasDirection => Read(static state => state.Headers.Direction) != Directions.None;
 
         public bool IsSenderFullyAddressed => SendingSilo is not null && !SendingGrain.IsDefault;
         public bool IsTargetFullyAddressed => TargetSilo is not null && !TargetGrain.IsDefault;
 
-        public bool IsExpired => _timeToExpiry is { IsDefault: false, ElapsedMilliseconds: > 0 };
+        public bool IsExpired => Read(static state => state.TimeToExpiry) is { IsDefault: false, ElapsedMilliseconds: > 0 };
 
         public short RetryCount
         {
-            get => _retryCount;
-            set => _retryCount = value;
+            get => Read(static state => state.RetryCount);
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.RetryCount = value;
+            }
         }
 
         public bool HasCacheInvalidationHeader => CacheInvalidationHeader is { Count: > 0 };
 
         public bool IsSystemMessage
         {
-            get => _headers.HasFlag(MessageFlags.SystemMessage);
-            set => _headers.SetFlag(MessageFlags.SystemMessage, value);
+            get => Read(static state => state.Headers.HasFlag(MessageFlags.SystemMessage));
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.Headers.SetFlag(MessageFlags.SystemMessage, value);
+            }
         }
 
         /// <summary>
@@ -120,20 +138,32 @@ namespace Orleans.Runtime
         /// </remarks>
         public bool IsReadOnly
         {
-            get => _headers.HasFlag(MessageFlags.ReadOnly);
-            set => _headers.SetFlag(MessageFlags.ReadOnly, value);
+            get => Read(static state => state.Headers.HasFlag(MessageFlags.ReadOnly));
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.Headers.SetFlag(MessageFlags.ReadOnly, value);
+            }
         }
 
         public bool IsAlwaysInterleave
         {
-            get => _headers.HasFlag(MessageFlags.AlwaysInterleave);
-            set => _headers.SetFlag(MessageFlags.AlwaysInterleave, value);
+            get => Read(static state => state.Headers.HasFlag(MessageFlags.AlwaysInterleave));
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.Headers.SetFlag(MessageFlags.AlwaysInterleave, value);
+            }
         }
 
         public bool IsUnordered
         {
-            get => _headers.HasFlag(MessageFlags.Unordered);
-            set => _headers.SetFlag(MessageFlags.Unordered, value);
+            get => Read(static state => state.Headers.HasFlag(MessageFlags.Unordered));
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.Headers.SetFlag(MessageFlags.Unordered, value);
+            }
         }
 
         /// <summary>
@@ -144,8 +174,12 @@ namespace Orleans.Runtime
         /// </remarks>
         public bool IsLocalOnly
         {
-            get => _headers.HasFlag(MessageFlags.IsLocalOnly);
-            set => _headers.SetFlag(MessageFlags.IsLocalOnly, value);
+            get => Read(static state => state.Headers.HasFlag(MessageFlags.IsLocalOnly));
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.Headers.SetFlag(MessageFlags.IsLocalOnly, value);
+            }
         }
 
         /// <summary>
@@ -156,77 +190,102 @@ namespace Orleans.Runtime
         /// </remarks>
         public bool IsKeepAlive
         {
-            get => !_headers.HasFlag(MessageFlags.SuppressKeepAlive);
-            set => _headers.SetFlag(MessageFlags.SuppressKeepAlive, !value);
+            get => !Read(static state => state.Headers.HasFlag(MessageFlags.SuppressKeepAlive));
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.Headers.SetFlag(MessageFlags.SuppressKeepAlive, !value);
+            }
         }
 
         public CorrelationId Id
         {
-            get => _id;
-            set => _id = value;
+            get => Read(static state => state.Id);
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.Id = value;
+            }
         }
 
         public int ForwardCount
         {
-            get => _headers.ForwardCount;
-            set => _headers.ForwardCount = value;
+            get => Read(static state => state.Headers.ForwardCount);
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.Headers.ForwardCount = value;
+            }
         }
 
         public SiloAddress? TargetSilo
         {
-            get => _targetSilo;
+            get => Read(static state => state.TargetSilo);
             set
             {
-                _targetSilo = value;
+                using var mutation = EnterMutation();
+                mutation.State.TargetSilo = value;
             }
         }
 
         public GrainId TargetGrain
         {
-            get => _targetGrain;
+            get => Read(static state => state.TargetGrain);
             set
             {
-                _targetGrain = value;
+                using var mutation = EnterMutation();
+                mutation.State.TargetGrain = value;
             }
         }
 
         public SiloAddress? SendingSilo
         {
-            get => _sendingSilo;
+            get => Read(static state => state.SendingSilo);
             set
             {
-                _sendingSilo = value;
+                using var mutation = EnterMutation();
+                mutation.State.SendingSilo = value;
             }
         }
 
         public GrainId SendingGrain
         {
-            get => _sendingGrain;
+            get => Read(static state => state.SendingGrain);
             set
             {
-                _sendingGrain = value;
+                using var mutation = EnterMutation();
+                mutation.State.SendingGrain = value;
             }
         }
 
         public ushort InterfaceVersion
         {
-            get => _interfaceVersion;
+            get => Read(static state => state.InterfaceVersion);
             set
             {
-                _interfaceVersion = value;
-                _headers.SetFlag(MessageFlags.HasInterfaceVersion, value is not 0);
+                using var mutation = EnterMutation();
+                mutation.State.InterfaceVersion = value;
+                mutation.State.Headers.SetFlag(MessageFlags.HasInterfaceVersion, value is not 0);
             }
         }
 
         public ResponseTypes Result
         {
-            get => _headers.ResponseType;
-            set => _headers.ResponseType = value;
+            get => Read(static state => state.Headers.ResponseType);
+            set
+            {
+                using var mutation = EnterMutation();
+                mutation.State.Headers.ResponseType = value;
+            }
         }
 
         public TimeSpan? TimeToLive
         {
-            get => _timeToExpiry.IsDefault ? null : -_timeToExpiry.Elapsed;
+            get
+            {
+                var stopwatch = Read(static state => state.TimeToExpiry);
+                return stopwatch.IsDefault ? null : -stopwatch.Elapsed;
+            }
             set
             {
                 if (value.HasValue)
@@ -240,47 +299,52 @@ namespace Orleans.Runtime
             }
         }
 
-        internal long GetTimeToLiveMilliseconds() => -_timeToExpiry.ElapsedMilliseconds;
+        internal long GetTimeToLiveMilliseconds() => -Read(static state => state.TimeToExpiry).ElapsedMilliseconds;
 
         internal void SetTimeToLiveMilliseconds(long milliseconds)
         {
-            _headers.SetFlag(MessageFlags.HasTimeToLive, true);
-            _timeToExpiry = CoarseStopwatch.StartNew(-milliseconds);
+            using var mutation = EnterMutation();
+            mutation.State.Headers.SetFlag(MessageFlags.HasTimeToLive, true);
+            mutation.State.TimeToExpiry = CoarseStopwatch.StartNew(-milliseconds);
         }
 
         internal void SetInfiniteTimeToLive()
         {
-            _headers.SetFlag(MessageFlags.HasTimeToLive, false);
-            _timeToExpiry = default;
+            using var mutation = EnterMutation();
+            mutation.State.Headers.SetFlag(MessageFlags.HasTimeToLive, false);
+            mutation.State.TimeToExpiry = default;
         }
 
         public List<GrainAddressCacheUpdate>? CacheInvalidationHeader
         {
-            get => _cacheInvalidationHeader;
+            get => Read(static state => state.CacheInvalidationHeader);
             set
             {
-                _cacheInvalidationHeader = value;
-                _headers.SetFlag(MessageFlags.HasCacheInvalidationHeader, value is not null);
+                using var mutation = EnterMutation();
+                mutation.State.CacheInvalidationHeader = value;
+                mutation.State.Headers.SetFlag(MessageFlags.HasCacheInvalidationHeader, value is not null);
             }
         }
 
         public Dictionary<string, object>? RequestContextData
         {
-            get => _requestContextData;
+            get => Read(static state => state.RequestContextData);
             set
             {
-                _requestContextData = value;
-                _headers.SetFlag(MessageFlags.HasRequestContextData, value is not null);
+                using var mutation = EnterMutation();
+                mutation.State.RequestContextData = value;
+                mutation.State.Headers.SetFlag(MessageFlags.HasRequestContextData, value is not null);
             }
         }
 
         public GrainInterfaceType InterfaceType
         {
-            get => _interfaceType;
+            get => Read(static state => state.InterfaceType);
             set
             {
-                _interfaceType = value;
-                _headers.SetFlag(MessageFlags.HasInterfaceType, !value.IsDefault);
+                using var mutation = EnterMutation();
+                mutation.State.InterfaceType = value;
+                mutation.State.Headers.SetFlag(MessageFlags.HasInterfaceType, !value.IsDefault);
             }
         }
 
@@ -295,12 +359,14 @@ namespace Orleans.Runtime
 
         internal void AddToCacheInvalidationHeader(GrainAddress invalidAddress, GrainAddress? validAddress)
         {
+            using var mutation = EnterMutation();
+            var state = mutation.State;
             var grainAddressCacheUpdate = new GrainAddressCacheUpdate(invalidAddress, validAddress);
-            var cacheInvalidationHeader = _cacheInvalidationHeader;
+            var cacheInvalidationHeader = state.CacheInvalidationHeader;
             if (cacheInvalidationHeader is null)
             {
                 var newList = new List<GrainAddressCacheUpdate> { grainAddressCacheUpdate };
-                if (Interlocked.CompareExchange(ref _cacheInvalidationHeader, newList, null) is { } existingCacheInvalidationHeader)
+                if (Interlocked.CompareExchange(ref state.CacheInvalidationHeader, newList, null) is { } existingCacheInvalidationHeader)
                 {
                     // Another thread initialized it, add to the existing list
                     lock (existingCacheInvalidationHeader)
@@ -310,7 +376,7 @@ namespace Orleans.Runtime
                 }
                 else
                 {
-                    _headers.SetFlag(MessageFlags.HasCacheInvalidationHeader, true);
+                    state.Headers.SetFlag(MessageFlags.HasCacheInvalidationHeader, true);
                 }
             }
             else
@@ -347,35 +413,25 @@ namespace Orleans.Runtime
 
         internal void InitializeRefCount()
         {
-            // Messages are acquired once when checked out from the pool.
-            // Additional owners must call Acquire() and Release().
-            _refCount = 1;
-#if DEBUG
-            _lastTransferTag = null;
-#endif
+            GetStateReference().EnsureInitialized(_generation);
         }
 
         internal void Acquire()
         {
-            var newRefCount = Interlocked.Increment(ref _refCount);
-            if (newRefCount <= 1)
+            if (!GetStateReference().TryAcquire(_generation))
             {
-                Interlocked.Decrement(ref _refCount);
-                ThrowInvalidOwnershipOperation("Cannot acquire a released message.");
+                throw new InvalidOperationException("The message handle refers to an inactive checkout.");
             }
         }
 
+        internal bool TryAcquire() => _state?.TryAcquire(_generation) == true;
+
         internal void Release()
         {
-            var newRefCount = Interlocked.Decrement(ref _refCount);
-            if (newRefCount == 0)
+            var state = GetStateReference();
+            if (state.Release(_generation))
             {
-                MessagePool.ReturnCore(this);
-            }
-            else if (newRefCount < 0)
-            {
-                Interlocked.Increment(ref _refCount);
-                ThrowInvalidOwnershipOperation("Cannot release a message which has no owner.");
+                MessagePool.ReturnCore(this, state);
             }
         }
 
@@ -383,7 +439,8 @@ namespace Orleans.Runtime
         internal void MarkTransferred(string tag)
         {
 #if DEBUG
-            _lastTransferTag = tag;
+            using var mutation = EnterMutation();
+            mutation.State.LastTransferTag = tag;
 #endif
         }
 
@@ -406,11 +463,19 @@ namespace Orleans.Runtime
         internal void AssertNotReleased([System.Runtime.CompilerServices.CallerMemberName] string? caller = null)
         {
 #if DEBUG
-            var currentRefCount = Volatile.Read(ref _refCount);
-            Debug.Assert(currentRefCount > 0,
-                $"Message used after release. Caller: {caller}, RefCount: {currentRefCount}, LastTransfer: {_lastTransferTag}");
+            GetState().AssertActive(_generation, caller);
 #endif
         }
+
+        public bool Equals(Message other) => ReferenceEquals(_state, other._state) && _generation == other._generation;
+
+        public override bool Equals(object? obj) => obj is Message other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(_state is null ? 0 : RuntimeHelpers.GetHashCode(_state), _generation);
+
+        public static bool operator ==(Message left, Message right) => left.Equals(right);
+
+        public static bool operator !=(Message left, Message right) => !left.Equals(right);
 
         public override string ToString() => $"{this}";
 
@@ -478,34 +543,256 @@ grow:
             }
         }
 
-        internal bool IsPing() => _requestContextData?.TryGetValue(RequestContext.PING_APPLICATION_HEADER, out var value) == true && value is bool isPing && isPing;
+        internal bool IsPing() => Read(static state =>
+            state.RequestContextData?.TryGetValue(RequestContext.PING_APPLICATION_HEADER, out var value) == true && value is bool isPing && isPing);
 
-        /// <summary>
-        /// Resets the message to its default state for reuse.
-        /// </summary>
-        internal void Reset()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private T Read<T>(Func<MessageState, T> reader)
         {
-            _retryCount = 0;
-            _timeToExpiry = default;
-            BodyObject = null;
-            _headers = default;
-            _id = default;
-            _refCount = 0;
-#if DEBUG
-            _lastTransferTag = null;
-#endif
-
-            _requestContextData = null;
-            _targetSilo = null;
-            _targetGrain = default;
-            _sendingSilo = null;
-            _sendingGrain = default;
-            _interfaceVersion = 0;
-            _interfaceType = default;
-            _cacheInvalidationHeader = null;
+            var state = GetStateReference();
+            state.ValidateActive(_generation);
+            var result = reader(state);
+            state.ValidateAfterRead(_generation);
+            return result;
         }
 
-        private static void ThrowInvalidOwnershipOperation(string message) => throw new InvalidOperationException(message);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private MessageState GetState()
+        {
+            var state = GetStateReference();
+            state.ValidateActive(_generation);
+            return state;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private MessageState GetStateReference() =>
+            _state ?? throw new InvalidOperationException("The message handle is uninitialized.");
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private MutationScope EnterMutation() => new(GetStateReference(), _generation);
+
+        internal object StateIdentity => GetState();
+        internal ulong GenerationForTesting => _generation;
+
+        private readonly ref struct MutationScope
+        {
+            public MutationScope(MessageState state, ulong generation)
+            {
+                State = state;
+                state.EnterMutation(generation);
+            }
+
+            public MessageState State { get; }
+
+            public void Dispose() => State.ExitMutation();
+        }
+
+        internal sealed class MessageState
+        {
+            private const ulong RefCountMask = ushort.MaxValue;
+            private const ulong MaxGeneration = (1UL << 48) - 1;
+            private readonly bool _isPoolable;
+            private long _ownership;
+            private int _activeMutations;
+
+            public MessageState(bool isPoolable)
+            {
+                _isPoolable = isPoolable;
+            }
+
+            public short RetryCount;
+            public CoarseStopwatch TimeToExpiry;
+            public object? BodyObject;
+            public PackedHeaders Headers;
+            public CorrelationId Id;
+            public Dictionary<string, object>? RequestContextData;
+            public SiloAddress? TargetSilo;
+            public GrainId TargetGrain;
+            public SiloAddress? SendingSilo;
+            public GrainId SendingGrain;
+            public ushort InterfaceVersion;
+            public GrainInterfaceType InterfaceType;
+            public List<GrainAddressCacheUpdate>? CacheInvalidationHeader;
+
+#if DEBUG
+            public string? LastTransferTag;
+#endif
+
+            public bool IsPoolable => _isPoolable;
+            internal uint RefCountForTesting => GetRefCount(Volatile.Read(ref _ownership));
+
+            public bool TryActivate(out ulong generation)
+            {
+                while (true)
+                {
+                    var current = Volatile.Read(ref _ownership);
+                    if (GetRefCount(current) != 0)
+                    {
+                        ThrowInvalidOwnershipOperation("Cannot activate message state which is still owned.");
+                    }
+
+                    if (Volatile.Read(ref _activeMutations) != 0)
+                    {
+                        var spinner = new SpinWait();
+                        do
+                        {
+                            spinner.SpinOnce();
+                        }
+                        while (Volatile.Read(ref _activeMutations) != 0);
+
+                        continue;
+                    }
+
+                    var currentGeneration = GetGeneration(current);
+                    if (currentGeneration == MaxGeneration)
+                    {
+                        generation = 0;
+                        return false;
+                    }
+
+                    generation = currentGeneration + 1;
+                    var updated = Pack(generation, 1);
+                    if (Interlocked.CompareExchange(ref _ownership, updated, current) == current)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            public void EnsureInitialized(ulong generation)
+            {
+                var current = Volatile.Read(ref _ownership);
+                if (GetGeneration(current) != generation || GetRefCount(current) != 1)
+                {
+                    ThrowInvalidOwnershipOperation("The message already has an owner.");
+                }
+            }
+
+            public bool TryAcquire(ulong generation)
+            {
+                while (true)
+                {
+                    var current = Volatile.Read(ref _ownership);
+                    if (GetGeneration(current) != generation || GetRefCount(current) == 0)
+                    {
+                        return false;
+                    }
+
+                    var refCount = GetRefCount(current);
+                    if (refCount == ushort.MaxValue)
+                    {
+                        ThrowInvalidOwnershipOperation("The message has reached its maximum owner count.");
+                    }
+
+                    var updated = Pack(generation, refCount + 1);
+                    if (Interlocked.CompareExchange(ref _ownership, updated, current) == current)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            public bool Release(ulong generation)
+            {
+                while (true)
+                {
+                    var current = Volatile.Read(ref _ownership);
+                    ValidateOwnership(current, generation);
+                    var refCount = GetRefCount(current);
+                    var updated = Pack(generation, refCount - 1);
+                    if (Interlocked.CompareExchange(ref _ownership, updated, current) == current)
+                    {
+                        if (refCount == 1)
+                        {
+                            var spinner = new SpinWait();
+                            while (Volatile.Read(ref _activeMutations) != 0)
+                            {
+                                spinner.SpinOnce();
+                            }
+                        }
+
+                        return refCount == 1;
+                    }
+                }
+            }
+
+            public void EnterMutation(ulong generation)
+            {
+                var ownership = Volatile.Read(ref _ownership);
+                ValidateOwnership(ownership, generation);
+                Interlocked.Increment(ref _activeMutations);
+
+                ownership = Volatile.Read(ref _ownership);
+                if (GetGeneration(ownership) == generation && GetRefCount(ownership) > 0)
+                {
+                    return;
+                }
+
+                Interlocked.Decrement(ref _activeMutations);
+                ThrowInvalidOwnershipOperation("The message handle refers to an inactive checkout.");
+            }
+
+            public void ExitMutation() => Interlocked.Decrement(ref _activeMutations);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void ValidateActive(ulong generation)
+            {
+                ValidateOwnership(Volatile.Read(ref _ownership), generation);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void ValidateAfterRead(ulong generation)
+            {
+                ValidateOwnership(Interlocked.Read(ref _ownership), generation);
+            }
+
+            [Conditional("DEBUG")]
+            public void AssertActive(ulong generation, string? caller)
+            {
+#if DEBUG
+                var ownership = Volatile.Read(ref _ownership);
+                Debug.Assert(
+                    GetGeneration(ownership) == generation && GetRefCount(ownership) > 0,
+                    $"Message used after release. Caller: {caller}, Generation: {generation}, CurrentGeneration: {GetGeneration(ownership)}, RefCount: {GetRefCount(ownership)}, LastTransfer: {LastTransferTag}");
+#endif
+            }
+
+            public void Reset()
+            {
+                RetryCount = 0;
+                TimeToExpiry = default;
+                BodyObject = null;
+                Headers = default;
+                Id = default;
+                RequestContextData = null;
+                TargetSilo = null;
+                TargetGrain = default;
+                SendingSilo = null;
+                SendingGrain = default;
+                InterfaceVersion = 0;
+                InterfaceType = default;
+                CacheInvalidationHeader = null;
+#if DEBUG
+                LastTransferTag = null;
+#endif
+            }
+
+            private static void ValidateOwnership(long ownership, ulong generation)
+            {
+                if (GetGeneration(ownership) != generation || GetRefCount(ownership) == 0)
+                {
+                    ThrowInvalidOwnershipOperation("The message handle refers to an inactive checkout.");
+                }
+            }
+
+            private static long Pack(ulong generation, uint refCount) => unchecked((long)(generation << 16 | refCount));
+
+            private static ulong GetGeneration(long ownership) => (ulong)ownership >> 16;
+
+            private static uint GetRefCount(long ownership) => (uint)((ulong)ownership & RefCountMask);
+
+            private static void ThrowInvalidOwnershipOperation(string message) => throw new InvalidOperationException(message);
+        }
 
         [Flags]
         internal enum MessageFlags : ushort

--- a/src/Orleans.Core/Messaging/MessageFactory.cs
+++ b/src/Orleans.Core/Messaging/MessageFactory.cs
@@ -32,16 +32,14 @@ namespace Orleans.Runtime
 
         public Message CreateMessage(object body, InvokeMethodOptions options)
         {
-            var message = new Message
-            {
-                Direction = (options & InvokeMethodOptions.OneWay) != 0 ? Message.Directions.OneWay : Message.Directions.Request,
-                Id = GetNextCorrelationId(),
-                IsReadOnly = (options & InvokeMethodOptions.ReadOnly) != 0,
-                IsUnordered = (options & InvokeMethodOptions.Unordered) != 0,
-                IsAlwaysInterleave = (options & InvokeMethodOptions.AlwaysInterleave) != 0,
-                BodyObject = body,
-                RequestContextData = RequestContextExtensions.Export(_deepCopier),
-            };
+            var message = MessagePool.Get();
+            message.Direction = (options & InvokeMethodOptions.OneWay) != 0 ? Message.Directions.OneWay : Message.Directions.Request;
+            message.Id = GetNextCorrelationId();
+            message.IsReadOnly = (options & InvokeMethodOptions.ReadOnly) != 0;
+            message.IsUnordered = (options & InvokeMethodOptions.Unordered) != 0;
+            message.IsAlwaysInterleave = (options & InvokeMethodOptions.AlwaysInterleave) != 0;
+            message.BodyObject = body;
+            message.RequestContextData = RequestContextExtensions.Export(_deepCopier);
 
             _messagingTrace.OnCreateMessage(message);
             return message;
@@ -55,21 +53,19 @@ namespace Orleans.Runtime
 
         public Message CreateResponseMessage(Message request)
         {
-            var response = new Message
-            {
-                IsSystemMessage = request.IsSystemMessage,
-                Direction = Message.Directions.Response,
-                Id = request.Id,
-                IsReadOnly = request.IsReadOnly,
-                IsAlwaysInterleave = request.IsAlwaysInterleave,
-                TargetSilo = request.SendingSilo,
-                TargetGrain = request.SendingGrain,
-                SendingSilo = request.TargetSilo,
-                SendingGrain = request.TargetGrain,
-                CacheInvalidationHeader = request.CacheInvalidationHeader,
-                TimeToLive = request.TimeToLive,
-                RequestContextData = RequestContextExtensions.Export(_deepCopier),
-            };
+            var response = MessagePool.Get();
+            response.IsSystemMessage = request.IsSystemMessage;
+            response.Direction = Message.Directions.Response;
+            response.Id = request.Id;
+            response.IsReadOnly = request.IsReadOnly;
+            response.IsAlwaysInterleave = request.IsAlwaysInterleave;
+            response.TargetSilo = request.SendingSilo;
+            response.TargetGrain = request.SendingGrain;
+            response.SendingSilo = request.TargetSilo;
+            response.SendingGrain = request.TargetGrain;
+            response.CacheInvalidationHeader = request.CacheInvalidationHeader;
+            response.TimeToLive = request.TimeToLive;
+            response.RequestContextData = RequestContextExtensions.Export(_deepCopier);
 
             _messagingTrace.OnCreateMessage(response);
             return response;

--- a/src/Orleans.Core/Messaging/MessageFactory.cs
+++ b/src/Orleans.Core/Messaging/MessageFactory.cs
@@ -29,18 +29,24 @@ namespace Orleans.Runtime
 
         public Message CreateMessage(object? body, InvokeMethodOptions options)
         {
-            var message = new Message
+            var message = MessagePool.Get();
+            try
             {
-                Direction = (options & InvokeMethodOptions.OneWay) != 0 ? Message.Directions.OneWay : Message.Directions.Request,
-                Id = GetNextCorrelationId(),
-                IsReadOnly = (options & InvokeMethodOptions.ReadOnly) != 0,
-                IsUnordered = (options & InvokeMethodOptions.Unordered) != 0,
-                IsAlwaysInterleave = (options & InvokeMethodOptions.AlwaysInterleave) != 0,
-                BodyObject = body,
-                RequestContextData = RequestContextExtensions.Export(_deepCopier),
-            };
+                message.Direction = (options & InvokeMethodOptions.OneWay) != 0 ? Message.Directions.OneWay : Message.Directions.Request;
+                message.Id = GetNextCorrelationId();
+                message.IsReadOnly = (options & InvokeMethodOptions.ReadOnly) != 0;
+                message.IsUnordered = (options & InvokeMethodOptions.Unordered) != 0;
+                message.IsAlwaysInterleave = (options & InvokeMethodOptions.AlwaysInterleave) != 0;
+                message.BodyObject = body;
+                message.RequestContextData = RequestContextExtensions.Export(_deepCopier);
 
-            return message;
+                return message;
+            }
+            catch
+            {
+                message.ReleaseDropped("MessageCreationFailed");
+                throw;
+            }
         }
 
         private CorrelationId GetNextCorrelationId()
@@ -51,23 +57,29 @@ namespace Orleans.Runtime
 
         public Message CreateResponseMessage(Message request)
         {
-            var response = new Message
+            var response = MessagePool.Get();
+            try
             {
-                IsSystemMessage = request.IsSystemMessage,
-                Direction = Message.Directions.Response,
-                Id = request.Id,
-                IsReadOnly = request.IsReadOnly,
-                IsAlwaysInterleave = request.IsAlwaysInterleave,
-                TargetSilo = request.SendingSilo,
-                TargetGrain = request.SendingGrain,
-                SendingSilo = request.TargetSilo,
-                SendingGrain = request.TargetGrain,
-                CacheInvalidationHeader = request.CacheInvalidationHeader,
-                TimeToLive = request.TimeToLive,
-                RequestContextData = RequestContextExtensions.Export(_deepCopier),
-            };
+                response.IsSystemMessage = request.IsSystemMessage;
+                response.Direction = Message.Directions.Response;
+                response.Id = request.Id;
+                response.IsReadOnly = request.IsReadOnly;
+                response.IsAlwaysInterleave = request.IsAlwaysInterleave;
+                response.TargetSilo = request.SendingSilo;
+                response.TargetGrain = request.SendingGrain;
+                response.SendingSilo = request.TargetSilo;
+                response.SendingGrain = request.TargetGrain;
+                response.CacheInvalidationHeader = request.CacheInvalidationHeader;
+                response.TimeToLive = request.TimeToLive;
+                response.RequestContextData = RequestContextExtensions.Export(_deepCopier);
 
-            return response;
+                return response;
+            }
+            catch
+            {
+                response.ReleaseDropped("ResponseMessageCreationFailed");
+                throw;
+            }
         }
 
         public Message CreateRejectionResponse(Message request, Message.RejectionTypes type, string info, Exception? ex = null)

--- a/src/Orleans.Core/Messaging/MessagePool.cs
+++ b/src/Orleans.Core/Messaging/MessagePool.cs
@@ -1,0 +1,120 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Orleans.Runtime
+{
+    /// <summary>
+    /// A thread-local object pool for <see cref="Message"/> instances.
+    /// </summary>
+    internal static class MessagePool
+    {
+        private static readonly ThreadLocal<Stack<Message>> _messages = new(() => new());
+
+#if DEBUG
+        /// <summary>
+        /// Tracks all messages that have been allocated but not returned to the pool.
+        /// Only available in DEBUG builds. Must be enabled via <see cref="EnableLeakTracking"/>.
+        /// </summary>
+        private static readonly ConcurrentDictionary<Message, MessageAllocationInfo> _outstandingMessages = new();
+
+        /// <summary>
+        /// When true, tracks all message allocations for leak detection.
+        /// Only available in DEBUG builds.
+        /// </summary>
+        public static bool EnableLeakTracking { get; set; }
+
+        /// <summary>
+        /// Gets all messages that have been allocated but not returned to the pool.
+        /// Only available in DEBUG builds and when <see cref="EnableLeakTracking"/> is true.
+        /// </summary>
+        public static IReadOnlyCollection<MessageAllocationInfo> GetOutstandingMessages()
+        {
+            return _outstandingMessages.Values.ToArray();
+        }
+
+        /// <summary>
+        /// Clears the outstanding messages tracking. Call this at the start of a test.
+        /// </summary>
+        public static void ClearLeakTracking()
+        {
+            _outstandingMessages.Clear();
+        }
+
+        /// <summary>
+        /// Information about a message allocation for leak tracking.
+        /// </summary>
+        public sealed class MessageAllocationInfo
+        {
+            public Message Message { get; }
+            public string AllocationStack { get; }
+            public DateTime AllocationTime { get; }
+
+            public MessageAllocationInfo(Message message, string allocationStack)
+            {
+                Message = message;
+                AllocationStack = allocationStack;
+                AllocationTime = DateTime.UtcNow;
+            }
+
+            public override string ToString() =>
+                $"Message allocated at {AllocationTime:HH:mm:ss.fff}, Direction={Message.Direction}, Id={Message.Id}\nStack:\n{AllocationStack}";
+        }
+#endif
+
+        /// <summary>
+        /// The maximum number of messages to keep per thread.
+        /// </summary>
+        public static int MaxPoolSizePerThread { get; set; } = 128;
+
+        /// <summary>
+        /// Gets a message from the pool, or creates a new one if the pool is empty.
+        /// </summary>
+        public static Message Get()
+        {
+            var stack = _messages.Value!;
+            if (!stack.TryPop(out var message))
+            {
+                message = new Message();
+            }
+
+            message.InitializeRefCount();
+
+#if DEBUG
+            if (EnableLeakTracking)
+            {
+                var info = new MessageAllocationInfo(message, Environment.StackTrace);
+                _outstandingMessages[message] = info;
+            }
+#endif
+
+            return message;
+        }
+
+        /// <summary>
+        /// Returns a message to the pool after resetting it.
+        /// </summary>
+        public static void Return(Message message) => message.Release();
+
+        internal static void ReturnCore(Message message)
+        {
+#if DEBUG
+            if (EnableLeakTracking)
+            {
+                _outstandingMessages.TryRemove(message, out _);
+            }
+#endif
+
+            message.Reset();
+
+            var stack = _messages.Value!;
+            if (stack.Count < MaxPoolSizePerThread)
+            {
+                stack.Push(message);
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/Messaging/MessagePool.cs
+++ b/src/Orleans.Core/Messaging/MessagePool.cs
@@ -116,4 +116,8 @@ internal static class MessagePool
             stack.Push(message);
         }
     }
+
+    internal static int GetCachedMessageCount() => _messages.Value!.Count;
+
+    internal static void ClearCurrentThreadPool() => _messages.Value!.Clear();
 }

--- a/src/Orleans.Core/Messaging/MessagePool.cs
+++ b/src/Orleans.Core/Messaging/MessagePool.cs
@@ -1,0 +1,119 @@
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Orleans.Runtime;
+
+/// <summary>
+/// A thread-local object pool for <see cref="Message"/> instances.
+/// </summary>
+internal static class MessagePool
+{
+    private static readonly ThreadLocal<Stack<Message>> _messages = new(() => new());
+
+#if DEBUG
+    /// <summary>
+    /// Tracks all messages that have been allocated but not returned to the pool.
+    /// Only available in DEBUG builds. Must be enabled via <see cref="EnableLeakTracking"/>.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Message, MessageAllocationInfo> _outstandingMessages = new();
+
+    /// <summary>
+    /// When true, tracks all message allocations for leak detection.
+    /// Only available in DEBUG builds.
+    /// </summary>
+    public static bool EnableLeakTracking { get; set; }
+
+    /// <summary>
+    /// Gets all messages that have been allocated but not returned to the pool.
+    /// Only available in DEBUG builds and when <see cref="EnableLeakTracking"/> is true.
+    /// </summary>
+    public static IReadOnlyCollection<MessageAllocationInfo> GetOutstandingMessages()
+    {
+        return _outstandingMessages.Values.ToArray();
+    }
+
+    /// <summary>
+    /// Clears the outstanding messages tracking. Call this at the start of a test.
+    /// </summary>
+    public static void ClearLeakTracking()
+    {
+        _outstandingMessages.Clear();
+    }
+
+    /// <summary>
+    /// Information about a message allocation for leak tracking.
+    /// </summary>
+    public sealed class MessageAllocationInfo
+    {
+        public Message Message { get; }
+        public string AllocationStack { get; }
+        public DateTime AllocationTime { get; }
+
+        public MessageAllocationInfo(Message message, string allocationStack)
+        {
+            Message = message;
+            AllocationStack = allocationStack;
+            AllocationTime = DateTime.UtcNow;
+        }
+
+        public override string ToString() =>
+            $"Message allocated at {AllocationTime:HH:mm:ss.fff}, Direction={Message.Direction}, Id={Message.Id}\nStack:\n{AllocationStack}";
+    }
+#endif
+
+    /// <summary>
+    /// The maximum number of messages to keep per thread.
+    /// </summary>
+    public static int MaxPoolSizePerThread { get; set; } = 128;
+
+    /// <summary>
+    /// Gets a message from the pool, or creates a new one if the pool is empty.
+    /// </summary>
+    public static Message Get()
+    {
+        var stack = _messages.Value!;
+        if (!stack.TryPop(out var message))
+        {
+            message = new Message();
+        }
+
+        message.InitializeRefCount();
+
+#if DEBUG
+        if (EnableLeakTracking)
+        {
+            var info = new MessageAllocationInfo(message, Environment.StackTrace);
+            _outstandingMessages[message] = info;
+        }
+#endif
+
+        return message;
+    }
+
+    /// <summary>
+    /// Returns a message to the pool after resetting it.
+    /// </summary>
+    public static void Return(Message message) => message.Release();
+
+    internal static void ReturnCore(Message message)
+    {
+#if DEBUG
+        if (EnableLeakTracking)
+        {
+            _outstandingMessages.TryRemove(message, out _);
+        }
+#endif
+
+        message.Reset();
+
+        var stack = _messages.Value!;
+        if (stack.Count < MaxPoolSizePerThread)
+        {
+            stack.Push(message);
+        }
+    }
+}

--- a/src/Orleans.Core/Messaging/MessagePool.cs
+++ b/src/Orleans.Core/Messaging/MessagePool.cs
@@ -8,11 +8,11 @@ using System.Threading;
 namespace Orleans.Runtime;
 
 /// <summary>
-/// A thread-local object pool for <see cref="Message"/> instances.
+/// A thread-local object pool for the backing state used by generation-tagged <see cref="Message"/> handles.
 /// </summary>
 internal static class MessagePool
 {
-    private static readonly ThreadLocal<Stack<Message>> _messages = new(() => new());
+    private static readonly ThreadLocal<Stack<Message.MessageState>> _states = new(() => new());
 
 #if DEBUG
     /// <summary>
@@ -66,40 +66,46 @@ internal static class MessagePool
 #endif
 
     /// <summary>
-    /// The maximum number of messages to keep per thread.
+    /// The maximum number of reset message states to keep per thread.
     /// </summary>
     public static int MaxPoolSizePerThread { get; set; } = 128;
 
     /// <summary>
-    /// Gets a message from the pool, or creates a new one if the pool is empty.
+    /// Gets a generation-tagged message handle backed by cached state, or by new state when the cache is empty.
     /// </summary>
     public static Message Get()
     {
-        var stack = _messages.Value!;
-        if (!stack.TryPop(out var message))
+        var stack = _states.Value!;
+        while (true)
         {
-            message = new Message();
-        }
+            if (!stack.TryPop(out var state))
+            {
+                state = new Message.MessageState(isPoolable: true);
+            }
 
-        message.InitializeRefCount();
+            if (state.TryActivate(out var generation))
+            {
+                var message = new Message(state, generation);
 
 #if DEBUG
-        if (EnableLeakTracking)
-        {
-            var info = new MessageAllocationInfo(message, Environment.StackTrace);
-            _outstandingMessages[message] = info;
-        }
+                if (EnableLeakTracking)
+                {
+                    var info = new MessageAllocationInfo(message, Environment.StackTrace);
+                    _outstandingMessages[message] = info;
+                }
 #endif
 
-        return message;
+                return message;
+            }
+        }
     }
 
     /// <summary>
-    /// Returns a message to the pool after resetting it.
+    /// Releases the caller's ownership of a message handle.
     /// </summary>
     public static void Return(Message message) => message.Release();
 
-    internal static void ReturnCore(Message message)
+    internal static void ReturnCore(Message message, Message.MessageState state)
     {
 #if DEBUG
         if (EnableLeakTracking)
@@ -108,16 +114,20 @@ internal static class MessagePool
         }
 #endif
 
-        message.Reset();
+        state.Reset();
+        if (!state.IsPoolable)
+        {
+            return;
+        }
 
-        var stack = _messages.Value!;
+        var stack = _states.Value!;
         if (stack.Count < MaxPoolSizePerThread)
         {
-            stack.Push(message);
+            stack.Push(state);
         }
     }
 
-    internal static int GetCachedMessageCount() => _messages.Value!.Count;
+    internal static int GetCachedMessageCount() => _states.Value!.Count;
 
-    internal static void ClearCurrentThreadPool() => _messages.Value!.Clear();
+    internal static void ClearCurrentThreadPool() => _states.Value!.Clear();
 }

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -85,7 +85,8 @@ namespace Orleans.Runtime.Messaging
                 var body = input.Slice(bodyOffset, bodyLength);
 
                 // Build message
-                message = new();
+                message = MessagePool.Get();
+
                 if (header.IsSingleSegment)
                 {
                     var headersReader = Reader.Create(header.First.Span, _deserializationSession);

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -99,17 +99,18 @@ namespace Orleans.Runtime.Messaging
                 var body = input.Slice(bodyOffset, bodyLength);
 
                 // Build message
-                message = MessagePool.Get();
+                var result = MessagePool.Get();
+                message = result;
 
                 if (header.IsSingleSegment)
                 {
                     var headersReader = Reader.Create(header.First.Span, _deserializationSession);
-                    Deserialize(ref headersReader, message);
+                    Deserialize(ref headersReader, result);
                 }
                 else
                 {
                     var headersReader = Reader.Create(header, _deserializationSession);
-                    Deserialize(ref headersReader, message);
+                    Deserialize(ref headersReader, result);
                 }
 
                 if (bodyLength != 0)
@@ -121,12 +122,12 @@ namespace Orleans.Runtime.Messaging
                     if (body.IsSingleSegment)
                     {
                         var reader = Reader.Create(body.First.Span, _deserializationSession);
-                        ReadBodyObject(message, ref reader);
+                        ReadBodyObject(result, ref reader);
                     }
                     else
                     {
                         var reader = Reader.Create(body, _deserializationSession);
-                        ReadBodyObject(message, ref reader);
+                        ReadBodyObject(result, ref reader);
                     }
                 }
 

--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -99,7 +99,8 @@ namespace Orleans.Runtime.Messaging
                 var body = input.Slice(bodyOffset, bodyLength);
 
                 // Build message
-                message = new();
+                message = MessagePool.Get();
+
                 if (header.IsSingleSegment)
                 {
                     var headersReader = Reader.Create(header.First.Span, _deserializationSession);

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -121,8 +121,6 @@ namespace Orleans.Runtime.Messaging
 
         protected override void RetryMessage(Message msg, Exception? ex = null)
         {
-            if (msg == null) return;
-
             if (msg.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
                 ++msg.RetryCount;

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -45,12 +45,12 @@ namespace Orleans.Runtime.Messaging
 
         protected override void RecordMessageReceive(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstrumentation.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
+            MessagingMetrics.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
         }
 
         protected override void RecordMessageSend(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstrumentation.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
+            MessagingMetrics.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
         }
 
         protected override void OnReceivedMessage(Message message)
@@ -142,7 +142,7 @@ namespace Orleans.Runtime.Messaging
 
         internal void SendRejection(Message msg, Message.RejectionTypes rejectionType, string reason)
         {
-            MessagingInstrumentation.OnRejectedMessage(msg);
+            MessagingMetrics.OnRejectedMessage(msg);
             if (string.IsNullOrEmpty(reason)) reason = "Rejection from silo - Unknown reason.";
             var error = this.MessageFactory.CreateRejectionResponse(msg, rejectionType, reason);
 
@@ -152,17 +152,24 @@ namespace Orleans.Runtime.Messaging
 
         public void FailMessage(Message msg, string reason)
         {
-            MessagingInstrumentation.OnFailedSentMessage(msg);
-            if (msg.Direction == Message.Directions.Request)
+            try
             {
-                LogDebugClientIsRejectingMessage(this.Log, msg, reason);
-                // Done retrying, send back an error instead
-                this.SendRejection(msg, Message.RejectionTypes.Transient, $"Client is rejecting message: {msg}. Reason = {reason}");
+                MessagingMetrics.OnFailedSentMessage(msg);
+                if (msg.Direction == Message.Directions.Request)
+                {
+                    LogDebugClientIsRejectingMessage(this.Log, msg, reason);
+                    // Done retrying, send back an error instead
+                    this.SendRejection(msg, Message.RejectionTypes.Transient, $"Client is rejecting message: {msg}. Reason = {reason}");
+                }
+                else
+                {
+                    LogInformationClientIsDroppingMessage(this.Log, msg, reason);
+                    MessagingMetrics.OnDroppedSentMessage(msg);
+                }
             }
-            else
+            finally
             {
-                LogInformationClientIsDroppingMessage(this.Log, msg, reason);
-                MessagingInstrumentation.OnDroppedSentMessage(msg);
+                msg.ReleaseDropped("ClientOutboundConnection.FailMessage");
             }
         }
 

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -374,12 +374,25 @@ namespace Orleans.Runtime.Messaging
                         {
                             throw;
                         }
+
+                        if (message is not null)
+                        {
+                            inflight.Remove(message);
+                            message = null;
+                        }
                     }
 
                     var flushResult = await output.FlushAsync();
                     if (flushResult.IsCompleted || flushResult.IsCanceled)
                     {
                         break;
+                    }
+
+                    // Release the send pipeline's reference after bytes have been flushed.
+                    foreach (var msg in inflight)
+                    {
+                        msg.MarkTransferred("Connection.ProcessOutgoing:Sent");
+                        msg.Release();
                     }
 
                     inflight.Clear();
@@ -490,6 +503,8 @@ namespace Orleans.Runtime.Messaging
                 response.BodyObject = Response.FromException(exception);
 
                 this.MessageCenter.DispatchLocalMessage(response);
+                message.MarkTransferred("Connection.HandleSendMessageFailure:RequestFailed");
+                message.Release();
             }
             else if (message.Direction == Message.Directions.Response && message.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
@@ -509,6 +524,8 @@ namespace Orleans.Runtime.Messaging
                     message);
 
                 MessagingInstruments.OnDroppedSentMessage(message);
+                message.MarkTransferred("Connection.HandleSendMessageFailure:Dropped");
+                message.Release();
             }
 
             return true;

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -310,10 +310,11 @@ namespace Orleans.Runtime.Messaging
                                 if (requiredBytes == 0)
                                 {
                                     Debug.Assert(message is not null);
+                                    var receivedMessage = message.Value;
                                     MarkMessageReceived();
-                                    RecordMessageReceive(message, bodyLength + headerLength, headerLength);
+                                    RecordMessageReceive(receivedMessage, bodyLength + headerLength, headerLength);
                                     var handler = MessageHandlerPool.Get();
-                                    handler.Set(message, this);
+                                    handler.Set(receivedMessage, this);
                                     ThreadPool.UnsafeQueueUserWorkItem(handler, preferLocal: true);
                                 }
                             }
@@ -375,12 +376,18 @@ namespace Orleans.Runtime.Messaging
                     Message? message = default;
                     try
                     {
-                        while (inflight.Count < inflight.Capacity && reader.TryRead(out message) && this.PrepareMessageForSend(message))
+                        while (inflight.Count < inflight.Capacity && reader.TryRead(out var dequeuedMessage))
                         {
-                            inflight.Add(message);
-                            var (headerLength, bodyLength) = serializer.Write(output, message);
-                            RecordMessageSend(message, headerLength + bodyLength, headerLength);
-                            messageObserver?.Invoke(message);
+                            message = dequeuedMessage;
+                            if (!this.PrepareMessageForSend(dequeuedMessage))
+                            {
+                                break;
+                            }
+
+                            inflight.Add(dequeuedMessage);
+                            var (headerLength, bodyLength) = serializer.Write(output, dequeuedMessage);
+                            RecordMessageSend(dequeuedMessage, headerLength + bodyLength, headerLength);
+                            messageObserver?.Invoke(dequeuedMessage);
                             message = null;
                         }
                     }
@@ -391,9 +398,9 @@ namespace Orleans.Runtime.Messaging
                             throw;
                         }
 
-                        if (message is not null)
+                        if (message is { } failedMessage)
                         {
-                            inflight.Remove(message);
+                            inflight.Remove(failedMessage);
                             message = null;
                         }
                     }
@@ -469,37 +476,39 @@ namespace Orleans.Runtime.Messaging
                 return false;
             }
 
-            // The message body was not successfully decoded, but the headers were.
-            MessagingMetrics.OnRejectedMessage(message);
+            var failedMessage = message.Value;
 
-            if (message.HasDirection)
+            // The message body was not successfully decoded, but the headers were.
+            MessagingMetrics.OnRejectedMessage(failedMessage);
+
+            if (failedMessage.HasDirection)
             {
-                if (message.Direction == Message.Directions.Request)
+                if (failedMessage.Direction == Message.Directions.Request)
                 {
                     // Send a fast fail to the caller.
-                    var response = this.MessageFactory.CreateResponseMessage(message);
+                    var response = this.MessageFactory.CreateResponseMessage(failedMessage);
                     response.Result = Message.ResponseTypes.Error;
                     response.BodyObject = Response.FromException(exception);
 
                     // Send the error response and continue processing the next message.
                     this.Send(response);
-                    message.ReleaseDropped("ReceiveMessageDeserializationFailure");
+                    failedMessage.ReleaseDropped("ReceiveMessageDeserializationFailure");
                 }
-                else if (message.Direction == Message.Directions.Response)
+                else if (failedMessage.Direction == Message.Directions.Response)
                 {
                     // If the message was a response, propagate the exception to the intended recipient.
-                    message.Result = Message.ResponseTypes.Error;
-                    message.BodyObject = Response.FromException(exception);
-                    this.OnReceivedMessage(message);
+                    failedMessage.Result = Message.ResponseTypes.Error;
+                    failedMessage.BodyObject = Response.FromException(exception);
+                    this.OnReceivedMessage(failedMessage);
                 }
                 else
                 {
-                    message.ReleaseDropped("ReceiveMessageDeserializationFailure");
+                    failedMessage.ReleaseDropped("ReceiveMessageDeserializationFailure");
                 }
             }
             else
             {
-                message.ReleaseDropped("ReceiveMessageDeserializationFailure");
+                failedMessage.ReleaseDropped("ReceiveMessageDeserializationFailure");
             }
 
             // The exception has been handled by propagating it onwards.
@@ -519,38 +528,39 @@ namespace Orleans.Runtime.Messaging
                 return false;
             }
 
-            MessagingMetrics.OnFailedSentMessage(message);
+            var failedMessage = message.Value;
+            MessagingMetrics.OnFailedSentMessage(failedMessage);
 
-            if (message.Direction == Message.Directions.Request)
+            if (failedMessage.Direction == Message.Directions.Request)
             {
-                var response = this.MessageFactory.CreateResponseMessage(message);
+                var response = this.MessageFactory.CreateResponseMessage(failedMessage);
                 response.Result = Message.ResponseTypes.Error;
                 response.BodyObject = Response.FromException(exception);
 
                 this.MessageCenter.DispatchLocalMessage(response);
-                message.MarkTransferred("Connection.HandleSendMessageFailure:RequestFailed");
-                message.Release();
+                failedMessage.MarkTransferred("Connection.HandleSendMessageFailure:RequestFailed");
+                failedMessage.Release();
             }
-            else if (message.Direction == Message.Directions.Response && message.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
+            else if (failedMessage.Direction == Message.Directions.Response && failedMessage.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
                 // If we failed sending an original response, turn the response body into an error and reply with it.
                 // unless we have already tried sending the response multiple times.
-                message.Result = Message.ResponseTypes.Error;
-                message.BodyObject = Response.FromException(exception);
-                ++message.RetryCount;
+                failedMessage.Result = Message.ResponseTypes.Error;
+                failedMessage.BodyObject = Response.FromException(exception);
+                ++failedMessage.RetryCount;
 
-                this.Send(message);
+                this.Send(failedMessage);
             }
             else
             {
                 LogWarningDroppingMessage(
                     this.Log,
                     exception,
-                    message);
+                    failedMessage);
 
-                MessagingMetrics.OnDroppedSentMessage(message);
-                message.MarkTransferred("Connection.HandleSendMessageFailure:Dropped");
-                message.Release();
+                MessagingMetrics.OnDroppedSentMessage(failedMessage);
+                failedMessage.MarkTransferred("Connection.HandleSendMessageFailure:Dropped");
+                failedMessage.Release();
             }
 
             return true;
@@ -580,7 +590,7 @@ namespace Orleans.Runtime.Messaging
 
             public void Execute()
             {
-                this.connection!.OnReceivedMessage(this.message!);
+                this.connection!.OnReceivedMessage(this.message!.Value);
                 MessageHandlerPool.Return(this);
             }
 

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -66,7 +66,8 @@ namespace Orleans.Runtime.Messaging
         protected ConnectionContext Context { get; }
         protected ILogger Log => this.shared.Logger;
         protected MessagingTrace MessagingTrace => this.shared.MessagingTrace;
-        protected MessagingInstruments MessagingInstrumentation => this.shared.MessagingInstruments;
+        protected MessagingInstruments MessagingMetrics => this.shared.MessagingInstruments;
+        protected NetworkingInstruments NetworkingMetrics => this.shared.NetworkingInstruments;
         protected abstract ConnectionDirection ConnectionDirection { get; }
         protected MessageFactory MessageFactory => this.shared.MessageFactory;
         protected abstract IMessageCenter MessageCenter { get; }
@@ -75,17 +76,12 @@ namespace Orleans.Runtime.Messaging
 
         public Task Initialized => _initializationTcs.Task;
 
-        /// <summary>
-        /// Gets the time elapsed since the last message was received on this connection,
-        /// or <see langword="null"/> if no message has been received yet.
-        /// </summary>
         public TimeSpan? ElapsedSinceLastMessageReceived
         {
             get
             {
                 var timestamp = Volatile.Read(ref _lastMessageReceivedTimestamp);
-                if (timestamp == 0) return null;
-                return TimeSpan.FromMilliseconds(CoarseStopwatch.GetTimestamp() - timestamp);
+                return timestamp == 0 ? null : TimeSpan.FromMilliseconds(CoarseStopwatch.GetTimestamp() - timestamp);
             }
         }
 
@@ -120,7 +116,7 @@ namespace Orleans.Runtime.Messaging
             var connection = context.Features.Get<Connection>();
             context.ConnectionClosed.Register(OnConnectionClosedDelegate, connection);
 
-            connection!.shared.NetworkingInstruments.OnOpenedSocket(connection.ConnectionDirection);
+            connection!.NetworkingMetrics.OnOpenedSocket(connection.ConnectionDirection);
             return connection.RunInternal();
         }
 
@@ -180,7 +176,7 @@ namespace Orleans.Runtime.Messaging
         /// </summary>
         private async Task CloseAsync()
         {
-            this.shared.NetworkingInstruments.OnClosedSocket(this.ConnectionDirection);
+            NetworkingMetrics.OnClosedSocket(this.ConnectionDirection);
 
             // Signal the outgoing message processor to exit gracefully.
             this.outgoingMessageWriter.TryComplete();
@@ -293,7 +289,6 @@ namespace Orleans.Runtime.Messaging
             Exception? error = default;
             using var serializerScope = this.shared.ServiceProvider.CreateScope();
             var serializer = serializerScope.ServiceProvider.GetRequiredService<MessageSerializer>();
-            var prevBufferLength = 0L;
             try
             {
                 var input = this._transport!.Input;
@@ -303,15 +298,8 @@ namespace Orleans.Runtime.Messaging
                     var readResult = await input.ReadAsync();
 
                     var buffer = readResult.Buffer;
-                    if (buffer.Length > prevBufferLength)
-                    {
-                        prevBufferLength = buffer.Length;
-                        MarkMessageReceived();
-                    }
-
                     if (buffer.Length >= requiredBytes)
                     {
-                        prevBufferLength = 0;
                         do
                         {
                             Message? message = default;
@@ -322,6 +310,7 @@ namespace Orleans.Runtime.Messaging
                                 if (requiredBytes == 0)
                                 {
                                     Debug.Assert(message is not null);
+                                    MarkMessageReceived();
                                     RecordMessageReceive(message, bodyLength + headerLength, headerLength);
                                     var handler = MessageHandlerPool.Get();
                                     handler.Set(message, this);
@@ -401,12 +390,25 @@ namespace Orleans.Runtime.Messaging
                         {
                             throw;
                         }
+
+                        if (message is not null)
+                        {
+                            inflight.Remove(message);
+                            message = null;
+                        }
                     }
 
                     var flushResult = await output.FlushAsync();
                     if (flushResult.IsCompleted || flushResult.IsCanceled)
                     {
                         break;
+                    }
+
+                    // Release the send pipeline's reference after bytes have been flushed.
+                    foreach (var msg in inflight)
+                    {
+                        msg.MarkTransferred("Connection.ProcessOutgoing:Sent");
+                        msg.Release();
                     }
 
                     inflight.Clear();
@@ -468,7 +470,7 @@ namespace Orleans.Runtime.Messaging
             }
 
             // The message body was not successfully decoded, but the headers were.
-            MessagingInstrumentation.OnRejectedMessage(message);
+            MessagingMetrics.OnRejectedMessage(message);
 
             if (message.HasDirection)
             {
@@ -481,6 +483,7 @@ namespace Orleans.Runtime.Messaging
 
                     // Send the error response and continue processing the next message.
                     this.Send(response);
+                    message.ReleaseDropped("ReceiveMessageDeserializationFailure");
                 }
                 else if (message.Direction == Message.Directions.Response)
                 {
@@ -489,6 +492,14 @@ namespace Orleans.Runtime.Messaging
                     message.BodyObject = Response.FromException(exception);
                     this.OnReceivedMessage(message);
                 }
+                else
+                {
+                    message.ReleaseDropped("ReceiveMessageDeserializationFailure");
+                }
+            }
+            else
+            {
+                message.ReleaseDropped("ReceiveMessageDeserializationFailure");
             }
 
             // The exception has been handled by propagating it onwards.
@@ -508,7 +519,7 @@ namespace Orleans.Runtime.Messaging
                 return false;
             }
 
-            MessagingInstrumentation.OnFailedSentMessage(message);
+            MessagingMetrics.OnFailedSentMessage(message);
 
             if (message.Direction == Message.Directions.Request)
             {
@@ -517,6 +528,8 @@ namespace Orleans.Runtime.Messaging
                 response.BodyObject = Response.FromException(exception);
 
                 this.MessageCenter.DispatchLocalMessage(response);
+                message.MarkTransferred("Connection.HandleSendMessageFailure:RequestFailed");
+                message.Release();
             }
             else if (message.Direction == Message.Directions.Response && message.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
@@ -535,7 +548,9 @@ namespace Orleans.Runtime.Messaging
                     exception,
                     message);
 
-                MessagingInstrumentation.OnDroppedSentMessage(message);
+                MessagingMetrics.OnDroppedSentMessage(message);
+                message.MarkTransferred("Connection.HandleSendMessageFailure:Dropped");
+                message.Release();
             }
 
             return true;
@@ -627,13 +642,13 @@ namespace Orleans.Runtime.Messaging
             Level = LogLevel.Warning,
             Message = "Exception while processing messages from remote endpoint {EndPoint}"
         )]
-        private static partial void LogWarningExceptionProcessingMessagesFromRemote(ILogger logger, Exception exception, EndPoint? endPoint);
+        private static partial void LogWarningExceptionProcessingMessagesFromRemote(ILogger logger, Exception exception, EndPoint endPoint);
 
         [LoggerMessage(
             Level = LogLevel.Warning,
             Message = "Exception while processing messages to remote endpoint {EndPoint}"
         )]
-        private static partial void LogWarningExceptionProcessingMessagesToRemote(ILogger logger, Exception exception, EndPoint? endPoint);
+        private static partial void LogWarningExceptionProcessingMessagesToRemote(ILogger logger, Exception exception, EndPoint endPoint);
 
         [LoggerMessage(
             Level = LogLevel.Information,
@@ -645,13 +660,13 @@ namespace Orleans.Runtime.Messaging
             Level = LogLevel.Error,
             Message = "Exception reading message {Message} from remote endpoint {Remote} to local endpoint {Local}"
         )]
-        private static partial void LogErrorExceptionReadingMessage(ILogger logger, Exception exception, Message? message, EndPoint? remote, EndPoint? local);
+        private static partial void LogErrorExceptionReadingMessage(ILogger logger, Exception exception, Message? message, EndPoint remote, EndPoint local);
 
         [LoggerMessage(
             Level = LogLevel.Error,
             Message = "Exception sending message {Message} to remote endpoint {Remote} from local endpoint {Local}"
         )]
-        private static partial void LogErrorExceptionSendingMessage(ILogger logger, Exception exception, Message? message, EndPoint? remote, EndPoint? local);
+        private static partial void LogErrorExceptionSendingMessage(ILogger logger, Exception exception, Message? message, EndPoint remote, EndPoint local);
 
         [LoggerMessage(
             EventId = (int)ErrorCode.Messaging_OutgoingMS_DroppingMessage,

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -87,6 +87,17 @@ namespace Orleans.Runtime.Messaging
 
         protected void MarkMessageReceived() => Volatile.Write(ref _lastMessageReceivedTimestamp, CoarseStopwatch.GetTimestamp());
 
+        protected bool MarkBytesReceived(long availableBytes, long retainedBytes)
+        {
+            if (availableBytes > retainedBytes)
+            {
+                MarkMessageReceived();
+                return true;
+            }
+
+            return false;
+        }
+
         public static void ConfigureBuilder(ConnectionBuilder builder) => builder.Run(OnConnectedDelegate);
 
         /// <summary>
@@ -293,11 +304,13 @@ namespace Orleans.Runtime.Messaging
             {
                 var input = this._transport!.Input;
                 var requiredBytes = 0;
+                var retainedBytes = 0L;
                 while (true)
                 {
                     var readResult = await input.ReadAsync();
 
                     var buffer = readResult.Buffer;
+                    MarkBytesReceived(buffer.Length, retainedBytes);
                     if (buffer.Length >= requiredBytes)
                     {
                         do
@@ -311,7 +324,6 @@ namespace Orleans.Runtime.Messaging
                                 {
                                     Debug.Assert(message is not null);
                                     var receivedMessage = message.Value;
-                                    MarkMessageReceived();
                                     RecordMessageReceive(receivedMessage, bodyLength + headerLength, headerLength);
                                     var handler = MessageHandlerPool.Get();
                                     handler.Set(receivedMessage, this);
@@ -328,6 +340,7 @@ namespace Orleans.Runtime.Messaging
                         } while (requiredBytes == 0);
                     }
 
+                    retainedBytes = buffer.Length;
                     if (readResult.IsCanceled || readResult.IsCompleted)
                     {
                         break;

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -55,14 +55,14 @@ namespace Orleans.Runtime.Messaging
             // Set the connection on the connection context so that it can be retrieved by the middleware.
             this.Context.Features.Set<Connection>(this);
 
-            this.RemoteEndPoint = NormalizeEndpoint(this.Context.RemoteEndPoint)!;
-            this.LocalEndPoint = NormalizeEndpoint(this.Context.LocalEndPoint)!;
+            this.RemoteEndPoint = NormalizeEndpoint(this.Context.RemoteEndPoint);
+            this.LocalEndPoint = NormalizeEndpoint(this.Context.LocalEndPoint);
         }
 
         public ConnectionCommon Shared => shared;
         public string ConnectionId => (this.Context?.ConnectionId)!;
-        public virtual EndPoint RemoteEndPoint { get; }
-        public virtual EndPoint LocalEndPoint { get; }
+        public virtual EndPoint? RemoteEndPoint { get; }
+        public virtual EndPoint? LocalEndPoint { get; }
         protected ConnectionContext Context { get; }
         protected ILogger Log => this.shared.Logger;
         protected MessagingTrace MessagingTrace => this.shared.MessagingTrace;
@@ -665,13 +665,13 @@ namespace Orleans.Runtime.Messaging
             Level = LogLevel.Warning,
             Message = "Exception while processing messages from remote endpoint {EndPoint}"
         )]
-        private static partial void LogWarningExceptionProcessingMessagesFromRemote(ILogger logger, Exception exception, EndPoint endPoint);
+        private static partial void LogWarningExceptionProcessingMessagesFromRemote(ILogger logger, Exception exception, EndPoint? endPoint);
 
         [LoggerMessage(
             Level = LogLevel.Warning,
             Message = "Exception while processing messages to remote endpoint {EndPoint}"
         )]
-        private static partial void LogWarningExceptionProcessingMessagesToRemote(ILogger logger, Exception exception, EndPoint endPoint);
+        private static partial void LogWarningExceptionProcessingMessagesToRemote(ILogger logger, Exception exception, EndPoint? endPoint);
 
         [LoggerMessage(
             Level = LogLevel.Information,
@@ -683,13 +683,13 @@ namespace Orleans.Runtime.Messaging
             Level = LogLevel.Error,
             Message = "Exception reading message {Message} from remote endpoint {Remote} to local endpoint {Local}"
         )]
-        private static partial void LogErrorExceptionReadingMessage(ILogger logger, Exception exception, Message? message, EndPoint remote, EndPoint local);
+        private static partial void LogErrorExceptionReadingMessage(ILogger logger, Exception exception, Message? message, EndPoint? remote, EndPoint? local);
 
         [LoggerMessage(
             Level = LogLevel.Error,
             Message = "Exception sending message {Message} to remote endpoint {Remote} from local endpoint {Local}"
         )]
-        private static partial void LogErrorExceptionSendingMessage(ILogger logger, Exception exception, Message? message, EndPoint remote, EndPoint local);
+        private static partial void LogErrorExceptionSendingMessage(ILogger logger, Exception exception, Message? message, EndPoint? remote, EndPoint? local);
 
         [LoggerMessage(
             EventId = (int)ErrorCode.Messaging_OutgoingMS_DroppingMessage,

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -24,6 +24,8 @@ namespace Orleans.Runtime
         {
             this.shared = shared;
             this.context = ctx;
+            // CallbackData holds a reference to the request message while awaiting completion.
+            msg.Acquire();
             this.Message = msg;
             _applicationRequestInstruments = applicationRequestInstruments;
             this.stopwatch = ValueStopwatch.StartNew();
@@ -108,6 +110,7 @@ namespace Orleans.Runtime
             OrleansCallBackDataEvent.Instance.OnCanceled(Message);
             context.Complete(Response.FromException(new OperationCanceledException(_cancellationTokenRegistration.Token)));
             _cancellationTokenRegistration.Dispose();
+            ReleaseRequest("CallbackData.OnCancellation");
         }
 
         public void OnTimeout()
@@ -138,6 +141,7 @@ namespace Orleans.Runtime
 
             var exception = new TimeoutException($"Response did not arrive on time in {timeout} for message: {msg}. {statusMessage}");
             context.Complete(Response.FromException(exception));
+            ReleaseRequest("CallbackData.OnTimeout");
         }
 
         public void OnTargetSiloFail()
@@ -158,6 +162,7 @@ namespace Orleans.Runtime
             LogTargetSiloFail(this.shared.Logger, msg, statusMessage, Constants.TroubleshootingHelpLink);
             var exception = new SiloUnavailableException($"The target silo became unavailable for message: {msg}. {statusMessage}See {Constants.TroubleshootingHelpLink} for troubleshooting help.");
             this.context.Complete(Response.FromException(exception));
+            ReleaseRequest("CallbackData.OnTargetSiloFail");
         }
 
         public void DoCallback(Message response)
@@ -175,6 +180,13 @@ namespace Orleans.Runtime
 
             // do callback outside the CallbackData lock. Just not a good practice to hold a lock for this unrelated operation.
             ResponseCallback(response, this.context);
+            ReleaseRequest("CallbackData.DoCallback");
+        }
+
+        private void ReleaseRequest(string tag)
+        {
+            Message.MarkTransferred($"{tag}:ReleaseRequest");
+            Message.Release();
         }
 
         private static void ResponseCallback(Message message, IResponseCompletionSource context)

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -255,8 +255,14 @@ namespace Orleans.Runtime
             _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
 
             // do callback outside the CallbackData lock. Just not a good practice to hold a lock for this unrelated operation.
-            ResponseCallback(response, this.context);
-            ReleaseRequest("CallbackData.DoCallback");
+            try
+            {
+                ResponseCallback(response, this.context);
+            }
+            finally
+            {
+                ReleaseRequest("CallbackData.DoCallback");
+            }
         }
 
         private bool TryComplete() => (Interlocked.Or(ref _state, StateCompleted) & StateCompleted) == 0;

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -29,6 +29,8 @@ namespace Orleans.Runtime
         {
             this.shared = shared;
             this.context = ctx;
+            // CallbackData holds a reference to the request message while awaiting completion.
+            msg.Acquire();
             this.Message = msg;
             _applicationRequestInstruments = applicationRequestInstruments;
             this.stopwatch = ValueStopwatch.StartNew();
@@ -133,8 +135,15 @@ namespace Orleans.Runtime
             _applicationRequestInstruments.OnAppRequestsEnd((long)stopwatch.Elapsed.TotalMilliseconds);
             _applicationRequestInstruments.OnAppRequestsCanceled(GetTargetGrainType());
             OrleansCallBackDataEvent.Instance.OnCanceled(Message);
-            context.Complete(Response.FromException(new OperationCanceledException(cancellationToken)));
-            DisposeCancellationRegistration();
+            try
+            {
+                context.Complete(Response.FromException(new OperationCanceledException(cancellationToken)));
+            }
+            finally
+            {
+                DisposeCancellationRegistration();
+                ReleaseRequest("CallbackData.OnCancellation");
+            }
         }
 
         public void OnTimeout()
@@ -164,7 +173,14 @@ namespace Orleans.Runtime
             LogTimeout(this.shared.Logger, timeout, msg, statusMessage);
 
             var exception = new TimeoutException($"Response did not arrive on time in {timeout} for message: {msg}. {statusMessage}");
-            context.Complete(Response.FromException(exception));
+            try
+            {
+                context.Complete(Response.FromException(exception));
+            }
+            finally
+            {
+                ReleaseRequest("CallbackData.OnTimeout");
+            }
         }
 
         public void OnTargetSiloFail()
@@ -184,7 +200,14 @@ namespace Orleans.Runtime
             var statusMessage = lastKnownStatus is StatusResponse status ? $"Last known status is {status}. " : string.Empty;
             LogTargetSiloFail(this.shared.Logger, msg, statusMessage, Constants.TroubleshootingHelpLink);
             var exception = new SiloUnavailableException($"The target silo became unavailable for message: {msg}. {statusMessage}See {Constants.TroubleshootingHelpLink} for troubleshooting help.");
-            this.context.Complete(Response.FromException(exception));
+            try
+            {
+                this.context.Complete(Response.FromException(exception));
+            }
+            finally
+            {
+                ReleaseRequest("CallbackData.OnTargetSiloFail");
+            }
         }
 
         public void OnHostShutdown()
@@ -194,14 +217,21 @@ namespace Orleans.Runtime
                 return;
             }
 
-            this.stopwatch.Stop();
-            this.shared.Unregister(this.Message);
+            stopwatch.Stop();
+            shared.Unregister(Message);
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            _applicationRequestInstruments.OnAppRequestsEnd((long)stopwatch.Elapsed.TotalMilliseconds);
 
-            var msg = this.Message;
-            var exception = new SiloUnavailableException($"The local Orleans host is shutting down and can no longer process the request: {msg}.");
-            this.context.Complete(Response.FromException(exception));
+            var message = Message;
+            var exception = new SiloUnavailableException($"The local Orleans host is shutting down and can no longer process the request: {message}.");
+            try
+            {
+                context.Complete(Response.FromException(exception));
+            }
+            finally
+            {
+                ReleaseRequest("CallbackData.OnHostShutdown");
+            }
         }
 
         public void DoCallback(Message response)
@@ -219,17 +249,24 @@ namespace Orleans.Runtime
 
             // do callback outside the CallbackData lock. Just not a good practice to hold a lock for this unrelated operation.
             ResponseCallback(response, this.context);
+            ReleaseRequest("CallbackData.DoCallback");
         }
 
         private bool TryComplete() => (Interlocked.Or(ref _state, StateCompleted) & StateCompleted) == 0;
 
         private void DisposeCancellationRegistration()
         {
-            // If registration is still pending, its publisher observes completion and disposes it.
+            // The publisher disposes a pending registration after observing completion.
             if ((Volatile.Read(ref _state) & StateCancellationRegistrationPublished) != 0)
             {
                 _cancellationTokenRegistration.Dispose();
             }
+        }
+
+        private void ReleaseRequest(string tag)
+        {
+            Message.MarkTransferred($"{tag}:ReleaseRequest");
+            Message.Release();
         }
 
         private static void ResponseCallback(Message message, IResponseCompletionSource context)

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -16,6 +16,7 @@ namespace Orleans.Runtime
         private readonly SharedCallbackData shared;
         private readonly IResponseCompletionSource context;
         private readonly ApplicationRequestInstruments _applicationRequestInstruments;
+        private readonly TimeSpan? _defaultResponseTimeout;
         private int _state;
         private StatusResponse? lastKnownStatus;
         private ValueStopwatch stopwatch;
@@ -32,11 +33,18 @@ namespace Orleans.Runtime
             // CallbackData holds a reference to the request message while awaiting completion.
             msg.Acquire();
             this.Message = msg;
+            _defaultResponseTimeout = (msg.BodyObject as IInvokable)?.GetDefaultResponseTimeout();
             _applicationRequestInstruments = applicationRequestInstruments;
             this.stopwatch = ValueStopwatch.StartNew();
         }
 
         public Message Message { get; } // might hold metadata used by response pipeline
+
+        public bool TryAcquireMessage(out Message message)
+        {
+            message = Message;
+            return message.TryAcquire();
+        }
 
         public bool IsCompleted => (Volatile.Read(ref _state) & StateCompleted) != 0;
 
@@ -95,16 +103,15 @@ namespace Orleans.Runtime
 
         private long GetResponseTimeoutStopwatchTicks()
         {
-            var defaultResponseTimeout = (Message.BodyObject as IInvokable)?.GetDefaultResponseTimeout();
-            if (defaultResponseTimeout.HasValue)
+            if (_defaultResponseTimeout.HasValue)
             {
-                return (long)(defaultResponseTimeout.Value.TotalSeconds * Stopwatch.Frequency);
+                return (long)(_defaultResponseTimeout.Value.TotalSeconds * Stopwatch.Frequency);
             }
 
             return shared.ResponseTimeoutStopwatchTicks;
         }
 
-        private TimeSpan GetResponseTimeout() => (Message.BodyObject as IInvokable)?.GetDefaultResponseTimeout() ?? shared.ResponseTimeout;
+        private TimeSpan GetResponseTimeout() => _defaultResponseTimeout ?? shared.ResponseTimeout;
 
         private string GetTargetGrainType()
         {

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -63,6 +63,7 @@ namespace Orleans
             if (!ObserverGrainId.TryParse(message.TargetGrain, out var observerId))
             {
                 LogNotAddressedToAnObserver(logger, message);
+                message.ReleaseDropped("NotAddressedToObserver");
                 return;
             }
 
@@ -73,6 +74,7 @@ namespace Orleans
             else
             {
                 LogUnexpectedTargetInRequest(logger, message.TargetGrain, message);
+                message.ReleaseDropped("ObserverNotFound");
             }
         }
 
@@ -159,6 +161,7 @@ namespace Orleans
                     LogObserverGarbageCollected(_manager.logger, this.ObserverId, message);
                     // Try to remove. If it's not there, we don't care.
                     _manager.TryDeregister(this.ObserverId);
+                    message.ReleaseDropped("ObserverGarbageCollected");
                     return;
                 }
 
@@ -258,6 +261,7 @@ namespace Orleans
                     if (message.IsExpired)
                     {
                         _manager.messagingTrace.OnDropExpiredMessage(message, MessagingInstruments.Phase.Invoke);
+                        message.ReleaseDropped("ExpiredAtInvoke");
                         return;
                     }
 
@@ -333,6 +337,7 @@ namespace Orleans
                 if (message.IsExpired)
                 {
                     _manager.messagingTrace.OnDropExpiredMessage(message, MessagingInstruments.Phase.Respond);
+                    message.ReleaseDropped("ExpiredAtRespond");
                     return;
                 }
 

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -68,6 +68,7 @@ namespace Orleans
             if (!ObserverGrainId.TryParse(message.TargetGrain, out var observerId))
             {
                 LogNotAddressedToAnObserver(logger, message);
+                message.ReleaseDropped("NotAddressedToObserver");
                 return;
             }
 
@@ -78,6 +79,7 @@ namespace Orleans
             else
             {
                 LogUnexpectedTargetInRequest(logger, message.TargetGrain, message);
+                message.ReleaseDropped("ObserverNotFound");
             }
         }
 
@@ -160,6 +162,7 @@ namespace Orleans
                     LogObserverGarbageCollected(_manager.logger, this.ObserverId, message);
                     // Try to remove. If it's not there, we don't care.
                     _manager.TryDeregister(this.ObserverId);
+                    message.ReleaseDropped("ObserverGarbageCollected");
                     return;
                 }
 
@@ -344,19 +347,21 @@ namespace Orleans
                     {
                         this.ReportException(message, exc);
                     }
-                    finally
-                    {
-                        // Clear the running request when done.
-                        lock (Messages)
-                        {
-                            _runningRequests.Remove(message);
-                        }
-                    }
                 }
                 catch (Exception outerException)
                 {
                     // Ignore and keep looping.
                     LogErrorProcessingMessage(_manager.logger, outerException, message);
+                }
+                finally
+                {
+                    lock (Messages)
+                    {
+                        _runningRequests.Remove(message);
+                    }
+
+                    message.MarkTransferred("InvokableObjectManager.ProcessMessageAsync");
+                    message.Release();
                 }
             }
 
@@ -390,8 +395,17 @@ namespace Orleans
                 }
             }
 
-            private void SendCanceledResponse(Message message) =>
-                _manager.runtimeClient.SendResponse(message, Response.FromException(new OperationCanceledException()));
+            private void SendCanceledResponse(Message message)
+            {
+                try
+                {
+                    _manager.runtimeClient.SendResponse(message, Response.FromException(new OperationCanceledException()));
+                }
+                finally
+                {
+                    message.ReleaseDropped("CanceledWhileWaiting");
+                }
+            }
 
             private void SendResponseAsync(Message message, Response resultObject)
             {

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -152,9 +152,10 @@ namespace Orleans
 
             bool IEquatable<IGrainContext>.Equals(IGrainContext? other) => ReferenceEquals(this, other);
 
-            public void ReceiveMessage(object msg)
+            public void ReceiveMessage(object msg) => ReceiveMessage((Message)msg);
+
+            public void ReceiveMessage(Message message)
             {
-                var message = (Message)msg;
                 var obj = this.LocalObject.Target;
                 if (obj is null)
                 {
@@ -261,7 +262,7 @@ namespace Orleans
                     await ProcessMessageAsync(message);
                 }
 
-                bool TryDequeueMessage([NotNullWhen(true)] out Message? message)
+                bool TryDequeueMessage(out Message message)
                 {
                     lock (Messages)
                     {
@@ -272,7 +273,7 @@ namespace Orleans
                         }
                         else
                         {
-                            _runningRequests.Add(message!, _messagePumpTask);
+                            _runningRequests.Add(message, _messagePumpTask);
                         }
 
                         return result;
@@ -495,6 +496,7 @@ namespace Orleans
                     Message? message = null;
                     var wasWaiting = false;
                     var key = (senderGrainId, messageId);
+                    var acquiredRunningMessage = false;
                     lock (Messages)
                     {
                         // Check the running requests.
@@ -502,7 +504,9 @@ namespace Orleans
                         {
                             if (runningRequest.Id == messageId && runningRequest.SendingGrain == senderGrainId)
                             {
+                                runningRequest.Acquire();
                                 message = runningRequest;
+                                acquiredRunningMessage = true;
                                 break;
                             }
                         }
@@ -523,7 +527,7 @@ namespace Orleans
                                     for (var i = 0; i < initialCount; i++)
                                     {
                                         var current = Messages.Dequeue();
-                                        if (!ReferenceEquals(current, message))
+                                        if (current != message)
                                         {
                                             Messages.Enqueue(current);
                                         }
@@ -542,32 +546,42 @@ namespace Orleans
                         }
                     }
 
-                    var didCancel = false;
-                    if (message is not null)
+                    try
                     {
-                        // The message never began executing, so send a canceled response immediately.
-                        // If the message did begin executing, wait for it to observe the cancellation token and respond itself.
-                        if (wasWaiting)
+                        var didCancel = false;
+                        if (message is { } targetMessage)
                         {
-                            SendCanceledResponse(message);
-                            didCancel = true;
+                            // The message never began executing, so send a canceled response immediately.
+                            // If the message did begin executing, wait for it to observe the cancellation token and respond itself.
+                            if (wasWaiting)
+                            {
+                                SendCanceledResponse(targetMessage);
+                                didCancel = true;
+                            }
+                            else if (targetMessage.BodyObject is IInvokable invokableRequest)
+                            {
+                                didCancel = TryCancelInvokable(invokableRequest) || !invokableRequest.IsCancellable;
+                            }
+                            else
+                            {
+                                // Assume the request is not cancellable.
+                                didCancel = true;
+                            }
                         }
-                        else if (message.BodyObject is IInvokable invokableRequest)
+
+                        if (didCancel)
                         {
-                            didCancel = TryCancelInvokable(invokableRequest) || !invokableRequest.IsCancellable;
-                        }
-                        else
-                        {
-                            // Assume the request is not cancellable.
-                            didCancel = true;
+                            lock (Messages)
+                            {
+                                RemovePendingCancellation(key);
+                            }
                         }
                     }
-
-                    if (didCancel)
+                    finally
                     {
-                        lock (Messages)
+                        if (acquiredRunningMessage)
                         {
-                            RemovePendingCancellation(key);
+                            message!.Value.Release();
                         }
                     }
                 }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -336,6 +336,8 @@ namespace Orleans
                     }
                 }
 
+                // Release the status response message - it's been fully processed
+                response.ReleaseDropped("StatusResponseHandled");
                 return;
             }
 
@@ -347,10 +349,13 @@ namespace Orleans
                 // Unfortunately, it is not enough, since CallContext.LogicalGetData will not flow "up" from task completion source into the resolved task.
                 // RequestContextExtensions.Import(response.RequestContextData);
                 callbackData.DoCallback(response);
+                response.MarkTransferred("OutsideRuntimeClient.ReceiveResponse:AfterDoCallback");
+                response.Release();
             }
             else
             {
                 LogDebugNoCallbackForResponseMessage(logger, response);
+                response.ReleaseDropped("NoCallbackNotFound");
             }
         }
 

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -160,11 +160,9 @@ namespace Orleans
         public async Task StopAsync(CancellationToken cancellationToken)
         {
             Volatile.Write(ref _isStopping, 1);
-            this.callbackTimer.Dispose();
-
-            // Fault callbacks before any cancellation-sensitive waits. Completing them can resume code
-            // which issues follow-up calls, so request admission must already be closed.
             BreakOutstandingMessages();
+
+            this.callbackTimer.Dispose();
 
             if (this.callbackTimerTask is { } task)
             {
@@ -198,13 +196,13 @@ namespace Orleans
             MessageCenter = ActivatorUtilities.CreateInstance<ClientMessageCenter>(this.ServiceProvider);
             MessageCenter.RegisterLocalMessageHandler(this.HandleMessage);
             await ExecuteWithRetries(
-                async () => await MessageCenter!.StartAsync(cancellationToken),
+                async () => await MessageCenter.StartAsync(cancellationToken),
                 retryFilter,
                 cancellationToken);
             CurrentActivationAddress = GrainAddress.NewActivationAddress(MessageCenter.MyAddress, _localClientDetails.ClientId.GrainId);
 
             this.gatewayObserver = new ClientGatewayObserver(gatewayManager);
-            this.InternalGrainFactory.CreateObjectReference<IClientGatewayObserver>(this.gatewayObserver!);
+            this.InternalGrainFactory.CreateObjectReference<IClientGatewayObserver>(this.gatewayObserver);
 
             await ExecuteWithRetries(
                 _manifestProvider!.StartAsync,
@@ -250,6 +248,7 @@ namespace Orleans
                     }
                 default:
                     LogMessageNotSupported(logger, message);
+                    message.ReleaseDropped("UnsupportedMessageDirection");
                     break;
             }
         }
@@ -298,6 +297,7 @@ namespace Orleans
                 if (Volatile.Read(ref _isStopping) != 0)
                 {
                     callbackData.OnHostShutdown();
+                    message.ReleaseDropped("ClientStoppingBeforeCallbackRegistration");
                     return;
                 }
 
@@ -307,6 +307,7 @@ namespace Orleans
                 if (Volatile.Read(ref _isStopping) != 0)
                 {
                     callbackData.OnHostShutdown();
+                    message.ReleaseDropped("ClientStoppingBeforeSend");
                     return;
                 }
             }
@@ -315,6 +316,7 @@ namespace Orleans
                 context?.Complete();
                 if (Volatile.Read(ref _isStopping) != 0)
                 {
+                    message.ReleaseDropped("ClientStoppingBeforeOneWaySend");
                     return;
                 }
             }
@@ -361,6 +363,8 @@ namespace Orleans
                     }
                 }
 
+                // Release the status response message - it's been fully processed
+                response.ReleaseDropped("StatusResponseHandled");
                 return;
             }
 
@@ -372,10 +376,13 @@ namespace Orleans
                 // Unfortunately, it is not enough, since CallContext.LogicalGetData will not flow "up" from task completion source into the resolved task.
                 // RequestContextExtensions.Import(response.RequestContextData);
                 callbackData!.DoCallback(response);
+                response.MarkTransferred("OutsideRuntimeClient.ReceiveResponse:AfterDoCallback");
+                response.Release();
             }
             else
             {
                 LogDebugNoCallbackForResponseMessage(logger, response);
+                response.ReleaseDropped("NoCallbackNotFound");
             }
         }
 
@@ -449,17 +456,6 @@ namespace Orleans
             disposed = true;
         }
 
-        public void BreakOutstandingMessagesToSilo(SiloAddress deadSilo)
-        {
-            foreach (var callback in callbacks)
-            {
-                if (deadSilo.Equals(callback.Value.Message.TargetSilo))
-                {
-                    callback.Value.OnTargetSiloFail();
-                }
-            }
-        }
-
         private void BreakOutstandingMessages()
         {
             foreach (var (_, callback) in callbacks)
@@ -471,6 +467,17 @@ namespace Orleans
                 catch (Exception exception)
                 {
                     LogErrorWhileProcessingCallbackExpiry(logger, exception);
+                }
+            }
+        }
+
+        public void BreakOutstandingMessagesToSilo(SiloAddress deadSilo)
+        {
+            foreach (var callback in callbacks)
+            {
+                if (deadSilo.Equals(callback.Value.Message.TargetSilo))
+                {
+                    callback.Value.OnTargetSiloFail();
                 }
             }
         }
@@ -542,7 +549,7 @@ namespace Orleans
 
         private void ThrowIfDisposed()
         {
-            if (disposed)
+            if (disposing || disposed)
             {
                 ThrowObjectDisposedException();
             }

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -327,68 +327,73 @@ namespace Orleans
 
         public void ReceiveResponse(Message response)
         {
-            OrleansOutsideRuntimeClientEvent.Instance.ReceiveResponse(response);
-
-            LogReceivedMessage(logger, response);
-
-            if (response.Result is Message.ResponseTypes.Status)
+            try
             {
-                var status = (StatusResponse)response.BodyObject!;
-                callbacks.TryGetValue(response.Id, out var callback);
-                if (callback is not null && callback.TryAcquireMessage(out var requestMessage))
+                OrleansOutsideRuntimeClientEvent.Instance.ReceiveResponse(response);
+                LogReceivedMessage(logger, response);
+
+                if (response.Result is Message.ResponseTypes.Status)
                 {
-                    try
+                    var status = (StatusResponse)response.BodyObject!;
+                    callbacks.TryGetValue(response.Id, out var callback);
+                    if (callback is not null && callback.TryAcquireMessage(out var requestMessage))
                     {
-                        callback.OnStatusUpdate(status);
-                        if (status.Diagnostics != null && status.Diagnostics.Count > 0)
+                        try
                         {
-                            LogReceivedStatusUpdateForPendingRequest(logger, requestMessage, new(status.Diagnostics));
+                            callback.OnStatusUpdate(status);
+                            if (status.Diagnostics != null && status.Diagnostics.Count > 0)
+                            {
+                                LogReceivedStatusUpdateForPendingRequest(logger, requestMessage, new(status.Diagnostics));
+                            }
+                        }
+                        finally
+                        {
+                            requestMessage.Release();
                         }
                     }
-                    finally
+                    else
                     {
-                        requestMessage.Release();
+                        if (clientMessagingOptions.CancelUnknownRequestOnStatusUpdate)
+                        {
+                            // Cancel the call since the caller has abandoned it.
+                            // Note that the target and sender arguments are swapped because this is a response to the original request.
+                            _cancellationManager?.SignalCancellation(
+                                response.SendingSilo,
+                                targetGrainId: response.SendingGrain,
+                                sendingGrainId: response.TargetGrain,
+                                messageId: response.Id);
+                        }
+
+                        if (status.Diagnostics != null && status.Diagnostics.Count > 0)
+                        {
+                            LogReceivedStatusUpdateForUnknownRequest(logger, response, new(status.Diagnostics));
+                        }
                     }
+
+                    return;
+                }
+
+                CallbackData? callbackData;
+                var found = callbacks.TryRemove(response.Id, out callbackData);
+                if (found)
+                {
+                    // We need to import the RequestContext here as well.
+                    // Unfortunately, it is not enough, since CallContext.LogicalGetData will not flow "up" from task completion source into the resolved task.
+                    // RequestContextExtensions.Import(response.RequestContextData);
+                    callbackData!.DoCallback(response);
                 }
                 else
                 {
-                    if (clientMessagingOptions.CancelUnknownRequestOnStatusUpdate)
-                    {
-                        // Cancel the call since the caller has abandoned it.
-                        // Note that the target and sender arguments are swapped because this is a response to the original request.
-                        _cancellationManager?.SignalCancellation(
-                            response.SendingSilo,
-                            targetGrainId: response.SendingGrain,
-                            sendingGrainId: response.TargetGrain,
-                            messageId: response.Id);
-                    }
-
-                    if (status.Diagnostics != null && status.Diagnostics.Count > 0)
-                    {
-                        LogReceivedStatusUpdateForUnknownRequest(logger, response, new(status.Diagnostics));
-                    }
+                    LogDebugNoCallbackForResponseMessage(logger, response);
                 }
-
-                // Release the status response message - it's been fully processed
-                response.ReleaseDropped("StatusResponseHandled");
-                return;
             }
-
-            CallbackData? callbackData;
-            var found = callbacks.TryRemove(response.Id, out callbackData);
-            if (found)
+            catch (Exception exception)
             {
-                // We need to import the RequestContext here as well.
-                // Unfortunately, it is not enough, since CallContext.LogicalGetData will not flow "up" from task completion source into the resolved task.
-                // RequestContextExtensions.Import(response.RequestContextData);
-                callbackData!.DoCallback(response);
-                response.MarkTransferred("OutsideRuntimeClient.ReceiveResponse:AfterDoCallback");
-                response.Release();
+                LogErrorProcessingResponse(logger, exception, response);
             }
-            else
+            finally
             {
-                LogDebugNoCallbackForResponseMessage(logger, response);
-                response.ReleaseDropped("NoCallbackNotFound");
+                response.ReleaseDropped("ResponseHandled");
             }
         }
 
@@ -636,6 +641,12 @@ namespace Orleans
             Message = "Message not supported: '{Message}'."
         )]
         private static partial void LogMessageNotSupported(ILogger logger, Message message);
+
+        [LoggerMessage(
+            Level = LogLevel.Error,
+            Message = "Error processing response message '{Message}'."
+        )]
+        private static partial void LogErrorProcessingResponse(ILogger logger, Exception exception, Message message);
 
         [LoggerMessage(
             Level = LogLevel.Warning,

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -335,13 +335,19 @@ namespace Orleans
             {
                 var status = (StatusResponse)response.BodyObject!;
                 callbacks.TryGetValue(response.Id, out var callback);
-                var request = callback?.Message;
-                if (request is not null)
+                if (callback is not null && callback.TryAcquireMessage(out var requestMessage))
                 {
-                    callback!.OnStatusUpdate(status);
-                    if (status.Diagnostics != null && status.Diagnostics.Count > 0)
+                    try
                     {
-                        LogReceivedStatusUpdateForPendingRequest(logger, request, new(status.Diagnostics));
+                        callback.OnStatusUpdate(status);
+                        if (status.Diagnostics != null && status.Diagnostics.Count > 0)
+                        {
+                            LogReceivedStatusUpdateForPendingRequest(logger, requestMessage, new(status.Diagnostics));
+                        }
+                    }
+                    finally
+                    {
+                        requestMessage.Release();
                     }
                 }
                 else
@@ -475,15 +481,50 @@ namespace Orleans
         {
             foreach (var callback in callbacks)
             {
-                if (deadSilo.Equals(callback.Value.Message.TargetSilo))
+                if (!callback.Value.TryAcquireMessage(out var message))
                 {
-                    callback.Value.OnTargetSiloFail();
+                    continue;
+                }
+
+                try
+                {
+                    if (deadSilo.Equals(message.TargetSilo))
+                    {
+                        callback.Value.OnTargetSiloFail();
+                    }
+                }
+                finally
+                {
+                    message.Release();
                 }
             }
         }
 
         public int GetRunningRequestsCount(GrainInterfaceType grainInterfaceType)
-            => this.callbacks.Count(c => c.Value.Message.InterfaceType == grainInterfaceType);
+        {
+            var count = 0;
+            foreach (var callback in callbacks.Values)
+            {
+                if (!callback.TryAcquireMessage(out var message))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (message.InterfaceType == grainInterfaceType)
+                    {
+                        count++;
+                    }
+                }
+                finally
+                {
+                    message.Release();
+                }
+            }
+
+            return count;
+        }
 
         /// <inheritdoc />
         public void NotifyClusterConnectionLost()

--- a/src/Orleans.Core/Runtime/RequestContextExtensions.cs
+++ b/src/Orleans.Core/Runtime/RequestContextExtensions.cs
@@ -46,7 +46,7 @@ namespace Orleans.Runtime
             return resultValues;
         }
 
-        internal static Guid GetReentrancyId(this Message message) => GetReentrancyId(message?.RequestContextData);
+        internal static Guid GetReentrancyId(this Message message) => GetReentrancyId(message.RequestContextData);
 
         internal static Guid GetReentrancyId(Dictionary<string, object>? contextData)
         {

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1088,6 +1088,7 @@ internal sealed partial class ActivationData :
                             _shared.InternalRuntime.MessageCenter.RejectMessage(message, Message.RejectionTypes.Transient, exception);
                         }
 
+                        message.ReleaseDropped("SchedulingException");
                         _waitingRequests.RemoveAt(i);
                         continue;
                     }
@@ -1496,6 +1497,11 @@ internal sealed partial class ActivationData :
 
         // Signal the message pump to see if there is another request which can be processed now that this one has completed
         _workSignal.Signal();
+
+        // Release the message - for local messages, CallbackData still holds a ref so it won't return to pool yet.
+        // For remote messages, this is the terminal owner so it returns to pool.
+        message.MarkTransferred("ActivationData.OnCompletedRequest");
+        message.Release();
     }
 
     public void ReceiveMessage(object message) => ReceiveMessage((Message)message);
@@ -1508,6 +1514,7 @@ internal sealed partial class ActivationData :
         {
             MessagingProcessingInstruments.OnDispatcherMessageProcessedError(message);
             _shared.InternalRuntime.MessagingTrace.OnDropExpiredMessage(message, MessagingInstruments.Phase.Dispatch);
+            message.ReleaseDropped("ExpiredAtDispatch");
             return;
         }
 
@@ -1546,6 +1553,7 @@ internal sealed partial class ActivationData :
         {
             MessagingProcessingInstruments.OnDispatcherMessageProcessedError(message);
             _shared.InternalRuntime.MessageCenter.RejectMessage(message, Message.RejectionTypes.Overloaded, overloadException, "Target activation is overloaded " + this);
+            message.ReleaseDropped("RejectedOverload");
             return;
         }
 

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -531,6 +531,7 @@ internal sealed partial class ActivationData :
                 // Local-only messages are not allowed to escape the activation.
                 if (message.IsLocalOnly)
                 {
+                    message.ReleaseDropped("ActivationInvalidated");
                     continue;
                 }
 
@@ -1211,6 +1212,7 @@ internal sealed partial class ActivationData :
                             _shared.InternalRuntime.MessageCenter.RejectMessage(message, Message.RejectionTypes.Transient, exception);
                         }
 
+                        message.ReleaseDropped("SchedulingException");
                         _waitingRequests.RemoveAt(i);
                         continue;
                     }
@@ -1618,6 +1620,11 @@ internal sealed partial class ActivationData :
 
         // Signal the message pump to see if there is another request which can be processed now that this one has completed
         _workSignal.Signal();
+
+        // Release the message - for local messages, CallbackData still holds a ref so it won't return to pool yet.
+        // For remote messages, this is the terminal owner so it returns to pool.
+        message.MarkTransferred("ActivationData.OnCompletedRequest");
+        message.Release();
     }
 
     public void ReceiveMessage(object message) => ReceiveMessage((Message)message);
@@ -1630,6 +1637,7 @@ internal sealed partial class ActivationData :
         {
             _shared.MessagingProcessingInstruments.OnDispatcherMessageProcessedError(message);
             _shared.InternalRuntime.MessagingTrace.OnDropExpiredMessage(message, MessagingInstruments.Phase.Dispatch);
+            message.ReleaseDropped("ExpiredAtDispatch");
             return;
         }
 
@@ -1666,6 +1674,7 @@ internal sealed partial class ActivationData :
         {
             _shared.MessagingProcessingInstruments.OnDispatcherMessageProcessedError(message);
             _shared.InternalRuntime.MessageCenter.RejectMessage(message, Message.RejectionTypes.Overloaded, overloadException, "Target activation is overloaded " + this);
+            message.ReleaseDropped("RejectedOverload");
             return;
         }
 
@@ -2411,8 +2420,15 @@ internal sealed partial class ActivationData :
                 if (wasWaiting)
                 {
                     // If the request was waiting, then we necessarily did manage to cancel it, so send the response now.
-                    _shared.InternalRuntime.RuntimeClient.SendResponse(message, Response.FromException(new OperationCanceledException()));
-                    didCancel = true;
+                    try
+                    {
+                        _shared.InternalRuntime.RuntimeClient.SendResponse(message, Response.FromException(new OperationCanceledException()));
+                        didCancel = true;
+                    }
+                    finally
+                    {
+                        message.ReleaseDropped("CanceledWhileWaiting");
+                    }
                 }
                 else
                 {

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -850,9 +850,9 @@ internal sealed partial class ActivationData :
                 return;
             }
 
-            if (_blockingRequest is not null)
+            if (_blockingRequest is { } blockingMessage)
             {
-                var message = _blockingRequest;
+                var message = blockingMessage;
                 TimeSpan? timeSinceQueued = default;
                 if (_runningRequests.TryGetValue(message, out var waitTime))
                 {
@@ -881,7 +881,7 @@ internal sealed partial class ActivationData :
             {
                 var message = running.Key;
                 var runDuration = running.Value;
-                if (ReferenceEquals(message, _blockingRequest) || message.IsLocalOnly)
+                if ((_blockingRequest is { } currentBlockingMessage && message == currentBlockingMessage) || message.IsLocalOnly)
                 {
                     continue;
                 }
@@ -1137,7 +1137,7 @@ internal sealed partial class ActivationData :
 
             do
             {
-                Message? message = null;
+                Message message = default;
                 lock (_lock)
                 {
                     if (_waitingRequests.Count <= i)
@@ -1162,7 +1162,7 @@ internal sealed partial class ActivationData :
                             // The activation is not able to process this message right now, so try the next message.
                             ++i;
 
-                            if (_blockingRequest != null)
+                            if (_blockingRequest is { } blockingRequest)
                             {
                                 var currentRequestActiveTime = _busyDuration.Elapsed;
                                 if (currentRequestActiveTime > _shared.MaxRequestProcessingTime && !IsStuckProcessingMessage)
@@ -1176,7 +1176,7 @@ internal sealed partial class ActivationData :
                                         _shared.Logger,
                                         currentRequestActiveTime,
                                         new(this),
-                                        _blockingRequest,
+                                        blockingRequest,
                                         message);
                                 }
                             }
@@ -1315,12 +1315,12 @@ internal sealed partial class ActivationData :
                 return true;
             }
 
-            if (_blockingRequest is null)
+            if (_blockingRequest is not { } blockingRequest)
             {
                 return true;
             }
 
-            if (_blockingRequest.IsReadOnly && incoming.IsReadOnly)
+            if (blockingRequest.IsReadOnly && incoming.IsReadOnly)
             {
                 return true;
             }
@@ -1337,7 +1337,7 @@ internal sealed partial class ActivationData :
                 try
                 {
                     return canInterleave.MayInterleave(GrainInstance, incoming)
-                        || canInterleave.MayInterleave(GrainInstance, _blockingRequest);
+                        || canInterleave.MayInterleave(GrainInstance, blockingRequest);
                 }
                 catch (Exception exception)
                 {
@@ -2385,6 +2385,7 @@ internal sealed partial class ActivationData :
         {
             Message? message = null;
             var wasWaiting = false;
+            var acquiredRunningMessage = false;
             lock (_lock)
             {
                 // Check the running requests.
@@ -2392,7 +2393,9 @@ internal sealed partial class ActivationData :
                 {
                     if (candidate.Id == messageId && candidate.SendingGrain == senderGrainId)
                     {
+                        candidate.Acquire();
                         message = candidate;
+                        acquiredRunningMessage = true;
                         break;
                     }
                 }
@@ -2414,29 +2417,39 @@ internal sealed partial class ActivationData :
                 }
             }
 
-            var didCancel = false;
-            if (message is not null && message.BodyObject is IInvokable request)
+            try
             {
-                if (wasWaiting)
+                var didCancel = false;
+                if (message is { } targetMessage && targetMessage.BodyObject is IInvokable request)
                 {
-                    // If the request was waiting, then we necessarily did manage to cancel it, so send the response now.
-                    try
+                    if (wasWaiting)
                     {
-                        _shared.InternalRuntime.RuntimeClient.SendResponse(message, Response.FromException(new OperationCanceledException()));
-                        didCancel = true;
+                        // If the request was waiting, then we necessarily did manage to cancel it, so send the response now.
+                        try
+                        {
+                            _shared.InternalRuntime.RuntimeClient.SendResponse(targetMessage, Response.FromException(new OperationCanceledException()));
+                            didCancel = true;
+                        }
+                        finally
+                        {
+                            targetMessage.ReleaseDropped("CanceledWhileWaiting");
+                        }
                     }
-                    finally
+                    else
                     {
-                        message.ReleaseDropped("CanceledWhileWaiting");
+                        didCancel = TryCancelInvokable(request) || !request.IsCancellable;
                     }
                 }
-                else
+
+                return didCancel;
+            }
+            finally
+            {
+                if (acquiredRunningMessage)
                 {
-                    didCancel = TryCancelInvokable(request) || !request.IsCancellable;
+                    message!.Value.Release();
                 }
             }
-
-            return didCancel;
         }
 
         bool TryCancelInvokable(IInvokable request)

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -298,6 +298,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
                 Message.RejectionTypes.Transient,
                 exception,
                 "Exception while creating grain context");
+            msg.ReleaseDropped("ExceptionCreatingContext");
         }
     }
 

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -312,6 +312,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
                 Message.RejectionTypes.Transient,
                 exception,
                 "Exception while creating grain context");
+            msg.ReleaseDropped("ExceptionCreatingContext");
         }
     }
 

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -18,7 +18,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
     private readonly StatelessWorkerGrainTypeSharedContext _shared;
     private readonly IGrainContextActivator _innerActivator;
     private readonly List<ActivationData> _workers = [];
-    private readonly ConcurrentQueue<(WorkItemType Type, object State)> _workItems = new();
+    private readonly ConcurrentQueue<WorkItem> _workItems = new();
     private readonly SingleWaiterAutoResetEvent _workSignal = new() { RunContinuationsAsynchronously = false };
     private readonly TaskCompletionSource _disposalTask = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -97,7 +97,13 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
     public void Activate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken) { }
 
-    public void ReceiveMessage(object message) => EnqueueWorkItem(WorkItemType.Message, message);
+    public void ReceiveMessage(object message) => ReceiveMessage((Message)message);
+
+    public void ReceiveMessage(Message message)
+    {
+        _workItems.Enqueue(new(WorkItemType.Message, message, null));
+        _workSignal.Signal();
+    }
 
     public void Deactivate(DeactivationReason deactivationReason, CancellationToken cancellationToken) =>
         EnqueueWorkItem(WorkItemType.Deactivate, new DeactivateWorkItemState(deactivationReason, cancellationToken));
@@ -110,7 +116,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
     private void EnqueueWorkItem(WorkItemType type, object state)
     {
-        _workItems.Enqueue(new(type, state));
+        _workItems.Enqueue(new(type, default, state));
         _workSignal.Signal();
     }
 
@@ -145,17 +151,17 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
                     switch (workItem.Type)
                     {
                         case WorkItemType.Message:
-                            ReceiveMessageInternal(workItem.State);
+                            ReceiveMessageInternal(workItem.Message);
                             break;
                         case WorkItemType.Deactivate:
                             {
-                                var state = (DeactivateWorkItemState)workItem.State;
+                                var state = (DeactivateWorkItemState)workItem.State!;
                                 DeactivateInternal(state.DeactivationReason, state.CancellationToken);
                                 break;
                             }
                         case WorkItemType.DeactivatedTask:
                             {
-                                var state = (DeactivatedTaskWorkItemState)workItem.State;
+                                var state = (DeactivatedTaskWorkItemState)workItem.State!;
                                 _ = DeactivatedTaskInternal(state.Completion);
                                 break;
                             }
@@ -166,7 +172,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
                             }
                         case WorkItemType.OnDestroyActivation:
                             {
-                                var grainContext = (ActivationData)workItem.State;
+                                var grainContext = (ActivationData)workItem.State!;
                                 _workers.Remove(grainContext);
 
                                 if (_workers.Count == 0)
@@ -245,13 +251,13 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
         }
     }
 
-    private void ReceiveMessageInternal(object message)
+    private void ReceiveMessageInternal(Message message)
     {
         try
         {
             if (_terminated)
             {
-                ForwardToReplacementContext((Message)message);
+                ForwardToReplacementContext(message);
                 return;
             }
 
@@ -305,14 +311,14 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
             worker.ReceiveMessage(message);
         }
-        catch (Exception exception) when (message is Message msg)
+        catch (Exception exception)
         {
             _shared.Shared.InternalRuntime.MessageCenter.RejectMessage(
-                msg,
+                message,
                 Message.RejectionTypes.Transient,
                 exception,
                 "Exception while creating grain context");
-            msg.ReleaseDropped("ExceptionCreatingContext");
+            message.ReleaseDropped("ExceptionCreatingContext");
         }
     }
 
@@ -328,10 +334,10 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
             rehydrationContext: null)!;
         Debug.Assert(!ReferenceEquals(replacement, this), "Catalog must not resolve to a terminated stateless worker context.");
         StatelessWorkerEvents.EmitMessageForwarded(this, replacement, message);
-        replacement.ReceiveMessage(message);
+        RuntimeMessageDispatcher.Dispatch(replacement, message);
     }
 
-    private ActivationData CreateWorker(object? message)
+    private ActivationData CreateWorker(Message? message)
     {
         Debug.Assert(!_terminated, "CreateWorker must not be called on a terminated stateless worker context.");
         var address = GrainAddress.GetAddress(Address.SiloAddress, Address.GrainId, ActivationId.NewId());
@@ -341,7 +347,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
         newWorker.SetComponent<IActivationLifecycleObserver>(this);
 
         // If this is a new worker and there is a message in scope, try to get the request context and activate the worker
-        var requestContext = (message as Message)?.RequestContextData ?? [];
+        var requestContext = message is { } request ? request.RequestContextData ?? [] : [];
         var cancellation = new CancellationTokenSource(_shared.Shared.InternalRuntime.CollectionOptions.Value.ActivationTimeout);
 
         newWorker.Activate(requestContext, cancellation.Token);
@@ -440,6 +446,7 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
         CollectIdleWorkers
     }
 
+    private readonly record struct WorkItem(WorkItemType Type, Message Message, object? State);
     private record ActivateWorkItemState(Dictionary<string, object>? RequestContext, CancellationToken CancellationToken);
     private record DeactivateWorkItemState(DeactivationReason DeactivationReason, CancellationToken CancellationToken);
     private record DeactivatedTaskWorkItemState(TaskCompletionSource Completion);

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -247,14 +247,14 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
     private void ReceiveMessageInternal(object message)
     {
-        if (_terminated)
-        {
-            ForwardToReplacementContext((Message)message);
-            return;
-        }
-
         try
         {
+            if (_terminated)
+            {
+                ForwardToReplacementContext((Message)message);
+                return;
+            }
+
             ActivationData? worker = null;
             ActivationData? minimumWaitingCountWorker = null;
             var minimumWaitingCount = int.MaxValue;

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -194,6 +194,7 @@ namespace Orleans.Runtime
             if (message.IsExpired)
             {
                 this.messagingTrace.OnDropExpiredMessage(message, MessagingInstruments.Phase.Receive);
+                message.ReleaseDropped("ExpiredAtDispatch");
                 return true;
             }
 

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -194,6 +194,7 @@ namespace Orleans.Runtime
             if (message.IsExpired)
             {
                 this.messagingTrace.OnDropExpiredMessage(message, MessagingInstruments.Phase.Receive);
+                message.ReleaseDropped("ExpiredAtDispatch");
                 return true;
             }
 
@@ -213,7 +214,10 @@ namespace Orleans.Runtime
             else
             {
                 // Requests against client objects are scheduled for execution on the client.
-                this.incomingMessages.Writer.TryWrite(msg);
+                if (!this.incomingMessages.Writer.TryWrite(msg))
+                {
+                    msg.ReleaseDropped("HostedClientStopped");
+                }
             }
         }
 
@@ -258,6 +262,7 @@ namespace Orleans.Runtime
                                 break;
                             default:
                                 LogErrorUnsupportedMessage(this.logger, message);
+                                message.ReleaseDropped("UnsupportedMessageDirection");
                                 break;
                         }
                     }

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -256,7 +256,6 @@ namespace Orleans.Runtime
 
                     while (reader.TryRead(out var message))
                     {
-                        if (message == null) continue;
                         switch (message.Direction)
                         {
                             case Message.Directions.OneWay:

--- a/src/Orleans.Runtime/Core/HostedClient.cs
+++ b/src/Orleans.Runtime/Core/HostedClient.cs
@@ -204,8 +204,11 @@ namespace Orleans.Runtime
 
         public void ReceiveMessage(object message)
         {
-            var msg = (Message)message;
+            ReceiveMessage((Message)message);
+        }
 
+        public void ReceiveMessage(Message msg)
+        {
             if (msg.Direction == Message.Directions.Response)
             {
                 // Requests are made through the runtime client, so deliver responses to the runtime client so that the request callback can be executed.

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -198,6 +198,8 @@ namespace Orleans.Runtime
             if (request.IsExpired)
             {
                 this.messagingTrace.OnDropExpiredMessage(request, MessagingInstruments.Phase.Respond);
+                // Note: We don't release here because the request message is still owned by the activation.
+                // It will be released in ActivationData.OnCompletedRequest when invoke completes.
                 return;
             }
 
@@ -264,6 +266,8 @@ namespace Orleans.Runtime
                 if (message.IsExpired)
                 {
                     this.messagingTrace.OnDropExpiredMessage(message, MessagingInstruments.Phase.Invoke);
+                    // Note: We don't release here because the message is still owned by the activation.
+                    // It will be released in ActivationData.OnCompletedRequest when this method returns.
                     return;
                 }
 
@@ -413,6 +417,7 @@ namespace Orleans.Runtime
                         break;
                     case Message.RejectionTypes.CacheInvalidation when message.HasCacheInvalidationHeader:
                         // The message targeted an invalid (eg, defunct) activation and this response serves only to invalidate this silo's activation cache.
+                        message.ReleaseDropped("CacheInvalidationResponse");
                         return;
                     default:
                         LogErrorUnsupportedRejectionType(this.logger, rejection.RejectionType);
@@ -452,6 +457,7 @@ namespace Orleans.Runtime
                     }
                 }
 
+                message.ReleaseDropped("StatusResponseHandled");
                 return;
             }
 
@@ -462,11 +468,16 @@ namespace Orleans.Runtime
                 // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
                 // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
                 callbackData.DoCallback(message);
+                message.MarkTransferred("InsideRuntimeClient.ReceiveResponse:AfterDoCallback");
+                message.Release();
             }
             else
             {
                 LogDebugNoCallbackForResponse(this.logger, message);
+                message.MarkTransferred("InsideRuntimeClient.ReceiveResponse:NoCallbackNotFound");
+                message.Release();
             }
+
         }
 
         public string CurrentActivationIdentity => RuntimeContext.Current?.Address.ToString() ?? this.HostedClient.ToString();

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -46,7 +46,7 @@ namespace Orleans.Runtime
         private IGrainCallCancellationManager _cancellationManager = null!;
         private HostedClient hostedClient = null!;
 
-        private HostedClient HostedClient => this.hostedClient;
+        private HostedClient HostedClient => this.hostedClient ??= this.ServiceProvider.GetRequiredService<HostedClient>();
         private readonly MessageFactory messageFactory;
         private IGrainReferenceRuntime grainReferenceRuntime = null!;
         private Task? callbackTimerTask;
@@ -112,25 +112,15 @@ namespace Orleans.Runtime
 
         public GrainFactory ConcreteGrainFactory { get; }
 
-        private GrainLocator GrainLocator => this.grainLocator;
+        private GrainLocator GrainLocator
+            => this.grainLocator;
 
-        private List<IIncomingGrainCallFilter> GrainCallFilters => this.grainCallFilters;
+        private List<IIncomingGrainCallFilter> GrainCallFilters
+            => this.grainCallFilters;
 
-        private MessageCenter MessageCenter => this.messageCenter;
+        private MessageCenter MessageCenter => this.messageCenter ?? (this.messageCenter = this.ServiceProvider.GetRequiredService<MessageCenter>());
 
-        public IGrainReferenceRuntime GrainReferenceRuntime => this.grainReferenceRuntime;
-
-        internal void ConsumeServices()
-        {
-            this.grainLocator = this.ServiceProvider.GetRequiredService<GrainLocator>();
-            this.grainCallFilters = new List<IIncomingGrainCallFilter>(this.ServiceProvider.GetServices<IIncomingGrainCallFilter>());
-            this.messageCenter = this.ServiceProvider.GetRequiredService<MessageCenter>();
-            this.grainReferenceRuntime = this.ServiceProvider.GetRequiredService<IGrainReferenceRuntime>();
-            this.hostedClient = this.ServiceProvider.GetRequiredService<HostedClient>();
-            _cancellationManager = this.ServiceProvider.GetRequiredService<IGrainCallCancellationManager>();
-            sharedCallbackData.CancellationManager = _cancellationManager;
-            systemSharedCallbackData.CancellationManager = _cancellationManager;
-        }
+        public IGrainReferenceRuntime GrainReferenceRuntime => this.grainReferenceRuntime ?? (this.grainReferenceRuntime = this.ServiceProvider.GetRequiredService<IGrainReferenceRuntime>());
 
         public void SendRequest(
             GrainReference target,
@@ -188,10 +178,11 @@ namespace Orleans.Runtime
                 Debug.Assert(context is not null);
 
                 // Register a callback for the request.
-                callbackData = new CallbackData(sharedData, context, message, _applicationRequestInstruments);
+                callbackData = new CallbackData(sharedData, context!, message, _applicationRequestInstruments);
                 if (Volatile.Read(ref _isStopping) != 0)
                 {
                     callbackData.OnHostShutdown();
+                    message.ReleaseDropped("SiloStoppingBeforeCallbackRegistration");
                     return;
                 }
 
@@ -203,6 +194,7 @@ namespace Orleans.Runtime
                 context?.Complete();
                 if (Volatile.Read(ref _isStopping) != 0)
                 {
+                    message.ReleaseDropped("SiloStoppingBeforeOneWaySend");
                     return;
                 }
             }
@@ -212,6 +204,7 @@ namespace Orleans.Runtime
             if (Volatile.Read(ref _isStopping) != 0)
             {
                 callbackData?.OnHostShutdown();
+                message.ReleaseDropped("SiloStoppingBeforeSend");
                 return;
             }
 
@@ -227,6 +220,8 @@ namespace Orleans.Runtime
             if (request.IsExpired)
             {
                 this.messagingTrace.OnDropExpiredMessage(request, MessagingInstruments.Phase.Respond);
+                // Note: We don't release here because the request message is still owned by the activation.
+                // It will be released in ActivationData.OnCompletedRequest when invoke completes.
                 return;
             }
 
@@ -293,6 +288,8 @@ namespace Orleans.Runtime
                 if (message.IsExpired)
                 {
                     this.messagingTrace.OnDropExpiredMessage(message, MessagingInstruments.Phase.Invoke);
+                    // Note: We don't release here because the message is still owned by the activation.
+                    // It will be released in ActivationData.OnCompletedRequest when this method returns.
                     return;
                 }
 
@@ -320,7 +317,6 @@ namespace Orleans.Runtime
                                 else
                                 {
                                     response = await invokable.Invoke();
-                                    // The copier preserves the null state of its input.
                                     response = this.responseCopier.Copy(response)!;
                                 }
 
@@ -382,7 +378,6 @@ namespace Orleans.Runtime
         {
             try
             {
-                // The copier preserves the null state of its input.
                 SendResponse(message, (Response)this._deepCopier.Copy(response)!);
             }
             catch (Exception exc)
@@ -415,15 +410,7 @@ namespace Orleans.Runtime
         public void ReceiveResponse(Message message)
         {
             OrleansInsideRuntimeClientEvent.Instance.ReceiveResponse(message);
-
-            var result = message.Result;
-            if (result != Message.ResponseTypes.Rejection && result != Message.ResponseTypes.Status)
-            {
-                ProcessResponseCallback(message);
-                return;
-            }
-
-            if (result is Message.ResponseTypes.Rejection)
+            if (message.Result is Message.ResponseTypes.Rejection)
             {
                 if (!message.TargetSilo!.Matches(this.MySilo))
                 {
@@ -452,71 +439,67 @@ namespace Orleans.Runtime
                         break;
                     case Message.RejectionTypes.CacheInvalidation when message.HasCacheInvalidationHeader:
                         // The message targeted an invalid (eg, defunct) activation and this response serves only to invalidate this silo's activation cache.
+                        message.ReleaseDropped("CacheInvalidationResponse");
                         return;
                     default:
                         LogErrorUnsupportedRejectionType(this.logger, rejection.RejectionType);
                         break;
                 }
-
-                ProcessResponseCallback(message);
             }
-            else
+            else if (message.Result == Message.ResponseTypes.Status)
             {
-                ProcessStatusResponse(message);
-            }
-        }
+                var status = (StatusResponse)message.BodyObject!;
+                callbacks.TryGetValue((message.TargetGrain, message.Id), out var callback);
+                var request = callback?.Message;
+                if (request is not null)
+                {
+                    callback!.OnStatusUpdate(status);
+                    if (status.Diagnostics != null && status.Diagnostics.Count > 0)
+                    {
+                        LogInformationReceivedStatusUpdate(this.logger, request, status.Diagnostics);
+                    }
+                }
+                else
+                {
+                    if (messagingOptions.CancelUnknownRequestOnStatusUpdate)
+                    {
+                        // Cancel the call since the caller has abandoned it.
+                        // Note that the target and sender arguments are swapped because this is a response to the original request.
+                        _cancellationManager.SignalCancellation(
+                            message.SendingSilo,
+                            targetGrainId: message.SendingGrain,
+                            sendingGrainId: message.TargetGrain,
+                            messageId: message.Id);
+                    }
 
-        private void ProcessResponseCallback(Message message)
-        {
-            if (callbacks.TryRemove((message.TargetGrain, message.Id), out var callbackData))
+                    if (status.Diagnostics != null && status.Diagnostics.Count > 0 && logger.IsEnabled(LogLevel.Debug))
+                    {
+                        var diagnosticsString = string.Join("\n", status.Diagnostics);
+                        LogDebugReceivedStatusUpdateUnknownRequest(this.logger, message, diagnosticsString);
+                    }
+                }
+
+                message.ReleaseDropped("StatusResponseHandled");
+                return;
+            }
+
+            CallbackData? callbackData;
+            bool found = callbacks.TryRemove((message.TargetGrain, message.Id), out callbackData);
+            if (found)
             {
                 // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
                 // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
-                callbackData.DoCallback(message);
+                callbackData!.DoCallback(message);
+                message.MarkTransferred("InsideRuntimeClient.ReceiveResponse:AfterDoCallback");
+                message.Release();
             }
             else
             {
                 LogDebugNoCallbackForResponse(this.logger, message);
-            }
-        }
-
-        private void ProcessStatusResponse(Message message)
-        {
-            var status = (StatusResponse)message.BodyObject!;
-            callbacks.TryGetValue((message.TargetGrain, message.Id), out var callback);
-            var request = callback?.Message;
-            if (request is not null)
-            {
-                callback!.OnStatusUpdate(status);
-                if (status.Diagnostics is { Count: > 0 })
-                {
-                    LogInformationReceivedStatusUpdate(this.logger, request, status.Diagnostics);
-                }
-
-                return;
+                message.MarkTransferred("InsideRuntimeClient.ReceiveResponse:NoCallbackNotFound");
+                message.Release();
             }
 
-            HandleUnknownStatusUpdate(message, status);
-        }
-
-        private void HandleUnknownStatusUpdate(Message message, StatusResponse status)
-        {
-            if (messagingOptions.CancelUnknownRequestOnStatusUpdate)
-            {
-                // Cancel the call since the caller has abandoned it.
-                // Note that the target and sender arguments are swapped because this is a response to the original request.
-                _cancellationManager.SignalCancellation(
-                    message.SendingSilo,
-                    targetGrainId: message.SendingGrain,
-                    sendingGrainId: message.TargetGrain,
-                    messageId: message.Id);
-            }
-
-            if (status.Diagnostics is { Count: > 0 } && logger.IsEnabled(LogLevel.Debug))
-            {
-                var diagnosticsString = string.Join("\n", status.Diagnostics);
-                LogDebugReceivedStatusUpdateUnknownRequest(this.logger, message, diagnosticsString);
-            }
         }
 
         public string CurrentActivationIdentity => RuntimeContext.Current?.Address.ToString() ?? this.HostedClient.ToString();
@@ -611,7 +594,11 @@ namespace Orleans.Runtime
 
         public void Participate(ISiloLifecycle lifecycle)
         {
-            ConsumeServices();
+            grainLocator = ServiceProvider.GetRequiredService<GrainLocator>();
+            grainCallFilters = new List<IIncomingGrainCallFilter>(ServiceProvider.GetServices<IIncomingGrainCallFilter>());
+            _cancellationManager = this.ServiceProvider.GetRequiredService<IGrainCallCancellationManager>();
+            sharedCallbackData.CancellationManager = _cancellationManager;
+            systemSharedCallbackData.CancellationManager = _cancellationManager;
             lifecycle.Subscribe<InsideRuntimeClient>(ServiceLifecycleStage.RuntimeInitialize, OnRuntimeInitializeStart, OnRuntimeInitializeStop);
         }
 

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -491,19 +491,26 @@ namespace Orleans.Runtime
 
             CallbackData? callbackData;
             bool found = callbacks.TryRemove((message.TargetGrain, message.Id), out callbackData);
-            if (found)
+            try
             {
-                // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
-                // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
-                callbackData!.DoCallback(message);
-                message.MarkTransferred("InsideRuntimeClient.ReceiveResponse:AfterDoCallback");
-                message.Release();
+                if (found)
+                {
+                    // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
+                    // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
+                    callbackData!.DoCallback(message);
+                }
+                else
+                {
+                    LogDebugNoCallbackForResponse(this.logger, message);
+                }
             }
-            else
+            catch (Exception exception)
             {
-                LogDebugNoCallbackForResponse(this.logger, message);
-                message.MarkTransferred("InsideRuntimeClient.ReceiveResponse:NoCallbackNotFound");
-                message.Release();
+                LogErrorProcessingResponse(this.logger, exception, message);
+            }
+            finally
+            {
+                message.ReleaseDropped("ResponseHandled");
             }
 
         }
@@ -746,6 +753,11 @@ namespace Orleans.Runtime
             EventId = (int)ErrorCode.Dispatcher_NoCallbackForResp,
             Message = "No callback for response message {Message}")]
         private static partial void LogDebugNoCallbackForResponse(ILogger logger, Message message);
+
+        [LoggerMessage(
+            Level = LogLevel.Error,
+            Message = "Error processing response message '{Message}'.")]
+        private static partial void LogErrorProcessingResponse(ILogger logger, Exception exception, Message message);
 
         [LoggerMessage(
             Level = LogLevel.Debug,

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -450,13 +450,19 @@ namespace Orleans.Runtime
             {
                 var status = (StatusResponse)message.BodyObject!;
                 callbacks.TryGetValue((message.TargetGrain, message.Id), out var callback);
-                var request = callback?.Message;
-                if (request is not null)
+                if (callback is not null && callback.TryAcquireMessage(out var requestMessage))
                 {
-                    callback!.OnStatusUpdate(status);
-                    if (status.Diagnostics != null && status.Diagnostics.Count > 0)
+                    try
                     {
-                        LogInformationReceivedStatusUpdate(this.logger, request, status.Diagnostics);
+                        callback.OnStatusUpdate(status);
+                        if (status.Diagnostics != null && status.Diagnostics.Count > 0)
+                        {
+                            LogInformationReceivedStatusUpdate(this.logger, requestMessage, status.Diagnostics);
+                        }
+                    }
+                    finally
+                    {
+                        requestMessage.Release();
                     }
                 }
                 else
@@ -585,9 +591,21 @@ namespace Orleans.Runtime
         {
             foreach (var callback in callbacks)
             {
-                if (deadSilo.Equals(callback.Value.Message.TargetSilo))
+                if (!callback.Value.TryAcquireMessage(out var message))
                 {
-                    callback.Value.OnTargetSiloFail();
+                    continue;
+                }
+
+                try
+                {
+                    if (deadSilo.Equals(message.TargetSilo))
+                    {
+                        callback.Value.OnTargetSiloFail();
+                    }
+                }
+                finally
+                {
+                    message.Release();
                 }
             }
         }
@@ -603,7 +621,30 @@ namespace Orleans.Runtime
         }
 
         public int GetRunningRequestsCount(GrainInterfaceType grainInterfaceType)
-            => this.callbacks.Count(c => c.Value.Message.InterfaceType == grainInterfaceType);
+        {
+            var count = 0;
+            foreach (var callback in callbacks.Values)
+            {
+                if (!callback.TryAcquireMessage(out var message))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (message.InterfaceType == grainInterfaceType)
+                    {
+                        count++;
+                    }
+                }
+                finally
+                {
+                    message.Release();
+                }
+            }
+
+            return count;
+        }
 
         private async Task MonitorCallbackExpiry()
         {

--- a/src/Orleans.Runtime/Core/RuntimeMessageDispatcher.cs
+++ b/src/Orleans.Runtime/Core/RuntimeMessageDispatcher.cs
@@ -1,0 +1,26 @@
+namespace Orleans.Runtime;
+
+internal static class RuntimeMessageDispatcher
+{
+    public static void Dispatch(IGrainContext context, Message message)
+    {
+        switch (context)
+        {
+            case ActivationData activation:
+                activation.ReceiveMessage(message);
+                break;
+            case StatelessWorkerGrainContext statelessWorker:
+                statelessWorker.ReceiveMessage(message);
+                break;
+            case HostedClient hostedClient:
+                hostedClient.ReceiveMessage(message);
+                break;
+            case SystemTarget systemTarget:
+                systemTarget.ReceiveMessage(message);
+                break;
+            default:
+                context.ReceiveMessage(message);
+                break;
+        }
+    }
+}

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -161,6 +161,9 @@ namespace Orleans.Runtime
                 {
                     _runningRequests.Remove(request);
                 }
+
+                request.MarkTransferred("SystemTarget.HandleNewRequest");
+                request.Release();
             }
         }
 

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -373,6 +373,7 @@ namespace Orleans.Runtime
 
                 default:
                     LogInvalidMessage(_logger, msg);
+                    msg.ReleaseDropped("UnsupportedMessageDirection");
                     break;
             }
         }

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -353,7 +353,11 @@ namespace Orleans.Runtime
         /// <inheritdoc/>
         public void ReceiveMessage(object message)
         {
-            var msg = (Message)message;
+            ReceiveMessage((Message)message);
+        }
+
+        internal void ReceiveMessage(Message msg)
+        {
             switch (msg.Direction)
             {
                 case Message.Directions.Request:
@@ -493,6 +497,7 @@ namespace Orleans.Runtime
             bool TryCancelRequest()
             {
                 Message? message = null;
+                var acquiredRunningMessage = false;
 
                 lock (_runningRequests)
                 {
@@ -501,27 +506,39 @@ namespace Orleans.Runtime
                     {
                         if (runningRequest.Id == messageId && runningRequest.SendingGrain == senderGrainId)
                         {
+                            runningRequest.Acquire();
                             message = runningRequest;
+                            acquiredRunningMessage = true;
                             break;
                         }
                     }
                 }
 
-                var didCancel = false;
-                if (message is not null)
+                try
                 {
-                    if (message.BodyObject is IInvokable invokableRequest)
+                    var didCancel = false;
+                    if (message is { } targetMessage)
                     {
-                        didCancel = TryCancelInvokable(invokableRequest) || !invokableRequest.IsCancellable;
+                        if (targetMessage.BodyObject is IInvokable invokableRequest)
+                        {
+                            didCancel = TryCancelInvokable(invokableRequest) || !invokableRequest.IsCancellable;
+                        }
+                        else
+                        {
+                            // Assume the request is not cancellable.
+                            didCancel = true;
+                        }
                     }
-                    else
+
+                    return didCancel;
+                }
+                finally
+                {
+                    if (acquiredRunningMessage)
                     {
-                        // Assume the request is not cancellable.
-                        didCancel = true;
+                        message!.Value.Release();
                     }
                 }
-
-                return didCancel;
             }
 
             bool TryCancelInvokable(IInvokable request)

--- a/src/Orleans.Runtime/Diagnostics/DispatcherEvents.cs
+++ b/src/Orleans.Runtime/Diagnostics/DispatcherEvents.cs
@@ -18,53 +18,53 @@ internal static class DispatcherEvents
     }
 
     internal sealed class ReceivedInvalidActivation(
-        Message message,
+        MessageSnapshot message,
         ActivationState activationState) : DispatcherEvent
     {
-        public readonly Message Message = message;
+        public readonly MessageSnapshot Message = message;
         public readonly ActivationState ActivationState = activationState;
     }
 
     internal sealed class DetectedDeadlock(
-        Message message,
+        MessageSnapshot message,
         ActivationData activation) : DispatcherEvent
     {
-        public readonly Message Message = message;
+        public readonly MessageSnapshot Message = message;
         public readonly ActivationData Activation = activation;
     }
 
     internal sealed class DiscardedRejection(
-        Message message,
+        MessageSnapshot message,
         Message.RejectionTypes rejectionType,
         string? reason,
         Exception? exception) : DispatcherEvent
     {
-        public readonly Message Message = message;
+        public readonly MessageSnapshot Message = message;
         public readonly Message.RejectionTypes RejectionType = rejectionType;
         public readonly string? Reason = reason;
         public readonly Exception? Exception = exception;
     }
 
     internal sealed class Rejected(
-        Message message,
+        MessageSnapshot message,
         Message.RejectionTypes rejectionType,
         string? reason,
         Exception? exception) : DispatcherEvent
     {
-        public readonly Message Message = message;
+        public readonly MessageSnapshot Message = message;
         public readonly Message.RejectionTypes RejectionType = rejectionType;
         public readonly string? Reason = reason;
         public readonly Exception? Exception = exception;
     }
 
     internal sealed class Forwarding(
-        Message message,
+        MessageSnapshot message,
         GrainAddress? oldAddress,
         SiloAddress? forwardingAddress,
         string? failedOperation,
         Exception? exception) : DispatcherEvent
     {
-        public readonly Message Message = message;
+        public readonly MessageSnapshot Message = message;
         public readonly GrainAddress? OldAddress = oldAddress;
         public readonly SiloAddress? ForwardingAddress = forwardingAddress;
         public readonly string? FailedOperation = failedOperation;
@@ -72,13 +72,13 @@ internal static class DispatcherEvents
     }
 
     internal sealed class ForwardingFailed(
-        Message message,
+        MessageSnapshot message,
         GrainAddress? oldAddress,
         SiloAddress? forwardingAddress,
         string? failedOperation,
         Exception? exception) : DispatcherEvent
     {
-        public readonly Message Message = message;
+        public readonly MessageSnapshot Message = message;
         public readonly GrainAddress? OldAddress = oldAddress;
         public readonly SiloAddress? ForwardingAddress = forwardingAddress;
         public readonly string? FailedOperation = failedOperation;
@@ -100,10 +100,10 @@ internal static class DispatcherEvents
     }
 
     internal sealed class SelectTargetFailed(
-        Message message,
+        MessageSnapshot message,
         Exception exception) : DispatcherEvent
     {
-        public readonly Message Message = message;
+        public readonly MessageSnapshot Message = message;
         public readonly Exception Exception = exception;
     }
 
@@ -119,7 +119,7 @@ internal static class DispatcherEvents
         [MethodImpl(MethodImplOptions.NoInlining)]
         static void Emit(Message message, ActivationData activation)
         {
-            Listener.Write(nameof(DetectedDeadlock), new DetectedDeadlock(message, activation));
+            Listener.Write(nameof(DetectedDeadlock), new DetectedDeadlock(message.CaptureSnapshot(), activation));
         }
     }
 
@@ -143,7 +143,7 @@ internal static class DispatcherEvents
             string? reason,
             Exception? exception)
         {
-            Listener.Write(nameof(DiscardedRejection), new DiscardedRejection(message, rejectionType, reason, exception));
+            Listener.Write(nameof(DiscardedRejection), new DiscardedRejection(message.CaptureSnapshot(), rejectionType, reason, exception));
         }
     }
 
@@ -169,7 +169,7 @@ internal static class DispatcherEvents
             string? failedOperation,
             Exception? exception)
         {
-            Listener.Write(nameof(Forwarding), new Forwarding(message, oldAddress, forwardingAddress, failedOperation, exception));
+            Listener.Write(nameof(Forwarding), new Forwarding(message.CaptureSnapshot(), oldAddress, forwardingAddress, failedOperation, exception));
         }
     }
 
@@ -195,7 +195,7 @@ internal static class DispatcherEvents
             string? failedOperation,
             Exception? exception)
         {
-            Listener.Write(nameof(ForwardingFailed), new ForwardingFailed(message, oldAddress, forwardingAddress, failedOperation, exception));
+            Listener.Write(nameof(ForwardingFailed), new ForwardingFailed(message.CaptureSnapshot(), oldAddress, forwardingAddress, failedOperation, exception));
         }
     }
 
@@ -242,7 +242,7 @@ internal static class DispatcherEvents
         [MethodImpl(MethodImplOptions.NoInlining)]
         static void Emit(Message message, ActivationState activationState)
         {
-            Listener.Write(nameof(ReceivedInvalidActivation), new ReceivedInvalidActivation(message, activationState));
+            Listener.Write(nameof(ReceivedInvalidActivation), new ReceivedInvalidActivation(message.CaptureSnapshot(), activationState));
         }
     }
 
@@ -266,7 +266,7 @@ internal static class DispatcherEvents
             string? reason,
             Exception? exception)
         {
-            Listener.Write(nameof(Rejected), new Rejected(message, rejectionType, reason, exception));
+            Listener.Write(nameof(Rejected), new Rejected(message.CaptureSnapshot(), rejectionType, reason, exception));
         }
     }
 
@@ -282,7 +282,7 @@ internal static class DispatcherEvents
         [MethodImpl(MethodImplOptions.NoInlining)]
         static void Emit(Message message, Exception exception)
         {
-            Listener.Write(nameof(SelectTargetFailed), new SelectTargetFailed(message, exception));
+            Listener.Write(nameof(SelectTargetFailed), new SelectTargetFailed(message.CaptureSnapshot(), exception));
         }
     }
 

--- a/src/Orleans.Runtime/Diagnostics/StatelessWorkerEvents.cs
+++ b/src/Orleans.Runtime/Diagnostics/StatelessWorkerEvents.cs
@@ -36,10 +36,10 @@ internal static class StatelessWorkerEvents
     internal sealed class MessageForwarded(
         IGrainContext context,
         IGrainContext replacementContext,
-        Message message) : StatelessWorkerEvent(context)
+        MessageSnapshot message) : StatelessWorkerEvent(context)
     {
         public readonly IGrainContext ReplacementContext = replacementContext;
-        public readonly Message Message = message;
+        public readonly MessageSnapshot Message = message;
     }
 
     internal static void EmitWorkerCreated(IGrainContext context, IGrainContext workerContext, int workerCount)
@@ -86,7 +86,7 @@ internal static class StatelessWorkerEvents
         [MethodImpl(MethodImplOptions.NoInlining)]
         static void Emit(IGrainContext context, IGrainContext replacementContext, Message message)
         {
-            Listener.Write(nameof(MessageForwarded), new MessageForwarded(context, replacementContext, message));
+            Listener.Write(nameof(MessageForwarded), new MessageForwarded(context, replacementContext, message.CaptureSnapshot()));
         }
     }
 

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -410,6 +410,7 @@ namespace Orleans.Runtime.Messaging
                 {
                     exception ??= new ClientNotAvailableException(Id.GrainId);
                     _gateway.messageCenter.RejectMessage(message, Message.RejectionTypes.Transient, exc: exception, rejectInfo: "Client dropped");
+                    message.ReleaseDropped("ClientDropped");
                 }
             }
 

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -519,7 +519,7 @@ namespace Orleans.Runtime.Messaging
             Level = LogLevel.Information,
             Message = "Recorded opened connection from endpoint {EndPoint}, client ID {ClientId}."
         )]
-        private static partial void LogInformationGatewayClientOpenedSocket(ILogger logger, EndPoint endPoint, ClientGrainId clientId);
+        private static partial void LogInformationGatewayClientOpenedSocket(ILogger logger, EndPoint? endPoint, ClientGrainId clientId);
 
         [LoggerMessage(
             EventId = (int)ErrorCode.GatewayClientClosedSocket,

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -412,15 +412,23 @@ namespace Orleans.Runtime.Messaging
                         // Send all pending messages.
                         while (_pendingToSend.TryDequeue(out var message))
                         {
-                            if (TrySend(connection, message))
+                            message.Acquire();
+                            try
                             {
-                                LogTraceSentQueuedMessage(_gateway.logger, message, Id);
+                                if (TrySend(connection, message))
+                                {
+                                    LogTraceSentQueuedMessage(_gateway.logger, message, Id);
+                                }
+                                else
+                                {
+                                    // Re-enqueue the message. It's ok that it is at the end of the queue: message ordering is not guaranteed.
+                                    _pendingToSend.Enqueue(message);
+                                    return;
+                                }
                             }
-                            else
+                            finally
                             {
-                                // Re-enqueue the message. It's ok that it is at the end of the queue: message ordering is not guaranteed.
-                                _pendingToSend.Enqueue(message);
-                                return;
+                                message.Release();
                             }
                         }
                     }

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -438,6 +438,7 @@ namespace Orleans.Runtime.Messaging
                 {
                     exception ??= new ClientNotAvailableException(Id.GrainId);
                     _gateway.messageCenter.RejectMessage(message, Message.RejectionTypes.Transient, exc: exception, rejectInfo: "Client dropped");
+                    message.ReleaseDropped("ClientDropped");
                 }
             }
 

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -534,8 +534,8 @@ namespace Orleans.Runtime.Messaging
                         return;
                     }
 
-                    targetActivation.ReceiveMessage(msg);
                     _messageObserver?.Invoke(msg);
+                    targetActivation.ReceiveMessage(msg);
                 }
             }
             catch (Exception ex)

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -143,6 +143,7 @@ namespace Orleans.Runtime.Messaging
             {
                 // Drop the message on the floor if it's an application message that isn't a rejection
                 this.messagingTrace.OnDropBlockedApplicationMessage(msg);
+                msg.ReleaseDropped("BlockedApplicationMessage");
             }
             else
             {
@@ -159,6 +160,7 @@ namespace Orleans.Runtime.Messaging
                 if (msg.IsExpired)
                 {
                     this.messagingTrace.OnDropExpiredMessage(msg, MessagingInstruments.Phase.Send);
+                    msg.ReleaseDropped("ExpiredAtSend");
                     return;
                 }
 

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -390,6 +390,7 @@ namespace Orleans.Runtime.Messaging
         {
             Debug.Assert(!message.IsLocalOnly);
 
+            message.Acquire();
             bool forwardingSucceeded = false;
             var forwardingAddress = destination?.SiloAddress;
             try
@@ -435,6 +436,9 @@ namespace Orleans.Runtime.Messaging
 
                     message.ReleaseDropped("ForwardingFailed");
                 }
+
+                message.MarkTransferred("MessageCenter.TryForwardRequest");
+                message.Release();
             }
         }
 

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -436,8 +436,11 @@ namespace Orleans.Runtime.Messaging
 
                     message.ReleaseDropped("ForwardingFailed");
                 }
+                else
+                {
+                    message.MarkTransferred("MessageCenter.TryForwardRequest");
+                }
 
-                message.MarkTransferred("MessageCenter.TryForwardRequest");
                 message.Release();
             }
         }

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -77,14 +77,23 @@ namespace Orleans.Runtime.Messaging
         public bool TryDeliverToProxy(Message msg)
         {
             if (!msg.TargetGrain.IsClient()) return false;
-            if (this.Gateway is Gateway gateway && gateway.TryDeliverToProxy(msg)
-                || this.hostedClient is HostedClient client && client.TryDispatchToClient(msg))
-            {
-                _messageObserver?.Invoke(msg);
-                return true;
-            }
 
-            return false;
+            msg.Acquire();
+            try
+            {
+                if (this.Gateway is Gateway gateway && gateway.TryDeliverToProxy(msg)
+                    || this.hostedClient is HostedClient client && client.TryDispatchToClient(msg))
+                {
+                    _messageObserver?.Invoke(msg);
+                    return true;
+                }
+
+                return false;
+            }
+            finally
+            {
+                msg.Release();
+            }
         }
 
         public async Task StopAsync()
@@ -98,9 +107,8 @@ namespace Orleans.Runtime.Messaging
         /// Indicates that application messages should be blocked from being sent or received.
         /// This method is used by the "fast stop" process.
         /// <para>
-        /// Specifically, all outbound application requests and one-way messages are rejected or dropped,
-        /// while responses and messages to the membership table grain are allowed to complete.
-        /// Inbound application requests are rejected with cache invalidation, and other inbound application messages are dropped.
+        /// Specifically, all outbound application messages are dropped, except for rejections and messages to the membership table grain.
+        /// Inbound application requests are rejected, and other inbound application messages are dropped.
         /// </para>
         /// </summary>
         public void BlockApplicationMessages()
@@ -164,9 +172,8 @@ namespace Orleans.Runtime.Messaging
                 else
                 {
                     this.messagingTrace.OnDropBlockedApplicationMessage(msg);
+                    msg.ReleaseDropped("BlockedApplicationMessage");
                 }
-
-                return;
             }
             else
             {
@@ -176,6 +183,7 @@ namespace Orleans.Runtime.Messaging
                 {
                     LogInformationMessageQueuedAfterStop(log, msg);
                     SendRejection(msg, Message.RejectionTypes.Unrecoverable, "Message was queued for sending after outbound queue was stopped");
+                    msg.ReleaseDropped("MessageCenterStopped");
                     return;
                 }
 
@@ -183,6 +191,7 @@ namespace Orleans.Runtime.Messaging
                 if (msg.IsExpired)
                 {
                     this.messagingTrace.OnDropExpiredMessage(msg, MessagingInstruments.Phase.Send);
+                    msg.ReleaseDropped("ExpiredAtSend");
                     return;
                 }
 
@@ -197,6 +206,7 @@ namespace Orleans.Runtime.Messaging
                 {
                     LogErrorMessageNoTargetSilo(log, msg, new());
                     SendRejection(msg, Message.RejectionTypes.Unrecoverable, "Message to be sent does not have a target silo.");
+                    msg.ReleaseDropped("MissingTargetSilo");
                     return;
                 }
 
@@ -224,6 +234,7 @@ namespace Orleans.Runtime.Messaging
                             this.SendRejection(msg, Message.RejectionTypes.Transient, "Target silo is known to be dead", new SiloUnavailableException());
                         }
 
+                        msg.ReleaseDropped("TargetSiloDead");
                         return;
                     }
                     else
@@ -248,6 +259,7 @@ namespace Orleans.Runtime.Messaging
                                 catch (Exception exception)
                                 {
                                     messageCenter.SendRejection(msg, Message.RejectionTypes.Transient, $"Exception while sending message: {exception}");
+                                    msg.ReleaseDropped("ConnectionFailure");
                                 }
                             }
                         }
@@ -309,6 +321,7 @@ namespace Orleans.Runtime.Messaging
                     }
 
                     RejectMessage(message, Message.RejectionTypes.Transient, exc, failedOperation);
+                    message.ReleaseDropped("InvalidActivation");
                 }
             }
             else
@@ -356,6 +369,7 @@ namespace Orleans.Runtime.Messaging
                 }
 
                 this.RejectMessage(message, Message.RejectionTypes.Transient, exc, failedOperation);
+                message.ReleaseDropped("InvalidActivation");
             }
             else
             {
@@ -418,6 +432,8 @@ namespace Orleans.Runtime.Messaging
                         var str = $"Forwarding failed: tried to forward message {message} for {message.ForwardCount} times after \"{failedOperation}\" to invalid activation. Rejecting now.";
                         RejectMessage(message, Message.RejectionTypes.Transient, exc, str);
                     }
+
+                    message.ReleaseDropped("ForwardingFailed");
                 }
             }
         }
@@ -515,6 +531,7 @@ namespace Orleans.Runtime.Messaging
             {
                 this.messagingTrace.OnDispatcherSelectTargetFailed(m, ex);
                 RejectMessage(m, Message.RejectionTypes.Unrecoverable, ex);
+                m.ReleaseDropped("AddressingFailure");
             }
         }
 
@@ -559,8 +576,8 @@ namespace Orleans.Runtime.Messaging
                         return;
                     }
 
-                    targetActivation.ReceiveMessage(msg);
                     _messageObserver?.Invoke(msg);
+                    targetActivation.ReceiveMessage(msg);
                 }
             }
             catch (Exception ex)
@@ -574,6 +591,7 @@ namespace Orleans.Runtime.Messaging
                 LogErrorCreatingActivation(log, ex, msg.TargetGrain, msg.InterfaceType, msg);
 
                 this.RejectMessage(msg, Message.RejectionTypes.Transient, ex);
+                msg.ReleaseDropped("ReceiveFailure");
             }
         }
 
@@ -595,6 +613,8 @@ namespace Orleans.Runtime.Messaging
 
                     SendMessage(response);
                 }
+
+                msg.ReleaseDropped("UnknownSystemTarget");
             }
             else
             {

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -581,7 +581,7 @@ namespace Orleans.Runtime.Messaging
                     }
 
                     _messageObserver?.Invoke(msg);
-                    targetActivation.ReceiveMessage(msg);
+                    RuntimeMessageDispatcher.Dispatch(targetActivation, msg);
                 }
             }
             catch (Exception ex)

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -62,6 +62,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.IsExpired)
             {
                 this.MessagingTrace.OnDropExpiredMessage(msg, MessagingInstruments.Phase.Receive);
+                msg.ReleaseDropped("ExpiredAtReceive");
                 return;
             }
 
@@ -73,6 +74,7 @@ namespace Orleans.Runtime.Messaging
                 this.messageCenter.TryDeliverToProxy(rejection);
                 LogRejectingRequestDueToOverloading(this.Log, msg);
                 GatewayInstruments.GatewayLoadShedding.Add(1);
+                msg.ReleaseDropped("RejectedGatewayOverload");
                 return;
             }
 
@@ -147,6 +149,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.IsExpired)
             {
                 this.MessagingTrace.OnDropExpiredMessage(msg, MessagingInstruments.Phase.Send);
+                msg.ReleaseDropped("ExpiredAtSend");
                 return false;
             }
 
@@ -169,11 +172,13 @@ namespace Orleans.Runtime.Messaging
                     Message.RejectionTypes.Transient,
                     $"Silo {this.myAddress} is rejecting message: {msg}. Reason = {reason}",
                     new SiloUnavailableException());
+                msg.ReleaseDropped("FailedSendRequest");
             }
             else
             {
                 LogSiloDroppingMessage(this.Log, this.myAddress, msg, reason);
                 MessagingInstruments.OnDroppedSentMessage(msg);
+                msg.ReleaseDropped("FailedSendNonRequest");
             }
         }
 

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -190,8 +190,6 @@ namespace Orleans.Runtime.Messaging
 
         protected override void RetryMessage(Message msg, Exception? ex = null)
         {
-            if (msg == null) return;
-
             if (msg.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
                 msg.RetryCount++;

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -48,14 +48,14 @@ namespace Orleans.Runtime.Messaging
 
         protected override void RecordMessageReceive(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstrumentation.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection);
-            this.gatewayInstruments.OnGatewayReceived();
+            MessagingMetrics.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection);
+            gatewayInstruments.OnGatewayReceived();
         }
 
         protected override void RecordMessageSend(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstrumentation.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection);
-            this.gatewayInstruments.OnGatewaySent();
+            MessagingMetrics.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection);
+            gatewayInstruments.OnGatewaySent();
         }
 
         protected override void OnReceivedMessage(Message msg)
@@ -64,17 +64,19 @@ namespace Orleans.Runtime.Messaging
             if (msg.IsExpired)
             {
                 this.MessagingTrace.OnDropExpiredMessage(msg, MessagingInstruments.Phase.Receive);
+                msg.ReleaseDropped("ExpiredAtReceive");
                 return;
             }
 
             // Are we overloaded?
             if (this.overloadDetector.IsOverloaded)
             {
-                MessagingInstrumentation.OnRejectedMessage(msg);
+                MessagingMetrics.OnRejectedMessage(msg);
                 Message rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.GatewayTooBusy, "Shedding load");
                 this.messageCenter.TryDeliverToProxy(rejection);
                 LogRejectingRequestDueToOverloading(this.Log, msg);
-                this.gatewayInstruments.OnGatewayLoadShedding();
+                gatewayInstruments.OnGatewayLoadShedding();
+                msg.ReleaseDropped("RejectedGatewayOverload");
                 return;
             }
 
@@ -91,7 +93,7 @@ namespace Orleans.Runtime.Messaging
                     msg.TargetGrain = systemTargetId.WithSiloAddress(this.myAddress).GrainId;
                 }
 
-                MessagingInstrumentation.OnMessageReRoute(msg);
+                MessagingMetrics.OnMessageReRoute(msg);
                 this.messageCenter.RerouteMessage(msg);
             }
             else
@@ -149,6 +151,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.IsExpired)
             {
                 this.MessagingTrace.OnDropExpiredMessage(msg, MessagingInstruments.Phase.Send);
+                msg.ReleaseDropped("ExpiredAtSend");
                 return false;
             }
 
@@ -160,7 +163,7 @@ namespace Orleans.Runtime.Messaging
 
         public void FailMessage(Message msg, string reason)
         {
-            MessagingInstrumentation.OnFailedSentMessage(msg);
+            MessagingMetrics.OnFailedSentMessage(msg);
             if (msg.Direction == Message.Directions.Request)
             {
                 LogSiloRejectingMessage(this.Log, this.myAddress, msg, reason);
@@ -171,11 +174,13 @@ namespace Orleans.Runtime.Messaging
                     Message.RejectionTypes.Transient,
                     $"Silo {this.myAddress} is rejecting message: {msg}. Reason = {reason}",
                     new SiloUnavailableException());
+                msg.ReleaseDropped("FailedSendRequest");
             }
             else
             {
                 LogSiloDroppingMessage(this.Log, this.myAddress, msg, reason);
-                MessagingInstrumentation.OnDroppedSentMessage(msg);
+                MessagingMetrics.OnDroppedSentMessage(msg);
+                msg.ReleaseDropped("FailedSendNonRequest");
             }
         }
 

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -73,7 +73,11 @@ namespace Orleans.Runtime.Messaging
             {
                 MessagingMetrics.OnRejectedMessage(msg);
                 Message rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.GatewayTooBusy, "Shedding load");
-                this.messageCenter.TryDeliverToProxy(rejection);
+                if (!this.messageCenter.TryDeliverToProxy(rejection))
+                {
+                    rejection.ReleaseDropped("GatewayOverloadRejectionUndeliverable");
+                }
+
                 LogRejectingRequestDueToOverloading(this.Log, msg);
                 gatewayInstruments.OnGatewayLoadShedding();
                 msg.ReleaseDropped("RejectedGatewayOverload");

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -81,6 +81,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.IsExpired)
             {
                 this.MessagingTrace.OnDropExpiredMessage(msg, MessagingInstruments.Phase.Receive);
+                msg.ReleaseDropped("ExpiredAtReceive");
                 return;
             }
 
@@ -92,12 +93,14 @@ namespace Orleans.Runtime.Messaging
                 if (msg.Direction != Message.Directions.Request)
                 {
                     this.MessagingTrace.OnDropBlockedApplicationMessage(msg);
+                    msg.ReleaseDropped("BlockedApplicationMessage");
                     return;
                 }
 
                 MessagingInstruments.OnRejectedMessage(msg);
                 var rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable, "Silo stopping", new SiloUnavailableException());
                 this.Send(rejection);
+                msg.ReleaseDropped("RejectedSiloStopping");
                 return;
             }
 
@@ -134,8 +137,14 @@ namespace Orleans.Runtime.Messaging
                 }
 
                 this.Send(rejection);
+                msg.ReleaseDropped("RejectedObsoleteEpoch");
 
                 LogDebugRejectingObsoleteRequest(this.Log, msg.TargetSilo?.ToString() ?? "null", this.LocalSiloAddress.ToString(), msg);
+            }
+            else
+            {
+                // Response or OneWay to obsolete epoch - drop it
+                msg.ReleaseDropped("DroppedObsoleteEpoch");
             }
         }
 
@@ -153,6 +162,7 @@ namespace Orleans.Runtime.Messaging
                 Message rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable,
                     $"The target silo is no longer active: target was {msg.TargetSilo}, but this silo is {LocalSiloAddress}. The rejected ping message is {msg}.");
                 this.Send(rejection);
+                msg.ReleaseDropped("RejectedPingObsoleteEpoch");
             }
             else
             {
@@ -160,6 +170,8 @@ namespace Orleans.Runtime.Messaging
                 var response = this.MessageFactory.CreateResponseMessage(msg);
                 response.BodyObject = PingResponse;
                 this.Send(response);
+                msg.MarkTransferred("SiloConnection.HandlePingMessage");
+                msg.Release();
             }
         }
 
@@ -234,6 +246,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.IsExpired)
             {
                 this.MessagingTrace.OnDropExpiredMessage(msg, MessagingInstruments.Phase.Send);
+                msg.ReleaseDropped("ExpiredAtSend");
 
                 if (msg.IsPing())
                 {
@@ -277,10 +290,12 @@ namespace Orleans.Runtime.Messaging
                     Message.RejectionTypes.Transient,
                     $"Silo {this.LocalSiloAddress} is rejecting message: {msg}. Reason = {reason}",
                     new SiloUnavailableException());
+                msg.ReleaseDropped("FailedSendRequest");
             }
             else
             {
                 this.MessagingTrace.OnSiloDropSendingMessage(this.LocalSiloAddress, msg, reason);
+                msg.ReleaseDropped("FailedSendNonRequest");
             }
         }
 

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -57,12 +57,12 @@ namespace Orleans.Runtime.Messaging
 
         protected override void RecordMessageReceive(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstrumentation.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
+            MessagingMetrics.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
         }
 
         protected override void RecordMessageSend(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstrumentation.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
+            MessagingMetrics.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
         }
 
         protected override void OnReceivedMessage(Message msg)
@@ -81,10 +81,11 @@ namespace Orleans.Runtime.Messaging
             if (msg.IsExpired)
             {
                 this.MessagingTrace.OnDropExpiredMessage(msg, MessagingInstruments.Phase.Receive);
+                msg.ReleaseDropped("ExpiredAtReceive");
                 return;
             }
 
-            // If we've stopped application message processing, then reject requests and filter out other messages.
+            // If we've stopped application message processing, then filter those out now
             // Note that if we identify or add other grains that are required for proper stopping, we will need to treat them as we do the membership table grain here.
             if (messageCenter.IsBlockingApplicationMessages && !msg.IsSystemMessage)
             {
@@ -92,6 +93,7 @@ namespace Orleans.Runtime.Messaging
                 if (msg.Direction != Message.Directions.Request)
                 {
                     this.MessagingTrace.OnDropBlockedApplicationMessage(msg);
+                    msg.ReleaseDropped("BlockedApplicationMessage");
                     return;
                 }
 
@@ -124,7 +126,7 @@ namespace Orleans.Runtime.Messaging
             // (if it was a request), or drop it on the floor if it was a response or one-way.
             if (msg.Direction == Message.Directions.Request)
             {
-                MessagingInstrumentation.OnRejectedMessage(msg);
+                MessagingMetrics.OnRejectedMessage(msg);
                 var rejection = this.MessageFactory.CreateRejectionResponse(
                     msg,
                     Message.RejectionTypes.Transient,
@@ -137,19 +139,25 @@ namespace Orleans.Runtime.Messaging
                 }
 
                 this.Send(rejection);
-
                 if (this.Log.IsEnabled(LogLevel.Debug))
                 {
                     var targetSilo = msg.TargetSilo?.ToString() ?? "null";
                     var siloAddress = this.LocalSiloAddress.ToString();
                     LogDebugRejectingObsoleteRequest(this.Log, targetSilo, siloAddress, msg);
                 }
+
+                msg.ReleaseDropped("RejectedObsoleteEpoch");
+            }
+            else
+            {
+                // Response or OneWay to obsolete epoch - drop it
+                msg.ReleaseDropped("DroppedObsoleteEpoch");
             }
         }
 
         private void HandlePingMessage(Message msg)
         {
-            MessagingInstrumentation.OnPingReceive(msg.SendingSilo!);
+            MessagingMetrics.OnPingReceive(msg.SendingSilo!);
 
             var objectId = RuntimeHelpers.GetHashCode(msg);
             LogTraceRespondingToPing(this.Log, msg.SendingSilo!, objectId, msg);
@@ -157,10 +165,11 @@ namespace Orleans.Runtime.Messaging
             if (!this.LocalSiloAddress.Equals(msg.TargetSilo))
             {
                 // Got ping that is not destined to me. For example, got a ping to my older incarnation.
-                MessagingInstrumentation.OnRejectedMessage(msg);
+                MessagingMetrics.OnRejectedMessage(msg);
                 Message rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable,
                     $"The target silo is no longer active: target was {msg.TargetSilo}, but this silo is {LocalSiloAddress}. The rejected ping message is {msg}.");
                 this.Send(rejection);
+                msg.ReleaseDropped("RejectedPingObsoleteEpoch");
             }
             else
             {
@@ -168,6 +177,8 @@ namespace Orleans.Runtime.Messaging
                 var response = this.MessageFactory.CreateResponseMessage(msg);
                 response.BodyObject = PingResponse;
                 this.Send(response);
+                msg.MarkTransferred("SiloConnection.HandlePingMessage");
+                msg.Release();
             }
         }
 
@@ -248,6 +259,7 @@ namespace Orleans.Runtime.Messaging
                     LogWarningDroppingExpiredPingMessage(this.Log, msg);
                 }
 
+                msg.ReleaseDropped("ExpiredAtSend");
                 return false;
             }
 
@@ -274,7 +286,7 @@ namespace Orleans.Runtime.Messaging
                 LogWarningFailedPingMessage(this.Log, msg);
             }
 
-            MessagingInstrumentation.OnFailedSentMessage(msg);
+            MessagingMetrics.OnFailedSentMessage(msg);
             if (msg.Direction == Message.Directions.Request)
             {
                 LogDebugSiloRejectingMessage(this.Log, this.LocalSiloAddress, msg, reason);
@@ -285,10 +297,12 @@ namespace Orleans.Runtime.Messaging
                     Message.RejectionTypes.Transient,
                     $"Silo {this.LocalSiloAddress} is rejecting message: {msg}. Reason = {reason}",
                     new SiloUnavailableException());
+                msg.ReleaseDropped("FailedSendRequest");
             }
             else
             {
                 this.MessagingTrace.OnSiloDropSendingMessage(this.LocalSiloAddress, msg, reason);
+                msg.ReleaseDropped("FailedSendNonRequest");
             }
         }
 

--- a/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.MessageSink.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.MessageSink.cs
@@ -41,7 +41,7 @@ internal sealed partial class ActivationRepartitioner : IMessageStatisticsSink
     {
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding | ConfigureAwaitOptions.ContinueOnCapturedContext);
 
-        var drainBuffer = new Message[128];
+        var drainBuffer = new RecordedMessage[128];
         var iteration = 0;
         const int MaxIterationsPerYield = 128;
         while (!cancellationToken.IsCancellationRequested)
@@ -51,8 +51,7 @@ internal sealed partial class ActivationRepartitioner : IMessageStatisticsSink
             {
                 foreach (var message in drainBuffer[..count])
                 {
-                    if (!IsFullyAddressed(message) || // The silo addresses (likely the target) is set null some time later (after the message is recorded), this can lead to a NRE
-                        !_messageFilter.IsAcceptable(message, out var isSenderMigratable, out var isTargetMigratable))
+                    if (!_messageFilter.IsAcceptable(message.SendingGrain, message.TargetGrain, out var isSenderMigratable, out var isTargetMigratable))
                     {
                         continue;
                     }
@@ -122,7 +121,8 @@ internal sealed partial class ActivationRepartitioner : IMessageStatisticsSink
             return;
         }
 
-        if (_pendingMessages.TryAdd(message) == Utilities.BufferStatus.Success)
+        var recordedMessage = new RecordedMessage(message.SendingGrain, message.SendingSilo!, message.TargetGrain, message.TargetSilo!);
+        if (_pendingMessages.TryAdd(recordedMessage) == Utilities.BufferStatus.Success)
         {
             _pendingMessageEvent.Signal();
         }
@@ -131,6 +131,14 @@ internal sealed partial class ActivationRepartitioner : IMessageStatisticsSink
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsFullyAddressed(Message message) =>
         message.IsSenderFullyAddressed && message.IsTargetFullyAddressed;
+
+    private sealed class RecordedMessage(GrainId sendingGrain, SiloAddress sendingSilo, GrainId targetGrain, SiloAddress targetSilo)
+    {
+        public GrainId SendingGrain { get; } = sendingGrain;
+        public SiloAddress SendingSilo { get; } = sendingSilo;
+        public GrainId TargetGrain { get; } = targetGrain;
+        public SiloAddress TargetSilo { get; } = targetSilo;
+    }
 
     async ValueTask IActivationRepartitionerSystemTarget.FlushBuffers()
     {

--- a/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.MessageSink.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.MessageSink.cs
@@ -41,7 +41,7 @@ internal sealed partial class ActivationRepartitioner : IMessageStatisticsSink
     {
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding | ConfigureAwaitOptions.ContinueOnCapturedContext);
 
-        var drainBuffer = new Message[128];
+        var drainBuffer = new RecordedMessage[128];
         var iteration = 0;
         const int MaxIterationsPerYield = 128;
         while (!cancellationToken.IsCancellationRequested)
@@ -51,8 +51,7 @@ internal sealed partial class ActivationRepartitioner : IMessageStatisticsSink
             {
                 foreach (var message in drainBuffer[..count])
                 {
-                    if (!IsFullyAddressed(message) || // The silo addresses (likely the target) is set null some time later (after the message is recorded), this can lead to a NRE
-                        !_messageFilter.IsAcceptable(message, out var isSenderMigratable, out var isTargetMigratable))
+                    if (!_messageFilter.IsAcceptable(message.SendingGrain, message.TargetGrain, out var isSenderMigratable, out var isTargetMigratable))
                     {
                         continue;
                     }
@@ -122,7 +121,8 @@ internal sealed partial class ActivationRepartitioner : IMessageStatisticsSink
             return;
         }
 
-        if (_pendingMessages.TryAdd(message) == Utilities.BufferStatus.Success)
+        var recordedMessage = new RecordedMessage(message.SendingGrain, message.SendingSilo!, message.TargetGrain, message.TargetSilo!);
+        if (_pendingMessages.TryAdd(recordedMessage) == Utilities.BufferStatus.Success)
         {
             _pendingMessageEvent.Signal();
         }
@@ -131,6 +131,14 @@ internal sealed partial class ActivationRepartitioner : IMessageStatisticsSink
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsFullyAddressed(Message message) =>
         message.IsSenderFullyAddressed && message.IsTargetFullyAddressed;
+
+    private sealed class RecordedMessage(GrainId sendingGrain, SiloAddress sendingSilo, GrainId targetGrain, SiloAddress targetSilo)
+    {
+        public GrainId SendingGrain { get; } = sendingGrain;
+        public SiloAddress SendingSilo { get; } = sendingSilo;
+        public GrainId TargetGrain { get; } = targetGrain;
+        public SiloAddress TargetSilo { get; } = targetSilo;
+    }
 
     async ValueTask IActivationRepartitionerSystemTarget.FlushBuffers(CancellationToken cancellationToken)
     {

--- a/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs
@@ -30,7 +30,7 @@ internal sealed partial class ActivationRepartitioner : SystemTarget, IActivatio
     private readonly ActivationDirectory _activationDirectory;
     private readonly TimeProvider _timeProvider;
     private readonly ActivationRepartitionerOptions _options;
-    private readonly StripedMpscBuffer<Message> _pendingMessages;
+    private readonly StripedMpscBuffer<RecordedMessage> _pendingMessages;
     private readonly SingleWaiterAutoResetEvent _pendingMessageEvent = new() { RunContinuationsAsynchronously = true };
     private readonly FrequentEdgeCounter _edgeWeights;
     private readonly IGrainTimer _timer;
@@ -63,7 +63,7 @@ internal sealed partial class ActivationRepartitioner : SystemTarget, IActivatio
         _timeProvider = timeProvider;
         _edgeWeights = new(options.Value.MaxEdgeCount);
         _lastExchangedStopwatch = CoarseStopwatch.StartNew();
-        _pendingMessages = new StripedMpscBuffer<Message>(Environment.ProcessorCount, options.Value.MaxUnprocessedEdges / Environment.ProcessorCount);
+        _pendingMessages = new StripedMpscBuffer<RecordedMessage>(Environment.ProcessorCount, options.Value.MaxUnprocessedEdges / Environment.ProcessorCount);
         shared.ActivationDirectory.RecordNewTarget(this);
         _siloStatusOracle.SubscribeToSiloStatusEvents(this);
         _timer = RegisterTimer(_ => TriggerExchangeRequest().AsTask(), null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);

--- a/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs
@@ -78,7 +78,7 @@ internal sealed partial class ActivationRepartitioner : SystemTarget, IActivatio
     private readonly ActivationDirectory _activationDirectory;
     private readonly TimeProvider _timeProvider;
     private readonly ActivationRepartitionerOptions _options;
-    private readonly StripedMpscBuffer<Message> _pendingMessages;
+    private readonly StripedMpscBuffer<RecordedMessage> _pendingMessages;
     private readonly SingleWaiterAutoResetEvent _pendingMessageEvent = new() { RunContinuationsAsynchronously = true };
     private readonly FrequentEdgeCounter _edgeWeights;
     private readonly IGrainTimer _timer;
@@ -113,7 +113,7 @@ internal sealed partial class ActivationRepartitioner : SystemTarget, IActivatio
         _timeProvider = timeProvider;
         _edgeWeights = new(options.Value.MaxEdgeCount);
         _lastExchangedStopwatch = CoarseStopwatch.StartNew();
-        _pendingMessages = new StripedMpscBuffer<Message>(Environment.ProcessorCount, options.Value.MaxUnprocessedEdges / Environment.ProcessorCount);
+        _pendingMessages = new StripedMpscBuffer<RecordedMessage>(Environment.ProcessorCount, options.Value.MaxUnprocessedEdges / Environment.ProcessorCount);
         shared.ActivationDirectory.RecordNewTarget(this);
         _siloStatusOracle.SubscribeToSiloStatusEvents(this);
         _timer = RegisterTimer(

--- a/src/Orleans.Runtime/Placement/Repartitioning/RepartitionerMessageFilter.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/RepartitionerMessageFilter.cs
@@ -5,12 +5,12 @@ namespace Orleans.Runtime.Placement.Repartitioning;
 
 internal interface IRepartitionerMessageFilter
 {
-    bool IsAcceptable(Message message, out bool isSenderMigratable, out bool isTargetMigratable);
+    bool IsAcceptable(GrainId sendingGrain, GrainId targetGrain, out bool isSenderMigratable, out bool isTargetMigratable);
 }
 
 internal sealed class RepartitionerMessageFilter(GrainMigratabilityChecker checker) : IRepartitionerMessageFilter
 {
-    public bool IsAcceptable(Message message, out bool isSenderMigratable, out bool isTargetMigratable)
+    public bool IsAcceptable(GrainId sendingGrain, GrainId targetGrain, out bool isSenderMigratable, out bool isTargetMigratable)
     {
         isSenderMigratable = false;
         isTargetMigratable = false;
@@ -18,13 +18,13 @@ internal sealed class RepartitionerMessageFilter(GrainMigratabilityChecker check
         // There are some edge cases when this can happen i.e. a grain invoking another one of its methods via AsReference<>, but we still exclude it
         // as wherever this grain would be located in the cluster, it would always be a local call (since it targets itself), this would add negative transfer cost
         // which would skew a potential relocation of this grain, while it shouldn't, because whenever this grain is located, it would still make local calls to itself.
-        if (message.SendingGrain == message.TargetGrain)
+        if (sendingGrain == targetGrain)
         {
             return false;
         }
 
-        isSenderMigratable = checker.IsMigratable(message.SendingGrain.Type, ImmovableKind.Repartitioner);
-        isTargetMigratable = checker.IsMigratable(message.TargetGrain.Type, ImmovableKind.Repartitioner);
+        isSenderMigratable = checker.IsMigratable(sendingGrain.Type, ImmovableKind.Repartitioner);
+        isTargetMigratable = checker.IsMigratable(targetGrain.Type, ImmovableKind.Repartitioner);
 
         // If both are not migratable types we ignore this. But if one of them is not, then we allow passing, as we wish to move grains closer to them, as with any type of grain.
         return isSenderMigratable || isTargetMigratable;

--- a/src/Orleans.Runtime/Timers/GrainTimer.cs
+++ b/src/Orleans.Runtime/Timers/GrainTimer.cs
@@ -65,13 +65,14 @@ internal abstract partial class GrainTimer : IGrainTimer
 
     protected void ScheduleTickOnActivation()
     {
+        Message? msg = null;
         try
         {
             // Indicate that the timer is firing so that the effect of the next change call is deferred until after the tick completes.
             _firing = true;
 
             // Note: this does not execute on the activation's execution context.
-            var msg = _shared.MessageFactory.CreateMessage(body: _invoker, options: InvokeMethodOptions.OneWay);
+            msg = _shared.MessageFactory.CreateMessage(body: _invoker, options: InvokeMethodOptions.OneWay);
             msg.SetInfiniteTimeToLive();
             msg.SendingGrain = _grainContext.GrainId;
             msg.TargetGrain = _grainContext.GrainId;
@@ -85,9 +86,11 @@ internal abstract partial class GrainTimer : IGrainTimer
             msg.IsLocalOnly = true;
 
             _grainContext.ReceiveMessage(msg);
+            msg = null;
         }
         catch (Exception exception)
         {
+            msg?.ReleaseDropped("GrainTimerScheduleFailed");
             try
             {
                 LogErrorScheduleTickOnActivation(Logger, exception, this);

--- a/src/Orleans.Runtime/Timers/GrainTimer.cs
+++ b/src/Orleans.Runtime/Timers/GrainTimer.cs
@@ -65,7 +65,8 @@ internal abstract partial class GrainTimer : IGrainTimer
 
     protected void ScheduleTickOnActivation()
     {
-        Message? msg = null;
+        Message msg = default;
+        var ownsMessage = false;
         try
         {
             // Indicate that the timer is firing so that the effect of the next change call is deferred until after the tick completes.
@@ -73,6 +74,7 @@ internal abstract partial class GrainTimer : IGrainTimer
 
             // Note: this does not execute on the activation's execution context.
             msg = _shared.MessageFactory.CreateMessage(body: _invoker, options: InvokeMethodOptions.OneWay);
+            ownsMessage = true;
             msg.SetInfiniteTimeToLive();
             msg.SendingGrain = _grainContext.GrainId;
             msg.TargetGrain = _grainContext.GrainId;
@@ -85,12 +87,16 @@ internal abstract partial class GrainTimer : IGrainTimer
             // Prevent the message from being forwarded in the case of deactivation.
             msg.IsLocalOnly = true;
 
-            _grainContext.ReceiveMessage(msg);
-            msg = null;
+            RuntimeMessageDispatcher.Dispatch(_grainContext, msg);
+            ownsMessage = false;
         }
         catch (Exception exception)
         {
-            msg?.ReleaseDropped("GrainTimerScheduleFailed");
+            if (ownsMessage)
+            {
+                msg.ReleaseDropped("GrainTimerScheduleFailed");
+            }
+
             try
             {
                 LogErrorScheduleTickOnActivation(Logger, exception, this);

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -971,6 +971,20 @@ namespace NonSilo.Tests.Membership
             return new TestConnection(context, middleware, shared);
         }
 
+        [Fact]
+        public void Connection_PartialReadMarksReceiveActivity()
+        {
+            var connection = CreateTestConnection(this.loggerFactory);
+
+            Assert.False(connection.SimulateBytesReceived(availableBytes: 0, retainedBytes: 0));
+            Assert.Null(connection.ElapsedSinceLastMessageReceived);
+
+            Assert.True(connection.SimulateBytesReceived(availableBytes: 1, retainedBytes: 0));
+            Assert.NotNull(connection.ElapsedSinceLastMessageReceived);
+
+            Assert.False(connection.SimulateBytesReceived(availableBytes: 1, retainedBytes: 1));
+        }
+
         private sealed class TestConnection(ConnectionContext context, ConnectionDelegate middleware, ConnectionCommon shared)
             : Connection(context, middleware, shared)
         {
@@ -983,6 +997,7 @@ namespace NonSilo.Tests.Membership
             protected override void OnSendMessageFailure(Message message, string error) { }
             protected override void RetryMessage(Message msg, Exception? ex = null) { }
             public void SimulateMessageReceived() => MarkMessageReceived();
+            public bool SimulateBytesReceived(long availableBytes, long retainedBytes) => MarkBytesReceived(availableBytes, retainedBytes);
         }
 
         [Fact]

--- a/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
+++ b/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
@@ -1,0 +1,181 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.CodeGeneration;
+using Orleans.Runtime;
+using Orleans.Runtime.Messaging;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.Messaging
+{
+    /// <summary>
+    /// Tests for Message pooling and ownership tracking.
+    /// </summary>
+    [Collection(TestEnvironmentFixture.DefaultCollection)]
+    public class MessagePoolTests
+    {
+        private readonly MessageFactory _messageFactory;
+
+        public MessagePoolTests(TestEnvironmentFixture fixture)
+        {
+            _messageFactory = fixture.Services.GetRequiredService<MessageFactory>();
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+        public void Message_RefCount_InitializedToOne()
+        {
+            var message = MessagePool.Get();
+
+            Assert.NotNull(message);
+
+            message.Release();
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+        public void Message_Acquire_IncrementsRefCount()
+        {
+            var message = MessagePool.Get();
+
+            message.Acquire();
+
+            message.Release();
+            message.Release();
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+        public void Message_ReleaseDropped_ReleasesMessage()
+        {
+            var message = MessagePool.Get();
+
+            message.ReleaseDropped("TestReason");
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+        public void Message_MultipleAcquireRelease_WorksCorrectly()
+        {
+            var message = MessagePool.Get();
+
+            message.Acquire();
+            message.Acquire();
+
+            message.Release();
+            message.Release();
+            message.Release();
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+        public void MessageFactory_CreateMessage_ReturnsPooledMessage()
+        {
+            var message = _messageFactory.CreateMessage(null, InvokeMethodOptions.None);
+
+            Assert.NotNull(message);
+            Assert.Equal(Message.Directions.Request, message.Direction);
+
+            message.Release();
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+        public void Message_MarkTransferred_DoesNotThrow()
+        {
+            var message = MessagePool.Get();
+
+            message.MarkTransferred("TestTransfer");
+            message.MarkTransferred("AnotherTransfer");
+
+            message.Release();
+        }
+
+#if DEBUG
+        [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+        public void MessagePool_LeakTracking_TracksOutstandingMessages()
+        {
+            MessagePool.ClearLeakTracking();
+            MessagePool.EnableLeakTracking = true;
+
+            try
+            {
+                var message1 = MessagePool.Get();
+                var message2 = MessagePool.Get();
+
+                var outstanding = MessagePool.GetOutstandingMessages();
+                Assert.Equal(2, outstanding.Count);
+
+                message1.Release();
+                outstanding = MessagePool.GetOutstandingMessages();
+                Assert.Single(outstanding);
+
+                message2.Release();
+                outstanding = MessagePool.GetOutstandingMessages();
+                Assert.Empty(outstanding);
+            }
+            finally
+            {
+                MessagePool.EnableLeakTracking = false;
+                MessagePool.ClearLeakTracking();
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+        public void MessagePool_LeakTracking_CapturesAllocationInfo()
+        {
+            MessagePool.ClearLeakTracking();
+            MessagePool.EnableLeakTracking = true;
+
+            try
+            {
+                var message = MessagePool.Get();
+
+                var outstanding = MessagePool.GetOutstandingMessages();
+                Assert.Single(outstanding);
+
+                var info = outstanding.First();
+
+                Assert.Same(message, info.Message);
+                Assert.NotNull(info.AllocationStack);
+                Assert.True(info.AllocationTime <= DateTime.UtcNow);
+
+                message.Release();
+            }
+            finally
+            {
+                MessagePool.EnableLeakTracking = false;
+                MessagePool.ClearLeakTracking();
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+        public void MessagePool_LeakTracking_DisabledByDefault()
+        {
+            MessagePool.EnableLeakTracking = false;
+            MessagePool.ClearLeakTracking();
+
+            var message = MessagePool.Get();
+
+            var outstanding = MessagePool.GetOutstandingMessages();
+            Assert.Empty(outstanding);
+
+            message.Release();
+        }
+#endif
+
+        [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+        public void Message_Reset_ClearsAllFields()
+        {
+            var message = MessagePool.Get();
+            message.Direction = Message.Directions.Request;
+            message.TargetGrain = GrainId.Create("test", "key");
+            message.SendingGrain = GrainId.Create("sender", "key");
+            message.BodyObject = "test body";
+
+            message.Release();
+
+            var newMessage = MessagePool.Get();
+
+            Assert.Equal(Message.Directions.None, newMessage.Direction);
+            Assert.True(newMessage.TargetGrain.IsDefault);
+            Assert.True(newMessage.SendingGrain.IsDefault);
+            Assert.Null(newMessage.BodyObject);
+
+            newMessage.Release();
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
+++ b/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
@@ -23,11 +23,18 @@ public class MessagePoolTests
     [Fact, TestCategory("BVT"), TestCategory("Messaging")]
     public void Message_RefCount_InitializedToOne()
     {
+        MessagePool.ClearCurrentThreadPool();
         var message = MessagePool.Get();
 
-        Assert.NotNull(message);
+        Assert.Equal(0, MessagePool.GetCachedMessageCount());
 
         message.Release();
+
+        Assert.Equal(1, MessagePool.GetCachedMessageCount());
+        var reused = MessagePool.Get();
+        Assert.Same(message, reused);
+        Assert.Equal(0, MessagePool.GetCachedMessageCount());
+        reused.Release();
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Messaging")]
@@ -176,5 +183,31 @@ public class MessagePoolTests
         Assert.Null(newMessage.BodyObject);
 
         newMessage.Release();
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void Message_DoubleReleaseThrows()
+    {
+        MessagePool.ClearCurrentThreadPool();
+        var message = MessagePool.Get();
+        message.Release();
+
+        Assert.Throws<InvalidOperationException>(() => message.Release());
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void Message_ConcurrentOwnersReturnStateOnce()
+    {
+        MessagePool.ClearCurrentThreadPool();
+        var message = MessagePool.Get();
+
+        Parallel.For(0, 10_000, _ =>
+        {
+            message.Acquire();
+            message.Release();
+        });
+
+        message.Release();
+        Assert.Equal(1, MessagePool.GetCachedMessageCount());
     }
 }

--- a/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
+++ b/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
@@ -25,6 +25,7 @@ public class MessagePoolTests
     {
         MessagePool.ClearCurrentThreadPool();
         var message = MessagePool.Get();
+        var state = message.StateIdentity;
 
         Assert.Equal(0, MessagePool.GetCachedMessageCount());
 
@@ -32,7 +33,7 @@ public class MessagePoolTests
 
         Assert.Equal(1, MessagePool.GetCachedMessageCount());
         var reused = MessagePool.Get();
-        Assert.Same(message, reused);
+        Assert.Same(state, reused.StateIdentity);
         Assert.Equal(0, MessagePool.GetCachedMessageCount());
         reused.Release();
     }
@@ -74,7 +75,6 @@ public class MessagePoolTests
     {
         var message = _messageFactory.CreateMessage(null, InvokeMethodOptions.None);
 
-        Assert.NotNull(message);
         Assert.Equal(Message.Directions.Request, message.Direction);
 
         message.Release();
@@ -136,7 +136,7 @@ public class MessagePoolTests
 
             var info = outstanding.First();
 
-            Assert.Same(message, info.Message);
+            Assert.Equal(message, info.Message);
             Assert.NotNull(info.AllocationStack);
             Assert.True(info.AllocationTime <= DateTime.UtcNow);
 
@@ -196,6 +196,26 @@ public class MessagePoolTests
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void Message_StaleHandleCannotAffectReusedState()
+    {
+        MessagePool.ClearCurrentThreadPool();
+        var stale = MessagePool.Get();
+        var state = stale.StateIdentity;
+        stale.BodyObject = "stale";
+        stale.Release();
+
+        var current = MessagePool.Get();
+        Assert.Same(state, current.StateIdentity);
+        current.BodyObject = "current";
+
+        Assert.Throws<InvalidOperationException>(() => stale.BodyObject = "corrupt");
+        Assert.Throws<InvalidOperationException>(() => stale.Release());
+        Assert.Equal("current", current.BodyObject);
+
+        current.Release();
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
     public void Message_ConcurrentOwnersReturnStateOnce()
     {
         MessagePool.ClearCurrentThreadPool();
@@ -209,5 +229,43 @@ public class MessagePoolTests
 
         message.Release();
         Assert.Equal(1, MessagePool.GetCachedMessageCount());
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public async Task Message_FinalReleaseWaitsForActiveMutation()
+    {
+        MessagePool.ClearCurrentThreadPool();
+        var stale = MessagePool.Get();
+        var state = Assert.IsType<Message.MessageState>(stale.StateIdentity);
+        state.EnterMutation(stale.GenerationForTesting);
+
+        var releaseStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseTask = Task.Run(() =>
+        {
+            releaseStarted.SetResult();
+            stale.Release();
+        });
+
+        try
+        {
+            await releaseStarted.Task;
+            Assert.True(SpinWait.SpinUntil(() => state.RefCountForTesting == 0, TimeSpan.FromSeconds(5)));
+            Assert.False(releaseTask.IsCompleted);
+        }
+        finally
+        {
+            state.ExitMutation();
+        }
+
+        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var current = MessagePool.Get();
+        Assert.Same(state, current.StateIdentity);
+        current.BodyObject = "current";
+
+        Assert.Throws<InvalidOperationException>(() => stale.BodyObject = "corrupt");
+        Assert.Throws<InvalidOperationException>(() => stale.Release());
+        Assert.Equal("current", current.BodyObject);
+
+        current.Release();
     }
 }

--- a/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
+++ b/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
@@ -1,0 +1,180 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.CodeGeneration;
+using Orleans.Runtime;
+using Orleans.Runtime.Messaging;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.Messaging;
+
+/// <summary>
+/// Tests for Message pooling and ownership tracking.
+/// </summary>
+[Collection(TestEnvironmentFixture.DefaultCollection)]
+public class MessagePoolTests
+{
+    private readonly MessageFactory _messageFactory;
+
+    public MessagePoolTests(TestEnvironmentFixture fixture)
+    {
+        _messageFactory = fixture.Services.GetRequiredService<MessageFactory>();
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void Message_RefCount_InitializedToOne()
+    {
+        var message = MessagePool.Get();
+
+        Assert.NotNull(message);
+
+        message.Release();
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void Message_Acquire_IncrementsRefCount()
+    {
+        var message = MessagePool.Get();
+
+        message.Acquire();
+
+        message.Release();
+        message.Release();
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void Message_ReleaseDropped_ReleasesMessage()
+    {
+        var message = MessagePool.Get();
+
+        message.ReleaseDropped("TestReason");
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void Message_MultipleAcquireRelease_WorksCorrectly()
+    {
+        var message = MessagePool.Get();
+
+        message.Acquire();
+        message.Acquire();
+
+        message.Release();
+        message.Release();
+        message.Release();
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void MessageFactory_CreateMessage_ReturnsPooledMessage()
+    {
+        var message = _messageFactory.CreateMessage(null, InvokeMethodOptions.None);
+
+        Assert.NotNull(message);
+        Assert.Equal(Message.Directions.Request, message.Direction);
+
+        message.Release();
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void Message_MarkTransferred_DoesNotThrow()
+    {
+        var message = MessagePool.Get();
+
+        message.MarkTransferred("TestTransfer");
+        message.MarkTransferred("AnotherTransfer");
+
+        message.Release();
+    }
+
+#if DEBUG
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void MessagePool_LeakTracking_TracksOutstandingMessages()
+    {
+        MessagePool.ClearLeakTracking();
+        MessagePool.EnableLeakTracking = true;
+
+        try
+        {
+            var message1 = MessagePool.Get();
+            var message2 = MessagePool.Get();
+
+            var outstanding = MessagePool.GetOutstandingMessages();
+            Assert.Equal(2, outstanding.Count);
+
+            message1.Release();
+            outstanding = MessagePool.GetOutstandingMessages();
+            Assert.Single(outstanding);
+
+            message2.Release();
+            outstanding = MessagePool.GetOutstandingMessages();
+            Assert.Empty(outstanding);
+        }
+        finally
+        {
+            MessagePool.EnableLeakTracking = false;
+            MessagePool.ClearLeakTracking();
+        }
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void MessagePool_LeakTracking_CapturesAllocationInfo()
+    {
+        MessagePool.ClearLeakTracking();
+        MessagePool.EnableLeakTracking = true;
+
+        try
+        {
+            var message = MessagePool.Get();
+
+            var outstanding = MessagePool.GetOutstandingMessages();
+            Assert.Single(outstanding);
+
+            var info = outstanding.First();
+
+            Assert.Same(message, info.Message);
+            Assert.NotNull(info.AllocationStack);
+            Assert.True(info.AllocationTime <= DateTime.UtcNow);
+
+            message.Release();
+        }
+        finally
+        {
+            MessagePool.EnableLeakTracking = false;
+            MessagePool.ClearLeakTracking();
+        }
+    }
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void MessagePool_LeakTracking_DisabledByDefault()
+    {
+        MessagePool.EnableLeakTracking = false;
+        MessagePool.ClearLeakTracking();
+
+        var message = MessagePool.Get();
+
+        var outstanding = MessagePool.GetOutstandingMessages();
+        Assert.Empty(outstanding);
+
+        message.Release();
+    }
+#endif
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void Message_Reset_ClearsAllFields()
+    {
+        var message = MessagePool.Get();
+        message.Direction = Message.Directions.Request;
+        message.TargetGrain = GrainId.Create("test", "key");
+        message.SendingGrain = GrainId.Create("sender", "key");
+        message.BodyObject = "test body";
+
+        message.Release();
+
+        var newMessage = MessagePool.Get();
+
+        Assert.Equal(Message.Directions.None, newMessage.Direction);
+        Assert.True(newMessage.TargetGrain.IsDefault);
+        Assert.True(newMessage.SendingGrain.IsDefault);
+        Assert.Null(newMessage.BodyObject);
+
+        newMessage.Release();
+    }
+}

--- a/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
+++ b/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.CodeGeneration;
 using Orleans.Runtime;
@@ -7,10 +9,16 @@ using Xunit;
 
 namespace UnitTests.Messaging;
 
+[CollectionDefinition(MessagePoolTestCollection.Name, DisableParallelization = true)]
+public sealed class MessagePoolTestCollection : ICollectionFixture<TestEnvironmentFixture>
+{
+    public const string Name = "MessagePoolTests";
+}
+
 /// <summary>
 /// Tests for Message pooling and ownership tracking.
 /// </summary>
-[Collection(TestEnvironmentFixture.DefaultCollection)]
+[Collection(MessagePoolTestCollection.Name)]
 public class MessagePoolTests
 {
     private readonly MessageFactory _messageFactory;
@@ -167,20 +175,58 @@ public class MessagePoolTests
     [Fact, TestCategory("BVT"), TestCategory("Messaging")]
     public void Message_Reset_ClearsAllFields()
     {
+        MessagePool.ClearCurrentThreadPool();
         var message = MessagePool.Get();
+        var state = message.StateIdentity;
         message.Direction = Message.Directions.Request;
+        message.Result = Message.ResponseTypes.Error;
+        message.RetryCount = 3;
+        message.ForwardCount = 4;
+        message.Id = CorrelationId.GetNext();
+        message.IsSystemMessage = true;
+        message.IsReadOnly = true;
+        message.IsAlwaysInterleave = true;
+        message.IsUnordered = true;
+        message.IsLocalOnly = true;
+        message.IsKeepAlive = false;
+        message.TimeToLive = TimeSpan.FromSeconds(30);
+        message.TargetSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 11111), 1);
         message.TargetGrain = GrainId.Create("test", "key");
+        message.SendingSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 11112), 2);
         message.SendingGrain = GrainId.Create("sender", "key");
+        message.InterfaceType = GrainInterfaceType.Create("test.interface");
+        message.InterfaceVersion = 7;
         message.BodyObject = "test body";
+        message.RequestContextData = new Dictionary<string, object> { ["key"] = "value" };
+        var invalidAddress = GrainAddress.NewActivationAddress(message.TargetSilo, message.TargetGrain);
+        message.CacheInvalidationHeader = [new GrainAddressCacheUpdate(invalidAddress, validAddress: null)];
 
         message.Release();
 
         var newMessage = MessagePool.Get();
 
+        Assert.Same(state, newMessage.StateIdentity);
         Assert.Equal(Message.Directions.None, newMessage.Direction);
+        Assert.Equal(Message.ResponseTypes.None, newMessage.Result);
+        Assert.Equal(0, newMessage.RetryCount);
+        Assert.Equal(0, newMessage.ForwardCount);
+        Assert.Equal(default, newMessage.Id);
+        Assert.False(newMessage.IsSystemMessage);
+        Assert.False(newMessage.IsReadOnly);
+        Assert.False(newMessage.IsAlwaysInterleave);
+        Assert.False(newMessage.IsUnordered);
+        Assert.False(newMessage.IsLocalOnly);
+        Assert.True(newMessage.IsKeepAlive);
+        Assert.Null(newMessage.TimeToLive);
+        Assert.Null(newMessage.TargetSilo);
         Assert.True(newMessage.TargetGrain.IsDefault);
+        Assert.Null(newMessage.SendingSilo);
         Assert.True(newMessage.SendingGrain.IsDefault);
+        Assert.True(newMessage.InterfaceType.IsDefault);
+        Assert.Equal(0, newMessage.InterfaceVersion);
         Assert.Null(newMessage.BodyObject);
+        Assert.Null(newMessage.RequestContextData);
+        Assert.Null(newMessage.CacheInvalidationHeader);
 
         newMessage.Release();
     }
@@ -216,6 +262,81 @@ public class MessagePoolTests
     }
 
     [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public async Task Message_StaleHandleCannotAffectStateReusedOnAnotherThread()
+    {
+        var stale = MessagePool.Get();
+        var state = stale.StateIdentity;
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var releaseCurrent = new ManualResetEventSlim();
+        var currentSource = new TaskCompletionSource<Message>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var consumer = new Thread(() =>
+        {
+            stale.Release();
+            var current = MessagePool.Get();
+            current.BodyObject = "current";
+            currentSource.SetResult(current);
+            releaseCurrent.Wait(cancellationToken);
+            current.Release();
+        });
+        consumer.Start();
+
+        var current = await currentSource.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+        try
+        {
+            Assert.Same(state, current.StateIdentity);
+            Assert.Throws<InvalidOperationException>(() => stale.BodyObject = "corrupt");
+            Assert.Throws<InvalidOperationException>(() => stale.Release());
+            Assert.Equal("current", current.BodyObject);
+        }
+        finally
+        {
+            releaseCurrent.Set();
+            consumer.Join();
+        }
+    }
+
+#if DEBUG
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
+    public void MessagePool_CrossThreadReleaseLeavesNoOutstandingOwnership()
+    {
+        MessagePool.ClearLeakTracking();
+        MessagePool.EnableLeakTracking = true;
+        using var queue = new BlockingCollection<Message>(boundedCapacity: 32);
+        var consumer = new Thread(() =>
+        {
+            foreach (var message in queue.GetConsumingEnumerable())
+            {
+                message.Release();
+            }
+        });
+
+        try
+        {
+            consumer.Start();
+            for (var i = 0; i < 256; i++)
+            {
+                queue.Add(MessagePool.Get(), TestContext.Current.CancellationToken);
+            }
+
+            queue.CompleteAdding();
+            consumer.Join();
+            Assert.Empty(MessagePool.GetOutstandingMessages());
+        }
+        finally
+        {
+            queue.CompleteAdding();
+            if (consumer.IsAlive)
+            {
+                consumer.Join();
+            }
+
+            MessagePool.EnableLeakTracking = false;
+            MessagePool.ClearLeakTracking();
+        }
+    }
+#endif
+
+    [Fact, TestCategory("BVT"), TestCategory("Messaging")]
     public void Message_ConcurrentOwnersReturnStateOnce()
     {
         MessagePool.ClearCurrentThreadPool();
@@ -244,11 +365,11 @@ public class MessagePoolTests
         {
             releaseStarted.SetResult();
             stale.Release();
-        });
+        }, TestContext.Current.CancellationToken);
 
         try
         {
-            await releaseStarted.Task;
+            await releaseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
             Assert.True(SpinWait.SpinUntil(() => state.RefCountForTesting == 0, TimeSpan.FromSeconds(5)));
             Assert.False(releaseTask.IsCompleted);
         }
@@ -257,7 +378,7 @@ public class MessagePoolTests
             state.ExitMutation();
         }
 
-        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5));
+        await releaseTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         var current = MessagePool.Get();
         Assert.Same(state, current.StateIdentity);
         current.BodyObject = "current";

--- a/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
+++ b/test/Orleans.Core.Tests/Messaging/MessagePoolTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.Net;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans.CodeGeneration;
 using Orleans.Runtime;
 using Orleans.Runtime.Messaging;
 using TestExtensions;
@@ -81,7 +80,7 @@ public class MessagePoolTests
     [Fact, TestCategory("BVT"), TestCategory("Messaging")]
     public void MessageFactory_CreateMessage_ReturnsPooledMessage()
     {
-        var message = _messageFactory.CreateMessage(null, InvokeMethodOptions.None);
+        var message = _messageFactory.CreateMessage(null, Orleans.CodeGeneration.InvokeMethodOptions.None);
 
         Assert.Equal(Message.Directions.Request, message.Direction);
 

--- a/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
+++ b/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
@@ -49,21 +49,27 @@ namespace UnitTests.Serialization
         public void MessageTest_TtlUpdatedOnAccess(int initialTimeToLiveMilliseconds)
         {
             var message = this.messageFactory.CreateMessage(null, InvokeMethodOptions.None);
+            try
+            {
+                message.TimeToLive = TimeSpan.FromMilliseconds(initialTimeToLiveMilliseconds);
+                var expirationTimestamp = message.GetTimeToExpiryTimestamp();
+                WaitForTimestamp(expirationTimestamp - initialTimeToLiveMilliseconds + 10);
 
-            message.TimeToLive = TimeSpan.FromMilliseconds(initialTimeToLiveMilliseconds);
-            var expirationTimestamp = message.GetTimeToExpiryTimestamp();
-            WaitForTimestamp(expirationTimestamp - initialTimeToLiveMilliseconds + 10);
+                var accessStarted = CoarseStopwatch.GetTimestamp();
+                var timeToLive = message.TimeToLive;
+                var accessCompleted = CoarseStopwatch.GetTimestamp();
 
-            var accessStarted = CoarseStopwatch.GetTimestamp();
-            var timeToLive = message.TimeToLive;
-            var accessCompleted = CoarseStopwatch.GetTimestamp();
-
-            Assert.NotNull(timeToLive);
-            Assert.True(timeToLive.Value < TimeSpan.FromMilliseconds(initialTimeToLiveMilliseconds));
-            Assert.InRange(
-                timeToLive.Value,
-                TimeSpan.FromMilliseconds(expirationTimestamp - accessCompleted),
-                TimeSpan.FromMilliseconds(expirationTimestamp - accessStarted));
+                Assert.NotNull(timeToLive);
+                Assert.True(timeToLive.Value < TimeSpan.FromMilliseconds(initialTimeToLiveMilliseconds));
+                Assert.InRange(
+                    timeToLive.Value,
+                    TimeSpan.FromMilliseconds(expirationTimestamp - accessCompleted),
+                    TimeSpan.FromMilliseconds(expirationTimestamp - accessStarted));
+            }
+            finally
+            {
+                message.Release();
+            }
         }
 
         [TestSuite("Functional")]
@@ -74,18 +80,31 @@ namespace UnitTests.Serialization
         public void MessageTest_TtlUpdatedOnSerialization(int initialTimeToLiveMilliseconds)
         {
             var message = this.messageFactory.CreateMessage(null, InvokeMethodOptions.None);
+            try
+            {
+                message.TimeToLive = TimeSpan.FromMilliseconds(initialTimeToLiveMilliseconds);
+                var sourceExpirationTimestamp = message.GetTimeToExpiryTimestamp();
+                WaitForTimestamp(sourceExpirationTimestamp - initialTimeToLiveMilliseconds + 10);
+                var deserializedMessage = RoundTripMessage(message, out var serialization, out var deserialization);
+                try
+                {
+                    var deserializedExpirationTimestamp = deserializedMessage.GetTimeToExpiryTimestamp();
 
-            message.TimeToLive = TimeSpan.FromMilliseconds(initialTimeToLiveMilliseconds);
-            var sourceExpirationTimestamp = message.GetTimeToExpiryTimestamp();
-            WaitForTimestamp(sourceExpirationTimestamp - initialTimeToLiveMilliseconds + 10);
-            var deserializedMessage = RoundTripMessage(message, out var serialization, out var deserialization);
-            var deserializedExpirationTimestamp = deserializedMessage.GetTimeToExpiryTimestamp();
-
-            Assert.NotNull(deserializedMessage.TimeToLive);
-            Assert.InRange(
-                deserializedExpirationTimestamp,
-                sourceExpirationTimestamp - serialization.Completed + deserialization.Started,
-                sourceExpirationTimestamp - serialization.Started + deserialization.Completed);
+                    Assert.NotNull(deserializedMessage.TimeToLive);
+                    Assert.InRange(
+                        deserializedExpirationTimestamp,
+                        sourceExpirationTimestamp - serialization.Completed + deserialization.Started,
+                        sourceExpirationTimestamp - serialization.Started + deserialization.Completed);
+                }
+                finally
+                {
+                    deserializedMessage.Release();
+                }
+            }
+            finally
+            {
+                message.Release();
+            }
         }
 
         private static void WaitForTimestamp(long timestamp)
@@ -103,10 +122,16 @@ namespace UnitTests.Serialization
                 RequestContext.Set("big_object", new byte[maxHeaderSize + 1]);
 
                 var message = this.messageFactory.CreateMessage(null, InvokeMethodOptions.None);
-
-                var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 0));
-                var writer = pipe.Writer;
-                Assert.Throws<InvalidMessageFrameException>(() => this.messageSerializer.Write(writer, message));
+                try
+                {
+                    var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 0));
+                    var writer = pipe.Writer;
+                    Assert.Throws<InvalidMessageFrameException>(() => this.messageSerializer.Write(writer, message));
+                }
+                finally
+                {
+                    message.Release();
+                }
             }
             finally
             {
@@ -125,10 +150,16 @@ namespace UnitTests.Serialization
             var arg = new byte[maxBodySize + 1];
             var request = new[] { arg };
             var message = this.messageFactory.CreateMessage(request, InvokeMethodOptions.None);
-
-            var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 0));
-            var writer = pipe.Writer;
-            Assert.Throws<InvalidMessageFrameException>(() => this.messageSerializer.Write(writer, message));
+            try
+            {
+                var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 0));
+                var writer = pipe.Writer;
+                Assert.Throws<InvalidMessageFrameException>(() => this.messageSerializer.Write(writer, message));
+            }
+            finally
+            {
+                message.Release();
+            }
         }
 
         [TestSuite("Functional")]
@@ -233,15 +264,28 @@ namespace UnitTests.Serialization
             }
 
             var message = this.messageFactory.CreateMessage(null, InvokeMethodOptions.None);
-            message.RequestContextData = requestContext;
-
-            var deserializedMessage = RoundTripMessage(message);
-
-            Assert.NotNull(deserializedMessage.RequestContextData);
-            Assert.Equal(entryCount, deserializedMessage.RequestContextData.Count);
-            for (var i = 0; i < entryCount; i++)
+            try
             {
-                Assert.Equal(i, deserializedMessage.RequestContextData[$"key-{i}"]);
+                message.RequestContextData = requestContext;
+
+                var deserializedMessage = RoundTripMessage(message);
+                try
+                {
+                    Assert.NotNull(deserializedMessage.RequestContextData);
+                    Assert.Equal(entryCount, deserializedMessage.RequestContextData.Count);
+                    for (var i = 0; i < entryCount; i++)
+                    {
+                        Assert.Equal(i, deserializedMessage.RequestContextData[$"key-{i}"]);
+                    }
+                }
+                finally
+                {
+                    deserializedMessage.Release();
+                }
+            }
+            finally
+            {
+                message.Release();
             }
         }
 

--- a/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
+++ b/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
@@ -51,7 +51,7 @@ namespace UnitTests.Serialization
             var message = this.messageFactory.CreateMessage(null, InvokeMethodOptions.None);
 
             message.TimeToLive = TimeSpan.FromMilliseconds(initialTimeToLiveMilliseconds);
-            var expirationTimestamp = message._timeToExpiry.GetRawTimestamp();
+            var expirationTimestamp = message.GetTimeToExpiryTimestamp();
             WaitForTimestamp(expirationTimestamp - initialTimeToLiveMilliseconds + 10);
 
             var accessStarted = CoarseStopwatch.GetTimestamp();
@@ -76,10 +76,10 @@ namespace UnitTests.Serialization
             var message = this.messageFactory.CreateMessage(null, InvokeMethodOptions.None);
 
             message.TimeToLive = TimeSpan.FromMilliseconds(initialTimeToLiveMilliseconds);
-            var sourceExpirationTimestamp = message._timeToExpiry.GetRawTimestamp();
+            var sourceExpirationTimestamp = message.GetTimeToExpiryTimestamp();
             WaitForTimestamp(sourceExpirationTimestamp - initialTimeToLiveMilliseconds + 10);
             var deserializedMessage = RoundTripMessage(message, out var serialization, out var deserialization);
-            var deserializedExpirationTimestamp = deserializedMessage._timeToExpiry.GetRawTimestamp();
+            var deserializedExpirationTimestamp = deserializedMessage.GetTimeToExpiryTimestamp();
 
             Assert.NotNull(deserializedMessage.TimeToLive);
             Assert.InRange(
@@ -201,9 +201,10 @@ namespace UnitTests.Serialization
             var (requiredBytes, _, _) = this.messageSerializer.TryRead(ref reader, out var deserializedMessage);
             var deserializationCompleted = CoarseStopwatch.GetTimestamp();
             Assert.Equal(0, requiredBytes);
+            Assert.NotNull(deserializedMessage);
             serialization = (serializationStarted, serializationCompleted);
             deserialization = (deserializationStarted, deserializationCompleted);
-            return deserializedMessage!;
+            return deserializedMessage.Value;
         }
 
         [TestSuite("Functional")]

--- a/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
+++ b/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
@@ -180,7 +180,7 @@ namespace UnitTests.Serialization
             var reader = readResult.Buffer;
             var (requiredBytes, _, _) = this.messageSerializer.TryRead(ref reader, out var deserializedMessage);
             Assert.Equal(0, requiredBytes);
-            return deserializedMessage!;
+            return deserializedMessage!.Value;
         }
 
         private Message RoundTripMessage(

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/TestMessageFilter.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/TestMessageFilter.cs
@@ -10,7 +10,7 @@ internal sealed class TestMessageFilter(GrainMigratabilityChecker checker) : IRe
 {
     private readonly RepartitionerMessageFilter _messageFilter = new(checker);
 
-    public bool IsAcceptable(Message message, out bool isSenderMigratable, out bool isTargetMigratable) =>
-        _messageFilter.IsAcceptable(message, out isSenderMigratable, out isTargetMigratable) &&
-        !message.SendingGrain.IsClient() && !message.TargetGrain.IsClient();
+    public bool IsAcceptable(GrainId sendingGrain, GrainId targetGrain, out bool isSenderMigratable, out bool isTargetMigratable) =>
+        _messageFilter.IsAcceptable(sendingGrain, targetGrain, out isSenderMigratable, out isTargetMigratable) &&
+        !sendingGrain.IsClient() && !targetGrain.IsClient();
 }

--- a/test/Orleans.Runtime.Internal.Tests/Diagnostics/DispatcherEventsTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Diagnostics/DispatcherEventsTests.cs
@@ -23,7 +23,7 @@ public class DispatcherEventsTests
 
         trace.OnDispatcherRejectMessage(message, Message.RejectionTypes.Transient, "reason", exception);
 
-        var rejected = Assert.Single(observer.Events.OfType<DispatcherEvents.Rejected>(), evt => ReferenceEquals(evt.Message, message));
+        var rejected = Assert.Single(observer.Events.OfType<DispatcherEvents.Rejected>(), evt => evt.Message == message);
         Assert.Equal(Message.RejectionTypes.Transient, rejected.RejectionType);
         Assert.Equal("reason", rejected.Reason);
         Assert.Same(exception, rejected.Exception);

--- a/test/Orleans.Runtime.Internal.Tests/Diagnostics/DispatcherEventsTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Diagnostics/DispatcherEventsTests.cs
@@ -18,12 +18,21 @@ public class DispatcherEventsTests
     {
         using var observer = new Observer(DispatcherEvents.AllEvents);
         var trace = new RuntimeMessagingTrace(NullLoggerFactory.Instance, CreateMessagingInstruments(), CreateMessagingProcessingInstruments());
-        var message = new Message();
+        var message = new Message
+        {
+            Id = CorrelationId.GetNext(),
+            Direction = Message.Directions.Request,
+            TargetGrain = GrainId.Create("test", "target"),
+        };
+        var messageId = message.Id;
         var exception = new InvalidOperationException("boom");
 
         trace.OnDispatcherRejectMessage(message, Message.RejectionTypes.Transient, "reason", exception);
+        message.Release();
 
-        var rejected = Assert.Single(observer.Events.OfType<DispatcherEvents.Rejected>(), evt => evt.Message == message);
+        var rejected = Assert.Single(observer.Events.OfType<DispatcherEvents.Rejected>(), evt => evt.Message.Id == messageId);
+        Assert.Equal(Message.Directions.Request, rejected.Message.Direction);
+        Assert.Equal(GrainId.Create("test", "target"), rejected.Message.TargetGrain);
         Assert.Equal(Message.RejectionTypes.Transient, rejected.RejectionType);
         Assert.Equal("reason", rejected.Reason);
         Assert.Same(exception, rejected.Exception);

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -78,7 +78,11 @@ public class CallbackDataTests
             cancelOnTimeout: false,
             waitForCancellationAcknowledgement: false,
             cancellationManager: null);
-        return new CallbackData(shared, completion, new Message(), instruments);
+        var message = new Message();
+        message.InitializeRefCount();
+        var callback = new CallbackData(shared, completion, message, instruments);
+        message.Release();
+        return callback;
     }
 
     private static ServiceProvider CreateServiceProvider()

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -55,6 +55,26 @@ public class CallbackDataTests
         GC.KeepAlive(cancellation);
     }
 
+    [TestSuite("BVT")]
+    [TestProvider("None")]
+    [Fact, TestCategory("BVT")]
+    public void CallbackExceptionReleasesRequestOwnership()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        var expectedException = new InvalidOperationException("Test completion failure");
+        var callback = CreateCallback(
+            new ThrowingResponseCompletionSource(expectedException),
+            _ => { },
+            CreateInstruments(serviceProvider));
+        var response = new Message { BodyObject = Orleans.Serialization.Invocation.Response.Completed };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => callback.DoCallback(response));
+        Assert.Same(expectedException, exception);
+        Assert.False(callback.TryAcquireMessage(out _));
+
+        response.Release();
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference CreateCompletedCallback(CancellationToken cancellationToken, ApplicationRequestInstruments instruments)
     {
@@ -102,5 +122,12 @@ public class CallbackDataTests
         public void Complete(Response value) => Response = value;
 
         public void Complete() => Response = Orleans.Serialization.Invocation.Response.Completed;
+    }
+
+    private sealed class ThrowingResponseCompletionSource(InvalidOperationException exception) : IResponseCompletionSource
+    {
+        public void Complete(Response value) => throw exception;
+
+        public void Complete() => throw exception;
     }
 }

--- a/test/Orleans.Runtime.Tests/InsideRuntimeClientTests.cs
+++ b/test/Orleans.Runtime.Tests/InsideRuntimeClientTests.cs
@@ -36,6 +36,7 @@ public class InsideRuntimeClientTests
                 RejectionInfo = "The outbound queue is stopped",
             },
         };
+        rejection.InitializeRefCount();
 
         await silo.StopSiloAsync(stopGracefully: false);
         await silo.DisposeAsync();


### PR DESCRIPTION
## Summary
- Adds a thread-local `MessagePool` and ref-counted message ownership APIs for safe message reuse.
- Moves message creation/deserialization onto pooled `Message` instances and resets messages when they return to the pool.
- Updates core/runtime send, receive, drop, and callback lifecycle paths to release message references explicitly.
- Updates activation repartitioning to record message addresses instead of retaining `Message` instances, and adds focused message pool tests.

## Validation
- `git diff --check`
- conflict-marker scan
- `dotnet build src\Orleans.Core\Orleans.Core.csproj -m`
- `dotnet build src\Orleans.Runtime\Orleans.Runtime.csproj -m`
- `dotnet test test\Orleans.Core.Tests\Orleans.Core.Tests.csproj --filter MessagePool` (20 passed)

## Dependencies / notes
- Excludes callback pooling/dictionary, invokable pooling, benchmarks, SEDA, and the transport rewrite.
- `NonSilo.Tests.csproj` was not present on the current base, so message pool tests live under `Orleans.Core.Tests`.
- Additional end-to-end networking lifecycle/leak stress coverage would still be valuable.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10072)
