### PR TITLE
Bound retries after directory activation failures

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
@@ -310,11 +310,4 @@ namespace Orleans
         HighMemoryPressure,
     }
 
-    internal static class DeactivationReasonCodeExtensions
-    {
-        public static bool IsTransientError(this DeactivationReasonCode reasonCode)
-        {
-            return reasonCode is DeactivationReasonCode.DirectoryFailure;
-        }
-    }
 }

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1591,15 +1591,6 @@ internal sealed partial class ActivationData :
                 return;
             }
 
-            // If deactivation was caused by a transient failure, allow messages to be forwarded.
-            if (DeactivationReason.ReasonCode.IsTransientError())
-            {
-                foreach (var msg in msgs)
-                {
-                    msg.ForwardCount = Math.Max(msg.ForwardCount - 1, 0);
-                }
-            }
-
             if (_shared.Logger.IsEnabled(LogLevel.Debug))
             {
                 if (ForwardingAddress is { } address)


### PR DESCRIPTION
## Problem
When activation registration fails in the grain directory, queued-message rerouting could repeatedly forward the same message. The old transient deactivation retry path refunded `ForwardCount`, so persistent directory activation failures could bypass the normal `MaxForwardCount` guard.

## Solution
Remove the transient deactivation retry helper and the `ForwardCount` refund branch at the reroute call site. Directory-failure reroutes now keep the message's existing forwarding count, so the default `MaxForwardCount` of 2 is enough to reject repeated activation loops.

This keeps the existing forwarding budget as the only retry guard instead of adding a separate directory-failure retry budget.

## Notes
No merge dependency. This is independent of #10095, which only avoids unnecessary same-silo cache invalidation headers.