### PR TITLE
Refresh membership before directory RPC routing

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -130,7 +130,7 @@ namespace Orleans.Runtime.GrainDirectory
 
             for (var i = singleActivations.Count - 1; i >= 0; i--)
             {
-                if (singleActivations[i].SiloAddress is not { } siloAddress || this.siloStatusOracle.GetApproximateSiloStatus(siloAddress).IsTerminating())
+                if (singleActivations[i].SiloAddress is not { } siloAddress || this.siloStatusOracle.GetApproximateSiloStatus(siloAddress) == SiloStatus.Dead)
                 {
                     singleActivations.RemoveAt(i);
                 }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -320,6 +320,48 @@ namespace Orleans.Runtime.GrainDirectory
             return result;
         }
 
+        private Task RefreshMembershipIfNewer(GrainAddress address, GrainAddress? previousAddress = null)
+        {
+            var targetVersion = address.MembershipVersion;
+            if (previousAddress is not null && previousAddress.MembershipVersion > targetVersion)
+            {
+                targetVersion = previousAddress.MembershipVersion;
+            }
+
+            return RefreshMembershipIfNewer(targetVersion);
+        }
+
+        private Task RefreshMembershipIfNewer(List<GrainAddress> addresses)
+        {
+            var targetVersion = MembershipVersion.MinValue;
+            foreach (var address in addresses)
+            {
+                if (address.MembershipVersion > targetVersion)
+                {
+                    targetVersion = address.MembershipVersion;
+                }
+            }
+
+            return RefreshMembershipIfNewer(targetVersion);
+        }
+
+        private async Task RefreshMembershipIfNewer(MembershipVersion targetVersion)
+        {
+            if (targetVersion <= appliedClusterMembershipSnapshot.Version)
+            {
+                return;
+            }
+
+            var snapshot = clusterMembershipService.CurrentSnapshot;
+            if (targetVersion > snapshot.Version)
+            {
+                await clusterMembershipService.Refresh(targetVersion);
+                snapshot = clusterMembershipService.CurrentSnapshot;
+            }
+
+            await ApplyMembershipSnapshot(snapshot);
+        }
+
         private void OnSiloStatusChange(DirectoryMembership previousMembership, SiloAddress updatedSilo, SiloStatus status)
         {
             if (updatedSilo.Equals(MyAddress) || !status.IsTerminating())
@@ -580,6 +622,8 @@ namespace Orleans.Runtime.GrainDirectory
                 DirectoryInstruments.RegistrationsSingleActIssued.Add(1);
             }
 
+            await RefreshMembershipIfNewer(address, previousAddress);
+
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "RegisterAsync");
 
@@ -630,20 +674,22 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        public Task UnregisterAfterNonexistingActivation(GrainAddress addr, SiloAddress origin)
+        public async Task UnregisterAfterNonexistingActivation(GrainAddress addr, SiloAddress origin)
         {
             LogTraceUnregisterAfterNonexistingActivation(addr, origin);
+
+            await RefreshMembershipIfNewer(addr);
 
             if (origin == null || this.directoryMembership.MembershipCache.Contains(origin))
             {
                 // the request originated in this cluster, call unregister here
-                return UnregisterAsync(addr, UnregistrationCause.NonexistentActivation, 0);
+                await UnregisterAsync(addr, UnregistrationCause.NonexistentActivation, 0);
             }
             else
             {
                 // the request originated in another cluster, call unregister there
                 var remoteDirectory = GetDirectoryReference(origin);
-                return remoteDirectory.UnregisterAsync(addr, UnregistrationCause.NonexistentActivation);
+                await remoteDirectory.UnregisterAsync(addr, UnregistrationCause.NonexistentActivation);
             }
         }
 
@@ -660,6 +706,8 @@ namespace Orleans.Runtime.GrainDirectory
 
             if (hopCount == 0)
                 InvalidateCacheEntry(address);
+
+            await RefreshMembershipIfNewer(address);
 
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "UnregisterAsync");
@@ -726,6 +774,8 @@ namespace Orleans.Runtime.GrainDirectory
             {
                 DirectoryInstruments.UnregistrationsManyIssued.Add(1);
             }
