### PR TITLE
fix(streaming): prevent checkpoint gaps causing replay

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -56,12 +57,13 @@ namespace Orleans.Streaming.EventHubs
         private IStreamQueueCheckpointer<string> checkpointer;
         private AggregatedQueueFlowController flowController;
 
-        // Per-subscription delivery tracking for low-watermark checkpointing.
-        // Tracks the max delivered EventHub offset per (stream, subscription) so we can compute
-        // the partition-wide minimum (safe checkpoint offset). This ensures a fast consumer
-        // on one subscription doesn't advance the checkpoint past a slow consumer on another.
-        private readonly Dictionary<(StreamId StreamId, GuidId SubscriptionId), (long Offset, DateTime LastUpdated)> deliveredOffsets = new();
-        private static readonly TimeSpan DeliveryTrackingExpiry = TimeSpan.FromMinutes(30);
+        // Per-subscription progress tracking for low-watermark checkpointing.
+        // Tracks the max processed EventHub offset per (stream, subscription) so a fast
+        // subscription cannot advance the checkpoint past a slower active subscription.
+        private readonly object deliveryTrackingLock = new();
+        private readonly Dictionary<(StreamId StreamId, GuidId SubscriptionId), long?> processedOffsets = new();
+        private readonly HashSet<StreamId> pendingRegistrations = new();
+        private long? cachePurgeOffset;
 
         // Receiver life cycle
         private int receiverState = ReceiverShutdown;
@@ -120,7 +122,7 @@ namespace Orleans.Streaming.EventHubs
                     this.cache.Dispose();
                     this.cache = null;
                 }
-                this.cache = this.cacheFactory(this.settings.Partition, this.checkpointer, this.loggerFactory);
+                this.cache = this.cacheFactory(this.settings.Partition, new CachePurgeCheckpointer(this), this.loggerFactory);
                 this.flowController = new AggregatedQueueFlowController(MaxMessagesPerRead) { this.cache, LoadShedQueueFlowController.CreateAsPercentOfLoadSheddingLimit(this.loadSheddingOptions, environmentStatisticsProvider) };
                 string offset = await this.checkpointer.Load();
                 this.receiver = this.eventHubReceiverFactory(this.settings, offset, this.logger);
@@ -208,25 +210,6 @@ namespace Orleans.Streaming.EventHubs
             if (!this.IsUnderPressure())
                 this.cache.SignalPurge();
 
-            // Clean up stale delivery tracking entries for subscriptions that are no longer active.
-            var now = DateTime.UtcNow;
-            List<(StreamId, GuidId)> staleKeys = null;
-            foreach (var kvp in deliveredOffsets)
-            {
-                if (now - kvp.Value.LastUpdated > DeliveryTrackingExpiry)
-                {
-                    staleKeys ??= new();
-                    staleKeys.Add(kvp.Key);
-                }
-            }
-            if (staleKeys is not null)
-            {
-                foreach (var key in staleKeys)
-                {
-                    deliveredOffsets.Remove(key);
-                }
-            }
-
             return false;
         }
 
@@ -245,40 +228,146 @@ namespace Orleans.Streaming.EventHubs
             return Task.CompletedTask;
         }
 
-        public void NotifyBatchDelivered(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token)
+        public void NotifyStreamRegistrationStarted(StreamId streamId)
         {
-            if (this.checkpointer == null || token is not IEventHubPartitionLocation location)
+            lock (deliveryTrackingLock)
             {
-                return;
+                pendingRegistrations.Add(streamId);
+            }
+        }
+
+        public void NotifyStreamRegistrationCompleted(StreamId streamId)
+        {
+            string checkpointOffset;
+            lock (deliveryTrackingLock)
+            {
+                pendingRegistrations.Remove(streamId);
+                checkpointOffset = GetCheckpointOffset();
             }
 
-            if (!long.TryParse(location.EventHubOffset, out var offset))
-            {
-                return;
-            }
+            UpdateCheckpoint(checkpointOffset, DateTime.UtcNow);
+        }
 
-            // Track the max delivered offset per (stream, subscription).
+        public void NotifySubscriptionAdded(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token)
+        {
+            var hasStartOffset = TryGetOffset(token, out var startOffset);
+            string checkpointOffset;
             var key = (streamId, subscriptionId);
-            if (!deliveredOffsets.TryGetValue(key, out var entry) || offset > entry.Offset)
+            lock (deliveryTrackingLock)
             {
-                deliveredOffsets[key] = (offset, DateTime.UtcNow);
-            }
-
-            // Compute the partition-wide low watermark: the minimum across all subscriptions.
-            // The checkpoint only advances when ALL tracked subscriptions have delivered past it.
-            long watermark = long.MaxValue;
-            foreach (var kvp in deliveredOffsets)
-            {
-                if (kvp.Value.Offset < watermark)
+                if (!processedOffsets.TryGetValue(key, out var offset)
+                    || (hasStartOffset && (!offset.HasValue || startOffset < offset.Value)))
                 {
-                    watermark = kvp.Value.Offset;
+                    processedOffsets[key] = hasStartOffset ? startOffset : null;
                 }
+
+                checkpointOffset = GetCheckpointOffset();
             }
 
-            if (watermark != long.MaxValue)
+            UpdateCheckpoint(checkpointOffset, DateTime.UtcNow);
+        }
+
+        public void NotifySubscriptionRemoved(StreamId streamId, GuidId subscriptionId)
+        {
+            string checkpointOffset;
+            lock (deliveryTrackingLock)
             {
-                this.checkpointer.Update(watermark.ToString(), DateTime.UtcNow);
+                processedOffsets.Remove((streamId, subscriptionId));
+                checkpointOffset = GetCheckpointOffset();
             }
+
+            UpdateCheckpoint(checkpointOffset, DateTime.UtcNow);
+        }
+
+        public void NotifyBatchProcessed(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token)
+        {
+            if (!TryGetOffset(token, out var offset))
+            {
+                return;
+            }
+
+            string checkpointOffset;
+            var key = (streamId, subscriptionId);
+            lock (deliveryTrackingLock)
+            {
+                if (!processedOffsets.TryGetValue(key, out var currentOffset)
+                    || !currentOffset.HasValue
+                    || offset > currentOffset.Value)
+                {
+                    processedOffsets[key] = offset;
+                }
+
+                checkpointOffset = GetCheckpointOffset();
+            }
+
+            UpdateCheckpoint(checkpointOffset, DateTime.UtcNow);
+        }
+
+        private void NotifyCachePurged(string offset, DateTime utcNow)
+        {
+            if (!long.TryParse(offset, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedOffset))
+            {
+                return;
+            }
+
+            string checkpointOffset;
+            lock (deliveryTrackingLock)
+            {
+                if (!cachePurgeOffset.HasValue || parsedOffset > cachePurgeOffset.Value)
+                {
+                    cachePurgeOffset = parsedOffset;
+                }
+
+                checkpointOffset = GetCheckpointOffset();
+            }
+
+            UpdateCheckpoint(checkpointOffset, utcNow);
+        }
+
+        private string GetCheckpointOffset()
+        {
+            if (pendingRegistrations.Count > 0)
+            {
+                return null;
+            }
+
+            if (processedOffsets.Count == 0)
+            {
+                return cachePurgeOffset?.ToString(CultureInfo.InvariantCulture);
+            }
+
+            long watermark = long.MaxValue;
+            foreach (var offset in processedOffsets.Values)
+            {
+                if (!offset.HasValue)
+                {
+                    return null;
+                }
+
+                watermark = Math.Min(watermark, offset.Value);
+            }
+
+            return watermark == long.MaxValue ? null : watermark.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private void UpdateCheckpoint(string offset, DateTime utcNow)
+        {
+            if (offset is not null)
+            {
+                this.checkpointer?.Update(offset, utcNow);
+            }
+        }
+
+        private static bool TryGetOffset(StreamSequenceToken token, out long offset)
+        {
+            if (token is IEventHubPartitionLocation location
+                && long.TryParse(location.EventHubOffset, NumberStyles.Integer, CultureInfo.InvariantCulture, out offset))
+            {
+                return true;
+            }
+
+            offset = 0;
+            return false;
         }
 
         public async Task Shutdown(TimeSpan timeout)
@@ -331,6 +420,26 @@ namespace Orleans.Streaming.EventHubs
         private static IEventHubReceiver CreateReceiver(EventHubPartitionSettings partitionSettings, string offset, ILogger logger)
         {
             return new EventHubReceiverProxy(partitionSettings, offset, logger);
+        }
+
+        private sealed class CachePurgeCheckpointer(EventHubAdapterReceiver receiver) : IStreamQueueCheckpointer<string>
+        {
+            public bool CheckpointExists => receiver.checkpointer?.CheckpointExists ?? false;
+
+            public Task<string> Load()
+            {
+                return receiver.checkpointer?.Load() ?? Task.FromResult(EventHubConstants.StartOfStream);
+            }
+
+            public void Update(string offset, DateTime utcNow)
+            {
+                receiver.NotifyCachePurged(offset, utcNow);
+            }
+
+            public Task FlushAsync()
+            {
+                return receiver.checkpointer?.FlushAsync() ?? Task.CompletedTask;
+            }
         }
 
         /// <summary>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -56,6 +56,13 @@ namespace Orleans.Streaming.EventHubs
         private IStreamQueueCheckpointer<string> checkpointer;
         private AggregatedQueueFlowController flowController;
 
+        // Per-subscription delivery tracking for low-watermark checkpointing.
+        // Tracks the max delivered EventHub offset per (stream, subscription) so we can compute
+        // the partition-wide minimum (safe checkpoint offset). This ensures a fast consumer
+        // on one subscription doesn't advance the checkpoint past a slow consumer on another.
+        private readonly Dictionary<(StreamId StreamId, GuidId SubscriptionId), (long Offset, DateTime LastUpdated)> deliveredOffsets = new();
+        private static readonly TimeSpan DeliveryTrackingExpiry = TimeSpan.FromMinutes(30);
+
         // Receiver life cycle
         private int receiverState = ReceiverShutdown;
 
@@ -184,12 +191,6 @@ namespace Orleans.Streaming.EventHubs
             {
                 batches.Add(new StreamActivityNotificationBatch(streamPosition));
             }
-            if (!this.checkpointer.CheckpointExists)
-            {
-                this.checkpointer.Update(
-                    messages[0].OffsetString,
-                    DateTime.UtcNow);
-            }
             return batches;
         }
 
@@ -206,6 +207,26 @@ namespace Orleans.Streaming.EventHubs
             //if under pressure, which means consuming speed is less than producing speed, then shouldn't purge, and don't read more message into the cache
             if (!this.IsUnderPressure())
                 this.cache.SignalPurge();
+
+            // Clean up stale delivery tracking entries for subscriptions that are no longer active.
+            var now = DateTime.UtcNow;
+            List<(StreamId, GuidId)> staleKeys = null;
+            foreach (var kvp in deliveredOffsets)
+            {
+                if (now - kvp.Value.LastUpdated > DeliveryTrackingExpiry)
+                {
+                    staleKeys ??= new();
+                    staleKeys.Add(kvp.Key);
+                }
+            }
+            if (staleKeys is not null)
+            {
+                foreach (var key in staleKeys)
+                {
+                    deliveredOffsets.Remove(key);
+                }
+            }
+
             return false;
         }
 
@@ -224,6 +245,42 @@ namespace Orleans.Streaming.EventHubs
             return Task.CompletedTask;
         }
 
+        public void NotifyBatchDelivered(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token)
+        {
+            if (this.checkpointer == null || token is not IEventHubPartitionLocation location)
+            {
+                return;
+            }
+
+            if (!long.TryParse(location.EventHubOffset, out var offset))
+            {
+                return;
+            }
+
+            // Track the max delivered offset per (stream, subscription).
+            var key = (streamId, subscriptionId);
+            if (!deliveredOffsets.TryGetValue(key, out var entry) || offset > entry.Offset)
+            {
+                deliveredOffsets[key] = (offset, DateTime.UtcNow);
+            }
+
+            // Compute the partition-wide low watermark: the minimum across all subscriptions.
+            // The checkpoint only advances when ALL tracked subscriptions have delivered past it.
+            long watermark = long.MaxValue;
+            foreach (var kvp in deliveredOffsets)
+            {
+                if (kvp.Value.Offset < watermark)
+                {
+                    watermark = kvp.Value.Offset;
+                }
+            }
+
+            if (watermark != long.MaxValue)
+            {
+                this.checkpointer.Update(watermark.ToString(), DateTime.UtcNow);
+            }
+        }
+
         public async Task Shutdown(TimeSpan timeout)
         {
             var watch = Stopwatch.StartNew();
@@ -236,6 +293,13 @@ namespace Orleans.Streaming.EventHubs
                 }
 
                 LogInfoStoppingReadingFromEventHubPartition(this.settings.Hub.EventHubName, this.settings.Partition);
+
+                // Flush the checkpoint before disposing the cache or closing the receiver,
+                // so the latest processed offset is persisted and not replayed on restart.
+                if (this.checkpointer != null)
+                {
+                    await this.checkpointer.FlushAsync();
+                }
 
                 // clear cache and receiver
                 IEventHubQueueCache localCache = Interlocked.Exchange(ref this.cache, null);

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -289,12 +290,21 @@ namespace Orleans.Streaming.EventHubs
 
                 LogInfoStoppingReadingFromEventHubPartition(this.settings.Hub.EventHubName, this.settings.Partition);
 
-                // Flush the checkpoint before disposing the cache or closing the receiver,
-                // so the latest processed offset is persisted and not replayed on restart.
-                if (this.checkpointer != null)
+                var shutdownExceptions = new List<Exception>();
+
+                try
                 {
-                    using var flushCancellation = timeout == Timeout.InfiniteTimeSpan ? null : new CancellationTokenSource(timeout);
-                    await this.checkpointer.FlushAsync(flushCancellation?.Token ?? CancellationToken.None);
+                    // Flush the checkpoint before disposing the cache or closing the receiver,
+                    // so the latest processed offset is persisted and not replayed on restart.
+                    if (this.checkpointer != null)
+                    {
+                        using var flushCancellation = timeout == Timeout.InfiniteTimeSpan ? null : new CancellationTokenSource(timeout);
+                        await this.checkpointer.FlushAsync(flushCancellation?.Token ?? CancellationToken.None);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    shutdownExceptions.Add(ex);
                 }
 
                 // clear cache and receiver
@@ -304,15 +314,40 @@ namespace Orleans.Streaming.EventHubs
 
                 // start closing receiver
                 Task closeTask = Task.CompletedTask;
-                if (localReceiver != null)
+                try
                 {
-                    closeTask = localReceiver.CloseAsync();
+                    if (localReceiver != null)
+                    {
+                        closeTask = localReceiver.CloseAsync();
+                    }
                 }
+                catch (Exception ex)
+                {
+                    shutdownExceptions.Add(ex);
+                }
+
                 // dispose of cache
-                localCache?.Dispose();
+                try
+                {
+                    localCache?.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    shutdownExceptions.Add(ex);
+                }
 
                 // finish return receiver closing task
-                await closeTask;
+                try
+                {
+                    await closeTask;
+                }
+                catch (Exception ex)
+                {
+                    shutdownExceptions.Add(ex);
+                }
+
+                ThrowIfAny(shutdownExceptions);
+
                 watch.Stop();
                 this.monitor?.TrackShutdown(true, watch.Elapsed, null);
             }
@@ -321,6 +356,19 @@ namespace Orleans.Streaming.EventHubs
                 watch.Stop();
                 this.monitor?.TrackShutdown(false, watch.Elapsed, ex);
                 throw;
+            }
+
+            static void ThrowIfAny(List<Exception> exceptions)
+            {
+                if (exceptions.Count == 1)
+                {
+                    ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+                }
+
+                if (exceptions.Count > 1)
+                {
+                    throw new AggregateException(exceptions);
+                }
             }
         }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -221,44 +221,13 @@ namespace Orleans.Streaming.EventHubs
             return Task.CompletedTask;
         }
 
-        public bool IsUpdateDue(DateTime utcNow)
-        {
-            return this.checkpointer?.IsUpdateDue(utcNow) ?? false;
-        }
-
         public void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken, DateTime utcNow)
         {
-            string checkpointOffset;
-            if (earliestSubscriptionToken is null)
+            if (earliestSubscriptionToken is IEventHubPartitionLocation location
+                && long.TryParse(location.EventHubOffset, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
             {
-                return;
+                this.checkpointer?.Update(location.EventHubOffset, utcNow);
             }
-            else
-            {
-                if (!TryGetOffset(earliestSubscriptionToken, out var offset))
-                {
-                    return;
-                }
-
-                checkpointOffset = offset.ToString(CultureInfo.InvariantCulture);
-            }
-
-            if (checkpointOffset is not null)
-            {
-                this.checkpointer?.Update(checkpointOffset, utcNow);
-            }
-        }
-
-        private static bool TryGetOffset(StreamSequenceToken token, out long offset)
-        {
-            if (token is IEventHubPartitionLocation location
-                && long.TryParse(location.EventHubOffset, NumberStyles.Integer, CultureInfo.InvariantCulture, out offset))
-            {
-                return true;
-            }
-
-            offset = 0;
-            return false;
         }
 
         public async Task Shutdown(TimeSpan timeout)

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -224,27 +224,12 @@ namespace Orleans.Streaming.EventHubs
             return Task.CompletedTask;
         }
 
-        public void UpdateDeliveryProgress(TryGetDeliveryProgress tryGetDeliveryProgress, bool force)
+        public bool IsUpdateDue(DateTime utcNow)
         {
-            ArgumentNullException.ThrowIfNull(tryGetDeliveryProgress);
-
-            var utcNow = DateTime.UtcNow;
-            if (!force
-                && this.checkpointer is { } checkpointer
-                && !checkpointer.IsUpdateDue(utcNow))
-            {
-                return;
-            }
-
-            if (!tryGetDeliveryProgress(out var earliestSubscriptionToken))
-            {
-                return;
-            }
-
-            UpdateDeliveryProgress(earliestSubscriptionToken, utcNow);
+            return this.checkpointer?.IsUpdateDue(utcNow) ?? false;
         }
 
-        private void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken, DateTime utcNow)
+        public void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken, DateTime utcNow)
         {
             string checkpointOffset;
             if (earliestSubscriptionToken is null)

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -224,7 +224,27 @@ namespace Orleans.Streaming.EventHubs
             return Task.CompletedTask;
         }
 
-        public void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken)
+        public void UpdateDeliveryProgress(TryGetDeliveryProgress tryGetDeliveryProgress, bool force)
+        {
+            ArgumentNullException.ThrowIfNull(tryGetDeliveryProgress);
+
+            var utcNow = DateTime.UtcNow;
+            if (!force
+                && this.checkpointer is IEventHubCheckpointerUpdateCadence updateCadence
+                && !updateCadence.IsUpdateDue(utcNow))
+            {
+                return;
+            }
+
+            if (!tryGetDeliveryProgress(out var earliestSubscriptionToken))
+            {
+                return;
+            }
+
+            UpdateDeliveryProgress(earliestSubscriptionToken, utcNow);
+        }
+
+        private void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken, DateTime utcNow)
         {
             string checkpointOffset;
             if (earliestSubscriptionToken is null)
@@ -244,7 +264,7 @@ namespace Orleans.Streaming.EventHubs
 
             if (checkpointOffset is not null)
             {
-                this.checkpointer?.Update(checkpointOffset, DateTime.UtcNow);
+                this.checkpointer?.Update(checkpointOffset, utcNow);
             }
         }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -230,8 +230,8 @@ namespace Orleans.Streaming.EventHubs
 
             var utcNow = DateTime.UtcNow;
             if (!force
-                && this.checkpointer is IEventHubCheckpointerUpdateCadence updateCadence
-                && !updateCadence.IsUpdateDue(utcNow))
+                && this.checkpointer is { } checkpointer
+                && !checkpointer.IsUpdateDue(utcNow))
             {
                 return;
             }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -58,10 +58,6 @@ namespace Orleans.Streaming.EventHubs
         private IStreamQueueCheckpointer<string> checkpointer;
         private AggregatedQueueFlowController flowController;
 
-        // Tracks the purge offset reported by the cache eviction strategy.
-        // Used as a fallback checkpoint when no active subscriptions exist.
-        private long? cachePurgeOffset;
-
         // Receiver life cycle
         private int receiverState = ReceiverShutdown;
 
@@ -119,7 +115,7 @@ namespace Orleans.Streaming.EventHubs
                     this.cache.Dispose();
                     this.cache = null;
                 }
-                this.cache = this.cacheFactory(this.settings.Partition, new CachePurgeCheckpointer(this), this.loggerFactory);
+                this.cache = this.cacheFactory(this.settings.Partition, this.checkpointer, this.loggerFactory);
                 this.flowController = new AggregatedQueueFlowController(MaxMessagesPerRead) { this.cache, LoadShedQueueFlowController.CreateAsPercentOfLoadSheddingLimit(this.loadSheddingOptions, environmentStatisticsProvider) };
                 string offset = await this.checkpointer.Load();
                 this.receiver = this.eventHubReceiverFactory(this.settings, offset, this.logger);
@@ -235,8 +231,7 @@ namespace Orleans.Streaming.EventHubs
             string checkpointOffset;
             if (earliestSubscriptionToken is null)
             {
-                // No active subscriptions — fall back to the cache purge offset.
-                checkpointOffset = cachePurgeOffset?.ToString(CultureInfo.InvariantCulture);
+                return;
             }
             else
             {
@@ -251,17 +246,6 @@ namespace Orleans.Streaming.EventHubs
             if (checkpointOffset is not null)
             {
                 this.checkpointer?.Update(checkpointOffset, utcNow);
-            }
-        }
-
-        private void NotifyCachePurged(string offset)
-        {
-            if (long.TryParse(offset, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedOffset))
-            {
-                if (!cachePurgeOffset.HasValue || parsedOffset > cachePurgeOffset.Value)
-                {
-                    cachePurgeOffset = parsedOffset;
-                }
             }
         }
 
@@ -375,28 +359,6 @@ namespace Orleans.Streaming.EventHubs
         private static IEventHubReceiver CreateReceiver(EventHubPartitionSettings partitionSettings, string offset, ILogger logger)
         {
             return new EventHubReceiverProxy(partitionSettings, offset, logger);
-        }
-
-        private sealed class CachePurgeCheckpointer(EventHubAdapterReceiver receiver) : IStreamQueueCheckpointer<string>
-        {
-            public bool CheckpointExists => receiver.checkpointer?.CheckpointExists ?? false;
-
-            public Task<string> Load()
-            {
-                return receiver.checkpointer?.Load() ?? Task.FromResult(EventHubConstants.StartOfStream);
-            }
-
-            public void Update(string offset, DateTime utcNow)
-            {
-                // Only track the purge offset — do not checkpoint directly.
-                // UpdateDeliveryProgress uses this as a fallback when no subscriptions exist.
-                receiver.NotifyCachePurged(offset);
-            }
-
-            public Task FlushAsync(CancellationToken cancellationToken)
-            {
-                return receiver.checkpointer?.FlushAsync(cancellationToken) ?? Task.CompletedTask;
-            }
         }
 
         /// <summary>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -288,7 +288,8 @@ namespace Orleans.Streaming.EventHubs
                 // so the latest processed offset is persisted and not replayed on restart.
                 if (this.checkpointer != null)
                 {
-                    await this.checkpointer.FlushAsync();
+                    using var flushCancellation = timeout == Timeout.InfiniteTimeSpan ? null : new CancellationTokenSource(timeout);
+                    await this.checkpointer.FlushAsync(flushCancellation?.Token ?? CancellationToken.None);
                 }
 
                 // clear cache and receiver
@@ -339,9 +340,9 @@ namespace Orleans.Streaming.EventHubs
                 receiver.NotifyCachePurged(offset);
             }
 
-            public Task FlushAsync()
+            public Task FlushAsync(CancellationToken cancellationToken)
             {
-                return receiver.checkpointer?.FlushAsync() ?? Task.CompletedTask;
+                return receiver.checkpointer?.FlushAsync(cancellationToken) ?? Task.CompletedTask;
             }
         }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -57,12 +57,8 @@ namespace Orleans.Streaming.EventHubs
         private IStreamQueueCheckpointer<string> checkpointer;
         private AggregatedQueueFlowController flowController;
 
-        // Per-subscription progress tracking for low-watermark checkpointing.
-        // Tracks the max processed EventHub offset per (stream, subscription) so a fast
-        // subscription cannot advance the checkpoint past a slower active subscription.
-        private readonly object deliveryTrackingLock = new();
-        private readonly Dictionary<(StreamId StreamId, GuidId SubscriptionId), long?> processedOffsets = new();
-        private readonly HashSet<StreamId> pendingRegistrations = new();
+        // Tracks the purge offset reported by the cache eviction strategy.
+        // Used as a fallback checkpoint when no active subscriptions exist.
         private long? cachePurgeOffset;
 
         // Receiver life cycle
@@ -228,133 +224,50 @@ namespace Orleans.Streaming.EventHubs
             return Task.CompletedTask;
         }
 
-        public void NotifyStreamRegistrationStarted(StreamId streamId)
+        public void UpdateDeliveryProgress(IReadOnlyList<StreamSequenceToken> subscriptionTokens, bool hasPendingRegistrations)
         {
-            lock (deliveryTrackingLock)
-            {
-                pendingRegistrations.Add(streamId);
-            }
-        }
-
-        public void NotifyStreamRegistrationCompleted(StreamId streamId)
-        {
-            string checkpointOffset;
-            lock (deliveryTrackingLock)
-            {
-                pendingRegistrations.Remove(streamId);
-                checkpointOffset = GetCheckpointOffset();
-            }
-
-            UpdateCheckpoint(checkpointOffset, DateTime.UtcNow);
-        }
-
-        public void NotifySubscriptionAdded(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token)
-        {
-            var hasStartOffset = TryGetOffset(token, out var startOffset);
-            string checkpointOffset;
-            var key = (streamId, subscriptionId);
-            lock (deliveryTrackingLock)
-            {
-                if (!processedOffsets.TryGetValue(key, out var offset)
-                    || (hasStartOffset && (!offset.HasValue || startOffset < offset.Value)))
-                {
-                    processedOffsets[key] = hasStartOffset ? startOffset : null;
-                }
-
-                checkpointOffset = GetCheckpointOffset();
-            }
-
-            UpdateCheckpoint(checkpointOffset, DateTime.UtcNow);
-        }
-
-        public void NotifySubscriptionRemoved(StreamId streamId, GuidId subscriptionId)
-        {
-            string checkpointOffset;
-            lock (deliveryTrackingLock)
-            {
-                processedOffsets.Remove((streamId, subscriptionId));
-                checkpointOffset = GetCheckpointOffset();
-            }
-
-            UpdateCheckpoint(checkpointOffset, DateTime.UtcNow);
-        }
-
-        public void NotifyBatchProcessed(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token)
-        {
-            if (!TryGetOffset(token, out var offset))
+            if (hasPendingRegistrations)
             {
                 return;
             }
 
             string checkpointOffset;
-            var key = (streamId, subscriptionId);
-            lock (deliveryTrackingLock)
+            if (subscriptionTokens.Count == 0)
             {
-                if (!processedOffsets.TryGetValue(key, out var currentOffset)
-                    || !currentOffset.HasValue
-                    || offset > currentOffset.Value)
+                // No active subscriptions — fall back to the cache purge offset.
+                checkpointOffset = cachePurgeOffset?.ToString(CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                long watermark = long.MaxValue;
+                foreach (var token in subscriptionTokens)
                 {
-                    processedOffsets[key] = offset;
+                    if (!TryGetOffset(token, out var offset))
+                    {
+                        // A subscription has unknown progress — don't advance the checkpoint.
+                        return;
+                    }
+
+                    watermark = Math.Min(watermark, offset);
                 }
 
-                checkpointOffset = GetCheckpointOffset();
+                checkpointOffset = watermark == long.MaxValue ? null : watermark.ToString(CultureInfo.InvariantCulture);
             }
 
-            UpdateCheckpoint(checkpointOffset, DateTime.UtcNow);
+            if (checkpointOffset is not null)
+            {
+                this.checkpointer?.Update(checkpointOffset, DateTime.UtcNow);
+            }
         }
 
-        private void NotifyCachePurged(string offset, DateTime utcNow)
+        private void NotifyCachePurged(string offset)
         {
-            if (!long.TryParse(offset, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedOffset))
-            {
-                return;
-            }
-
-            string checkpointOffset;
-            lock (deliveryTrackingLock)
+            if (long.TryParse(offset, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedOffset))
             {
                 if (!cachePurgeOffset.HasValue || parsedOffset > cachePurgeOffset.Value)
                 {
                     cachePurgeOffset = parsedOffset;
                 }
-
-                checkpointOffset = GetCheckpointOffset();
-            }
-
-            UpdateCheckpoint(checkpointOffset, utcNow);
-        }
-
-        private string GetCheckpointOffset()
-        {
-            if (pendingRegistrations.Count > 0)
-            {
-                return null;
-            }
-
-            if (processedOffsets.Count == 0)
-            {
-                return cachePurgeOffset?.ToString(CultureInfo.InvariantCulture);
-            }
-
-            long watermark = long.MaxValue;
-            foreach (var offset in processedOffsets.Values)
-            {
-                if (!offset.HasValue)
-                {
-                    return null;
-                }
-
-                watermark = Math.Min(watermark, offset.Value);
-            }
-
-            return watermark == long.MaxValue ? null : watermark.ToString(CultureInfo.InvariantCulture);
-        }
-
-        private void UpdateCheckpoint(string offset, DateTime utcNow)
-        {
-            if (offset is not null)
-            {
-                this.checkpointer?.Update(offset, utcNow);
             }
         }
 
@@ -433,7 +346,9 @@ namespace Orleans.Streaming.EventHubs
 
             public void Update(string offset, DateTime utcNow)
             {
-                receiver.NotifyCachePurged(offset, utcNow);
+                // Only track the purge offset — do not checkpoint directly.
+                // UpdateDeliveryProgress uses this as a fallback when no subscriptions exist.
+                receiver.NotifyCachePurged(offset);
             }
 
             public Task FlushAsync()

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -224,13 +224,8 @@ namespace Orleans.Streaming.EventHubs
             return Task.CompletedTask;
         }
 
