### PR TITLE
Refine directory forwarding retry checks

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -169,10 +169,10 @@ namespace Orleans.Runtime.GrainDirectory
             var updates = this.clusterMembershipService.MembershipUpdates.WithCancellation(this.shutdownToken.Token);
             await foreach (var snapshot in updates)
             {
-                // Active filtering: detect silos that went down and try to clean proactively the directory
+                // Active filtering: detect dead silos and try to clean proactively the directory
                 var changes = snapshot.CreateUpdate(previousSnapshot).Changes;
                 var deadSilos = changes
-                    .Where(member => member.Status.IsTerminating())
+                    .Where(member => member.Status == SiloStatus.Dead)
                     .Select(member => member.SiloAddress)
                     .ToList();
 
@@ -196,17 +196,7 @@ namespace Orleans.Runtime.GrainDirectory
         private bool IsKnownDeadSilo(SiloAddress siloAddress, MembershipVersion membershipVersion)
         {
             var current = this.clusterMembershipService.CurrentSnapshot;
-
-            // Check if the target silo is in the cluster
-            if (current.Members.TryGetValue(siloAddress, out var value))
-            {
-                // It is, check if it's alive
-                return value.Status.IsTerminating();
-            }
-
-            // We didn't find it in the cluster. If the silo entry is too old, it has been cleaned in the membership table: the entry isn't valid anymore.
-            // Otherwise, maybe the membership service isn't up to date yet. The entry should be valid
-            return current.Version > membershipVersion;
+            return siloAddress is null || current.GetSiloStatus(siloAddress, membershipVersion) == SiloStatus.Dead;
         }
 
         private static void ThrowUnsupportedGrainType(GrainId grainId) => throw new InvalidOperationException($"Unsupported grain type for grain {grainId}");
@@ -222,10 +212,10 @@ namespace Orleans.Runtime.GrainDirectory
                 ThrowUnsupportedGrainType(grainId);
             }
 
-            if (this.cache.LookUp(grainId, out address, out var version))
+            if (this.cache.LookUp(grainId, out address, out _))
             {
                 // If the silo is dead, remove the entry
-                if (IsKnownDeadSilo(address.SiloAddress, new MembershipVersion(version)))
+                if (IsKnownDeadSilo(address))
                 {
                     address = default;
                     this.cache.Remove(grainId);

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -187,6 +187,7 @@ namespace Orleans.Runtime.GrainDirectory
                 }
 
                 ((ITestAccessor)this).LastMembershipVersion = snapshot.Version;
+                previousSnapshot = snapshot;
             }
         }
 
@@ -201,7 +202,11 @@ namespace Orleans.Runtime.GrainDirectory
 
         private static void ThrowUnsupportedGrainType(GrainId grainId) => throw new InvalidOperationException($"Unsupported grain type for grain {grainId}");
 
-        public void UpdateCache(GrainId grainId, SiloAddress siloAddress) => cache.AddOrUpdate(new GrainAddress { GrainId = grainId, SiloAddress = siloAddress }, 0);
+        public void UpdateCache(GrainId grainId, SiloAddress siloAddress)
+        {
+            var membershipVersion = this.clusterMembershipService.CurrentSnapshot.Version;
+            cache.AddOrUpdate(new GrainAddress { GrainId = grainId, SiloAddress = siloAddress, MembershipVersion = membershipVersion }, (int)membershipVersion.Value);
+        }
         public void InvalidateCache(GrainId grainId) => cache.Remove(grainId);
         public void InvalidateCache(GrainAddress address) => cache.Remove(address);
         public bool TryLookupInCache(GrainId grainId, out GrainAddress address)

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryHandoffManager.cs
@@ -17,24 +17,24 @@ namespace Orleans.Runtime.GrainDirectory
         private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(250);
         private readonly LocalGrainDirectory localDirectory;
         private readonly ISiloStatusOracle siloStatusOracle;
+        private readonly IClusterMembershipService clusterMembershipService;
         private readonly IInternalGrainFactory grainFactory;
         private readonly ILogger logger;
-        private readonly Factory<LocalGrainDirectoryPartition> createPartion;
         private readonly Queue<(string name, object state, Func<GrainDirectoryHandoffManager, object, Task> action)> pendingOperations = new();
         private readonly AsyncLock executorLock = new AsyncLock();
 
         internal GrainDirectoryHandoffManager(
             LocalGrainDirectory localDirectory,
             ISiloStatusOracle siloStatusOracle,
+            IClusterMembershipService clusterMembershipService,
             IInternalGrainFactory grainFactory,
-            Factory<LocalGrainDirectoryPartition> createPartion,
             ILoggerFactory loggerFactory)
         {
             logger = loggerFactory.CreateLogger<GrainDirectoryHandoffManager>();
             this.localDirectory = localDirectory;
             this.siloStatusOracle = siloStatusOracle;
+            this.clusterMembershipService = clusterMembershipService;
             this.grainFactory = grainFactory;
-            this.createPartion = createPartion;
         }
 
         internal void ProcessSiloAddEvent(SiloAddress addedSilo)
@@ -128,9 +128,10 @@ namespace Orleans.Runtime.GrainDirectory
         {
             if (!this.localDirectory.Running) return;
 
+            var snapshot = this.clusterMembershipService.CurrentSnapshot;
             for (var i = singleActivations.Count - 1; i >= 0; i--)
             {
-                if (singleActivations[i].SiloAddress is not { } siloAddress || this.siloStatusOracle.GetApproximateSiloStatus(siloAddress) == SiloStatus.Dead)
+                if (!IsTransferableRegistration(singleActivations[i], snapshot))
                 {
                     singleActivations.RemoveAt(i);
                 }
@@ -197,6 +198,16 @@ namespace Orleans.Runtime.GrainDirectory
 
                 duplicates.Remove(pair.Key);
             }
+        }
+
+        internal static bool IsTransferableRegistration(GrainAddress address, ClusterMembershipSnapshot snapshot)
+        {
+            if (address.SiloAddress is not { } silo)
+            {
+                return false;
+            }
+
+            return snapshot.GetSiloStatus(silo, address.MembershipVersion) != SiloStatus.Dead;
         }
 
         private void EnqueueOperation(string name, object state, Func<GrainDirectoryHandoffManager, object, Task> action)

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
@@ -111,7 +111,8 @@ internal sealed partial class GrainDirectoryPartition
         return existing;
     }
 
