### PR TITLE
Fix Cosmos indexing paths for latest emulator

### DIFF
--- a/src/Azure/Orleans.Clustering.Cosmos/Membership/CosmosMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.Cosmos/Membership/CosmosMembershipTable.cs
@@ -352,15 +352,15 @@ internal partial class CosmosMembershipTable : IMembershipTable
         var containerProperties = new ContainerProperties(_options.ContainerName, PARTITION_KEY);
         containerProperties.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
         containerProperties.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = "/*" });
-        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/Address/*" });
-        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/Port/*" });
-        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/Generation/*" });
-        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/Hostname/*" });
-        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/SiloName/*" });
-        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/\"SuspectingSilos\"/*" });
-        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/\"SuspectingTimes\"/*" });
-        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/StartTime/*" });
-        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/IAmAliveTime/*" });
+        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/Address/?" });
+        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/Port/?" });
+        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/Generation/?" });
+        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/Hostname/?" });
+        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/SiloName/?" });
+        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/\"SuspectingSilos\"/[]/?" });
+        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/\"SuspectingTimes\"/[]/?" });
+        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/StartTime/?" });
+        containerProperties.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/IAmAliveTime/?" });
 
         const int maxRetries = 3;
         for (var retry = 0; retry <= maxRetries; ++retry)

--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorage.cs
@@ -317,8 +317,9 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
 
         var stateContainer = new ContainerProperties(_options.ContainerName, _options.PartitionKeyPath);
         stateContainer.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
-        stateContainer.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = "/*" });
-        stateContainer.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/\"State\"/*" });
+        stateContainer.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/*" });
+        stateContainer.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = $"/{nameof(GrainStateEntity<object>.GrainType)}/?" });
+        stateContainer.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = ToScalarIndexPath(_options.PartitionKeyPath) });
 
         if (_options.StateFieldsToIndex != null)
         {
@@ -367,6 +368,16 @@ public sealed partial class CosmosGrainStorage : IGrainStorage, ILifecyclePartic
             WrappedException.CreateAndRethrow(ex);
             throw;
         }
+    }
+
+    private static string ToScalarIndexPath(string path)
+    {
+        if (path.EndsWith("/?", StringComparison.Ordinal))
+        {
+            return path;
+        }
+
+        return path.EndsWith("/", StringComparison.Ordinal) ? $"{path}?" : $"{path}/?";
     }
 
     private void ResetGrainState<T>(IGrainState<T> grainState)

--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
@@ -343,8 +343,8 @@ internal partial class CosmosReminderTable : IReminderTable
 
         remindersCollection.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
         remindersCollection.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = "/*" });
-        remindersCollection.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/StartAt/*" });
-        remindersCollection.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/Period/*" });
+        remindersCollection.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/StartAt/?" });
+        remindersCollection.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/Period/?" });
         remindersCollection.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
 
         const int maxRetries = 3;


### PR DESCRIPTION
## Problem
Newer Linux Cosmos emulator builds reject non-root wildcard paths in indexing policy exclusions such as `/StartAt/*`, `/Address/*`, and `/"State"/*`. That prevents new Cosmos containers from being created in the reminders, clustering, and persistence providers.

## Solution
Update known scalar fields to use terminal scalar paths (`/?`), update scalar array exclusions to use `/[]/?`, and change the grain storage container policy to exclude root while including metadata and configured `StateFieldsToIndex` paths. This follows the Cosmos indexing policy docs for scalar and array paths while preserving the existing opt-in state indexing behavior.

Docs: https://learn.microsoft.com/en-us/azure/cosmos-db/index-policy#including-and-excluding-property-paths

## Reviewer focus
Please look closely at `CosmosGrainStorage`'s excluded-root policy, since it replaces the prior recursive `State` exclusion without broadening default `State` indexing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10084)