-        public void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken, bool hasPendingRegistrations)
+        public void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken)
         {
-            if (hasPendingRegistrations)
-            {
-                return;
-            }
-
             string checkpointOffset;
             if (earliestSubscriptionToken is null)
             {

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -224,7 +224,7 @@ namespace Orleans.Streaming.EventHubs
             return Task.CompletedTask;
         }
 
-        public void UpdateDeliveryProgress(IReadOnlyList<StreamSequenceToken> subscriptionTokens, bool hasPendingRegistrations)
+        public void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken, bool hasPendingRegistrations)
         {
             if (hasPendingRegistrations)
             {
@@ -232,26 +232,19 @@ namespace Orleans.Streaming.EventHubs
             }
 
             string checkpointOffset;
-            if (subscriptionTokens.Count == 0)
+            if (earliestSubscriptionToken is null)
             {
                 // No active subscriptions — fall back to the cache purge offset.
                 checkpointOffset = cachePurgeOffset?.ToString(CultureInfo.InvariantCulture);
             }
             else
             {
-                long watermark = long.MaxValue;
-                foreach (var token in subscriptionTokens)
+                if (!TryGetOffset(earliestSubscriptionToken, out var offset))
                 {
-                    if (!TryGetOffset(token, out var offset))
-                    {
-                        // A subscription has unknown progress — don't advance the checkpoint.
-                        return;
-                    }
-
-                    watermark = Math.Min(watermark, offset);
+                    return;
                 }
 
-                checkpointOffset = watermark == long.MaxValue ? null : watermark.ToString(CultureInfo.InvariantCulture);
+                checkpointOffset = offset.ToString(CultureInfo.InvariantCulture);
             }
 
             if (checkpointOffset is not null)

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Streams;
@@ -131,28 +132,38 @@ namespace Orleans.Streaming.EventHubs
                 return;
             }
 
-            // Only move the in-memory offset forward (Event Hub offsets are numeric strings).
-            // This prevents a purge-based checkpoint from regressing past a read-based checkpoint.
-            if (long.TryParse(offset, out var newOffset)
-                && long.TryParse(latestOffset, out var currentOffset)
-                && newOffset <= currentOffset)
-            {
-                return;
-            }
+            var mustSaveNow = IsBefore(offset, entity.Offset);
 
             // Always track the latest offset in memory so FlushAsync can persist it.
             latestOffset = offset;
 
-            // if we've saved before but it's not time for another save or the last save operation has not completed, do nothing
-            if (throttleSavesUntilUtc.HasValue && (throttleSavesUntilUtc.Value > utcNow || !inProgressSave.IsCompleted))
+            // If we've saved before but it's not time for another save or the last save operation has not completed,
+            // do nothing unless this update lowers the checkpoint to protect a slower subscription.
+            if (!mustSaveNow && throttleSavesUntilUtc.HasValue && (throttleSavesUntilUtc.Value > utcNow || !inProgressSave.IsCompleted))
             {
                 return;
             }
 
-            entity.Offset = offset;
             throttleSavesUntilUtc = utcNow + persistInterval;
-            inProgressSave = dataManager.UpsertTableEntryAsync(entity);
+            if (inProgressSave.IsCompleted)
+            {
+                entity.Offset = latestOffset;
+                inProgressSave = dataManager.UpsertTableEntryAsync(entity);
+            }
+            else
+            {
+                var previousSave = inProgressSave;
+                inProgressSave = SaveLatestAfter(previousSave);
+            }
+
             inProgressSave.Ignore();
+        }
+
+        private async Task SaveLatestAfter(Task previousSave)
+        {
+            await previousSave;
+            entity.Offset = latestOffset;
+            await dataManager.UpsertTableEntryAsync(entity);
         }
 
         /// <summary>
@@ -168,6 +179,13 @@ namespace Orleans.Streaming.EventHubs
                 inProgressSave = dataManager.UpsertTableEntryAsync(entity);
                 await inProgressSave;
             }
+        }
+
+        private static bool IsBefore(string offset, string currentOffset)
+        {
+            return long.TryParse(offset, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedOffset)
+                && long.TryParse(currentOffset, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedCurrentOffset)
+                && parsedOffset < parsedCurrentOffset;
         }
 
         [LoggerMessage(

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -48,8 +48,9 @@ namespace Orleans.Streaming.EventHubs
         private readonly ILogger logger;
 
         private EventHubPartitionCheckpointEntity entity;
-        private Task inProgressSave;
+        private Task inProgressSave = Task.CompletedTask;
         private DateTime? throttleSavesUntilUtc;
+        private string latestOffset;
 
         /// <summary>
         /// Indicates if a checkpoint exists
@@ -112,21 +113,35 @@ namespace Orleans.Streaming.EventHubs
                 entity = results.Entity;
             }
 
+            latestOffset = entity.Offset;
             return entity.Offset;
         }
 
         /// <summary>
         /// Updates the checkpoint.  This is a best effort.  It does not always update the checkpoint.
+        /// The latest offset is always tracked in memory so that <see cref="FlushAsync"/> can persist it on shutdown.
         /// </summary>
         /// <param name="offset"></param>
         /// <param name="utcNow"></param>
         public void Update(string offset, DateTime utcNow)
         {
             // if offset has not changed, do nothing
-            if (string.Compare(entity.Offset, offset, StringComparison.Ordinal) == 0)
+            if (string.Compare(latestOffset, offset, StringComparison.Ordinal) == 0)
             {
                 return;
             }
+
+            // Only move the in-memory offset forward (Event Hub offsets are numeric strings).
+            // This prevents a purge-based checkpoint from regressing past a read-based checkpoint.
+            if (long.TryParse(offset, out var newOffset)
+                && long.TryParse(latestOffset, out var currentOffset)
+                && newOffset <= currentOffset)
+            {
+                return;
+            }
+
+            // Always track the latest offset in memory so FlushAsync can persist it.
+            latestOffset = offset;
 
             // if we've saved before but it's not time for another save or the last save operation has not completed, do nothing
             if (throttleSavesUntilUtc.HasValue && (throttleSavesUntilUtc.Value > utcNow || !inProgressSave.IsCompleted))
@@ -138,6 +153,21 @@ namespace Orleans.Streaming.EventHubs
             throttleSavesUntilUtc = utcNow + persistInterval;
             inProgressSave = dataManager.UpsertTableEntryAsync(entity);
             inProgressSave.Ignore();
+        }
+
+        /// <summary>
+        /// Flushes any pending checkpoint to persistent storage.
+        /// Awaits any in-progress save, then persists the latest offset if it has advanced beyond the last saved value.
+        /// </summary>
+        public async Task FlushAsync()
+        {
+            await inProgressSave;
+            if (string.Compare(entity.Offset, latestOffset, StringComparison.Ordinal) != 0)
+            {
+                entity.Offset = latestOffset;
+                inProgressSave = dataManager.UpsertTableEntryAsync(entity);
+                await inProgressSave;
+            }
         }
 
         [LoggerMessage(

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -133,7 +133,6 @@ namespace Orleans.Streaming.EventHubs
             // the current checkpoint, keep the checkpoint at the latest safe offset.
             if (!IsAfter(offset, latestOffset))
             {
-                throttleSavesUntilUtc = utcNow + persistInterval;
                 return;
             }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -133,9 +133,13 @@ namespace Orleans.Streaming.EventHubs
                 return;
             }
 
+            // The safe delivery watermark can move backwards when a newly registered
+            // subscriber requests replay from an older token. Persist that rewind
+            // immediately so recovery starts before the slowest known subscriber's
+            // required event.
             var mustSaveNow = IsBefore(offset, entity.Offset);
 
-            // Always track the latest offset in memory so FlushAsync can persist it.
+            // Always track the latest safe offset in memory so FlushAsync can persist it.
             latestOffset = offset;
 
             // If we've saved before but it's not time for another save or the last save operation has not completed,

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -12,6 +12,11 @@ using Orleans.Configuration.Overrides;
 #nullable disable
 namespace Orleans.Streaming.EventHubs
 {
+    internal interface IEventHubCheckpointerUpdateCadence
+    {
+        bool IsUpdateDue(DateTime utcNow);
+    }
+
     public class EventHubCheckpointerFactory : IStreamQueueCheckpointerFactory
     {
         private readonly ILoggerFactory loggerFactory;
@@ -43,7 +48,7 @@ namespace Orleans.Streaming.EventHubs
     /// <summary>
     /// This class stores EventHub partition checkpointer information (a partition offset) in azure table storage.
     /// </summary>
-    public partial class EventHubCheckpointer : IStreamQueueCheckpointer<string>
+    public partial class EventHubCheckpointer : IStreamQueueCheckpointer<string>, IEventHubCheckpointerUpdateCadence
     {
         private readonly AzureTableDataManager<EventHubPartitionCheckpointEntity> dataManager;
         private readonly TimeSpan persistInterval;
@@ -130,6 +135,7 @@ namespace Orleans.Streaming.EventHubs
             // if offset has not changed, do nothing
             if (string.Compare(latestOffset, offset, StringComparison.Ordinal) == 0)
             {
+                throttleSavesUntilUtc = utcNow + persistInterval;
                 return;
             }
 
@@ -162,6 +168,12 @@ namespace Orleans.Streaming.EventHubs
             }
 
             inProgressSave.Ignore();
+        }
+
+        bool IEventHubCheckpointerUpdateCadence.IsUpdateDue(DateTime utcNow)
+        {
+            return inProgressSave.IsCompleted
+                && (!throttleSavesUntilUtc.HasValue || throttleSavesUntilUtc.Value <= utcNow);
         }
 
         private async Task SaveLatestAfter(Task previousSave)

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -53,6 +53,8 @@ namespace Orleans.Streaming.EventHubs
         private Task inProgressSave = Task.CompletedTask;
         private DateTime? throttleSavesUntilUtc;
         private string latestOffset = EventHubConstants.StartOfStream;
+        private string persistedOffset = EventHubConstants.StartOfStream;
+        private bool saveRequested;
 
         /// <summary>
         /// Indicates if a checkpoint exists
@@ -116,6 +118,7 @@ namespace Orleans.Streaming.EventHubs
             }
 
             latestOffset = entity.Offset ?? EventHubConstants.StartOfStream;
+            persistedOffset = latestOffset;
             return latestOffset;
         }
 
@@ -138,38 +141,58 @@ namespace Orleans.Streaming.EventHubs
             // Always track the latest safe offset in memory so FlushAsync can persist it.
             latestOffset = offset;
 
-            // If we've saved before but it's not time for another save or the last save operation has not completed, do nothing.
-            if (throttleSavesUntilUtc.HasValue && (throttleSavesUntilUtc.Value > utcNow || !inProgressSave.IsCompleted))
+            // If we've saved before but it's not time for another save, do nothing.
+            if (throttleSavesUntilUtc.HasValue && throttleSavesUntilUtc.Value > utcNow)
             {
                 return;
             }
 
             throttleSavesUntilUtc = utcNow + persistInterval;
+            RequestSave();
+        }
+
+        private void RequestSave()
+        {
+            saveRequested = true;
             if (inProgressSave.IsCompleted)
             {
-                entity.Offset = latestOffset;
-                inProgressSave = dataManager.UpsertTableEntryAsync(entity);
+                inProgressSave = SaveRequestedOffsets();
+                inProgressSave.Ignore();
             }
-            else
-            {
-                var previousSave = inProgressSave;
-                inProgressSave = SaveLatestAfter(previousSave);
-            }
-
-            inProgressSave.Ignore();
         }
 
-        bool IStreamQueueCheckpointer<string>.IsUpdateDue(DateTime utcNow)
+        private async Task SaveLatest()
         {
-            return inProgressSave.IsCompleted
-                && (!throttleSavesUntilUtc.HasValue || throttleSavesUntilUtc.Value <= utcNow);
-        }
-
-        private async Task SaveLatestAfter(Task previousSave)
-        {
-            await previousSave;
-            entity.Offset = latestOffset;
+            var offset = latestOffset;
+            entity.Offset = offset;
             await dataManager.UpsertTableEntryAsync(entity);
+            persistedOffset = offset;
+        }
+
+        private async Task SaveRequestedOffsets()
+        {
+            try
+            {
+                while (saveRequested)
+                {
+                    saveRequested = false;
+                    var saveTask = SaveLatest();
+                    await saveTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+                    if (!saveTask.IsCompletedSuccessfully)
+                    {
+                        if (saveRequested)
+                        {
+                            continue;
+                        }
+
+                        await saveTask.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
+                    }
+                }
+            }
+            finally
+            {
+                inProgressSave = Task.CompletedTask;
+            }
         }
 
         /// <summary>
@@ -180,10 +203,9 @@ namespace Orleans.Streaming.EventHubs
         public async Task FlushAsync(CancellationToken cancellationToken)
         {
             await inProgressSave.WaitAsync(cancellationToken);
-            if (string.Compare(entity.Offset, latestOffset, StringComparison.Ordinal) != 0)
+            if (string.Compare(persistedOffset, latestOffset, StringComparison.Ordinal) != 0)
             {
-                entity.Offset = latestOffset;
-                inProgressSave = dataManager.UpsertTableEntryAsync(entity);
+                inProgressSave = SaveLatest();
                 await inProgressSave.WaitAsync(cancellationToken);
             }
         }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -52,7 +52,7 @@ namespace Orleans.Streaming.EventHubs
         private EventHubPartitionCheckpointEntity entity;
         private Task inProgressSave = Task.CompletedTask;
         private DateTime? throttleSavesUntilUtc;
-        private string latestOffset;
+        private string latestOffset = EventHubConstants.StartOfStream;
 
         /// <summary>
         /// Indicates if a checkpoint exists
@@ -115,8 +115,8 @@ namespace Orleans.Streaming.EventHubs
                 entity = results.Entity;
             }
 
-            latestOffset = entity.Offset;
-            return entity.Offset;
+            latestOffset = entity.Offset ?? EventHubConstants.StartOfStream;
+            return latestOffset;
         }
 
         /// <summary>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Streams;
@@ -120,7 +121,7 @@ namespace Orleans.Streaming.EventHubs
 
         /// <summary>
         /// Updates the checkpoint.  This is a best effort.  It does not always update the checkpoint.
-        /// The latest offset is always tracked in memory so that <see cref="FlushAsync"/> can persist it on shutdown.
+        /// The latest offset is always tracked in memory so that <see cref="FlushAsync(CancellationToken)"/> can persist it on shutdown.
         /// </summary>
         /// <param name="offset"></param>
         /// <param name="utcNow"></param>
@@ -170,14 +171,15 @@ namespace Orleans.Streaming.EventHubs
         /// Flushes any pending checkpoint to persistent storage.
         /// Awaits any in-progress save, then persists the latest offset if it has advanced beyond the last saved value.
         /// </summary>
-        public async Task FlushAsync()
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public async Task FlushAsync(CancellationToken cancellationToken)
         {
-            await inProgressSave;
+            await inProgressSave.WaitAsync(cancellationToken);
             if (string.Compare(entity.Offset, latestOffset, StringComparison.Ordinal) != 0)
             {
                 entity.Offset = latestOffset;
                 inProgressSave = dataManager.UpsertTableEntryAsync(entity);
-                await inProgressSave;
+                await inProgressSave.WaitAsync(cancellationToken);
             }
         }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -54,7 +54,6 @@ namespace Orleans.Streaming.EventHubs
         private DateTime? throttleSavesUntilUtc;
         private string latestOffset = EventHubConstants.StartOfStream;
         private string persistedOffset = EventHubConstants.StartOfStream;
-        private bool saveRequested;
 
         /// <summary>
         /// Indicates if a checkpoint exists
@@ -141,58 +140,22 @@ namespace Orleans.Streaming.EventHubs
             // Always track the latest safe offset in memory so FlushAsync can persist it.
             latestOffset = offset;
 
-            // If we've saved before but it's not time for another save, do nothing.
-            if (throttleSavesUntilUtc.HasValue && throttleSavesUntilUtc.Value > utcNow)
+            // If we've saved before but it's not time for another save or the last save operation has not completed, do nothing.
+            if (throttleSavesUntilUtc.HasValue && (throttleSavesUntilUtc.Value > utcNow || !inProgressSave.IsCompleted))
             {
                 return;
             }
 
             throttleSavesUntilUtc = utcNow + persistInterval;
-            RequestSave();
+            inProgressSave = SaveOffset(latestOffset);
+            inProgressSave.Ignore();
         }
 
-        private void RequestSave()
+        private async Task SaveOffset(string offset)
         {
-            saveRequested = true;
-            if (inProgressSave.IsCompleted)
-            {
-                inProgressSave = SaveRequestedOffsets();
-                inProgressSave.Ignore();
-            }
-        }
-
-        private async Task SaveLatest()
-        {
-            var offset = latestOffset;
             entity.Offset = offset;
             await dataManager.UpsertTableEntryAsync(entity);
             persistedOffset = offset;
-        }
-
-        private async Task SaveRequestedOffsets()
-        {
-            try
-            {
-                while (saveRequested)
-                {
-                    saveRequested = false;
-                    var saveTask = SaveLatest();
-                    await saveTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
-                    if (!saveTask.IsCompletedSuccessfully)
-                    {
-                        if (saveRequested)
-                        {
-                            continue;
-                        }
-
-                        await saveTask.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext);
-                    }
-                }
-            }
-            finally
-            {
-                inProgressSave = Task.CompletedTask;
-            }
         }
 
         /// <summary>
@@ -202,10 +165,12 @@ namespace Orleans.Streaming.EventHubs
         /// <param name="cancellationToken">The cancellation token.</param>
         public async Task FlushAsync(CancellationToken cancellationToken)
         {
-            await inProgressSave.WaitAsync(cancellationToken);
+            await inProgressSave.WaitAsync(cancellationToken)
+                .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
+            cancellationToken.ThrowIfCancellationRequested();
             if (string.Compare(persistedOffset, latestOffset, StringComparison.Ordinal) != 0)
             {
-                inProgressSave = SaveLatest();
+                inProgressSave = SaveOffset(latestOffset);
                 await inProgressSave.WaitAsync(cancellationToken);
             }
         }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -12,11 +12,6 @@ using Orleans.Configuration.Overrides;
 #nullable disable
 namespace Orleans.Streaming.EventHubs
 {
-    internal interface IEventHubCheckpointerUpdateCadence
-    {
-        bool IsUpdateDue(DateTime utcNow);
-    }
-
     public class EventHubCheckpointerFactory : IStreamQueueCheckpointerFactory
     {
         private readonly ILoggerFactory loggerFactory;
@@ -48,7 +43,7 @@ namespace Orleans.Streaming.EventHubs
     /// <summary>
     /// This class stores EventHub partition checkpointer information (a partition offset) in azure table storage.
     /// </summary>
-    public partial class EventHubCheckpointer : IStreamQueueCheckpointer<string>, IEventHubCheckpointerUpdateCadence
+    public partial class EventHubCheckpointer : IStreamQueueCheckpointer<string>
     {
         private readonly AzureTableDataManager<EventHubPartitionCheckpointEntity> dataManager;
         private readonly TimeSpan persistInterval;
@@ -132,25 +127,19 @@ namespace Orleans.Streaming.EventHubs
         /// <param name="utcNow"></param>
         public void Update(string offset, DateTime utcNow)
         {
-            // if offset has not changed, do nothing
-            if (string.Compare(latestOffset, offset, StringComparison.Ordinal) == 0)
+            // Checkpoints are monotonic: if a subscriber requests replay from before
+            // the current checkpoint, keep the checkpoint at the latest safe offset.
+            if (!IsAfter(offset, latestOffset))
             {
                 throttleSavesUntilUtc = utcNow + persistInterval;
                 return;
             }
 
-            // The safe delivery watermark can move backwards when a newly registered
-            // subscriber requests replay from an older token. Persist that rewind
-            // immediately so recovery starts before the slowest known subscriber's
-            // required event.
-            var mustSaveNow = IsBefore(offset, entity.Offset);
-
             // Always track the latest safe offset in memory so FlushAsync can persist it.
             latestOffset = offset;
 
-            // If we've saved before but it's not time for another save or the last save operation has not completed,
-            // do nothing unless this update lowers the checkpoint to protect a slower subscription.
-            if (!mustSaveNow && throttleSavesUntilUtc.HasValue && (throttleSavesUntilUtc.Value > utcNow || !inProgressSave.IsCompleted))
+            // If we've saved before but it's not time for another save or the last save operation has not completed, do nothing.
+            if (throttleSavesUntilUtc.HasValue && (throttleSavesUntilUtc.Value > utcNow || !inProgressSave.IsCompleted))
             {
                 return;
             }
@@ -170,7 +159,7 @@ namespace Orleans.Streaming.EventHubs
             inProgressSave.Ignore();
         }
 
-        bool IEventHubCheckpointerUpdateCadence.IsUpdateDue(DateTime utcNow)
+        bool IStreamQueueCheckpointer<string>.IsUpdateDue(DateTime utcNow)
         {
             return inProgressSave.IsCompleted
                 && (!throttleSavesUntilUtc.HasValue || throttleSavesUntilUtc.Value <= utcNow);
@@ -199,11 +188,13 @@ namespace Orleans.Streaming.EventHubs
             }
         }
 
-        private static bool IsBefore(string offset, string currentOffset)
+        private static bool IsAfter(string offset, string currentOffset)
         {
+            currentOffset ??= EventHubConstants.StartOfStream;
+
             return long.TryParse(offset, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedOffset)
                 && long.TryParse(currentOffset, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedCurrentOffset)
-                && parsedOffset < parsedCurrentOffset;
+                && parsedOffset > parsedCurrentOffset;
         }
 
         [LoggerMessage(

--- a/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
+++ b/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
@@ -40,5 +40,12 @@ namespace Orleans.Streams
         /// <param name="offset">The offset.</param>
         /// <param name="utcNow">The current UTC time.</param>
         void Update(TCheckpoint offset, DateTime utcNow);
+
+        /// <summary>
+        /// Flushes any pending checkpoint to persistent storage, ensuring the latest offset is durably saved.
+        /// Called during shutdown or rebalancing to prevent message replay on restart.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the flush operation.</returns>
+        Task FlushAsync() => Task.CompletedTask;
     }
 }

--- a/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
+++ b/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
@@ -43,6 +43,13 @@ namespace Orleans.Streams
         void Update(TCheckpoint offset, DateTime utcNow);
 
         /// <summary>
+        /// Returns <see langword="true"/> if the checkpointer is due for an update.
+        /// </summary>
+        /// <param name="utcNow">The current UTC time.</param>
+        /// <returns><see langword="true"/> if an update is due; otherwise, <see langword="false"/>.</returns>
+        bool IsUpdateDue(DateTime utcNow) => true;
+
+        /// <summary>
         /// Flushes any pending checkpoint to persistent storage, ensuring the latest offset is durably saved.
         /// Called during shutdown or rebalancing to prevent message replay on restart.
         /// </summary>

--- a/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
+++ b/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
@@ -43,13 +43,6 @@ namespace Orleans.Streams
         void Update(TCheckpoint offset, DateTime utcNow);
 
         /// <summary>
-        /// Returns <see langword="true"/> if the checkpointer is due for an update.
-        /// </summary>
-        /// <param name="utcNow">The current UTC time.</param>
-        /// <returns><see langword="true"/> if an update is due; otherwise, <see langword="false"/>.</returns>
-        bool IsUpdateDue(DateTime utcNow) => true;
-
-        /// <summary>
         /// Flushes any pending checkpoint to persistent storage, ensuring the latest offset is durably saved.
         /// Called during shutdown or rebalancing to prevent message replay on restart.
         /// </summary>

--- a/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
+++ b/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.Streams
@@ -45,7 +46,8 @@ namespace Orleans.Streams
         /// Flushes any pending checkpoint to persistent storage, ensuring the latest offset is durably saved.
         /// Called during shutdown or rebalancing to prevent message replay on restart.
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the flush operation.</returns>
-        Task FlushAsync() => Task.CompletedTask;
+        Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -543,40 +543,29 @@ namespace Orleans.Streams
 
             LogTraceGotMessages(multiBatch.Count, new(myQueueId), numMessages);
 
-            var streamGroups =
+            foreach (var group in
                 multiBatch
                 .Where(m => m != null)
-                .GroupBy(container => container.StreamId)
-                .Select(group => (StreamId: new QualifiedStreamId(queueAdapter.Name, group.Key), StartToken: group.First().SequenceToken))
-                .ToList();
-
-            foreach (var group in streamGroups)
+                .GroupBy(container => container.StreamId))
             {
                 if (IsShutdown || cancellationToken.IsCancellationRequested)
                 {
                     return false;
                 }
 
-                if (!pubSubCache.ContainsKey(group.StreamId))
-                {
-                    // Start all cold-stream registrations before waking any existing cursors so
-                    // delivery-based checkpointing sees pending streams before progress advances.
-                    RegisterStream(group.StreamId, group.StartToken, now);
-                }
-            }
-
-            foreach (var group in streamGroups)
-            {
-                if (IsShutdown || cancellationToken.IsCancellationRequested)
-                {
-                    return false;
-                }
-
+                var streamId = new QualifiedStreamId(queueAdapter.Name, group.Key);
+                StreamSequenceToken startToken = group.First().SequenceToken;
                 StreamConsumerCollection streamData;
-                if (pubSubCache.TryGetValue(group.StreamId, out streamData))
+                if (pubSubCache.TryGetValue(streamId, out streamData))
                 {
                     streamData.RefreshActivity(now);
-                    StartInactiveCursors(streamData, group.StartToken);
+                    StartInactiveCursors(streamData, startToken);
+                }
+                else
+                {
+                    // Run registration in the background so that cold-stream pubsub
+                    // calls do not stall message delivery for other streams on the same queue.
+                    RegisterStream(streamId, startToken, now);
                 }
             }
 

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -767,6 +767,11 @@ namespace Orleans.Streams
                                 (exception, i) => exception is not ClientNotAvailableException && !IsShutdown,
                                 this.options.MaxEventDeliveryTime,
                                 deliveryBackoffProvider);
+
+                            // Notify the cache that this batch was delivered so it can
+                            // advance the checkpoint based on actual delivery progress.
+                            queueCache?.NotifyBatchDelivered(consumerData.StreamId.StreamId, consumerData.SubscriptionId, batch.SequenceToken);
+
                             if (newToken != null)
                             {
                                 consumerData.LastToken = newToken;

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -42,9 +42,6 @@ namespace Orleans.Streams
         private DateTime lastTimeCleanedPubSubCache;
         private IGrainTimer timer;
 
-        // Reusable list to avoid allocation in the periodic delivery progress scan.
-        private readonly List<StreamSequenceToken> _deliveryProgressTokens = new();
-
         private Task receiverInitTask;
         private Task _activePumpTask = Task.CompletedTask;
         private bool IsShutdown => timer is null;
@@ -613,26 +610,37 @@ namespace Orleans.Streams
         {
             if (queueCache is null) return;
 
-            _deliveryProgressTokens.Clear();
-            bool hasPending = false;
+            StreamSequenceToken earliest = null;
 
-            foreach (var (_, collection) in pubSubCache)
+            foreach (var streamConsumers in pubSubCache.Values)
             {
-                if (collection.RegistrationTask is { IsCompleted: false })
+                if (streamConsumers.RegistrationTask is { IsCompleted: false })
                 {
-                    hasPending = true;
+                    queueCache.UpdateDeliveryProgress(earliestSubscriptionToken: null, hasPendingRegistrations: true);
+                    return;
                 }
 
-                foreach (var consumer in collection.AllConsumers())
+                foreach (var consumer in streamConsumers.AllConsumers())
                 {
-                    if (consumer.IsRegistered)
+                    if (!consumer.IsRegistered)
                     {
-                        _deliveryProgressTokens.Add(consumer.LastProcessedToken);
+                        continue;
+                    }
+
+                    var current = consumer.LastProcessedToken;
+                    if (current is null)
+                    {
+                        return;
+                    }
+
+                    if (earliest is null || current.CompareTo(earliest) < 0)
+                    {
+                        earliest = current;
                     }
                 }
             }
 
-            queueCache.UpdateDeliveryProgress(_deliveryProgressTokens, hasPending);
+            queueCache.UpdateDeliveryProgress(earliest, hasPendingRegistrations: false);
         }
 
         private void RegisterStream(QualifiedStreamId streamId, StreamSequenceToken firstToken, DateTime now)

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -602,7 +602,7 @@ namespace Orleans.Streams
         }
 
         /// <summary>
-        /// Scans <see cref="pubSubCache"/> for the current delivery progress of all registered
+        /// Scans <see cref="pubSubCache"/> for the current delivery progress of all
         /// subscriptions and pushes a snapshot to the queue cache so it can compute a safe
         /// checkpoint watermark. Called periodically from the read loop and once at shutdown.
         /// Skips notifying the cache while stream registrations are pending.
@@ -624,7 +624,7 @@ namespace Orleans.Streams
                 {
                     if (!consumer.IsRegistered)
                     {
-                        continue;
+                        return;
                     }
 
                     var current = consumer.LastProcessedToken;
@@ -633,7 +633,7 @@ namespace Orleans.Streams
                         return;
                     }
 
-                    if (earliest is null || current.CompareTo(earliest) < 0)
+                    if (earliest is null || IsBefore(current, earliest))
                     {
                         earliest = current;
                     }
@@ -641,6 +641,12 @@ namespace Orleans.Streams
             }
 
             queueCache.UpdateDeliveryProgress(earliest);
