### PR TITLE
Fix TransactionResponse diagnostic formatting

### DIFF
--- a/src/Orleans.Transactions/TransactionAttribute.cs
+++ b/src/Orleans.Transactions/TransactionAttribute.cs
@@ -334,6 +334,8 @@ namespace Orleans
 
         public Exception GetException() => _response.Exception;
 
+        public override string ToString() => _response?.ToString() ?? "[null]";
+
         public override void Dispose()
         {
             TransactionInfo = null;

--- a/src/api/Orleans.Transactions/Orleans.Transactions.cs
+++ b/src/api/Orleans.Transactions/Orleans.Transactions.cs
@@ -120,6 +120,8 @@ namespace Orleans
         public System.Exception GetException() { throw null; }
 
         public override T GetResult<T>() { throw null; }
+
+        public override string ToString() { throw null; }
     }
 
     [SerializerTransparent]

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionResponseTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionResponseTests.cs
@@ -1,0 +1,23 @@
+using Orleans.Serialization.Invocation;
+using Orleans.Transactions;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class TransactionResponseTests
+{
+    [Fact]
+    public void ToString_ReturnsInnerResponseTextWithoutThrowing()
+    {
+        var exception = new OrleansTransactionAbortedException("transaction-id", new InvalidOperationException("boom"));
+        var response = TransactionResponse.Create(Response.FromException(exception), new TransactionInfo());
+
+        var text = response.ToString();
+
+        Assert.Contains(nameof(OrleansTransactionAbortedException), text);
+        Assert.Contains("transaction-id", text);
+        Assert.Throws<OrleansTransactionAbortedException>(() => _ = response.Result);
+    }
+}


### PR DESCRIPTION
## Problem
The Azure storage CI job can crash the testhost while logging a dropped transaction response during silo shutdown. `TransactionResponse.Exception` intentionally returns `null`, so the inherited `Response.ToString()` falls through to `Result`, which rethrows the transaction exception during log formatting.

## Solution
Override `TransactionResponse.ToString()` to format the wrapped inner response instead of evaluating `Result`. This preserves the existing transaction exception behavior for callers while making diagnostic/log formatting side-effect-free. A regression test covers exception-backed transaction responses.

## Review focus
Confirm that delegating to the inner response preserves the intended transaction exception suppression semantics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10083)