-    private bool IsSiloDead(GrainAddress existing) => _owner.ClusterMembershipSnapshot.GetSiloStatus(existing.SiloAddress) == SiloStatus.Dead;
+    private bool IsSiloDead(GrainAddress existing)
+        => existing.SiloAddress is null || _owner.ClusterMembershipSnapshot.GetSiloStatus(existing.SiloAddress, existing.MembershipVersion) == SiloStatus.Dead;
 
     [LoggerMessage(
         Level = LogLevel.Trace,

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -24,7 +24,6 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly IClusterMembershipService clusterMembershipService;
         private readonly IInternalGrainFactory grainFactory;
         private readonly ActivationDirectory localActivations;
-        private readonly InsideRuntimeClient runtimeClient;
         private readonly IServiceProvider _serviceProvider;
         private readonly CancellationTokenSource _membershipUpdatesCancellation = new();
         private DirectoryMembership directoryMembership = DirectoryMembership.Default;
@@ -71,7 +70,6 @@ namespace Orleans.Runtime.GrainDirectory
             this.clusterMembershipService = clusterMembershipService;
             this.grainFactory = grainFactory;
             this.localActivations = systemTargetShared.ActivationDirectory;
-            this.runtimeClient = systemTargetShared.RuntimeClient;
 
             DirectoryCache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value, out this.disposeDirectoryCache);
 
@@ -319,17 +317,6 @@ namespace Orleans.Runtime.GrainDirectory
             return result;
         }
 
-        private Task RefreshMembershipIfNewer(GrainAddress address, GrainAddress? previousAddress = null)
-        {
-            var targetVersion = address.MembershipVersion;
-            if (previousAddress is not null && previousAddress.MembershipVersion > targetVersion)
-            {
-                targetVersion = previousAddress.MembershipVersion;
-            }
-
-            return RefreshMembershipIfNewer(targetVersion);
-        }
-
         private Task RefreshMembershipIfNewer(List<GrainAddress> addresses)
         {
             var targetVersion = MembershipVersion.MinValue;
@@ -364,11 +351,6 @@ namespace Orleans.Runtime.GrainDirectory
             if (updatedSilo.Equals(MyAddress) || !status.IsTerminating())
             {
                 return;
-            }
-
-            if (status == SiloStatus.Dead)
-            {
-                runtimeClient.BreakOutstandingMessagesToSilo(updatedSilo);
             }
 
             var activationsToShutdown = new List<IGrainContext>();
@@ -460,24 +442,14 @@ namespace Orleans.Runtime.GrainDirectory
             }
         }
 
-        private static bool IsDefunctActivation(GrainAddress address, ClusterMembershipSnapshot snapshot)
+        internal static bool IsDefunctActivation(GrainAddress address, ClusterMembershipSnapshot snapshot)
         {
             if (address.SiloAddress is not { } silo)
             {
                 return true;
             }
 
-            if (snapshot.Members.TryGetValue(silo, out var member))
-            {
-                // If this is a known host, remove the activation if the host is dead.
-                return member.Status == SiloStatus.Dead;
-            }
-
-            // If this is not a known host, remove the activation if it was registered at an older membership version.
-            // This indicates that the host must have been removed.
-            // Hosts cannot activate grains before they are active, and we ensure that we refresh the membership before processing messages,
-            // so this is a reliable indicator of a defunct activation.
-            return address.MembershipVersion < snapshot.Version;
+            return snapshot.GetSiloStatus(silo) == SiloStatus.Dead;
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)
@@ -624,13 +596,13 @@ namespace Orleans.Runtime.GrainDirectory
                 DirectoryInstruments.RegistrationsSingleActIssued.Add(1);
             }
 
-            await RefreshMembershipIfNewer(address, previousAddress);
+            await RefreshMembershipIfNewer(address.MembershipVersion);
 
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "RegisterAsync");
 
-            // on all silos other than first, we insert a retry delay and recheck owner before forwarding
-            if (hopCount > 0 && forwardAddress != null)
+            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
                 forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "RegisterAsync");
@@ -680,7 +652,7 @@ namespace Orleans.Runtime.GrainDirectory
         {
             LogTraceUnregisterAfterNonexistingActivation(addr, origin);
 
-            await RefreshMembershipIfNewer(addr);
+            await RefreshMembershipIfNewer(addr.MembershipVersion);
 
             if (origin == null || this.directoryMembership.MembershipCache.Contains(origin))
             {
@@ -709,13 +681,13 @@ namespace Orleans.Runtime.GrainDirectory
             if (hopCount == 0)
                 InvalidateCacheEntry(address);
 
-            await RefreshMembershipIfNewer(address);
+            await RefreshMembershipIfNewer(address.MembershipVersion);
 
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "UnregisterAsync");
 
-            // on all silos other than first, we insert a retry delay and recheck owner before forwarding
-            if (hopCount > 0 && forwardAddress != null)
+            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
                 forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "UnregisterAsync");

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -601,7 +601,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "RegisterAsync");
 
-            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            // The first forwarded owner (hopCount == 1) forwards immediately if ownership changed again.
+            // Once the request has already been re-forwarded, pause and recheck before bouncing it again.
             if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
@@ -686,7 +687,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(address.GrainId, hopCount, "UnregisterAsync");
 
-            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            // The first forwarded owner (hopCount == 1) forwards immediately if ownership changed again.
+            // Once the request has already been re-forwarded, pause and recheck before bouncing it again.
             if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
@@ -754,7 +756,8 @@ namespace Orleans.Runtime.GrainDirectory
 
             UnregisterOrPutInForwardList(addresses, cause, hopCount, ref forwardlist, "UnregisterManyAsync");
 
-            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            // The first forwarded owner (hopCount == 1) forwards immediately if ownership changed again.
+            // Once the request has already been re-forwarded, pause and recheck before bouncing it again.
             if (hopCount > 1 && forwardlist != null)
             {
                 await Task.Delay(RETRY_DELAY);
@@ -868,7 +871,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "LookUpAsync");
 
-            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            // The first forwarded owner (hopCount == 1) forwards immediately if ownership changed again.
+            // Once the request has already been re-forwarded, pause and recheck before bouncing it again.
             if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
@@ -929,7 +933,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "DeleteGrainAsync");
 