+        }
+
+        private static bool IsBefore(StreamSequenceToken current, StreamSequenceToken other)
+        {
+            var difference = current.SequenceNumber.CompareTo(other.SequenceNumber);
+            return difference < 0 || difference == 0 && current.EventIndex < other.EventIndex;
         }
 
         private void RegisterStream(QualifiedStreamId streamId, StreamSequenceToken firstToken, DateTime now)

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -825,7 +825,6 @@ namespace Orleans.Streams
                         if (nextBatch.Batch != null)
                         {
                             var batch = nextBatch.Batch;
-                            StreamInstruments.PersistentStreamSentMessages.Add(1);
                             StreamHandshakeToken newToken = await AsyncExecutorWithRetries.ExecuteWithRetries(
                                 i => DeliverBatchToConsumer(consumerData, batch),
                                 AsyncExecutorWithRetries.INFINITE_RETRIES,

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -208,7 +208,7 @@ namespace Orleans.Streams
 
             // Final delivery progress scan so the receiver has the latest watermark
             // before FlushAsync persists the checkpoint.
-            NotifyDeliveryProgress(force: true);
+            NotifyDeliveryProgress();
 
             this.queueCache = null;
 
@@ -415,9 +415,6 @@ namespace Orleans.Streams
                 return Task.CompletedTask;
             }
 
-            // Let the cache lazily request delivery progress when its checkpoint cadence elapses.
-            NotifyDeliveryProgress(force: false);
-
             if (!_activePumpTask.IsCompleted)
             {
                 return _activePumpTask;
@@ -600,18 +597,13 @@ namespace Orleans.Streams
         }
 
         /// <summary>
-        /// Computes delivery progress when the queue cache is ready for a checkpoint update.
+        /// Computes delivery progress before shutdown so the queue can persist the latest handoff checkpoint.
         /// </summary>
-        private void NotifyDeliveryProgress(bool force)
+        private void NotifyDeliveryProgress()
         {
             if (queueCache is null) return;
 
             var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
-            if (!force && !queueCache.IsUpdateDue(utcNow))
-            {
-                return;
-            }
-
             if (TryGetDeliveryProgress(out var earliest))
             {
                 queueCache.UpdateDeliveryProgress(earliest, utcNow);

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -313,10 +313,6 @@ namespace Orleans.Streams
                 data.LastProcessedToken = startToken;
                 data.PendingStartToken = null;
                 data.IsRegistered = true;
-                // A newly registered subscriber can request an older token than the
-                // current checkpoint. Force a progress update so the receiver can
-                // persist that rewind immediately instead of waiting for its cadence.
-                NotifyDeliveryProgress(force: true);
                 StreamingEvents.EmitSubscriptionAttached(streamProviderName, streamId.StreamId, subscriptionId.Guid, streamConsumer, Silo);
                 if (data.State == StreamConsumerDataState.Inactive)
                     RunConsumerCursor(data).Ignore(); // Start delivering events if not actively doing so
@@ -718,7 +714,6 @@ namespace Orleans.Streams
                 finally
                 {
                     streamData.RegistrationTask = null;
-                    NotifyDeliveryProgress(force: true);
 
                     // Disposed after all initial subscriber handshakes complete so the first
                     // batch stays pinned until each subscriber has its own cache cursor.

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -853,11 +853,9 @@ namespace Orleans.Streams
                                 this.options.MaxEventDeliveryTime,
                                 deliveryBackoffProvider);
 
-                            // Track progress for the periodic delivery scan.
-                            consumerData.LastProcessedToken = nextBatch.ProgressToken;
-
                             if (newToken != null)
                             {
+                                consumerData.LastProcessedToken = newToken.Token;
                                 consumerData.LastToken = newToken;
                                 IQueueCacheCursor newCursor = queueCache.GetCacheCursor(consumerData.StreamId, newToken.Token);
                                 // The handshake token points to an already processed event, we need to advance the cursor to
@@ -865,6 +863,11 @@ namespace Orleans.Streams
                                 newCursor.MoveNext();
                                 consumerData.SafeDisposeCursor(logger);
                                 consumerData.Cursor = newCursor;
+                            }
+                            else
+                            {
+                                // Track progress for the periodic delivery scan.
+                                consumerData.LastProcessedToken = nextBatch.ProgressToken;
                             }
                         }
                     }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -303,6 +303,8 @@ namespace Orleans.Streams
 
             if (await DoHandshakeWithConsumer(data, cacheToken))
             {
+                var startToken = data.LastToken?.Token ?? cacheToken ?? data.PendingStartToken;
+                queueCache?.NotifySubscriptionAdded(streamId.StreamId, subscriptionId, startToken);
                 data.PendingStartToken = null;
                 data.IsRegistered = true;
                 StreamingEvents.EmitSubscriptionAttached(streamProviderName, streamId.StreamId, subscriptionId.Guid, streamConsumer, Silo);
@@ -392,6 +394,7 @@ namespace Orleans.Streams
             bool removed = streamData.RemoveConsumer(subscriptionId, logger);
             if (removed)
             {
+                queueCache?.NotifySubscriptionRemoved(streamId.StreamId, subscriptionId);
                 StreamingEvents.EmitSubscriptionDetached(streamProviderName, streamId.StreamId, subscriptionId.Guid, Silo);
                 StreamingEvents.EmitSubscriptionRemoved(streamProviderName, streamId.StreamId, subscriptionId.Guid, Silo);
                 LogDebugRemovedConsumer(subscriptionId, streamId);
@@ -537,29 +540,40 @@ namespace Orleans.Streams
 
             LogTraceGotMessages(multiBatch.Count, new(myQueueId), numMessages);
 
-            foreach (var group in
+            var streamGroups =
                 multiBatch
                 .Where(m => m != null)
-                .GroupBy(container => container.StreamId))
+                .GroupBy(container => container.StreamId)
+                .Select(group => (StreamId: new QualifiedStreamId(queueAdapter.Name, group.Key), StartToken: group.First().SequenceToken))
+                .ToList();
+
+            foreach (var group in streamGroups)
             {
                 if (IsShutdown || cancellationToken.IsCancellationRequested)
                 {
                     return false;
                 }
 
-                var streamId = new QualifiedStreamId(queueAdapter.Name, group.Key);
-                StreamSequenceToken startToken = group.First().SequenceToken;
+                if (!pubSubCache.ContainsKey(group.StreamId))
+                {
+                    // Start all cold-stream registrations before waking any existing cursors so
+                    // delivery-based checkpointing sees pending streams before progress advances.
+                    RegisterStream(group.StreamId, group.StartToken, now);
+                }
+            }
+
+            foreach (var group in streamGroups)
+            {
+                if (IsShutdown || cancellationToken.IsCancellationRequested)
+                {
+                    return false;
+                }
+
                 StreamConsumerCollection streamData;
-                if (pubSubCache.TryGetValue(streamId, out streamData))
+                if (pubSubCache.TryGetValue(group.StreamId, out streamData))
                 {
                     streamData.RefreshActivity(now);
-                    StartInactiveCursors(streamData, startToken);
-                }
-                else
-                {
-                    // Run registration in the background so that cold-stream pubsub
-                    // calls do not stall message delivery for other streams on the same queue.
-                    RegisterStream(streamId, startToken, now);
+                    StartInactiveCursors(streamData, group.StartToken);
                 }
             }
 
@@ -573,9 +587,18 @@ namespace Orleans.Streams
                 if (tuple.Value.IsInactive(now, options.StreamInactivityPeriod))
                 {
                     pubSubCache.Remove(tuple.Key);
+                    NotifySubscriptionsRemoved(tuple.Key, tuple.Value);
                     tuple.Value.DisposeAll(logger);
                     StreamingEvents.EmitStreamInactive(streamProviderName, tuple.Key.StreamId, options.StreamInactivityPeriod, Silo);
                 }
+            }
+        }
+
+        private void NotifySubscriptionsRemoved(QualifiedStreamId streamId, StreamConsumerCollection streamData)
+        {
+            foreach (var consumerData in streamData.AllConsumers())
+            {
+                queueCache?.NotifySubscriptionRemoved(streamId.StreamId, consumerData.SubscriptionId);
             }
         }
 
@@ -593,6 +616,7 @@ namespace Orleans.Streams
             // This will help ensure the "casual consistency" between pre-existing subscripton (of a potentially new already subscribed consumer)
             // and later production.
             var pinCursor = queueCache?.GetCacheCursor(streamId, firstToken);
+            queueCache?.NotifyStreamRegistrationStarted(streamId.StreamId);
             streamData.RegistrationTask = RegisterStreamAsync();
             pubSubCache.Add(streamId, streamData);
 
@@ -600,13 +624,13 @@ namespace Orleans.Streams
             {
                 await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext | ConfigureAwaitOptions.ForceYielding);
 
-                if (IsShutdown)
-                {
-                    return;
-                }
-
                 try
                 {
+                    if (IsShutdown)
+                    {
+                        return;
+                    }
+
                     var subscribers = await RegisterAsStreamProducer(streamId);
 
                     if (IsShutdown)
@@ -641,6 +665,7 @@ namespace Orleans.Streams
                 finally
                 {
                     streamData.RegistrationTask = null;
+                    queueCache?.NotifyStreamRegistrationCompleted(streamId.StreamId);
 
                     // Disposed after all initial subscriber handshakes complete so the first
                     // batch stays pinned until each subscriber has its own cache cursor.
@@ -659,6 +684,7 @@ namespace Orleans.Streams
                     pubSubCache.Remove(streamId);
                 }
 
+                NotifySubscriptionsRemoved(streamId, streamData);
                 streamData.DisposeAll(logger);
             }
 
@@ -722,12 +748,12 @@ namespace Orleans.Streams
                 var deliveredAny = false;
                 while (!IsShutdown && consumerData.Cursor != null)
                 {
-                    IBatchContainer batch = null;
+                    ConsumerBatch nextBatch = default;
                     Exception exceptionOccured = null;
                     try
                     {
-                        batch = GetBatchForConsumer(consumerData.Cursor, consumerData.StreamId, consumerData.FilterData);
-                        if (batch == null)
+                        nextBatch = GetBatchForConsumer(consumerData.Cursor, consumerData.StreamId, consumerData.FilterData);
+                        if (!nextBatch.HasProgress)
                         {
                             // Only emit cursor-drained when we transitioned from delivering to empty,
                             // not on every empty poll.
@@ -743,11 +769,15 @@ namespace Orleans.Streams
                         consumerData.Cursor = queueCache.GetCacheCursor(consumerData.StreamId, null);
                     }
 
-                    if (batch != null)
+                    if (exceptionOccured is null)
                     {
                         deliveredAny = true;
-                        if (!ShouldDeliverBatch(consumerData.StreamId, batch, consumerData.FilterData))
+
+                        if (nextBatch.Batch is null)
+                        {
+                            queueCache?.NotifyBatchProcessed(consumerData.StreamId.StreamId, consumerData.SubscriptionId, nextBatch.ProgressToken);
                             continue;
+                        }
                     }
 
                     try
@@ -758,8 +788,10 @@ namespace Orleans.Streams
                             break;
                         }
 
-                        if (batch != null)
+                        if (nextBatch.Batch != null)
                         {
+                            var batch = nextBatch.Batch;
+                            StreamInstruments.PersistentStreamSentMessages.Add(1);
                             StreamHandshakeToken newToken = await AsyncExecutorWithRetries.ExecuteWithRetries(
                                 i => DeliverBatchToConsumer(consumerData, batch),
                                 AsyncExecutorWithRetries.INFINITE_RETRIES,
@@ -768,9 +800,9 @@ namespace Orleans.Streams
                                 this.options.MaxEventDeliveryTime,
                                 deliveryBackoffProvider);
 
-                            // Notify the cache that this batch was delivered so it can
-                            // advance the checkpoint based on actual delivery progress.
-                            queueCache?.NotifyBatchDelivered(consumerData.StreamId.StreamId, consumerData.SubscriptionId, batch.SequenceToken);
+                            // Notify the cache after successful delivery so it can advance checkpoints
+                            // based on actual subscription progress, including filtered batches.
+                            queueCache?.NotifyBatchProcessed(consumerData.StreamId.StreamId, consumerData.SubscriptionId, nextBatch.ProgressToken);
 
                             if (newToken != null)
                             {
@@ -796,6 +828,7 @@ namespace Orleans.Streams
                     // if we failed to deliver a batch
                     if (exceptionOccured != null)
                     {
+                        var batch = nextBatch.Batch;
                         bool faultedSubscription = await ErrorProtocol(consumerData, exceptionOccured, true, batch, batch?.SequenceToken);
                         if (faultedSubscription) return;
                     }
@@ -811,21 +844,38 @@ namespace Orleans.Streams
             }
         }
 
-        private IBatchContainer GetBatchForConsumer(IQueueCacheCursor cursor, StreamId streamId, string filterData)
+        private readonly struct ConsumerBatch
+        {
+            public ConsumerBatch(IBatchContainer batch, StreamSequenceToken progressToken)
+            {
+                Batch = batch;
+                ProgressToken = progressToken;
+            }
+
+            public IBatchContainer Batch { get; }
+            public StreamSequenceToken ProgressToken { get; }
+            public bool HasProgress => ProgressToken is not null;
+        }
+
+        private ConsumerBatch GetBatchForConsumer(IQueueCacheCursor cursor, StreamId streamId, string filterData)
         {
             if (this.options.BatchContainerBatchSize <= 1)
             {
                 if (!cursor.MoveNext())
                 {
-                    return null;
+                    return default;
                 }
 
-                return cursor.GetCurrent(out _);
+                var batchContainer = cursor.GetCurrent(out _);
+                return ShouldDeliverBatch(streamId, batchContainer, filterData)
+                    ? new ConsumerBatch(batchContainer, batchContainer.SequenceToken)
+                    : new ConsumerBatch(null, batchContainer.SequenceToken);
             }
             else if (this.options.BatchContainerBatchSize > 1)
             {
                 int i = 0;
                 var batchContainers = new List<IBatchContainer>();
+                StreamSequenceToken progressToken = null;
 
                 while (i < this.options.BatchContainerBatchSize)
                 {
@@ -835,6 +885,7 @@ namespace Orleans.Streams
                     }
 
                     var batchContainer = cursor.GetCurrent(out _);
+                    progressToken = batchContainer.SequenceToken;
 
                     if (!ShouldDeliverBatch(streamId, batchContainer, filterData))
                         continue;
@@ -843,15 +894,17 @@ namespace Orleans.Streams
                     i++;
                 }
 
-                if (i == 0)
+                if (progressToken is null)
                 {
-                    return null;
+                    return default;
                 }
 
-                return new BatchContainerBatch(batchContainers);
+                return i == 0
+                    ? new ConsumerBatch(null, progressToken)
+                    : new ConsumerBatch(new BatchContainerBatch(batchContainers), progressToken);
             }
 
-            return null;
+            return default;
         }
 
         private async Task<StreamHandshakeToken> DeliverBatchToConsumer(StreamConsumerData consumerData, IBatchContainer batch)
@@ -916,6 +969,7 @@ namespace Orleans.Streams
             if (exceptionOccured is ClientNotAvailableException)
             {
                 LogWarningConsumerIsDead(consumerData.StreamConsumer, consumerData.StreamId);
+                queueCache?.NotifySubscriptionRemoved(consumerData.StreamId.StreamId, consumerData.SubscriptionId);
                 pubSub.UnregisterConsumer(consumerData.SubscriptionId, consumerData.StreamId).Ignore();
                 return true;
             }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -42,6 +42,9 @@ namespace Orleans.Streams
         private DateTime lastTimeCleanedPubSubCache;
         private IGrainTimer timer;
 
+        // Reusable list to avoid allocation in the periodic delivery progress scan.
+        private readonly List<StreamSequenceToken> _deliveryProgressTokens = new();
+
         private Task receiverInitTask;
         private Task _activePumpTask = Task.CompletedTask;
         private bool IsShutdown => timer is null;
@@ -206,6 +209,10 @@ namespace Orleans.Streams
 
             await _activePumpTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing | ConfigureAwaitOptions.ContinueOnCapturedContext);
 
+            // Final delivery progress scan so the receiver has the latest watermark
+            // before FlushAsync persists the checkpoint.
+            NotifyDeliveryProgress();
+
             this.queueCache = null;
 
             try
@@ -304,7 +311,7 @@ namespace Orleans.Streams
             if (await DoHandshakeWithConsumer(data, cacheToken))
             {
                 var startToken = data.LastToken?.Token ?? cacheToken ?? data.PendingStartToken;
-                queueCache?.NotifySubscriptionAdded(streamId.StreamId, subscriptionId, startToken);
+                data.LastProcessedToken = startToken;
                 data.PendingStartToken = null;
                 data.IsRegistered = true;
                 StreamingEvents.EmitSubscriptionAttached(streamProviderName, streamId.StreamId, subscriptionId.Guid, streamConsumer, Silo);
@@ -394,7 +401,6 @@ namespace Orleans.Streams
             bool removed = streamData.RemoveConsumer(subscriptionId, logger);
             if (removed)
             {
-                queueCache?.NotifySubscriptionRemoved(streamId.StreamId, subscriptionId);
                 StreamingEvents.EmitSubscriptionDetached(streamProviderName, streamId.StreamId, subscriptionId.Guid, Silo);
                 StreamingEvents.EmitSubscriptionRemoved(streamProviderName, streamId.StreamId, subscriptionId.Guid, Silo);
                 LogDebugRemovedConsumer(subscriptionId, streamId);
@@ -411,6 +417,11 @@ namespace Orleans.Streams
             {
                 return Task.CompletedTask;
             }
+
+            // Push delivery progress on every timer tick (~100ms) so checkpoint
+            // advancement reflects cursor delivery that happens asynchronously,
+            // even while a pump is still reading from the queue.
+            NotifyDeliveryProgress();
 
             if (!_activePumpTask.IsCompleted)
             {
@@ -587,19 +598,41 @@ namespace Orleans.Streams
                 if (tuple.Value.IsInactive(now, options.StreamInactivityPeriod))
                 {
                     pubSubCache.Remove(tuple.Key);
-                    NotifySubscriptionsRemoved(tuple.Key, tuple.Value);
                     tuple.Value.DisposeAll(logger);
                     StreamingEvents.EmitStreamInactive(streamProviderName, tuple.Key.StreamId, options.StreamInactivityPeriod, Silo);
                 }
             }
         }
 
-        private void NotifySubscriptionsRemoved(QualifiedStreamId streamId, StreamConsumerCollection streamData)
+        /// <summary>
+        /// Scans <see cref="pubSubCache"/> for the current delivery progress of all registered
+        /// subscriptions and pushes a snapshot to the queue cache so it can compute a safe
+        /// checkpoint watermark. Called periodically from the read loop and once at shutdown.
+        /// </summary>
+        private void NotifyDeliveryProgress()
         {
-            foreach (var consumerData in streamData.AllConsumers())
+            if (queueCache is null) return;
+
+            _deliveryProgressTokens.Clear();
+            bool hasPending = false;
+
+            foreach (var (_, collection) in pubSubCache)
             {
-                queueCache?.NotifySubscriptionRemoved(streamId.StreamId, consumerData.SubscriptionId);
+                if (collection.RegistrationTask is { IsCompleted: false })
+                {
+                    hasPending = true;
+                }
+
+                foreach (var consumer in collection.AllConsumers())
+                {
+                    if (consumer.IsRegistered)
+                    {
+                        _deliveryProgressTokens.Add(consumer.LastProcessedToken);
+                    }
+                }
             }
+
+            queueCache.UpdateDeliveryProgress(_deliveryProgressTokens, hasPending);
         }
 
         private void RegisterStream(QualifiedStreamId streamId, StreamSequenceToken firstToken, DateTime now)
@@ -616,7 +649,6 @@ namespace Orleans.Streams
             // This will help ensure the "casual consistency" between pre-existing subscripton (of a potentially new already subscribed consumer)
             // and later production.
             var pinCursor = queueCache?.GetCacheCursor(streamId, firstToken);
-            queueCache?.NotifyStreamRegistrationStarted(streamId.StreamId);
             streamData.RegistrationTask = RegisterStreamAsync();
             pubSubCache.Add(streamId, streamData);
 
@@ -665,7 +697,6 @@ namespace Orleans.Streams
                 finally
                 {
                     streamData.RegistrationTask = null;
-                    queueCache?.NotifyStreamRegistrationCompleted(streamId.StreamId);
 
                     // Disposed after all initial subscriber handshakes complete so the first
                     // batch stays pinned until each subscriber has its own cache cursor.
@@ -684,7 +715,6 @@ namespace Orleans.Streams
                     pubSubCache.Remove(streamId);
                 }
 
-                NotifySubscriptionsRemoved(streamId, streamData);
                 streamData.DisposeAll(logger);
             }
 
@@ -775,7 +805,7 @@ namespace Orleans.Streams
 
                         if (nextBatch.Batch is null)
                         {
-                            queueCache?.NotifyBatchProcessed(consumerData.StreamId.StreamId, consumerData.SubscriptionId, nextBatch.ProgressToken);
+                            consumerData.LastProcessedToken = nextBatch.ProgressToken;
                             continue;
                         }
                     }
@@ -800,9 +830,8 @@ namespace Orleans.Streams
                                 this.options.MaxEventDeliveryTime,
                                 deliveryBackoffProvider);
 
-                            // Notify the cache after successful delivery so it can advance checkpoints
-                            // based on actual subscription progress, including filtered batches.
-                            queueCache?.NotifyBatchProcessed(consumerData.StreamId.StreamId, consumerData.SubscriptionId, nextBatch.ProgressToken);
+                            // Track progress for the periodic delivery scan.
+                            consumerData.LastProcessedToken = nextBatch.ProgressToken;
 
                             if (newToken != null)
                             {
@@ -969,7 +998,6 @@ namespace Orleans.Streams
             if (exceptionOccured is ClientNotAvailableException)
             {
                 LogWarningConsumerIsDead(consumerData.StreamConsumer, consumerData.StreamId);
-                queueCache?.NotifySubscriptionRemoved(consumerData.StreamId.StreamId, consumerData.SubscriptionId);
                 pubSub.UnregisterConsumer(consumerData.SubscriptionId, consumerData.StreamId).Ignore();
                 return true;
             }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -605,6 +605,7 @@ namespace Orleans.Streams
         /// Scans <see cref="pubSubCache"/> for the current delivery progress of all registered
         /// subscriptions and pushes a snapshot to the queue cache so it can compute a safe
         /// checkpoint watermark. Called periodically from the read loop and once at shutdown.
+        /// Skips notifying the cache while stream registrations are pending.
         /// </summary>
         private void NotifyDeliveryProgress()
         {
@@ -616,7 +617,6 @@ namespace Orleans.Streams
             {
                 if (streamConsumers.RegistrationTask is { IsCompleted: false })
                 {
-                    queueCache.UpdateDeliveryProgress(earliestSubscriptionToken: null, hasPendingRegistrations: true);
                     return;
                 }
 
@@ -640,7 +640,7 @@ namespace Orleans.Streams
                 }
             }
 
-            queueCache.UpdateDeliveryProgress(earliest, hasPendingRegistrations: false);
+            queueCache.UpdateDeliveryProgress(earliest);
         }
 
         private void RegisterStream(QualifiedStreamId streamId, StreamSequenceToken firstToken, DateTime now)

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -34,7 +34,6 @@ namespace Orleans.Streams
         private readonly IStreamFailureHandler streamFailureHandler;
         private readonly StreamInstruments _streamInstruments;
         private readonly TimeProvider _timeProvider;
-        private readonly TryGetDeliveryProgress _tryGetDeliveryProgress;
         internal readonly QueueId QueueId;
 
         private int numMessages;
@@ -89,7 +88,6 @@ namespace Orleans.Streams
             this.queueReaderBackoffProvider = queueReaderBackoffProvider;
             _streamInstruments = streamInstruments;
             _timeProvider = timeProvider ?? TimeProvider.System;
-            _tryGetDeliveryProgress = TryGetDeliveryProgress;
             numMessages = 0;
 
             logger = shared.LoggerFactory.CreateLogger($"{this.GetType().Namespace}.{streamProviderName}");
@@ -602,14 +600,22 @@ namespace Orleans.Streams
         }
 
         /// <summary>
