### PR TITLE
Fix version-aware grain directory membership cleanup

### DIFF
--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -11,9 +11,7 @@ namespace Orleans.Runtime
 {
     internal sealed partial class Catalog : SystemTarget, ICatalog, ILifecycleParticipant<ISiloLifecycle>
     {
-        private readonly SiloAddress _siloAddress;
         private readonly ActivationCollector activationCollector;
-        private readonly GrainDirectoryResolver grainDirectoryResolver;
         private readonly ActivationDirectory activations;
         private readonly IServiceProvider serviceProvider;
         private readonly ILogger logger;
@@ -30,8 +28,6 @@ namespace Orleans.Runtime
 #endif
 
         public Catalog(
-            ILocalSiloDetails localSiloDetails,
-            GrainDirectoryResolver grainDirectoryResolver,
             ActivationDirectory activationDirectory,
             ActivationCollector activationCollector,
             IServiceProvider serviceProvider,
@@ -40,8 +36,6 @@ namespace Orleans.Runtime
             SystemTargetShared shared)
             : base(Constants.CatalogType, shared)
         {
-            this._siloAddress = localSiloDetails.SiloAddress;
-            this.grainDirectoryResolver = grainDirectoryResolver;
             this.activations = activationDirectory;
             this.serviceProvider = serviceProvider;
             this.grainActivator = grainActivator;
@@ -328,98 +322,11 @@ namespace Orleans.Runtime
             });
         }
 
-        // TODO move this logic in the LocalGrainDirectory
-        internal void OnSiloStatusChange(ILocalGrainDirectory directory, SiloAddress updatedSilo, SiloStatus status)
-        {
-            // ignore joining events and also events on myself.
-            if (updatedSilo.Equals(_siloAddress)) return;
-
-            // We deactivate those activations when silo goes either of ShuttingDown/Stopping/Dead states,
-            // since this is what Directory is doing as well. Directory removes a silo based on all those 3 statuses,
-            // thus it will only deliver a "remove" notification for a given silo once to us. Therefore, we need to react the fist time we are notified.
-            // We may review the directory behavior in the future and treat ShuttingDown differently ("drain only") and then this code will have to change a well.
-            if (!status.IsTerminating()) return;
-            if (status == SiloStatus.Dead)
-            {
-                this.RuntimeClient.BreakOutstandingMessagesToSilo(updatedSilo);
-            }
-
-            var activationsToShutdown = new List<IGrainContext>();
-            try
-            {
-                // scan all activations in activation directory and deactivate the ones that the removed silo is their primary partition owner.
-                // Note: No lock needed here since ActivationDirectory uses ConcurrentDictionary which provides thread-safe enumeration
-                foreach (var activation in activations)
-                {
-                    try
-                    {
-                        var activationData = activation.Value;
-                        var placementStrategy = activationData.GetComponent<PlacementStrategy>();
-                        var isUsingGrainDirectory = placementStrategy is { IsUsingGrainDirectory: true };
-                        if (!isUsingGrainDirectory || !grainDirectoryResolver.IsUsingDefaultDirectory(activationData.GrainId.Type)) continue;
-                        if (!updatedSilo.Equals(directory.GetPrimaryForGrain(activationData.GrainId))) continue;
-
-                        activationsToShutdown.Add(activationData);
-                    }
-                    catch (Exception exc)
-                    {
-                        LogErrorCatalogSiloStatusChangeNotification(new(updatedSilo), exc);
-                    }
-                }
-
-                if (activationsToShutdown.Count > 0)
-                {
-                    LogInfoCatalogSiloStatusChangeNotification(activationsToShutdown.Count, new(updatedSilo));
-                }
-            }
-            finally
-            {
-                // outside the lock.
-                if (activationsToShutdown.Count > 0)
-                {
-                    var reasonText = $"This activation is being deactivated due to a failure of server {updatedSilo}, since it was responsible for this activation's grain directory registration.";
-                    var reason = new DeactivationReason(DeactivationReasonCode.DirectoryFailure, reasonText);
-                    StartDeactivatingActivations(reason, activationsToShutdown, CancellationToken.None);
-                }
-            }
-
-            void StartDeactivatingActivations(DeactivationReason reason, List<IGrainContext> list, CancellationToken cancellationToken)
-            {
-                if (list == null || list.Count == 0) return;
-
-                LogDebugDeactivateActivations(list.Count);
-
-                foreach (var activation in list)
-                {
-                    activation.Deactivate(reason, cancellationToken);
-                }
-            }
-        }
-
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
         {
             // Do nothing, just ensure that this instance is created so that it can register itself in the activation directory.
             _siloStatusOracle = serviceProvider.GetRequiredService<ISiloStatusOracle>();
         }
-
-        private readonly struct SiloAddressLogValue(SiloAddress silo)
-        {
-            public override string ToString() => silo.ToStringWithHashCode();
-        }
-
-        [LoggerMessage(
-            Level = LogLevel.Error,
-            EventId = (int)ErrorCode.Catalog_SiloStatusChangeNotification_Exception,
-            Message = "Catalog has thrown an exception while handling removal of silo {Silo}"
-        )]
-        private partial void LogErrorCatalogSiloStatusChangeNotification(SiloAddressLogValue silo, Exception exception);
-
-        [LoggerMessage(
-            Level = LogLevel.Information,
-            EventId = (int)ErrorCode.Catalog_SiloStatusChangeNotification,
-            Message = "Catalog is deactivating {Count} activations due to a failure of silo {Silo}, since it is a primary directory partition to these grain ids."
-        )]
-        private partial void LogInfoCatalogSiloStatusChangeNotification(int count, SiloAddressLogValue silo);
 
         [LoggerMessage(
             Level = LogLevel.Trace,

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -169,10 +169,10 @@ namespace Orleans.Runtime.GrainDirectory
             var updates = this.clusterMembershipService.MembershipUpdates.WithCancellation(this.shutdownToken.Token);
             await foreach (var snapshot in updates)
             {
-                // Active filtering: detect silos that went down and try to clean proactively the directory
+                // Active filtering: detect dead silos and try to clean proactively the directory
                 var changes = snapshot.CreateUpdate(previousSnapshot).Changes;
                 var deadSilos = changes
-                    .Where(member => member.Status.IsTerminating())
+                    .Where(member => member.Status == SiloStatus.Dead)
                     .Select(member => member.SiloAddress)
                     .ToList();
 
@@ -196,17 +196,7 @@ namespace Orleans.Runtime.GrainDirectory
         private bool IsKnownDeadSilo(SiloAddress siloAddress, MembershipVersion membershipVersion)
         {
             var current = this.clusterMembershipService.CurrentSnapshot;
-
-            // Check if the target silo is in the cluster
-            if (current.Members.TryGetValue(siloAddress, out var value))
-            {
-                // It is, check if it's alive
-                return value.Status.IsTerminating();
-            }
-
-            // We didn't find it in the cluster. If the silo entry is too old, it has been cleaned in the membership table: the entry isn't valid anymore.
-            // Otherwise, maybe the membership service isn't up to date yet. The entry should be valid
-            return current.Version > membershipVersion;
+            return siloAddress is null || current.GetSiloStatus(siloAddress, membershipVersion) == SiloStatus.Dead;
         }
 
         private static void ThrowUnsupportedGrainType(GrainId grainId) => throw new InvalidOperationException($"Unsupported grain type for grain {grainId}");
@@ -222,10 +212,10 @@ namespace Orleans.Runtime.GrainDirectory
                 ThrowUnsupportedGrainType(grainId);
             }
 
-            if (this.cache.LookUp(grainId, out address, out var version))
+            if (this.cache.LookUp(grainId, out address, out _))
             {
                 // If the silo is dead, remove the entry
-                if (IsKnownDeadSilo(address.SiloAddress, new MembershipVersion(version)))
+                if (IsKnownDeadSilo(address))
                 {
                     address = default;
                     this.cache.Remove(grainId);

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -187,6 +187,7 @@ namespace Orleans.Runtime.GrainDirectory
                 }
 
                 ((ITestAccessor)this).LastMembershipVersion = snapshot.Version;
+                previousSnapshot = snapshot;
             }
         }
 
@@ -201,7 +202,11 @@ namespace Orleans.Runtime.GrainDirectory
 
         private static void ThrowUnsupportedGrainType(GrainId grainId) => throw new InvalidOperationException($"Unsupported grain type for grain {grainId}");
 
-        public void UpdateCache(GrainId grainId, SiloAddress siloAddress) => cache.AddOrUpdate(new GrainAddress { GrainId = grainId, SiloAddress = siloAddress }, 0);
+        public void UpdateCache(GrainId grainId, SiloAddress siloAddress)
+        {
+            var membershipVersion = this.clusterMembershipService.CurrentSnapshot.Version;
+            cache.AddOrUpdate(new GrainAddress { GrainId = grainId, SiloAddress = siloAddress, MembershipVersion = membershipVersion }, (int)membershipVersion.Value);
+        }
         public void InvalidateCache(GrainId grainId) => cache.Remove(grainId);
         public void InvalidateCache(GrainAddress address) => cache.Remove(address);
         public bool TryLookupInCache(GrainId grainId, out GrainAddress address)

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -204,7 +204,10 @@ namespace Orleans.Runtime.GrainDirectory
             lock (this)
             {
                 this.pendingOperations.Enqueue((name, state, action));
-                this.localDirectory.RemoteGrainDirectory.WorkItemGroup.QueueTask(ExecutePendingOperations, localDirectory.RemoteGrainDirectory);
+                if (this.pendingOperations.Count <= 2)
+                {
+                    this.localDirectory.RemoteGrainDirectory.WorkItemGroup.QueueTask(ExecutePendingOperations, localDirectory.RemoteGrainDirectory);
+                }
             }
         }
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -17,24 +17,24 @@ namespace Orleans.Runtime.GrainDirectory
         private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(250);
         private readonly LocalGrainDirectory localDirectory;
         private readonly ISiloStatusOracle siloStatusOracle;
+        private readonly IClusterMembershipService clusterMembershipService;
         private readonly IInternalGrainFactory grainFactory;
         private readonly ILogger logger;
-        private readonly Factory<LocalGrainDirectoryPartition> createPartion;
         private readonly Queue<(string name, object state, Func<GrainDirectoryHandoffManager, object, Task> action)> pendingOperations = new();
         private readonly AsyncLock executorLock = new AsyncLock();
 
         internal GrainDirectoryHandoffManager(
             LocalGrainDirectory localDirectory,
             ISiloStatusOracle siloStatusOracle,
+            IClusterMembershipService clusterMembershipService,
             IInternalGrainFactory grainFactory,
-            Factory<LocalGrainDirectoryPartition> createPartion,
             ILoggerFactory loggerFactory)
         {
             logger = loggerFactory.CreateLogger<GrainDirectoryHandoffManager>();
             this.localDirectory = localDirectory;
             this.siloStatusOracle = siloStatusOracle;
+            this.clusterMembershipService = clusterMembershipService;
             this.grainFactory = grainFactory;
-            this.createPartion = createPartion;
         }
 
         internal void ProcessSiloAddEvent(SiloAddress addedSilo)