-            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            // The first forwarded owner (hopCount == 1) forwards immediately if ownership changed again.
+            // Once the request has already been re-forwarded, pause and recheck before bouncing it again.
             if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -449,7 +449,8 @@ namespace Orleans.Runtime.GrainDirectory
                 return true;
             }
 
-            return address.MembershipVersion < snapshot.Version && snapshot.GetSiloStatus(silo) == SiloStatus.Dead;
+            var status = snapshot.GetSiloStatus(silo);
+            return status == SiloStatus.Dead || (status == SiloStatus.None && address.MembershipVersion < snapshot.Version);
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -80,7 +80,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
 
             DirectoryPartition = grainDirectoryPartitionFactory();
-            HandoffManager = new GrainDirectoryHandoffManager(this, siloStatusOracle, grainFactory, grainDirectoryPartitionFactory, loggerFactory);
+            HandoffManager = new GrainDirectoryHandoffManager(this, siloStatusOracle, clusterMembershipService, grainFactory, loggerFactory);
 
             // When DistributedGrainDirectory is active, it registers its own IRemoteGrainDirectory system targets.
             // In that case, create the RemoteGrainDirectory objects (still needed for WorkItemGroup scheduling)
@@ -449,8 +449,7 @@ namespace Orleans.Runtime.GrainDirectory
                 return true;
             }
 
-            var status = snapshot.GetSiloStatus(silo);
-            return status == SiloStatus.Dead || (status == SiloStatus.None && address.MembershipVersion < snapshot.Version);
+            return snapshot.GetSiloStatus(silo, address.MembershipVersion) == SiloStatus.Dead;
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)
@@ -640,7 +639,7 @@ namespace Orleans.Runtime.GrainDirectory
                 // this way next local lookup will find this ActivationAddress in the cache and we will save a full lookup!
                 if (result.Address == null) return result;
 
-                if (!address.Equals(result.Address) || !IsValidSilo(address.SiloAddress)) return result;
+                if (!address.Equals(result.Address) || IsDefunctActivation(address, clusterMembershipService.CurrentSnapshot)) return result;
 
                 // update the cache so next local lookup will find this ActivationAddress in the cache and we will save full lookup.
                 DirectoryCache.AddOrUpdate(result.Address, result.VersionTag);
@@ -845,7 +844,15 @@ namespace Orleans.Runtime.GrainDirectory
 
         public AddressAndTag GetLocalDirectoryData(GrainId grain) => DirectoryPartition.LookUpActivation(grain);
 
-        public GrainAddress? GetLocalCacheData(GrainId grain) => DirectoryCache.LookUp(grain, out var cache) && IsValidSilo(cache.SiloAddress) ? cache : null;
+        public GrainAddress? GetLocalCacheData(GrainId grain)
+        {
+            if (!DirectoryCache.LookUp(grain, out var cache))
+            {
+                return null;
+            }
+
+            return IsDefunctActivation(cache, clusterMembershipService.CurrentSnapshot) ? null : cache;
+        }
 
         public async Task<AddressAndTag> LookupAsync(GrainId grainId, int hopCount = 0)
         {
@@ -906,7 +913,7 @@ namespace Orleans.Runtime.GrainDirectory
                 var result = await GetDirectoryReference(forwardAddress).LookupAsync(grainId, hopCount + 1);
 
                 // update the cache
-                if (result.Address is { } address && IsValidSilo(address.SiloAddress))
+                if (result.Address is { } address && !IsDefunctActivation(address, clusterMembershipService.CurrentSnapshot))
                 {
                     DirectoryCache.AddOrUpdate(address, result.VersionTag);
                 }

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -754,8 +754,8 @@ namespace Orleans.Runtime.GrainDirectory
 
             UnregisterOrPutInForwardList(addresses, cause, hopCount, ref forwardlist, "UnregisterManyAsync");
 
-            // before forwarding to other silos, we insert a retry delay and re-check destination
-            if (hopCount > 0 && forwardlist != null)
+            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            if (hopCount > 1 && forwardlist != null)
             {
                 await Task.Delay(RETRY_DELAY);
                 Dictionary<SiloAddress, List<GrainAddress>>? forwardlist2 = null;
@@ -868,8 +868,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "LookUpAsync");
 
-            // on all silos other than first, we insert a retry delay and recheck owner before forwarding
-            if (hopCount > 0 && forwardAddress != null)
+            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
                 forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "LookUpAsync");
@@ -929,8 +929,8 @@ namespace Orleans.Runtime.GrainDirectory
             // see if the owner is somewhere else (returns null if we are owner)
             var forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "DeleteGrainAsync");
 
-            // on all silos other than first, we insert a retry delay and recheck owner before forwarding
-            if (hopCount > 0 && forwardAddress != null)
+            // After the first forward, we insert a retry delay and recheck owner before forwarding again
+            if (hopCount > 1 && forwardAddress != null)
             {
                 await Task.Delay(RETRY_DELAY);
                 forwardAddress = this.CheckIfShouldForward(grainId, hopCount, "DeleteGrainAsync");

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -449,7 +449,7 @@ namespace Orleans.Runtime.GrainDirectory
                 return true;
             }
 
-            return snapshot.GetSiloStatus(silo) == SiloStatus.Dead;
+            return address.MembershipVersion < snapshot.Version && snapshot.GetSiloStatus(silo) == SiloStatus.Dead;
         }
 
         internal SiloAddress? FindPredecessor(SiloAddress silo)

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryPartition.cs
@@ -112,21 +112,22 @@ namespace Orleans.Runtime.GrainDirectory
         private Dictionary<GrainId, GrainInfo> partitionData;
         private readonly object lockable;
         private readonly ILogger log;
-        private readonly ISiloStatusOracle siloStatusOracle;
+        private readonly IClusterMembershipService clusterMembershipService;
         private readonly IOptions<GrainDirectoryOptions> grainDirectoryOptions;
 
         internal int Count { get { return partitionData.Count; } }
 
-        public LocalGrainDirectoryPartition(ISiloStatusOracle siloStatusOracle, IOptions<GrainDirectoryOptions> grainDirectoryOptions, ILoggerFactory loggerFactory)
+        public LocalGrainDirectoryPartition(IClusterMembershipService clusterMembershipService, IOptions<GrainDirectoryOptions> grainDirectoryOptions, ILoggerFactory loggerFactory)
         {
             partitionData = new Dictionary<GrainId, GrainInfo>();
             lockable = new object();
             log = loggerFactory.CreateLogger<LocalGrainDirectoryPartition>();
-            this.siloStatusOracle = siloStatusOracle;
+            this.clusterMembershipService = clusterMembershipService;
             this.grainDirectoryOptions = grainDirectoryOptions;
         }
 