-        /// Gives the queue cache a lazy callback for retrieving delivery progress.
-        /// The cache invokes the callback when it needs a current checkpoint watermark.
+        /// Computes delivery progress when the queue cache is ready for a checkpoint update.
         /// </summary>
         private void NotifyDeliveryProgress(bool force)
         {
             if (queueCache is null) return;
 
-            queueCache.UpdateDeliveryProgress(_tryGetDeliveryProgress, force);
+            var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+            if (!force && !queueCache.IsUpdateDue(utcNow))
+            {
+                return;
+            }
+
+            if (TryGetDeliveryProgress(out var earliest))
+            {
+                queueCache.UpdateDeliveryProgress(earliest, utcNow);
+            }
         }
 
         private bool TryGetDeliveryProgress(out StreamSequenceToken earliest)

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -34,6 +34,7 @@ namespace Orleans.Streams
         private readonly IStreamFailureHandler streamFailureHandler;
         private readonly StreamInstruments _streamInstruments;
         private readonly TimeProvider _timeProvider;
+        private readonly TryGetDeliveryProgress _tryGetDeliveryProgress;
         internal readonly QueueId QueueId;
 
         private int numMessages;
@@ -88,6 +89,7 @@ namespace Orleans.Streams
             this.queueReaderBackoffProvider = queueReaderBackoffProvider;
             _streamInstruments = streamInstruments;
             _timeProvider = timeProvider ?? TimeProvider.System;
+            _tryGetDeliveryProgress = TryGetDeliveryProgress;
             numMessages = 0;
 
             logger = shared.LoggerFactory.CreateLogger($"{this.GetType().Namespace}.{streamProviderName}");
@@ -208,7 +210,7 @@ namespace Orleans.Streams
 
             // Final delivery progress scan so the receiver has the latest watermark
             // before FlushAsync persists the checkpoint.
-            NotifyDeliveryProgress();
+            NotifyDeliveryProgress(force: true);
 
             this.queueCache = null;
 
@@ -311,6 +313,10 @@ namespace Orleans.Streams
                 data.LastProcessedToken = startToken;
                 data.PendingStartToken = null;
                 data.IsRegistered = true;
+                // A newly registered subscriber can request an older token than the
+                // current checkpoint. Force a progress update so the receiver can
+                // persist that rewind immediately instead of waiting for its cadence.
+                NotifyDeliveryProgress(force: true);
                 StreamingEvents.EmitSubscriptionAttached(streamProviderName, streamId.StreamId, subscriptionId.Guid, streamConsumer, Silo);
                 if (data.State == StreamConsumerDataState.Inactive)
                     RunConsumerCursor(data).Ignore(); // Start delivering events if not actively doing so
@@ -415,10 +421,8 @@ namespace Orleans.Streams
                 return Task.CompletedTask;
             }
 
-            // Push delivery progress on every timer tick (~100ms) so checkpoint
-            // advancement reflects cursor delivery that happens asynchronously,
-            // even while a pump is still reading from the queue.
-            NotifyDeliveryProgress();
+            // Let the cache lazily request delivery progress when its checkpoint cadence elapses.
+            NotifyDeliveryProgress(force: false);
 
             if (!_activePumpTask.IsCompleted)
             {
@@ -602,35 +606,38 @@ namespace Orleans.Streams
         }
 
         /// <summary>
-        /// Scans <see cref="pubSubCache"/> for the current delivery progress of all
-        /// subscriptions and pushes a snapshot to the queue cache so it can compute a safe
-        /// checkpoint watermark. Called periodically from the read loop and once at shutdown.
-        /// Skips notifying the cache while stream registrations are pending.
+        /// Gives the queue cache a lazy callback for retrieving delivery progress.
+        /// The cache invokes the callback when it needs a current checkpoint watermark.
         /// </summary>
-        private void NotifyDeliveryProgress()
+        private void NotifyDeliveryProgress(bool force)
         {
             if (queueCache is null) return;
 
-            StreamSequenceToken earliest = null;
+            queueCache.UpdateDeliveryProgress(_tryGetDeliveryProgress, force);
+        }
+
+        private bool TryGetDeliveryProgress(out StreamSequenceToken earliest)
+        {
+            earliest = null;
 
             foreach (var streamConsumers in pubSubCache.Values)
             {
                 if (streamConsumers.RegistrationTask is { IsCompleted: false })
                 {
-                    return;
+                    return false;
                 }
 
                 foreach (var consumer in streamConsumers.AllConsumers())
                 {
                     if (!consumer.IsRegistered)
                     {
-                        return;
+                        return false;
                     }
 
                     var current = consumer.LastProcessedToken;
                     if (current is null)
                     {
-                        return;
+                        return false;
                     }
 
                     if (earliest is null || IsBefore(current, earliest))
@@ -640,7 +647,7 @@ namespace Orleans.Streams
                 }
             }
 
-            queueCache.UpdateDeliveryProgress(earliest);
+            return true;
         }
 
         private static bool IsBefore(StreamSequenceToken current, StreamSequenceToken other)
@@ -711,6 +718,7 @@ namespace Orleans.Streams
                 finally
                 {
                     streamData.RegistrationTask = null;
+                    NotifyDeliveryProgress(force: true);
 
                     // Disposed after all initial subscriber handshakes complete so the first
                     // batch stays pinned until each subscriber has its own cache cursor.

--- a/src/Orleans.Streaming/PersistentStreams/QueueStreamDataStructures.cs
+++ b/src/Orleans.Streaming/PersistentStreams/QueueStreamDataStructures.cs
@@ -35,6 +35,13 @@ namespace Orleans.Streams
         [NonSerialized]
         public StreamSequenceToken? PendingStartToken;
 
+        /// <summary>
+        /// The sequence token of the last batch processed (delivered or filtered) by this subscription.
+        /// Used by the pulling agent's periodic scan to compute the delivery-based checkpoint watermark.
+        /// </summary>
+        [NonSerialized]
+        public StreamSequenceToken? LastProcessedToken;
+
         public StreamConsumerData(GuidId subscriptionId, QualifiedStreamId streamId, IStreamConsumerExtension streamConsumer, string filterData)
         {
             SubscriptionId = subscriptionId;

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
@@ -34,13 +34,41 @@ namespace Orleans.Streams
         bool IsUnderPressure();
 
         /// <summary>
-        /// Notifies the cache that a batch with the given sequence token has been successfully
-        /// delivered to a specific subscription on the specified stream. Implementations can use
-        /// this to advance checkpoints based on delivery rather than cache eviction.
+        /// Notifies the cache that stream registration has started and checkpoints should not advance past this stream
+        /// until registration completes.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        void NotifyStreamRegistrationStarted(StreamId streamId) { }
+
+        /// <summary>
+        /// Notifies the cache that stream registration has completed.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        void NotifyStreamRegistrationCompleted(StreamId streamId) { }
+
+        /// <summary>
+        /// Notifies the cache that a subscription is active on the specified stream.
         /// </summary>
         /// <param name="streamId">The stream identifier.</param>
         /// <param name="subscriptionId">The subscription identifier.</param>
-        /// <param name="token">The sequence token of the delivered batch.</param>
-        void NotifyBatchDelivered(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token) { }
+        /// <param name="token">The sequence token from which the subscription starts, or <see langword="null"/> if unknown.</param>
+        void NotifySubscriptionAdded(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token) { }
+
+        /// <summary>
+        /// Notifies the cache that a subscription is no longer active on the specified stream.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="subscriptionId">The subscription identifier.</param>
+        void NotifySubscriptionRemoved(StreamId streamId, GuidId subscriptionId) { }
+
+        /// <summary>
+        /// Notifies the cache that a batch with the given sequence token has been successfully
+        /// processed by a specific subscription on the specified stream. Processing can mean either
+        /// delivery to the subscription or filtering/skipping by the pulling agent.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="subscriptionId">The subscription identifier.</param>
+        /// <param name="token">The sequence token of the processed batch.</param>
+        void NotifyBatchProcessed(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token) { }
     }
 }

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
@@ -32,5 +32,15 @@ namespace Orleans.Streams
         /// </summary>
         /// <returns><see langword="true" /> if this cache is under pressure; otherwise, <see langword="false" />.</returns>
         bool IsUnderPressure();
+
+        /// <summary>
+        /// Notifies the cache that a batch with the given sequence token has been successfully
+        /// delivered to a specific subscription on the specified stream. Implementations can use
+        /// this to advance checkpoints based on delivery rather than cache eviction.
+        /// </summary>
+        /// <param name="streamId">The stream identifier.</param>
+        /// <param name="subscriptionId">The subscription identifier.</param>
+        /// <param name="token">The sequence token of the delivered batch.</param>
+        void NotifyBatchDelivered(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token) { }
     }
 }

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
@@ -1,21 +1,9 @@
+using System;
 using System.Collections.Generic;
 using Orleans.Runtime;
 
 namespace Orleans.Streams
 {
-    /// <summary>
-    /// Attempts to retrieve the current delivery progress for a queue cache.
-    /// </summary>
-    /// <param name="earliestSubscriptionToken">
-    /// The earliest last processed sequence token across registered subscriptions,
-    /// or <see langword="null"/> when there are no active subscriptions.
-    /// </param>
-    /// <returns>
-    /// <see langword="true"/> if delivery progress was available; otherwise,
-    /// <see langword="false"/> when progress is temporarily unavailable.
-    /// </returns>
-    public delegate bool TryGetDeliveryProgress(out StreamSequenceToken? earliestSubscriptionToken);
-
     public interface IQueueCache : IQueueFlowController
     {
         /// <summary>
@@ -47,14 +35,21 @@ namespace Orleans.Streams
         bool IsUnderPressure();
 
         /// <summary>
-        /// Updates the cache with the current delivery progress of all active subscriptions.
-        /// The cache invokes <paramref name="tryGetDeliveryProgress"/> when it needs a current
-        /// delivery-progress snapshot to compute a safe checkpoint offset.
+        /// Returns <see langword="true"/> if the cache is due for a delivery progress update.
         /// </summary>
-        /// <param name="tryGetDeliveryProgress">The callback used to retrieve current delivery progress.</param>
-        /// <param name="force">
-        /// <see langword="true"/> when the cache should retrieve progress even if its normal checkpointing cadence has not elapsed.
+        /// <param name="utcNow">The current UTC time.</param>
+        /// <returns><see langword="true"/> if an update is due; otherwise, <see langword="false"/>.</returns>
+        bool IsUpdateDue(DateTime utcNow) => true;
+
+        /// <summary>
+        /// Updates the cache with the current delivery progress of all active subscriptions.
+        /// </summary>
+        /// <param name="earliestSubscriptionToken">
+        /// The earliest last processed sequence token across registered subscriptions.
+        /// A <see langword="null"/> value indicates that there are no active subscriptions.
+        /// The token is only valid for the duration of the call and must not be stored.
         /// </param>
-        void UpdateDeliveryProgress(TryGetDeliveryProgress tryGetDeliveryProgress, bool force) { }
+        /// <param name="utcNow">The current UTC time.</param>
+        void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken, DateTime utcNow) { }
     }
 }

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
@@ -3,6 +3,19 @@ using Orleans.Runtime;
 
 namespace Orleans.Streams
 {
+    /// <summary>
+    /// Attempts to retrieve the current delivery progress for a queue cache.
+    /// </summary>
+    /// <param name="earliestSubscriptionToken">
+    /// The earliest last processed sequence token across registered subscriptions,
+    /// or <see langword="null"/> when there are no active subscriptions.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if delivery progress was available; otherwise,
+    /// <see langword="false"/> when progress is temporarily unavailable.
+    /// </returns>
+    public delegate bool TryGetDeliveryProgress(out StreamSequenceToken? earliestSubscriptionToken);
+
     public interface IQueueCache : IQueueFlowController
     {
         /// <summary>
@@ -35,14 +48,13 @@ namespace Orleans.Streams
 
         /// <summary>
         /// Updates the cache with the current delivery progress of all active subscriptions.
-        /// Called periodically by the pulling agent when no registrations are pending so the cache
-        /// can compute a safe checkpoint offset (e.g., the low watermark across all subscriptions).
+        /// The cache invokes <paramref name="tryGetDeliveryProgress"/> when it needs a current
+        /// delivery-progress snapshot to compute a safe checkpoint offset.
         /// </summary>
-        /// <param name="earliestSubscriptionToken">
-        /// The earliest last processed sequence token across registered subscriptions.
-        /// A <see langword="null"/> value indicates that there are no active subscriptions.
-        /// The token is only valid for the duration of the call and must not be stored.
+        /// <param name="tryGetDeliveryProgress">The callback used to retrieve current delivery progress.</param>
+        /// <param name="force">
+        /// <see langword="true"/> when the cache should retrieve progress even if its normal checkpointing cadence has not elapsed.
         /// </param>
-        void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken) { }
+        void UpdateDeliveryProgress(TryGetDeliveryProgress tryGetDeliveryProgress, bool force) { }
     }
 }

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
@@ -35,18 +35,14 @@ namespace Orleans.Streams
 
         /// <summary>
         /// Updates the cache with the current delivery progress of all active subscriptions.
-        /// Called periodically by the pulling agent so the cache can compute a safe checkpoint
-        /// offset (e.g., the low watermark across all subscriptions).
+        /// Called periodically by the pulling agent when no registrations are pending so the cache
+        /// can compute a safe checkpoint offset (e.g., the low watermark across all subscriptions).
         /// </summary>
         /// <param name="earliestSubscriptionToken">
         /// The earliest last processed sequence token across registered subscriptions.
         /// A <see langword="null"/> value indicates that there are no active subscriptions.
         /// The token is only valid for the duration of the call and must not be stored.
         /// </param>
-        /// <param name="hasPendingRegistrations">
-        /// <see langword="true"/> if any stream registration is still in progress,
-        /// meaning the full set of subscriptions is not yet known and checkpoints should not advance.
-        /// </param>
-        void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken, bool hasPendingRegistrations) { }
+        void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken) { }
     }
 }

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
@@ -34,41 +34,20 @@ namespace Orleans.Streams
         bool IsUnderPressure();
 
         /// <summary>
-        /// Notifies the cache that stream registration has started and checkpoints should not advance past this stream
-        /// until registration completes.
+        /// Updates the cache with the current delivery progress of all active subscriptions.
+        /// Called periodically by the pulling agent so the cache can compute a safe checkpoint
+        /// offset (e.g., the low watermark across all subscriptions).
         /// </summary>
-        /// <param name="streamId">The stream identifier.</param>
-        void NotifyStreamRegistrationStarted(StreamId streamId) { }
-
-        /// <summary>
-        /// Notifies the cache that stream registration has completed.
-        /// </summary>
-        /// <param name="streamId">The stream identifier.</param>
-        void NotifyStreamRegistrationCompleted(StreamId streamId) { }
-
-        /// <summary>
-        /// Notifies the cache that a subscription is active on the specified stream.
-        /// </summary>
-        /// <param name="streamId">The stream identifier.</param>
-        /// <param name="subscriptionId">The subscription identifier.</param>
-        /// <param name="token">The sequence token from which the subscription starts, or <see langword="null"/> if unknown.</param>
-        void NotifySubscriptionAdded(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token) { }
-
-        /// <summary>
-        /// Notifies the cache that a subscription is no longer active on the specified stream.
-        /// </summary>
-        /// <param name="streamId">The stream identifier.</param>
-        /// <param name="subscriptionId">The subscription identifier.</param>
-        void NotifySubscriptionRemoved(StreamId streamId, GuidId subscriptionId) { }
-
-        /// <summary>
-        /// Notifies the cache that a batch with the given sequence token has been successfully
-        /// processed by a specific subscription on the specified stream. Processing can mean either
-        /// delivery to the subscription or filtering/skipping by the pulling agent.
-        /// </summary>
-        /// <param name="streamId">The stream identifier.</param>
-        /// <param name="subscriptionId">The subscription identifier.</param>
-        /// <param name="token">The sequence token of the processed batch.</param>
-        void NotifyBatchProcessed(StreamId streamId, GuidId subscriptionId, StreamSequenceToken token) { }
+        /// <param name="subscriptionTokens">
+        /// The last processed sequence token for each registered subscription.
+        /// A <see langword="null"/> entry indicates a subscription whose progress is not yet known
+        /// (e.g., it has not processed any batch), which should block checkpoint advancement.
+        /// The list is only valid for the duration of the call and must not be stored.
+        /// </param>
+        /// <param name="hasPendingRegistrations">
+        /// <see langword="true"/> if any stream registration is still in progress,
+        /// meaning the full set of subscriptions is not yet known and checkpoints should not advance.
+        /// </param>
+        void UpdateDeliveryProgress(IReadOnlyList<StreamSequenceToken> subscriptionTokens, bool hasPendingRegistrations) { }
     }
 }

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
@@ -35,13 +35,6 @@ namespace Orleans.Streams
         bool IsUnderPressure();
 
         /// <summary>
-        /// Returns <see langword="true"/> if the cache is due for a delivery progress update.
-        /// </summary>
-        /// <param name="utcNow">The current UTC time.</param>
-        /// <returns><see langword="true"/> if an update is due; otherwise, <see langword="false"/>.</returns>
-        bool IsUpdateDue(DateTime utcNow) => true;
-
-        /// <summary>
         /// Updates the cache with the current delivery progress of all active subscriptions.
         /// </summary>
         /// <param name="earliestSubscriptionToken">

--- a/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueCache.cs
@@ -38,16 +38,15 @@ namespace Orleans.Streams
         /// Called periodically by the pulling agent so the cache can compute a safe checkpoint
         /// offset (e.g., the low watermark across all subscriptions).
         /// </summary>
-        /// <param name="subscriptionTokens">
-        /// The last processed sequence token for each registered subscription.
-        /// A <see langword="null"/> entry indicates a subscription whose progress is not yet known
-        /// (e.g., it has not processed any batch), which should block checkpoint advancement.
-        /// The list is only valid for the duration of the call and must not be stored.
+        /// <param name="earliestSubscriptionToken">
+        /// The earliest last processed sequence token across registered subscriptions.
+        /// A <see langword="null"/> value indicates that there are no active subscriptions.
+        /// The token is only valid for the duration of the call and must not be stored.
         /// </param>
         /// <param name="hasPendingRegistrations">
         /// <see langword="true"/> if any stream registration is still in progress,
         /// meaning the full set of subscriptions is not yet known and checkpoints should not advance.
         /// </param>
-        void UpdateDeliveryProgress(IReadOnlyList<StreamSequenceToken> subscriptionTokens, bool hasPendingRegistrations) { }
+        void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken, bool hasPendingRegistrations) { }
     }
 }

--- a/src/Redis/Orleans.Streaming.Redis/Storage/RedisStreamCheckpointer.cs
+++ b/src/Redis/Orleans.Streaming.Redis/Storage/RedisStreamCheckpointer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using StackExchange.Redis;
 using static System.FormattableString;
@@ -55,16 +56,17 @@ internal sealed class RedisStreamCheckpointer
         }
     }
 
-    public async Task FlushAsync()
+    public async Task FlushAsync(CancellationToken cancellationToken)
     {
         while (true)
         {
-            await _inProgressSave;
+            await _inProgressSave.WaitAsync(cancellationToken);
             if (string.Equals(_persistedOffset, Offset, StringComparison.Ordinal))
             {
                 return;
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             StartSave(Offset!, DateTime.UtcNow);
         }
     }

--- a/src/Redis/Orleans.Streaming.Redis/Storage/RedisStreamStorage.cs
+++ b/src/Redis/Orleans.Streaming.Redis/Storage/RedisStreamStorage.cs
@@ -145,7 +145,7 @@ internal sealed class RedisStreamStorage
 
         if (checkpointer is not null)
         {
-            await checkpointer.FlushAsync();
+            await checkpointer.FlushAsync(CancellationToken.None);
         }
 
         if (multiplexer is not null && !isSharedMultiplexer)

--- a/src/Redis/Orleans.Streaming.Redis/Storage/RedisStreamStorage.cs
+++ b/src/Redis/Orleans.Streaming.Redis/Storage/RedisStreamStorage.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Orleans.Configuration;
 using Orleans.Streams;
@@ -143,14 +145,45 @@ internal sealed class RedisStreamStorage
         _multiplexer = null;
         _isSharedMultiplexer = false;
 
-        if (checkpointer is not null)
+        var shutdownExceptions = new List<Exception>();
+
+        try
         {
-            await checkpointer.FlushAsync(CancellationToken.None);
+            if (checkpointer is not null)
+            {
+                await checkpointer.FlushAsync(CancellationToken.None);
+            }
+        }
+        catch (Exception ex)
+        {
+            shutdownExceptions.Add(ex);
         }
 
-        if (multiplexer is not null && !isSharedMultiplexer)
+        try
         {
-            await DisposeMultiplexerAsync(multiplexer);
+            if (multiplexer is not null && !isSharedMultiplexer)
+            {
+                await DisposeMultiplexerAsync(multiplexer);
+            }
+        }
+        catch (Exception ex)
+        {
+            shutdownExceptions.Add(ex);
+        }
+
+        ThrowIfAny(shutdownExceptions);
+
+        static void ThrowIfAny(List<Exception> exceptions)
+        {
+            if (exceptions.Count == 1)
+            {
+                ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+            }
+
+            if (exceptions.Count > 1)
+            {
+                throw new AggregateException(exceptions);
+            }
         }
     }
 

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -358,7 +358,7 @@ namespace Orleans.Streaming.EventHubs
 
         public void Update(string offset, System.DateTime utcNow) { }
 
-        public System.Threading.Tasks.Task FlushAsync() { throw null; }
+        public System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
     }
 
     public partial class EventHubCheckpointerFactory : Streams.IStreamQueueCheckpointerFactory

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -357,6 +357,8 @@ namespace Orleans.Streaming.EventHubs
         public System.Threading.Tasks.Task<string> Load() { throw null; }
 
         public void Update(string offset, System.DateTime utcNow) { }
+
+        public System.Threading.Tasks.Task FlushAsync() { throw null; }
     }
 
     public partial class EventHubCheckpointerFactory : Streams.IStreamQueueCheckpointerFactory

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1479,7 +1479,11 @@ namespace Orleans.Streams
         void AddToCache(System.Collections.Generic.IList<IBatchContainer> messages);
         IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken token);
         bool IsUnderPressure();
-        void NotifyBatchDelivered(Runtime.StreamId streamId, Runtime.GuidId subscriptionId, StreamSequenceToken token) { }
+        void NotifyBatchProcessed(Runtime.StreamId streamId, Runtime.GuidId subscriptionId, StreamSequenceToken token) { }
+        void NotifyStreamRegistrationCompleted(Runtime.StreamId streamId) { }
+        void NotifyStreamRegistrationStarted(Runtime.StreamId streamId) { }
+        void NotifySubscriptionAdded(Runtime.StreamId streamId, Runtime.GuidId subscriptionId, StreamSequenceToken token) { }
+        void NotifySubscriptionRemoved(Runtime.StreamId streamId, Runtime.GuidId subscriptionId) { }
         bool TryPurgeFromCache(out System.Collections.Generic.IList<IBatchContainer> purgedItems);
     }
 

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1479,6 +1479,7 @@ namespace Orleans.Streams
         void AddToCache(System.Collections.Generic.IList<IBatchContainer> messages);
         IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken token);
         bool IsUnderPressure();
+        void NotifyBatchDelivered(Runtime.StreamId streamId, Runtime.GuidId subscriptionId, StreamSequenceToken token) { }
         bool TryPurgeFromCache(out System.Collections.Generic.IList<IBatchContainer> purgedItems);
     }
 
@@ -1584,6 +1585,7 @@ namespace Orleans.Streams
 
         System.Threading.Tasks.Task<TCheckpoint> Load();
         void Update(TCheckpoint offset, System.DateTime utcNow);
+        System.Threading.Tasks.Task FlushAsync() { return System.Threading.Tasks.Task.CompletedTask; }
     }
 
     public partial interface IStreamQueueMapper

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1480,7 +1480,7 @@ namespace Orleans.Streams
         IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken token);
         bool IsUnderPressure();
         bool TryPurgeFromCache(out System.Collections.Generic.IList<IBatchContainer> purgedItems);
-        void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken, bool hasPendingRegistrations) { }
+        void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken) { }
     }
 
     public partial interface IQueueCacheCursor : System.IDisposable

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1474,15 +1474,14 @@ namespace Orleans.Streams
         System.Threading.Tasks.Task Shutdown(System.TimeSpan timeout);
     }
 
-    public delegate bool TryGetDeliveryProgress(out StreamSequenceToken? earliestSubscriptionToken);
-
     public partial interface IQueueCache : IQueueFlowController
     {
         void AddToCache(System.Collections.Generic.IList<IBatchContainer> messages);
         IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken token);
         bool IsUnderPressure();
+        bool IsUpdateDue(System.DateTime utcNow) { return true; }
         bool TryPurgeFromCache(out System.Collections.Generic.IList<IBatchContainer> purgedItems);
-        void UpdateDeliveryProgress(TryGetDeliveryProgress tryGetDeliveryProgress, bool force) { }
+        void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken, System.DateTime utcNow) { }
     }
 
     public partial interface IQueueCacheCursor : System.IDisposable

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1585,7 +1585,7 @@ namespace Orleans.Streams
 
         System.Threading.Tasks.Task<TCheckpoint> Load();
         void Update(TCheckpoint offset, System.DateTime utcNow);
-        System.Threading.Tasks.Task FlushAsync() { return System.Threading.Tasks.Task.CompletedTask; }
+        System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return System.Threading.Tasks.Task.CompletedTask; }
     }
 
     public partial interface IStreamQueueMapper

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1474,13 +1474,15 @@ namespace Orleans.Streams
         System.Threading.Tasks.Task Shutdown(System.TimeSpan timeout);
     }
 
+    public delegate bool TryGetDeliveryProgress(out StreamSequenceToken? earliestSubscriptionToken);
+
     public partial interface IQueueCache : IQueueFlowController
     {
         void AddToCache(System.Collections.Generic.IList<IBatchContainer> messages);
         IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken token);
         bool IsUnderPressure();
         bool TryPurgeFromCache(out System.Collections.Generic.IList<IBatchContainer> purgedItems);
-        void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken) { }
+        void UpdateDeliveryProgress(TryGetDeliveryProgress tryGetDeliveryProgress, bool force) { }
     }
 
     public partial interface IQueueCacheCursor : System.IDisposable

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1479,7 +1479,6 @@ namespace Orleans.Streams
         void AddToCache(System.Collections.Generic.IList<IBatchContainer> messages);
         IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken token);
         bool IsUnderPressure();
-        bool IsUpdateDue(System.DateTime utcNow) { return true; }
         bool TryPurgeFromCache(out System.Collections.Generic.IList<IBatchContainer> purgedItems);
         void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken, System.DateTime utcNow) { }
     }
@@ -1583,10 +1582,8 @@ namespace Orleans.Streams
     public partial interface IStreamQueueCheckpointer<TCheckpoint>
     {
         bool CheckpointExists { get; }
-
         System.Threading.Tasks.Task<TCheckpoint> Load();
         void Update(TCheckpoint offset, System.DateTime utcNow);
-        bool IsUpdateDue(System.DateTime utcNow) { return true; }
         System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return System.Threading.Tasks.Task.CompletedTask; }
     }
 

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1479,12 +1479,8 @@ namespace Orleans.Streams
         void AddToCache(System.Collections.Generic.IList<IBatchContainer> messages);
         IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken token);
         bool IsUnderPressure();
-        void NotifyBatchProcessed(Runtime.StreamId streamId, Runtime.GuidId subscriptionId, StreamSequenceToken token) { }
-        void NotifyStreamRegistrationCompleted(Runtime.StreamId streamId) { }
-        void NotifyStreamRegistrationStarted(Runtime.StreamId streamId) { }
-        void NotifySubscriptionAdded(Runtime.StreamId streamId, Runtime.GuidId subscriptionId, StreamSequenceToken token) { }
-        void NotifySubscriptionRemoved(Runtime.StreamId streamId, Runtime.GuidId subscriptionId) { }
         bool TryPurgeFromCache(out System.Collections.Generic.IList<IBatchContainer> purgedItems);