+
+            await RefreshMembershipIfNewer(addresses);
 
             Dictionary<SiloAddress, List<GrainAddress>>? forwardlist = null;
 

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -227,8 +227,8 @@ namespace Orleans.Runtime.GrainDirectory
             var addedSilos = GetMembershipDifference(targetMembership, previousMembership);
 
             ProcessSiloStatusChanges(snapshot, previousSnapshot, previousMembership);
-            AdjustLocalDirectory(targetMembership);
-            AdjustLocalCache(targetMembership);
+            AdjustLocalDirectory(snapshot);
+            AdjustLocalCache(snapshot, targetMembership);
 
             foreach (var silo in removedSilos)
             {
@@ -365,14 +365,14 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        private void AdjustLocalDirectory(DirectoryMembership targetMembership)
+        private void AdjustLocalDirectory(ClusterMembershipSnapshot snapshot)
         {
             var activationsToRemove = new List<(GrainId, ActivationId)>();
             foreach (var entry in this.DirectoryPartition.GetItems())
             {
                 if (entry.Value.Activation is { } address)
                 {
-                    if (IsDefunctActivationSilo(targetMembership, address.SiloAddress))
+                    if (IsDefunctActivation(address, snapshot))
                     {
                         activationsToRemove.Add((entry.Key, address.ActivationId));
                     }
@@ -385,7 +385,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        private void AdjustLocalCache(DirectoryMembership targetMembership)
+        private void AdjustLocalCache(ClusterMembershipSnapshot snapshot, DirectoryMembership targetMembership)
         {
             foreach (var tuple in DirectoryCache.KeyValues)
             {
@@ -398,16 +398,26 @@ namespace Orleans.Runtime.GrainDirectory
                     continue;
                 }
 
-                if (IsDefunctActivationSilo(targetMembership, activationAddress.SiloAddress))
+                if (IsDefunctActivation(activationAddress, snapshot))
                 {
                     DirectoryCache.Remove(activationAddress.GrainId);
                 }
             }
         }
 
-        private static bool IsDefunctActivationSilo(DirectoryMembership targetMembership, SiloAddress? silo)
+        private static bool IsDefunctActivation(GrainAddress address, ClusterMembershipSnapshot snapshot)
         {
-            return silo is null || !targetMembership.MembershipCache.Contains(silo);
+            if (address.SiloAddress is not { } silo)
+            {
+                return true;
+            }
+
+            if (snapshot.Members.TryGetValue(silo, out var member))
+            {
+                return member.Status.IsTerminating();
+            }
+
+            return address.MembershipVersion < snapshot.Version;
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.GrainDirectory;
 using Orleans.Internal;
+using Orleans.Runtime.Internal;
 using Orleans.Runtime.Scheduler;
 
 namespace Orleans.Runtime.GrainDirectory
@@ -122,6 +123,7 @@ namespace Orleans.Runtime.GrainDirectory
             LogDebugStart();
 
             Running = true;
+            using var _ = new ExecutionContextSuppressor();
             membershipUpdatesTask = Task.Run(() => ProcessMembershipUpdates(_membershipUpdatesCancellation.Token));
         }
 
@@ -141,14 +143,28 @@ namespace Orleans.Runtime.GrainDirectory
             //mark Running as false will exclude myself from CalculateGrainDirectoryPartition(grainId)
             Running = false;
             _membershipUpdatesCancellation.Cancel();
-            if (membershipUpdatesTask is { } task)
+            try
             {
-                await task.SuppressThrowing();
+                if (membershipUpdatesTask is { } task)
+                {
+                    await task.SuppressThrowing();
+                }
+            }
+            finally
+            {
+                _membershipUpdatesCancellation.Dispose();
             }
 
             if (this.disposeDirectoryCache)
             {
-                await GrainDirectoryCacheFactory.DisposeGrainDirectoryCacheAsync(DirectoryCache).SuppressThrowing();
+                try
+                {
+                    await GrainDirectoryCacheFactory.DisposeGrainDirectoryCacheAsync(DirectoryCache);
+                }
+                catch (Exception exception)
+                {
+                    LogWarningDisposeDirectoryCacheFailed(exception);
+                }
             }
 
             DirectoryPartition.Clear();
@@ -414,7 +430,7 @@ namespace Orleans.Runtime.GrainDirectory
 
             if (snapshot.Members.TryGetValue(silo, out var member))
             {
-                return member.Status.IsTerminating();
+                return member.Status == SiloStatus.Dead;
             }
 
             return address.MembershipVersion < snapshot.Version;
@@ -1026,6 +1042,12 @@ namespace Orleans.Runtime.GrainDirectory
             Message = "Failed to refresh cluster membership after a directory membership update processing error."
         )]
         private partial void LogWarningRefreshingClusterMembershipFailed(Exception exception);
+
+        [LoggerMessage(
+            Level = LogLevel.Warning,
+            Message = "Failed to dispose the grain directory cache."
+        )]
+        private partial void LogWarningDisposeDirectoryCacheFailed(Exception exception);
 
         [LoggerMessage(
             Level = LogLevel.Debug,

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -177,6 +177,72 @@ namespace UnitTests.Directory
         }
 
         [Fact]
+        public async Task LocalGrainDirectoryAppliesNewerMembershipBeforeRegisterForwarding()
+        {
+            var localSilo = GenerateSiloAddress();
+            var remoteSilo = GenerateSiloAddress();
+            var membershipService = new MockClusterMembershipService(new()
+            {
+                [localSilo] = (SiloStatus.Active, "local")
+            });
+            var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+            localSiloDetails.SiloAddress.Returns(localSilo);
+            localSiloDetails.GatewayAddress.Returns(localSilo);
+            localSiloDetails.DnsHostName.Returns("localhost");
+            localSiloDetails.Name.Returns("TestSilo");
+            localSiloDetails.ClusterId.Returns("TestCluster");
+            var siloStatusOracle = Substitute.For<ISiloStatusOracle>();
+            var grainFactory = Substitute.For<IInternalGrainFactory>();
+            var remoteDirectory = Substitute.For<IRemoteGrainDirectory>();
+            grainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceType, remoteSilo).Returns(remoteDirectory);
+            var services = new ServiceCollection().BuildServiceProvider();
+            Factory<LocalGrainDirectoryPartition> partitionFactory = () => new LocalGrainDirectoryPartition(
+                siloStatusOracle,
+                Options.Create(new GrainDirectoryOptions()),
+                this.loggerFactory);
+            var systemTargetShared = new SystemTargetShared(
+                runtimeClient: null!,
+                localSiloDetails: localSiloDetails,
+                loggerFactory: this.loggerFactory,
+                schedulingOptions: Options.Create(new SchedulingOptions()),
+                grainReferenceActivator: null,
+                timerRegistry: null,
+                activations: new ActivationDirectory());
+            var localGrainDirectory = new LocalGrainDirectory(
+                serviceProvider: services,
+                siloDetails: localSiloDetails,
+                siloStatusOracle: siloStatusOracle,
+                clusterMembershipService: membershipService.Target,
+                grainFactory: grainFactory,
+                grainDirectoryPartitionFactory: partitionFactory,
+                developmentClusterMembershipOptions: Options.Create(new DevelopmentClusterMembershipOptions()),
+                grainDirectoryOptions: Options.Create(new GrainDirectoryOptions()),
+                loggerFactory: this.loggerFactory,
+                systemTargetShared: systemTargetShared)
+            {
+                Running = true
+            };
+
+            membershipService.UpdateSiloStatus(remoteSilo, SiloStatus.Active, "remote");
+            var address = GenerateGrainAddressOwnedBy(remoteSilo, localSilo, remoteSilo, membershipService.CurrentVersion);
+            remoteDirectory.RegisterAsync(address, null, 1).Returns(Task.FromResult(new AddressAndTag(address, 1)));
+
+            try
+            {
+                var result = await localGrainDirectory.RegisterAsync(address, hopCount: 0);
+
+                Assert.Equal(address, result.Address);
+                Assert.Equal(0, membershipService.RefreshCallCount);
+                await remoteDirectory.Received(1).RegisterAsync(address, null, 1);
+                Assert.Null(localGrainDirectory.GetLocalDirectoryData(address.GrainId).Address);
+            }
+            finally
+            {
+                await localGrainDirectory.StopAsync();
+            }
+        }
+
+        [Fact]
         public async Task RegisterWhenOtherEntryExists()
         {
             var expectedSilo = GenerateSiloAddress();
@@ -567,15 +633,49 @@ namespace UnitTests.Directory
             Assert.True(this.grainLocator.TryLookupInCache(secondAddr.GrainId, out _));
         }
 
-        private GrainAddress GenerateGrainAddress(SiloAddress siloAddress = null)
+        private GrainAddress GenerateGrainAddress(SiloAddress siloAddress = null, MembershipVersion? membershipVersion = null)
         {
             return new GrainAddress
             {
                 GrainId = GrainId.Create(GrainType.Create("test"), GrainIdKeyExtensions.CreateGuidKey(Guid.NewGuid())),
                 ActivationId = ActivationId.NewId(),
                 SiloAddress = siloAddress ?? GenerateSiloAddress(),
-                MembershipVersion = this.mockMembershipService.CurrentVersion,
+                MembershipVersion = membershipVersion ?? this.mockMembershipService.CurrentVersion,
             };
+        }
+
+        private GrainAddress GenerateGrainAddressOwnedBy(SiloAddress owner, SiloAddress localSilo, SiloAddress remoteSilo, MembershipVersion membershipVersion)
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                var candidate = GenerateGrainAddress(localSilo, membershipVersion);
+                if (CalculateDirectoryOwner(candidate.GrainId, localSilo, remoteSilo).Equals(owner))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new InvalidOperationException($"Unable to generate a grain id owned by {owner}.");
+        }
+
+        private static SiloAddress CalculateDirectoryOwner(GrainId grainId, params SiloAddress[] silos)
+        {
+            Array.Sort(silos, static (left, right) =>
+            {
+                var hashComparison = left.GetConsistentHashCode().CompareTo(right.GetConsistentHashCode());
+                return hashComparison != 0 ? hashComparison : left.CompareTo(right);
+            });
+
+            var hash = unchecked((int)grainId.GetUniformHashCode());
+            for (var i = silos.Length - 1; i >= 0; --i)
+            {
+                if (silos[i].GetConsistentHashCode() <= hash)
+                {
+                    return silos[i];
+                }
+            }
+
+            return silos[^1];
         }
 
         private int generation = 0;