@@ -128,9 +128,10 @@ namespace Orleans.Runtime.GrainDirectory
         {
             if (!this.localDirectory.Running) return;
 
+            var snapshot = this.clusterMembershipService.CurrentSnapshot;
             for (var i = singleActivations.Count - 1; i >= 0; i--)
             {
-                if (singleActivations[i].SiloAddress is not { } siloAddress || this.siloStatusOracle.GetApproximateSiloStatus(siloAddress).IsTerminating())
+                if (!IsTransferableRegistration(singleActivations[i], snapshot))
                 {
                     singleActivations.RemoveAt(i);
                 }
@@ -197,6 +198,16 @@ namespace Orleans.Runtime.GrainDirectory
 
                 duplicates.Remove(pair.Key);
             }
+        }
+
+        internal static bool IsTransferableRegistration(GrainAddress address, ClusterMembershipSnapshot snapshot)
+        {
+            if (address.SiloAddress is not { } silo)
+            {
+                return false;
+            }
+
+            return snapshot.GetSiloStatus(silo, address.MembershipVersion) != SiloStatus.Dead;
         }
 
         private void EnqueueOperation(string name, object state, Func<GrainDirectoryHandoffManager, object, Task> action)

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -15,7 +15,6 @@ namespace Orleans.Runtime.GrainDirectory
     internal sealed partial class GrainDirectoryHandoffManager
     {
         private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(250);
-        private const int MAX_OPERATION_DEQUEUE = 2;
         private readonly LocalGrainDirectory localDirectory;
         private readonly ISiloStatusOracle siloStatusOracle;
         private readonly IInternalGrainFactory grainFactory;
@@ -71,6 +70,11 @@ namespace Orleans.Runtime.GrainDirectory
         private async Task ProcessAddedSiloAsync(SiloAddress addedSilo, List<GrainAddress> splitPartListSingle)
         {
             if (!this.localDirectory.Running) return;
+            if (!addedSilo.Equals(localDirectory.FindSuccessor(localDirectory.MyAddress)))
+            {
+                LogDebugNotImmediateSuccessor(logger, addedSilo);
+                return;
+            }
 
             if (this.siloStatusOracle.GetApproximateSiloStatus(addedSilo) == SiloStatus.Active)
             {
@@ -123,6 +127,16 @@ namespace Orleans.Runtime.GrainDirectory
         private async Task AcceptExistingRegistrationsAsync(List<GrainAddress> singleActivations)
         {
             if (!this.localDirectory.Running) return;
+
+            for (var i = singleActivations.Count - 1; i >= 0; i--)
+            {
+                if (singleActivations[i].SiloAddress is not { } siloAddress || this.siloStatusOracle.GetApproximateSiloStatus(siloAddress).IsTerminating())
+                {
+                    singleActivations.RemoveAt(i);
+                }
+            }
+
+            if (singleActivations.Count == 0) return;
 
             LogDebugAcceptingRegistrations(logger, singleActivations.Count);
 
@@ -190,10 +204,7 @@ namespace Orleans.Runtime.GrainDirectory
             lock (this)
             {
                 this.pendingOperations.Enqueue((name, state, action));
-                if (this.pendingOperations.Count <= 2)
-                {
-                    this.localDirectory.RemoteGrainDirectory.WorkItemGroup.QueueTask(ExecutePendingOperations, localDirectory.RemoteGrainDirectory);
-                }
+                this.localDirectory.RemoteGrainDirectory.WorkItemGroup.QueueTask(ExecutePendingOperations, localDirectory.RemoteGrainDirectory);
             }
         }
 
@@ -201,7 +212,6 @@ namespace Orleans.Runtime.GrainDirectory
         {
             using (await executorLock.LockAsync())
             {
-                var dequeueCount = 0;
                 while (true)
                 {
                     // Get the next operation, or exit if there are none.
@@ -213,34 +223,23 @@ namespace Orleans.Runtime.GrainDirectory
                         op = this.pendingOperations.Peek();
                     }
 
-                    dequeueCount++;
-
                     try
                     {
                         await op.Action(this, op.State);
-                        // Success, reset the dequeue count
-                        dequeueCount = 0;
+                        lock (this)
+                        {
+                            this.pendingOperations.Dequeue();
+                        }
                     }
                     catch (Exception exception)
                     {
-                        if (dequeueCount < MAX_OPERATION_DEQUEUE)
+                        if (!this.localDirectory.Running)
                         {
-                            LogWarningOperationFailedRetry(logger, exception, op.Name);
-                            await Task.Delay(RetryDelay);
+                            return;
                         }
-                        else
-                        {
-                            LogWarningOperationFailedNoRetry(logger, exception, op.Name);
-                        }
-                    }
-                    if (dequeueCount == 0 || dequeueCount >= MAX_OPERATION_DEQUEUE)
-                    {
-                        lock (this)
-                        {
-                            // Remove the operation from the queue if it was a success
-                            // or if we tried too many times
-                            this.pendingOperations.Dequeue();
-                        }
+
+                        LogWarningOperationFailedRetry(logger, exception, op.Name);
+                        await Task.Delay(RetryDelay);
                     }
                 }
             }
@@ -335,10 +334,5 @@ namespace Orleans.Runtime.GrainDirectory
         )]
         private static partial void LogWarningOperationFailedRetry(ILogger logger, Exception exception, string operation);
 
-        [LoggerMessage(
-            Level = LogLevel.Warning,
-            Message = "{Operation} failed, will NOT be retried"
-        )]
-        private static partial void LogWarningOperationFailedNoRetry(ILogger logger, Exception exception, string operation);
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
@@ -111,7 +111,8 @@ internal sealed partial class GrainDirectoryPartition
         return existing;
     }
 
-    private bool IsSiloDead(GrainAddress existing) => _owner.ClusterMembershipSnapshot.GetSiloStatus(existing.SiloAddress) == SiloStatus.Dead;
+    private bool IsSiloDead(GrainAddress existing)
+        => existing.SiloAddress is null || _owner.ClusterMembershipSnapshot.GetSiloStatus(existing.SiloAddress, existing.MembershipVersion) == SiloStatus.Dead;
 
     [LoggerMessage(
         Level = LogLevel.Trace,

--- a/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
@@ -95,12 +95,5 @@ namespace Orleans.Runtime.GrainDirectory
         /// Attempts to find the specified grain in the directory cache.
         /// </summary>
         bool TryCachedLookup(GrainId grainId, [NotNullWhen(true)] out GrainAddress? address);
-
-        /// <summary>
-        /// For determining message forwarding logic, we sometimes check if a silo is part of this cluster or not
-        /// </summary>
-        /// <param name="silo">the address of the silo</param>
-        /// <returns>true if the silo is known to be part of this cluster</returns>
-        bool IsSiloInCluster(SiloAddress silo);
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -23,7 +23,6 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly IClusterMembershipService clusterMembershipService;
         private readonly IInternalGrainFactory grainFactory;
         private readonly ActivationDirectory localActivations;
-        private readonly InsideRuntimeClient runtimeClient;
         private readonly IServiceProvider _serviceProvider;
         private readonly CancellationTokenSource _membershipUpdatesCancellation = new();
         private DirectoryMembership directoryMembership = DirectoryMembership.Default;
@@ -70,7 +69,6 @@ namespace Orleans.Runtime.GrainDirectory
             this.clusterMembershipService = clusterMembershipService;
             this.grainFactory = grainFactory;
             this.localActivations = systemTargetShared.ActivationDirectory;
-            this.runtimeClient = systemTargetShared.RuntimeClient;
 
             DirectoryCache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value, out this.disposeDirectoryCache);
 
@@ -303,17 +301,6 @@ namespace Orleans.Runtime.GrainDirectory
             return result;
         }
 
-        private Task RefreshMembershipIfNewer(GrainAddress address, GrainAddress? previousAddress = null)
-        {
-            var targetVersion = address.MembershipVersion;
-            if (previousAddress is not null && previousAddress.MembershipVersion > targetVersion)
-            {
-                targetVersion = previousAddress.MembershipVersion;
-            }
-
-            return RefreshMembershipIfNewer(targetVersion);
-        }
-
         private Task RefreshMembershipIfNewer(List<GrainAddress> addresses)
         {
             var targetVersion = MembershipVersion.MinValue;
@@ -348,11 +335,6 @@ namespace Orleans.Runtime.GrainDirectory
             if (updatedSilo.Equals(MyAddress) || !status.IsTerminating())
             {
                 return;
-            }
-
-            if (status == SiloStatus.Dead)
-            {
-                runtimeClient.BreakOutstandingMessagesToSilo(updatedSilo);
             }
 
             var activationsToShutdown = new List<IGrainContext>();
@@ -444,24 +426,14 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        private static bool IsDefunctActivation(GrainAddress address, ClusterMembershipSnapshot snapshot)
+        internal static bool IsDefunctActivation(GrainAddress address, ClusterMembershipSnapshot snapshot)
         {
             if (address.SiloAddress is not { } silo)
             {
                 return true;
             }
 
-            if (snapshot.Members.TryGetValue(silo, out var member))
-            {
-                // If this is a known host, remove the activation if the host is dead.
-                return member.Status == SiloStatus.Dead;
-            }
-
-            // If this is not a known host, remove the activation if it was registered at an older membership version.
-            // This indicates that the host must have been removed.
-            // Hosts cannot activate grains before they are active, and we ensure that we refresh the membership before processing messages,
-            // so this is a reliable indicator of a defunct activation.
-            return address.MembershipVersion < snapshot.Version;
+            return snapshot.GetSiloStatus(silo) == SiloStatus.Dead;
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)
@@ -608,13 +580,13 @@ namespace Orleans.Runtime.GrainDirectory
                 DirectoryInstruments.RegistrationsSingleActIssued.Add(1);
             }
 
-            await RefreshMembershipIfNewer(address, previousAddress);
+            await RefreshMembershipIfNewer(address.MembershipVersion);
 
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "RegisterAsync");
 
-            // on all silos other than first, we insert a retry delay and recheck owner before forwarding
-            if (hopCount > 0 && forwardAddress != null)
+            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
                 forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "RegisterAsync");
@@ -664,7 +636,7 @@ namespace Orleans.Runtime.GrainDirectory
         {
             LogTraceUnregisterAfterNonexistingActivation(addr, origin);
 
-            await RefreshMembershipIfNewer(addr);
+            await RefreshMembershipIfNewer(addr.MembershipVersion);
 
             if (origin == null || this.directoryMembership.MembershipCache.Contains(origin))
             {
@@ -693,13 +665,13 @@ namespace Orleans.Runtime.GrainDirectory
             if (hopCount == 0)
                 InvalidateCacheEntry(address);
 
-            await RefreshMembershipIfNewer(address);
+            await RefreshMembershipIfNewer(address.MembershipVersion);
 
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "UnregisterAsync");
 
-            // on all silos other than first, we insert a retry delay and recheck owner before forwarding
-            if (hopCount > 0 && forwardAddress != null)
+            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
                 forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "UnregisterAsync");

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -433,7 +433,7 @@ namespace Orleans.Runtime.GrainDirectory
                 return true;
             }
 
-            return snapshot.GetSiloStatus(silo) == SiloStatus.Dead;
+            return address.MembershipVersion < snapshot.Version && snapshot.GetSiloStatus(silo) == SiloStatus.Dead;
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -227,8 +227,8 @@ namespace Orleans.Runtime.GrainDirectory
             var addedSilos = GetMembershipDifference(targetMembership, previousMembership);
 
             ProcessSiloStatusChanges(snapshot, previousSnapshot, previousMembership);
-            AdjustLocalDirectory(targetMembership);
-            AdjustLocalCache(targetMembership);
+            AdjustLocalDirectory(snapshot);
+            AdjustLocalCache(snapshot, targetMembership);
 
             foreach (var silo in removedSilos)
             {
@@ -365,14 +365,14 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        private void AdjustLocalDirectory(DirectoryMembership targetMembership)
+        private void AdjustLocalDirectory(ClusterMembershipSnapshot snapshot)
         {
             var activationsToRemove = new List<(GrainId, ActivationId)>();
             foreach (var entry in this.DirectoryPartition.GetItems())
             {
                 if (entry.Value.Activation is { } address)
                 {
-                    if (IsDefunctActivationSilo(targetMembership, address.SiloAddress))
+                    if (IsDefunctActivation(address, snapshot))
                     {
                         activationsToRemove.Add((entry.Key, address.ActivationId));
                     }
@@ -385,7 +385,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        private void AdjustLocalCache(DirectoryMembership targetMembership)
+        private void AdjustLocalCache(ClusterMembershipSnapshot snapshot, DirectoryMembership targetMembership)
         {
             foreach (var tuple in DirectoryCache.KeyValues)
             {
@@ -398,16 +398,26 @@ namespace Orleans.Runtime.GrainDirectory
                     continue;
                 }
 
-                if (IsDefunctActivationSilo(targetMembership, activationAddress.SiloAddress))
+                if (IsDefunctActivation(activationAddress, snapshot))
                 {
                     DirectoryCache.Remove(activationAddress.GrainId);
                 }
             }
         }
 
-        private static bool IsDefunctActivationSilo(DirectoryMembership targetMembership, SiloAddress? silo)
+        private static bool IsDefunctActivation(GrainAddress address, ClusterMembershipSnapshot snapshot)
         {
-            return silo is null || !targetMembership.MembershipCache.Contains(silo);
+            if (address.SiloAddress is not { } silo)
+            {
+                return true;
+            }
+
+            if (snapshot.Members.TryGetValue(silo, out var member))
+            {
+                return member.Status.IsTerminating();
+            }
+
+            return address.MembershipVersion < snapshot.Version;
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -453,9 +453,14 @@ namespace Orleans.Runtime.GrainDirectory
 
             if (snapshot.Members.TryGetValue(silo, out var member))
             {
+                // If this is a known host, remove the activation if the host is dead.
                 return member.Status == SiloStatus.Dead;
             }
 
+            // If this is not a known host, remove the activation if it was registered at an older membership version.
+            // This indicates that the host must have been removed.
+            // Hosts cannot activate grains before they are active, and we ensure that we refresh the membership before processing messages,
+            // so this is a reliable indicator of a defunct activation.
             return address.MembershipVersion < snapshot.Version;
         }
 

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -433,7 +433,8 @@ namespace Orleans.Runtime.GrainDirectory
                 return true;
             }
 
-            return address.MembershipVersion < snapshot.Version && snapshot.GetSiloStatus(silo) == SiloStatus.Dead;
+            var status = snapshot.GetSiloStatus(silo);
+            return status == SiloStatus.Dead || (status == SiloStatus.None && address.MembershipVersion < snapshot.Version);
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.GrainDirectory;
+using Orleans.Internal;
 using Orleans.Runtime.Scheduler;
 
 namespace Orleans.Runtime.GrainDirectory
@@ -147,12 +148,12 @@ namespace Orleans.Runtime.GrainDirectory
             _membershipUpdatesCancellation.Cancel();
             if (membershipUpdatesTask is { } task)
             {
-                await task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+                await task.SuppressThrowing();
             }
 
             if (this.disposeDirectoryCache)
             {
-                await GrainDirectoryCacheFactory.DisposeGrainDirectoryCacheAsync(DirectoryCache);
+                await GrainDirectoryCacheFactory.DisposeGrainDirectoryCacheAsync(DirectoryCache).SuppressThrowing();
             }
 
             DirectoryPartition.Clear();
@@ -196,7 +197,7 @@ namespace Orleans.Runtime.GrainDirectory
                     }
 
                     snapshot = clusterMembershipService.CurrentSnapshot;
-                    await Task.Delay(RETRY_DELAY, cancellationToken);
+                    await Task.Delay(RETRY_DELAY, cancellationToken).SuppressThrowing();
                 }
             }
         }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -738,8 +738,8 @@ namespace Orleans.Runtime.GrainDirectory
 
             UnregisterOrPutInForwardList(addresses, cause, hopCount, ref forwardlist, "UnregisterManyAsync");
 