+        void UpdateDeliveryProgress(System.Collections.Generic.IReadOnlyList<StreamSequenceToken> subscriptionTokens, bool hasPendingRegistrations) { }
     }
 
     public partial interface IQueueCacheCursor : System.IDisposable

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1587,6 +1587,7 @@ namespace Orleans.Streams
 
         System.Threading.Tasks.Task<TCheckpoint> Load();
         void Update(TCheckpoint offset, System.DateTime utcNow);
+        bool IsUpdateDue(System.DateTime utcNow) { return true; }
         System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { return System.Threading.Tasks.Task.CompletedTask; }
     }
 

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1480,7 +1480,7 @@ namespace Orleans.Streams
         IQueueCacheCursor GetCacheCursor(Runtime.StreamId streamId, StreamSequenceToken token);
         bool IsUnderPressure();
         bool TryPurgeFromCache(out System.Collections.Generic.IList<IBatchContainer> purgedItems);
-        void UpdateDeliveryProgress(System.Collections.Generic.IReadOnlyList<StreamSequenceToken> subscriptionTokens, bool hasPendingRegistrations) { }
+        void UpdateDeliveryProgress(StreamSequenceToken? earliestSubscriptionToken, bool hasPendingRegistrations) { }
     }
 
     public partial interface IQueueCacheCursor : System.IDisposable

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -1,0 +1,215 @@
+using Orleans.Runtime;
+using Orleans.Streaming.EventHubs;
+using Orleans.Streaming.EventHubs.Testing;
+using Orleans.Streams;
+using Xunit;
+
+namespace ServiceBus.Tests.CheckpointerTests;
+
+/// <summary>
+/// Tests for EventHub delivery-based checkpointing and low-watermark tracking.
+/// </summary>
+[TestCategory("EventHub"), TestCategory("Streaming")]
+public class EventHubCheckpointerTests
+{
+    /// <summary>
+    /// A test checkpointer that records all updates for verification.
+    /// </summary>
+    private class TestCheckpointer : IStreamQueueCheckpointer<string>
+    {
+        public bool CheckpointExists => true;
+        public string LastOffset { get; private set; }
+        public int UpdateCount { get; private set; }
+
+        public Task<string> Load() => Task.FromResult("-1");
+
+        public void Update(string offset, DateTime utcNow)
+        {
+            LastOffset = offset;
+            UpdateCount++;
+        }
+
+        public Task FlushAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private static EventHubSequenceToken MakeToken(long offset, long sequenceNumber = 0)
+    {
+        return new EventHubSequenceToken(offset.ToString(), sequenceNumber, 0);
+    }
+
+    private static StreamId MakeStreamId(string name)
+    {
+        return StreamId.Create("TestNamespace", name);
+    }
+
+    private static GuidId MakeSubscriptionId()
+    {
+        return GuidId.GetGuidId(Guid.NewGuid());
+    }
+
+    private EventHubAdapterReceiver CreateReceiver(TestCheckpointer checkpointer)
+    {
+        var settings = new EventHubPartitionSettings
+        {
+            Hub = new Orleans.Configuration.EventHubOptions(),
+            Partition = "TestPartition",
+            ReceiverOptions = new Orleans.Configuration.EventHubReceiverOptions()
+        };
+
+        var receiver = new EventHubAdapterReceiver(
+            settings,
+            cacheFactory: (_, _, _) => throw new NotImplementedException(),
+            checkpointerFactory: _ => Task.FromResult<IStreamQueueCheckpointer<string>>(checkpointer),
+            loggerFactory: Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance,
+            monitor: new Orleans.Streaming.EventHubs.DefaultEventHubReceiverMonitor(
+                new EventHubReceiverMonitorDimensions
+                {
+                    EventHubPartition = settings.Partition,
+                    EventHubPath = settings.Hub.EventHubName,
+                }),
+            loadSheddingOptions: new Orleans.Configuration.LoadSheddingOptions(),
+            environmentStatisticsProvider: new Orleans.Statistics.EnvironmentStatisticsProvider());
+
+        // Initialize the receiver so the checkpointer is created.
+        receiver.Initialize(TimeSpan.FromSeconds(5));
+
+        return receiver;
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void SingleStream_SingleSubscription_CheckpointsDeliveredOffset()
+    {
+        var checkpointer = new TestCheckpointer();
+        var receiver = CreateReceiver(checkpointer);
+
+        var stream = MakeStreamId("A");
+        var sub = MakeSubscriptionId();
+
+        receiver.NotifyBatchDelivered(stream, sub, MakeToken(100));
+
+        Assert.Equal("100", checkpointer.LastOffset);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void MultipleStreams_CheckpointsMinimumWatermark()
+    {
+        var checkpointer = new TestCheckpointer();
+        var receiver = CreateReceiver(checkpointer);
+
+        var streamA = MakeStreamId("A");
+        var streamB = MakeStreamId("B");
+        var subA = MakeSubscriptionId();
+        var subB = MakeSubscriptionId();
+
+        // Stream A delivers at offset 200
+        receiver.NotifyBatchDelivered(streamA, subA, MakeToken(200));
+        Assert.Equal("200", checkpointer.LastOffset);
+
+        // Stream B delivers at offset 95 — watermark should drop to 95
+        receiver.NotifyBatchDelivered(streamB, subB, MakeToken(95));
+        Assert.Equal("95", checkpointer.LastOffset);
+
+        // Stream B advances to 210 — watermark should now be 200 (stream A's max)
+        receiver.NotifyBatchDelivered(streamB, subB, MakeToken(210));
+        Assert.Equal("200", checkpointer.LastOffset);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void MultipleSubscriptions_SameStream_CheckpointsMinimum()
+    {
+        var checkpointer = new TestCheckpointer();
+        var receiver = CreateReceiver(checkpointer);
+
+        var stream = MakeStreamId("A");
+        var sub1 = MakeSubscriptionId();
+        var sub2 = MakeSubscriptionId();
+
+        // Sub1 delivers at offset 200
+        receiver.NotifyBatchDelivered(stream, sub1, MakeToken(200));
+        Assert.Equal("200", checkpointer.LastOffset);
+
+        // Sub2 delivers at offset 50 — watermark drops to 50
+        receiver.NotifyBatchDelivered(stream, sub2, MakeToken(50));
+        Assert.Equal("50", checkpointer.LastOffset);
+
+        // Sub2 catches up to 200 — watermark should now be 200
+        receiver.NotifyBatchDelivered(stream, sub2, MakeToken(200));
+        Assert.Equal("200", checkpointer.LastOffset);
+
+        // Sub1 advances to 300 — watermark is 200 (sub2's max)
+        receiver.NotifyBatchDelivered(stream, sub1, MakeToken(300));
+        Assert.Equal("200", checkpointer.LastOffset);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void MultipleStreams_MultipleSubscriptions_InterleavedDelivery()
+    {
+        var checkpointer = new TestCheckpointer();
+        var receiver = CreateReceiver(checkpointer);
+
+        var streamA = MakeStreamId("A");
+        var streamB = MakeStreamId("B");
+        var subA1 = MakeSubscriptionId();
+        var subA2 = MakeSubscriptionId();
+        var subB1 = MakeSubscriptionId();
+
+        // Stream A sub1 delivers at offset 100
+        receiver.NotifyBatchDelivered(streamA, subA1, MakeToken(100));
+        Assert.Equal("100", checkpointer.LastOffset);
+
+        // Stream A sub2 delivers at offset 80 — watermark drops to 80 (sub2 is behind)
+        receiver.NotifyBatchDelivered(streamA, subA2, MakeToken(80));
+        Assert.Equal("80", checkpointer.LastOffset);
+
+        // Stream B sub1 delivers at offset 50 — watermark drops to 50
+        receiver.NotifyBatchDelivered(streamB, subB1, MakeToken(50));
+        Assert.Equal("50", checkpointer.LastOffset);
+
+        // Stream B advances to 90 — watermark is now 80 (stream A sub2 is the laggard)
+        receiver.NotifyBatchDelivered(streamB, subB1, MakeToken(90));
+        Assert.Equal("80", checkpointer.LastOffset);
+
+        // Stream A sub2 catches up to 120 — watermark is now 90 (stream B sub1)
+        receiver.NotifyBatchDelivered(streamA, subA2, MakeToken(120));
+        Assert.Equal("90", checkpointer.LastOffset);
+
+        // Stream B advances to 150 — watermark is now 100 (stream A sub1)
+        receiver.NotifyBatchDelivered(streamB, subB1, MakeToken(150));
+        Assert.Equal("100", checkpointer.LastOffset);
+
+        // Stream A sub1 advances to 200 — watermark is now 120 (stream A sub2)
+        receiver.NotifyBatchDelivered(streamA, subA1, MakeToken(200));
+        Assert.Equal("120", checkpointer.LastOffset);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void PerSubscriptionMax_PreventsRegression()
+    {
+        var checkpointer = new TestCheckpointer();
+        var receiver = CreateReceiver(checkpointer);
+
+        var stream = MakeStreamId("A");
+        var sub = MakeSubscriptionId();
+
+        receiver.NotifyBatchDelivered(stream, sub, MakeToken(100));
+        Assert.Equal("100", checkpointer.LastOffset);
+
+        // Same subscription reports an earlier offset (shouldn't happen normally,
+        // but the per-subscription max should prevent regression)
+        receiver.NotifyBatchDelivered(stream, sub, MakeToken(50));
+        Assert.Equal("100", checkpointer.LastOffset);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void NoNotifications_NoCheckpoint()
+    {
+        var checkpointer = new TestCheckpointer();
+        _ = CreateReceiver(checkpointer);
+
+        Assert.Null(checkpointer.LastOffset);
+        Assert.Equal(0, checkpointer.UpdateCount);
+    }
+}

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -1,3 +1,5 @@
+using Azure.Messaging.EventHubs;
+using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.Streaming.EventHubs;
 using Orleans.Streaming.EventHubs.Testing;
@@ -35,6 +37,46 @@ public class EventHubCheckpointerTests
         }
     }
 
+    private sealed class TestEventHubQueueCache : IEventHubQueueCache
+    {
+        public int GetMaxAddCount() => 1_000;
+
+        public List<StreamPosition> Add(List<EventData> message, DateTime dequeueTimeUtc) => [];
+
+        public object GetCursor(StreamId streamId, StreamSequenceToken sequenceToken) => new();
+
+        public bool TryGetNextMessage(object cursorObj, out IBatchContainer message)
+        {
+            message = null;
+            return false;
+        }
+
+        public void AddCachePressureMonitor(ICachePressureMonitor monitor)
+        {
+        }
+
+        public void SignalPurge()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class TestEventHubReceiver : IEventHubReceiver
+    {
+        public Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime)
+        {
+            return Task.FromResult<IEnumerable<EventData>>([]);
+        }
+
+        public Task CloseAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+
     private static EventHubSequenceToken MakeToken(long offset, long sequenceNumber = 0)
     {
         return new EventHubSequenceToken(offset.ToString(), sequenceNumber, 0);
@@ -50,7 +92,7 @@ public class EventHubCheckpointerTests
         return GuidId.GetGuidId(Guid.NewGuid());
     }
 
-    private EventHubAdapterReceiver CreateReceiver(TestCheckpointer checkpointer)
+    private static async Task<EventHubAdapterReceiver> CreateReceiver(TestCheckpointer checkpointer)
     {
         var settings = new EventHubPartitionSettings
         {
@@ -61,7 +103,7 @@ public class EventHubCheckpointerTests
 
         var receiver = new EventHubAdapterReceiver(
             settings,
-            cacheFactory: (_, _, _) => throw new NotImplementedException(),
+            cacheFactory: (_, _, _) => new TestEventHubQueueCache(),
             checkpointerFactory: _ => Task.FromResult<IStreamQueueCheckpointer<string>>(checkpointer),
             loggerFactory: Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance,
             monitor: new Orleans.Streaming.EventHubs.DefaultEventHubReceiverMonitor(
@@ -71,84 +113,105 @@ public class EventHubCheckpointerTests
                     EventHubPath = settings.Hub.EventHubName,
                 }),
             loadSheddingOptions: new Orleans.Configuration.LoadSheddingOptions(),
-            environmentStatisticsProvider: new Orleans.Statistics.EnvironmentStatisticsProvider());
+            environmentStatisticsProvider: new Orleans.Statistics.EnvironmentStatisticsProvider(),
+            eventHubReceiverFactory: (_, _, _) => new TestEventHubReceiver());
 
-        // Initialize the receiver so the checkpointer is created.
-        receiver.Initialize(TimeSpan.FromSeconds(5));
+        await receiver.Initialize(TimeSpan.FromSeconds(5));
 
         return receiver;
     }
 
     [Fact, TestCategory("BVT")]
-    public void SingleStream_SingleSubscription_CheckpointsDeliveredOffset()
+    public async Task SingleStream_SingleSubscription_CheckpointsProcessedOffset()
     {
         var checkpointer = new TestCheckpointer();
-        var receiver = CreateReceiver(checkpointer);
+        var receiver = await CreateReceiver(checkpointer);
 
         var stream = MakeStreamId("A");
         var sub = MakeSubscriptionId();
 
-        receiver.NotifyBatchDelivered(stream, sub, MakeToken(100));
+        receiver.NotifySubscriptionAdded(stream, sub, null);
+        Assert.Null(checkpointer.LastOffset);
+
+        receiver.NotifyBatchProcessed(stream, sub, MakeToken(100));
 
         Assert.Equal("100", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public void MultipleStreams_CheckpointsMinimumWatermark()
+    public async Task MultipleStreams_CheckpointsMinimumWatermark()
     {
         var checkpointer = new TestCheckpointer();
-        var receiver = CreateReceiver(checkpointer);
+        var receiver = await CreateReceiver(checkpointer);
 
         var streamA = MakeStreamId("A");
         var streamB = MakeStreamId("B");
         var subA = MakeSubscriptionId();
         var subB = MakeSubscriptionId();
 
-        // Stream A delivers at offset 200
-        receiver.NotifyBatchDelivered(streamA, subA, MakeToken(200));
+        receiver.NotifySubscriptionAdded(streamA, subA, MakeToken(200));
         Assert.Equal("200", checkpointer.LastOffset);
 
-        // Stream B delivers at offset 95 — watermark should drop to 95
-        receiver.NotifyBatchDelivered(streamB, subB, MakeToken(95));
+        receiver.NotifySubscriptionAdded(streamB, subB, MakeToken(95));
         Assert.Equal("95", checkpointer.LastOffset);
 
-        // Stream B advances to 210 — watermark should now be 200 (stream A's max)
-        receiver.NotifyBatchDelivered(streamB, subB, MakeToken(210));
+        receiver.NotifyBatchProcessed(streamB, subB, MakeToken(210));
         Assert.Equal("200", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public void MultipleSubscriptions_SameStream_CheckpointsMinimum()
+    public async Task PendingRegistration_BlocksCheckpointUntilSubscriptionsAreKnown()
     {
         var checkpointer = new TestCheckpointer();
-        var receiver = CreateReceiver(checkpointer);
+        var receiver = await CreateReceiver(checkpointer);
 
         var stream = MakeStreamId("A");
         var sub1 = MakeSubscriptionId();
         var sub2 = MakeSubscriptionId();
 
-        // Sub1 delivers at offset 200
-        receiver.NotifyBatchDelivered(stream, sub1, MakeToken(200));
-        Assert.Equal("200", checkpointer.LastOffset);
+        receiver.NotifyStreamRegistrationStarted(stream);
+        receiver.NotifySubscriptionAdded(stream, sub1, MakeToken(200));
+        receiver.NotifySubscriptionAdded(stream, sub2, MakeToken(50));
+        Assert.Null(checkpointer.LastOffset);
 
-        // Sub2 delivers at offset 50 — watermark drops to 50
-        receiver.NotifyBatchDelivered(stream, sub2, MakeToken(50));
+        receiver.NotifyStreamRegistrationCompleted(stream);
         Assert.Equal("50", checkpointer.LastOffset);
 
-        // Sub2 catches up to 200 — watermark should now be 200
-        receiver.NotifyBatchDelivered(stream, sub2, MakeToken(200));
+        receiver.NotifyBatchProcessed(stream, sub2, MakeToken(200));
         Assert.Equal("200", checkpointer.LastOffset);
 
-        // Sub1 advances to 300 — watermark is 200 (sub2's max)
-        receiver.NotifyBatchDelivered(stream, sub1, MakeToken(300));
+        receiver.NotifyBatchProcessed(stream, sub1, MakeToken(300));
         Assert.Equal("200", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public void MultipleStreams_MultipleSubscriptions_InterleavedDelivery()
+    public async Task RemovedSubscription_NoLongerHoldsWatermark()
     {
         var checkpointer = new TestCheckpointer();
-        var receiver = CreateReceiver(checkpointer);
+        var receiver = await CreateReceiver(checkpointer);
+
+        var stream = MakeStreamId("A");
+        var sub1 = MakeSubscriptionId();
+        var sub2 = MakeSubscriptionId();
+
+        receiver.NotifySubscriptionAdded(stream, sub1, null);
+        receiver.NotifySubscriptionAdded(stream, sub2, null);
+
+        receiver.NotifyBatchProcessed(stream, sub1, MakeToken(200));
+        Assert.Null(checkpointer.LastOffset);
+
+        receiver.NotifyBatchProcessed(stream, sub2, MakeToken(50));
+        Assert.Equal("50", checkpointer.LastOffset);
+
+        receiver.NotifySubscriptionRemoved(stream, sub2);
+        Assert.Equal("200", checkpointer.LastOffset);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task MultipleStreams_MultipleSubscriptions_InterleavedDelivery()
+    {
+        var checkpointer = new TestCheckpointer();
+        var receiver = await CreateReceiver(checkpointer);
 
         var streamA = MakeStreamId("A");
         var streamB = MakeStreamId("B");
@@ -156,58 +219,54 @@ public class EventHubCheckpointerTests
         var subA2 = MakeSubscriptionId();
         var subB1 = MakeSubscriptionId();
 
-        // Stream A sub1 delivers at offset 100
-        receiver.NotifyBatchDelivered(streamA, subA1, MakeToken(100));
-        Assert.Equal("100", checkpointer.LastOffset);
+        receiver.NotifySubscriptionAdded(streamA, subA1, null);
+        receiver.NotifySubscriptionAdded(streamA, subA2, null);
+        receiver.NotifySubscriptionAdded(streamB, subB1, null);
 
-        // Stream A sub2 delivers at offset 80 — watermark drops to 80 (sub2 is behind)
-        receiver.NotifyBatchDelivered(streamA, subA2, MakeToken(80));
-        Assert.Equal("80", checkpointer.LastOffset);
+        receiver.NotifyBatchProcessed(streamA, subA1, MakeToken(100));
+        Assert.Null(checkpointer.LastOffset);
 
-        // Stream B sub1 delivers at offset 50 — watermark drops to 50
-        receiver.NotifyBatchDelivered(streamB, subB1, MakeToken(50));
+        receiver.NotifyBatchProcessed(streamA, subA2, MakeToken(80));
+        Assert.Null(checkpointer.LastOffset);
+
+        receiver.NotifyBatchProcessed(streamB, subB1, MakeToken(50));
         Assert.Equal("50", checkpointer.LastOffset);
 
-        // Stream B advances to 90 — watermark is now 80 (stream A sub2 is the laggard)
-        receiver.NotifyBatchDelivered(streamB, subB1, MakeToken(90));
+        receiver.NotifyBatchProcessed(streamB, subB1, MakeToken(90));
         Assert.Equal("80", checkpointer.LastOffset);
 
-        // Stream A sub2 catches up to 120 — watermark is now 90 (stream B sub1)
-        receiver.NotifyBatchDelivered(streamA, subA2, MakeToken(120));
+        receiver.NotifyBatchProcessed(streamA, subA2, MakeToken(120));
         Assert.Equal("90", checkpointer.LastOffset);
 
-        // Stream B advances to 150 — watermark is now 100 (stream A sub1)
-        receiver.NotifyBatchDelivered(streamB, subB1, MakeToken(150));
+        receiver.NotifyBatchProcessed(streamB, subB1, MakeToken(150));
         Assert.Equal("100", checkpointer.LastOffset);
 
-        // Stream A sub1 advances to 200 — watermark is now 120 (stream A sub2)
-        receiver.NotifyBatchDelivered(streamA, subA1, MakeToken(200));
+        receiver.NotifyBatchProcessed(streamA, subA1, MakeToken(200));
         Assert.Equal("120", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public void PerSubscriptionMax_PreventsRegression()
+    public async Task PerSubscriptionMax_PreventsRegression()
     {
         var checkpointer = new TestCheckpointer();
-        var receiver = CreateReceiver(checkpointer);
+        var receiver = await CreateReceiver(checkpointer);
 
         var stream = MakeStreamId("A");
         var sub = MakeSubscriptionId();
 
-        receiver.NotifyBatchDelivered(stream, sub, MakeToken(100));
+        receiver.NotifySubscriptionAdded(stream, sub, null);
+        receiver.NotifyBatchProcessed(stream, sub, MakeToken(100));
         Assert.Equal("100", checkpointer.LastOffset);
 
-        // Same subscription reports an earlier offset (shouldn't happen normally,
-        // but the per-subscription max should prevent regression)
-        receiver.NotifyBatchDelivered(stream, sub, MakeToken(50));
+        receiver.NotifyBatchProcessed(stream, sub, MakeToken(50));
         Assert.Equal("100", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public void NoNotifications_NoCheckpoint()
+    public async Task NoNotifications_NoCheckpoint()
     {
         var checkpointer = new TestCheckpointer();
-        _ = CreateReceiver(checkpointer);
+        _ = await CreateReceiver(checkpointer);
 
         Assert.Null(checkpointer.LastOffset);
         Assert.Equal(0, checkpointer.UpdateCount);

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -8,9 +8,9 @@ using Xunit;
 namespace ServiceBus.Tests.CheckpointerTests;
 
 /// <summary>
-/// Tests for EventHub delivery-based checkpointing via the periodic scan approach.
-/// The pulling agent periodically scans its subscription state and pushes the current
-/// low-watermark token to the receiver via <see cref="IQueueCache.UpdateDeliveryProgress"/>.
+/// Tests for EventHub delivery-based checkpointing via lazy delivery progress callbacks.
+/// The pulling agent exposes its current subscription state to the receiver, which evaluates
+/// it only when a checkpoint update is due or a forced update is needed.
 /// </summary>
 [TestCategory("EventHub"), TestCategory("Streaming")]
 public class EventHubCheckpointerTests
@@ -35,6 +35,18 @@ public class EventHubCheckpointerTests
         public Task FlushAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrottledTestCheckpointer : TestCheckpointer, IEventHubCheckpointerUpdateCadence
+    {
+        public bool IsUpdateDueResult { get; set; }
+        public int IsUpdateDueCount { get; private set; }
+
+        public bool IsUpdateDue(DateTime utcNow)
+        {
+            IsUpdateDueCount++;
+            return IsUpdateDueResult;
         }
     }
 
@@ -83,6 +95,28 @@ public class EventHubCheckpointerTests
         return new EventHubSequenceToken(offset.ToString(), sequenceNumber, 0);
     }
 
+    private static void UpdateDeliveryProgress(EventHubAdapterReceiver receiver, StreamSequenceToken token, bool force = true)
+    {
+        receiver.UpdateDeliveryProgress(
+            (out StreamSequenceToken earliestSubscriptionToken) =>
+            {
+                earliestSubscriptionToken = token;
+                return true;
+            },
+            force);
+    }
+
+    private static void UpdateDeliveryProgressWithNoSubscriptions(EventHubAdapterReceiver receiver, bool force = true)
+    {
+        receiver.UpdateDeliveryProgress(
+            (out StreamSequenceToken earliestSubscriptionToken) =>
+            {
+                earliestSubscriptionToken = null;
+                return true;
+            },
+            force);
+    }
+
     private static async Task<EventHubAdapterReceiver> CreateReceiver(TestCheckpointer checkpointer)
     {
         var settings = new EventHubPartitionSettings
@@ -113,13 +147,46 @@ public class EventHubCheckpointerTests
     }
 
     [Fact, TestCategory("BVT")]
+    public async Task DeliveryProgress_IsEvaluatedOnlyWhenCheckpointUpdateIsDue()
+    {
+        var checkpointer = new ThrottledTestCheckpointer { IsUpdateDueResult = false };
+        var receiver = await CreateReceiver(checkpointer);
+        var wasEvaluated = false;
+
+        receiver.UpdateDeliveryProgress(
+            (out StreamSequenceToken earliestSubscriptionToken) =>
+            {
+                wasEvaluated = true;
+                earliestSubscriptionToken = MakeToken(100);
+                return true;
+            },
+            force: false);
+
+        Assert.Equal(1, checkpointer.IsUpdateDueCount);
+        Assert.False(wasEvaluated);
+        Assert.Null(checkpointer.LastOffset);
+
+        receiver.UpdateDeliveryProgress(
+            (out StreamSequenceToken earliestSubscriptionToken) =>
+            {
+                wasEvaluated = true;
+                earliestSubscriptionToken = MakeToken(100);
+                return true;
+            },
+            force: true);
+
+        Assert.True(wasEvaluated);
+        Assert.Equal("100", checkpointer.LastOffset);
+    }
+
+    [Fact, TestCategory("BVT")]
     public async Task SingleSubscription_CheckpointsProcessedOffset()
     {
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
         // Single subscription with a known processed offset.
-        receiver.UpdateDeliveryProgress(MakeToken(100));
+        UpdateDeliveryProgress(receiver, MakeToken(100));
 
         Assert.Equal("100", checkpointer.LastOffset);
     }
@@ -131,7 +198,7 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(checkpointer);
 
         // The pulling agent passes the lowest subscription offset as the watermark.
-        receiver.UpdateDeliveryProgress(MakeToken(95));
+        UpdateDeliveryProgress(receiver, MakeToken(95));
 
         Assert.Equal("95", checkpointer.LastOffset);
     }
@@ -143,11 +210,11 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(checkpointer);
 
         // Two subscriptions, one slow.
-        receiver.UpdateDeliveryProgress(MakeToken(50));
+        UpdateDeliveryProgress(receiver, MakeToken(50));
         Assert.Equal("50", checkpointer.LastOffset);
 
         // After the slow subscription is removed, watermark advances.
-        receiver.UpdateDeliveryProgress(MakeToken(200));
+        UpdateDeliveryProgress(receiver, MakeToken(200));
         Assert.Equal("200", checkpointer.LastOffset);
     }
 
@@ -158,15 +225,15 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(checkpointer);
 
         // Three subscriptions at different positions: the pulling agent passes the lowest token.
-        receiver.UpdateDeliveryProgress(MakeToken(50));
+        UpdateDeliveryProgress(receiver, MakeToken(50));
         Assert.Equal("50", checkpointer.LastOffset);
 
         // Slowest catches up.
-        receiver.UpdateDeliveryProgress(MakeToken(80));
+        UpdateDeliveryProgress(receiver, MakeToken(80));
         Assert.Equal("80", checkpointer.LastOffset);
 
         // All converge.
-        receiver.UpdateDeliveryProgress(MakeToken(120));
+        UpdateDeliveryProgress(receiver, MakeToken(120));
         Assert.Equal("120", checkpointer.LastOffset);
     }
 
@@ -176,13 +243,13 @@ public class EventHubCheckpointerTests
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
-        receiver.UpdateDeliveryProgress(MakeToken(200));
+        UpdateDeliveryProgress(receiver, MakeToken(200));
         Assert.Equal("200", checkpointer.LastOffset);
 
         // A newly registered subscriber can request replay from an older token.
         // The safe delivery watermark must be allowed to move backwards so a
         // restart does not skip the messages that subscriber still needs.
-        receiver.UpdateDeliveryProgress(MakeToken(50));
+        UpdateDeliveryProgress(receiver, MakeToken(50));
         Assert.Equal("50", checkpointer.LastOffset);
     }
 
@@ -203,7 +270,7 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(checkpointer);
 
         // No subscriptions and cachePurgeOffset is null, so there is no checkpoint.
-        receiver.UpdateDeliveryProgress(earliestSubscriptionToken: null);
+        UpdateDeliveryProgressWithNoSubscriptions(receiver);
 
         Assert.Null(checkpointer.LastOffset);
     }
@@ -225,13 +292,13 @@ public class EventHubCheckpointerTests
         // call that includes subscriptions, then removing all subscriptions.
 
         // First: some subscription progress establishes a checkpoint.
-        receiver.UpdateDeliveryProgress(MakeToken(100));
+        UpdateDeliveryProgress(receiver, MakeToken(100));
         Assert.Equal("100", checkpointer.LastOffset);
 
         // Now with no subscriptions, the purge offset isn't set yet so no checkpoint change.
         // (cachePurgeOffset is only set via the CachePurgeCheckpointer, which we can't
         // trigger without a real cache eviction.)
-        receiver.UpdateDeliveryProgress(earliestSubscriptionToken: null);
+        UpdateDeliveryProgressWithNoSubscriptions(receiver);
         // cachePurgeOffset is null → no update, LastOffset stays at previous value.
         Assert.Equal("100", checkpointer.LastOffset);
     }
@@ -244,11 +311,11 @@ public class EventHubCheckpointerTests
 
         // With active subscriptions, the watermark comes from subscription tokens,
         // not from the cache purge offset.
-        receiver.UpdateDeliveryProgress(MakeToken(50));
+        UpdateDeliveryProgress(receiver, MakeToken(50));
         Assert.Equal("50", checkpointer.LastOffset);
 
         // Even after progress, subscriptions remain authoritative.
-        receiver.UpdateDeliveryProgress(MakeToken(75));
+        UpdateDeliveryProgress(receiver, MakeToken(75));
         Assert.Equal("75", checkpointer.LastOffset);
     }
 }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -32,7 +32,7 @@ public class EventHubCheckpointerTests
             UpdateCount++;
         }
 
-        public Task FlushAsync()
+        public Task FlushAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -9,9 +9,8 @@ using Xunit;
 namespace ServiceBus.Tests.CheckpointerTests;
 
 /// <summary>
-/// Tests for EventHub delivery-based checkpointing via lazy delivery progress callbacks.
-/// The pulling agent exposes its current subscription state to the receiver, which evaluates
-/// it only when a checkpoint update is due or a forced update is needed.
+/// Tests for EventHub delivery-based checkpointing via pulling-agent progress snapshots.
+/// The pulling agent asks the receiver whether an update is due before computing progress.
 /// </summary>
 [TestCategory("EventHub"), TestCategory("Streaming")]
 public class EventHubCheckpointerTests
@@ -104,26 +103,14 @@ public class EventHubCheckpointerTests
         return new EventHubSequenceToken(offset.ToString(), sequenceNumber, 0);
     }
 
-    private static void UpdateDeliveryProgress(EventHubAdapterReceiver receiver, StreamSequenceToken token, bool force = true)
+    private static void UpdateDeliveryProgress(EventHubAdapterReceiver receiver, StreamSequenceToken token)
     {
-        receiver.UpdateDeliveryProgress(
-            (out StreamSequenceToken earliestSubscriptionToken) =>
-            {
-                earliestSubscriptionToken = token;
-                return true;
-            },
-            force);
+        receiver.UpdateDeliveryProgress(token, DateTime.UtcNow);
     }
 
-    private static void UpdateDeliveryProgressWithNoSubscriptions(EventHubAdapterReceiver receiver, bool force = true)
+    private static void UpdateDeliveryProgressWithNoSubscriptions(EventHubAdapterReceiver receiver)
     {
-        receiver.UpdateDeliveryProgress(
-            (out StreamSequenceToken earliestSubscriptionToken) =>
-            {
-                earliestSubscriptionToken = null;
-                return true;
-            },
-            force);
+        receiver.UpdateDeliveryProgress(null, DateTime.UtcNow);
     }
 
     private static async Task<EventHubAdapterReceiver> CreateReceiver(TestCheckpointer checkpointer)
@@ -156,36 +143,18 @@ public class EventHubCheckpointerTests
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task DeliveryProgress_IsEvaluatedOnlyWhenCheckpointUpdateIsDue()
+    public async Task IsUpdateDue_UsesCheckpointerCadence()
     {
         var checkpointer = new ThrottledTestCheckpointer { IsUpdateDueResult = false };
         var receiver = await CreateReceiver(checkpointer);
-        var wasEvaluated = false;
 
-        receiver.UpdateDeliveryProgress(
-            (out StreamSequenceToken earliestSubscriptionToken) =>
-            {
-                wasEvaluated = true;
-                earliestSubscriptionToken = MakeToken(100);
-                return true;
-            },
-            force: false);
-
+        Assert.False(receiver.IsUpdateDue(DateTime.UtcNow));
         Assert.Equal(1, checkpointer.IsUpdateDueCount);
-        Assert.False(wasEvaluated);
-        Assert.Null(checkpointer.LastOffset);
 
-        receiver.UpdateDeliveryProgress(
-            (out StreamSequenceToken earliestSubscriptionToken) =>
-            {
-                wasEvaluated = true;
-                earliestSubscriptionToken = MakeToken(100);
-                return true;
-            },
-            force: true);
+        checkpointer.IsUpdateDueResult = true;
 
-        Assert.True(wasEvaluated);
-        Assert.Equal("100", checkpointer.LastOffset);
+        Assert.True(receiver.IsUpdateDue(DateTime.UtcNow));
+        Assert.Equal(2, checkpointer.IsUpdateDueCount);
     }
 
     [Fact, TestCategory("BVT")]

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -171,6 +171,22 @@ public class EventHubCheckpointerTests
     }
 
     [Fact, TestCategory("BVT")]
+    public async Task ReplayingSubscription_CanMoveCheckpointBackward()
+    {
+        var checkpointer = new TestCheckpointer();
+        var receiver = await CreateReceiver(checkpointer);
+
+        receiver.UpdateDeliveryProgress(MakeToken(200));
+        Assert.Equal("200", checkpointer.LastOffset);
+
+        // A newly registered subscriber can request replay from an older token.
+        // The safe delivery watermark must be allowed to move backwards so a
+        // restart does not skip the messages that subscriber still needs.
+        receiver.UpdateDeliveryProgress(MakeToken(50));
+        Assert.Equal("50", checkpointer.LastOffset);
+    }
+
+    [Fact, TestCategory("BVT")]
     public async Task NoSubscriptions_NoCheckpoint()
     {
         var checkpointer = new TestCheckpointer();

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -9,8 +9,8 @@ namespace ServiceBus.Tests.CheckpointerTests;
 
 /// <summary>
 /// Tests for EventHub delivery-based checkpointing via the periodic scan approach.
-/// The pulling agent periodically scans its subscription state and pushes a snapshot
-/// of processed tokens to the receiver via <see cref="IQueueCache.UpdateDeliveryProgress"/>.
+/// The pulling agent periodically scans its subscription state and pushes the current
+/// low-watermark token to the receiver via <see cref="IQueueCache.UpdateDeliveryProgress"/>.
 /// </summary>
 [TestCategory("EventHub"), TestCategory("Streaming")]
 public class EventHubCheckpointerTests
@@ -119,7 +119,7 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(checkpointer);
 
         // Single subscription with a known processed offset.
-        receiver.UpdateDeliveryProgress([MakeToken(100)], hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(100), hasPendingRegistrations: false);
 
         Assert.Equal("100", checkpointer.LastOffset);
     }
@@ -130,9 +130,9 @@ public class EventHubCheckpointerTests
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
-        // Two subscriptions at different offsets — watermark is the minimum.
+        // The pulling agent passes the lowest subscription offset as the watermark.
         receiver.UpdateDeliveryProgress(
-            [MakeToken(200), MakeToken(95)],
+            MakeToken(95),
             hasPendingRegistrations: false);
 
         Assert.Equal("95", checkpointer.LastOffset);
@@ -146,14 +146,14 @@ public class EventHubCheckpointerTests
 
         // hasPendingRegistrations blocks checkpointing even with known tokens.
         receiver.UpdateDeliveryProgress(
-            [MakeToken(200), MakeToken(50)],
+            MakeToken(50),
             hasPendingRegistrations: true);
 
         Assert.Null(checkpointer.LastOffset);
 
         // Once registrations complete, the watermark advances.
         receiver.UpdateDeliveryProgress(
-            [MakeToken(200), MakeToken(50)],
+            MakeToken(50),
             hasPendingRegistrations: false);
 
         Assert.Equal("50", checkpointer.LastOffset);
@@ -167,29 +167,15 @@ public class EventHubCheckpointerTests
 
         // Two subscriptions, one slow.
         receiver.UpdateDeliveryProgress(
-            [MakeToken(200), MakeToken(50)],
+            MakeToken(50),
             hasPendingRegistrations: false);
         Assert.Equal("50", checkpointer.LastOffset);
 
         // After the slow subscription is removed, watermark advances.
         receiver.UpdateDeliveryProgress(
-            [MakeToken(200)],
+            MakeToken(200),
             hasPendingRegistrations: false);
         Assert.Equal("200", checkpointer.LastOffset);
-    }
-
-    [Fact, TestCategory("BVT")]
-    public async Task NullToken_BlocksCheckpoint()
-    {
-        var checkpointer = new TestCheckpointer();
-        var receiver = await CreateReceiver(checkpointer);
-
-        // A null token (subscription hasn't processed anything) blocks checkpointing.
-        receiver.UpdateDeliveryProgress(
-            [MakeToken(200), null],
-            hasPendingRegistrations: false);
-
-        Assert.Null(checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
@@ -198,21 +184,21 @@ public class EventHubCheckpointerTests
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
-        // Three subscriptions at different positions.
+        // Three subscriptions at different positions: the pulling agent passes the lowest token.
         receiver.UpdateDeliveryProgress(
-            [MakeToken(100), MakeToken(80), MakeToken(50)],
+            MakeToken(50),
             hasPendingRegistrations: false);
         Assert.Equal("50", checkpointer.LastOffset);
 
         // Slowest catches up.
         receiver.UpdateDeliveryProgress(
-            [MakeToken(100), MakeToken(80), MakeToken(90)],
+            MakeToken(80),
             hasPendingRegistrations: false);
         Assert.Equal("80", checkpointer.LastOffset);
 
         // All converge.
         receiver.UpdateDeliveryProgress(
-            [MakeToken(150), MakeToken(120), MakeToken(120)],
+            MakeToken(120),
             hasPendingRegistrations: false);
         Assert.Equal("120", checkpointer.LastOffset);
     }
@@ -228,13 +214,15 @@ public class EventHubCheckpointerTests
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task EmptySubscriptionList_NoPendingRegistrations_NoCheckpoint()
+    public async Task NoActiveSubscriptions_NoPendingRegistrations_NoCheckpoint()
     {
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
         // No subscriptions and no pending registrations — cachePurgeOffset is null so no checkpoint.
-        receiver.UpdateDeliveryProgress([], hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(
+            earliestSubscriptionToken: null,
+            hasPendingRegistrations: false);
 
         Assert.Null(checkpointer.LastOffset);
     }
@@ -248,7 +236,7 @@ public class EventHubCheckpointerTests
         // Trigger cache purge via TryPurgeFromCache → SignalPurge → CachePurgeCheckpointer.
         // Since we can't easily trigger the real cache eviction path, we simulate by calling
         // TryPurgeFromCache (which calls SignalPurge on the cache) and then testing that
-        // after a purge offset is recorded, UpdateDeliveryProgress with empty subscriptions
+        // after a purge offset is recorded, UpdateDeliveryProgress with no active subscriptions
         // falls back to the purge offset.
         //
         // The CachePurgeCheckpointer is constructed in Initialize and wraps the real checkpointer.
@@ -256,13 +244,15 @@ public class EventHubCheckpointerTests
         // call that includes subscriptions, then removing all subscriptions.
 
         // First: some subscription progress establishes a checkpoint.
-        receiver.UpdateDeliveryProgress([MakeToken(100)], hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(100), hasPendingRegistrations: false);
         Assert.Equal("100", checkpointer.LastOffset);
 
         // Now with no subscriptions, the purge offset isn't set yet so no checkpoint change.
         // (cachePurgeOffset is only set via the CachePurgeCheckpointer, which we can't
         // trigger without a real cache eviction.)
-        receiver.UpdateDeliveryProgress([], hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(
+            earliestSubscriptionToken: null,
+            hasPendingRegistrations: false);
         // cachePurgeOffset is null → no update, LastOffset stays at previous value.
         Assert.Equal("100", checkpointer.LastOffset);
     }
@@ -275,11 +265,11 @@ public class EventHubCheckpointerTests
 
         // With active subscriptions, the watermark comes from subscription tokens,
         // not from the cache purge offset.
-        receiver.UpdateDeliveryProgress([MakeToken(50)], hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(50), hasPendingRegistrations: false);
         Assert.Equal("50", checkpointer.LastOffset);
 
         // Even after progress, subscriptions remain authoritative.
-        receiver.UpdateDeliveryProgress([MakeToken(75)], hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(75), hasPendingRegistrations: false);
         Assert.Equal("75", checkpointer.LastOffset);
     }
 }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Azure.Messaging.EventHubs;
 using Orleans.Providers.Streams.Common;
 using Orleans.Streaming.EventHubs;
@@ -28,6 +29,12 @@ public class EventHubCheckpointerTests
 
         public void Update(string offset, DateTime utcNow)
         {
+            if (LastOffset is not null
+                && long.Parse(offset, CultureInfo.InvariantCulture) <= long.Parse(LastOffset, CultureInfo.InvariantCulture))
+            {
+                return;
+            }
+
             LastOffset = offset;
             UpdateCount++;
         }
@@ -36,14 +43,16 @@ public class EventHubCheckpointerTests
         {
             return Task.CompletedTask;
         }
+
+        public virtual bool IsUpdateDue(DateTime utcNow) => true;
     }
 
-    private sealed class ThrottledTestCheckpointer : TestCheckpointer, IEventHubCheckpointerUpdateCadence
+    private sealed class ThrottledTestCheckpointer : TestCheckpointer
     {
         public bool IsUpdateDueResult { get; set; }
         public int IsUpdateDueCount { get; private set; }
 
-        public bool IsUpdateDue(DateTime utcNow)
+        public override bool IsUpdateDue(DateTime utcNow)
         {
             IsUpdateDueCount++;
             return IsUpdateDueResult;
@@ -238,7 +247,7 @@ public class EventHubCheckpointerTests
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task ReplayingSubscription_CanMoveCheckpointBackward()
+    public async Task ReplayingSubscription_DoesNotMoveCheckpointBackward()
     {
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
@@ -246,11 +255,10 @@ public class EventHubCheckpointerTests
         UpdateDeliveryProgress(receiver, MakeToken(200));
         Assert.Equal("200", checkpointer.LastOffset);
 
-        // A newly registered subscriber can request replay from an older token.
-        // The safe delivery watermark must be allowed to move backwards so a
-        // restart does not skip the messages that subscriber still needs.
+        // A newly registered subscriber can request replay from an older token,
+        // but the checkpoint only advances and must not move backwards.
         UpdateDeliveryProgress(receiver, MakeToken(50));
-        Assert.Equal("50", checkpointer.LastOffset);
+        Assert.Equal("200", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -1,7 +1,9 @@
 using System.Globalization;
 using System.Reflection;
 using Azure.Messaging.EventHubs;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
 using Orleans.Streaming.EventHubs;
 using Orleans.Streaming.EventHubs.Testing;
 using Orleans.Streams;
@@ -140,6 +142,11 @@ public class EventHubCheckpointerTests
             Partition = "TestPartition",
             ReceiverOptions = new Orleans.Configuration.EventHubReceiverOptions()
         };
+        var instruments = new ServiceCollection()
+            .AddMetrics()
+            .AddSingleton<OrleansInstruments>()
+            .BuildServiceProvider()
+            .GetRequiredService<OrleansInstruments>();
 
         var receiver = new EventHubAdapterReceiver(
             settings,
@@ -151,7 +158,8 @@ public class EventHubCheckpointerTests
                 {
                     EventHubPartition = settings.Partition,
                     EventHubPath = settings.Hub.EventHubName,
-                }),
+                },
+                instruments),
             loadSheddingOptions: new Orleans.Configuration.LoadSheddingOptions(),
             environmentStatisticsProvider: new Orleans.Statistics.EnvironmentStatisticsProvider(),
             eventHubReceiverFactory: (_, _, _) => eventHubReceiver ?? new TestEventHubReceiver());

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -72,7 +72,15 @@ public class EventHubCheckpointerTests
 
     private sealed class TestEventHubQueueCache : IEventHubQueueCache
     {
+        private readonly IStreamQueueCheckpointer<string> checkpointer;
+
+        public TestEventHubQueueCache(IStreamQueueCheckpointer<string> checkpointer = null)
+        {
+            this.checkpointer = checkpointer;
+        }
+
         public int DisposeCount { get; private set; }
+        public string PurgeOffsetToReport { get; set; }
 
         public int GetMaxAddCount() => 1_000;
 
@@ -92,6 +100,10 @@ public class EventHubCheckpointerTests
 
         public void SignalPurge()
         {
+            if (PurgeOffsetToReport is not null)
+            {
+                checkpointer?.Update(PurgeOffsetToReport, DateTime.UtcNow);
+            }
         }
 
         public void Dispose()
@@ -145,7 +157,7 @@ public class EventHubCheckpointerTests
 
         var receiver = new EventHubAdapterReceiver(
             settings,
-            cacheFactory: (_, _, _) => cache ?? new TestEventHubQueueCache(),
+            cacheFactory: (_, createdCheckpointer, _) => cache ?? new TestEventHubQueueCache(createdCheckpointer),
             checkpointerFactory: _ => Task.FromResult<IStreamQueueCheckpointer<string>>(checkpointer),
             loggerFactory: Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance,
             monitor: new Orleans.Streaming.EventHubs.DefaultEventHubReceiverMonitor(
@@ -304,52 +316,33 @@ public class EventHubCheckpointerTests
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
-        // No subscriptions and cachePurgeOffset is null, so there is no checkpoint.
+        // No subscription progress is available; cache purge checkpointing is handled directly by the cache.
         UpdateDeliveryProgressWithNoSubscriptions(receiver);
 
         Assert.Null(checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task CachePurge_UsedAsFallbackWhenNoSubscriptions()
+    public async Task CachePurge_UpdatesCheckpointDirectly()
     {
         var checkpointer = new TestCheckpointer();
-        var receiver = await CreateReceiver(checkpointer);
+        var cache = new TestEventHubQueueCache(checkpointer) { PurgeOffsetToReport = "100" };
+        var receiver = await CreateReceiver(checkpointer, cache);
 
-        // Trigger cache purge via TryPurgeFromCache → SignalPurge → CachePurgeCheckpointer.
-        // Since we can't easily trigger the real cache eviction path, we simulate by calling
-        // TryPurgeFromCache (which calls SignalPurge on the cache) and then testing that
-        // after a purge offset is recorded, UpdateDeliveryProgress with no active subscriptions
-        // falls back to the purge offset.
-        //
-        // The CachePurgeCheckpointer is constructed in Initialize and wraps the real checkpointer.
-        // We verify the fallback by first establishing a purge offset via a delivery progress
-        // call that includes subscriptions, then removing all subscriptions.
+        receiver.TryPurgeFromCache(out _);
 
-        // First: some subscription progress establishes a checkpoint.
-        UpdateDeliveryProgress(receiver, MakeToken(100));
-        Assert.Equal("100", checkpointer.LastOffset);
-
-        // Now with no subscriptions, the purge offset isn't set yet so no checkpoint change.
-        // (cachePurgeOffset is only set via the CachePurgeCheckpointer, which we can't
-        // trigger without a real cache eviction.)
-        UpdateDeliveryProgressWithNoSubscriptions(receiver);
-        // cachePurgeOffset is null → no update, LastOffset stays at previous value.
         Assert.Equal("100", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task ActiveSubscriptions_TakesPriorityOverCachePurge()
+    public async Task DeliveryProgress_UpdatesCheckpoint()
     {
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
-        // With active subscriptions, the watermark comes from subscription tokens,
-        // not from the cache purge offset.
         UpdateDeliveryProgress(receiver, MakeToken(50));
         Assert.Equal("50", checkpointer.LastOffset);
 
-        // Even after progress, subscriptions remain authoritative.
         UpdateDeliveryProgress(receiver, MakeToken(75));
         Assert.Equal("75", checkpointer.LastOffset);
     }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -119,7 +119,7 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(checkpointer);
 
         // Single subscription with a known processed offset.
-        receiver.UpdateDeliveryProgress(MakeToken(100), hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(100));
 
         Assert.Equal("100", checkpointer.LastOffset);
     }
@@ -131,32 +131,9 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(checkpointer);
 
         // The pulling agent passes the lowest subscription offset as the watermark.
-        receiver.UpdateDeliveryProgress(
-            MakeToken(95),
-            hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(95));
 
         Assert.Equal("95", checkpointer.LastOffset);
-    }
-
-    [Fact, TestCategory("BVT")]
-    public async Task PendingRegistration_BlocksCheckpoint()
-    {
-        var checkpointer = new TestCheckpointer();
-        var receiver = await CreateReceiver(checkpointer);
-
-        // hasPendingRegistrations blocks checkpointing even with known tokens.
-        receiver.UpdateDeliveryProgress(
-            MakeToken(50),
-            hasPendingRegistrations: true);
-
-        Assert.Null(checkpointer.LastOffset);
-
-        // Once registrations complete, the watermark advances.
-        receiver.UpdateDeliveryProgress(
-            MakeToken(50),
-            hasPendingRegistrations: false);
-
-        Assert.Equal("50", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
@@ -166,15 +143,11 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(checkpointer);
 
         // Two subscriptions, one slow.
-        receiver.UpdateDeliveryProgress(
-            MakeToken(50),
-            hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(50));
         Assert.Equal("50", checkpointer.LastOffset);
 
         // After the slow subscription is removed, watermark advances.
-        receiver.UpdateDeliveryProgress(
-            MakeToken(200),
-            hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(200));
         Assert.Equal("200", checkpointer.LastOffset);
     }
 
@@ -185,21 +158,15 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(checkpointer);
 
         // Three subscriptions at different positions: the pulling agent passes the lowest token.
-        receiver.UpdateDeliveryProgress(
-            MakeToken(50),
-            hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(50));
         Assert.Equal("50", checkpointer.LastOffset);
 
         // Slowest catches up.
-        receiver.UpdateDeliveryProgress(
-            MakeToken(80),
-            hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(80));
         Assert.Equal("80", checkpointer.LastOffset);
 
         // All converge.
-        receiver.UpdateDeliveryProgress(
-            MakeToken(120),
-            hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(120));
         Assert.Equal("120", checkpointer.LastOffset);
     }
 
@@ -214,15 +181,13 @@ public class EventHubCheckpointerTests
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task NoActiveSubscriptions_NoPendingRegistrations_NoCheckpoint()
+    public async Task NoActiveSubscriptions_NoCheckpoint()
     {
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
-        // No subscriptions and no pending registrations — cachePurgeOffset is null so no checkpoint.
-        receiver.UpdateDeliveryProgress(
-            earliestSubscriptionToken: null,
-            hasPendingRegistrations: false);
+        // No subscriptions and cachePurgeOffset is null, so there is no checkpoint.
+        receiver.UpdateDeliveryProgress(earliestSubscriptionToken: null);
 
         Assert.Null(checkpointer.LastOffset);
     }
@@ -244,15 +209,13 @@ public class EventHubCheckpointerTests
         // call that includes subscriptions, then removing all subscriptions.
 
         // First: some subscription progress establishes a checkpoint.
-        receiver.UpdateDeliveryProgress(MakeToken(100), hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(100));
         Assert.Equal("100", checkpointer.LastOffset);
 
         // Now with no subscriptions, the purge offset isn't set yet so no checkpoint change.
         // (cachePurgeOffset is only set via the CachePurgeCheckpointer, which we can't
         // trigger without a real cache eviction.)
-        receiver.UpdateDeliveryProgress(
-            earliestSubscriptionToken: null,
-            hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(earliestSubscriptionToken: null);
         // cachePurgeOffset is null → no update, LastOffset stays at previous value.
         Assert.Equal("100", checkpointer.LastOffset);
     }
@@ -265,11 +228,11 @@ public class EventHubCheckpointerTests
 
         // With active subscriptions, the watermark comes from subscription tokens,
         // not from the cache purge offset.
-        receiver.UpdateDeliveryProgress(MakeToken(50), hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(50));
         Assert.Equal("50", checkpointer.LastOffset);
 
         // Even after progress, subscriptions remain authoritative.
-        receiver.UpdateDeliveryProgress(MakeToken(75), hasPendingRegistrations: false);
+        receiver.UpdateDeliveryProgress(MakeToken(75));
         Assert.Equal("75", checkpointer.LastOffset);
     }
 }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Reflection;
 using Azure.Messaging.EventHubs;
 using Orleans.Providers.Streams.Common;
 using Orleans.Streaming.EventHubs;
@@ -23,6 +24,7 @@ public class EventHubCheckpointerTests
         public bool CheckpointExists => true;
         public string LastOffset { get; private set; }
         public int UpdateCount { get; private set; }
+        public int FlushCount { get; private set; }
 
         public Task<string> Load() => Task.FromResult("-1");
 
@@ -38,8 +40,9 @@ public class EventHubCheckpointerTests
             UpdateCount++;
         }
 
-        public Task FlushAsync(CancellationToken cancellationToken)
+        public virtual Task FlushAsync(CancellationToken cancellationToken)
         {
+            FlushCount++;
             return Task.CompletedTask;
         }
 
@@ -58,8 +61,19 @@ public class EventHubCheckpointerTests
         }
     }
 
+    private sealed class FailingFlushCheckpointer : TestCheckpointer
+    {
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            _ = base.FlushAsync(cancellationToken);
+            throw new InvalidOperationException("Flush failed");
+        }
+    }
+
     private sealed class TestEventHubQueueCache : IEventHubQueueCache
     {
+        public int DisposeCount { get; private set; }
+
         public int GetMaxAddCount() => 1_000;
 
         public List<StreamPosition> Add(List<EventData> message, DateTime dequeueTimeUtc) => [];
@@ -82,11 +96,14 @@ public class EventHubCheckpointerTests
 
         public void Dispose()
         {
+            DisposeCount++;
         }
     }
 
     private sealed class TestEventHubReceiver : IEventHubReceiver
     {
+        public int CloseCount { get; private set; }
+
         public Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime)
         {
             return Task.FromResult<IEnumerable<EventData>>([]);
@@ -94,6 +111,7 @@ public class EventHubCheckpointerTests
 
         public Task CloseAsync()
         {
+            CloseCount++;
             return Task.CompletedTask;
         }
     }
@@ -113,7 +131,10 @@ public class EventHubCheckpointerTests
         receiver.UpdateDeliveryProgress(null, DateTime.UtcNow);
     }
 
