### PR TITLE
Set target silo for cached silo connections

### DIFF
--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -515,7 +515,7 @@ namespace Orleans.Runtime.Messaging
             return true;
         }
 
-        void IMessageReceiver.ReceiveMessage(Message message, IMessageReceiverCache cache)
+        public virtual void ReceiveMessage(Message message, IMessageReceiverCache cache)
         {
             if (!IsValid)
             {

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -308,6 +308,12 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
+        public override void ReceiveMessage(Message message, IMessageReceiverCache cache)
+        {
+            message.TargetSilo ??= this.RemoteSiloAddress;
+            base.ReceiveMessage(message, cache);
+        }
+
         [LoggerMessage(
             Level = LogLevel.Trace,
             Message = "Forwarding message {MessageId} from {SendingSilo} to silo {TargetSilo}"


### PR DESCRIPTION
## Summary
- make Connection.ReceiveMessage virtual so connection types can customize cached-receiver handling
- set TargetSilo when a cached SiloConnection receives a message, restoring the destination normally assigned by addressing

## Validation
- dotnet build src\Orleans.Runtime\Orleans.Runtime.csproj --framework net10.0 -bl:artifacts\logs\silo-connection-virtual-receive.binlog
- dotnet test test\Transactions\Orleans.Transactions.Tests\Orleans.Transactions.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~Orleans.Transactions.Tests.ExclusiveLockTransactionMemoryTests.ConcurrentReadThenWriteWithoutExclusiveLock_ThrowsLockException" -- -parallel none -noshadow
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10080)