-            // before forwarding to other silos, we insert a retry delay and re-check destination
-            if (hopCount > 0 && forwardlist != null)
+            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            if (hopCount > 1 && forwardlist != null)
             {
                 await Task.Delay(RETRY_DELAY);
                 Dictionary<SiloAddress, List<GrainAddress>>? forwardlist2 = null;
@@ -852,8 +852,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "LookUpAsync");
 
-            // on all silos other than first, we insert a retry delay and recheck owner before forwarding
-            if (hopCount > 0 && forwardAddress != null)
+            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
                 forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "LookUpAsync");
@@ -913,8 +913,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "DeleteGrainAsync");
 
-            // on all silos other than first, we insert a retry delay and recheck owner before forwarding
-            if (hopCount > 0 && forwardAddress != null)
+            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
                 forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "DeleteGrainAsync");

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -24,11 +24,6 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly IInternalGrainFactory grainFactory;
         private readonly ActivationDirectory localActivations;
         private readonly InsideRuntimeClient runtimeClient;
-#if NET9_0_OR_GREATER
-        private readonly Lock writeLock = new();
-#else
-        private readonly object writeLock = new();
-#endif
         private readonly IServiceProvider _serviceProvider;
         private readonly CancellationTokenSource _membershipUpdatesCancellation = new();
         private DirectoryMembership directoryMembership = DirectoryMembership.Default;
@@ -167,12 +162,12 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 try
                 {
-                    await ApplyMembershipSnapshot(snapshot, cancellationToken);
+                    await ApplyMembershipSnapshot(snapshot);
 
                     await foreach (var update in clusterMembershipService.MembershipUpdates.WithCancellation(cancellationToken))
                     {
                         snapshot = update;
-                        await ApplyMembershipSnapshot(snapshot, cancellationToken);
+                        await ApplyMembershipSnapshot(snapshot);
                     }
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -202,92 +197,75 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        private Task ApplyMembershipSnapshot(ClusterMembershipSnapshot snapshot, CancellationToken cancellationToken)
+        private Task ApplyMembershipSnapshot(ClusterMembershipSnapshot snapshot)
         {
             return CacheValidator.RunOrQueueTask(() =>
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                ApplyMembershipSnapshot(snapshot);
+                ApplyMembershipSnapshotCore(snapshot);
                 return Task.CompletedTask;
             });
         }
 
-        private void ApplyMembershipSnapshot(ClusterMembershipSnapshot snapshot)
+        private void ApplyMembershipSnapshotCore(ClusterMembershipSnapshot snapshot)
         {
             if (!Running)
             {
                 return;
             }
 
-            lock (this.writeLock)
+            var previousSnapshot = hasAppliedClusterMembershipSnapshot ? appliedClusterMembershipSnapshot : ClusterMembershipSnapshot.Default;
+            if (hasAppliedClusterMembershipSnapshot && snapshot.Version <= previousSnapshot.Version)
             {
-                var previousSnapshot = hasAppliedClusterMembershipSnapshot ? appliedClusterMembershipSnapshot : ClusterMembershipSnapshot.Default;
-                if (hasAppliedClusterMembershipSnapshot && snapshot.Version <= previousSnapshot.Version)
+                return;
+            }
+
+            var previousMembership = CreateDirectoryMembership(previousSnapshot);
+            var targetMembership = CreateDirectoryMembership(snapshot);
+            this.directoryMembership = targetMembership;
+
+            var removedSilos = GetMembershipDifference(previousMembership, targetMembership);
+            var addedSilos = GetMembershipDifference(targetMembership, previousMembership);
+
+            ProcessSiloStatusChanges(snapshot, previousSnapshot, previousMembership);
+            AdjustLocalDirectory(targetMembership);
+            AdjustLocalCache(targetMembership);
+
+            foreach (var silo in removedSilos)
+            {
+                LogDebugSiloRemovedSilo(MyAddress, silo);
+            }
+
+            foreach (var silo in addedSilos)
+            {
+                HandoffManager.ProcessSiloAddEvent(silo);
+                LogDebugSiloAddedSilo(MyAddress, silo);
+            }
+
+            appliedClusterMembershipSnapshot = snapshot;
+            hasAppliedClusterMembershipSnapshot = true;
+        }
+
+        private void ProcessSiloStatusChanges(
+            ClusterMembershipSnapshot snapshot,
+            ClusterMembershipSnapshot previousSnapshot,
+            DirectoryMembership previousMembership)
+        {
+            var changes = previousSnapshot.Version != MembershipVersion.MinValue
+                ? snapshot.CreateUpdate(previousSnapshot)
+                : snapshot.AsUpdate();
+            var statusChanges = new List<ClusterMember>();
+            foreach (var change in changes.Changes)
+            {
+                if (!change.SiloAddress.Equals(MyAddress) && change.Status.IsTerminating())
                 {
-                    return;
+                    statusChanges.Add(change);
                 }
+            }
 
-                var previousMembership = CreateDirectoryMembership(previousSnapshot);
-                var targetMembership = CreateDirectoryMembership(snapshot);
-                var changes = hasAppliedClusterMembershipSnapshot && previousSnapshot.Version != MembershipVersion.MinValue
-                    ? snapshot.CreateUpdate(previousSnapshot)
-                    : snapshot.AsUpdate();
-                var statusChanges = new List<ClusterMember>();
-                foreach (var change in changes.Changes)
-                {
-                    if (!change.SiloAddress.Equals(MyAddress) && change.Status.IsTerminating())
-                    {
-                        statusChanges.Add(change);
-                    }
-                }
-
-                statusChanges.Sort(static (left, right) => CompareSiloAddress(left.SiloAddress, right.SiloAddress));
-                foreach (var change in statusChanges)
-                {
-                    OnSiloStatusChange(previousMembership, change.SiloAddress, change.Status);
-                }
-
-                var removedSilos = new List<(SiloAddress Silo, SiloStatus Status)>();
-                foreach (var silo in previousMembership.MembershipRingList)
-                {
-                    if (!silo.Equals(MyAddress) && !targetMembership.MembershipCache.Contains(silo))
-                    {
-                        var status = snapshot.GetSiloStatus(silo);
-                        removedSilos.Add((silo, status == SiloStatus.None ? SiloStatus.Dead : status));
-                    }
-                }
-
-                var addedSilos = new List<SiloAddress>();
-                foreach (var silo in targetMembership.MembershipRingList)
-                {
-                    if (!silo.Equals(MyAddress) && !previousMembership.MembershipCache.Contains(silo))
-                    {
-                        addedSilos.Add(silo);
-                    }
-                }
-
-                this.directoryMembership = targetMembership;
-
-                foreach (var (silo, _) in removedSilos)
-                {
-                    AdjustLocalDirectory(silo, dead: true);
-                    AdjustLocalCache(silo, dead: true);
-
-                    LogDebugSiloRemovedSilo(MyAddress, silo);
-                }
-
-                foreach (var silo in addedSilos)
-                {
-                    HandoffManager.ProcessSiloAddEvent(silo);
-
-                    AdjustLocalDirectory(silo, dead: false);
-                    AdjustLocalCache(silo, dead: false);
-
-                    LogDebugSiloAddedSilo(MyAddress, silo);
-                }
-
-                appliedClusterMembershipSnapshot = snapshot;
-                hasAppliedClusterMembershipSnapshot = true;
+            statusChanges.Sort(static (left, right) => CompareSiloAddress(left.SiloAddress, right.SiloAddress));
+            foreach (var change in statusChanges)
+            {
+                OnSiloStatusChange(previousMembership, change.SiloAddress, change.Status);
             }
         }
 
@@ -308,6 +286,22 @@ namespace Orleans.Runtime.GrainDirectory
             }
 
             return DirectoryMembership.Create(members);
+        }
+
+        private List<SiloAddress> GetMembershipDifference(
+            DirectoryMembership currentMembership,
+            DirectoryMembership otherMembership)
+        {
+            var result = new List<SiloAddress>();
+            foreach (var silo in currentMembership.MembershipRingList)
+            {
+                if (!silo.Equals(MyAddress) && !otherMembership.MembershipCache.Contains(silo))
+                {
+                    result.Add(silo);
+                }
+            }
+
+            return result;
         }
 
         private void OnSiloStatusChange(DirectoryMembership previousMembership, SiloAddress updatedSilo, SiloStatus status)
@@ -371,62 +365,49 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        /// <summary>
-        /// Adjust local directory following the addition/removal of a silo
-        /// </summary>
-        private void AdjustLocalDirectory(SiloAddress silo, bool dead)
+        private void AdjustLocalDirectory(DirectoryMembership targetMembership)
         {
-            // Determine which activations to remove.
             var activationsToRemove = new List<(GrainId, ActivationId)>();
             foreach (var entry in this.DirectoryPartition.GetItems())
             {
                 if (entry.Value.Activation is { } address)
                 {
-                    // Include any activations from dead silos and from predecessors.
-                    if (dead && address.SiloAddress!.Equals(silo) || address.SiloAddress!.IsPredecessorOf(silo))
+                    if (IsDefunctActivationSilo(targetMembership, address.SiloAddress))
                     {
                         activationsToRemove.Add((entry.Key, address.ActivationId));
                     }
                 }
             }
 
-            // Remove all defunct activations.
             foreach (var activation in activationsToRemove)
             {
                 DirectoryPartition.RemoveActivation(activation.Item1, activation.Item2);
             }
         }
 
-        /// Adjust local cache following the removal of a silo by dropping:
-        /// 1) entries that point to activations located on the removed silo
-        /// 2) entries for grains that are now owned by this silo (me)
-        /// 3) entries for grains that were owned by this removed silo - we currently do NOT do that.
-        ///     If we did 3, we need to do that BEFORE we change the membershipRingList (based on old Membership).
-        ///     We don't do that since first cache refresh handles that.
-        ///     Second, since Membership events are not guaranteed to be ordered, we may remove a cache entry that does not really point to a failed silo.
-        ///     To do that properly, we need to store for each cache entry who was the directory owner that registered this activation (the original partition owner).
-        private void AdjustLocalCache(SiloAddress silo, bool dead)
+        private void AdjustLocalCache(DirectoryMembership targetMembership)
         {
-            // remove all records of activations located on the removed silo
             foreach (var tuple in DirectoryCache.KeyValues)
             {
                 var activationAddress = tuple.ActivationAddress;
 
-                // 2) remove entries now owned by me (they should be retrieved from my directory partition)
-                if (MyAddress.Equals(CalculateGrainDirectoryPartition(activationAddress.GrainId)))
+                // Remove entries now owned by me. They should be retrieved from my directory partition.
+                if (MyAddress.Equals(CalculateGrainDirectoryPartition(activationAddress.GrainId, targetMembership)))
                 {
                     DirectoryCache.Remove(activationAddress.GrainId);
                     continue;
                 }
 
-                // 1) remove entries that point to activations located on the removed silo
-                // For dead silos, remove any activation registered to that silo or one of its predecessors.
-                // For new silos, remove any activation registered to one of its predecessors.
-                if (activationAddress.SiloAddress!.IsPredecessorOf(silo) || dead && activationAddress.SiloAddress.Equals(silo))
+                if (IsDefunctActivationSilo(targetMembership, activationAddress.SiloAddress))
                 {
                     DirectoryCache.Remove(activationAddress.GrainId);
                 }
             }
+        }
+
+        private static bool IsDefunctActivationSilo(DirectoryMembership targetMembership, SiloAddress? silo)
+        {
+            return silo is null || !targetMembership.MembershipCache.Contains(silo);
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -387,9 +387,9 @@ namespace Orleans.Runtime.GrainDirectory
                 return;
             }
 
-            LogInfoSiloStatusChangeNotification(activationsToShutdown.Count, new(updatedSilo));
+            LogInfoSiloStatusChangeNotification(activationsToShutdown.Count, new(updatedSilo), status);
 
-            var reasonText = $"This activation is being deactivated due to a failure of server {updatedSilo}, since it was responsible for this activation's grain directory registration.";
+            var reasonText = $"This activation is being deactivated because server {updatedSilo} entered status {status} and was responsible for this activation's grain directory registration.";
             var reason = new DeactivationReason(DeactivationReasonCode.DirectoryFailure, reasonText);
             foreach (var activation in activationsToShutdown)
             {
@@ -1050,13 +1050,13 @@ namespace Orleans.Runtime.GrainDirectory
         [LoggerMessage(
             Level = LogLevel.Information,
             EventId = (int)ErrorCode.Catalog_SiloStatusChangeNotification,
-            Message = "LocalGrainDirectory is deactivating {Count} activations due to a failure of silo {Silo}, since it is a primary directory partition to these grain ids."
+            Message = "LocalGrainDirectory is deactivating {Count} activations because silo {Silo} entered status {Status} and was the primary directory partition for these grain ids."
         )]
-        private partial void LogInfoSiloStatusChangeNotification(int count, SiloAddressLogValue silo);
+        private partial void LogInfoSiloStatusChangeNotification(int count, SiloAddressLogValue silo, SiloStatus status);
 
         [LoggerMessage(
             Level = LogLevel.Error,
-            EventId = (int)ErrorCode.Catalog_SiloStatusChangeNotification_Exception,
+            EventId = (int)ErrorCode.Catalog_DeactivateActivation_Exception,
             Message = "LocalGrainDirectory has thrown an exception while deactivating activation {GrainId} due to removal of silo {Silo}."
         )]
         private partial void LogErrorDeactivatingActivationForRemovedSilo(Exception exception, GrainId grainId, SiloAddressLogValue silo);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -79,7 +79,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
 
             DirectoryPartition = grainDirectoryPartitionFactory();
-            HandoffManager = new GrainDirectoryHandoffManager(this, siloStatusOracle, grainFactory, grainDirectoryPartitionFactory, loggerFactory);
+            HandoffManager = new GrainDirectoryHandoffManager(this, siloStatusOracle, clusterMembershipService, grainFactory, loggerFactory);
 
             // When DistributedGrainDirectory is active, it registers its own IRemoteGrainDirectory system targets.
             // In that case, create the RemoteGrainDirectory objects (still needed for WorkItemGroup scheduling)
@@ -433,8 +433,7 @@ namespace Orleans.Runtime.GrainDirectory
                 return true;
             }
 