-    private static async Task<EventHubAdapterReceiver> CreateReceiver(TestCheckpointer checkpointer)
+    private static async Task<EventHubAdapterReceiver> CreateReceiver(
+        TestCheckpointer checkpointer,
+        TestEventHubQueueCache cache = null,
+        TestEventHubReceiver eventHubReceiver = null)
     {
         var settings = new EventHubPartitionSettings
         {
@@ -124,7 +145,7 @@ public class EventHubCheckpointerTests
 
         var receiver = new EventHubAdapterReceiver(
             settings,
-            cacheFactory: (_, _, _) => new TestEventHubQueueCache(),
+            cacheFactory: (_, _, _) => cache ?? new TestEventHubQueueCache(),
             checkpointerFactory: _ => Task.FromResult<IStreamQueueCheckpointer<string>>(checkpointer),
             loggerFactory: Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance,
             monitor: new Orleans.Streaming.EventHubs.DefaultEventHubReceiverMonitor(
@@ -135,11 +156,48 @@ public class EventHubCheckpointerTests
                 }),
             loadSheddingOptions: new Orleans.Configuration.LoadSheddingOptions(),
             environmentStatisticsProvider: new Orleans.Statistics.EnvironmentStatisticsProvider(),
-            eventHubReceiverFactory: (_, _, _) => new TestEventHubReceiver());
+            eventHubReceiverFactory: (_, _, _) => eventHubReceiver ?? new TestEventHubReceiver());
 
         await receiver.Initialize(TimeSpan.FromSeconds(5));
 
         return receiver;
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task Shutdown_DisposesCacheAndClosesReceiver_WhenFlushFails()
+    {
+        var checkpointer = new FailingFlushCheckpointer();
+        var cache = new TestEventHubQueueCache();
+        var eventHubReceiver = new TestEventHubReceiver();
+        var receiver = await CreateReceiver(checkpointer, cache, eventHubReceiver);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => receiver.Shutdown(TimeSpan.FromSeconds(5)));
+
+        Assert.Equal(1, checkpointer.FlushCount);
+        Assert.Equal(1, cache.DisposeCount);
+        Assert.Equal(1, eventHubReceiver.CloseCount);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task FlushBeforeLoad_DoesNotPersistUninitializedOffset()
+    {
+        var constructor = typeof(EventHubCheckpointer).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            new[] { typeof(Orleans.Configuration.AzureTableStreamCheckpointerOptions), typeof(string), typeof(string), typeof(string), typeof(Microsoft.Extensions.Logging.ILoggerFactory) },
+            modifiers: null);
+        Assert.NotNull(constructor);
+
+        var checkpointer = (EventHubCheckpointer)constructor.Invoke(new object[]
+        {
+            new Orleans.Configuration.AzureTableStreamCheckpointerOptions(),
+            "provider",
+            "partition",
+            "service",
+            Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance
+        });
+
+        await checkpointer.FlushAsync(CancellationToken.None);
     }
 
     [Fact, TestCategory("BVT")]

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -11,7 +11,6 @@ namespace ServiceBus.Tests.CheckpointerTests;
 
 /// <summary>
 /// Tests for EventHub delivery-based checkpointing via pulling-agent progress snapshots.
