### PR TITLE
Use membership versions for stale directory cleanup

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -130,7 +130,7 @@ namespace Orleans.Runtime.GrainDirectory
 
             for (var i = singleActivations.Count - 1; i >= 0; i--)
             {
-                if (singleActivations[i].SiloAddress is not { } siloAddress || this.siloStatusOracle.GetApproximateSiloStatus(siloAddress).IsTerminating())
+                if (singleActivations[i].SiloAddress is not { } siloAddress || this.siloStatusOracle.GetApproximateSiloStatus(siloAddress) == SiloStatus.Dead)
                 {
                     singleActivations.RemoveAt(i);
                 }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -227,8 +227,8 @@ namespace Orleans.Runtime.GrainDirectory
             var addedSilos = GetMembershipDifference(targetMembership, previousMembership);
 
             ProcessSiloStatusChanges(snapshot, previousSnapshot, previousMembership);
-            AdjustLocalDirectory(targetMembership);
-            AdjustLocalCache(targetMembership);
+            AdjustLocalDirectory(snapshot);
+            AdjustLocalCache(snapshot, targetMembership);
 
             foreach (var silo in removedSilos)
             {
@@ -365,14 +365,14 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        private void AdjustLocalDirectory(DirectoryMembership targetMembership)
+        private void AdjustLocalDirectory(ClusterMembershipSnapshot snapshot)
         {
             var activationsToRemove = new List<(GrainId, ActivationId)>();
             foreach (var entry in this.DirectoryPartition.GetItems())
             {
                 if (entry.Value.Activation is { } address)
                 {
-                    if (IsDefunctActivationSilo(targetMembership, address.SiloAddress))
+                    if (IsDefunctActivation(address, snapshot))
                     {
                         activationsToRemove.Add((entry.Key, address.ActivationId));
                     }
@@ -385,7 +385,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        private void AdjustLocalCache(DirectoryMembership targetMembership)
+        private void AdjustLocalCache(ClusterMembershipSnapshot snapshot, DirectoryMembership targetMembership)
         {
             foreach (var tuple in DirectoryCache.KeyValues)
             {
@@ -398,16 +398,26 @@ namespace Orleans.Runtime.GrainDirectory
                     continue;
                 }
 
-                if (IsDefunctActivationSilo(targetMembership, activationAddress.SiloAddress))
+                if (IsDefunctActivation(activationAddress, snapshot))
                 {
                     DirectoryCache.Remove(activationAddress.GrainId);
                 }
             }
         }
 
-        private static bool IsDefunctActivationSilo(DirectoryMembership targetMembership, SiloAddress? silo)
+        private static bool IsDefunctActivation(GrainAddress address, ClusterMembershipSnapshot snapshot)
         {
-            return silo is null || !targetMembership.MembershipCache.Contains(silo);
+            if (address.SiloAddress is not { } silo)
+            {
+                return true;
+            }
+
+            if (snapshot.Members.TryGetValue(silo, out var member))
+            {
+                return member.Status.IsTerminating();
+            }
+
+            return address.MembershipVersion < snapshot.Version;
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.GrainDirectory;
 using Orleans.Internal;
+using Orleans.Runtime.Internal;
 using Orleans.Runtime.Scheduler;
 
 namespace Orleans.Runtime.GrainDirectory
@@ -122,6 +123,7 @@ namespace Orleans.Runtime.GrainDirectory
             LogDebugStart();
 
             Running = true;
+            using var _ = new ExecutionContextSuppressor();
             membershipUpdatesTask = Task.Run(() => ProcessMembershipUpdates(_membershipUpdatesCancellation.Token));
         }
 
@@ -141,14 +143,28 @@ namespace Orleans.Runtime.GrainDirectory
             //mark Running as false will exclude myself from CalculateGrainDirectoryPartition(grainId)
             Running = false;
             _membershipUpdatesCancellation.Cancel();
-            if (membershipUpdatesTask is { } task)
+            try
             {
-                await task.SuppressThrowing();
+                if (membershipUpdatesTask is { } task)
+                {
+                    await task.SuppressThrowing();
+                }
+            }
+            finally
+            {
+                _membershipUpdatesCancellation.Dispose();
             }
 
             if (this.disposeDirectoryCache)
             {
-                await GrainDirectoryCacheFactory.DisposeGrainDirectoryCacheAsync(DirectoryCache).SuppressThrowing();
+                try
+                {
+                    await GrainDirectoryCacheFactory.DisposeGrainDirectoryCacheAsync(DirectoryCache);
+                }
+                catch (Exception exception)
+                {
+                    LogWarningDisposeDirectoryCacheFailed(exception);
+                }
             }
 
             DirectoryPartition.Clear();
@@ -414,7 +430,7 @@ namespace Orleans.Runtime.GrainDirectory
 
             if (snapshot.Members.TryGetValue(silo, out var member))
             {
-                return member.Status.IsTerminating();
+                return member.Status == SiloStatus.Dead;
             }
 
             return address.MembershipVersion < snapshot.Version;
@@ -1026,6 +1042,12 @@ namespace Orleans.Runtime.GrainDirectory
             Message = "Failed to refresh cluster membership after a directory membership update processing error."
         )]
         private partial void LogWarningRefreshingClusterMembershipFailed(Exception exception);
+
+        [LoggerMessage(
+            Level = LogLevel.Warning,
+            Message = "Failed to dispose the grain directory cache."
+        )]
+        private partial void LogWarningDisposeDirectoryCacheFailed(Exception exception);
 
         [LoggerMessage(
             Level = LogLevel.Debug,


### PR DESCRIPTION
Part 2 of 7 split from #10085.

Problem:
Directory cleanup could remove registrations for silos which are absent from the current snapshot even when the registration was observed at the same or a newer membership version.

Solution:
Use the registration membership version to distinguish stale unknown-silo entries from entries which may be newer than the applied membership snapshot.

Stack:
Merge after #10086. This branch is stacked on split/pr10085-01-membership-reconcile; until #10086 merges, GitHub may show earlier stack changes in this PR. Incremental compare: https://github.com/ReubenBond/orleans/compare/split/pr10085-01-membership-reconcile...split/pr10085-02-stale-version-cleanup

Review focus:
The stale-entry predicate for unknown silos and the point where LocalGrainDirectory removes directory/cache entries.