-            var status = snapshot.GetSiloStatus(silo);
-            return status == SiloStatus.Dead || (status == SiloStatus.None && address.MembershipVersion < snapshot.Version);
+            return snapshot.GetSiloStatus(silo, address.MembershipVersion) == SiloStatus.Dead;
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)
@@ -624,7 +623,7 @@ namespace Orleans.Runtime.GrainDirectory
                 // this way next local lookup will find this ActivationAddress in the cache and we will save a full lookup!
                 if (result.Address == null) return result;
 
-                if (!address.Equals(result.Address) || !IsValidSilo(address.SiloAddress)) return result;
+                if (!address.Equals(result.Address) || IsDefunctActivation(address, clusterMembershipService.CurrentSnapshot)) return result;
 
                 // update the cache so next local lookup will find this ActivationAddress in the cache and we will save full lookup.
                 DirectoryCache.AddOrUpdate(result.Address, result.VersionTag);
@@ -829,7 +828,15 @@ namespace Orleans.Runtime.GrainDirectory
 
         public AddressAndTag GetLocalDirectoryData(GrainId grain) => DirectoryPartition.LookUpActivation(grain);
 
-        public GrainAddress? GetLocalCacheData(GrainId grain) => DirectoryCache.LookUp(grain, out var cache) && IsValidSilo(cache.SiloAddress) ? cache : null;
+        public GrainAddress? GetLocalCacheData(GrainId grain)
+        {
+            if (!DirectoryCache.LookUp(grain, out var cache))
+            {
+                return null;
+            }
+
+            return IsDefunctActivation(cache, clusterMembershipService.CurrentSnapshot) ? null : cache;
+        }
 
         public async Task<AddressAndTag> LookupAsync(GrainId grainId, int hopCount = 0)
         {
@@ -890,7 +897,7 @@ namespace Orleans.Runtime.GrainDirectory
                 var result = await GetDirectoryReference(forwardAddress).LookupAsync(grainId, hopCount + 1);
 
                 // update the cache
-                if (result.Address is { } address && IsValidSilo(address.SiloAddress))
+                if (result.Address is { } address && !IsDefunctActivation(address, clusterMembershipService.CurrentSnapshot))
                 {
                     DirectoryCache.AddOrUpdate(address, result.VersionTag);
                 }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -14,25 +14,32 @@ using Orleans.Runtime.Scheduler;
 
 namespace Orleans.Runtime.GrainDirectory
 {
-    internal sealed partial class LocalGrainDirectory : ILocalGrainDirectory, ISiloStatusListener, ILifecycleParticipant<ISiloLifecycle>
+    internal sealed partial class LocalGrainDirectory : ILocalGrainDirectory, ILifecycleParticipant<ISiloLifecycle>
     {
         private readonly ILogger log;
         private readonly SiloAddress? seed;
         private readonly ISiloStatusOracle siloStatusOracle;
+        private readonly IClusterMembershipService clusterMembershipService;
         private readonly IInternalGrainFactory grainFactory;
+        private readonly ActivationDirectory localActivations;
+        private readonly InsideRuntimeClient runtimeClient;
 #if NET9_0_OR_GREATER
         private readonly Lock writeLock = new();
 #else
         private readonly object writeLock = new();
 #endif
         private readonly IServiceProvider _serviceProvider;
+        private readonly CancellationTokenSource _membershipUpdatesCancellation = new();
         private DirectoryMembership directoryMembership = DirectoryMembership.Default;
+        private ClusterMembershipSnapshot appliedClusterMembershipSnapshot = ClusterMembershipSnapshot.Default;
+        private GrainDirectoryResolver? grainDirectoryResolver;
+        private bool hasAppliedClusterMembershipSnapshot;
 
         // Consider: move these constants into an appropriate place
         internal const int HOP_LIMIT = 6; // forward a remote request no more than 5 times
         public static readonly TimeSpan RETRY_DELAY = TimeSpan.FromMilliseconds(200); // Pause 200ms between forwards to let the membership directory settle down
         internal bool Running;
-        private Catalog? _catalog;
+        private Task? membershipUpdatesTask;
 
         internal SiloAddress MyAddress { get; }
 
@@ -51,6 +58,7 @@ namespace Orleans.Runtime.GrainDirectory
             IServiceProvider serviceProvider,
             ILocalSiloDetails siloDetails,
             ISiloStatusOracle siloStatusOracle,
+            IClusterMembershipService clusterMembershipService,
             IInternalGrainFactory grainFactory,
             Factory<LocalGrainDirectoryPartition> grainDirectoryPartitionFactory,
             IOptions<DevelopmentClusterMembershipOptions> developmentClusterMembershipOptions,
@@ -63,7 +71,10 @@ namespace Orleans.Runtime.GrainDirectory
             MyAddress = siloDetails.SiloAddress;
 
             this.siloStatusOracle = siloStatusOracle;
+            this.clusterMembershipService = clusterMembershipService;
             this.grainFactory = grainFactory;
+            this.localActivations = systemTargetShared.ActivationDirectory;
+            this.runtimeClient = systemTargetShared.RuntimeClient;
 
             DirectoryCache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value, out this.disposeDirectoryCache);
 
@@ -96,8 +107,7 @@ namespace Orleans.Runtime.GrainDirectory
                 DistributedGrainDirectoryPartitionCompatibilities = compatibilityPartitions.MoveToImmutable();
             }
 
-            // add myself to the list of members
-            AddServer(MyAddress);
+            this.directoryMembership = DirectoryMembership.Create([MyAddress]);
 
             DirectoryInstruments.RegisterDirectoryPartitionSizeObserve(() => DirectoryPartition.Count);
             DirectoryInstruments.RegisterMyPortionRingDistanceObserve(() => RingDistanceToSuccessor());
@@ -116,8 +126,7 @@ namespace Orleans.Runtime.GrainDirectory
             LogDebugStart();
 
             Running = true;
-
-            siloStatusOracle.SubscribeToSiloStatusEvents(this);
+            membershipUpdatesTask = Task.Run(() => ProcessMembershipUpdates(_membershipUpdatesCancellation.Token));
         }
 
         // Note that this implementation stops processing directory change requests (Register, Unregister, etc.) when the Stop event is raised.
@@ -135,6 +144,11 @@ namespace Orleans.Runtime.GrainDirectory
 
             //mark Running as false will exclude myself from CalculateGrainDirectoryPartition(grainId)
             Running = false;
+            _membershipUpdatesCancellation.Cancel();
+            if (membershipUpdatesTask is { } task)
+            {
+                await task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            }
 
             if (this.disposeDirectoryCache)
             {
@@ -145,68 +159,214 @@ namespace Orleans.Runtime.GrainDirectory
             DirectoryCache.Clear();
         }
 
-        private void AddServer(SiloAddress silo)
+        private async Task ProcessMembershipUpdates(CancellationToken cancellationToken)
         {
-            lock (this.writeLock)
-            {
-                var existing = this.directoryMembership;
-                if (existing.MembershipCache.Contains(silo))
-                {
-                    // we have already cached this silo
-                    return;
-                }
-
-                // insert new silo in the sorted order
-                long hash = silo.GetConsistentHashCode();
-
-                // Find the last silo with hash smaller than the new silo, and insert the latter after (this is why we have +1 here) the former.
-                // Notice that FindLastIndex might return -1 if this should be the first silo in the list, but then
-                // 'index' will get 0, as needed.
-                int index = existing.MembershipRingList.FindLastIndex(siloAddr => siloAddr.GetConsistentHashCode() < hash) + 1;
-
-                this.directoryMembership = new DirectoryMembership(
-                    existing.MembershipRingList.Insert(index, silo),
-                    existing.MembershipCache.Add(silo));
-
-                HandoffManager.ProcessSiloAddEvent(silo);
-
-                AdjustLocalDirectory(silo, dead: false);
-                AdjustLocalCache(silo, dead: false);
-
-                LogDebugSiloAddedSilo(MyAddress, silo);
-            }
-        }
-
-        private void RemoveServer(SiloAddress silo, SiloStatus status)
-        {
-            lock (this.writeLock)
+            var snapshot = clusterMembershipService.CurrentSnapshot;
+            while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {
-                    // Only notify the catalog once. Order is important: call BEFORE updating membershipRingList.
-                    _catalog = _serviceProvider.GetRequiredService<Catalog>();
-                    _catalog.OnSiloStatusChange(this, silo, status);
-                }
-                catch (Exception exc)
-                {
-                    LogErrorCatalogSiloStatusChangeNotificationException(exc, new(silo));
-                }
+                    await ApplyMembershipSnapshot(snapshot, cancellationToken);
 
-                var existing = this.directoryMembership;
-                if (!existing.MembershipCache.Contains(silo))
+                    await foreach (var update in clusterMembershipService.MembershipUpdates.WithCancellation(cancellationToken))
+                    {
+                        snapshot = update;
+                        await ApplyMembershipSnapshot(snapshot, cancellationToken);
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    // we have already removed this silo
+                    break;
+                }
+                catch (Exception exception)
+                {
+                    LogErrorProcessingMembershipUpdates(exception);
+
+                    try
+                    {
+                        await clusterMembershipService.Refresh(cancellationToken: cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                    catch (Exception refreshException)
+                    {
+                        LogWarningRefreshingClusterMembershipFailed(refreshException);
+                    }
+
+                    snapshot = clusterMembershipService.CurrentSnapshot;
+                    await Task.Delay(RETRY_DELAY, cancellationToken);
+                }
+            }
+        }
+
+        private Task ApplyMembershipSnapshot(ClusterMembershipSnapshot snapshot, CancellationToken cancellationToken)
+        {
+            return CacheValidator.RunOrQueueTask(() =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                ApplyMembershipSnapshot(snapshot);
+                return Task.CompletedTask;
+            });
+        }
+
+        private void ApplyMembershipSnapshot(ClusterMembershipSnapshot snapshot)
+        {
+            if (!Running)
+            {
+                return;
+            }
+
+            lock (this.writeLock)
+            {
+                var previousSnapshot = hasAppliedClusterMembershipSnapshot ? appliedClusterMembershipSnapshot : ClusterMembershipSnapshot.Default;
+                if (hasAppliedClusterMembershipSnapshot && snapshot.Version <= previousSnapshot.Version)
+                {
                     return;
                 }
 
-                this.directoryMembership = new DirectoryMembership(
-                    existing.MembershipRingList.Remove(silo),
-                    existing.MembershipCache.Remove(silo));
+                var previousMembership = CreateDirectoryMembership(previousSnapshot);
+                var targetMembership = CreateDirectoryMembership(snapshot);
+                var changes = hasAppliedClusterMembershipSnapshot && previousSnapshot.Version != MembershipVersion.MinValue
+                    ? snapshot.CreateUpdate(previousSnapshot)
+                    : snapshot.AsUpdate();
+                var statusChanges = new List<ClusterMember>();
+                foreach (var change in changes.Changes)
+                {
+                    if (!change.SiloAddress.Equals(MyAddress) && change.Status.IsTerminating())
+                    {
+                        statusChanges.Add(change);
+                    }
+                }
 
-                AdjustLocalDirectory(silo, dead: true);
-                AdjustLocalCache(silo, dead: true);
+                statusChanges.Sort(static (left, right) => CompareSiloAddress(left.SiloAddress, right.SiloAddress));
+                foreach (var change in statusChanges)
+                {
+                    OnSiloStatusChange(previousMembership, change.SiloAddress, change.Status);
+                }
 
-                LogDebugSiloRemovedSilo(MyAddress, silo);
+                var removedSilos = new List<(SiloAddress Silo, SiloStatus Status)>();
+                foreach (var silo in previousMembership.MembershipRingList)
+                {
+                    if (!silo.Equals(MyAddress) && !targetMembership.MembershipCache.Contains(silo))
+                    {
+                        var status = snapshot.GetSiloStatus(silo);
+                        removedSilos.Add((silo, status == SiloStatus.None ? SiloStatus.Dead : status));
+                    }
+                }
+
+                var addedSilos = new List<SiloAddress>();
+                foreach (var silo in targetMembership.MembershipRingList)
+                {
+                    if (!silo.Equals(MyAddress) && !previousMembership.MembershipCache.Contains(silo))
+                    {
+                        addedSilos.Add(silo);
+                    }
+                }
+
+                this.directoryMembership = targetMembership;
+
+                foreach (var (silo, _) in removedSilos)
+                {
+                    AdjustLocalDirectory(silo, dead: true);
+                    AdjustLocalCache(silo, dead: true);
+
+                    LogDebugSiloRemovedSilo(MyAddress, silo);
+                }
+
+                foreach (var silo in addedSilos)
+                {
+                    HandoffManager.ProcessSiloAddEvent(silo);
+
+                    AdjustLocalDirectory(silo, dead: false);
+                    AdjustLocalCache(silo, dead: false);
+
+                    LogDebugSiloAddedSilo(MyAddress, silo);
+                }
+
+                appliedClusterMembershipSnapshot = snapshot;
+                hasAppliedClusterMembershipSnapshot = true;
+            }
+        }
+
+        private DirectoryMembership CreateDirectoryMembership(ClusterMembershipSnapshot snapshot)
+        {
+            var members = new List<SiloAddress>();
+            foreach (var member in snapshot.Members)
+            {
+                if (member.Value.Status == SiloStatus.Active)
+                {
+                    members.Add(member.Key);
+                }
+            }
+
+            if (Running && !members.Contains(MyAddress))
+            {
+                members.Add(MyAddress);
+            }
+
+            return DirectoryMembership.Create(members);
+        }
+
+        private void OnSiloStatusChange(DirectoryMembership previousMembership, SiloAddress updatedSilo, SiloStatus status)
+        {
+            if (updatedSilo.Equals(MyAddress) || !status.IsTerminating())
+            {
+                return;
+            }
+
+            if (status == SiloStatus.Dead)
+            {
+                runtimeClient.BreakOutstandingMessagesToSilo(updatedSilo);
+            }
+
+            var activationsToShutdown = new List<IGrainContext>();
+            var resolver = grainDirectoryResolver ??= _serviceProvider.GetRequiredService<GrainDirectoryResolver>();
+            foreach (var activation in localActivations)
+            {
+                try
+                {
+                    var activationData = activation.Value;
+                    var placementStrategy = activationData.GetComponent<PlacementStrategy>();
+                    var isUsingGrainDirectory = placementStrategy is { IsUsingGrainDirectory: true };
+                    if (!isUsingGrainDirectory || !resolver.IsUsingDefaultDirectory(activationData.GrainId.Type))
+                    {
+                        continue;
+                    }
+
+                    if (!updatedSilo.Equals(CalculateGrainDirectoryPartition(activationData.GrainId, previousMembership)))
+                    {
+                        continue;
+                    }
+
+                    activationsToShutdown.Add(activationData);
+                }
+                catch (Exception exception)
+                {
+                    LogErrorSiloStatusChangeNotification(new(updatedSilo), exception);
+                }
+            }
+
+            if (activationsToShutdown.Count == 0)
+            {
+                return;
+            }
+
+            LogInfoSiloStatusChangeNotification(activationsToShutdown.Count, new(updatedSilo));
+
+            var reasonText = $"This activation is being deactivated due to a failure of server {updatedSilo}, since it was responsible for this activation's grain directory registration.";
+            var reason = new DeactivationReason(DeactivationReasonCode.DirectoryFailure, reasonText);
+            foreach (var activation in activationsToShutdown)
+            {
+                try
+                {
+                    activation.Deactivate(reason, CancellationToken.None);
+                }
+                catch (Exception exception)
+                {
+                    LogErrorDeactivatingActivationForRemovedSilo(exception, activation.GrainId, new(updatedSilo));
+                }
             }
         }
 