-/// The pulling agent asks the receiver whether an update is due before computing progress.
 /// </summary>
 [TestCategory("EventHub"), TestCategory("Streaming")]
 public class EventHubCheckpointerTests
@@ -46,19 +45,6 @@ public class EventHubCheckpointerTests
             return Task.CompletedTask;
         }
 
-        public virtual bool IsUpdateDue(DateTime utcNow) => true;
-    }
-
-    private sealed class ThrottledTestCheckpointer : TestCheckpointer
-    {
-        public bool IsUpdateDueResult { get; set; }
-        public int IsUpdateDueCount { get; private set; }
-
-        public override bool IsUpdateDue(DateTime utcNow)
-        {
-            IsUpdateDueCount++;
-            return IsUpdateDueResult;
-        }
     }
 
     private sealed class FailingFlushCheckpointer : TestCheckpointer
@@ -210,21 +196,6 @@ public class EventHubCheckpointerTests
         });
 
         await checkpointer.FlushAsync(CancellationToken.None);
-    }
-
-    [Fact, TestCategory("BVT")]
-    public async Task IsUpdateDue_UsesCheckpointerCadence()
-    {
-        var checkpointer = new ThrottledTestCheckpointer { IsUpdateDueResult = false };
-        var receiver = await CreateReceiver(checkpointer);
-
-        Assert.False(receiver.IsUpdateDue(DateTime.UtcNow));
-        Assert.Equal(1, checkpointer.IsUpdateDueCount);
-
-        checkpointer.IsUpdateDueResult = true;
-
-        Assert.True(receiver.IsUpdateDue(DateTime.UtcNow));
-        Assert.Equal(2, checkpointer.IsUpdateDueCount);
     }
 
     [Fact, TestCategory("BVT")]

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -1,6 +1,5 @@
 using Azure.Messaging.EventHubs;
 using Orleans.Providers.Streams.Common;
-using Orleans.Runtime;
 using Orleans.Streaming.EventHubs;
 using Orleans.Streaming.EventHubs.Testing;
 using Orleans.Streams;
@@ -9,7 +8,9 @@ using Xunit;
 namespace ServiceBus.Tests.CheckpointerTests;
 
 /// <summary>
-/// Tests for EventHub delivery-based checkpointing and low-watermark tracking.
+/// Tests for EventHub delivery-based checkpointing via the periodic scan approach.
+/// The pulling agent periodically scans its subscription state and pushes a snapshot
+/// of processed tokens to the receiver via <see cref="IQueueCache.UpdateDeliveryProgress"/>.
 /// </summary>
 [TestCategory("EventHub"), TestCategory("Streaming")]
 public class EventHubCheckpointerTests
@@ -82,16 +83,6 @@ public class EventHubCheckpointerTests
         return new EventHubSequenceToken(offset.ToString(), sequenceNumber, 0);
     }
 
-    private static StreamId MakeStreamId(string name)
-    {
-        return StreamId.Create("TestNamespace", name);
-    }
-
-    private static GuidId MakeSubscriptionId()
-    {
-        return GuidId.GetGuidId(Guid.NewGuid());
-    }
-
     private static async Task<EventHubAdapterReceiver> CreateReceiver(TestCheckpointer checkpointer)
     {
         var settings = new EventHubPartitionSettings
@@ -122,153 +113,173 @@ public class EventHubCheckpointerTests
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task SingleStream_SingleSubscription_CheckpointsProcessedOffset()
+    public async Task SingleSubscription_CheckpointsProcessedOffset()
     {
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
-        var stream = MakeStreamId("A");
-        var sub = MakeSubscriptionId();
-
-        receiver.NotifySubscriptionAdded(stream, sub, null);
-        Assert.Null(checkpointer.LastOffset);
-
-        receiver.NotifyBatchProcessed(stream, sub, MakeToken(100));
+        // Single subscription with a known processed offset.
+        receiver.UpdateDeliveryProgress([MakeToken(100)], hasPendingRegistrations: false);
 
         Assert.Equal("100", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task MultipleStreams_CheckpointsMinimumWatermark()
+    public async Task MultipleSubscriptions_CheckpointsMinimumWatermark()
     {
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
-        var streamA = MakeStreamId("A");
-        var streamB = MakeStreamId("B");
-        var subA = MakeSubscriptionId();
-        var subB = MakeSubscriptionId();
+        // Two subscriptions at different offsets — watermark is the minimum.
+        receiver.UpdateDeliveryProgress(
+            [MakeToken(200), MakeToken(95)],
+            hasPendingRegistrations: false);
 
-        receiver.NotifySubscriptionAdded(streamA, subA, MakeToken(200));
-        Assert.Equal("200", checkpointer.LastOffset);
-
-        receiver.NotifySubscriptionAdded(streamB, subB, MakeToken(95));
         Assert.Equal("95", checkpointer.LastOffset);
-
-        receiver.NotifyBatchProcessed(streamB, subB, MakeToken(210));
-        Assert.Equal("200", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task PendingRegistration_BlocksCheckpointUntilSubscriptionsAreKnown()
+    public async Task PendingRegistration_BlocksCheckpoint()
     {
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
-        var stream = MakeStreamId("A");
-        var sub1 = MakeSubscriptionId();
-        var sub2 = MakeSubscriptionId();
+        // hasPendingRegistrations blocks checkpointing even with known tokens.
+        receiver.UpdateDeliveryProgress(
+            [MakeToken(200), MakeToken(50)],
+            hasPendingRegistrations: true);
 
-        receiver.NotifyStreamRegistrationStarted(stream);
-        receiver.NotifySubscriptionAdded(stream, sub1, MakeToken(200));
-        receiver.NotifySubscriptionAdded(stream, sub2, MakeToken(50));
         Assert.Null(checkpointer.LastOffset);
 
-        receiver.NotifyStreamRegistrationCompleted(stream);
+        // Once registrations complete, the watermark advances.
+        receiver.UpdateDeliveryProgress(
+            [MakeToken(200), MakeToken(50)],
+            hasPendingRegistrations: false);
+
         Assert.Equal("50", checkpointer.LastOffset);
-
-        receiver.NotifyBatchProcessed(stream, sub2, MakeToken(200));
-        Assert.Equal("200", checkpointer.LastOffset);
-
-        receiver.NotifyBatchProcessed(stream, sub1, MakeToken(300));
-        Assert.Equal("200", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task RemovedSubscription_NoLongerHoldsWatermark()
+    public async Task SubscriptionRemoved_NoLongerHoldsWatermark()
     {
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
-        var stream = MakeStreamId("A");
-        var sub1 = MakeSubscriptionId();
-        var sub2 = MakeSubscriptionId();
-
-        receiver.NotifySubscriptionAdded(stream, sub1, null);
-        receiver.NotifySubscriptionAdded(stream, sub2, null);
-
-        receiver.NotifyBatchProcessed(stream, sub1, MakeToken(200));
-        Assert.Null(checkpointer.LastOffset);
-
-        receiver.NotifyBatchProcessed(stream, sub2, MakeToken(50));
+        // Two subscriptions, one slow.
+        receiver.UpdateDeliveryProgress(
+            [MakeToken(200), MakeToken(50)],
+            hasPendingRegistrations: false);
         Assert.Equal("50", checkpointer.LastOffset);
 
-        receiver.NotifySubscriptionRemoved(stream, sub2);
+        // After the slow subscription is removed, watermark advances.
+        receiver.UpdateDeliveryProgress(
+            [MakeToken(200)],
+            hasPendingRegistrations: false);
         Assert.Equal("200", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task MultipleStreams_MultipleSubscriptions_InterleavedDelivery()
+    public async Task NullToken_BlocksCheckpoint()
     {
         var checkpointer = new TestCheckpointer();
         var receiver = await CreateReceiver(checkpointer);
 
-        var streamA = MakeStreamId("A");
-        var streamB = MakeStreamId("B");
-        var subA1 = MakeSubscriptionId();
-        var subA2 = MakeSubscriptionId();
-        var subB1 = MakeSubscriptionId();
+        // A null token (subscription hasn't processed anything) blocks checkpointing.
+        receiver.UpdateDeliveryProgress(
+            [MakeToken(200), null],
+            hasPendingRegistrations: false);
 
-        receiver.NotifySubscriptionAdded(streamA, subA1, null);
-        receiver.NotifySubscriptionAdded(streamA, subA2, null);
-        receiver.NotifySubscriptionAdded(streamB, subB1, null);
-
-        receiver.NotifyBatchProcessed(streamA, subA1, MakeToken(100));
         Assert.Null(checkpointer.LastOffset);
+    }
 
-        receiver.NotifyBatchProcessed(streamA, subA2, MakeToken(80));
-        Assert.Null(checkpointer.LastOffset);
+    [Fact, TestCategory("BVT")]
+    public async Task WatermarkAdvances_AsSubscriptionsCatchUp()
+    {
+        var checkpointer = new TestCheckpointer();
+        var receiver = await CreateReceiver(checkpointer);
 
-        receiver.NotifyBatchProcessed(streamB, subB1, MakeToken(50));
+        // Three subscriptions at different positions.
+        receiver.UpdateDeliveryProgress(
+            [MakeToken(100), MakeToken(80), MakeToken(50)],
+            hasPendingRegistrations: false);
         Assert.Equal("50", checkpointer.LastOffset);
 
-        receiver.NotifyBatchProcessed(streamB, subB1, MakeToken(90));
+        // Slowest catches up.
+        receiver.UpdateDeliveryProgress(
+            [MakeToken(100), MakeToken(80), MakeToken(90)],
+            hasPendingRegistrations: false);
         Assert.Equal("80", checkpointer.LastOffset);
 
-        receiver.NotifyBatchProcessed(streamA, subA2, MakeToken(120));
-        Assert.Equal("90", checkpointer.LastOffset);
-
-        receiver.NotifyBatchProcessed(streamB, subB1, MakeToken(150));
-        Assert.Equal("100", checkpointer.LastOffset);
-
-        receiver.NotifyBatchProcessed(streamA, subA1, MakeToken(200));
+        // All converge.
+        receiver.UpdateDeliveryProgress(
+            [MakeToken(150), MakeToken(120), MakeToken(120)],
+            hasPendingRegistrations: false);
         Assert.Equal("120", checkpointer.LastOffset);
     }
 
     [Fact, TestCategory("BVT")]
-    public async Task PerSubscriptionMax_PreventsRegression()
-    {
-        var checkpointer = new TestCheckpointer();
-        var receiver = await CreateReceiver(checkpointer);
-
-        var stream = MakeStreamId("A");
-        var sub = MakeSubscriptionId();
-
-        receiver.NotifySubscriptionAdded(stream, sub, null);
-        receiver.NotifyBatchProcessed(stream, sub, MakeToken(100));
-        Assert.Equal("100", checkpointer.LastOffset);
-
-        receiver.NotifyBatchProcessed(stream, sub, MakeToken(50));
-        Assert.Equal("100", checkpointer.LastOffset);
-    }
-
-    [Fact, TestCategory("BVT")]
-    public async Task NoNotifications_NoCheckpoint()
+    public async Task NoSubscriptions_NoCheckpoint()
     {
         var checkpointer = new TestCheckpointer();
         _ = await CreateReceiver(checkpointer);
 
         Assert.Null(checkpointer.LastOffset);
         Assert.Equal(0, checkpointer.UpdateCount);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task EmptySubscriptionList_NoPendingRegistrations_NoCheckpoint()
+    {
+        var checkpointer = new TestCheckpointer();
+        var receiver = await CreateReceiver(checkpointer);
+
+        // No subscriptions and no pending registrations — cachePurgeOffset is null so no checkpoint.
+        receiver.UpdateDeliveryProgress([], hasPendingRegistrations: false);
+
+        Assert.Null(checkpointer.LastOffset);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task CachePurge_UsedAsFallbackWhenNoSubscriptions()
+    {
+        var checkpointer = new TestCheckpointer();
+        var receiver = await CreateReceiver(checkpointer);
+
+        // Trigger cache purge via TryPurgeFromCache → SignalPurge → CachePurgeCheckpointer.
+        // Since we can't easily trigger the real cache eviction path, we simulate by calling
+        // TryPurgeFromCache (which calls SignalPurge on the cache) and then testing that
+        // after a purge offset is recorded, UpdateDeliveryProgress with empty subscriptions
+        // falls back to the purge offset.
+        //
+        // The CachePurgeCheckpointer is constructed in Initialize and wraps the real checkpointer.
+        // We verify the fallback by first establishing a purge offset via a delivery progress
+        // call that includes subscriptions, then removing all subscriptions.
+
+        // First: some subscription progress establishes a checkpoint.
+        receiver.UpdateDeliveryProgress([MakeToken(100)], hasPendingRegistrations: false);
+        Assert.Equal("100", checkpointer.LastOffset);
+
+        // Now with no subscriptions, the purge offset isn't set yet so no checkpoint change.
+        // (cachePurgeOffset is only set via the CachePurgeCheckpointer, which we can't
+        // trigger without a real cache eviction.)
+        receiver.UpdateDeliveryProgress([], hasPendingRegistrations: false);
+        // cachePurgeOffset is null → no update, LastOffset stays at previous value.
+        Assert.Equal("100", checkpointer.LastOffset);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task ActiveSubscriptions_TakesPriorityOverCachePurge()
+    {
+        var checkpointer = new TestCheckpointer();
+        var receiver = await CreateReceiver(checkpointer);
+
+        // With active subscriptions, the watermark comes from subscription tokens,
+        // not from the cache purge offset.
+        receiver.UpdateDeliveryProgress([MakeToken(50)], hasPendingRegistrations: false);
+        Assert.Equal("50", checkpointer.LastOffset);
+
+        // Even after progress, subscriptions remain authoritative.
+        receiver.UpdateDeliveryProgress([MakeToken(75)], hasPendingRegistrations: false);
+        Assert.Equal("75", checkpointer.LastOffset);
     }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -196,6 +196,56 @@ namespace UnitTests.StreamingTests
                 shared);
         }
 
+        private sealed class RecordingQueueCache : IQueueCache
+        {
+            public int DeliveryProgressCallCount { get; private set; }
+            public int UnavailableDeliveryProgressCount { get; private set; }
+            public bool LastForce { get; private set; }
+            public List<StreamSequenceToken> DeliveryProgressTokens { get; } = new();
+
+            public int GetMaxAddCount() => 1000;
+
+            public void AddToCache(IList<IBatchContainer> messages)
+            {
+            }
+
+            public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
+            {
+                purgedItems = null;
+                return false;
+            }
+
+            public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken token)
+            {
+                return Substitute.For<IQueueCacheCursor>();
+            }
+
+            public bool IsUnderPressure() => false;
+
+            public void UpdateDeliveryProgress(TryGetDeliveryProgress tryGetDeliveryProgress, bool force)
+            {
+                DeliveryProgressCallCount++;
+                LastForce = force;
+
+                if (tryGetDeliveryProgress(out var token))
+                {
+                    DeliveryProgressTokens.Add(token);
+                }
+                else
+                {
+                    UnavailableDeliveryProgressCount++;
+                }
+            }
+
+            public void ClearDeliveryProgress()
+            {
+                DeliveryProgressCallCount = 0;
+                UnavailableDeliveryProgressCount = 0;
+                LastForce = false;
+                DeliveryProgressTokens.Clear();
+            }
+        }
+
         private static Task InitializeAgent(PersistentStreamPullingAgent agent) => agent.RunOrQueueTask(() => agent.Initialize());
 
         private static SchedulerInstruments CreateSchedulerInstruments()
@@ -335,8 +385,7 @@ namespace UnitTests.StreamingTests
             receiver.GetQueueMessagesAsync(Arg.Any<int>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
 
-            var queueCache = Substitute.For<IQueueCache>();
-            queueCache.GetMaxAddCount().Returns(1000);
+            var queueCache = new RecordingQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
             queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
 
@@ -346,8 +395,10 @@ namespace UnitTests.StreamingTests
 
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
-            // RunQueuePump should call UpdateDeliveryProgress on the cache.
-            queueCache.Received().UpdateDeliveryProgress(Arg.Any<StreamSequenceToken>());
+            // RunQueuePump should provide a lazy delivery progress callback to the cache.
+            Assert.Equal(1, queueCache.DeliveryProgressCallCount);
+            Assert.Single(queueCache.DeliveryProgressTokens);
+            Assert.Null(queueCache.DeliveryProgressTokens[0]);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -362,8 +413,7 @@ namespace UnitTests.StreamingTests
             receiver.GetQueueMessagesAsync(Arg.Any<int>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
 
-            var queueCache = Substitute.For<IQueueCache>();
-            queueCache.GetMaxAddCount().Returns(1000);
+            var queueCache = new RecordingQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
             queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
 
@@ -375,6 +425,7 @@ namespace UnitTests.StreamingTests
 
             var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
             Assert.Null(streamData.RegistrationTask);
+            queueCache.ClearDeliveryProgress();
 
             var newestConsumer = streamData.AddConsumer(
                 GuidId.GetGuidId(Guid.NewGuid()),
@@ -396,7 +447,7 @@ namespace UnitTests.StreamingTests
 
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
-            queueCache.Received().UpdateDeliveryProgress(earliestConsumer.LastProcessedToken);
+            Assert.Equal(earliestConsumer.LastProcessedToken, Assert.Single(queueCache.DeliveryProgressTokens));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -411,8 +462,7 @@ namespace UnitTests.StreamingTests
             receiver.GetQueueMessagesAsync(Arg.Any<int>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
 
-            var queueCache = Substitute.For<IQueueCache>();
-            queueCache.GetMaxAddCount().Returns(1000);
+            var queueCache = new RecordingQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
             queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
 
@@ -424,6 +474,7 @@ namespace UnitTests.StreamingTests
 
             var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
             Assert.Null(streamData.RegistrationTask);
+            queueCache.ClearDeliveryProgress();
 
             var newestConsumer = streamData.AddConsumer(
                 GuidId.GetGuidId(Guid.NewGuid()),
@@ -445,7 +496,7 @@ namespace UnitTests.StreamingTests
 
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
-            queueCache.Received().UpdateDeliveryProgress(earliestConsumer.LastProcessedToken);
+            Assert.Equal(earliestConsumer.LastProcessedToken, Assert.Single(queueCache.DeliveryProgressTokens));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -466,8 +517,7 @@ namespace UnitTests.StreamingTests
                     ]),
                     Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
 
-            var queueCache = Substitute.For<IQueueCache>();
-            queueCache.GetMaxAddCount().Returns(1000);
+            var queueCache = new RecordingQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
             queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
 
@@ -485,10 +535,11 @@ namespace UnitTests.StreamingTests
             Assert.NotNull(streamData.RegistrationTask);
             Assert.False(streamData.RegistrationTask.IsCompleted, "Registration should still be in progress");
 
-            queueCache.ClearReceivedCalls();
+            queueCache.ClearDeliveryProgress();
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
-            queueCache.DidNotReceive().UpdateDeliveryProgress(Arg.Any<StreamSequenceToken>());
+            Assert.Empty(queueCache.DeliveryProgressTokens);
+            Assert.Equal(1, queueCache.UnavailableDeliveryProgressCount);
 
             // Complete registration so shutdown can proceed cleanly.
             registration.SetResult(new HashSet<PubSubSubscriptionState>());
@@ -506,8 +557,7 @@ namespace UnitTests.StreamingTests
             receiver.GetQueueMessagesAsync(Arg.Any<int>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
 
-            var queueCache = Substitute.For<IQueueCache>();
-            queueCache.GetMaxAddCount().Returns(1000);
+            var queueCache = new RecordingQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
             queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
 
@@ -519,6 +569,7 @@ namespace UnitTests.StreamingTests
 
             var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
             Assert.Null(streamData.RegistrationTask);
+            queueCache.ClearDeliveryProgress();
 
             var registeredConsumer = streamData.AddConsumer(
                 GuidId.GetGuidId(Guid.NewGuid()),
@@ -539,7 +590,8 @@ namespace UnitTests.StreamingTests
 
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
-            queueCache.DidNotReceive().UpdateDeliveryProgress(Arg.Any<StreamSequenceToken>());
+            Assert.Empty(queueCache.DeliveryProgressTokens);
+            Assert.Equal(1, queueCache.UnavailableDeliveryProgressCount);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -549,7 +601,7 @@ namespace UnitTests.StreamingTests
             var receiver = Substitute.For<IQueueAdapterReceiver>();
             receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
-            var queueCache = Substitute.For<IQueueCache>();
+            var queueCache = new RecordingQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
             queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
 
@@ -559,8 +611,9 @@ namespace UnitTests.StreamingTests
 
             await testAccessor.Shutdown();
 
-            // Shutdown should push a final delivery progress snapshot before tearing down.
-            queueCache.Received().UpdateDeliveryProgress(Arg.Any<StreamSequenceToken>());
+            // Shutdown should force a final delivery progress snapshot before tearing down.
+            Assert.True(queueCache.LastForce);
+            Assert.Single(queueCache.DeliveryProgressTokens);
         }
     }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -348,8 +348,57 @@ namespace UnitTests.StreamingTests
 
             // RunQueuePump should call UpdateDeliveryProgress on the cache.
             queueCache.Received().UpdateDeliveryProgress(
-                Arg.Any<IReadOnlyList<StreamSequenceToken>>(),
+                Arg.Any<StreamSequenceToken>(),
                 Arg.Any<bool>());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task RunQueuePump_PushesEarliestDeliveryProgressTokenToCache()
+        {
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
+
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+                .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+
+            var queueCache = Substitute.For<IQueueCache>();
+            queueCache.GetMaxAddCount().Returns(1000);
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+
+            var streamId = new QualifiedStreamId("provider", StreamId.Create("namespace", Guid.NewGuid()));
+            var agent = CreateAgent(pubSub, queueId, receiver, queueAdapterCache);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            await testAccessor.RegisterStream(streamId, new EventSequenceTokenV2(1), DateTime.UtcNow);
+
+            var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
+            var newestConsumer = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                streamId,
+                streamConsumer: null,
+                filterData: null,
+                now: DateTime.UtcNow);
+            newestConsumer.IsRegistered = true;
+            newestConsumer.LastProcessedToken = new EventSequenceTokenV2(200);
+
+            var earliestConsumer = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                streamId,
+                streamConsumer: null,
+                filterData: null,
+                now: DateTime.UtcNow);
+            earliestConsumer.IsRegistered = true;
+            earliestConsumer.LastProcessedToken = new EventSequenceTokenV2(95);
+
+            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+
+            queueCache.Received().UpdateDeliveryProgress(
+                earliestConsumer.LastProcessedToken,
+                hasPendingRegistrations: false);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -389,6 +438,12 @@ namespace UnitTests.StreamingTests
             Assert.NotNull(streamData.RegistrationTask);
             Assert.False(streamData.RegistrationTask.IsCompleted, "Registration should still be in progress");
 
+            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+
+            queueCache.Received().UpdateDeliveryProgress(
+                earliestSubscriptionToken: null,
+                hasPendingRegistrations: true);
+
             // Complete registration so shutdown can proceed cleanly.
             registration.SetResult(new HashSet<PubSubSubscriptionState>());
         }
@@ -412,7 +467,7 @@ namespace UnitTests.StreamingTests
 
             // Shutdown should push a final delivery progress snapshot before tearing down.
             queueCache.Received().UpdateDeliveryProgress(
-                Arg.Any<IReadOnlyList<StreamSequenceToken>>(),
+                Arg.Any<StreamSequenceToken>(),
                 Arg.Any<bool>());
         }
     }

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -400,6 +400,55 @@ namespace UnitTests.StreamingTests
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task RunQueuePump_PushesEarliestDeliveryProgressUsingBaseTokenPosition()
+        {
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
+
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+                .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+
+            var queueCache = Substitute.For<IQueueCache>();
+            queueCache.GetMaxAddCount().Returns(1000);
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+
+            var streamId = new QualifiedStreamId("provider", StreamId.Create("namespace", Guid.NewGuid()));
+            var agent = CreateAgent(pubSub, queueId, receiver, queueAdapterCache);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            await testAccessor.RegisterStream(streamId, new EventSequenceTokenV2(1), DateTime.UtcNow);
+
+            var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
+            Assert.Null(streamData.RegistrationTask);
+
+            var newestConsumer = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                streamId,
+                streamConsumer: null,
+                filterData: null,
+                now: DateTime.UtcNow);
+            newestConsumer.IsRegistered = true;
+            newestConsumer.LastProcessedToken = new EventSequenceToken(200);
+
+            var earliestConsumer = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                streamId,
+                streamConsumer: null,
+                filterData: null,
+                now: DateTime.UtcNow);
+            earliestConsumer.IsRegistered = true;
+            earliestConsumer.LastProcessedToken = new EventSequenceTokenV2(95);
+
+            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+
+            queueCache.Received().UpdateDeliveryProgress(earliestConsumer.LastProcessedToken);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task RunQueuePump_SkipsDeliveryProgressForPendingRegistrations()
         {
             var registration = new TaskCompletionSource<ISet<PubSubSubscriptionState>>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -443,6 +492,54 @@ namespace UnitTests.StreamingTests
 
             // Complete registration so shutdown can proceed cleanly.
             registration.SetResult(new HashSet<PubSubSubscriptionState>());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task RunQueuePump_SkipsDeliveryProgressForUnregisteredConsumer()
+        {
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
+
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+                .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+
+            var queueCache = Substitute.For<IQueueCache>();
+            queueCache.GetMaxAddCount().Returns(1000);
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+
+            var streamId = new QualifiedStreamId("provider", StreamId.Create("namespace", Guid.NewGuid()));
+            var agent = CreateAgent(pubSub, queueId, receiver, queueAdapterCache);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            await testAccessor.RegisterStream(streamId, new EventSequenceTokenV2(1), DateTime.UtcNow);
+
+            var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
+            Assert.Null(streamData.RegistrationTask);
+
+            var registeredConsumer = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                streamId,
+                streamConsumer: null,
+                filterData: null,
+                now: DateTime.UtcNow);
+            registeredConsumer.IsRegistered = true;
+            registeredConsumer.LastProcessedToken = new EventSequenceTokenV2(200);
+
+            var unregisteredConsumer = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                streamId,
+                streamConsumer: null,
+                filterData: null,
+                now: DateTime.UtcNow);
+            unregisteredConsumer.PendingStartToken = new EventSequenceTokenV2(50);
+
+            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+
+            queueCache.DidNotReceive().UpdateDeliveryProgress(Arg.Any<StreamSequenceToken>());
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -242,6 +242,175 @@ namespace UnitTests.StreamingTests
             }
         }
 
+        private sealed class ScriptedQueueCache : IQueueCache
+        {
+            private readonly List<IBatchContainer> messages = new();
+
+            public int DeliveryProgressCallCount { get; private set; }
+            public List<StreamSequenceToken> DeliveryProgressTokens { get; } = new();
+
+            public int GetMaxAddCount() => 1000;
+
+            public void AddToCache(IList<IBatchContainer> messages)
+            {
+                this.messages.AddRange(messages);
+            }
+
+            public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
+            {
+                purgedItems = null;
+                return false;
+            }
+
+            public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken token)
+            {
+                return new ScriptedQueueCursor(messages, streamId, token);
+            }
+
+            public bool IsUnderPressure() => false;
+
+            public bool IsUpdateDue(DateTime utcNow) => true;
+
+            public void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken, DateTime utcNow)
+            {
+                DeliveryProgressCallCount++;
+                DeliveryProgressTokens.Add(earliestSubscriptionToken);
+            }
+
+            public void ClearDeliveryProgress()
+            {
+                DeliveryProgressCallCount = 0;
+                DeliveryProgressTokens.Clear();
+            }
+        }
+
+        private sealed class ScriptedQueueCursor(List<IBatchContainer> messages, StreamId streamId, StreamSequenceToken token) : IQueueCacheCursor
+        {
+            private int index = -1;
+            private IBatchContainer current;
+
+            public void Dispose()
+            {
+            }
+
+            public IBatchContainer GetCurrent(out Exception exception)
+            {
+                exception = null;
+                return current;
+            }
+
+            public bool MoveNext()
+            {
+                for (index++; index < messages.Count; index++)
+                {
+                    var candidate = messages[index];
+                    if (candidate.StreamId.Equals(streamId) && (token is null || candidate.SequenceToken.Newer(token)))
+                    {
+                        current = candidate;
+                        return true;
+                    }
+                }
+
+                current = null;
+                return false;
+            }
+
+            public void Refresh(StreamSequenceToken token)
+            {
+            }
+
+            public void RecordDeliveryFailure()
+            {
+            }
+        }
+
+        private sealed class TestBatchContainer(StreamId streamId, StreamSequenceToken token) : IBatchContainer
+        {
+            public StreamId StreamId { get; } = streamId;
+            public StreamSequenceToken SequenceToken { get; } = token;
+            public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>() => [];
+            public bool ImportRequestContext() => false;
+        }
+
+        private sealed class RewindConsumer(StreamHandshakeToken rewindToken) : IStreamConsumerExtension
+        {
+            public TaskCompletionSource<bool> Delivered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task<StreamHandshakeToken> DeliverImmutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken)
+            {
+                throw new NotSupportedException();
+            }
+
+            public Task<StreamHandshakeToken> DeliverMutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken)
+            {
+                throw new NotSupportedException();
+            }
+
+            public Task<StreamHandshakeToken> DeliverBatch(GuidId subscriptionId, QualifiedStreamId streamId, IBatchContainer item, StreamHandshakeToken handshakeToken)
+            {
+                Delivered.TrySetResult(true);
+                return Task.FromResult(rewindToken);
+            }
+
+            public Task CompleteStream(GuidId subscriptionId) => Task.CompletedTask;
+
+            public Task ErrorInStream(GuidId subscriptionId, Exception exc) => Task.CompletedTask;
+
+            public Task<StreamHandshakeToken> GetSequenceToken(GuidId subscriptionId) => Task.FromResult(rewindToken);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task RunQueuePump_UsesReturnedHandshakeTokenForDeliveryProgress()
+        {
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
+
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var streamId = StreamId.Create("namespace", Guid.NewGuid());
+            var qualifiedStreamId = new QualifiedStreamId("provider", streamId);
+            var previousToken = new EventSequenceTokenV2(1);
+            var attemptedToken = new EventSequenceTokenV2(2);
+            var rewindToken = StreamHandshakeToken.CreateDeliveyToken(previousToken);
+            var consumer = new RewindConsumer(rewindToken);
+
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+                .Returns(
+                    Task.FromResult<IList<IBatchContainer>>([new TestBatchContainer(streamId, attemptedToken)]),
+                    Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+
+            var queueCache = new ScriptedQueueCache();
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+
+            var agent = CreateAgent(pubSub, queueId, receiver, queueAdapterCache);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            await testAccessor.RegisterStream(qualifiedStreamId, previousToken, DateTime.UtcNow);
+
+            var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
+            var consumerData = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                qualifiedStreamId,
+                consumer,
+                filterData: null,
+                now: DateTime.UtcNow);
+            consumerData.IsRegistered = true;
+            consumerData.LastToken = rewindToken;
+            consumerData.LastProcessedToken = previousToken;
+            consumerData.Cursor = queueCache.GetCacheCursor(qualifiedStreamId, previousToken);
+
+            queueCache.ClearDeliveryProgress();
+            await testAccessor.ReadFromQueue(queueId, receiver, maxCacheAddCount: 1);
+            await consumer.Delivered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            queueCache.ClearDeliveryProgress();
+            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+
+            Assert.Equal(previousToken, Assert.Single(queueCache.DeliveryProgressTokens));
+        }
+
         private static Task InitializeAgent(PersistentStreamPullingAgent agent) => agent.RunOrQueueTask(() => agent.Initialize());
 
         private static SchedulerInstruments CreateSchedulerInstruments()

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -199,8 +199,8 @@ namespace UnitTests.StreamingTests
         private sealed class RecordingQueueCache : IQueueCache
         {
             public int DeliveryProgressCallCount { get; private set; }
-            public int UnavailableDeliveryProgressCount { get; private set; }
-            public bool LastForce { get; private set; }
+            public int IsUpdateDueCallCount { get; private set; }
+            public bool IsUpdateDueResult { get; set; } = true;
             public List<StreamSequenceToken> DeliveryProgressTokens { get; } = new();
 
             public int GetMaxAddCount() => 1000;
@@ -222,26 +222,22 @@ namespace UnitTests.StreamingTests
 
             public bool IsUnderPressure() => false;
 
-            public void UpdateDeliveryProgress(TryGetDeliveryProgress tryGetDeliveryProgress, bool force)
+            public bool IsUpdateDue(DateTime utcNow)
+            {
+                IsUpdateDueCallCount++;
+                return IsUpdateDueResult;
+            }
+
+            public void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken, DateTime utcNow)
             {
                 DeliveryProgressCallCount++;
-                LastForce = force;
-
-                if (tryGetDeliveryProgress(out var token))
-                {
-                    DeliveryProgressTokens.Add(token);
-                }
-                else
-                {
-                    UnavailableDeliveryProgressCount++;
-                }
+                DeliveryProgressTokens.Add(earliestSubscriptionToken);
             }
 
             public void ClearDeliveryProgress()
             {
                 DeliveryProgressCallCount = 0;
-                UnavailableDeliveryProgressCount = 0;
-                LastForce = false;
+                IsUpdateDueCallCount = 0;
                 DeliveryProgressTokens.Clear();
             }
         }
@@ -395,10 +391,34 @@ namespace UnitTests.StreamingTests
 
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
-            // RunQueuePump should provide a lazy delivery progress callback to the cache.
+            // RunQueuePump should push delivery progress when the cache update is due.
+            Assert.Equal(1, queueCache.IsUpdateDueCallCount);
             Assert.Equal(1, queueCache.DeliveryProgressCallCount);
             Assert.Single(queueCache.DeliveryProgressTokens);
             Assert.Null(queueCache.DeliveryProgressTokens[0]);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task RunQueuePump_SkipsDeliveryProgressWhenUpdateIsNotDue()
+        {
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+                .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+
+            var queueCache = new RecordingQueueCache { IsUpdateDueResult = false };
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+
+            var agent = CreateAgent(pubSub: null, queueId, receiver, queueAdapterCache);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+
+            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+
+            Assert.Equal(1, queueCache.IsUpdateDueCallCount);
+            Assert.Equal(0, queueCache.DeliveryProgressCallCount);
+            Assert.Empty(queueCache.DeliveryProgressTokens);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -539,7 +559,7 @@ namespace UnitTests.StreamingTests
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
             Assert.Empty(queueCache.DeliveryProgressTokens);
-            Assert.Equal(1, queueCache.UnavailableDeliveryProgressCount);
+            Assert.Equal(0, queueCache.DeliveryProgressCallCount);
 
             // Complete registration so shutdown can proceed cleanly.
             registration.SetResult(new HashSet<PubSubSubscriptionState>());
@@ -591,7 +611,7 @@ namespace UnitTests.StreamingTests
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
             Assert.Empty(queueCache.DeliveryProgressTokens);
-            Assert.Equal(1, queueCache.UnavailableDeliveryProgressCount);
+            Assert.Equal(0, queueCache.DeliveryProgressCallCount);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -601,7 +621,7 @@ namespace UnitTests.StreamingTests
             var receiver = Substitute.For<IQueueAdapterReceiver>();
             receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
-            var queueCache = new RecordingQueueCache();
+            var queueCache = new RecordingQueueCache { IsUpdateDueResult = false };
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
             queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
 
@@ -611,8 +631,9 @@ namespace UnitTests.StreamingTests
 
             await testAccessor.Shutdown();
 
-            // Shutdown should force a final delivery progress snapshot before tearing down.
-            Assert.True(queueCache.LastForce);
+            // Shutdown should push a final delivery progress snapshot before tearing down,
+            // even if the regular checkpoint cadence is not due.
+            Assert.Equal(0, queueCache.IsUpdateDueCallCount);
             Assert.Single(queueCache.DeliveryProgressTokens);
         }
     }

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -199,8 +199,6 @@ namespace UnitTests.StreamingTests
         private sealed class RecordingQueueCache : IQueueCache
         {
             public int DeliveryProgressCallCount { get; private set; }
-            public int IsUpdateDueCallCount { get; private set; }
-            public bool IsUpdateDueResult { get; set; } = true;
             public List<StreamSequenceToken> DeliveryProgressTokens { get; } = new();
 
             public int GetMaxAddCount() => 1000;
@@ -222,12 +220,6 @@ namespace UnitTests.StreamingTests
 
             public bool IsUnderPressure() => false;
 
-            public bool IsUpdateDue(DateTime utcNow)
-            {
-                IsUpdateDueCallCount++;
-                return IsUpdateDueResult;
-            }
-
             public void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken, DateTime utcNow)
             {
                 DeliveryProgressCallCount++;
@@ -237,7 +229,6 @@ namespace UnitTests.StreamingTests
             public void ClearDeliveryProgress()
             {
                 DeliveryProgressCallCount = 0;
-                IsUpdateDueCallCount = 0;
                 DeliveryProgressTokens.Clear();
             }
         }
