### PR TITLE
Fix stateless worker late-delivery race test flake

### DIFF
--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/StatelessWorkerSingleActivationRaceTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/StatelessWorkerSingleActivationRaceTests.cs
@@ -38,9 +38,9 @@ public class StatelessWorkerSingleActivationRaceTests(StatelessWorkerSingleActiv
                 hostBuilder.Services.AddSingleton<StatelessWorkerSingleActivationTracker>();
                 hostBuilder.Services.Configure<StatelessWorkerOptions>(options =>
                 {
-                    // These tests explicitly terminate the wrapper after capturing it from the directory.
-                    // Disable proactive idle collection so the setup is not racing a timer.
-                    options.RemoveIdleWorkers = false;
+                    options.RemoveIdleWorkers = true;
+                    options.IdleWorkersInspectionPeriod = TimeSpan.FromMilliseconds(5);
+                    options.MinIdleCyclesBeforeRemoval = 1;
                 });
             }
         }
@@ -66,9 +66,7 @@ public class StatelessWorkerSingleActivationRaceTests(StatelessWorkerSingleActiv
 
         await grain.DoWork();
 
-        var c1 = Assert.IsType<StatelessWorkerGrainContext>(directory.FindTarget(grainId));
-        collector.Clear();
-
+        var c1 = Assert.IsType<StatelessWorkerGrainContext>((await WaitForWorkerCreatedAsync(collector, grainId)).Context);
         c1.Deactivate(new DeactivationReason(DeactivationReasonCode.RuntimeRequested, "test"), CancellationToken.None);
 
         var terminated = await WaitForContextTerminatedAsync(collector, c1);
@@ -107,9 +105,7 @@ public class StatelessWorkerSingleActivationRaceTests(StatelessWorkerSingleActiv
         tracker.Reset();
         await grain.DoWork();
 
-        var c1 = Assert.IsType<StatelessWorkerGrainContext>(directory.FindTarget(grainId));
-        collector.Clear();
-
+        var c1 = Assert.IsType<StatelessWorkerGrainContext>((await WaitForWorkerCreatedAsync(collector, grainId)).Context);
         c1.Deactivate(new DeactivationReason(DeactivationReasonCode.RuntimeRequested, "test"), CancellationToken.None);
         _ = await WaitForContextTerminatedAsync(collector, c1);
 
@@ -185,6 +181,18 @@ public class StatelessWorkerSingleActivationRaceTests(StatelessWorkerSingleActiv
                 && ReferenceEquals(forwarded.Context, context),
             TimeSpan.FromSeconds(10));
         return Assert.IsType<StatelessWorkerEvents.MessageForwarded>(evt.Payload);
+    }
+
+    private static async Task<StatelessWorkerEvents.WorkerCreated> WaitForWorkerCreatedAsync(
+        DiagnosticEventCollector collector,
+        GrainId grainId)
+    {
+        var evt = await collector.WaitForEventAsync(
+            nameof(StatelessWorkerEvents.WorkerCreated),
+            diagnosticEvent => diagnosticEvent.Payload is StatelessWorkerEvents.WorkerCreated workerCreated
+                && workerCreated.GrainId.Equals(grainId),
+            TimeSpan.FromSeconds(10));
+        return Assert.IsType<StatelessWorkerEvents.WorkerCreated>(evt.Payload);
     }
 
     private static async Task<StatelessWorkerEvents.WorkerCreated> WaitForWorkerCreatedAsync(

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/StatelessWorkerSingleActivationRaceTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/StatelessWorkerSingleActivationRaceTests.cs
@@ -38,9 +38,9 @@ public class StatelessWorkerSingleActivationRaceTests(StatelessWorkerSingleActiv
                 hostBuilder.Services.AddSingleton<StatelessWorkerSingleActivationTracker>();
                 hostBuilder.Services.Configure<StatelessWorkerOptions>(options =>
                 {
-                    options.RemoveIdleWorkers = true;
-                    options.IdleWorkersInspectionPeriod = TimeSpan.FromMilliseconds(5);
-                    options.MinIdleCyclesBeforeRemoval = 1;
+                    // These tests explicitly terminate the wrapper after capturing it from the directory.
+                    // Disable proactive idle collection so the setup is not racing a timer.
+                    options.RemoveIdleWorkers = false;
                 });
             }
         }


### PR DESCRIPTION
## Summary
- keep the aggressive stateless-worker idle cleanup settings enabled in the race regression tests
- capture the wrapper from the `WorkerCreated` diagnostic event instead of sampling `ActivationDirectory` after the initial call
- allow either explicit deactivation or the idle timer to terminate the captured wrapper before exercising late-delivery forwarding

## Testing
- `dotnet test test\Orleans.Runtime.Internal.Tests\Orleans.Runtime.Internal.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~StatelessWorkerSingleActivationRaceTests" -- -parallel none -noshadow`
- 50x `dotnet test test\Orleans.Runtime.Internal.Tests\Orleans.Runtime.Internal.Tests.csproj --no-build --framework net10.0 --filter "FullyQualifiedName~StatelessWorkerSingleActivationRaceTests.TerminatedContextForwardsLateDeliveryToFreshWrapper" -- -parallel none -noshadow`