@@ -294,24 +454,6 @@ namespace Orleans.Runtime.GrainDirectory
             return existing.Count > 1 ? existing[(index + 1) % existing.Count] : null;
         }
 
-        public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
-        {
-            // This silo's status has changed
-            if (!Equals(updatedSilo, MyAddress)) // Status change for some other silo
-            {
-                if (status.IsTerminating())
-                {
-                    // QueueAction up the "Remove" to run on a system turn
-                    CacheValidator.WorkItemGroup.QueueAction(() => RemoveServer(updatedSilo, status));
-                }
-                else if (status == SiloStatus.Active)      // do not do anything with SiloStatus.Starting -- wait until it actually becomes active
-                {
-                    // QueueAction up the "Remove" to run on a system turn
-                    CacheValidator.WorkItemGroup.QueueAction(() => AddServer(updatedSilo));
-                }
-            }
-        }
-
         private bool IsValidSilo(SiloAddress? silo) => siloStatusOracle.IsFunctionalDirectory(silo);
 
         /// <summary>
@@ -321,6 +463,9 @@ namespace Orleans.Runtime.GrainDirectory
         /// <param name="grainId"></param>
         /// <returns></returns>
         public SiloAddress? CalculateGrainDirectoryPartition(GrainId grainId)
+            => CalculateGrainDirectoryPartition(grainId, this.directoryMembership);
+
+        private SiloAddress? CalculateGrainDirectoryPartition(GrainId grainId, DirectoryMembership membership)
         {
             // give a special treatment for special grains
             if (grainId.IsSystemTarget())
@@ -352,7 +497,7 @@ namespace Orleans.Runtime.GrainDirectory
             // is doing something valuable.
             bool excludeMySelf = !Running;
 
-            var existing = this.directoryMembership;
+            var existing = membership;
             if (existing.MembershipRingList.Count == 0)
             {
                 // If the membership ring is empty, then we're the owner by default unless we're stopping.
@@ -812,6 +957,12 @@ namespace Orleans.Runtime.GrainDirectory
             return siloAddr.GetConsistentHashCode() <= hash && (!excludeMySelf || !siloAddr.Equals(MyAddress));
         }
 
+        private static int CompareSiloAddress(SiloAddress left, SiloAddress right)
+        {
+            var hashComparison = left.GetConsistentHashCode().CompareTo(right.GetConsistentHashCode());
+            return hashComparison != 0 ? hashComparison : left.CompareTo(right);
+        }
+
         public bool IsSiloInCluster(SiloAddress silo)
         {
             return this.directoryMembership.MembershipCache.Contains(silo);
@@ -852,11 +1003,37 @@ namespace Orleans.Runtime.GrainDirectory
         private partial void LogDebugSiloAddedSilo(SiloAddress siloAddress, SiloAddress otherSiloAddress);
 
         [LoggerMessage(
-            EventId = (int)ErrorCode.Directory_SiloStatusChangeNotification_Exception,
             Level = LogLevel.Error,
-            Message = "CatalogSiloStatusListener.SiloStatusChangeNotification has thrown an exception when notified about removed silo {Silo}."
+            EventId = (int)ErrorCode.Catalog_SiloStatusChangeNotification_Exception,
+            Message = "LocalGrainDirectory has thrown an exception while handling removal of silo {Silo}."
         )]
-        private partial void LogErrorCatalogSiloStatusChangeNotificationException(Exception exception, SiloAddressLogValue silo);
+        private partial void LogErrorSiloStatusChangeNotification(SiloAddressLogValue silo, Exception exception);
+
+        [LoggerMessage(
+            Level = LogLevel.Information,
+            EventId = (int)ErrorCode.Catalog_SiloStatusChangeNotification,
+            Message = "LocalGrainDirectory is deactivating {Count} activations due to a failure of silo {Silo}, since it is a primary directory partition to these grain ids."
+        )]
+        private partial void LogInfoSiloStatusChangeNotification(int count, SiloAddressLogValue silo);
+
+        [LoggerMessage(
+            Level = LogLevel.Error,
+            EventId = (int)ErrorCode.Catalog_SiloStatusChangeNotification_Exception,
+            Message = "LocalGrainDirectory has thrown an exception while deactivating activation {GrainId} due to removal of silo {Silo}."
+        )]
+        private partial void LogErrorDeactivatingActivationForRemovedSilo(Exception exception, GrainId grainId, SiloAddressLogValue silo);
+
+        [LoggerMessage(
+            Level = LogLevel.Error,
+            Message = "Error processing cluster membership updates."
+        )]
+        private partial void LogErrorProcessingMembershipUpdates(Exception exception);
+
+        [LoggerMessage(
+            Level = LogLevel.Warning,
+            Message = "Failed to refresh cluster membership after a directory membership update processing error."
+        )]
+        private partial void LogWarningRefreshingClusterMembershipFailed(Exception exception);
 
         [LoggerMessage(
             Level = LogLevel.Debug,
@@ -984,6 +1161,14 @@ namespace Orleans.Runtime.GrainDirectory
 
             public static DirectoryMembership Default { get; } = new DirectoryMembership(ImmutableList<SiloAddress>.Empty, ImmutableHashSet<SiloAddress>.Empty);
 
+            public static DirectoryMembership Create(IEnumerable<SiloAddress> members)
+            {
+                var builder = ImmutableList.CreateBuilder<SiloAddress>();
+                builder.AddRange(members);
+                builder.Sort(LocalGrainDirectory.CompareSiloAddress);
+                var ring = builder.ToImmutable();
+                return new DirectoryMembership(ring, ring.ToImmutableHashSet());
+            }
 
             public ImmutableList<SiloAddress> MembershipRingList { get; }
             public ImmutableHashSet<SiloAddress> MembershipCache { get; }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -585,7 +585,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "RegisterAsync");
 
-            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            // The first forwarded owner (hopCount == 1) forwards immediately if ownership changed again.
+            // Once the request has already been re-forwarded, pause and recheck before bouncing it again.
             if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
@@ -670,7 +671,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "UnregisterAsync");
 
-            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            // The first forwarded owner (hopCount == 1) forwards immediately if ownership changed again.
+            // Once the request has already been re-forwarded, pause and recheck before bouncing it again.
             if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
@@ -738,7 +740,8 @@ namespace Orleans.Runtime.GrainDirectory
 
             UnregisterOrPutInForwardList(addresses, cause, hopCount, ref forwardlist, "UnregisterManyAsync");
 
-            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            // The first forwarded owner (hopCount == 1) forwards immediately if ownership changed again.
+            // Once the request has already been re-forwarded, pause and recheck before bouncing it again.
             if (hopCount > 1 && forwardlist != null)
             {
                 await Task.Delay(RETRY_DELAY);
@@ -852,7 +855,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "LookUpAsync");
 
-            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            // The first forwarded owner (hopCount == 1) forwards immediately if ownership changed again.
+            // Once the request has already been re-forwarded, pause and recheck before bouncing it again.
             if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
@@ -913,7 +917,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "DeleteGrainAsync");
 
-            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            // The first forwarded owner (hopCount == 1) forwards immediately if ownership changed again.
+            // Once the request has already been re-forwarded, pause and recheck before bouncing it again.
             if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -304,6 +304,48 @@ namespace Orleans.Runtime.GrainDirectory
             return result;
         }
 
+        private Task RefreshMembershipIfNewer(GrainAddress address, GrainAddress? previousAddress = null)
+        {
+            var targetVersion = address.MembershipVersion;
+            if (previousAddress is not null && previousAddress.MembershipVersion > targetVersion)
+            {
+                targetVersion = previousAddress.MembershipVersion;
+            }
+
+            return RefreshMembershipIfNewer(targetVersion);
+        }
+
+        private Task RefreshMembershipIfNewer(List<GrainAddress> addresses)
+        {
+            var targetVersion = MembershipVersion.MinValue;
+            foreach (var address in addresses)
+            {
+                if (address.MembershipVersion > targetVersion)
+                {
+                    targetVersion = address.MembershipVersion;
+                }
+            }
+
+            return RefreshMembershipIfNewer(targetVersion);
+        }
+
+        private async Task RefreshMembershipIfNewer(MembershipVersion targetVersion)
+        {
+            if (targetVersion <= appliedClusterMembershipSnapshot.Version)
+            {
+                return;
+            }
+
+            var snapshot = clusterMembershipService.CurrentSnapshot;
+            if (targetVersion > snapshot.Version)
+            {
+                await clusterMembershipService.Refresh(targetVersion);
+                snapshot = clusterMembershipService.CurrentSnapshot;
+            }
+
+            await ApplyMembershipSnapshot(snapshot);
+        }
+
         private void OnSiloStatusChange(DirectoryMembership previousMembership, SiloAddress updatedSilo, SiloStatus status)
         {
             if (updatedSilo.Equals(MyAddress) || !status.IsTerminating())
@@ -564,6 +606,8 @@ namespace Orleans.Runtime.GrainDirectory
                 DirectoryInstruments.RegistrationsSingleActIssued.Add(1);
             }
 
+            await RefreshMembershipIfNewer(address, previousAddress);
+
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "RegisterAsync");
 
@@ -614,20 +658,22 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        public Task UnregisterAfterNonexistingActivation(GrainAddress addr, SiloAddress origin)
+        public async Task UnregisterAfterNonexistingActivation(GrainAddress addr, SiloAddress origin)
         {
             LogTraceUnregisterAfterNonexistingActivation(addr, origin);
+
+            await RefreshMembershipIfNewer(addr);
 
             if (origin == null || this.directoryMembership.MembershipCache.Contains(origin))
             {
                 // the request originated in this cluster, call unregister here
-                return UnregisterAsync(addr, UnregistrationCause.NonexistentActivation, 0);
+                await UnregisterAsync(addr, UnregistrationCause.NonexistentActivation, 0);
             }
             else
             {
                 // the request originated in another cluster, call unregister there
                 var remoteDirectory = GetDirectoryReference(origin);
-                return remoteDirectory.UnregisterAsync(addr, UnregistrationCause.NonexistentActivation);
+                await remoteDirectory.UnregisterAsync(addr, UnregistrationCause.NonexistentActivation);
             }
         }
 
@@ -644,6 +690,8 @@ namespace Orleans.Runtime.GrainDirectory
 
             if (hopCount == 0)
                 InvalidateCacheEntry(address);
+
+            await RefreshMembershipIfNewer(address);
 
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "UnregisterAsync");
@@ -710,6 +758,8 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 DirectoryInstruments.UnregistrationsManyIssued.Add(1);
             }
