### PR TITLE
Remove directory failure forwarding optimization

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -2014,11 +2014,6 @@ internal sealed partial class ActivationData :
                     }
                 }
             }
-            else if (isDirectoryFailure)
-            {
-                // Optimization: forward to the same host to restart activation without needing to invalidate caches.
-                ForwardingAddress ??= Address.SiloAddress;
-            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Problem
When an activation deactivates because of a directory failure, `FinishDeactivating` forced queued requests to be forwarded back to the same silo as an optimization to restart activation without invalidating caches. That can keep requests on the stale-address path and bypass the invalid-activation forwarding behavior which tells callers to evict stale directory entries.

## Solution
Remove that optimization. Directory failures now leave the forwarding address unset, so queued requests use the normal invalid-activation path, including cache invalidation headers, while existing forward-count limits bound retries.

No merge dependency: this can merge independently, and it complements #10094's retry-bound change.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10095)