@@ -268,8 +259,6 @@ namespace UnitTests.StreamingTests
             }
 
             public bool IsUnderPressure() => false;
-
-            public bool IsUpdateDue(DateTime utcNow) => true;
 
             public void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken, DateTime utcNow)
             {
@@ -360,7 +349,7 @@ namespace UnitTests.StreamingTests
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public async Task RunQueuePump_UsesReturnedHandshakeTokenForDeliveryProgress()
+        public async Task Shutdown_UsesReturnedHandshakeTokenForDeliveryProgress()
         {
             var pubSub = Substitute.For<IStreamPubSub>();
             pubSub.RegisterProducer(default, default)
@@ -379,6 +368,7 @@ namespace UnitTests.StreamingTests
                 .Returns(
                     Task.FromResult<IList<IBatchContainer>>([new TestBatchContainer(streamId, attemptedToken)]),
                     Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+            receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
             var queueCache = new ScriptedQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
@@ -406,7 +396,7 @@ namespace UnitTests.StreamingTests
             await consumer.Delivered.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             queueCache.ClearDeliveryProgress();
-            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+            await testAccessor.Shutdown();
 
             Assert.Equal(previousToken, Assert.Single(queueCache.DeliveryProgressTokens));
         }
@@ -543,55 +533,7 @@ namespace UnitTests.StreamingTests
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public async Task RunQueuePump_PushesDeliveryProgressToCache()
-        {
-            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
-            var receiver = Substitute.For<IQueueAdapterReceiver>();
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
-                .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
-
-            var queueCache = new RecordingQueueCache();
-            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
-            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
-
-            var agent = CreateAgent(pubSub: null, queueId, receiver, queueAdapterCache);
-            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
-            await InitializeAgent(agent);
-
-            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
-
-            // RunQueuePump should push delivery progress when the cache update is due.
-            Assert.Equal(1, queueCache.IsUpdateDueCallCount);
-            Assert.Equal(1, queueCache.DeliveryProgressCallCount);
-            Assert.Single(queueCache.DeliveryProgressTokens);
-            Assert.Null(queueCache.DeliveryProgressTokens[0]);
-        }
-
-        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public async Task RunQueuePump_SkipsDeliveryProgressWhenUpdateIsNotDue()
-        {
-            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
-            var receiver = Substitute.For<IQueueAdapterReceiver>();
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
-                .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
-
-            var queueCache = new RecordingQueueCache { IsUpdateDueResult = false };
-            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
-            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
-
-            var agent = CreateAgent(pubSub: null, queueId, receiver, queueAdapterCache);
-            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
-            await InitializeAgent(agent);
-
-            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
-
-            Assert.Equal(1, queueCache.IsUpdateDueCallCount);
-            Assert.Equal(0, queueCache.DeliveryProgressCallCount);
-            Assert.Empty(queueCache.DeliveryProgressTokens);
-        }
-
-        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public async Task RunQueuePump_PushesEarliestDeliveryProgressTokenToCache()
+        public async Task Shutdown_PushesEarliestDeliveryProgressTokenToCache()
         {
             var pubSub = Substitute.For<IStreamPubSub>();
             pubSub.RegisterProducer(default, default)
@@ -601,6 +543,7 @@ namespace UnitTests.StreamingTests
             var receiver = Substitute.For<IQueueAdapterReceiver>();
             receiver.GetQueueMessagesAsync(Arg.Any<int>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+            receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
             var queueCache = new RecordingQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
@@ -634,13 +577,13 @@ namespace UnitTests.StreamingTests
             earliestConsumer.IsRegistered = true;
             earliestConsumer.LastProcessedToken = new EventSequenceTokenV2(95);
 
-            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+            await testAccessor.Shutdown();
 
             Assert.Equal(earliestConsumer.LastProcessedToken, Assert.Single(queueCache.DeliveryProgressTokens));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public async Task RunQueuePump_PushesEarliestDeliveryProgressUsingBaseTokenPosition()
+        public async Task Shutdown_PushesEarliestDeliveryProgressUsingBaseTokenPosition()
         {
             var pubSub = Substitute.For<IStreamPubSub>();
             pubSub.RegisterProducer(default, default)
@@ -650,6 +593,7 @@ namespace UnitTests.StreamingTests
             var receiver = Substitute.For<IQueueAdapterReceiver>();
             receiver.GetQueueMessagesAsync(Arg.Any<int>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+            receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
             var queueCache = new RecordingQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
@@ -683,13 +627,13 @@ namespace UnitTests.StreamingTests
             earliestConsumer.IsRegistered = true;
             earliestConsumer.LastProcessedToken = new EventSequenceTokenV2(95);
 
-            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+            await testAccessor.Shutdown();
 
             Assert.Equal(earliestConsumer.LastProcessedToken, Assert.Single(queueCache.DeliveryProgressTokens));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public async Task RunQueuePump_SkipsDeliveryProgressForPendingRegistrations()
+        public async Task Shutdown_SkipsDeliveryProgressForPendingRegistrations()
         {
             var registration = new TaskCompletionSource<ISet<PubSubSubscriptionState>>(TaskCreationOptions.RunContinuationsAsynchronously);
             var pubSub = Substitute.For<IStreamPubSub>();
@@ -699,12 +643,18 @@ namespace UnitTests.StreamingTests
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);
             var streamId = StreamId.Create("namespace", Guid.NewGuid());
             var receiver = Substitute.For<IQueueAdapterReceiver>();
+            var receiverShutdownStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             receiver.GetQueueMessagesAsync(Arg.Any<int>())
                 .Returns(
                     Task.FromResult<IList<IBatchContainer>>([
                         new GeneratedBatchContainer(streamId, 1, new EventSequenceTokenV2(1)),
                     ]),
                     Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+            receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(_ =>
+            {
+                receiverShutdownStarted.SetResult(true);
+                return Task.CompletedTask;
+            });
 
             var queueCache = new RecordingQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
@@ -725,17 +675,19 @@ namespace UnitTests.StreamingTests
             Assert.False(streamData.RegistrationTask.IsCompleted, "Registration should still be in progress");
 
             queueCache.ClearDeliveryProgress();
-            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+            var shutdownTask = testAccessor.Shutdown();
+            await receiverShutdownStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             Assert.Empty(queueCache.DeliveryProgressTokens);
             Assert.Equal(0, queueCache.DeliveryProgressCallCount);
 
             // Complete registration so shutdown can proceed cleanly.
             registration.SetResult(new HashSet<PubSubSubscriptionState>());
+            await shutdownTask;
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public async Task RunQueuePump_SkipsDeliveryProgressForUnregisteredConsumer()
+        public async Task Shutdown_SkipsDeliveryProgressForUnregisteredConsumer()
         {
             var pubSub = Substitute.For<IStreamPubSub>();
             pubSub.RegisterProducer(default, default)
@@ -745,6 +697,7 @@ namespace UnitTests.StreamingTests
             var receiver = Substitute.For<IQueueAdapterReceiver>();
             receiver.GetQueueMessagesAsync(Arg.Any<int>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+            receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
             var queueCache = new RecordingQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
@@ -777,7 +730,7 @@ namespace UnitTests.StreamingTests
                 now: DateTime.UtcNow);
             unregisteredConsumer.PendingStartToken = new EventSequenceTokenV2(50);
 
-            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+            await testAccessor.Shutdown();
 
             Assert.Empty(queueCache.DeliveryProgressTokens);
             Assert.Equal(0, queueCache.DeliveryProgressCallCount);
@@ -790,7 +743,7 @@ namespace UnitTests.StreamingTests
             var receiver = Substitute.For<IQueueAdapterReceiver>();
             receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
-            var queueCache = new RecordingQueueCache { IsUpdateDueResult = false };
+            var queueCache = new RecordingQueueCache();
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
             queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
 
@@ -800,9 +753,7 @@ namespace UnitTests.StreamingTests
 
             await testAccessor.Shutdown();
 
-            // Shutdown should push a final delivery progress snapshot before tearing down,
-            // even if the regular checkpoint cadence is not due.
-            Assert.Equal(0, queueCache.IsUpdateDueCallCount);
+            // Shutdown should push a final delivery progress snapshot before tearing down.
             Assert.Single(queueCache.DeliveryProgressTokens);
         }
     }

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -347,9 +347,7 @@ namespace UnitTests.StreamingTests
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
             // RunQueuePump should call UpdateDeliveryProgress on the cache.
-            queueCache.Received().UpdateDeliveryProgress(
-                Arg.Any<StreamSequenceToken>(),
-                Arg.Any<bool>());
+            queueCache.Received().UpdateDeliveryProgress(Arg.Any<StreamSequenceToken>());
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -376,6 +374,8 @@ namespace UnitTests.StreamingTests
             await testAccessor.RegisterStream(streamId, new EventSequenceTokenV2(1), DateTime.UtcNow);
 
             var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
+            Assert.Null(streamData.RegistrationTask);
+
             var newestConsumer = streamData.AddConsumer(
                 GuidId.GetGuidId(Guid.NewGuid()),
                 streamId,
@@ -396,13 +396,11 @@ namespace UnitTests.StreamingTests
 
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
-            queueCache.Received().UpdateDeliveryProgress(
-                earliestConsumer.LastProcessedToken,
-                hasPendingRegistrations: false);
+            queueCache.Received().UpdateDeliveryProgress(earliestConsumer.LastProcessedToken);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
-        public async Task RunQueuePump_ReportsPendingRegistrations()
+        public async Task RunQueuePump_SkipsDeliveryProgressForPendingRegistrations()
         {
             var registration = new TaskCompletionSource<ISet<PubSubSubscriptionState>>(TaskCreationOptions.RunContinuationsAsynchronously);
             var pubSub = Substitute.For<IStreamPubSub>();
@@ -438,11 +436,10 @@ namespace UnitTests.StreamingTests
             Assert.NotNull(streamData.RegistrationTask);
             Assert.False(streamData.RegistrationTask.IsCompleted, "Registration should still be in progress");
 
+            queueCache.ClearReceivedCalls();
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
-            queueCache.Received().UpdateDeliveryProgress(
-                earliestSubscriptionToken: null,
-                hasPendingRegistrations: true);
+            queueCache.DidNotReceive().UpdateDeliveryProgress(Arg.Any<StreamSequenceToken>());
 
             // Complete registration so shutdown can proceed cleanly.
             registration.SetResult(new HashSet<PubSubSubscriptionState>());
@@ -466,9 +463,7 @@ namespace UnitTests.StreamingTests
             await testAccessor.Shutdown();
 
             // Shutdown should push a final delivery progress snapshot before tearing down.
-            queueCache.Received().UpdateDeliveryProgress(
-                Arg.Any<StreamSequenceToken>(),
-                Arg.Any<bool>());
+            queueCache.Received().UpdateDeliveryProgress(Arg.Any<StreamSequenceToken>());
         }
     }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -147,7 +147,7 @@ namespace UnitTests.StreamingTests
             Assert.Empty(pubSub.ReceivedCalls());
         }
 
-        private static PersistentStreamPullingAgent CreateAgent(IStreamPubSub pubSub, QueueId queueId, IQueueAdapterReceiver receiver = null)
+        private static PersistentStreamPullingAgent CreateAgent(IStreamPubSub pubSub, QueueId queueId, IQueueAdapterReceiver receiver = null, IQueueAdapterCache queueAdapterCache = null)
         {
             var siloAddress = SiloAddress.New(IPAddress.Loopback, 11111, 1);
             var localSiloDetails = Substitute.For<ILocalSiloDetails>();
@@ -188,7 +188,7 @@ namespace UnitTests.StreamingTests
                 queueId,
                 new StreamPullingAgentOptions(),
                 queueAdapter,
-                queueAdapterCache: null,
+                queueAdapterCache,
                 new NoOpStreamDeliveryFailureHandler(),
                 new FixedBackoff(TimeSpan.FromMilliseconds(1)),
                 new FixedBackoff(TimeSpan.FromMilliseconds(1)),
@@ -325,6 +325,95 @@ namespace UnitTests.StreamingTests
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
             await receiver.Received(1).GetQueueMessagesAsync(Arg.Any<int>());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task RunQueuePump_PushesDeliveryProgressToCache()
+        {
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+                .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+
+            var queueCache = Substitute.For<IQueueCache>();
+            queueCache.GetMaxAddCount().Returns(1000);
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+
+            var agent = CreateAgent(pubSub: null, queueId, receiver, queueAdapterCache);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+
+            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+
+            // RunQueuePump should call UpdateDeliveryProgress on the cache.
+            queueCache.Received().UpdateDeliveryProgress(
+                Arg.Any<IReadOnlyList<StreamSequenceToken>>(),
+                Arg.Any<bool>());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task RunQueuePump_ReportsPendingRegistrations()
+        {
+            var registration = new TaskCompletionSource<ISet<PubSubSubscriptionState>>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default)
+                .ReturnsForAnyArgs(_ => registration.Task);
+
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var streamId = StreamId.Create("namespace", Guid.NewGuid());
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+                .Returns(
+                    Task.FromResult<IList<IBatchContainer>>([
+                        new GeneratedBatchContainer(streamId, 1, new EventSequenceTokenV2(1)),
+                    ]),
+                    Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
+
+            var queueCache = Substitute.For<IQueueCache>();
+            queueCache.GetMaxAddCount().Returns(1000);
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+
+            var agent = CreateAgent(pubSub, queueId, receiver, queueAdapterCache);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+
+            // First tick: pump reads messages and kicks off a cold stream registration.
+            await testAccessor.RunQueuePump(queueId, CancellationToken.None);
+
+            // Verify the cache has the pending stream registered.
+            var cache = await testAccessor.GetPubSubCache();
+            Assert.Single(cache);
+            var (_, streamData) = cache.Single();
+            Assert.NotNull(streamData.RegistrationTask);
+            Assert.False(streamData.RegistrationTask.IsCompleted, "Registration should still be in progress");
+
+            // Complete registration so shutdown can proceed cleanly.
+            registration.SetResult(new HashSet<PubSubSubscriptionState>());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task Shutdown_PushesFinalDeliveryProgress()
+        {
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
+
+            var queueCache = Substitute.For<IQueueCache>();
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+
+            var agent = CreateAgent(pubSub: null, queueId, receiver, queueAdapterCache);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+
+            await testAccessor.Shutdown();
+
+            // Shutdown should push a final delivery progress snapshot before tearing down.
+            queueCache.Received().UpdateDeliveryProgress(
+                Arg.Any<IReadOnlyList<StreamSequenceToken>>(),
+                Arg.Any<bool>());
         }
     }
 }


### PR DESCRIPTION
## Problem

When an Event Hub streaming subscription is used, newly added silos replay too many streaming messages due to stale checkpoints (#10093). Three root causes:

1. **No checkpoint on shutdown/rebalance** — `EventHubAdapterReceiver.Shutdown()` disposed the cache and closed the receiver without persisting the latest offset.
2. **Checkpoint stalls under low/moderate throughput** — the only periodic checkpoint mechanism was cache eviction (`OnPurge`), which requires messages to be in cache >5 min AND have >30 min relative age. For streams that don't accumulate enough spread, purging never triggered.
3. **Throttled `Update()` dropped offsets** — `EventHubCheckpointer.Update()` silently discarded the offset entirely when the persist throttle was active.

## Solution

### Checkpointer fixes

- Add `FlushAsync()` default interface method to `IStreamQueueCheckpointer<T>` — non-breaking for third-party implementations.
- Fix `EventHubCheckpointer.Update()` to always track the latest offset in a separate `latestOffset` field (avoids mutating `entity` during in-flight Azure Table saves). Enforce monotonic offset advancement via `IsBefore` check.
- Implement `FlushAsync()` in `EventHubCheckpointer` — awaits any in-progress save, then persists `latestOffset` if it diverges.

### Delivery-based periodic checkpointing

The pulling agent already tracks per-subscription delivery progress in its `pubSubCache`. Rather than duplicating that state in the receiver (via lifecycle callbacks), we periodically scan it and push a snapshot to the cache.

- Add `UpdateDeliveryProgress(IReadOnlyList<StreamSequenceToken>, bool)` default interface method to `IQueueCache`. The pulling agent calls this every ~100ms pump tick and once at shutdown.
- Add `LastProcessedToken` to `StreamConsumerData` — set after each delivered or filtered batch, and seeded from the handshake start token when a subscription is added (so idle subscriptions don't block checkpointing).
- `PersistentStreamPullingAgent.NotifyDeliveryProgress()` scans `pubSubCache`, collects all `LastProcessedToken` values, and reports whether any stream registrations are still pending.
- `EventHubAdapterReceiver.UpdateDeliveryProgress()` computes a low-watermark (minimum EventHub offset across all subscription tokens). The checkpoint only advances to the minimum — ensuring no subscription's undelivered messages are skipped. Pending registrations block advancement entirely. When no subscriptions exist, falls back to the cache purge offset.
- Call `FlushAsync()` in `EventHubAdapterReceiver.Shutdown()` to persist the final checkpoint.

### What this preserves

- **At-least-once delivery** — the checkpoint never advances past the slowest subscriber's confirmed delivery point.
- **No new locking** — all `pubSubCache` access is on the SystemTarget scheduler; the receiver's `cachePurgeOffset` is also accessed from the same context.
- **Non-breaking for third-party `IQueueCache` implementations** — the new method is a default interface method (no-op).

Fixes #10093