+
+            await RefreshMembershipIfNewer(addresses);
 
             Dictionary<SiloAddress, List<GrainAddress>>? forwardlist = null;
 

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -107,11 +107,11 @@ namespace Orleans.Runtime.GrainDirectory
 
             DirectoryInstruments.RegisterDirectoryPartitionSizeObserve(() => DirectoryPartition.Count);
             DirectoryInstruments.RegisterMyPortionRingDistanceObserve(() => RingDistanceToSuccessor());
-            DirectoryInstruments.RegisterMyPortionRingPercentageObserve(() => (((float)this.RingDistanceToSuccessor()) / ((float)(int.MaxValue * 2L))) * 100);
+            DirectoryInstruments.RegisterMyPortionRingPercentageObserve(() => this.RingDistanceToSuccessor() / (float)(int.MaxValue * 2L) * 100);
             DirectoryInstruments.RegisterMyPortionAverageRingPercentageObserve(() =>
             {
                 var ring = this.directoryMembership.MembershipRingList;
-                return ring.Count == 0 ? 0 : ((float)100 / (float)ring.Count);
+                return ring.Count == 0 ? 0 : (100 / (float)ring.Count);
             });
             DirectoryInstruments.RegisterRingSizeObserve(() => this.directoryMembership.MembershipRingList.Count);
             _serviceProvider = serviceProvider;
@@ -157,17 +157,16 @@ namespace Orleans.Runtime.GrainDirectory
 
         private async Task ProcessMembershipUpdates(CancellationToken cancellationToken)
         {
-            var snapshot = clusterMembershipService.CurrentSnapshot;
             while (!cancellationToken.IsCancellationRequested)
             {
                 try
                 {
-                    await ApplyMembershipSnapshot(snapshot);
+                    await ApplyMembershipSnapshot();
 
-                    await foreach (var update in clusterMembershipService.MembershipUpdates.WithCancellation(cancellationToken))
+                    await foreach (var _ in clusterMembershipService.MembershipUpdates.WithCancellation(cancellationToken))
                     {
-                        snapshot = update;
-                        await ApplyMembershipSnapshot(snapshot);
+                        // Always apply the latest snapshot.
+                        await ApplyMembershipSnapshot();
                     }
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -191,58 +190,58 @@ namespace Orleans.Runtime.GrainDirectory
                         LogWarningRefreshingClusterMembershipFailed(refreshException);
                     }
 
-                    snapshot = clusterMembershipService.CurrentSnapshot;
                     await Task.Delay(RETRY_DELAY, cancellationToken).SuppressThrowing();
                 }
             }
         }
 
-        private Task ApplyMembershipSnapshot(ClusterMembershipSnapshot snapshot)
+        private Task ApplyMembershipSnapshot()
         {
             return CacheValidator.RunOrQueueTask(() =>
             {
-                ApplyMembershipSnapshotCore(snapshot);
+                ApplyMembershipSnapshotCore();
                 return Task.CompletedTask;
             });
-        }
 
-        private void ApplyMembershipSnapshotCore(ClusterMembershipSnapshot snapshot)
-        {
-            if (!Running)
+            void ApplyMembershipSnapshotCore()
             {
-                return;
+                if (!Running)
+                {
+                    return;
+                }
+
+                var snapshot = clusterMembershipService.CurrentSnapshot;
+                var previousSnapshot = hasAppliedClusterMembershipSnapshot ? appliedClusterMembershipSnapshot : ClusterMembershipSnapshot.Default;
+                if (hasAppliedClusterMembershipSnapshot && snapshot.Version <= previousSnapshot.Version)
+                {
+                    return;
+                }
+
+                var previousMembership = CreateDirectoryMembership(previousSnapshot);
+                var targetMembership = CreateDirectoryMembership(snapshot);
+                this.directoryMembership = targetMembership;
+
+                var removedSilos = GetMembershipDifference(previousMembership, targetMembership);
+                var addedSilos = GetMembershipDifference(targetMembership, previousMembership);
+
+                ProcessSiloStatusChanges(snapshot, previousSnapshot, previousMembership);
+                AdjustLocalDirectory(snapshot);
+                AdjustLocalCache(snapshot, targetMembership);
+
+                foreach (var silo in removedSilos)
+                {
+                    LogDebugSiloRemovedSilo(MyAddress, silo);
+                }
+
+                foreach (var silo in addedSilos)
+                {
+                    HandoffManager.ProcessSiloAddEvent(silo);
+                    LogDebugSiloAddedSilo(MyAddress, silo);
+                }
+
+                appliedClusterMembershipSnapshot = snapshot;
+                hasAppliedClusterMembershipSnapshot = true;
             }
-
-            var previousSnapshot = hasAppliedClusterMembershipSnapshot ? appliedClusterMembershipSnapshot : ClusterMembershipSnapshot.Default;
-            if (hasAppliedClusterMembershipSnapshot && snapshot.Version <= previousSnapshot.Version)
-            {
-                return;
-            }
-
-            var previousMembership = CreateDirectoryMembership(previousSnapshot);
-            var targetMembership = CreateDirectoryMembership(snapshot);
-            this.directoryMembership = targetMembership;
-
-            var removedSilos = GetMembershipDifference(previousMembership, targetMembership);
-            var addedSilos = GetMembershipDifference(targetMembership, previousMembership);
-
-            ProcessSiloStatusChanges(snapshot, previousSnapshot, previousMembership);
-            AdjustLocalDirectory(snapshot);
-            AdjustLocalCache(snapshot, targetMembership);
-
-            foreach (var silo in removedSilos)
-            {
-                LogDebugSiloRemovedSilo(MyAddress, silo);
-            }
-
-            foreach (var silo in addedSilos)
-            {
-                HandoffManager.ProcessSiloAddEvent(silo);
-                LogDebugSiloAddedSilo(MyAddress, silo);
-            }
-
-            appliedClusterMembershipSnapshot = snapshot;
-            hasAppliedClusterMembershipSnapshot = true;
         }
 
         private void ProcessSiloStatusChanges(
@@ -336,14 +335,12 @@ namespace Orleans.Runtime.GrainDirectory
                 return;
             }
 
-            var snapshot = clusterMembershipService.CurrentSnapshot;
-            if (targetVersion > snapshot.Version)
+            if (targetVersion > clusterMembershipService.CurrentSnapshot.Version)
             {
                 await clusterMembershipService.Refresh(targetVersion);
-                snapshot = clusterMembershipService.CurrentSnapshot;
             }
 
-            await ApplyMembershipSnapshot(snapshot);
+            await ApplyMembershipSnapshot();
         }
 
         private void OnSiloStatusChange(DirectoryMembership previousMembership, SiloAddress updatedSilo, SiloStatus status)
@@ -456,7 +453,7 @@ namespace Orleans.Runtime.GrainDirectory
 
             if (snapshot.Members.TryGetValue(silo, out var member))
             {
-                return member.Status.IsTerminating();
+                return member.Status == SiloStatus.Dead;
             }
 
             return address.MembershipVersion < snapshot.Version;
@@ -747,7 +744,6 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-
         public async Task UnregisterManyAsync(List<GrainAddress> addresses, UnregistrationCause cause, int hopCount)
         {
             if (hopCount > 0)
@@ -1005,11 +1001,6 @@ namespace Orleans.Runtime.GrainDirectory
             return hashComparison != 0 ? hashComparison : left.CompareTo(right);
         }
 
-        public bool IsSiloInCluster(SiloAddress silo)
-        {
-            return this.directoryMembership.MembershipCache.Contains(silo);
-        }
-
         public void AddOrUpdateCacheEntry(GrainId grainId, SiloAddress siloAddress) => this.DirectoryCache.AddOrUpdate(new GrainAddress { GrainId = grainId, SiloAddress = siloAddress }, 0);
         public bool TryCachedLookup(GrainId grainId, [NotNullWhen(true)] out GrainAddress? address) => (address = GetLocalCacheData(grainId)) is not null;
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
@@ -1193,27 +1184,21 @@ namespace Orleans.Runtime.GrainDirectory
         )]
         private partial void LogWarningDeleteGrainAsyncNotOwner(GrainId grainId, SiloAddress? forwardAddress, int hopCount);
 
-        private class DirectoryMembership
+        private class DirectoryMembership(ImmutableList<SiloAddress> membershipRingList, ImmutableHashSet<SiloAddress> membershipCache)
         {
-            public DirectoryMembership(ImmutableList<SiloAddress> membershipRingList, ImmutableHashSet<SiloAddress> membershipCache)
-            {
-                this.MembershipRingList = membershipRingList;
-                this.MembershipCache = membershipCache;
-            }
-
-            public static DirectoryMembership Default { get; } = new DirectoryMembership(ImmutableList<SiloAddress>.Empty, ImmutableHashSet<SiloAddress>.Empty);
+            public static DirectoryMembership Default { get; } = new DirectoryMembership([], []);
 
             public static DirectoryMembership Create(IEnumerable<SiloAddress> members)
             {
                 var builder = ImmutableList.CreateBuilder<SiloAddress>();
                 builder.AddRange(members);
-                builder.Sort(LocalGrainDirectory.CompareSiloAddress);
+                builder.Sort(CompareSiloAddress);
                 var ring = builder.ToImmutable();
-                return new DirectoryMembership(ring, ring.ToImmutableHashSet());
+                return new DirectoryMembership(ring, [.. ring]);
             }
 
-            public ImmutableList<SiloAddress> MembershipRingList { get; }
-            public ImmutableHashSet<SiloAddress> MembershipCache { get; }
+            public ImmutableList<SiloAddress> MembershipRingList { get; } = membershipRingList;
+            public ImmutableHashSet<SiloAddress> MembershipCache { get; } = membershipCache;
         }
     }
 }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryPartition.cs
@@ -112,21 +112,22 @@ namespace Orleans.Runtime.GrainDirectory
         private Dictionary<GrainId, GrainInfo> partitionData;
         private readonly object lockable;
         private readonly ILogger log;
-        private readonly ISiloStatusOracle siloStatusOracle;
+        private readonly IClusterMembershipService clusterMembershipService;
         private readonly IOptions<GrainDirectoryOptions> grainDirectoryOptions;
 
         internal int Count { get { return partitionData.Count; } }
 
-        public LocalGrainDirectoryPartition(ISiloStatusOracle siloStatusOracle, IOptions<GrainDirectoryOptions> grainDirectoryOptions, ILoggerFactory loggerFactory)
+        public LocalGrainDirectoryPartition(IClusterMembershipService clusterMembershipService, IOptions<GrainDirectoryOptions> grainDirectoryOptions, ILoggerFactory loggerFactory)
         {
             partitionData = new Dictionary<GrainId, GrainInfo>();
             lockable = new object();
             log = loggerFactory.CreateLogger<LocalGrainDirectoryPartition>();
-            this.siloStatusOracle = siloStatusOracle;
+            this.clusterMembershipService = clusterMembershipService;
             this.grainDirectoryOptions = grainDirectoryOptions;
         }
 