-        private bool IsValidSilo(SiloAddress? silo) => silo is not null && siloStatusOracle.IsFunctionalDirectory(silo);
+        private bool IsDefunctActivation(GrainAddress? address)
+            => address is null || LocalGrainDirectory.IsDefunctActivation(address, clusterMembershipService.CurrentSnapshot);
 
         internal void Clear()
         {
@@ -156,9 +157,11 @@ namespace Orleans.Runtime.GrainDirectory
         {
             LogTraceAddingSingleActivation(address.SiloAddress, address.GrainId, address.ActivationId);
 
-            if (!IsValidSilo(address.SiloAddress))
+            if (IsDefunctActivation(address))
             {
-                var siloStatus = this.siloStatusOracle.GetApproximateSiloStatus(address.SiloAddress);
+                var siloStatus = address.SiloAddress is { } siloAddress
+                    ? this.clusterMembershipService.CurrentSnapshot.GetSiloStatus(siloAddress, address.MembershipVersion)
+                    : SiloStatus.None;
                 throw new OrleansException($"Trying to register {address.GrainId} on invalid silo: {address.SiloAddress}. Known status: {siloStatus}");
             }
 
@@ -170,10 +173,8 @@ namespace Orleans.Runtime.GrainDirectory
                 }
                 else
                 {
-                    var siloAddress = grainInfo.Activation?.SiloAddress;
-
                     // If there is an existing entry pointing to an invalid silo then remove it 
-                    if (siloAddress != null && !IsValidSilo(siloAddress))
+                    if (IsDefunctActivation(grainInfo.Activation))
                     {
                         partitionData[address.GrainId] = grainInfo = new GrainInfo();
                     }
@@ -230,7 +231,7 @@ namespace Orleans.Runtime.GrainDirectory
                 result = new(grainInfo.Activation, grainInfo.VersionTag);
             }
 
-            if (!IsValidSilo(result.Address?.SiloAddress))
+            if (IsDefunctActivation(result.Address))
             {
                 result = new(null, result.VersionTag);
             }
@@ -308,7 +309,7 @@ namespace Orleans.Runtime.GrainDirectory
 
             for (var i = result.Count - 1; i >= 0; i--)
             {
-                if (!IsValidSilo(result[i].SiloAddress))
+                if (IsDefunctActivation(result[i]))
                 {
                     result.RemoveAt(i);
                 }

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipSnapshot.cs
@@ -62,6 +62,18 @@ namespace Orleans.Runtime
         }
 
         /// <summary>
+        /// Gets status of the specified silo, treating unknown silos as dead if this snapshot is newer than when the silo was seen.
+        /// </summary>
+        /// <param name="silo">The silo.</param>
+        /// <param name="seenAtVersion">The membership version when the silo was last seen.</param>
+        /// <returns>The status of the specified silo.</returns>
+        public SiloStatus GetSiloStatus(SiloAddress silo, MembershipVersion seenAtVersion)
+        {
+            var status = GetSiloStatus(silo);
+            return status == SiloStatus.None && this.Version > seenAtVersion ? SiloStatus.Dead : status;
+        }
+
+        /// <summary>
         /// Returns a <see cref="ClusterMembershipUpdate"/> which represents this instance.
         /// </summary>
         /// <returns>A <see cref="ClusterMembershipUpdate"/> which represents this instance.</returns>

--- a/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
@@ -11,7 +11,7 @@ namespace Orleans.Runtime.MembershipService;
 /// <summary>
 /// Manages <see cref="ISiloStatusListener"/> instances.
 /// </summary>
-internal partial class SiloStatusListenerManager : ILifecycleParticipant<ISiloLifecycle>
+internal sealed partial class SiloStatusListenerManager : ILifecycleParticipant<ISiloLifecycle>
 {
 #if NET9_0_OR_GREATER
     private readonly Lock _listenersLock = new();

--- a/src/Orleans.Runtime/Networking/SiloConnectionMaintainer.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionMaintainer.cs
@@ -9,15 +9,18 @@ namespace Orleans.Runtime.Messaging
     {
         private readonly ConnectionManager connectionManager;
         private readonly ISiloStatusOracle siloStatusOracle;
+        private readonly IRuntimeClient runtimeClient;
         private readonly ILogger<SiloConnectionMaintainer> log;
 
         public SiloConnectionMaintainer(
             ConnectionManager connectionManager,
             ISiloStatusOracle siloStatusOracle,
+            IRuntimeClient runtimeClient,
             ILogger<SiloConnectionMaintainer> log)
         {
             this.connectionManager = connectionManager;
             this.siloStatusOracle = siloStatusOracle;
+            this.runtimeClient = runtimeClient;
             this.log = log;
         }
 
@@ -42,6 +45,7 @@ namespace Orleans.Runtime.Messaging
         {
             if (status == SiloStatus.Dead && updatedSilo != siloStatusOracle.SiloAddress)
             {
+                this.runtimeClient.BreakOutstandingMessagesToSilo(updatedSilo);
                 _ = Task.Run(() => this.CloseConnectionAsync(updatedSilo));
             }
         }

--- a/src/api/Orleans.Runtime/Orleans.Runtime.cs
+++ b/src/api/Orleans.Runtime/Orleans.Runtime.cs
@@ -547,6 +547,8 @@ namespace Orleans.Runtime
 
         public SiloStatus GetSiloStatus(SiloAddress silo) { throw null; }
 
+        public SiloStatus GetSiloStatus(SiloAddress silo, MembershipVersion seenAtVersion) { throw null; }
+
         public override string ToString() { throw null; }
     }
 

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -146,7 +146,7 @@ namespace UnitTests.Directory
                 .AddSingleton<IGrainDirectoryCache>(cache)
                 .BuildServiceProvider();
             Factory<LocalGrainDirectoryPartition> partitionFactory = () => new LocalGrainDirectoryPartition(
-                siloStatusOracle,
+                membershipService.Target,
                 Options.Create(new GrainDirectoryOptions()),
                 this.loggerFactory);
             var systemTargetShared = new SystemTargetShared(
@@ -450,6 +450,35 @@ namespace UnitTests.Directory
             // Local lookup should never call the directory
             await this.grainDirectory.DidNotReceive().Lookup(outdatedAddr.GrainId);
             await this.grainDirectory.DidNotReceive().Unregister(outdatedAddr);
+
+            await this.lifecycle.OnStop();
+        }
+
+        [Theory]
+        [InlineData(SiloStatus.ShuttingDown)]
+        [InlineData(SiloStatus.Stopping)]
+        public async Task LocalLookupWhenCachedEntrySiloIsTerminatingButNotDead(SiloStatus status)
+        {
+            var silo = GenerateSiloAddress();
+
+            // Setup membership service
+            this.mockMembershipService.UpdateSiloStatus(silo, SiloStatus.Active, "silo");
+            await this.lifecycle.OnStart();
+            await WaitUntilClusterChangePropagated();
+
+            var address = GenerateGrainAddress(silo);
+            this.grainDirectory.Register(address, previousAddress: null).Returns(address);
+
+            await this.grainLocator.Register(address, previousAddress: null);
+            Assert.True(this.grainLocator.TryLookupInCache(address.GrainId, out var cached));
+            Assert.Equal(address, cached);
+
+            this.mockMembershipService.UpdateSiloStatus(silo, status, "silo");
+            await WaitUntilClusterChangePropagated();
+
+            Assert.True(this.grainLocator.TryLookupInCache(address.GrainId, out cached));
+            Assert.Equal(address, cached);
+            await this.grainDirectory.DidNotReceive().UnregisterSilos(Arg.Any<List<SiloAddress>>());
 
             await this.lifecycle.OnStop();
         }

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -532,6 +532,51 @@ namespace UnitTests.Directory
         }
 
         [Fact]
+        public async Task CleanupWhenSiloIsDeadOnlyProcessesIncrementalChanges()
+        {
+            var expectedSilo = GenerateSiloAddress();
+            var outdatedSilo = GenerateSiloAddress();
+
+            this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp");
+            this.mockMembershipService.UpdateSiloStatus(outdatedSilo, SiloStatus.Active, "old");
+            await this.lifecycle.OnStart();
+            await WaitUntilClusterChangePropagated();
+
+            this.mockMembershipService.UpdateSiloStatus(outdatedSilo, SiloStatus.Dead, "old");
+            await WaitUntilClusterChangePropagated();
+
+            await this.grainDirectory
+                .Received(1)
+                .UnregisterSilos(Arg.Is<List<SiloAddress>>(list => list.Count == 1 && list.Contains(outdatedSilo)));
+
+            this.mockMembershipService.UpdateSiloStatus(expectedSilo, SiloStatus.Active, "exp2");
+            await WaitUntilClusterChangePropagated();
+
+            await this.grainDirectory
+                .Received(1)
+                .UnregisterSilos(Arg.Is<List<SiloAddress>>(list => list.Count == 1 && list.Contains(outdatedSilo)));
+
+            await this.lifecycle.OnStop();
+        }
+
+        [Fact]
+        public async Task UpdateCacheStampsCurrentMembershipVersion()
+        {
+            await this.lifecycle.OnStart();
+
+            var grainId = GrainId.Create(GrainType.Create("test"), GrainIdKeyExtensions.CreateGuidKey(Guid.NewGuid()));
+            var silo = GenerateSiloAddress();
+
+            this.grainLocator.UpdateCache(grainId, silo);
+
+            Assert.True(this.grainLocator.TryLookupInCache(grainId, out var cached));
+            Assert.Equal(silo, cached.SiloAddress);
+            Assert.Equal(this.mockMembershipService.CurrentVersion, cached.MembershipVersion);
+
+            await this.lifecycle.OnStop();
+        }
+
+        [Fact]
         public async Task UnregisterCallDirectoryAndCleanCache()
         {
             var expectedSilo = GenerateSiloAddress();

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -197,7 +197,7 @@ namespace UnitTests.Directory
             grainFactory.GetSystemTarget<IRemoteGrainDirectory>(Constants.DirectoryServiceType, remoteSilo).Returns(remoteDirectory);
             var services = new ServiceCollection().BuildServiceProvider();
             Factory<LocalGrainDirectoryPartition> partitionFactory = () => new LocalGrainDirectoryPartition(
-                siloStatusOracle,
+                membershipService.Target,
                 Options.Create(new GrainDirectoryOptions()),
                 this.loggerFactory);
             var systemTargetShared = new SystemTargetShared(

--- a/test/Orleans.Runtime.Internal.Tests/ClusterMembershipSnapshotTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ClusterMembershipSnapshotTests.cs
@@ -1,0 +1,48 @@
+using System.Collections.Immutable;
+using System.Net;
+using Orleans.Runtime;
+using Xunit;
+
+namespace UnitTests;
+
+[TestCategory("BVT"), TestCategory("Membership")]
+public class ClusterMembershipSnapshotTests
+{
+    [Fact]
+    public void GetSiloStatus_ReturnsDeadForUnknownSiloSeenAtOlderVersion()
+    {
+        var unknownSilo = CreateSiloAddress(1);
+        var knownSilo = CreateSiloAddress(1, port: 11112);
+        var snapshot = CreateSnapshot(new ClusterMember(knownSilo, SiloStatus.Active, "known"), version: 2);
+
+        Assert.Equal(SiloStatus.Dead, snapshot.GetSiloStatus(unknownSilo, new MembershipVersion(1)));
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void GetSiloStatus_ReturnsNoneForUnknownSiloSeenAtCurrentOrNewerVersion(long seenAtVersion)
+    {
+        var unknownSilo = CreateSiloAddress(1);
+        var knownSilo = CreateSiloAddress(1, port: 11112);
+        var snapshot = CreateSnapshot(new ClusterMember(knownSilo, SiloStatus.Active, "known"), version: 2);
+
+        Assert.Equal(SiloStatus.None, snapshot.GetSiloStatus(unknownSilo, new MembershipVersion(seenAtVersion)));
+    }
+
+    [Fact]
+    public void GetSiloStatus_ReturnsDeadForSiloReplacedBySuccessor()
+    {
+        var silo = CreateSiloAddress(1);
+        var successor = CreateSiloAddress(2);
+        var snapshot = CreateSnapshot(new ClusterMember(successor, SiloStatus.Active, "silo"), version: 2);
+
+        Assert.Equal(SiloStatus.Dead, snapshot.GetSiloStatus(silo, new MembershipVersion(2)));
+    }
+
+    private static ClusterMembershipSnapshot CreateSnapshot(ClusterMember member, long version)
+        => new(ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(member.SiloAddress, member), new MembershipVersion(version));
+
+    private static SiloAddress CreateSiloAddress(int generation, int port = 11111)
+        => SiloAddress.New(new IPEndPoint(IPAddress.Loopback, port), generation);
+}

--- a/test/Orleans.Runtime.Internal.Tests/GrainDirectoryHandoffManagerTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/GrainDirectoryHandoffManagerTests.cs
@@ -1,0 +1,73 @@
+using System.Collections.Immutable;
+using System.Net;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Xunit;
+
+namespace UnitTests;
+
+[TestCategory("BVT"), TestCategory("GrainDirectory")]
+public class GrainDirectoryHandoffManagerTests
+{
+    [Theory]
+    [InlineData(SiloStatus.Active, true)]
+    [InlineData(SiloStatus.ShuttingDown, true)]
+    [InlineData(SiloStatus.Stopping, true)]
+    [InlineData(SiloStatus.Dead, false)]
+    public void IsTransferableRegistration_UsesSnapshotStatus(SiloStatus status, bool expected)
+    {
+        var silo = CreateSiloAddress(1);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
+        var snapshot = CreateSnapshot(new ClusterMember(silo, status, "silo"), version: 2);
+
+        Assert.Equal(expected, GrainDirectoryHandoffManager.IsTransferableRegistration(address, snapshot));
+    }
+
+    [Fact]
+    public void IsTransferableRegistration_AllowsUnknownSiloWithoutNewerMembershipVersion()
+    {
+        var silo = CreateSiloAddress(1);
+        var unrelatedSilo = CreateSiloAddress(1, port: 11112);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
+        var snapshot = CreateSnapshot(new ClusterMember(unrelatedSilo, SiloStatus.Active, "other"), version: 2);
+
+        Assert.True(GrainDirectoryHandoffManager.IsTransferableRegistration(address, snapshot));
+    }
+
+    [Fact]
+    public void IsTransferableRegistration_RejectsUnknownSiloWithOlderMembershipVersion()
+    {
+        var silo = CreateSiloAddress(1);
+        var unrelatedSilo = CreateSiloAddress(1, port: 11112);
+        var address = CreateGrainAddress(silo, membershipVersion: 1);
+        var snapshot = CreateSnapshot(new ClusterMember(unrelatedSilo, SiloStatus.Active, "other"), version: 2);
+
+        Assert.False(GrainDirectoryHandoffManager.IsTransferableRegistration(address, snapshot));
+    }
+
+    [Fact]
+    public void IsTransferableRegistration_RejectsSiloReplacedBySuccessor()
+    {
+        var silo = CreateSiloAddress(1);
+        var successor = CreateSiloAddress(2);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
+        var snapshot = CreateSnapshot(new ClusterMember(successor, SiloStatus.Active, "silo"), version: 2);
+
+        Assert.False(GrainDirectoryHandoffManager.IsTransferableRegistration(address, snapshot));
+    }
+
+    private static ClusterMembershipSnapshot CreateSnapshot(ClusterMember member, long version)
+        => new(ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(member.SiloAddress, member), new MembershipVersion(version));
+
+    private static GrainAddress CreateGrainAddress(SiloAddress siloAddress, long membershipVersion)
+        => new()
+        {
+            GrainId = GrainId.Create("test-grain", Guid.NewGuid().ToString("N")),
+            ActivationId = ActivationId.NewId(),
+            SiloAddress = siloAddress,
+            MembershipVersion = new MembershipVersion(membershipVersion)
+        };
+
+    private static SiloAddress CreateSiloAddress(int generation, int port = 11111)
+        => SiloAddress.New(new IPEndPoint(IPAddress.Loopback, port), generation);
+}

--- a/test/Orleans.Runtime.Internal.Tests/GrainDirectoryPartitionTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/GrainDirectoryPartitionTests.cs
@@ -31,15 +31,16 @@ namespace UnitTests;
 public class GrainDirectoryPartitionTests
 {
     private readonly LocalGrainDirectoryPartition _target;
-    private readonly MockSiloStatusOracle _siloStatusOracle;
-    private static readonly SiloAddress LocalSiloAddress =  SiloAddress.FromParsableString("127.0.0.1:11111@123");
-    private static readonly SiloAddress OtherSiloAddress =  SiloAddress.FromParsableString("127.0.0.2:11111@456");
+    private readonly MockClusterMembershipService _clusterMembershipService;
+    private static readonly SiloAddress LocalSiloAddress = SiloAddress.FromParsableString("127.0.0.1:11111@123");
+    private static readonly SiloAddress OtherSiloAddress = SiloAddress.FromParsableString("127.0.0.2:11111@456");
 
     public GrainDirectoryPartitionTests()
     {
-        _siloStatusOracle = new MockSiloStatusOracle();
+        _clusterMembershipService = new MockClusterMembershipService();
+        _clusterMembershipService.SetSiloStatus(LocalSiloAddress, SiloStatus.Active);
         _target = new LocalGrainDirectoryPartition(
-            _siloStatusOracle,
+            _clusterMembershipService,
             Options.Create(new GrainDirectoryOptions()),
             new LoggerFactory());
     }
@@ -53,7 +54,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void OverrideDeadEntryTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var firstGrainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -62,7 +63,7 @@ public class GrainDirectoryPartitionTests
         var firstRegister = _target.AddSingleActivation(firstGrainAddress, previousAddress: null);
         Assert.Equal(firstGrainAddress, firstRegister.Address);
 
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
 
         // Previous entry is now pointing to a dead silo, it should be possible to override it now
         var secondGrainAddress = GrainAddress.NewActivationAddress(LocalSiloAddress, grainId);
@@ -79,7 +80,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void DoNotInsertInvalidEntryTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var grainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -97,7 +98,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void DoNotOverrideValidEntryTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var grainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -121,7 +122,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void OverrideValidEntryIfMatchesTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var grainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -145,7 +146,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void DoNotOverrideValidEntryIfNoMatchTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var grainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -176,7 +177,7 @@ public class GrainDirectoryPartitionTests
     [Fact]
     public void DoNotReturnInvalidEntryTest()
     {
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Active);
 
         var grainId = GrainId.Create("testGrain", "myKey");
         var grainAddress1 = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
@@ -185,65 +186,54 @@ public class GrainDirectoryPartitionTests
         var register1 = _target.AddSingleActivation(grainAddress1, previousAddress: null);
         Assert.Equal(grainAddress1, register1.Address);
 
-        _siloStatusOracle.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, SiloStatus.Dead);
 
         // Previous entry is no longer still valid, it should not be returned
         var lookup = _target.LookUpActivation(grainId);
         Assert.Null(lookup.Address);
     }
 
-    /// <summary>
-    /// Mock implementation of ISiloStatusOracle for testing.
-    /// The silo status oracle provides membership information about
-    /// which silos are alive, dead, or in other states. The grain
-    /// directory uses this to validate entries and make placement decisions.
-    /// </summary>
-    private class MockSiloStatusOracle : ISiloStatusOracle
+    [Theory]
+    [InlineData(SiloStatus.ShuttingDown)]
+    [InlineData(SiloStatus.Stopping)]
+    public void ReturnEntryForTerminatingButNotDeadSilo(SiloStatus status)
     {
-        private readonly Dictionary<SiloAddress, SiloStatus> _content = new();
+        _clusterMembershipService.SetSiloStatus(OtherSiloAddress, status);
 
-        public MockSiloStatusOracle(SiloAddress siloAddress = null)
+        var grainId = GrainId.Create("testGrain", "myKey");
+        var grainAddress = GrainAddress.NewActivationAddress(OtherSiloAddress, grainId);
+
+        var register = _target.AddSingleActivation(grainAddress, previousAddress: null);
+        Assert.Equal(grainAddress, register.Address);
+
+        var lookup = _target.LookUpActivation(grainId);
+        Assert.Equal(grainAddress, lookup.Address);
+    }
+
+    private sealed class MockClusterMembershipService : IClusterMembershipService
+    {
+        private readonly Dictionary<SiloAddress, (SiloStatus Status, string Name)> _statuses = new();
+        private long _version;
+
+        public ClusterMembershipSnapshot CurrentSnapshot { get; private set; } =
+            new(ImmutableDictionary<SiloAddress, ClusterMember>.Empty, MembershipVersion.MinValue);
+
+        public IAsyncEnumerable<ClusterMembershipSnapshot> MembershipUpdates => throw new NotImplementedException();
+
+        public void SetSiloStatus(SiloAddress siloAddress, SiloStatus status)
         {
-            SiloAddress = siloAddress ?? LocalSiloAddress;
-            _content[SiloAddress] = SiloStatus.Active;
-        }
-
-        public SiloStatus CurrentStatus => SiloStatus.Active;
-
-        public string SiloName => "TestSilo";
-
-        public SiloAddress SiloAddress { get; }
-
-        public SiloStatus GetApproximateSiloStatus(SiloAddress siloAddress)
-        {
-            if (_content.TryGetValue(siloAddress, out var status))
+            _statuses[siloAddress] = (status, "TestSilo");
+            var members = ImmutableDictionary.CreateBuilder<SiloAddress, ClusterMember>();
+            foreach (var (silo, entry) in _statuses)
             {
-                return status;
+                members[silo] = new ClusterMember(silo, entry.Status, entry.Name);
             }
-            return SiloStatus.None;
+
+            CurrentSnapshot = new ClusterMembershipSnapshot(members.ToImmutable(), new MembershipVersion(++_version));
         }
 
-        public Dictionary<SiloAddress, SiloStatus> GetApproximateSiloStatuses(bool onlyActive = false)
-        {
-            return onlyActive
-                ? new Dictionary<SiloAddress, SiloStatus>(_content.Where(kvp => kvp.Value == SiloStatus.Active))
-                : new Dictionary<SiloAddress, SiloStatus>(_content);
-        }
+        public ValueTask Refresh(MembershipVersion minimumVersion = default, CancellationToken cancellationToken = default) => default;
 
-        public ImmutableArray<SiloAddress> GetActiveSilos() => _content.Keys.ToImmutableArray();
-
-        public void SetSiloStatus(SiloAddress siloAddress, SiloStatus status) => _content[siloAddress] = status;
-
-        public bool IsDeadSilo(SiloAddress silo) => GetApproximateSiloStatus(silo) == SiloStatus.Dead;
-
-        public bool IsFunctionalDirectory(SiloAddress siloAddress) => !GetApproximateSiloStatus(siloAddress).IsTerminating();
-
-        #region Not Implemented
-        public bool SubscribeToSiloStatusEvents(ISiloStatusListener observer) => throw new NotImplementedException();
-
-        public bool TryGetSiloName(SiloAddress siloAddress, out string siloName) => throw new NotImplementedException();
-
-        public bool UnSubscribeFromSiloStatusEvents(ISiloStatusListener observer) => throw new NotImplementedException();
-        #endregion
+        public Task<bool> TryKill(SiloAddress siloAddress) => throw new NotImplementedException();
     }
 }

--- a/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
@@ -33,6 +33,16 @@ public class LocalGrainDirectoryTests
     }
 
     [Fact]
+    public void IsDefunctActivation_DoesNotRemoveDeadSiloWithoutNewerMembershipVersion()
+    {
+        var silo = CreateSiloAddress(1);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
+        var snapshot = CreateSnapshot(new ClusterMember(silo, SiloStatus.Dead, "silo"), version: 2);
+
+        Assert.False(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+    }
+
+    [Fact]
     public void IsDefunctActivation_DoesNotRemoveUnknownSiloUntilKnownDead()
     {
         var silo = CreateSiloAddress(1);

--- a/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Immutable;
+using System.Net;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Xunit;
+
+namespace UnitTests;
+
+[TestCategory("BVT"), TestCategory("GrainDirectory")]
+public class LocalGrainDirectoryTests
+{
+    [Theory]
+    [InlineData(SiloStatus.Active)]
+    [InlineData(SiloStatus.ShuttingDown)]
+    [InlineData(SiloStatus.Stopping)]
+    public void IsDefunctActivation_DoesNotRemoveNonDeadSilos(SiloStatus status)
+    {
+        var silo = CreateSiloAddress(1);
+        var address = CreateGrainAddress(silo);
+        var snapshot = CreateSnapshot(new ClusterMember(silo, status, "silo"), version: 2);
+
+        Assert.False(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+    }
+
+    [Fact]
+    public void IsDefunctActivation_RemovesDeadSilos()
+    {
+        var silo = CreateSiloAddress(1);
+        var address = CreateGrainAddress(silo);
+        var snapshot = CreateSnapshot(new ClusterMember(silo, SiloStatus.Dead, "silo"), version: 2);
+
+        Assert.True(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+    }
+
+    [Fact]
+    public void IsDefunctActivation_DoesNotRemoveUnknownSiloUntilKnownDead()
+    {
+        var silo = CreateSiloAddress(1);
+        var unrelatedSilo = CreateSiloAddress(1, port: 11112);
+        var address = CreateGrainAddress(silo, membershipVersion: 1);
+        var snapshot = CreateSnapshot(new ClusterMember(unrelatedSilo, SiloStatus.Active, "other"), version: 2);
+
+        Assert.False(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+    }
+
+    [Fact]
+    public void IsDefunctActivation_RemovesSiloReplacedBySuccessor()
+    {
+        var silo = CreateSiloAddress(1);
+        var successor = CreateSiloAddress(2);
+        var address = CreateGrainAddress(silo, membershipVersion: 1);
+        var snapshot = CreateSnapshot(new ClusterMember(successor, SiloStatus.Active, "silo"), version: 2);
+
+        Assert.True(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+    }
+
+    private static ClusterMembershipSnapshot CreateSnapshot(ClusterMember member, long version)
+        => new(ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(member.SiloAddress, member), new MembershipVersion(version));
+
+    private static GrainAddress CreateGrainAddress(SiloAddress siloAddress, long membershipVersion = 1)
+        => new()
+        {
+            GrainId = GrainId.Create("test-grain", Guid.NewGuid().ToString("N")),
+            ActivationId = ActivationId.NewId(),
+            SiloAddress = siloAddress,
+            MembershipVersion = new MembershipVersion(membershipVersion)
+        };
+
+    private static SiloAddress CreateSiloAddress(int generation, int port = 11111)
+        => SiloAddress.New(new IPEndPoint(IPAddress.Loopback, port), generation);
+}

--- a/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/LocalGrainDirectoryTests.cs
@@ -26,31 +26,32 @@ public class LocalGrainDirectoryTests
     public void IsDefunctActivation_RemovesDeadSilos()
     {
         var silo = CreateSiloAddress(1);
-        var address = CreateGrainAddress(silo);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
         var snapshot = CreateSnapshot(new ClusterMember(silo, SiloStatus.Dead, "silo"), version: 2);
 
         Assert.True(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
     }
 
     [Fact]
-    public void IsDefunctActivation_DoesNotRemoveDeadSiloWithoutNewerMembershipVersion()
+    public void IsDefunctActivation_DoesNotRemoveUnknownSiloWithoutNewerMembershipVersion()
     {
         var silo = CreateSiloAddress(1);
+        var unrelatedSilo = CreateSiloAddress(1, port: 11112);
         var address = CreateGrainAddress(silo, membershipVersion: 2);
-        var snapshot = CreateSnapshot(new ClusterMember(silo, SiloStatus.Dead, "silo"), version: 2);
+        var snapshot = CreateSnapshot(new ClusterMember(unrelatedSilo, SiloStatus.Active, "other"), version: 2);
 
         Assert.False(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
     }
 
     [Fact]
-    public void IsDefunctActivation_DoesNotRemoveUnknownSiloUntilKnownDead()
+    public void IsDefunctActivation_RemovesUnknownSiloWithOlderMembershipVersion()
     {
         var silo = CreateSiloAddress(1);
         var unrelatedSilo = CreateSiloAddress(1, port: 11112);
         var address = CreateGrainAddress(silo, membershipVersion: 1);
         var snapshot = CreateSnapshot(new ClusterMember(unrelatedSilo, SiloStatus.Active, "other"), version: 2);
 
-        Assert.False(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
+        Assert.True(LocalGrainDirectory.IsDefunctActivation(address, snapshot));
     }
 
     [Fact]
@@ -58,7 +59,7 @@ public class LocalGrainDirectoryTests
     {
         var silo = CreateSiloAddress(1);
         var successor = CreateSiloAddress(2);
-        var address = CreateGrainAddress(silo, membershipVersion: 1);
+        var address = CreateGrainAddress(silo, membershipVersion: 2);
         var snapshot = CreateSnapshot(new ClusterMember(successor, SiloStatus.Active, "silo"), version: 2);
 
         Assert.True(LocalGrainDirectory.IsDefunctActivation(address, snapshot));

--- a/test/TestInfrastructure/TestExtensions/XunitLoggerProvider.cs
+++ b/test/TestInfrastructure/TestExtensions/XunitLoggerProvider.cs
@@ -5,6 +5,8 @@ namespace TestExtensions
 {
     public class XunitLoggerProvider : ILoggerProvider
     {
+        private const string NoActiveTestExceptionMessage = "There is no currently active test.";
+
         private readonly ITestOutputHelper output;
 
         public XunitLoggerProvider(ITestOutputHelper output)
@@ -37,7 +39,15 @@ namespace TestExtensions
 
             public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
             {
-                this.output.WriteLine($"{logLevel} [{this.category}.{eventId.Name ?? eventId.Id.ToString()}] {formatter(state, exception)}");
+                var message = $"{logLevel} [{this.category}.{eventId.Name ?? eventId.Id.ToString()}] {formatter(state, exception)}";
+                try
+                {
+                    this.output.WriteLine(message);
+                }
+                catch (InvalidOperationException invalidOperationException) when (invalidOperationException.Message == NoActiveTestExceptionMessage)
+                {
+                    Console.Error.WriteLine(message);
+                }
             }
         }
     }


### PR DESCRIPTION
Part 7 of 7 split from #10085.

Problem:
Some forwarded directory operations inserted the retry delay/recheck on the first forwarded request, unlike single-operation forwarding behavior.

Solution:
Only delay and recheck ownership after a request has already been forwarded once by using the hopCount > 1 guard consistently.

Stack:
Merge after #10091. This branch is stacked on split/pr10085-06-version-aware-status; until earlier PRs merge, GitHub may show earlier stack changes. Incremental compare: https://github.com/ReubenBond/orleans/compare/split/pr10085-06-version-aware-status...split/pr10085-07-hopcount-guard

Review focus:
The hopCount guard on UnregisterManyAsync, LookupAsync, and DeleteGrainAsync forwarding retry paths.