--- a/test/Orleans.Core.Tests/Directory/MockClusterMembershipService.cs
+++ b/test/Orleans.Core.Tests/Directory/MockClusterMembershipService.cs
@@ -7,6 +7,7 @@ namespace UnitTests.Directory
     internal class MockClusterMembershipService : IClusterMembershipService
     {
         private long version = 0;
+        private int refreshCallCount;
         private readonly Dictionary<SiloAddress, (SiloStatus Status, string Name)> statuses;
         private ClusterMembershipSnapshot snapshot;
         private readonly AsyncEnumerable<ClusterMembershipSnapshot> updates;
@@ -14,6 +15,10 @@ namespace UnitTests.Directory
         ClusterMembershipSnapshot IClusterMembershipService.CurrentSnapshot => this.snapshot;
 
         public MembershipVersion CurrentVersion => this.snapshot.Version;
+
+        public int RefreshCallCount => this.refreshCallCount;
+
+        public MembershipVersion LastRefreshMinimumVersion { get; private set; }
 
         IAsyncEnumerable<ClusterMembershipSnapshot> IClusterMembershipService.MembershipUpdates => this.updates;
 
@@ -44,7 +49,12 @@ namespace UnitTests.Directory
             return new ClusterMembershipSnapshot(dictBuilder.ToImmutable(), new MembershipVersion(version));
         }
 
-        public ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default) => new ValueTask();
+        public ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref this.refreshCallCount);
+            this.LastRefreshMinimumVersion = minimumVersion;
+            return new ValueTask();
+        }
 
         public Task<bool> TryKill(SiloAddress siloAddress) => throw new NotImplementedException();
     }


### PR DESCRIPTION
Part 3 of 7 split from #10085.

Problem:
Directory RPCs can receive GrainAddress values which were observed at a newer membership version than the local directory has applied, causing routing and ownership decisions to be made with stale membership data.

Solution:
Refresh and apply cluster membership before processing directory operations when incoming addresses reference a newer membership version.

Stack:
Merge after #10087. This branch is stacked on split/pr10085-02-stale-version-cleanup; until earlier PRs merge, GitHub may show earlier stack changes. Incremental compare: https://github.com/ReubenBond/orleans/compare/split/pr10085-02-stale-version-cleanup...split/pr10085-03-refresh-newer-membership

Review focus:
Refresh timing before register/unregister paths and avoiding unnecessary refreshes when the local snapshot is already current.