-        private bool IsValidSilo(SiloAddress? silo) => silo is not null && siloStatusOracle.IsFunctionalDirectory(silo);
+        private bool IsDefunctActivation(GrainAddress? address)
+            => address is null || LocalGrainDirectory.IsDefunctActivation(address, clusterMembershipService.CurrentSnapshot);
 
         internal void Clear()
         {
@@ -156,9 +157,11 @@ namespace Orleans.Runtime.GrainDirectory
         {
             LogTraceAddingSingleActivation(address.SiloAddress, address.GrainId, address.ActivationId);
 
-            if (!IsValidSilo(address.SiloAddress))
+            if (IsDefunctActivation(address))
             {
-                var siloStatus = this.siloStatusOracle.GetApproximateSiloStatus(address.SiloAddress);
+                var siloStatus = address.SiloAddress is { } siloAddress
+                    ? this.clusterMembershipService.CurrentSnapshot.GetSiloStatus(siloAddress, address.MembershipVersion)
+                    : SiloStatus.None;
                 throw new OrleansException($"Trying to register {address.GrainId} on invalid silo: {address.SiloAddress}. Known status: {siloStatus}");
             }
 
@@ -170,10 +173,8 @@ namespace Orleans.Runtime.GrainDirectory
                 }
                 else
                 {
-                    var siloAddress = grainInfo.Activation?.SiloAddress;
-
                     // If there is an existing entry pointing to an invalid silo then remove it 
-                    if (siloAddress != null && !IsValidSilo(siloAddress))
+                    if (IsDefunctActivation(grainInfo.Activation))
                     {
                         partitionData[address.GrainId] = grainInfo = new GrainInfo();
                     }
@@ -230,7 +231,7 @@ namespace Orleans.Runtime.GrainDirectory
                 result = new(grainInfo.Activation, grainInfo.VersionTag);
             }
 
-            if (!IsValidSilo(result.Address?.SiloAddress))
+            if (IsDefunctActivation(result.Address))
             {
                 result = new(null, result.VersionTag);
             }
@@ -308,7 +309,7 @@ namespace Orleans.Runtime.GrainDirectory
 
             for (var i = result.Count - 1; i >= 0; i--)
             {
-                if (!IsValidSilo(result[i].SiloAddress))
+                if (IsDefunctActivation(result[i]))
                 {
                     result.RemoveAt(i);
                 }

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipSnapshot.cs
@@ -62,6 +62,18 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// Gets status of the specified silo, treating unknown silos as dead if this snapshot is newer than when the silo was seen.
+        /// </summary>
+        /// <param name="silo">The silo.</param>
+        /// <param name="seenAtVersion">The membership version when the silo was last seen.</param>
+        /// <returns>The status of the specified silo.</returns>
+        public SiloStatus GetSiloStatus(SiloAddress silo, MembershipVersion seenAtVersion)
+        {
+            var status = GetSiloStatus(silo);
+            return status == SiloStatus.None && this.Version > seenAtVersion ? SiloStatus.Dead : status;
+        }
+
+        /// <summary>
         /// Returns a <see cref="ClusterMembershipUpdate"/> which represents this instance.
         /// </summary>
         /// <returns>A <see cref="ClusterMembershipUpdate"/> which represents this instance.</returns>

--- a/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
@@ -11,7 +11,7 @@ namespace Orleans.Runtime.MembershipService;
 /// <summary>
 /// Manages <see cref="ISiloStatusListener"/> instances.
 /// </summary>
-internal partial class SiloStatusListenerManager : ILifecycleParticipant<ISiloLifecycle>
+internal sealed partial class SiloStatusListenerManager : ILifecycleParticipant<ISiloLifecycle>
 {
 #if NET9_0_OR_GREATER
     private readonly Lock _listenersLock = new();

--- a/src/Orleans.Runtime/Networking/SiloConnectionMaintainer.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionMaintainer.cs
@@ -9,15 +9,18 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly ConnectionManager connectionManager;
         private readonly ISiloStatusOracle siloStatusOracle;
+        private readonly IRuntimeClient runtimeClient;
         private readonly ILogger<SiloConnectionMaintainer> log;
 
         public SiloConnectionMaintainer(
             ConnectionManager connectionManager,
             ISiloStatusOracle siloStatusOracle,
+            IRuntimeClient runtimeClient,
             ILogger<SiloConnectionMaintainer> log)
         {
             this.connectionManager = connectionManager;
             this.siloStatusOracle = siloStatusOracle;
+            this.runtimeClient = runtimeClient;
             this.log = log;
         }
 
@@ -42,6 +45,7 @@ namespace Orleans.Runtime.Messaging
         {
             if (status == SiloStatus.Dead && updatedSilo != siloStatusOracle.SiloAddress)
             {
+                this.runtimeClient.BreakOutstandingMessagesToSilo(updatedSilo);
                 _ = Task.Run(() => this.CloseConnectionAsync(updatedSilo));
             }
         }

--- a/src/api/Orleans.Runtime/Orleans.Runtime.cs
+++ b/src/api/Orleans.Runtime/Orleans.Runtime.cs
@@ -547,6 +547,8 @@ namespace Orleans.Runtime
 
         public SiloStatus GetSiloStatus(SiloAddress silo) { throw null; }
 
+        public SiloStatus GetSiloStatus(SiloAddress silo, MembershipVersion seenAtVersion) { throw null; }
+
         public override string ToString() { throw null; }
     }
 

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -140,6 +140,7 @@ namespace UnitTests.Directory
             localSiloDetails.Name.Returns("TestSilo");
             localSiloDetails.ClusterId.Returns("TestCluster");
             var siloStatusOracle = Substitute.For<ISiloStatusOracle>();
+            var membershipService = new MockClusterMembershipService();
             var grainFactory = Substitute.For<IInternalGrainFactory>();
             var services = new ServiceCollection()
                 .AddSingleton<IGrainDirectoryCache>(cache)
@@ -160,6 +161,7 @@ namespace UnitTests.Directory
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
                 siloStatusOracle: siloStatusOracle,
+                clusterMembershipService: membershipService.Target,
                 grainFactory: grainFactory,
                 grainDirectoryPartitionFactory: partitionFactory,
                 developmentClusterMembershipOptions: Options.Create(new DevelopmentClusterMembershipOptions()),

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -466,6 +466,51 @@ namespace UnitTests.Directory
         }
 
         [Fact]
+        public async Task CleanupWhenSiloIsDeadOnlyProcessesIncrementalChanges()
+        {
+            var expectedSilo = GenerateSiloAddress();
+            var outdatedSilo = GenerateSiloAddress();
+
+            this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
+            this.mockMembershipService.UpdateSiloStatus(outdatedSilo, SiloStatus.Active, "old");
+            await this.lifecycle.OnStart();
+            await WaitUntilClusterChangePropagated();
+
+            this.mockMembershipService.UpdateSiloStatus(outdatedSilo, SiloStatus.Dead, "old");
+            await WaitUntilClusterChangePropagated();
+
+            await this.grainDirectory
+                .Received(1)
+                .UnregisterSilos(Arg.Is<List<SiloAddress>>(list => list.Count == 1 && list.Contains(outdatedSilo)));
+
+            this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp2");
+            await WaitUntilClusterChangePropagated();
+
+            await this.grainDirectory
+                .Received(1)
+                .UnregisterSilos(Arg.Is<List<SiloAddress>>(list => list.Count == 1 && list.Contains(outdatedSilo)));
+
+            await this.lifecycle.OnStop();
+        }
+
+        [Fact]
+        public async Task UpdateCacheStampsCurrentMembershipVersion()
+        {
+            await this.lifecycle.OnStart();
+
+            var grainId = GrainId.Create(GrainType.Create("test"), GrainIdKeyExtensions.CreateGuidKey(Guid.NewGuid()));
+            var silo = GenerateSiloAddress();
+
+            this.grainLocator.UpdateCache(grainId, silo);
+
+            Assert.True(this.grainLocator.TryLookupInCache(grainId, out var cached));
+            Assert.Equal(silo, cached.SiloAddress);
+            Assert.Equal(this.mockMembershipService.CurrentVersion, cached.MembershipVersion);
+
+            await this.lifecycle.OnStop();
+        }
+
+        [Fact]
         public async Task UnregisterCallDirectoryAndCleanCache()
         {
             var expectedSilo = GenerateSiloAddress();

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -146,7 +146,7 @@ namespace UnitTests.Directory
                 .AddSingleton<IGrainDirectoryCache>(cache)
                 .BuildServiceProvider();
             Factory<LocalGrainDirectoryPartition> partitionFactory = () => new LocalGrainDirectoryPartition(
-                siloStatusOracle,
+                membershipService.Target,
                 Options.Create(new GrainDirectoryOptions()),
                 this.loggerFactory);
             var systemTargetShared = new SystemTargetShared(
@@ -384,6 +384,35 @@ namespace UnitTests.Directory
             // Local lookup should never call the directory
             await this.grainDirectory.DidNotReceive().Lookup(outdatedAddr.GrainId);
             await this.grainDirectory.DidNotReceive().Unregister(outdatedAddr);
+
+            await this.lifecycle.OnStop();
+        }
+
+        [Theory]
+        [InlineData(SiloStatus.ShuttingDown)]
+        [InlineData(SiloStatus.Stopping)]
+        public async Task LocalLookupWhenCachedEntrySiloIsTerminatingButNotDead(SiloStatus status)
+        {
+            var silo = GenerateSiloAddress();
+
+            // Setup membership service
+            this.mockMembershipService.UpdateSiloStatus(silo, SiloStatus.Active, "silo");
+            await this.lifecycle.OnStart();
+            await WaitUntilClusterChangePropagated();
+
+            var address = GenerateGrainAddress(silo);
+            this.grainDirectory.Register(address, previousAddress: null).Returns(address);
+
+            await this.grainLocator.Register(address, previousAddress: null);
+            Assert.True(this.grainLocator.TryLookupInCache(address.GrainId, out var cached));
+            Assert.Equal(address, cached);
+
+            this.mockMembershipService.UpdateSiloStatus(silo, status, "silo");
+            await WaitUntilClusterChangePropagated();
+
+            Assert.True(this.grainLocator.TryLookupInCache(address.GrainId, out cached));
+            Assert.Equal(address, cached);
+            await this.grainDirectory.DidNotReceive().UnregisterSilos(Arg.Any<List<SiloAddress>>());
 
             await this.lifecycle.OnStop();
         }

--- a/test/Orleans.Runtime.Internal.Tests/ClusterMembershipSnapshotTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ClusterMembershipSnapshotTests.cs
@@ -1,0 +1,48 @@
+using System.Collections.Immutable;
+using System.Net;
+using Orleans.Runtime;
+using Xunit;
+
+namespace UnitTests;
+
+[TestCategory("BVT"), TestCategory("Membership")]
+public class ClusterMembershipSnapshotTests
+{
+    [Fact]
+    public void GetSiloStatus_ReturnsDeadForUnknownSiloSeenAtOlderVersion()
+    {
+        var unknownSilo = CreateSiloAddress(1);
+        var knownSilo = CreateSiloAddress(1, port: 11112);
+        var snapshot = CreateSnapshot(new ClusterMember(knownSilo, SiloStatus.Active, "known"), version: 2);
+
+        Assert.Equal(SiloStatus.Dead, snapshot.GetSiloStatus(unknownSilo, new MembershipVersion(1)));
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void GetSiloStatus_ReturnsNoneForUnknownSiloSeenAtCurrentOrNewerVersion(long seenAtVersion)
+    {
+        var unknownSilo = CreateSiloAddress(1);
+        var knownSilo = CreateSiloAddress(1, port: 11112);
+        var snapshot = CreateSnapshot(new ClusterMember(knownSilo, SiloStatus.Active, "known"), version: 2);
+
+        Assert.Equal(SiloStatus.None, snapshot.GetSiloStatus(unknownSilo, new MembershipVersion(seenAtVersion)));
+    }
+
+    [Fact]
+    public void GetSiloStatus_ReturnsDeadForSiloReplacedBySuccessor()
+    {
+        var silo = CreateSiloAddress(1);
+        var successor = CreateSiloAddress(2);
+        var snapshot = CreateSnapshot(new ClusterMember(successor, SiloStatus.Active, "silo"), version: 2);
+
+        Assert.Equal(SiloStatus.Dead, snapshot.GetSiloStatus(silo, new MembershipVersion(2)));
+    }
+
+    private static ClusterMembershipSnapshot CreateSnapshot(ClusterMember member, long version)
+        => new(ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(member.SiloAddress, member), new MembershipVersion(version));
+
+    private static SiloAddress CreateSiloAddress(int generation, int port = 11111)
+        => SiloAddress.New(new IPEndPoint(IPAddress.Loopback, port), generation);
+}

--- a/test/Orleans.Runtime.Internal.Tests/GrainDirectoryHandoffManagerTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/GrainDirectoryHandoffManagerTests.cs
@@ -1,0 +1,73 @@
+using System.Collections.Immutable;
+using System.Net;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Xunit;
+
+namespace UnitTests;
+
+[TestCategory("BVT"), TestCategory("GrainDirectory")]
+public class GrainDirectoryHandoffManagerTests
+{
+    [Theory]
+    [InlineData(SiloStatus.Active, true)]
+    [InlineData(SiloStatus.ShuttingDown, true)]
+    [InlineData(SiloStatus.Stopping, true)]
+    [InlineData(SiloStatus.Dead, false)]
+    public void IsTransferableRegistration_UsesSnapshotStatus(SiloStatus status, bool expected)
+    {
+        var silo = CreateSiloAddress(1);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
+        var snapshot = CreateSnapshot(new ClusterMember(silo, status, "silo"), version: 2);
+
+        Assert.Equal(expected, GrainDirectoryHandoffManager.IsTransferableRegistration(address, snapshot));
+    }
+
+    [Fact]
+    public void IsTransferableRegistration_AllowsUnknownSiloWithoutNewerMembershipVersion()
+    {
+        var silo = CreateSiloAddress(1);
+        var unrelatedSilo = CreateSiloAddress(1, port: 11112);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
+        var snapshot = CreateSnapshot(new ClusterMember(unrelatedSilo, SiloStatus.Active, "other"), version: 2);
+
+        Assert.True(GrainDirectoryHandoffManager.IsTransferableRegistration(address, snapshot));
+    }
+
+    [Fact]
+    public void IsTransferableRegistration_RejectsUnknownSiloWithOlderMembershipVersion()
+    {
+        var silo = CreateSiloAddress(1);
+        var unrelatedSilo = CreateSiloAddress(1, port: 11112);
+        var address = CreateGrainAddress(silo, membershipVersion: 1);
+        var snapshot = CreateSnapshot(new ClusterMember(unrelatedSilo, SiloStatus.Active, "other"), version: 2);
+
+        Assert.False(GrainDirectoryHandoffManager.IsTransferableRegistration(address, snapshot));
+    }
+
+    [Fact]
+    public void IsTransferableRegistration_RejectsSiloReplacedBySuccessor()
+    {
+        var silo = CreateSiloAddress(1);
+        var successor = CreateSiloAddress(2);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
+        var snapshot = CreateSnapshot(new ClusterMember(successor, SiloStatus.Active, "silo"), version: 2);
+
+        Assert.False(GrainDirectoryHandoffManager.IsTransferableRegistration(address, snapshot));
+    }
+
+    private static ClusterMembershipSnapshot CreateSnapshot(ClusterMember member, long version)
+        => new(ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(member.SiloAddress, member), new MembershipVersion(version));
+
+    private static GrainAddress CreateGrainAddress(SiloAddress siloAddress, long membershipVersion)
+        => new()
+        {
+            GrainId = GrainId.Create("test-grain", Guid.NewGuid().ToString("N")),
+            ActivationId = ActivationId.NewId(),
+            SiloAddress = siloAddress,
+            MembershipVersion = new MembershipVersion(membershipVersion)
+        };
+
+    private static SiloAddress CreateSiloAddress(int generation, int port = 11111)
+        => SiloAddress.New(new IPEndPoint(IPAddress.Loopback, port), generation);
+}

--- a/test/Orleans.Runtime.Internal.Tests/GrainDirectoryPartitionTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/GrainDirectoryPartitionTests.cs
@@ -31,15 +31,16 @@ namespace UnitTests;
 public class GrainDirectoryPartitionTests
 {
     private readonly LocalGrainDirectoryPartition _target;
-    private readonly MockSiloStatusOracle _siloStatusOracle;
-    private static readonly SiloAddress LocalSiloAddress =  SiloAddress.FromParsableString("127.0.0.1:11111@123");
-    private static readonly SiloAddress OtherSiloAddress =  SiloAddress.FromParsableString("127.0.0.2:11111@456");
+    private readonly MockClusterMembershipService _clusterMembershipService;
+    private static readonly SiloAddress LocalSiloAddress = SiloAddress.FromParsableString("127.0.0.1:11111@123");
+    private static readonly SiloAddress OtherSiloAddress = SiloAddress.FromParsableString("127.0.0.2:11111@456");
 
     public GrainDirectoryPartitionTests()
     {
-        _siloStatusOracle = new MockSiloStatusOracle();
+        _clusterMembershipService = new MockClusterMembershipService();
+        _clusterMembershipService.SetSiloStatus(LocalSiloAddress, SiloStatus.Active);
         _target = new LocalGrainDirectoryPartition(
-            _siloStatusOracle,
+            _clusterMembershipService,
             Options.Create(new GrainDirectoryOptions()),
             new LoggerFactory());
     }
@@ -53,7 +54,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void OverrideDeadEntryTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var firstGrainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -62,7 +63,7 @@ public class GrainDirectoryPartitionTests
         var firstRegister = _target.AddSingleActivation(firstGrainAddress, previousAddress: null);
         Assert.Equal(firstGrainAddress, firstRegister.Address);
 
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
 
         // Previous entry is now pointing to a dead silo, it should be possible to override it now
         var secondGrainAddress = GrainAddress.NewActivationAddress(LocalSiloAddress, grainId);
@@ -79,7 +80,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void DoNotInsertInvalidEntryTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var grainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -97,7 +98,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void DoNotOverrideValidEntryTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var grainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -121,7 +122,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void OverrideValidEntryIfMatchesTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var grainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -145,7 +146,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void DoNotOverrideValidEntryIfNoMatchTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var grainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -176,7 +177,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void DoNotReturnInvalidEntryTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var grainAddress1 = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -185,65 +186,54 @@ public class GrainDirectoryPartitionTests
         var register1 = _target.AddSingleActivation(grainAddress1, previousAddress: null);
         Assert.Equal(grainAddress1, register1.Address);
 
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
 
         // Previous entry is no longer still valid, it should not be returned
         var lookup = _target.LookUpActivation(grainId);
         Assert.Null(lookup.Address);
     }
 
-    /// <summary>
-    /// Mock implementation of ISiloStatusOracle for testing.
-    /// The silo status oracle provides membership information about
-    /// which silos are alive, dead, or in other states. The grain
-    /// directory uses this to validate entries and make placement decisions.
-    /// </summary>
-    private class MockSiloStatusOracle : ISiloStatusOracle
+    [Theory]
+    [InlineData(SiloStatus.ShuttingDown)]
+    [InlineData(SiloStatus.Stopping)]
+    public void ReturnEntryForTerminatingButNotDeadSilo(SiloStatus status)
     {
-        private readonly Dictionary<SiloAddress, SiloStatus> _content = new();
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, status);
 
-        public MockSiloStatusOracle(SiloAddress siloAddress = null)
+        var grainId = GrainId.Create("testGrain", "myKey");
+        var grainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
+
+        var register = _target.AddSingleActivation(grainAddress, previousAddress: null);
+        Assert.Equal(grainAddress, register.Address);
+
+        var lookup = _target.LookUpActivation(grainId);
+        Assert.Equal(grainAddress, lookup.Address);
+    }
+
+    private sealed class MockClusterMembershipService : IClusterMembershipService
+    {
+        private readonly Dictionary<SiloAddress, (SiloStatus Status, string Name)> _statuses = new();
+        private long _version;
+
+        public ClusterMembershipSnapshot CurrentSnapshot { get; private set; } =
+            new(ImmutableDictionary<SiloAddress, ClusterMember>.Empty, MembershipVersion.MinValue);
+
+        public IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates => throw new NotImplementedException();
+
+        public void SetSiloStatus(SiloAddress siloAddress, SiloStatus status)
         {
-            SiloAddress = siloAddress ?? LocalSiloAddress;
-            _content[SiloAddress] = SiloStatus.Active;
-        }
-
-        public SiloStatus CurrentStatus => SiloStatus.Active;
-
-        public string SiloName => "TestSilo";
-
-        public SiloAddress SiloAddress { get; }
-
-        public SiloStatus GetApproximateSiloStatus(SiloAddress siloAddress)
-        {
-            if (_content.TryGetValue(siloAddress, out var status))
+            _statuses[siloAddress] = (status, "TestSilo");
+            var members = ImmutableDictionary.CreateBuilder<SiloAddress, ClusterMember>();
+            foreach (var (silo, entry) in _statuses)
             {
-                return status;
+                members[silo] = new ClusterMember(silo, entry.Status, entry.Name);
             }
-            return SiloStatus.None;
+
+            CurrentSnapshot = new ClusterMembershipSnapshot(members.ToImmutable(), new MembershipVersion(++_version));
         }
 
-        public Dictionary<SiloAddress, SiloStatus> GetApproximateSiloStatuses(bool onlyActive = false)
-        {
-            return onlyActive
-                ? new Dictionary<SiloAddress, SiloStatus>(_content.Where(kvp => kvp.Value == SiloStatus.Active))
-                : new Dictionary<SiloAddress, SiloStatus>(_content);
-        }
+        public ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default) => default;
 
-        public ImmutableArray<SiloAddress> GetActiveSilos() => _content.Keys.ToImmutableArray();
-
-        public void SetSiloStatus(SiloAddress siloAddress, SiloStatus status) => _content[siloAddress] = status;
-
-        public bool IsDeadSilo(SiloAddress silo) => GetApproximateSiloStatus(silo) == SiloStatus.Dead;
-
-        public bool IsFunctionalDirectory(SiloAddress siloAddress) => !GetApproximateSiloStatus(siloAddress).IsTerminating();
-
-        #region Not Implemented
-        public bool SubscribeToSiloStatusEvents(ISiloStatusListener observer) => throw new NotImplementedException();
-
-        public bool TryGetSiloName(SiloAddress siloAddress, out string siloName) => throw new NotImplementedException();
-
-        public bool UnSubscribeFromSiloStatusEvents(ISiloStatusListener observer) => throw new NotImplementedException();
-        #endregion
+        public Task<bool> TryKill(SiloAddress siloAddress) => throw new NotImplementedException();
     }
 }

--- a/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
@@ -33,6 +33,16 @@ public class LocalGrainDirectoryTests
     }
 
     [Fact]
+    public void IsDefunctActivation_DoesNotRemoveDeadSiloWithoutNewerMembershipVersion()
+    {
+        var silo = CreateSiloAddress(1);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
+        var snapshot = CreateSnapshot(new ClusterMember(silo, SiloStatus.Dead, "silo"), version: 2);
+
+        Assert.False(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+    }
+
+    [Fact]
     public void IsDefunctActivation_DoesNotRemoveUnknownSiloUntilKnownDead()
     {
         var silo = CreateSiloAddress(1);

--- a/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Immutable;
+using System.Net;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Xunit;
+
+namespace UnitTests;
+
+[TestCategory("BVT"), TestCategory("GrainDirectory")]
+public class LocalGrainDirectoryTests
+{
+    [Theory]
+    [InlineData(SiloStatus.Active)]
+    [InlineData(SiloStatus.ShuttingDown)]
+    [InlineData(SiloStatus.Stopping)]
+    public void IsDefunctActivation_DoesNotRemoveNonDeadSilos(SiloStatus status)
+    {
+        var silo = CreateSiloAddress(1);
+        var address = CreateGrainAddress(silo);
+        var snapshot = CreateSnapshot(new ClusterMember(silo, status, "silo"), version: 2);
+
+        Assert.False(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+    }
+
+    [Fact]
+    public void IsDefunctActivation_RemovesDeadSilos()
+    {
+        var silo = CreateSiloAddress(1);
+        var address = CreateGrainAddress(silo);
+        var snapshot = CreateSnapshot(new ClusterMember(silo, SiloStatus.Dead, "silo"), version: 2);
+
+        Assert.True(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+    }
+
+    [Fact]
+    public void IsDefunctActivation_DoesNotRemoveUnknownSiloUntilKnownDead()
+    {
+        var silo = CreateSiloAddress(1);
+        var unrelatedSilo = CreateSiloAddress(1, port: 11112);
+        var address = CreateGrainAddress(silo, membershipVersion: 1);
+        var snapshot = CreateSnapshot(new ClusterMember(unrelatedSilo, SiloStatus.Active, "other"), version: 2);
+
+        Assert.False(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+    }
+
+    [Fact]
+    public void IsDefunctActivation_RemovesSiloReplacedBySuccessor()
+    {
+        var silo = CreateSiloAddress(1);
+        var successor = CreateSiloAddress(2);
+        var address = CreateGrainAddress(silo, membershipVersion: 1);
+        var snapshot = CreateSnapshot(new ClusterMember(successor, SiloStatus.Active, "silo"), version: 2);
+
+        Assert.True(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+    }
+
+    private static ClusterMembershipSnapshot CreateSnapshot(ClusterMember member, long version)
+        => new(ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(member.SiloAddress, member), new MembershipVersion(version));
+
+    private static GrainAddress CreateGrainAddress(SiloAddress siloAddress, long membershipVersion = 1)
+        => new()
+        {
+            GrainId = GrainId.Create("test-grain", Guid.NewGuid().ToString("N")),
+            ActivationId = ActivationId.NewId(),
+            SiloAddress = siloAddress,
+            MembershipVersion = new MembershipVersion(membershipVersion)
+        };
+
+    private static SiloAddress CreateSiloAddress(int generation, int port = 11111)
+        => SiloAddress.New(new IPEndPoint(IPAddress.Loopback, port), generation);
+}

--- a/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
@@ -26,31 +26,32 @@ public class LocalGrainDirectoryTests
     public void IsDefunctActivation_RemovesDeadSilos()
     {
         var silo = CreateSiloAddress(1);
-        var address = CreateGrainAddress(silo);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
         var snapshot = CreateSnapshot(new ClusterMember(silo, SiloStatus.Dead, "silo"), version: 2);
 
         Assert.True(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
     }
 
     [Fact]
-    public void IsDefunctActivation_DoesNotRemoveDeadSiloWithoutNewerMembershipVersion()
+    public void IsDefunctActivation_DoesNotRemoveUnknownSiloWithoutNewerMembershipVersion()
     {
         var silo = CreateSiloAddress(1);
+        var unrelatedSilo = CreateSiloAddress(1, port: 11112);
         var address = CreateGrainAddress(silo, membershipVersion: 2);
-        var snapshot = CreateSnapshot(new ClusterMember(silo, SiloStatus.Dead, "silo"), version: 2);
+        var snapshot = CreateSnapshot(new ClusterMember(unrelatedSilo, SiloStatus.Active, "other"), version: 2);
 
         Assert.False(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
     }
 
     [Fact]
-    public void IsDefunctActivation_DoesNotRemoveUnknownSiloUntilKnownDead()
+    public void IsDefunctActivation_RemovesUnknownSiloWithOlderMembershipVersion()
     {
         var silo = CreateSiloAddress(1);
         var unrelatedSilo = CreateSiloAddress(1, port: 11112);
         var address = CreateGrainAddress(silo, membershipVersion: 1);
         var snapshot = CreateSnapshot(new ClusterMember(unrelatedSilo, SiloStatus.Active, "other"), version: 2);
 
-        Assert.False(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+        Assert.True(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
     }
 
     [Fact]
@@ -58,7 +59,7 @@ public class LocalGrainDirectoryTests
     {
         var silo = CreateSiloAddress(1);
         var successor = CreateSiloAddress(2);
-        var address = CreateGrainAddress(silo, membershipVersion: 1);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
         var snapshot = CreateSnapshot(new ClusterMember(successor, SiloStatus.Active, "silo"), version: 2);
 
         Assert.True(LocalGrainDirectory.IsDefunctActivation(address, snapshot));


### PR DESCRIPTION
## Problem
LocalGrainDirectory membership reconciliation and grain-directory entry validation were using lossy status events or approximate terminating-state checks. That could remove, reject, or stop returning registrations for silos which were `ShuttingDown` or `Stopping`, even though those registrations should remain valid until the silo is known to be `Dead`.

## Solution
- Reconcile LocalGrainDirectory membership from `IClusterMembershipService` snapshots.
- Add a version-aware `ClusterMembershipSnapshot.GetSiloStatus(silo, seenAtVersion)` overload so stale unknown silos can be treated as dead only when the snapshot is newer than the registration.
- Use that version-aware dead check consistently across LocalGrainDirectory cleanup, local/distributed directory return paths, cache validation, and handoff filtering.
- Keep handoff operations retryable and transfer registrations for `ShuttingDown`/`Stopping` silos while excluding only entries resolved as `Dead`.
- Move dead-silo outstanding-message breaking out of LocalGrainDirectory and into networking ownership.

## Review focus
Please focus on the `GetSiloStatus(..., seenAtVersion)` semantics and whether the dead-only filtering is applied consistently across directory, cache, and handoff paths.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10085)