### PR TITLE
Use immutable checkpoints for Azure journal compaction

### DIFF
--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -299,9 +299,14 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             return;
         }
 
-        await _currentLogClient.SealAsync(
+        var response = await _currentLogClient.SealAsync(
             new AppendBlobRequestConditions { IfMatch = _currentSegmentETag },
             cancellationToken).ConfigureAwait(false);
+        _currentSegmentETag = response.Value.ETag;
+        if (_currentSegmentId == 0)
+        {
+            _rootLogETag = response.Value.ETag;
+        }
     }
 
     private async ValueTask ReadWalSegmentsAsync(

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -25,6 +25,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private const int MaxBlocksPerBlob = 50_000;
     private const int HeadroomBlockCount = 100;
     private const int RequestCompactionBlockCount = 49_000;
+    private const int MaxSkipBufferBytes = 16 * 1024;
 
     private readonly SharedConfiguration _shared;
     private readonly IGrainContext _grainContext;
@@ -552,21 +553,26 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
 
         // Non-seekable streams can only advance by reading, so drain discarded bytes into a pooled buffer.
-        var buffer = ArrayPool<byte>.Shared.Rent((int)Math.Min(81920, length));
+        var maxChunkSize = (int)Math.Min(MaxSkipBufferBytes, length);
+        var buffer = ArrayPool<byte>.Shared.Rent(maxChunkSize);
+
         try
         {
             while (length > 0)
             {
-                var bytesRead = await input.ReadAsync(
-                    buffer.AsMemory(0, (int)Math.Min(buffer.Length, length)),
-                    cancellationToken).ConfigureAwait(false);
-                if (bytesRead == 0)
-                {
-                    throw new InvalidOperationException("Azure Blob journal WAL ended before the checkpoint offset was reached.");
-                }
+                // ArrayPool can return a larger array, so slice it to keep each skip read capped.
+                var toRead = (int)Math.Min(maxChunkSize, length);
 
-                length -= bytesRead;
+                // ReadExactlyAsync guarantees the buffer slice is completely filled before returning,
+                // or it throws an EndOfStreamException if the stream ends early.
+                await input.ReadExactlyAsync(buffer.AsMemory(0, toRead), cancellationToken).ConfigureAwait(false);
+
+                length -= toRead;
             }
+        }
+        catch (EndOfStreamException ex)
+        {
+            throw new InvalidOperationException("Azure Blob journal WAL ended before the checkpoint offset was reached.", ex);
         }
         finally
         {

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -15,9 +15,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     internal const string FormatMetadataKey = "format";
     internal const string GenerationMetadataKey = "generation";
     internal const string CheckpointMetadataKey = "checkpoint";
-    internal const string CheckpointETagMetadataKey = "checkpoint_etag";
-    internal const string CheckpointFormatMetadataKey = "checkpoint_format";
-    internal const string CheckpointLengthMetadataKey = "checkpoint_length";
 
     // Azure Append Blob hard limits documented at:
     // https://learn.microsoft.com/azure/storage/blobs/scalability-targets#scale-targets-for-blob-storage
@@ -150,7 +147,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         {
             response = await CreateRootAsync(
                 generation,
-                checkpoint: null,
+                checkpointName: null,
                 new AppendBlobRequestConditions { IfMatch = _rootLogETag },
                 cancellationToken).ConfigureAwait(false);
         }
@@ -189,15 +186,10 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         if (manifest.Checkpoint is { } checkpoint)
         {
             var checkpointClient = GetCheckpointClient(checkpoint.Name);
-            var checkpointResult = await checkpointClient.DownloadStreamingAsync(
-                new BlobDownloadOptions
-                {
-                    Conditions = new BlobRequestConditions { IfMatch = checkpoint.ETag }
-                },
-                cancellationToken).ConfigureAwait(false);
+            var checkpointResult = await checkpointClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             await using var checkpointStream = checkpointResult.Value.Content;
 
-            var checkpointMetadata = ValidateCheckpointMetadata(checkpoint, checkpointResult.Value.Details);
+            var checkpointMetadata = ValidateCheckpointMetadata(checkpoint, checkpointResult.Value.Details, expectedFormat);
             var totalCheckpointBytes = await ReadStreamAsync(
                 consumer,
                 checkpointStream,
@@ -233,7 +225,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             try
             {
                 checkpointStream.Position = 0;
-                var checkpointResult = await checkpointClient.UploadAsync(
+                await checkpointClient.UploadAsync(
                     checkpointStream,
                     new BlobUploadOptions
                     {
@@ -248,7 +240,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 {
                     rootResult = await CreateRootAsync(
                         generation,
-                        new CheckpointPublication(checkpointName, checkpointResult.Value.ETag, checkpointStream.Length),
+                        checkpointName,
                         new AppendBlobRequestConditions { IfMatch = rootETag },
                         cancellationToken).ConfigureAwait(false);
                 }
@@ -291,7 +283,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             {
                 response = await CreateRootAsync(
                     _currentGeneration,
-                    checkpoint: null,
+                    checkpointName: null,
                     new AppendBlobRequestConditions { IfNoneMatch = ETag.All },
                     cancellationToken).ConfigureAwait(false);
             }
@@ -469,7 +461,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private async ValueTask<Response<BlobContentInfo>> CreateRootAsync(
         ulong generation,
-        CheckpointPublication? checkpoint,
+        string? checkpointName,
         AppendBlobRequestConditions conditions,
         CancellationToken cancellationToken)
         => await _rootLogClient.CreateAsync(
@@ -477,7 +469,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             {
                 Conditions = conditions,
                 HttpHeaders = CreateHttpHeaders(),
-                Metadata = CreateRootMetadata(generation, checkpoint),
+                Metadata = CreateRootMetadata(generation, checkpointName),
             },
             cancellationToken).ConfigureAwait(false);
 
@@ -526,18 +518,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private Dictionary<string, string> CreateCheckpointBlobMetadata(ulong generation) => CreateMetadataDictionary(generation);
 
-    private Dictionary<string, string> CreateRootMetadata(ulong generation, CheckpointPublication? checkpoint)
+    private Dictionary<string, string> CreateRootMetadata(ulong generation, string? checkpointName)
     {
         var metadata = CreateMetadataDictionary(generation);
-        if (checkpoint is not null)
+        if (checkpointName is not null)
         {
-            metadata[CheckpointMetadataKey] = checkpoint.Name;
-            metadata[CheckpointETagMetadataKey] = checkpoint.ETag.ToString();
-            metadata[CheckpointLengthMetadataKey] = checkpoint.Length.ToString(CultureInfo.InvariantCulture);
-            if (_journalFormatKey is { Length: > 0 })
-            {
-                metadata[CheckpointFormatMetadataKey] = _journalFormatKey;
-            }
+            metadata[CheckpointMetadataKey] = checkpointName;
         }
 
         return metadata;
@@ -563,48 +549,13 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             : JournalFileMetadata.Empty;
         if (metadata is null || !metadata.TryGetValue(CheckpointMetadataKey, out var checkpointName) || checkpointName is not { Length: > 0 })
         {
-            EnsureNoCheckpointMetadata(metadata);
             return new RootManifest(generation, fileMetadata, Checkpoint: null);
         }
-
-        if (!metadata.TryGetValue(CheckpointETagMetadataKey, out var checkpointETag) || checkpointETag is not { Length: > 0 })
-        {
-            throw new InvalidOperationException(
-                $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include '{CheckpointETagMetadataKey}' metadata.");
-        }
-
-        if (!metadata.TryGetValue(CheckpointLengthMetadataKey, out var checkpointLengthValue)
-            || !long.TryParse(checkpointLengthValue, NumberStyles.None, CultureInfo.InvariantCulture, out var checkpointLength)
-            || checkpointLength < 0)
-        {
-            throw new InvalidOperationException(
-                $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include valid '{CheckpointLengthMetadataKey}' metadata.");
-        }
-
-        var checkpointFormat = metadata.TryGetValue(CheckpointFormatMetadataKey, out var storedCheckpointFormat)
-            && storedCheckpointFormat is { Length: > 0 }
-                ? storedCheckpointFormat
-                : null;
 
         return new RootManifest(
             generation,
             fileMetadata,
-            new CheckpointReference(checkpointName, new ETag(checkpointETag), generation, checkpointFormat, checkpointLength));
-    }
-
-    private static void EnsureNoCheckpointMetadata(IDictionary<string, string>? metadata)
-    {
-        if (metadata is null)
-        {
-            return;
-        }
-
-        if (metadata.ContainsKey(CheckpointETagMetadataKey)
-            || metadata.ContainsKey(CheckpointFormatMetadataKey)
-            || metadata.ContainsKey(CheckpointLengthMetadataKey))
-        {
-            throw new InvalidOperationException("Azure Blob journal root contains partial checkpoint metadata.");
-        }
+            new CheckpointReference(checkpointName, generation));
     }
 
     private async ValueTask<RootManifest?> ReadRootManifestForCollisionAsync(CancellationToken cancellationToken)
@@ -623,14 +574,8 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
     }
 
-    private IJournalFileMetadata ValidateCheckpointMetadata(CheckpointReference checkpoint, BlobDownloadDetails checkpointDetails)
+    private IJournalFileMetadata ValidateCheckpointMetadata(CheckpointReference checkpoint, BlobDownloadDetails checkpointDetails, string? expectedFormat)
     {
-        if (checkpointDetails.ContentLength != checkpoint.Length)
-        {
-            throw new InvalidOperationException(
-                $"Azure Blob journal checkpoint '{checkpoint.Name}' length is {checkpointDetails.ContentLength}, but marker metadata expected {checkpoint.Length}.");
-        }
-
         if (!TryGetUInt64Metadata(checkpointDetails.Metadata, GenerationMetadataKey, out var generation) || generation != checkpoint.Generation)
         {
             throw new InvalidOperationException(
@@ -638,22 +583,22 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
 
         var checkpointBlobFormat = GetFormatKeyMetadata(checkpointDetails.Metadata);
-        if (checkpoint.Format is { } markerCheckpointFormat
-            && checkpointBlobFormat is { }
-            && !string.Equals(markerCheckpointFormat, checkpointBlobFormat, StringComparison.Ordinal))
+        if (expectedFormat is { Length: > 0 })
         {
-            throw new InvalidOperationException(
-                $"Azure Blob journal checkpoint '{checkpoint.Name}' format metadata is '{checkpointBlobFormat}', but marker metadata expected '{markerCheckpointFormat}'.");
+            if (checkpointBlobFormat is null)
+            {
+                throw new InvalidOperationException(
+                    $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include format metadata.");
+            }
+
+            if (!string.Equals(expectedFormat, checkpointBlobFormat, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Azure Blob journal checkpoint '{checkpoint.Name}' format metadata is '{checkpointBlobFormat}', but recovery expected '{expectedFormat}'.");
+            }
         }
 
-        var effectiveCheckpointFormat = checkpoint.Format ?? checkpointBlobFormat;
-        if (checkpoint.Format is { } && checkpointBlobFormat is null)
-        {
-            throw new InvalidOperationException(
-                $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include format metadata.");
-        }
-
-        return effectiveCheckpointFormat is { } format
+        return checkpointBlobFormat is { } format
             ? new JournalFileMetadata(format)
             : JournalFileMetadata.Empty;
     }
@@ -775,9 +720,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private sealed record RootManifest(ulong Generation, IJournalFileMetadata Metadata, CheckpointReference? Checkpoint);
 
-    private sealed record CheckpointReference(string Name, ETag ETag, ulong Generation, string? Format, long Length);
-
-    private sealed record CheckpointPublication(string Name, ETag ETag, long Length);
+    private sealed record CheckpointReference(string Name, ulong Generation);
 
     internal abstract class BlobClientProvider
     {

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -1,19 +1,23 @@
 using System.Buffers;
 using System.Globalization;
 using Azure;
-using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
+using Orleans.Serialization.Buffers;
 
 namespace Orleans.Journaling;
 
 internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 {
     internal const string FormatMetadataKey = "format";
-    internal const string SnapshotMetadataKey = "snapshot";
-    internal const string SnapshotETagMetadataKey = "snapshot-etag";
-    internal const string SnapshotFormatMetadataKey = "snapshot-format";
-    internal const string SnapshotLengthMetadataKey = "snapshot-length";
+    internal const string CheckpointMetadataKey = "checkpoint";
+    internal const string CheckpointETagMetadataKey = "checkpoint-etag";
+    internal const string CheckpointFormatMetadataKey = "checkpoint-format";
+    internal const string CheckpointIdMetadataKey = "checkpoint-id";
+    internal const string CheckpointLengthMetadataKey = "checkpoint-length";
+    internal const string CheckpointReplaySegmentMetadataKey = "checkpoint-replay-segment";
+    internal const string CheckpointReplayOffsetMetadataKey = "checkpoint-replay-offset";
 
     // Azure Append Blob hard limits documented at:
     // https://learn.microsoft.com/azure/storage/blobs/scalability-targets#scale-targets-for-blob-storage
@@ -22,19 +26,26 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     // An append blob can hold up to 50,000 committed blocks. The compaction request
     // (IsCompactionRequested) trips far earlier (at 10 blocks), so this guard exists only
-    // to fail fast if a consumer ignores compaction requests for an extended period.
+    // to roll before hitting the hard Azure limit if a consumer ignores compaction requests.
     internal const int MaxAppendBlobBlocks = 50_000;
     private const int AppendBlobBlockCeilingHeadroom = 100;
 
-    private readonly AppendBlobClient _client;
-    private readonly Func<string> _snapshotNameFactory;
-    private readonly Func<string, BlockBlobClient> _snapshotClientFactory;
+    private readonly AppendBlobClient _rootLogClient;
+    private readonly Func<uint, string> _walNameFactory;
+    private readonly Func<uint, AppendBlobClient> _walClientFactory;
+    private readonly Func<uint, string> _checkpointNameFactory;
+    private readonly Func<string, BlockBlobClient> _checkpointClientFactory;
     private readonly string? _mimeType;
     private readonly string? _journalFormatKey;
     private readonly ILogger<AzureBlobJournalStorage> _logger;
-    private readonly AppendBlobAppendBlockOptions _appendOptions;
-    private bool _exists;
+    private AppendBlobClient _currentLogClient;
+    private uint _currentSegmentId;
+    private uint _nextCheckpointId;
+    private bool _currentSegmentExists;
+    private long _appendPosition;
     private int _numBlocks;
+    private ETag _currentSegmentETag;
+    private ETag _rootLogETag;
 
     public bool IsCompactionRequested => _numBlocks > 10;
 
@@ -53,176 +64,342 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         string? mimeType,
         ILogger<AzureBlobJournalStorage> logger,
         string? journalFormatKey = null,
-        Func<string>? snapshotNameFactory = null,
-        Func<string, BlockBlobClient>? snapshotClientFactory = null)
+        Func<uint, string>? walNameFactory = null,
+        Func<uint, AppendBlobClient>? walClientFactory = null,
+        Func<uint, string>? checkpointNameFactory = null,
+        Func<string, BlockBlobClient>? checkpointClientFactory = null)
     {
         ArgumentNullException.ThrowIfNull(client);
 
-        _client = client;
-        _snapshotNameFactory = snapshotNameFactory ?? CreateDefaultSnapshotNameFactory(client);
-        _snapshotClientFactory = snapshotClientFactory ?? CreateDefaultSnapshotClientFactory(client);
+        _rootLogClient = client;
+        _currentLogClient = client;
+        _walNameFactory = walNameFactory ?? CreateDefaultWalNameFactory(client);
+        _walClientFactory = walClientFactory ?? CreateDefaultWalClientFactory(client);
+        _checkpointNameFactory = checkpointNameFactory ?? CreateDefaultCheckpointNameFactory(client);
+        _checkpointClientFactory = checkpointClientFactory ?? CreateDefaultCheckpointClientFactory(client);
         _mimeType = mimeType;
         _journalFormatKey = journalFormatKey;
         _logger = logger;
-
-        // For the first request, if we have not performed a read yet, we want to guard against clobbering an existing blob.
-        _appendOptions = new AppendBlobAppendBlockOptions() { Conditions = new AppendBlobRequestConditions { IfNoneMatch = ETag.All } };
     }
 
     public async ValueTask AppendAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
-        ThrowIfBatchTooLarge(value.Length, isReplace: false);
-        ThrowIfBlockCeilingApproached();
-
-        if (!_exists)
+        ThrowIfBatchTooLarge(value.Length);
+        if (_currentSegmentExists && _numBlocks >= MaxAppendBlobBlocks - AppendBlobBlockCeilingHeadroom)
         {
-            var response = await _client.CreateAsync(CreateOptions(new AppendBlobRequestConditions { IfNoneMatch = ETag.All }), cancellationToken);
-            _appendOptions.Conditions.IfNoneMatch = default;
-            _appendOptions.Conditions.IfMatch = response.Value.ETag;
-            _exists = true;
+            await RollToNextSegmentAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        using var stream = new ReadOnlySequenceStream(value);
-        var result = await _client.AppendBlockAsync(stream, _appendOptions, cancellationToken).ConfigureAwait(false);
-        LogAppend(_logger, stream.Length, _client.BlobContainerName, _client.Name);
+        while (true)
+        {
+            await EnsureCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
 
-        _appendOptions.Conditions.IfNoneMatch = default;
-        _appendOptions.Conditions.IfMatch = result.Value.ETag;
-        _numBlocks = result.Value.BlobCommittedBlockCount;
+            using var stream = new ReadOnlySequenceStream(value);
+            try
+            {
+                var result = await _currentLogClient.AppendBlockAsync(
+                    stream,
+                    new AppendBlobAppendBlockOptions
+                    {
+                        Conditions = new AppendBlobRequestConditions
+                        {
+                            IfAppendPositionEqual = _appendPosition,
+                        }
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                LogAppend(_logger, stream.Length, _currentLogClient.BlobContainerName, _currentLogClient.Name);
+                _appendPosition += stream.Length;
+                _currentSegmentETag = result.Value.ETag;
+                _numBlocks = result.Value.BlobCommittedBlockCount;
+                if (_currentSegmentId == 0)
+                {
+                    _rootLogETag = result.Value.ETag;
+                }
+
+                return;
+            }
+            catch (RequestFailedException exception) when (IsBlobSealed(exception))
+            {
+                await RollToNextSegmentAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
     }
 
-    private static void ThrowIfBatchTooLarge(long length, bool isReplace)
+    private static void ThrowIfBatchTooLarge(long length)
     {
         if (length <= MaxAppendBlockBytes)
         {
             return;
         }
 
-        var operation = isReplace ? "compacted journal" : "journal batch";
         throw new InvalidOperationException(
-            $"Azure Append Blob {operation} of {length:N0} bytes exceeds the per-block limit of {MaxAppendBlockBytes:N0} bytes (100 MiB). " +
+            $"Azure Append Blob journal batch of {length:N0} bytes exceeds the per-block limit of {MaxAppendBlockBytes:N0} bytes (100 MiB). " +
             "Reduce the operation size or compact more aggressively.");
-    }
-
-    private void ThrowIfBlockCeilingApproached()
-    {
-        if (_numBlocks < MaxAppendBlobBlocks - AppendBlobBlockCeilingHeadroom)
-        {
-            return;
-        }
-
-        throw new InvalidOperationException(
-            $"Azure Append Blob '{_client.Name}' in container '{_client.BlobContainerName}' has reached {_numBlocks:N0} of the maximum {MaxAppendBlobBlocks:N0} committed blocks. " +
-            "Compaction must run (IsCompactionRequested has been signaled at 11 blocks). Refusing to append further to avoid hitting the hard Azure limit.");
     }
 
     public async ValueTask DeleteAsync(CancellationToken cancellationToken)
     {
-        var conditions = new BlobRequestConditions { IfMatch = _appendOptions.Conditions.IfMatch };
-        await _client.DeleteAsync(conditions: conditions, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var conditions = new BlobRequestConditions { IfMatch = _rootLogETag };
+        await _rootLogClient.DeleteAsync(conditions: conditions, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        // Expect no blob to have been created when we append to it.
-        _appendOptions.Conditions.IfNoneMatch = ETag.All;
-        _appendOptions.Conditions.IfMatch = default;
-        _exists = false;
-        _numBlocks = 0;
+        SetCurrentSegment(segmentId: 0, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
+        _rootLogETag = default;
+        _nextCheckpointId = 0;
     }
 
     public async ValueTask ReadAsync(IJournalStorageConsumer consumer, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(consumer);
 
-        Response<BlobDownloadStreamingResult> result;
+        Response<BlobDownloadStreamingResult> rootResult;
         try
         {
-            result = await _client.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            rootResult = await _rootLogClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         catch (RequestFailedException exception) when (exception.Status is 404)
         {
-            _exists = false;
+            SetCurrentSegment(segmentId: 0, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
+            _rootLogETag = default;
+            _nextCheckpointId = 0;
             consumer.Complete(metadata: null);
             return;
         }
 
-        await using var appendStream = result.Value.Content;
-        var metadata = result.Value.Details.Metadata;
-        var fileMetadata = CreateFileMetadata(metadata);
-
-        _numBlocks = result.Value.Details.BlobCommittedBlockCount;
-        _appendOptions.Conditions.IfNoneMatch = default;
-        _appendOptions.Conditions.IfMatch = result.Value.Details.ETag;
-        _exists = true;
-
-        var snapshot = CreateSnapshotReference(metadata);
-        if (snapshot is null)
+        await using var rootStream = rootResult.Value.Content;
+        _rootLogETag = rootResult.Value.Details.ETag;
+        var checkpoint = CreateCheckpointReference(rootResult.Value.Details.Metadata);
+        if (checkpoint is null)
         {
-            var totalBytesRead = await consumer.ReadAsync(appendStream, fileMetadata, cancellationToken).ConfigureAwait(false);
-            LogRead(_logger, totalBytesRead, _client.BlobContainerName, _client.Name);
+            await ReadWalSegmentsAsync(
+                consumer,
+                startSegmentId: 0,
+                startOffset: 0,
+                firstSegmentResult: rootResult,
+                firstSegmentStream: rootStream,
+                expectedFormat: GetFormatKeyMetadata(rootResult.Value.Details.Metadata),
+                cancellationToken).ConfigureAwait(false);
             return;
         }
 
-        var snapshotClient = _snapshotClientFactory(snapshot.Name);
-        if (snapshotClient is null)
+        var checkpointClient = _checkpointClientFactory(checkpoint.Name);
+        if (checkpointClient is null)
         {
-            throw new InvalidOperationException("The configured Azure Blob journal snapshot client factory returned null.");
+            throw new InvalidOperationException("The configured Azure Blob journal checkpoint client factory returned null.");
         }
 
-        var snapshotResult = await snapshotClient.DownloadStreamingAsync(
+        var checkpointResult = await checkpointClient.DownloadStreamingAsync(
             new BlobDownloadOptions
             {
-                Conditions = new BlobRequestConditions { IfMatch = snapshot.ETag }
+                Conditions = new BlobRequestConditions { IfMatch = checkpoint.ETag }
             },
             cancellationToken).ConfigureAwait(false);
-        await using var snapshotStream = snapshotResult.Value.Content;
+        await using var checkpointStream = checkpointResult.Value.Content;
 
-        var readMetadata = ValidateSnapshotMetadata(snapshot, snapshotResult.Value.Details, metadata);
-        await using var combinedStream = new ConcatenatedReadStream(snapshotStream, appendStream);
-        var combinedBytesRead = await consumer.ReadAsync(combinedStream, readMetadata, cancellationToken).ConfigureAwait(false);
-        LogRead(_logger, combinedBytesRead, _client.BlobContainerName, _client.Name);
+        var checkpointMetadata = ValidateCheckpointMetadata(checkpoint, checkpointResult.Value.Details);
+        var totalCheckpointBytes = await ReadStreamAsync(
+            consumer,
+            checkpointStream,
+            checkpointMetadata,
+            complete: false,
+            cancellationToken).ConfigureAwait(false);
+        LogRead(_logger, totalCheckpointBytes, checkpointClient.BlobContainerName, checkpointClient.Name);
+
+        await ReadWalSegmentsAsync(
+            consumer,
+            checkpoint.ReplaySegment,
+            checkpoint.ReplayOffset,
+            firstSegmentResult: null,
+            firstSegmentStream: null,
+            expectedFormat: checkpointMetadata.Format,
+            cancellationToken).ConfigureAwait(false);
     }
 
     public async ValueTask ReplaceAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
-        var snapshotName = _snapshotNameFactory();
-        if (string.IsNullOrWhiteSpace(snapshotName))
+        if (!_currentSegmentExists)
         {
-            throw new InvalidOperationException("The configured Azure Blob journal snapshot name factory returned an empty blob name.");
+            await EnsureCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var snapshotClient = _snapshotClientFactory(snapshotName);
-        if (snapshotClient is null)
+        var sealedSegmentId = _currentSegmentId;
+        await SealCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
+
+        var replaySegmentId = checked(sealedSegmentId + 1);
+        var replayOffset = 0L;
+        var checkpointId = _nextCheckpointId;
+        var checkpointName = _checkpointNameFactory(checkpointId);
+        if (string.IsNullOrWhiteSpace(checkpointName))
         {
-            throw new InvalidOperationException("The configured Azure Blob journal snapshot client factory returned null.");
+            throw new InvalidOperationException("The configured Azure Blob journal checkpoint name factory returned an empty blob name.");
         }
 
-        using var snapshotStream = new ReadOnlySequenceStream(value);
-        var snapshotResult = await snapshotClient.UploadAsync(
-            snapshotStream,
+        var checkpointClient = _checkpointClientFactory(checkpointName);
+        if (checkpointClient is null)
+        {
+            throw new InvalidOperationException("The configured Azure Blob journal checkpoint client factory returned null.");
+        }
+
+        using var checkpointStream = new ReadOnlySequenceStream(value);
+        var checkpointResult = await checkpointClient.UploadAsync(
+            checkpointStream,
             new BlobUploadOptions
             {
                 Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All },
                 HttpHeaders = CreateHttpHeaders(),
-                Metadata = CreateMetadata(),
+                Metadata = CreateCheckpointBlobMetadata(checkpointId, replaySegmentId, replayOffset),
             },
             cancellationToken).ConfigureAwait(false);
+        _nextCheckpointId = checked(checkpointId + 1);
 
-        // Open the append blob for writing, atomically replacing it with an empty tail marker.
-        var createOptions = new AppendBlobCreateOptions()
+        var rootMetadata = CreateCheckpointMarkerMetadata(
+            checkpointName,
+            checkpointResult.Value.ETag,
+            checkpointId,
+            checkpointStream.Length,
+            replaySegmentId,
+            replayOffset);
+        var metadataResult = await _rootLogClient.SetMetadataAsync(
+            rootMetadata,
+            new BlobRequestConditions { IfMatch = _rootLogETag },
+            cancellationToken).ConfigureAwait(false);
+
+        _rootLogETag = metadataResult.Value.ETag;
+        SetCurrentSegment(replaySegmentId, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
+        LogReplace(_logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
+    }
+
+    private async ValueTask EnsureCurrentSegmentAsync(CancellationToken cancellationToken)
+    {
+        if (_currentSegmentExists)
         {
-            Conditions = new AppendBlobRequestConditions
+            return;
+        }
+
+        var response = await _currentLogClient.CreateAsync(
+            CreateOptions(new AppendBlobRequestConditions { IfNoneMatch = ETag.All }),
+            cancellationToken).ConfigureAwait(false);
+        SetCurrentSegment(_currentSegmentId, exists: true, response.Value.ETag, appendPosition: 0, blockCount: 0);
+    }
+
+    private async ValueTask RollToNextSegmentAsync(CancellationToken cancellationToken)
+    {
+        if (_currentSegmentExists)
+        {
+            await SealCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        SetCurrentSegment(checked(_currentSegmentId + 1), exists: false, eTag: default, appendPosition: 0, blockCount: 0);
+    }
+
+    private async ValueTask SealCurrentSegmentAsync(CancellationToken cancellationToken)
+    {
+        if (!_currentSegmentExists)
+        {
+            return;
+        }
+
+        await _currentLogClient.SealAsync(
+            new AppendBlobRequestConditions { IfMatch = _currentSegmentETag },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async ValueTask ReadWalSegmentsAsync(
+        IJournalStorageConsumer consumer,
+        uint startSegmentId,
+        long startOffset,
+        Response<BlobDownloadStreamingResult>? firstSegmentResult,
+        Stream? firstSegmentStream,
+        string? expectedFormat,
+        CancellationToken cancellationToken)
+    {
+        var segmentId = startSegmentId;
+        var offset = startOffset;
+        var consumedFirst = firstSegmentResult is null;
+        var metadata = expectedFormat is { Length: > 0 } ? new JournalFileMetadata(expectedFormat) : JournalFileMetadata.Empty;
+        while (true)
+        {
+            Response<BlobDownloadStreamingResult> result;
+            Stream stream;
+            if (!consumedFirst && firstSegmentResult is not null && firstSegmentStream is not null)
             {
-                IfMatch = _appendOptions.Conditions.IfMatch,
-                IfNoneMatch = _appendOptions.Conditions.IfNoneMatch,
-            },
-            Metadata = CreateSnapshotMarkerMetadata(snapshotName, snapshotResult.Value.ETag, snapshotStream.Length),
-            HttpHeaders = CreateHttpHeaders(),
-        };
-        var createResult = await _client.CreateAsync(createOptions, cancellationToken).ConfigureAwait(false);
-        _appendOptions.Conditions.IfMatch = createResult.Value.ETag;
-        _appendOptions.Conditions.IfNoneMatch = default;
-        _exists = true;
-        _numBlocks = 0;
-        LogReplace(_logger, _client.BlobContainerName, _client.Name, snapshotStream.Length);
+                result = firstSegmentResult;
+                stream = firstSegmentStream;
+                consumedFirst = true;
+            }
+            else
+            {
+                var client = GetWalClient(segmentId);
+                try
+                {
+                    result = await client.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                catch (RequestFailedException exception) when (exception.Status is 404)
+                {
+                    SetCurrentSegment(segmentId, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
+                    consumer.Complete(metadata);
+                    return;
+                }
+
+                stream = result.Value.Content;
+            }
+
+            await using (stream.ConfigureAwait(false))
+            {
+                var details = result.Value.Details;
+                var segmentFormat = GetFormatKeyMetadata(details.Metadata);
+                EnsureCompatibleFormat(expectedFormat, segmentFormat, segmentId);
+                metadata = segmentFormat is { Length: > 0 } ? new JournalFileMetadata(segmentFormat) : metadata;
+                if (offset > details.ContentLength)
+                {
+                    throw new InvalidOperationException(
+                        $"Azure Blob journal checkpoint points to offset {offset:N0} in WAL segment {_walNameFactory(segmentId)}, but the segment length is {details.ContentLength:N0}.");
+                }
+
+                if (offset > 0)
+                {
+                    await SkipExactlyAsync(stream, offset, cancellationToken).ConfigureAwait(false);
+                }
+
+                var bytesRead = await ReadStreamAsync(consumer, stream, metadata, complete: false, cancellationToken).ConfigureAwait(false);
+                LogRead(_logger, bytesRead, _rootLogClient.BlobContainerName, _walNameFactory(segmentId));
+
+                if (!details.IsSealed)
+                {
+                    SetCurrentSegment(segmentId, exists: true, details.ETag, details.ContentLength, details.BlobCommittedBlockCount);
+                    consumer.Complete(metadata);
+                    return;
+                }
+            }
+
+            segmentId = checked(segmentId + 1);
+            offset = 0;
+        }
+    }
+
+    private void SetCurrentSegment(uint segmentId, bool exists, ETag eTag, long appendPosition, int blockCount)
+    {
+        _currentSegmentId = segmentId;
+        _currentLogClient = GetWalClient(segmentId);
+        _currentSegmentExists = exists;
+        _currentSegmentETag = eTag;
+        _appendPosition = appendPosition;
+        _numBlocks = blockCount;
+        if (segmentId == 0)
+        {
+            _rootLogETag = eTag;
+        }
+    }
+
+    private AppendBlobClient GetWalClient(uint segmentId)
+    {
+        if (segmentId == 0)
+        {
+            return _rootLogClient;
+        }
+
+        var client = _walClientFactory(segmentId);
+        return client ?? throw new InvalidOperationException("The configured Azure Blob journal WAL client factory returned null.");
     }
 
     private AppendBlobCreateOptions CreateOptions(AppendBlobRequestConditions conditions) => new()
@@ -237,11 +414,17 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private static BlobHttpHeaders? CreateHttpHeaders(string? contentType)
         => contentType is { Length: > 0 } ? new BlobHttpHeaders { ContentType = contentType } : null;
 
-    private static Func<string> CreateDefaultSnapshotNameFactory(AppendBlobClient client)
-        => () => $"{client.Name}.snapshots/{Guid.NewGuid():N}";
+    private static Func<uint, string> CreateDefaultWalNameFactory(AppendBlobClient client)
+        => segmentId => segmentId == 0 ? client.Name : $"{client.Name}.log.{segmentId:X8}";
 
-    private static Func<string, BlockBlobClient> CreateDefaultSnapshotClientFactory(AppendBlobClient client)
-        => snapshotName => client.GetParentBlobContainerClient().GetBlockBlobClient(snapshotName);
+    private static Func<uint, AppendBlobClient> CreateDefaultWalClientFactory(AppendBlobClient client)
+        => segmentId => segmentId == 0 ? client : client.GetParentBlobContainerClient().GetAppendBlobClient($"{client.Name}.log.{segmentId:X8}");
+
+    private static Func<uint, string> CreateDefaultCheckpointNameFactory(AppendBlobClient client)
+        => checkpointId => $"{client.Name}.checkpoint.{checkpointId:X8}";
+
+    private static Func<string, BlockBlobClient> CreateDefaultCheckpointClientFactory(AppendBlobClient client)
+        => checkpointName => client.GetParentBlobContainerClient().GetBlockBlobClient(checkpointName);
 
     private Dictionary<string, string> CreateMetadataDictionary()
     {
@@ -260,15 +443,30 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         return metadata.Count > 0 ? metadata : null;
     }
 
-    private Dictionary<string, string> CreateSnapshotMarkerMetadata(string snapshotName, ETag snapshotETag, long snapshotLength)
+    private Dictionary<string, string> CreateCheckpointBlobMetadata(uint checkpointId, uint replaySegmentId, long replayOffset)
     {
         var metadata = CreateMetadataDictionary();
-        metadata[SnapshotMetadataKey] = snapshotName;
-        metadata[SnapshotETagMetadataKey] = snapshotETag.ToString();
-        metadata[SnapshotLengthMetadataKey] = snapshotLength.ToString(CultureInfo.InvariantCulture);
+        metadata[CheckpointIdMetadataKey] = FormatUInt32(checkpointId);
+        metadata[CheckpointReplaySegmentMetadataKey] = FormatUInt32(replaySegmentId);
+        metadata[CheckpointReplayOffsetMetadataKey] = replayOffset.ToString(CultureInfo.InvariantCulture);
+        return metadata;
+    }
+
+    private Dictionary<string, string> CreateCheckpointMarkerMetadata(
+        string checkpointName,
+        ETag checkpointETag,
+        uint checkpointId,
+        long checkpointLength,
+        uint replaySegmentId,
+        long replayOffset)
+    {
+        var metadata = CreateCheckpointBlobMetadata(checkpointId, replaySegmentId, replayOffset);
+        metadata[CheckpointMetadataKey] = checkpointName;
+        metadata[CheckpointETagMetadataKey] = checkpointETag.ToString();
+        metadata[CheckpointLengthMetadataKey] = checkpointLength.ToString(CultureInfo.InvariantCulture);
         if (_journalFormatKey is { Length: > 0 })
         {
-            metadata[SnapshotFormatMetadataKey] = _journalFormatKey;
+            metadata[CheckpointFormatMetadataKey] = _journalFormatKey;
         }
 
         return metadata;
@@ -281,79 +479,192 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 ? storedKey
                 : null;
 
-    private static IJournalFileMetadata CreateFileMetadata(IDictionary<string, string>? metadata)
-        => GetFormatKeyMetadata(metadata) is { } format
-            ? new JournalFileMetadata(format)
-            : JournalFileMetadata.Empty;
-
-    private static SnapshotReference? CreateSnapshotReference(IDictionary<string, string>? metadata)
+    private static CheckpointReference? CreateCheckpointReference(IDictionary<string, string>? metadata)
     {
-        if (metadata is null || !metadata.TryGetValue(SnapshotMetadataKey, out var snapshotName) || snapshotName is not { Length: > 0 })
+        if (metadata is null || !metadata.TryGetValue(CheckpointMetadataKey, out var checkpointName) || checkpointName is not { Length: > 0 })
         {
             return null;
         }
 
-        if (!metadata.TryGetValue(SnapshotETagMetadataKey, out var snapshotETag) || snapshotETag is not { Length: > 0 })
+        if (!metadata.TryGetValue(CheckpointETagMetadataKey, out var checkpointETag) || checkpointETag is not { Length: > 0 })
         {
             throw new InvalidOperationException(
-                $"Azure Blob journal marker references snapshot blob '{snapshotName}' but does not include '{SnapshotETagMetadataKey}' metadata.");
+                $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include '{CheckpointETagMetadataKey}' metadata.");
         }
 
-        if (!metadata.TryGetValue(SnapshotLengthMetadataKey, out var snapshotLengthValue)
-            || !long.TryParse(snapshotLengthValue, NumberStyles.None, CultureInfo.InvariantCulture, out var snapshotLength)
-            || snapshotLength < 0)
+        if (!TryGetUInt32Metadata(metadata, CheckpointIdMetadataKey, out var checkpointId))
         {
             throw new InvalidOperationException(
-                $"Azure Blob journal marker references snapshot blob '{snapshotName}' but does not include valid '{SnapshotLengthMetadataKey}' metadata.");
+                $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include valid '{CheckpointIdMetadataKey}' metadata.");
         }
 
-        var snapshotFormat = metadata.TryGetValue(SnapshotFormatMetadataKey, out var storedSnapshotFormat)
-            && storedSnapshotFormat is { Length: > 0 }
-                ? storedSnapshotFormat
+        if (!metadata.TryGetValue(CheckpointLengthMetadataKey, out var checkpointLengthValue)
+            || !long.TryParse(checkpointLengthValue, NumberStyles.None, CultureInfo.InvariantCulture, out var checkpointLength)
+            || checkpointLength < 0)
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include valid '{CheckpointLengthMetadataKey}' metadata.");
+        }
+
+        if (!TryGetUInt32Metadata(metadata, CheckpointReplaySegmentMetadataKey, out var replaySegment))
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include valid '{CheckpointReplaySegmentMetadataKey}' metadata.");
+        }
+
+        if (!metadata.TryGetValue(CheckpointReplayOffsetMetadataKey, out var replayOffsetValue)
+            || !long.TryParse(replayOffsetValue, NumberStyles.None, CultureInfo.InvariantCulture, out var replayOffset)
+            || replayOffset < 0)
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include valid '{CheckpointReplayOffsetMetadataKey}' metadata.");
+        }
+
+        var checkpointFormat = metadata.TryGetValue(CheckpointFormatMetadataKey, out var storedCheckpointFormat)
+            && storedCheckpointFormat is { Length: > 0 }
+                ? storedCheckpointFormat
                 : null;
 
-        return new SnapshotReference(snapshotName, new ETag(snapshotETag), snapshotFormat, snapshotLength);
+        return new CheckpointReference(checkpointName, new ETag(checkpointETag), checkpointId, checkpointFormat, checkpointLength, replaySegment, replayOffset);
     }
 
-    private static IJournalFileMetadata ValidateSnapshotMetadata(
-        SnapshotReference snapshot,
-        BlobDownloadDetails snapshotDetails,
-        IDictionary<string, string>? markerMetadata)
+    private IJournalFileMetadata ValidateCheckpointMetadata(CheckpointReference checkpoint, BlobDownloadDetails checkpointDetails)
     {
-        if (snapshotDetails.ContentLength != snapshot.Length)
+        if (checkpointDetails.ContentLength != checkpoint.Length)
         {
             throw new InvalidOperationException(
-                $"Azure Blob journal snapshot '{snapshot.Name}' length is {snapshotDetails.ContentLength}, but marker metadata expected {snapshot.Length}.");
+                $"Azure Blob journal checkpoint '{checkpoint.Name}' length is {checkpointDetails.ContentLength}, but marker metadata expected {checkpoint.Length}.");
         }
 
-        var markerFormat = GetFormatKeyMetadata(markerMetadata);
-        var snapshotBlobFormat = GetFormatKeyMetadata(snapshotDetails.Metadata);
-        if (snapshot.Format is { } markerSnapshotFormat
-            && snapshotBlobFormat is { }
-            && !string.Equals(markerSnapshotFormat, snapshotBlobFormat, StringComparison.Ordinal))
+        if (!TryGetUInt32Metadata(checkpointDetails.Metadata, CheckpointIdMetadataKey, out var checkpointId) || checkpointId != checkpoint.Id)
         {
             throw new InvalidOperationException(
-                $"Azure Blob journal snapshot '{snapshot.Name}' format metadata is '{snapshotBlobFormat}', but marker metadata expected '{markerSnapshotFormat}'.");
+                $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include the expected checkpoint id '{FormatUInt32(checkpoint.Id)}'.");
         }
 
-        var effectiveSnapshotFormat = snapshot.Format ?? snapshotBlobFormat;
-        if (markerFormat is { } tailFormat
-            && effectiveSnapshotFormat is { }
-            && !string.Equals(tailFormat, effectiveSnapshotFormat, StringComparison.Ordinal))
+        if (!TryGetUInt32Metadata(checkpointDetails.Metadata, CheckpointReplaySegmentMetadataKey, out var replaySegment) || replaySegment != checkpoint.ReplaySegment)
         {
             throw new InvalidOperationException(
-                $"Azure Blob journal append tail format metadata is '{tailFormat}', but snapshot '{snapshot.Name}' uses format '{effectiveSnapshotFormat}'.");
+                $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include the expected replay segment '{FormatUInt32(checkpoint.ReplaySegment)}'.");
         }
 
-        if (markerFormat is { } && effectiveSnapshotFormat is null)
+        if (!checkpointDetails.Metadata.TryGetValue(CheckpointReplayOffsetMetadataKey, out var replayOffsetValue)
+            || !long.TryParse(replayOffsetValue, NumberStyles.None, CultureInfo.InvariantCulture, out var replayOffset)
+            || replayOffset != checkpoint.ReplayOffset)
         {
             throw new InvalidOperationException(
-                $"Azure Blob journal snapshot '{snapshot.Name}' does not include format metadata.");
+                $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include the expected replay offset '{checkpoint.ReplayOffset}'.");
         }
 
-        return effectiveSnapshotFormat is { } format
+        var checkpointBlobFormat = GetFormatKeyMetadata(checkpointDetails.Metadata);
+        if (checkpoint.Format is { } markerCheckpointFormat
+            && checkpointBlobFormat is { }
+            && !string.Equals(markerCheckpointFormat, checkpointBlobFormat, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal checkpoint '{checkpoint.Name}' format metadata is '{checkpointBlobFormat}', but marker metadata expected '{markerCheckpointFormat}'.");
+        }
+
+        var effectiveCheckpointFormat = checkpoint.Format ?? checkpointBlobFormat;
+        if (checkpoint.Format is { } && checkpointBlobFormat is null)
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include format metadata.");
+        }
+
+        _nextCheckpointId = Math.Max(_nextCheckpointId, checked(checkpoint.Id + 1));
+        return effectiveCheckpointFormat is { } format
             ? new JournalFileMetadata(format)
             : JournalFileMetadata.Empty;
+    }
+
+    private static void EnsureCompatibleFormat(string? expectedFormat, string? segmentFormat, uint segmentId)
+    {
+        if (expectedFormat is null || segmentFormat is null || string.Equals(expectedFormat, segmentFormat, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Azure Blob journal WAL segment {FormatUInt32(segmentId)} format metadata is '{segmentFormat}', but recovery expected '{expectedFormat}'.");
+    }
+
+    private static bool TryGetUInt32Metadata(IDictionary<string, string>? metadata, string key, out uint value)
+    {
+        value = default;
+        return metadata is not null
+            && metadata.TryGetValue(key, out var text)
+            && uint.TryParse(text, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
+    }
+
+    private static string FormatUInt32(uint value) => value.ToString("X8", CultureInfo.InvariantCulture);
+
+    private static bool IsBlobSealed(RequestFailedException exception)
+        => exception.Status == 409
+            && (string.Equals(exception.ErrorCode, "BlobIsSealed", StringComparison.Ordinal)
+                || exception.Message.Contains("sealed", StringComparison.OrdinalIgnoreCase));
+
+    private static async ValueTask<long> ReadStreamAsync(
+        IJournalStorageConsumer consumer,
+        Stream input,
+        IJournalFileMetadata? metadata,
+        bool complete,
+        CancellationToken cancellationToken)
+    {
+        metadata ??= JournalFileMetadata.Empty;
+        using var buffer = new ArcBufferWriter();
+        long totalBytesRead = 0;
+        while (true)
+        {
+            var memory = buffer.GetMemory();
+            var bytesRead = await input.ReadAsync(memory, cancellationToken).ConfigureAwait(false);
+            if (bytesRead == 0)
+            {
+                if (complete)
+                {
+                    ReadBuffer(consumer, buffer, metadata, isCompleted: true);
+                }
+
+                if (buffer.Length > 0)
+                {
+                    throw new InvalidOperationException("The journal storage consumer did not read all supplied journal data.");
+                }
+
+                return totalBytesRead;
+            }
+
+            buffer.AdvanceWriter(bytesRead);
+            totalBytesRead += bytesRead;
+            ReadBuffer(consumer, buffer, metadata, isCompleted: false);
+        }
+    }
+
+    private static async ValueTask SkipExactlyAsync(Stream stream, long bytesToSkip, CancellationToken cancellationToken)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+        try
+        {
+            while (bytesToSkip > 0)
+            {
+                var bytesRead = await stream.ReadAsync(buffer.AsMemory(0, (int)Math.Min(buffer.Length, bytesToSkip)), cancellationToken).ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    throw new InvalidOperationException("The stream ended before the requested WAL replay offset was reached.");
+                }
+
+                bytesToSkip -= bytesRead;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static void ReadBuffer(IJournalStorageConsumer consumer, ArcBufferWriter buffer, IJournalFileMetadata metadata, bool isCompleted)
+    {
+        var reader = new JournalBufferReader(buffer.Reader, isCompleted);
+        consumer.Read(reader, metadata);
     }
 
     [LoggerMessage(
@@ -368,118 +679,10 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     [LoggerMessage(
         Level = LogLevel.Debug,
-        Message = "Replaced blob \"{ContainerName}/{BlobName}\" with snapshot containing {Length} bytes")]
+        Message = "Wrote checkpoint blob \"{ContainerName}/{BlobName}\" containing {Length} bytes")]
     private static partial void LogReplace(ILogger logger, string containerName, string blobName, long length);
 
-    private sealed record SnapshotReference(string Name, ETag ETag, string? Format, long Length);
-
-    private sealed class ConcatenatedReadStream(Stream first, Stream second) : Stream
-    {
-        // The caller owns and disposes the underlying streams.
-        private Stream? _current = first;
-        private Stream? _next = second;
-        private bool _disposed;
-
-        public override bool CanRead => !_disposed;
-
-        public override bool CanSeek => false;
-
-        public override bool CanWrite => false;
-
-        public override long Length => throw GetSeekNotSupportedException();
-
-        public override long Position
-        {
-            get => throw GetSeekNotSupportedException();
-            set => throw GetSeekNotSupportedException();
-        }
-
-        public override void Flush()
-        {
-        }
-
-        public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
-
-        public override int Read(Span<byte> buffer)
-        {
-            ThrowIfDisposed();
-            while (_current is not null)
-            {
-                var bytesRead = _current.Read(buffer);
-                if (bytesRead != 0 || _next is null)
-                {
-                    return bytesRead;
-                }
-
-                _current = _next;
-                _next = null;
-            }
-
-            return 0;
-        }
-
-        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
-        {
-            ThrowIfDisposed();
-            while (_current is not null)
-            {
-                var bytesRead = await _current.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
-                if (bytesRead != 0 || _next is null)
-                {
-                    return bytesRead;
-                }
-
-                _current = _next;
-                _next = null;
-            }
-
-            return 0;
-        }
-
-        public override long Seek(long offset, SeekOrigin origin) => throw GetSeekNotSupportedException();
-
-        public override void SetLength(long value) => throw GetReadOnlyException();
-
-        public override void Write(byte[] buffer, int offset, int count) => throw GetReadOnlyException();
-
-        public override void Write(ReadOnlySpan<byte> buffer) => throw GetReadOnlyException();
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && !_disposed)
-            {
-                _current = null;
-                _next = null;
-                _disposed = true;
-            }
-
-            base.Dispose(disposing);
-        }
-
-        public override async ValueTask DisposeAsync()
-        {
-            if (!_disposed)
-            {
-                _current = null;
-                _next = null;
-                _disposed = true;
-            }
-
-            await base.DisposeAsync().ConfigureAwait(false);
-        }
-
-        private void ThrowIfDisposed()
-        {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(nameof(ConcatenatedReadStream));
-            }
-        }
-
-        private static NotSupportedException GetSeekNotSupportedException() => new("This stream does not support seeking.");
-
-        private static NotSupportedException GetReadOnlyException() => new("This stream is read-only.");
-    }
+    private sealed record CheckpointReference(string Name, ETag ETag, uint Id, string? Format, long Length, uint ReplaySegment, long ReplayOffset);
 
     private sealed class ReadOnlySequenceStream(ReadOnlySequence<byte> sequence) : Stream
     {
@@ -509,6 +712,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 ThrowIfDisposed();
                 return _position;
             }
+
             set
             {
                 ThrowIfDisposed();
@@ -523,6 +727,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
         public override void Flush()
         {
+            ThrowIfDisposed();
         }
 
         public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
@@ -530,43 +735,27 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         public override int Read(Span<byte> buffer)
         {
             ThrowIfDisposed();
-            if (buffer.IsEmpty)
+            if (buffer.IsEmpty || _position >= _sequence.Length)
             {
                 return 0;
             }
 
-            var remaining = _sequence.Length - _position;
-            if (remaining <= 0)
-            {
-                return 0;
-            }
-
-            var count = (int)Math.Min(buffer.Length, remaining);
-            _sequence.Slice(_position, count).CopyTo(buffer);
-            _position += count;
-            return count;
+            var length = (int)Math.Min(buffer.Length, _sequence.Length - _position);
+            _sequence.Slice(_position, length).CopyTo(buffer);
+            _position += length;
+            return length;
         }
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return new(Read(buffer.Span));
-        }
-
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled<int>(cancellationToken);
-            }
-
-            return Task.FromResult(Read(buffer.AsSpan(offset, count)));
+            return new ValueTask<int>(Read(buffer.Span));
         }
 
         public override long Seek(long offset, SeekOrigin origin)
         {
             ThrowIfDisposed();
-            var position = origin switch
+            var newPosition = origin switch
             {
                 SeekOrigin.Begin => offset,
                 SeekOrigin.Current => _position + offset,
@@ -574,23 +763,19 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 _ => throw new ArgumentOutOfRangeException(nameof(origin))
             };
 
-            Position = position;
+            Position = newPosition;
             return _position;
         }
 
-        public override void SetLength(long value) => throw GetReadOnlyException();
+        public override void SetLength(long value) => throw new NotSupportedException("This stream is read-only.");
 
-        public override void Write(byte[] buffer, int offset, int count) => throw GetReadOnlyException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException("This stream is read-only.");
 
-        public override void Write(ReadOnlySpan<byte> buffer) => throw GetReadOnlyException();
+        public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException("This stream is read-only.");
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                _disposed = true;
-            }
-
+            _disposed = true;
             base.Dispose(disposing);
         }
 
@@ -601,7 +786,5 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 throw new ObjectDisposedException(nameof(ReadOnlySequenceStream));
             }
         }
-
-        private static NotSupportedException GetReadOnlyException() => new("This stream is read-only.");
     }
 }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -11,13 +11,11 @@ namespace Orleans.Journaling;
 internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 {
     internal const string FormatMetadataKey = "format";
+    internal const string GenerationMetadataKey = "generation";
     internal const string CheckpointMetadataKey = "checkpoint";
     internal const string CheckpointETagMetadataKey = "checkpoint_etag";
     internal const string CheckpointFormatMetadataKey = "checkpoint_format";
-    internal const string CheckpointIdMetadataKey = "checkpoint_id";
     internal const string CheckpointLengthMetadataKey = "checkpoint_length";
-    internal const string CheckpointReplaySegmentMetadataKey = "checkpoint_replay_segment";
-    internal const string CheckpointReplayOffsetMetadataKey = "checkpoint_replay_offset";
 
     // Azure Append Blob hard limits documented at:
     // https://learn.microsoft.com/azure/storage/blobs/scalability-targets#scale-targets-for-blob-storage
@@ -31,16 +29,17 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private const int AppendBlobBlockCeilingHeadroom = 100;
 
     private readonly AppendBlobClient _rootLogClient;
-    private readonly Func<uint, string> _walNameFactory;
-    private readonly Func<uint, AppendBlobClient> _walClientFactory;
-    private readonly Func<uint, string> _checkpointNameFactory;
+    private readonly Func<ulong, uint, string> _walNameFactory;
+    private readonly Func<ulong, uint, AppendBlobClient> _walClientFactory;
+    private readonly Func<ulong, string> _checkpointNameFactory;
     private readonly Func<string, BlockBlobClient> _checkpointClientFactory;
     private readonly string? _mimeType;
     private readonly string? _journalFormatKey;
     private readonly ILogger<AzureBlobJournalStorage> _logger;
     private AppendBlobClient _currentLogClient;
+    private ulong _currentGeneration;
     private uint _currentSegmentId;
-    private uint _nextCheckpointId;
+    private bool _rootExists;
     private bool _currentSegmentExists;
     private long _appendPosition;
     private int _numBlocks;
@@ -64,9 +63,9 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         string? mimeType,
         ILogger<AzureBlobJournalStorage> logger,
         string? journalFormatKey = null,
-        Func<uint, string>? walNameFactory = null,
-        Func<uint, AppendBlobClient>? walClientFactory = null,
-        Func<uint, string>? checkpointNameFactory = null,
+        Func<ulong, uint, string>? walNameFactory = null,
+        Func<ulong, uint, AppendBlobClient>? walClientFactory = null,
+        Func<ulong, string>? checkpointNameFactory = null,
         Func<string, BlockBlobClient>? checkpointClientFactory = null)
     {
         ArgumentNullException.ThrowIfNull(client);
@@ -115,6 +114,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 if (_currentSegmentId == 0)
                 {
                     _rootLogETag = result.Value.ETag;
+                    _rootExists = true;
                 }
 
                 return;
@@ -140,12 +140,34 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     public async ValueTask DeleteAsync(CancellationToken cancellationToken)
     {
-        var conditions = new BlobRequestConditions { IfMatch = _rootLogETag };
-        await _rootLogClient.DeleteAsync(conditions: conditions, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (!_rootExists)
+        {
+            return;
+        }
 
-        SetCurrentSegment(segmentId: 0, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
-        _rootLogETag = default;
-        _nextCheckpointId = 0;
+        if (_currentSegmentExists)
+        {
+            await SealCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var generation = checked(_currentGeneration + 1);
+        Response<BlobContentInfo> response;
+        try
+        {
+            response = await CreateRootAsync(
+                generation,
+                checkpoint: null,
+                new AppendBlobRequestConditions { IfMatch = _rootLogETag },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException exception) when (IsRootMutationConflict(exception))
+        {
+            throw new InvalidOperationException("Azure Blob journal root changed while deleting the journal; recovery is required.", exception);
+        }
+
+        _currentGeneration = generation;
+        _rootExists = true;
+        SetCurrentSegment(segmentId: 0, exists: true, response.Value.ETag, appendPosition: 0, blockCount: 0);
     }
 
     public async ValueTask ReadAsync(IJournalStorageConsumer consumer, CancellationToken cancellationToken)
@@ -159,59 +181,52 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
         catch (RequestFailedException exception) when (exception.Status is 404)
         {
+            _currentGeneration = 0;
+            _rootExists = false;
             SetCurrentSegment(segmentId: 0, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
             _rootLogETag = default;
-            _nextCheckpointId = 0;
             consumer.Complete(metadata: null);
             return;
         }
 
         await using var rootStream = rootResult.Value.Content;
         _rootLogETag = rootResult.Value.Details.ETag;
-        var checkpoint = CreateCheckpointReference(rootResult.Value.Details.Metadata);
-        if (checkpoint is null)
+        _rootExists = true;
+        var manifest = CreateRootManifest(rootResult.Value.Details.Metadata);
+        _currentGeneration = manifest.Generation;
+        var expectedFormat = manifest.Metadata.Format;
+        if (manifest.Checkpoint is { } checkpoint)
         {
-            await ReadWalSegmentsAsync(
-                consumer,
-                startSegmentId: 0,
-                startOffset: 0,
-                firstSegmentResult: rootResult,
-                firstSegmentStream: rootStream,
-                expectedFormat: GetFormatKeyMetadata(rootResult.Value.Details.Metadata),
-                cancellationToken).ConfigureAwait(false);
-            return;
-        }
-
-        var checkpointClient = _checkpointClientFactory(checkpoint.Name);
-        if (checkpointClient is null)
-        {
-            throw new InvalidOperationException("The configured Azure Blob journal checkpoint client factory returned null.");
-        }
-
-        var checkpointResult = await checkpointClient.DownloadStreamingAsync(
-            new BlobDownloadOptions
+            var checkpointClient = _checkpointClientFactory(checkpoint.Name);
+            if (checkpointClient is null)
             {
-                Conditions = new BlobRequestConditions { IfMatch = checkpoint.ETag }
-            },
-            cancellationToken).ConfigureAwait(false);
-        await using var checkpointStream = checkpointResult.Value.Content;
+                throw new InvalidOperationException("The configured Azure Blob journal checkpoint client factory returned null.");
+            }
 
-        var checkpointMetadata = ValidateCheckpointMetadata(checkpoint, checkpointResult.Value.Details);
-        var totalCheckpointBytes = await ReadStreamAsync(
-            consumer,
-            checkpointStream,
-            checkpointMetadata,
-            complete: false,
-            cancellationToken).ConfigureAwait(false);
-        LogRead(_logger, totalCheckpointBytes, checkpointClient.BlobContainerName, checkpointClient.Name);
+            var checkpointResult = await checkpointClient.DownloadStreamingAsync(
+                new BlobDownloadOptions
+                {
+                    Conditions = new BlobRequestConditions { IfMatch = checkpoint.ETag }
+                },
+                cancellationToken).ConfigureAwait(false);
+            await using var checkpointStream = checkpointResult.Value.Content;
 
-        await ReadWalSegmentsAsync(
+            var checkpointMetadata = ValidateCheckpointMetadata(checkpoint, checkpointResult.Value.Details);
+            var totalCheckpointBytes = await ReadStreamAsync(
+                consumer,
+                checkpointStream,
+                checkpointMetadata,
+                complete: false,
+                cancellationToken).ConfigureAwait(false);
+            LogRead(_logger, totalCheckpointBytes, checkpointClient.BlobContainerName, checkpointClient.Name);
+            expectedFormat = checkpointMetadata.Format;
+        }
+
+        await ReadRootAndSegmentsAsync(
             consumer,
-            checkpoint.ReplaySegment,
-            checkpoint.ReplayOffset,
-            firstSegmentResult: null,
-            firstSegmentStream: null,
-            expectedFormat: checkpointMetadata.Format,
+            rootResult.Value.Details,
+            rootStream,
+            expectedFormat,
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -222,51 +237,69 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             await EnsureCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var sealedSegmentId = _currentSegmentId;
-        await SealCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
-
-        var replaySegmentId = checked(sealedSegmentId + 1);
-        var replayOffset = 0L;
-        var checkpointId = _nextCheckpointId;
-        var checkpointName = _checkpointNameFactory(checkpointId);
-        if (string.IsNullOrWhiteSpace(checkpointName))
-        {
-            throw new InvalidOperationException("The configured Azure Blob journal checkpoint name factory returned an empty blob name.");
-        }
-
-        var checkpointClient = _checkpointClientFactory(checkpointName);
-        if (checkpointClient is null)
-        {
-            throw new InvalidOperationException("The configured Azure Blob journal checkpoint client factory returned null.");
-        }
-
+        var rootETag = _rootLogETag;
+        var generation = checked(_currentGeneration + 1);
         using var checkpointStream = new ReadOnlySequenceStream(value);
-        var checkpointResult = await checkpointClient.UploadAsync(
-            checkpointStream,
-            new BlobUploadOptions
+        while (true)
+        {
+            var checkpointName = _checkpointNameFactory(generation);
+            if (string.IsNullOrWhiteSpace(checkpointName))
             {
-                Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All },
-                HttpHeaders = CreateHttpHeaders(),
-                Metadata = CreateCheckpointBlobMetadata(checkpointId, replaySegmentId, replayOffset),
-            },
-            cancellationToken).ConfigureAwait(false);
-        _nextCheckpointId = checked(checkpointId + 1);
+                throw new InvalidOperationException("The configured Azure Blob journal checkpoint name factory returned an empty blob name.");
+            }
 
-        var rootMetadata = CreateCheckpointMarkerMetadata(
-            checkpointName,
-            checkpointResult.Value.ETag,
-            checkpointId,
-            checkpointStream.Length,
-            replaySegmentId,
-            replayOffset);
-        var metadataResult = await _rootLogClient.SetMetadataAsync(
-            rootMetadata,
-            new BlobRequestConditions { IfMatch = _rootLogETag },
-            cancellationToken).ConfigureAwait(false);
+            var checkpointClient = _checkpointClientFactory(checkpointName);
+            if (checkpointClient is null)
+            {
+                throw new InvalidOperationException("The configured Azure Blob journal checkpoint client factory returned null.");
+            }
 
-        _rootLogETag = metadataResult.Value.ETag;
-        SetCurrentSegment(replaySegmentId, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
-        LogReplace(_logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
+            try
+            {
+                checkpointStream.Position = 0;
+                var checkpointResult = await checkpointClient.UploadAsync(
+                    checkpointStream,
+                    new BlobUploadOptions
+                    {
+                        Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All },
+                        HttpHeaders = CreateHttpHeaders(),
+                        Metadata = CreateCheckpointBlobMetadata(generation),
+                    },
+                    cancellationToken).ConfigureAwait(false);
+
+                Response<BlobContentInfo> rootResult;
+                try
+                {
+                    rootResult = await CreateRootAsync(
+                        generation,
+                        new CheckpointPublication(checkpointName, checkpointResult.Value.ETag, checkpointStream.Length),
+                        new AppendBlobRequestConditions { IfMatch = rootETag },
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch (RequestFailedException exception) when (IsRootMutationConflict(exception))
+                {
+                    throw new InvalidOperationException("Azure Blob journal root changed while publishing a checkpoint; recovery is required.", exception);
+                }
+
+                _currentGeneration = generation;
+                _rootExists = true;
+                SetCurrentSegment(segmentId: 0, exists: true, rootResult.Value.ETag, appendPosition: 0, blockCount: 0);
+                LogReplace(_logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
+                return;
+            }
+            catch (RequestFailedException exception) when (IsBlobAlreadyExists(exception))
+            {
+                var currentManifest = await ReadRootManifestForCollisionAsync(cancellationToken).ConfigureAwait(false);
+                if (currentManifest?.Checkpoint is { } checkpoint
+                    && currentManifest.Generation == generation
+                    && string.Equals(checkpoint.Name, checkpointName, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException("Azure Blob journal checkpoint was already published; recovery is required.", exception);
+                }
+
+                generation = checked(Math.Max(generation, currentManifest?.Generation ?? _currentGeneration) + 1);
+            }
+        }
     }
 
     private async ValueTask EnsureCurrentSegmentAsync(CancellationToken cancellationToken)
@@ -276,9 +309,37 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             return;
         }
 
-        var response = await _currentLogClient.CreateAsync(
-            CreateOptions(new AppendBlobRequestConditions { IfNoneMatch = ETag.All }),
-            cancellationToken).ConfigureAwait(false);
+        Response<BlobContentInfo> response;
+        if (_currentSegmentId == 0)
+        {
+            try
+            {
+                response = await CreateRootAsync(
+                    _currentGeneration,
+                    checkpoint: null,
+                    new AppendBlobRequestConditions { IfNoneMatch = ETag.All },
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (RequestFailedException exception) when (IsBlobAlreadyExists(exception))
+            {
+                await ReadAsync(DiscardingJournalStorageConsumer.Instance, cancellationToken).ConfigureAwait(false);
+                if (!_currentSegmentExists)
+                {
+                    await EnsureCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                return;
+            }
+
+            _rootExists = true;
+        }
+        else
+        {
+            response = await _currentLogClient.CreateAsync(
+                CreateOptions(new AppendBlobRequestConditions { IfNoneMatch = ETag.All }),
+                cancellationToken).ConfigureAwait(false);
+        }
+
         SetCurrentSegment(_currentSegmentId, exists: true, response.Value.ETag, appendPosition: 0, blockCount: 0);
     }
 
@@ -306,49 +367,69 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         if (_currentSegmentId == 0)
         {
             _rootLogETag = response.Value.ETag;
+            _rootExists = true;
         }
+    }
+
+    private async ValueTask ReadRootAndSegmentsAsync(
+        IJournalStorageConsumer consumer,
+        BlobDownloadDetails rootDetails,
+        Stream rootStream,
+        string? expectedFormat,
+        CancellationToken cancellationToken)
+    {
+        var rootFormat = GetFormatKeyMetadata(rootDetails.Metadata);
+        EnsureCompatibleFormat(expectedFormat, rootFormat, segmentId: 0);
+        var metadata = rootFormat is { Length: > 0 }
+            ? new JournalFileMetadata(rootFormat)
+            : expectedFormat is { Length: > 0 }
+                ? new JournalFileMetadata(expectedFormat)
+                : JournalFileMetadata.Empty;
+        var bytesRead = await ReadStreamAsync(consumer, rootStream, metadata, complete: false, cancellationToken).ConfigureAwait(false);
+        LogRead(_logger, bytesRead, _rootLogClient.BlobContainerName, _rootLogClient.Name);
+
+        if (!rootDetails.IsSealed)
+        {
+            SetCurrentSegment(segmentId: 0, exists: true, rootDetails.ETag, rootDetails.ContentLength, rootDetails.BlobCommittedBlockCount);
+            consumer.Complete(metadata);
+            return;
+        }
+
+        await ReadWalSegmentsAsync(
+            consumer,
+            startSegmentId: 1,
+            startOffset: 0,
+            expectedFormat: metadata.Format,
+            cancellationToken).ConfigureAwait(false);
     }
 
     private async ValueTask ReadWalSegmentsAsync(
         IJournalStorageConsumer consumer,
         uint startSegmentId,
         long startOffset,
-        Response<BlobDownloadStreamingResult>? firstSegmentResult,
-        Stream? firstSegmentStream,
         string? expectedFormat,
         CancellationToken cancellationToken)
     {
         var segmentId = startSegmentId;
         var offset = startOffset;
-        var consumedFirst = firstSegmentResult is null;
         var metadata = expectedFormat is { Length: > 0 } ? new JournalFileMetadata(expectedFormat) : JournalFileMetadata.Empty;
         while (true)
         {
             Response<BlobDownloadStreamingResult> result;
             Stream stream;
-            if (!consumedFirst && firstSegmentResult is not null && firstSegmentStream is not null)
+            var client = GetWalClient(segmentId);
+            try
             {
-                result = firstSegmentResult;
-                stream = firstSegmentStream;
-                consumedFirst = true;
+                result = await client.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
-            else
+            catch (RequestFailedException exception) when (exception.Status is 404)
             {
-                var client = GetWalClient(segmentId);
-                try
-                {
-                    result = await client.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-                catch (RequestFailedException exception) when (exception.Status is 404)
-                {
-                    SetCurrentSegment(segmentId, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
-                    consumer.Complete(metadata);
-                    return;
-                }
-
-                stream = result.Value.Content;
+                SetCurrentSegment(segmentId, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
+                consumer.Complete(metadata);
+                return;
             }
 
+            stream = result.Value.Content;
             await using (stream.ConfigureAwait(false))
             {
                 var details = result.Value.Details;
@@ -358,7 +439,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 if (offset > details.ContentLength)
                 {
                     throw new InvalidOperationException(
-                        $"Azure Blob journal checkpoint points to offset {offset:N0} in WAL segment {_walNameFactory(segmentId)}, but the segment length is {details.ContentLength:N0}.");
+                        $"Azure Blob journal checkpoint points to offset {offset:N0} in segment {GetWalName(segmentId)}, but the segment length is {details.ContentLength:N0}.");
                 }
 
                 if (offset > 0)
@@ -367,7 +448,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 }
 
                 var bytesRead = await ReadStreamAsync(consumer, stream, metadata, complete: false, cancellationToken).ConfigureAwait(false);
-                LogRead(_logger, bytesRead, _rootLogClient.BlobContainerName, _walNameFactory(segmentId));
+                LogRead(_logger, bytesRead, _rootLogClient.BlobContainerName, GetWalName(segmentId));
 
                 if (!details.IsSealed)
                 {
@@ -393,6 +474,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         if (segmentId == 0)
         {
             _rootLogETag = eTag;
+            _rootExists = exists;
         }
     }
 
@@ -403,37 +485,71 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             return _rootLogClient;
         }
 
-        var client = _walClientFactory(segmentId);
+        var client = _walClientFactory(_currentGeneration, checked(segmentId - 1));
         return client ?? throw new InvalidOperationException("The configured Azure Blob journal WAL client factory returned null.");
     }
+
+    private string GetWalName(uint segmentId)
+        => segmentId == 0 ? _rootLogClient.Name : _walNameFactory(_currentGeneration, checked(segmentId - 1));
 
     private AppendBlobCreateOptions CreateOptions(AppendBlobRequestConditions conditions) => new()
     {
         Conditions = conditions,
         HttpHeaders = CreateHttpHeaders(),
-        Metadata = CreateMetadata(),
+        Metadata = CreateSegmentMetadata(),
     };
+
+    private async ValueTask<Response<BlobContentInfo>> CreateRootAsync(
+        ulong generation,
+        CheckpointPublication? checkpoint,
+        AppendBlobRequestConditions conditions,
+        CancellationToken cancellationToken)
+        => await _rootLogClient.CreateAsync(
+            new AppendBlobCreateOptions
+            {
+                Conditions = conditions,
+                HttpHeaders = CreateHttpHeaders(),
+                Metadata = CreateRootMetadata(generation, checkpoint),
+            },
+            cancellationToken).ConfigureAwait(false);
 
     private BlobHttpHeaders? CreateHttpHeaders() => CreateHttpHeaders(_mimeType);
 
     private static BlobHttpHeaders? CreateHttpHeaders(string? contentType)
         => contentType is { Length: > 0 } ? new BlobHttpHeaders { ContentType = contentType } : null;
 
-    private static Func<uint, string> CreateDefaultWalNameFactory(AppendBlobClient client)
-        => segmentId => segmentId == 0 ? client.Name : $"{client.Name}.log.{segmentId:X8}";
+    private static Func<ulong, uint, string> CreateDefaultWalNameFactory(AppendBlobClient client)
+    {
+        var journalId = GetJournalId(client.Name);
+        return (generation, segmentId) => $"{journalId}/{FormatGeneration(generation)}/seg.{segmentId:X8}";
+    }
 
-    private static Func<uint, AppendBlobClient> CreateDefaultWalClientFactory(AppendBlobClient client)
-        => segmentId => segmentId == 0 ? client : client.GetParentBlobContainerClient().GetAppendBlobClient($"{client.Name}.log.{segmentId:X8}");
+    private static Func<ulong, uint, AppendBlobClient> CreateDefaultWalClientFactory(AppendBlobClient client)
+    {
+        var journalId = GetJournalId(client.Name);
+        return (generation, segmentId) => client.GetParentBlobContainerClient().GetAppendBlobClient($"{journalId}/{FormatGeneration(generation)}/seg.{segmentId:X8}");
+    }
 
-    private static Func<uint, string> CreateDefaultCheckpointNameFactory(AppendBlobClient client)
-        => checkpointId => $"{client.Name}.checkpoint.{checkpointId:X8}";
+    private static Func<ulong, string> CreateDefaultCheckpointNameFactory(AppendBlobClient client)
+    {
+        var journalId = GetJournalId(client.Name);
+        return generation => $"{journalId}/{FormatGeneration(generation)}/chk";
+    }
 
     private static Func<string, BlockBlobClient> CreateDefaultCheckpointClientFactory(AppendBlobClient client)
         => checkpointName => client.GetParentBlobContainerClient().GetBlockBlobClient(checkpointName);
 
-    private Dictionary<string, string> CreateMetadataDictionary()
+    private static string GetJournalId(string rootName)
+        => rootName.EndsWith("/root", StringComparison.Ordinal)
+            ? rootName[..^"/root".Length]
+            : rootName;
+
+    private Dictionary<string, string> CreateMetadataDictionary(ulong generation)
     {
-        var metadata = new Dictionary<string, string>();
+        var metadata = new Dictionary<string, string>
+        {
+            [GenerationMetadataKey] = FormatGeneration(generation),
+        };
         if (_journalFormatKey is { Length: > 0 })
         {
             metadata[FormatMetadataKey] = _journalFormatKey;
@@ -442,36 +558,22 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         return metadata;
     }
 
-    private Dictionary<string, string>? CreateMetadata()
-    {
-        var metadata = CreateMetadataDictionary();
-        return metadata.Count > 0 ? metadata : null;
-    }
+    private Dictionary<string, string> CreateSegmentMetadata() => CreateMetadataDictionary(_currentGeneration);
 
-    private Dictionary<string, string> CreateCheckpointBlobMetadata(uint checkpointId, uint replaySegmentId, long replayOffset)
-    {
-        var metadata = CreateMetadataDictionary();
-        metadata[CheckpointIdMetadataKey] = FormatUInt32(checkpointId);
-        metadata[CheckpointReplaySegmentMetadataKey] = FormatUInt32(replaySegmentId);
-        metadata[CheckpointReplayOffsetMetadataKey] = replayOffset.ToString(CultureInfo.InvariantCulture);
-        return metadata;
-    }
+    private Dictionary<string, string> CreateCheckpointBlobMetadata(ulong generation) => CreateMetadataDictionary(generation);
 
-    private Dictionary<string, string> CreateCheckpointMarkerMetadata(
-        string checkpointName,
-        ETag checkpointETag,
-        uint checkpointId,
-        long checkpointLength,
-        uint replaySegmentId,
-        long replayOffset)
+    private Dictionary<string, string> CreateRootMetadata(ulong generation, CheckpointPublication? checkpoint)
     {
-        var metadata = CreateCheckpointBlobMetadata(checkpointId, replaySegmentId, replayOffset);
-        metadata[CheckpointMetadataKey] = checkpointName;
-        metadata[CheckpointETagMetadataKey] = checkpointETag.ToString();
-        metadata[CheckpointLengthMetadataKey] = checkpointLength.ToString(CultureInfo.InvariantCulture);
-        if (_journalFormatKey is { Length: > 0 })
+        var metadata = CreateMetadataDictionary(generation);
+        if (checkpoint is not null)
         {
-            metadata[CheckpointFormatMetadataKey] = _journalFormatKey;
+            metadata[CheckpointMetadataKey] = checkpoint.Name;
+            metadata[CheckpointETagMetadataKey] = checkpoint.ETag.ToString();
+            metadata[CheckpointLengthMetadataKey] = checkpoint.Length.ToString(CultureInfo.InvariantCulture);
+            if (_journalFormatKey is { Length: > 0 })
+            {
+                metadata[CheckpointFormatMetadataKey] = _journalFormatKey;
+            }
         }
 
         return metadata;
@@ -484,23 +586,27 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 ? storedKey
                 : null;
 
-    private static CheckpointReference? CreateCheckpointReference(IDictionary<string, string>? metadata)
+    private RootManifest CreateRootManifest(IDictionary<string, string>? metadata)
     {
+        if (!TryGetUInt64Metadata(metadata, GenerationMetadataKey, out var generation))
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal root does not include valid '{GenerationMetadataKey}' metadata.");
+        }
+
+        var fileMetadata = GetFormatKeyMetadata(metadata) is { } format
+            ? new JournalFileMetadata(format)
+            : JournalFileMetadata.Empty;
         if (metadata is null || !metadata.TryGetValue(CheckpointMetadataKey, out var checkpointName) || checkpointName is not { Length: > 0 })
         {
-            return null;
+            EnsureNoCheckpointMetadata(metadata);
+            return new RootManifest(generation, fileMetadata, Checkpoint: null);
         }
 
         if (!metadata.TryGetValue(CheckpointETagMetadataKey, out var checkpointETag) || checkpointETag is not { Length: > 0 })
         {
             throw new InvalidOperationException(
                 $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include '{CheckpointETagMetadataKey}' metadata.");
-        }
-
-        if (!TryGetUInt32Metadata(metadata, CheckpointIdMetadataKey, out var checkpointId))
-        {
-            throw new InvalidOperationException(
-                $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include valid '{CheckpointIdMetadataKey}' metadata.");
         }
 
         if (!metadata.TryGetValue(CheckpointLengthMetadataKey, out var checkpointLengthValue)
@@ -511,26 +617,46 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include valid '{CheckpointLengthMetadataKey}' metadata.");
         }
 
-        if (!TryGetUInt32Metadata(metadata, CheckpointReplaySegmentMetadataKey, out var replaySegment))
-        {
-            throw new InvalidOperationException(
-                $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include valid '{CheckpointReplaySegmentMetadataKey}' metadata.");
-        }
-
-        if (!metadata.TryGetValue(CheckpointReplayOffsetMetadataKey, out var replayOffsetValue)
-            || !long.TryParse(replayOffsetValue, NumberStyles.None, CultureInfo.InvariantCulture, out var replayOffset)
-            || replayOffset < 0)
-        {
-            throw new InvalidOperationException(
-                $"Azure Blob journal marker references checkpoint blob '{checkpointName}' but does not include valid '{CheckpointReplayOffsetMetadataKey}' metadata.");
-        }
-
         var checkpointFormat = metadata.TryGetValue(CheckpointFormatMetadataKey, out var storedCheckpointFormat)
             && storedCheckpointFormat is { Length: > 0 }
                 ? storedCheckpointFormat
                 : null;
 
-        return new CheckpointReference(checkpointName, new ETag(checkpointETag), checkpointId, checkpointFormat, checkpointLength, replaySegment, replayOffset);
+        return new RootManifest(
+            generation,
+            fileMetadata,
+            new CheckpointReference(checkpointName, new ETag(checkpointETag), generation, checkpointFormat, checkpointLength));
+    }
+
+    private static void EnsureNoCheckpointMetadata(IDictionary<string, string>? metadata)
+    {
+        if (metadata is null)
+        {
+            return;
+        }
+
+        if (metadata.ContainsKey(CheckpointETagMetadataKey)
+            || metadata.ContainsKey(CheckpointFormatMetadataKey)
+            || metadata.ContainsKey(CheckpointLengthMetadataKey))
+        {
+            throw new InvalidOperationException("Azure Blob journal root contains partial checkpoint metadata.");
+        }
+    }
+
+    private async ValueTask<RootManifest?> ReadRootManifestForCollisionAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _rootLogClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            await using (result.Value.Content.ConfigureAwait(false))
+            {
+                return CreateRootManifest(result.Value.Details.Metadata);
+            }
+        }
+        catch (RequestFailedException exception) when (exception.Status is 404)
+        {
+            return null;
+        }
     }
 
     private IJournalFileMetadata ValidateCheckpointMetadata(CheckpointReference checkpoint, BlobDownloadDetails checkpointDetails)
@@ -541,24 +667,10 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 $"Azure Blob journal checkpoint '{checkpoint.Name}' length is {checkpointDetails.ContentLength}, but marker metadata expected {checkpoint.Length}.");
         }
 
-        if (!TryGetUInt32Metadata(checkpointDetails.Metadata, CheckpointIdMetadataKey, out var checkpointId) || checkpointId != checkpoint.Id)
+        if (!TryGetUInt64Metadata(checkpointDetails.Metadata, GenerationMetadataKey, out var generation) || generation != checkpoint.Generation)
         {
             throw new InvalidOperationException(
-                $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include the expected checkpoint id '{FormatUInt32(checkpoint.Id)}'.");
-        }
-
-        if (!TryGetUInt32Metadata(checkpointDetails.Metadata, CheckpointReplaySegmentMetadataKey, out var replaySegment) || replaySegment != checkpoint.ReplaySegment)
-        {
-            throw new InvalidOperationException(
-                $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include the expected replay segment '{FormatUInt32(checkpoint.ReplaySegment)}'.");
-        }
-
-        if (!checkpointDetails.Metadata.TryGetValue(CheckpointReplayOffsetMetadataKey, out var replayOffsetValue)
-            || !long.TryParse(replayOffsetValue, NumberStyles.None, CultureInfo.InvariantCulture, out var replayOffset)
-            || replayOffset != checkpoint.ReplayOffset)
-        {
-            throw new InvalidOperationException(
-                $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include the expected replay offset '{checkpoint.ReplayOffset}'.");
+                $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include the expected generation '{FormatGeneration(checkpoint.Generation)}'.");
         }
 
         var checkpointBlobFormat = GetFormatKeyMetadata(checkpointDetails.Metadata);
@@ -577,7 +689,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include format metadata.");
         }
 
-        _nextCheckpointId = Math.Max(_nextCheckpointId, checked(checkpoint.Id + 1));
         return effectiveCheckpointFormat is { } format
             ? new JournalFileMetadata(format)
             : JournalFileMetadata.Empty;
@@ -594,20 +705,31 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             $"Azure Blob journal WAL segment {FormatUInt32(segmentId)} format metadata is '{segmentFormat}', but recovery expected '{expectedFormat}'.");
     }
 
-    private static bool TryGetUInt32Metadata(IDictionary<string, string>? metadata, string key, out uint value)
+    private static bool TryGetUInt64Metadata(IDictionary<string, string>? metadata, string key, out ulong value)
     {
         value = default;
         return metadata is not null
             && metadata.TryGetValue(key, out var text)
-            && uint.TryParse(text, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
+            && ulong.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value);
     }
 
     private static string FormatUInt32(uint value) => value.ToString("X8", CultureInfo.InvariantCulture);
+
+    private static string FormatGeneration(ulong value) => value.ToString(CultureInfo.InvariantCulture);
 
     private static bool IsBlobSealed(RequestFailedException exception)
         => exception.Status == 409
             && (string.Equals(exception.ErrorCode, "BlobIsSealed", StringComparison.Ordinal)
                 || exception.Message.Contains("sealed", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsBlobAlreadyExists(RequestFailedException exception)
+        => exception.Status == 409
+            && (string.Equals(exception.ErrorCode, "BlobAlreadyExists", StringComparison.Ordinal)
+                || exception.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsRootMutationConflict(RequestFailedException exception)
+        => exception.Status is 404 or 412
+            || (exception.Status == 409 && string.Equals(exception.ErrorCode, "ConditionNotMet", StringComparison.Ordinal));
 
     private static async ValueTask<long> ReadStreamAsync(
         IJournalStorageConsumer consumer,
@@ -687,7 +809,18 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         Message = "Wrote checkpoint blob \"{ContainerName}/{BlobName}\" containing {Length} bytes")]
     private static partial void LogReplace(ILogger logger, string containerName, string blobName, long length);
 
-    private sealed record CheckpointReference(string Name, ETag ETag, uint Id, string? Format, long Length, uint ReplaySegment, long ReplayOffset);
+    private sealed record RootManifest(ulong Generation, IJournalFileMetadata Metadata, CheckpointReference? Checkpoint);
+
+    private sealed record CheckpointReference(string Name, ETag ETag, ulong Generation, string? Format, long Length);
+
+    private sealed record CheckpointPublication(string Name, ETag ETag, long Length);
+
+    private sealed class DiscardingJournalStorageConsumer : IJournalStorageConsumer
+    {
+        public static DiscardingJournalStorageConsumer Instance { get; } = new();
+
+        public void Read(JournalBufferReader buffer, IJournalFileMetadata? metadata) => buffer.Skip(buffer.Length);
+    }
 
     private sealed class ReadOnlySequenceStream(ReadOnlySequence<byte> sequence) : Stream
     {

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -4,7 +4,6 @@ using Azure;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
-using Orleans.Runtime;
 using Orleans.Serialization.Buffers;
 
 namespace Orleans.Journaling;
@@ -21,9 +20,11 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     internal const long MaxAppendBlockBytes = 100L * 1024 * 1024;
 
     // An append blob can hold up to 50,000 committed blocks. The compaction request
-    // (IsCompactionRequested) trips far earlier (at 10 blocks), so this guard exists only
+    // (IsCompactionRequested) trips earlier, above 49,000 blocks, so this guard exists only
     // to roll before hitting the hard Azure limit if a consumer ignores compaction requests.
-    private const int AppendBlobBlockCeilingHeadroom = 100;
+    private const int MaxBlocksPerBlob = 50_000;
+    private const int HeadroomBlockCount = 100;
+    private const int RequestCompactionBlockCount = 49_000;
 
     private readonly SharedConfiguration _shared;
     private readonly IGrainContext _grainContext;
@@ -38,7 +39,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private bool RootExists => _rootLogETag != default;
 
-    public bool IsCompactionRequested => _numBlocks > 10;
+    public bool IsCompactionRequested => _numBlocks > RequestCompactionBlockCount;
 
     internal AzureBlobJournalStorage(
         SharedConfiguration shared,
@@ -55,7 +56,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     public async ValueTask AppendAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
         ThrowIfBatchTooLarge(value.Length);
-        if (CurrentSegmentExists && _numBlocks >= _currentLogClient.AppendBlobMaxBlocks - AppendBlobBlockCeilingHeadroom)
+        if (CurrentSegmentExists && _numBlocks >= MaxBlocksPerBlob - HeadroomBlockCount)
         {
             await RollToNextSegmentAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -96,9 +97,9 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
     }
 
-    private void ThrowIfBatchTooLarge(long length)
+    private static void ThrowIfBatchTooLarge(long length)
     {
-        if (length <= _currentLogClient.AppendBlobMaxAppendBlockBytes)
+        if (length <= MaxAppendBlockBytes)
         {
             return;
         }
@@ -523,7 +524,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 ? storedKey
                 : null;
 
-    private RootManifest CreateRootManifest(IDictionary<string, string>? metadata)
+    private static RootManifest CreateRootManifest(IDictionary<string, string>? metadata)
     {
         if (!TryGetUInt32Metadata(metadata, GenerationMetadataKey, out var generation))
         {
@@ -561,7 +562,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
     }
 
-    private IJournalFileMetadata ValidateCheckpointMetadata(CheckpointReference checkpoint, BlobDownloadDetails checkpointDetails, string? expectedFormat)
+    private static IJournalFileMetadata ValidateCheckpointMetadata(CheckpointReference checkpoint, BlobDownloadDetails checkpointDetails, string? expectedFormat)
     {
         if (!TryGetUInt32Metadata(checkpointDetails.Metadata, GenerationMetadataKey, out var generation) || generation != checkpoint.Generation)
         {
@@ -625,7 +626,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private static bool IsRootMutationConflict(RequestFailedException exception)
         => exception.Status is 404 or 412
-            || (exception.Status == 409 && string.Equals(exception.ErrorCode, "ConditionNotMet", StringComparison.Ordinal));
+            || exception.Status == 409 && string.Equals(exception.ErrorCode, "ConditionNotMet", StringComparison.Ordinal);
 
     private static async ValueTask<long> ReadStreamAsync(
         IJournalStorageConsumer consumer,
@@ -788,7 +789,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         {
             get
             {
-                ThrowIfDisposed();
+                ObjectDisposedException.ThrowIf(_disposed, this);
                 return _sequence.Length;
             }
         }
@@ -797,13 +798,13 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         {
             get
             {
-                ThrowIfDisposed();
+                ObjectDisposedException.ThrowIf(_disposed, this);
                 return _position;
             }
 
             set
             {
-                ThrowIfDisposed();
+                ObjectDisposedException.ThrowIf(_disposed, this);
                 if (value < 0 || value > _sequence.Length)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value));
@@ -813,16 +814,13 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             }
         }
 
-        public override void Flush()
-        {
-            ThrowIfDisposed();
-        }
+        public override void Flush() => ObjectDisposedException.ThrowIf(_disposed, this);
 
         public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
 
         public override int Read(Span<byte> buffer)
         {
-            ThrowIfDisposed();
+            ObjectDisposedException.ThrowIf(_disposed, this);
             if (buffer.IsEmpty || _position >= _sequence.Length)
             {
                 return 0;
@@ -842,7 +840,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
         public override long Seek(long offset, SeekOrigin origin)
         {
-            ThrowIfDisposed();
+            ObjectDisposedException.ThrowIf(_disposed, this);
             var newPosition = origin switch
             {
                 SeekOrigin.Begin => offset,
@@ -865,14 +863,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         {
             _disposed = true;
             base.Dispose(disposing);
-        }
-
-        private void ThrowIfDisposed()
-        {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(nameof(ReadOnlySequenceStream));
-            }
         }
     }
 }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -1,7 +1,6 @@
 using System.Buffers;
 using System.Globalization;
 using Azure;
-using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
@@ -24,18 +23,13 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     // An append blob can hold up to 50,000 committed blocks. The compaction request
     // (IsCompactionRequested) trips far earlier (at 10 blocks), so this guard exists only
     // to roll before hitting the hard Azure limit if a consumer ignores compaction requests.
-    internal const int MaxAppendBlobBlocks = 50_000;
     private const int AppendBlobBlockCeilingHeadroom = 100;
 
-    private readonly AppendBlobClient _rootLogClient;
-    private readonly BlobClientProvider _blobClientProvider;
-    private readonly string? _mimeType;
-    private readonly string? _journalFormatKey;
-    private readonly ILogger<AzureBlobJournalStorage> _logger;
     private AppendBlobClient _currentLogClient;
-    private ulong _currentGeneration;
+    private readonly SharedConfiguration _shared;
+    private readonly IGrainContext _grainContext;
+    private uint _currentGeneration;
     private uint _currentSegmentId;
-    private long _appendPosition;
     private int _numBlocks;
     private ETag _currentSegmentETag;
     private ETag _rootLogETag;
@@ -46,37 +40,22 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     public bool IsCompactionRequested => _numBlocks > 10;
 
-    public AzureBlobJournalStorage(AppendBlobClient client, ILogger<AzureBlobJournalStorage> logger)
-        : this(client, mimeType: null, logger)
-    {
-    }
-
-    internal AzureBlobJournalStorage(AppendBlobClient client, string? mimeType, ILogger<AzureBlobJournalStorage> logger)
-        : this(client, mimeType, logger, journalFormatKey: null)
-    {
-    }
-
     internal AzureBlobJournalStorage(
-        AppendBlobClient client,
-        string? mimeType,
-        ILogger<AzureBlobJournalStorage> logger,
-        string? journalFormatKey = null,
-        BlobClientProvider? blobClientProvider = null)
+        SharedConfiguration shared,
+        IGrainContext grainContext)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(shared);
+        ArgumentNullException.ThrowIfNull(grainContext);
 
-        _rootLogClient = client;
-        _currentLogClient = client;
-        _blobClientProvider = blobClientProvider ?? DefaultBlobClientProvider.Instance;
-        _mimeType = mimeType;
-        _journalFormatKey = journalFormatKey;
-        _logger = logger;
+        _shared = shared;
+        _grainContext = grainContext;
+        _currentLogClient = GetRootClient();
     }
 
     public async ValueTask AppendAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
         ThrowIfBatchTooLarge(value.Length);
-        if (CurrentSegmentExists && _numBlocks >= MaxAppendBlobBlocks - AppendBlobBlockCeilingHeadroom)
+        if (CurrentSegmentExists && _numBlocks >= _currentLogClient.AppendBlobMaxBlocks - AppendBlobBlockCeilingHeadroom)
         {
             await RollToNextSegmentAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -84,23 +63,23 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         while (true)
         {
             await EnsureCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
+            var currentLogClient = _currentLogClient;
 
             using var stream = new ReadOnlySequenceStream(value);
             try
             {
-                var result = await _currentLogClient.AppendBlockAsync(
+                var result = await currentLogClient.AppendBlockAsync(
                     stream,
                     new AppendBlobAppendBlockOptions
                     {
                         Conditions = new AppendBlobRequestConditions
                         {
-                            IfAppendPositionEqual = _appendPosition,
+                            IfMatch = _currentSegmentETag,
                         }
                     },
                     cancellationToken).ConfigureAwait(false);
 
-                LogAppend(_logger, stream.Length, _currentLogClient.BlobContainerName, _currentLogClient.Name);
-                _appendPosition += stream.Length;
+                LogAppend(_shared.Logger, stream.Length, currentLogClient.BlobContainerName, currentLogClient.Name);
                 _currentSegmentETag = result.Value.ETag;
                 _numBlocks = result.Value.BlobCommittedBlockCount;
                 if (_currentSegmentId == 0)
@@ -117,9 +96,9 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
     }
 
-    private static void ThrowIfBatchTooLarge(long length)
+    private void ThrowIfBatchTooLarge(long length)
     {
-        if (length <= MaxAppendBlockBytes)
+        if (length <= _currentLogClient.AppendBlobMaxAppendBlockBytes)
         {
             return;
         }
@@ -141,7 +120,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             await SealCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        var generation = checked(_currentGeneration + 1);
+        var generation = checked(_currentGeneration + 1u);
         Response<BlobContentInfo> response;
         try
         {
@@ -157,7 +136,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
 
         _currentGeneration = generation;
-        SetCurrentSegment(segmentId: 0, exists: true, response.Value.ETag, appendPosition: 0, blockCount: 0);
+        SetCurrentSegment(segmentId: 0, exists: true, response.Value.ETag, blockCount: 0);
     }
 
     public async ValueTask ReadAsync(IJournalStorageConsumer consumer, CancellationToken cancellationToken)
@@ -167,12 +146,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         Response<BlobDownloadStreamingResult> rootResult;
         try
         {
-            rootResult = await _rootLogClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            rootResult = await GetRootLogClient().DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         catch (RequestFailedException exception) when (exception.Status is 404)
         {
             _currentGeneration = 0;
-            SetCurrentSegment(segmentId: 0, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
+            SetCurrentSegment(segmentId: 0, exists: false, eTag: default, blockCount: 0);
             _rootLogETag = default;
             consumer.Complete(metadata: null);
             return;
@@ -196,7 +175,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 checkpointMetadata,
                 complete: false,
                 cancellationToken).ConfigureAwait(false);
-            LogRead(_logger, totalCheckpointBytes, checkpointClient.BlobContainerName, checkpointClient.Name);
+            LogRead(_shared.Logger, totalCheckpointBytes, checkpointClient.BlobContainerName, checkpointClient.Name);
             expectedFormat = checkpointMetadata.Format;
         }
 
@@ -216,7 +195,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
 
         var rootETag = _rootLogETag;
-        var generation = checked(_currentGeneration + 1);
+        var generation = checked(_currentGeneration + 1u);
         using var checkpointStream = new ReadOnlySequenceStream(value);
         while (true)
         {
@@ -230,7 +209,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                     new BlobUploadOptions
                     {
                         Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All },
-                        HttpHeaders = CreateHttpHeaders(),
+                        HttpHeaders = CreateHttpHeaders(_shared.MimeType),
                         Metadata = CreateCheckpointBlobMetadata(generation),
                     },
                     cancellationToken).ConfigureAwait(false);
@@ -250,8 +229,8 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 }
 
                 _currentGeneration = generation;
-                SetCurrentSegment(segmentId: 0, exists: true, rootResult.Value.ETag, appendPosition: 0, blockCount: 0);
-                LogReplace(_logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
+                SetCurrentSegment(segmentId: 0, exists: true, rootResult.Value.ETag, blockCount: 0);
+                LogReplace(_shared.Logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
                 return;
             }
             catch (RequestFailedException exception) when (IsBlobAlreadyExists(exception))
@@ -264,7 +243,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                     throw new InvalidOperationException("Azure Blob journal checkpoint was already published; recovery is required.", exception);
                 }
 
-                generation = checked(Math.Max(generation, currentManifest?.Generation ?? _currentGeneration) + 1);
+                generation = checked(Math.Max(generation, currentManifest?.Generation ?? _currentGeneration) + 1u);
             }
         }
     }
@@ -306,7 +285,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 cancellationToken).ConfigureAwait(false);
         }
 
-        SetCurrentSegment(_currentSegmentId, exists: true, response.Value.ETag, appendPosition: 0, blockCount: 0);
+        SetCurrentSegment(_currentSegmentId, exists: true, response.Value.ETag, blockCount: 0);
     }
 
     private async ValueTask RollToNextSegmentAsync(CancellationToken cancellationToken)
@@ -316,7 +295,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             await SealCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        SetCurrentSegment(checked(_currentSegmentId + 1), exists: false, eTag: default, appendPosition: 0, blockCount: 0);
+        SetCurrentSegment(checked(_currentSegmentId + 1), exists: false, eTag: default, blockCount: 0);
     }
 
     private async ValueTask SealCurrentSegmentAsync(CancellationToken cancellationToken)
@@ -351,11 +330,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 ? new JournalFileMetadata(expectedFormat)
                 : JournalFileMetadata.Empty;
         var bytesRead = await ReadStreamAsync(consumer, rootStream, metadata, complete: false, cancellationToken).ConfigureAwait(false);
-        LogRead(_logger, bytesRead, _rootLogClient.BlobContainerName, _rootLogClient.Name);
+        var rootLogClient = GetRootLogClient();
+        LogRead(_shared.Logger, bytesRead, rootLogClient.BlobContainerName, rootLogClient.Name);
 
         if (!rootDetails.IsSealed)
         {
-            SetCurrentSegment(segmentId: 0, exists: true, rootDetails.ETag, rootDetails.ContentLength, rootDetails.BlobCommittedBlockCount);
+            SetCurrentSegment(segmentId: 0, exists: true, rootDetails.ETag, rootDetails.BlobCommittedBlockCount);
             consumer.Complete(metadata);
             return;
         }
@@ -389,7 +369,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             }
             catch (RequestFailedException exception) when (exception.Status is 404)
             {
-                SetCurrentSegment(segmentId, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
+                SetCurrentSegment(segmentId, exists: false, eTag: default, blockCount: 0);
                 consumer.Complete(metadata);
                 return;
             }
@@ -413,11 +393,11 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 }
 
                 var bytesRead = await ReadStreamAsync(consumer, stream, metadata, complete: false, cancellationToken).ConfigureAwait(false);
-                LogRead(_logger, bytesRead, _rootLogClient.BlobContainerName, client.Name);
+                LogRead(_shared.Logger, bytesRead, client.BlobContainerName, client.Name);
 
                 if (!details.IsSealed)
                 {
-                    SetCurrentSegment(segmentId, exists: true, details.ETag, details.ContentLength, details.BlobCommittedBlockCount);
+                    SetCurrentSegment(segmentId, exists: true, details.ETag, details.BlobCommittedBlockCount);
                     consumer.Complete(metadata);
                     return;
                 }
@@ -428,59 +408,71 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
     }
 
-    private void SetCurrentSegment(uint segmentId, bool exists, ETag eTag, long appendPosition, int blockCount)
+    private void SetCurrentSegment(uint segmentId, bool exists, ETag eTag, int blockCount)
     {
         _currentSegmentId = segmentId;
-        _currentLogClient = GetWalClient(segmentId);
         _currentSegmentETag = exists ? eTag : default;
-        _appendPosition = appendPosition;
         _numBlocks = blockCount;
+        _currentLogClient = GetLogClient(segmentId);
         if (segmentId == 0)
         {
             _rootLogETag = exists ? eTag : default;
         }
     }
 
+    private AppendBlobClient GetRootLogClient() => _currentSegmentId == 0 ? _currentLogClient : GetRootClient();
+
+    private AppendBlobClient GetLogClient(uint segmentId) => segmentId == 0 ? GetRootClient() : GetWalSegmentClient(segmentId);
+
     private AppendBlobClient GetWalClient(uint segmentId)
     {
         if (segmentId == 0)
         {
-            return _rootLogClient;
+            return GetRootLogClient();
         }
 
-        var client = _blobClientProvider.GetWalClient(_rootLogClient, _currentGeneration, checked(segmentId - 1));
+        return GetWalSegmentClient(segmentId);
+    }
+
+    private AppendBlobClient GetRootClient()
+    {
+        var client = _shared.BlobClientProvider.GetRootClient(_grainContext.GrainId);
+        return client ?? throw new InvalidOperationException("The configured Azure Blob journal root client provider returned null.");
+    }
+
+    private AppendBlobClient GetWalSegmentClient(uint segmentId)
+    {
+        var client = _shared.BlobClientProvider.GetWalClient(_grainContext.GrainId, _currentGeneration, checked(segmentId - 1));
         return client ?? throw new InvalidOperationException("The configured Azure Blob journal WAL client provider returned null.");
     }
 
     private AppendBlobCreateOptions CreateOptions(AppendBlobRequestConditions conditions) => new()
     {
         Conditions = conditions,
-        HttpHeaders = CreateHttpHeaders(),
+        HttpHeaders = CreateHttpHeaders(_shared.MimeType),
         Metadata = CreateSegmentMetadata(),
     };
 
     private async ValueTask<Response<BlobContentInfo>> CreateRootAsync(
-        ulong generation,
+        uint generation,
         string? checkpointName,
         AppendBlobRequestConditions conditions,
         CancellationToken cancellationToken)
-        => await _rootLogClient.CreateAsync(
+        => await GetRootLogClient().CreateAsync(
             new AppendBlobCreateOptions
             {
                 Conditions = conditions,
-                HttpHeaders = CreateHttpHeaders(),
+                HttpHeaders = CreateHttpHeaders(_shared.MimeType),
                 Metadata = CreateRootMetadata(generation, checkpointName),
             },
             cancellationToken).ConfigureAwait(false);
 
-    private BlobHttpHeaders? CreateHttpHeaders() => CreateHttpHeaders(_mimeType);
-
     private static BlobHttpHeaders? CreateHttpHeaders(string? contentType)
         => contentType is { Length: > 0 } ? new BlobHttpHeaders { ContentType = contentType } : null;
 
-    private string GetCheckpointName(ulong generation)
+    private string GetCheckpointName(uint generation)
     {
-        var checkpointName = _blobClientProvider.GetCheckpointName(_rootLogClient, generation);
+        var checkpointName = _shared.BlobClientProvider.GetCheckpointName(_grainContext.GrainId, generation);
         if (string.IsNullOrWhiteSpace(checkpointName))
         {
             throw new InvalidOperationException("The configured Azure Blob journal checkpoint client provider returned an empty blob name.");
@@ -491,24 +483,19 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private BlockBlobClient GetCheckpointClient(string checkpointName)
     {
-        var client = _blobClientProvider.GetCheckpointClient(_rootLogClient, checkpointName);
+        var client = _shared.BlobClientProvider.GetCheckpointClient(_grainContext.GrainId, checkpointName);
         return client ?? throw new InvalidOperationException("The configured Azure Blob journal checkpoint client provider returned null.");
     }
 
-    private static string GetJournalId(string rootName)
-        => rootName.EndsWith("/root", StringComparison.Ordinal)
-            ? rootName[..^"/root".Length]
-            : rootName;
-
-    private Dictionary<string, string> CreateMetadataDictionary(ulong generation)
+    private Dictionary<string, string> CreateMetadataDictionary(uint generation)
     {
         var metadata = new Dictionary<string, string>
         {
             [GenerationMetadataKey] = FormatGeneration(generation),
         };
-        if (_journalFormatKey is { Length: > 0 })
+        if (_shared.JournalFormatKey is { Length: > 0 })
         {
-            metadata[FormatMetadataKey] = _journalFormatKey;
+            metadata[FormatMetadataKey] = _shared.JournalFormatKey;
         }
 
         return metadata;
@@ -516,9 +503,9 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private Dictionary<string, string> CreateSegmentMetadata() => CreateMetadataDictionary(_currentGeneration);
 
-    private Dictionary<string, string> CreateCheckpointBlobMetadata(ulong generation) => CreateMetadataDictionary(generation);
+    private Dictionary<string, string> CreateCheckpointBlobMetadata(uint generation) => CreateMetadataDictionary(generation);
 
-    private Dictionary<string, string> CreateRootMetadata(ulong generation, string? checkpointName)
+    private Dictionary<string, string> CreateRootMetadata(uint generation, string? checkpointName)
     {
         var metadata = CreateMetadataDictionary(generation);
         if (checkpointName is not null)
@@ -538,7 +525,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private RootManifest CreateRootManifest(IDictionary<string, string>? metadata)
     {
-        if (!TryGetUInt64Metadata(metadata, GenerationMetadataKey, out var generation))
+        if (!TryGetUInt32Metadata(metadata, GenerationMetadataKey, out var generation))
         {
             throw new InvalidOperationException(
                 $"Azure Blob journal root does not include valid '{GenerationMetadataKey}' metadata.");
@@ -562,7 +549,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     {
         try
         {
-            var result = await _rootLogClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            var result = await GetRootLogClient().DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             await using (result.Value.Content.ConfigureAwait(false))
             {
                 return CreateRootManifest(result.Value.Details.Metadata);
@@ -576,7 +563,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private IJournalFileMetadata ValidateCheckpointMetadata(CheckpointReference checkpoint, BlobDownloadDetails checkpointDetails, string? expectedFormat)
     {
-        if (!TryGetUInt64Metadata(checkpointDetails.Metadata, GenerationMetadataKey, out var generation) || generation != checkpoint.Generation)
+        if (!TryGetUInt32Metadata(checkpointDetails.Metadata, GenerationMetadataKey, out var generation) || generation != checkpoint.Generation)
         {
             throw new InvalidOperationException(
                 $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include the expected generation '{FormatGeneration(checkpoint.Generation)}'.");
@@ -614,17 +601,17 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             $"Azure Blob journal WAL segment {FormatUInt32(segmentId)} format metadata is '{segmentFormat}', but recovery expected '{expectedFormat}'.");
     }
 
-    private static bool TryGetUInt64Metadata(IDictionary<string, string>? metadata, string key, out ulong value)
+    private static bool TryGetUInt32Metadata(IDictionary<string, string>? metadata, string key, out uint value)
     {
         value = default;
         return metadata is not null
             && metadata.TryGetValue(key, out var text)
-            && ulong.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value);
+            && uint.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value);
     }
 
     private static string FormatUInt32(uint value) => value.ToString("X8", CultureInfo.InvariantCulture);
 
-    private static string FormatGeneration(ulong value) => value.ToString(CultureInfo.InvariantCulture);
+    private static string FormatGeneration(uint value) => value.ToString(CultureInfo.InvariantCulture);
 
     private static bool IsBlobSealed(RequestFailedException exception)
         => exception.Status == 409
@@ -718,47 +705,64 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         Message = "Wrote checkpoint blob \"{ContainerName}/{BlobName}\" containing {Length} bytes")]
     private static partial void LogReplace(ILogger logger, string containerName, string blobName, long length);
 
-    private sealed record RootManifest(ulong Generation, IJournalFileMetadata Metadata, CheckpointReference? Checkpoint);
+    private sealed record RootManifest(uint Generation, IJournalFileMetadata Metadata, CheckpointReference? Checkpoint);
 
-    private sealed record CheckpointReference(string Name, ulong Generation);
+    private sealed record CheckpointReference(string Name, uint Generation);
+
+    internal sealed class SharedConfiguration
+    {
+        public SharedConfiguration(
+            ILogger<AzureBlobJournalStorage> logger,
+            BlobClientProvider blobClientProvider,
+            string? mimeType = null,
+            string? journalFormatKey = null)
+        {
+            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentNullException.ThrowIfNull(blobClientProvider);
+
+            Logger = logger;
+            MimeType = mimeType;
+            JournalFormatKey = journalFormatKey;
+            BlobClientProvider = blobClientProvider;
+        }
+
+        public ILogger<AzureBlobJournalStorage> Logger { get; }
+
+        public string? MimeType { get; }
+
+        public string? JournalFormatKey { get; }
+
+        public BlobClientProvider BlobClientProvider { get; }
+    }
 
     internal abstract class BlobClientProvider
     {
-        public abstract AppendBlobClient GetWalClient(AppendBlobClient rootLogClient, ulong generation, uint segmentId);
+        public abstract AppendBlobClient GetRootClient(GrainId grainId);
 
-        public abstract string GetCheckpointName(AppendBlobClient rootLogClient, ulong generation);
+        public abstract AppendBlobClient GetWalClient(GrainId grainId, uint generation, uint segmentId);
 
-        public abstract BlockBlobClient GetCheckpointClient(AppendBlobClient rootLogClient, string checkpointName);
+        public abstract string GetCheckpointName(GrainId grainId, uint generation);
+
+        public abstract BlockBlobClient GetCheckpointClient(GrainId grainId, string checkpointName);
     }
 
     internal sealed class OptionsBlobClientProvider(
-        BlobContainerClient containerClient,
-        AzureBlobJournalStorageOptions options,
-        GrainId grainId) : BlobClientProvider
+        IBlobContainerFactory containerFactory,
+        AzureBlobJournalStorageOptions options) : BlobClientProvider
     {
-        public override AppendBlobClient GetWalClient(AppendBlobClient rootLogClient, ulong generation, uint segmentId)
-            => containerClient.GetAppendBlobClient(options.GetWalSegmentBlobNameForJournal(grainId, GetJournalId(rootLogClient.Name), generation, segmentId));
+        public override AppendBlobClient GetRootClient(GrainId grainId)
+            => containerFactory.GetBlobContainerClient(grainId).GetAppendBlobClient(
+                options.GetRootBlobNameForJournal(grainId, options.GetBlobNameForJournal(grainId)));
 
-        public override string GetCheckpointName(AppendBlobClient rootLogClient, ulong generation)
-            => options.GetCheckpointBlobNameForJournal(grainId, GetJournalId(rootLogClient.Name), generation);
+        public override AppendBlobClient GetWalClient(GrainId grainId, uint generation, uint segmentId)
+            => containerFactory.GetBlobContainerClient(grainId).GetAppendBlobClient(
+                options.GetWalSegmentBlobNameForJournal(grainId, options.GetBlobNameForJournal(grainId), generation, segmentId));
 
-        public override BlockBlobClient GetCheckpointClient(AppendBlobClient rootLogClient, string checkpointName)
-            => containerClient.GetBlockBlobClient(checkpointName);
-    }
+        public override string GetCheckpointName(GrainId grainId, uint generation)
+            => options.GetCheckpointBlobNameForJournal(grainId, options.GetBlobNameForJournal(grainId), generation);
 
-    private sealed class DefaultBlobClientProvider : BlobClientProvider
-    {
-        public static DefaultBlobClientProvider Instance { get; } = new();
-
-        public override AppendBlobClient GetWalClient(AppendBlobClient rootLogClient, ulong generation, uint segmentId)
-            => rootLogClient.GetParentBlobContainerClient().GetAppendBlobClient(
-                AzureBlobJournalStorageOptions.GetDefaultWalSegmentBlobName(GetJournalId(rootLogClient.Name), generation, segmentId));
-
-        public override string GetCheckpointName(AppendBlobClient rootLogClient, ulong generation)
-            => AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName(GetJournalId(rootLogClient.Name), generation);
-
-        public override BlockBlobClient GetCheckpointClient(AppendBlobClient rootLogClient, string checkpointName)
-            => rootLogClient.GetParentBlobContainerClient().GetBlockBlobClient(checkpointName);
+        public override BlockBlobClient GetCheckpointClient(GrainId grainId, string checkpointName)
+            => containerFactory.GetBlobContainerClient(grainId).GetBlockBlobClient(checkpointName);
     }
 
     private sealed class DiscardingJournalStorageConsumer : IJournalStorageConsumer

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -11,8 +11,8 @@ namespace Orleans.Journaling;
 internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 {
     internal const string FormatMetadataKey = "format";
-    internal const string GenerationMetadataKey = "generation";
     internal const string CheckpointMetadataKey = "checkpoint";
+    internal const string CheckpointOffsetMetadataKey = "checkpoint_offset";
 
     // Azure Append Blob hard limits documented at:
     // https://learn.microsoft.com/azure/storage/blobs/scalability-targets#scale-targets-for-blob-storage
@@ -20,24 +20,21 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     internal const long MaxAppendBlockBytes = 100L * 1024 * 1024;
 
     // An append blob can hold up to 50,000 committed blocks. The compaction request
-    // (IsCompactionRequested) trips earlier, above 49,000 blocks, so this guard exists only
-    // to roll before hitting the hard Azure limit if a consumer ignores compaction requests.
+    // (IsCompactionRequested) trips earlier, above 49,000 blocks, so this guard exists
+    // only to fail clearly before Azure rejects the append.
     private const int MaxBlocksPerBlob = 50_000;
     private const int HeadroomBlockCount = 100;
     private const int RequestCompactionBlockCount = 49_000;
 
     private readonly SharedConfiguration _shared;
     private readonly IGrainContext _grainContext;
-    private AppendBlobClient _currentLogClient;
-    private uint _currentGeneration;
-    private uint _currentSegmentId;
+    private readonly AppendBlobClient _walClient;
     private int _numBlocks;
-    private ETag _currentSegmentETag;
-    private ETag _rootLogETag;
+    private long _walLength;
+    private ETag _walETag;
+    private string? _checkpointName;
 
-    private bool CurrentSegmentExists => _currentSegmentETag != default;
-
-    private bool RootExists => _rootLogETag != default;
+    private bool WalExists => _walETag != default;
 
     public bool IsCompactionRequested => _numBlocks > RequestCompactionBlockCount;
 
@@ -50,118 +47,90 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
         _shared = shared;
         _grainContext = grainContext;
-        _currentLogClient = GetRootClient();
+        _walClient = GetWalClient();
     }
 
     public async ValueTask AppendAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
         ThrowIfBatchTooLarge(value.Length);
-        if (CurrentSegmentExists && _numBlocks >= MaxBlocksPerBlob - HeadroomBlockCount)
+        await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
+        ThrowIfCompactionRequired();
+
+        using var stream = new ReadOnlySequenceStream(value);
+        try
         {
-            await RollToNextSegmentAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        while (true)
-        {
-            await EnsureCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
-            var currentLogClient = _currentLogClient;
-
-            using var stream = new ReadOnlySequenceStream(value);
-            try
-            {
-                var result = await currentLogClient.AppendBlockAsync(
-                    stream,
-                    new AppendBlobAppendBlockOptions
-                    {
-                        Conditions = new AppendBlobRequestConditions
-                        {
-                            IfMatch = _currentSegmentETag,
-                        }
-                    },
-                    cancellationToken).ConfigureAwait(false);
-
-                LogAppend(_shared.Logger, stream.Length, currentLogClient.BlobContainerName, currentLogClient.Name);
-                _currentSegmentETag = result.Value.ETag;
-                _numBlocks = result.Value.BlobCommittedBlockCount;
-                if (_currentSegmentId == 0)
+            var result = await _walClient.AppendBlockAsync(
+                stream,
+                new AppendBlobAppendBlockOptions
                 {
-                    _rootLogETag = result.Value.ETag;
-                }
+                    Conditions = new AppendBlobRequestConditions
+                    {
+                        IfMatch = _walETag,
+                    }
+                },
+                cancellationToken).ConfigureAwait(false);
 
-                return;
-            }
-            catch (RequestFailedException exception) when (IsBlobSealed(exception))
-            {
-                await RollToNextSegmentAsync(cancellationToken).ConfigureAwait(false);
-            }
+            LogAppend(_shared.Logger, stream.Length, _walClient.BlobContainerName, _walClient.Name);
+            SetWal(result.Value.ETag, result.Value.BlobCommittedBlockCount, _walLength + stream.Length, _checkpointName);
         }
-    }
-
-    private static void ThrowIfBatchTooLarge(long length)
-    {
-        if (length <= MaxAppendBlockBytes)
+        catch (RequestFailedException exception) when (IsBlobSealed(exception))
         {
-            return;
+            throw new InvalidOperationException("Azure Blob journal WAL is sealed; recovery is required before appending.", exception);
         }
-
-        throw new InvalidOperationException(
-            $"Azure Append Blob journal batch of {length:N0} bytes exceeds the per-block limit of {MaxAppendBlockBytes:N0} bytes (100 MiB). " +
-            "Reduce the operation size or compact more aggressively.");
+        catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
+        {
+            throw new InvalidOperationException("Azure Blob journal WAL changed while appending; recovery is required.", exception);
+        }
     }
 
     public async ValueTask DeleteAsync(CancellationToken cancellationToken)
     {
-        if (!RootExists)
+        if (!WalExists && !await TryLoadWalStateAsync(cancellationToken).ConfigureAwait(false))
         {
             return;
         }
 
-        if (CurrentSegmentExists)
-        {
-            await SealCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        var generation = checked(_currentGeneration + 1u);
-        Response<BlobContentInfo> response;
+        var checkpointName = _checkpointName;
         try
         {
-            response = await CreateRootAsync(
-                generation,
-                checkpointName: null,
-                new AppendBlobRequestConditions { IfMatch = _rootLogETag },
+            await _walClient.DeleteIfExistsAsync(
+                DeleteSnapshotsOption.None,
+                new BlobRequestConditions { IfMatch = _walETag },
                 cancellationToken).ConfigureAwait(false);
+            SetWal(eTag: default, blockCount: 0, length: 0, checkpointName: null);
         }
-        catch (RequestFailedException exception) when (IsRootMutationConflict(exception))
+        catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
         {
-            throw new InvalidOperationException("Azure Blob journal root changed while deleting the journal; recovery is required.", exception);
+            throw new InvalidOperationException("Azure Blob journal WAL changed while deleting the journal; recovery is required.", exception);
         }
 
-        _currentGeneration = generation;
-        SetCurrentSegment(segmentId: 0, exists: true, response.Value.ETag, blockCount: 0);
+        if (checkpointName is not null)
+        {
+            await DeleteCheckpointIfExistsAsync(checkpointName, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     public async ValueTask ReadAsync(IJournalStorageConsumer consumer, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(consumer);
 
-        Response<BlobDownloadStreamingResult> rootResult;
+        Response<BlobDownloadStreamingResult> walResult;
         try
         {
-            rootResult = await GetRootLogClient().DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            walResult = await _walClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         catch (RequestFailedException exception) when (exception.Status is 404)
         {
-            _currentGeneration = 0;
-            SetCurrentSegment(segmentId: 0, exists: false, eTag: default, blockCount: 0);
-            _rootLogETag = default;
+            SetWal(eTag: default, blockCount: 0, length: 0, checkpointName: null);
             consumer.Complete(metadata: null);
             return;
         }
 
-        await using var rootStream = rootResult.Value.Content;
-        _rootLogETag = rootResult.Value.Details.ETag;
-        var manifest = CreateRootManifest(rootResult.Value.Details.Metadata);
-        _currentGeneration = manifest.Generation;
+        var walDetails = walResult.Value.Details;
+        var manifest = CreateWalManifest(walDetails.Metadata);
+        SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount, walDetails.ContentLength, manifest.Checkpoint?.Name);
+
+        await using var walStream = walResult.Value.Content;
         var expectedFormat = manifest.Metadata.Format;
         if (manifest.Checkpoint is { } checkpoint)
         {
@@ -180,27 +149,42 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             expectedFormat = checkpointMetadata.Format;
         }
 
-        await ReadRootAndSegmentsAsync(
+        if (manifest.Checkpoint is { WalOffset: > 0 } checkpointOffset)
+        {
+            if (checkpointOffset.WalOffset > walDetails.ContentLength)
+            {
+                throw new InvalidOperationException(
+                    $"Azure Blob journal checkpoint offset {checkpointOffset.WalOffset:N0} exceeds WAL length {walDetails.ContentLength:N0}.");
+            }
+
+            await SkipStreamAsync(walStream, checkpointOffset.WalOffset, cancellationToken).ConfigureAwait(false);
+        }
+
+        var walMetadata = manifest.Metadata.Format is { Length: > 0 }
+            ? manifest.Metadata
+            : expectedFormat is { Length: > 0 }
+                ? new JournalFileMetadata(expectedFormat)
+                : JournalFileMetadata.Empty;
+        var totalWalBytes = await ReadStreamAsync(
             consumer,
-            rootResult.Value.Details,
-            rootStream,
-            expectedFormat,
+            walStream,
+            walMetadata,
+            complete: false,
             cancellationToken).ConfigureAwait(false);
+        LogRead(_shared.Logger, totalWalBytes, _walClient.BlobContainerName, _walClient.Name);
+        consumer.Complete(walMetadata);
     }
 
     public async ValueTask ReplaceAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
-        if (!CurrentSegmentExists)
-        {
-            await EnsureCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
-        }
+        await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
 
-        var rootETag = _rootLogETag;
-        var generation = checked(_currentGeneration + 1u);
+        var walETag = _walETag;
+        var previousCheckpointName = _checkpointName;
         using var checkpointStream = new ReadOnlySequenceStream(value);
         while (true)
         {
-            var checkpointName = GetCheckpointName(generation);
+            var checkpointName = GetCheckpointName(Guid.NewGuid().ToString("N"));
             var checkpointClient = GetCheckpointClient(checkpointName);
             try
             {
@@ -211,269 +195,136 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                     {
                         Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All },
                         HttpHeaders = CreateHttpHeaders(_shared.MimeType),
-                        Metadata = CreateCheckpointBlobMetadata(generation),
+                        Metadata = CreateCheckpointBlobMetadata(),
                     },
                     cancellationToken).ConfigureAwait(false);
-
-                Response<BlobContentInfo> rootResult;
-                try
-                {
-                    rootResult = await CreateRootAsync(
-                        generation,
-                        checkpointName,
-                        new AppendBlobRequestConditions { IfMatch = rootETag },
-                        cancellationToken).ConfigureAwait(false);
-                }
-                catch (RequestFailedException exception) when (IsRootMutationConflict(exception))
-                {
-                    throw new InvalidOperationException("Azure Blob journal root changed while publishing a checkpoint; recovery is required.", exception);
-                }
-
-                _currentGeneration = generation;
-                SetCurrentSegment(segmentId: 0, exists: true, rootResult.Value.ETag, blockCount: 0);
-                LogReplace(_shared.Logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
-                return;
             }
             catch (RequestFailedException exception) when (IsBlobAlreadyExists(exception))
             {
-                var currentManifest = await ReadRootManifestForCollisionAsync(cancellationToken).ConfigureAwait(false);
-                if (currentManifest?.Checkpoint is { } checkpoint
-                    && currentManifest.Generation == generation
-                    && string.Equals(checkpoint.Name, checkpointName, StringComparison.Ordinal))
-                {
-                    throw new InvalidOperationException("Azure Blob journal checkpoint was already published; recovery is required.", exception);
-                }
-
-                generation = checked(Math.Max(generation, currentManifest?.Generation ?? _currentGeneration) + 1u);
+                // Snapshot ids are random, so this should be vanishingly rare. Retry with a new id.
+                continue;
             }
+
+            try
+            {
+                var result = await CreateWalAsync(
+                    checkpointName,
+                    new AppendBlobRequestConditions { IfMatch = walETag },
+                    cancellationToken).ConfigureAwait(false);
+                SetWal(result.Value.ETag, blockCount: 0, length: 0, checkpointName);
+            }
+            catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
+            {
+                throw new InvalidOperationException("Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.", exception);
+            }
+
+            if (previousCheckpointName is not null && !string.Equals(previousCheckpointName, checkpointName, StringComparison.Ordinal))
+            {
+                await DeleteCheckpointIfExistsAsync(previousCheckpointName, cancellationToken).ConfigureAwait(false);
+            }
+
+            LogReplace(_shared.Logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
+            return;
         }
     }
 
-    private async ValueTask EnsureCurrentSegmentAsync(CancellationToken cancellationToken)
+    private static void ThrowIfBatchTooLarge(long length)
     {
-        if (CurrentSegmentExists)
+        if (length <= MaxAppendBlockBytes)
         {
             return;
         }
 
-        Response<BlobContentInfo> response;
-        if (_currentSegmentId == 0)
+        throw new InvalidOperationException(
+            $"Azure Append Blob journal batch of {length:N0} bytes exceeds the per-block limit of {MaxAppendBlockBytes:N0} bytes (100 MiB). " +
+            "Reduce the operation size or compact more aggressively.");
+    }
+
+    private void ThrowIfCompactionRequired()
+    {
+        if (_numBlocks < MaxBlocksPerBlob - HeadroomBlockCount)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Azure Blob journal WAL has {_numBlocks:N0} committed append blocks and must be compacted before more appends. " +
+            $"Azure Append Blob supports at most {MaxBlocksPerBlob:N0} committed blocks.");
+    }
+
+    private async ValueTask EnsureWalAsync(CancellationToken cancellationToken)
+    {
+        while (!WalExists)
         {
             try
             {
-                response = await CreateRootAsync(
-                    _currentGeneration,
+                var response = await CreateWalAsync(
                     checkpointName: null,
                     new AppendBlobRequestConditions { IfNoneMatch = ETag.All },
                     cancellationToken).ConfigureAwait(false);
+                SetWal(response.Value.ETag, blockCount: 0, length: 0, checkpointName: null);
+                return;
             }
             catch (RequestFailedException exception) when (IsBlobAlreadyExists(exception))
             {
                 await ReadAsync(DiscardingJournalStorageConsumer.Instance, cancellationToken).ConfigureAwait(false);
-                if (!CurrentSegmentExists)
-                {
-                    await EnsureCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
-                }
-
-                return;
             }
-
-        }
-        else
-        {
-            response = await _currentLogClient.CreateAsync(
-                CreateOptions(new AppendBlobRequestConditions { IfNoneMatch = ETag.All }),
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        SetCurrentSegment(_currentSegmentId, exists: true, response.Value.ETag, blockCount: 0);
-    }
-
-    private async ValueTask RollToNextSegmentAsync(CancellationToken cancellationToken)
-    {
-        if (CurrentSegmentExists)
-        {
-            await SealCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        SetCurrentSegment(checked(_currentSegmentId + 1), exists: false, eTag: default, blockCount: 0);
-    }
-
-    private async ValueTask SealCurrentSegmentAsync(CancellationToken cancellationToken)
-    {
-        if (!CurrentSegmentExists)
-        {
-            return;
-        }
-
-        var response = await _currentLogClient.SealAsync(
-            new AppendBlobRequestConditions { IfMatch = _currentSegmentETag },
-            cancellationToken).ConfigureAwait(false);
-        _currentSegmentETag = response.Value.ETag;
-        if (_currentSegmentId == 0)
-        {
-            _rootLogETag = response.Value.ETag;
         }
     }
 
-    private async ValueTask ReadRootAndSegmentsAsync(
-        IJournalStorageConsumer consumer,
-        BlobDownloadDetails rootDetails,
-        Stream rootStream,
-        string? expectedFormat,
-        CancellationToken cancellationToken)
+    private async ValueTask<bool> TryLoadWalStateAsync(CancellationToken cancellationToken)
     {
-        var rootFormat = GetFormatKeyMetadata(rootDetails.Metadata);
-        EnsureCompatibleFormat(expectedFormat, rootFormat, segmentId: 0);
-        var metadata = rootFormat is { Length: > 0 }
-            ? new JournalFileMetadata(rootFormat)
-            : expectedFormat is { Length: > 0 }
-                ? new JournalFileMetadata(expectedFormat)
-                : JournalFileMetadata.Empty;
-        var bytesRead = await ReadStreamAsync(consumer, rootStream, metadata, complete: false, cancellationToken).ConfigureAwait(false);
-        var rootLogClient = GetRootLogClient();
-        LogRead(_shared.Logger, bytesRead, rootLogClient.BlobContainerName, rootLogClient.Name);
-
-        if (!rootDetails.IsSealed)
+        Response<BlobDownloadStreamingResult> walResult;
+        try
         {
-            SetCurrentSegment(segmentId: 0, exists: true, rootDetails.ETag, rootDetails.BlobCommittedBlockCount);
-            consumer.Complete(metadata);
-            return;
+            walResult = await _walClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException exception) when (exception.Status is 404)
+        {
+            SetWal(eTag: default, blockCount: 0, length: 0, checkpointName: null);
+            return false;
         }
 
-        await ReadWalSegmentsAsync(
-            consumer,
-            startSegmentId: 1,
-            startOffset: 0,
-            expectedFormat: metadata.Format,
-            cancellationToken).ConfigureAwait(false);
+        await using var content = walResult.Value.Content;
+        var walDetails = walResult.Value.Details;
+        var manifest = CreateWalManifest(walDetails.Metadata);
+        SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount, walDetails.ContentLength, manifest.Checkpoint?.Name);
+        return true;
     }
 
-    private async ValueTask ReadWalSegmentsAsync(
-        IJournalStorageConsumer consumer,
-        uint startSegmentId,
-        long startOffset,
-        string? expectedFormat,
-        CancellationToken cancellationToken)
+    private void SetWal(ETag eTag, int blockCount, long length, string? checkpointName)
     {
-        var segmentId = startSegmentId;
-        var offset = startOffset;
-        var metadata = expectedFormat is { Length: > 0 } ? new JournalFileMetadata(expectedFormat) : JournalFileMetadata.Empty;
-        while (true)
-        {
-            Response<BlobDownloadStreamingResult> result;
-            Stream stream;
-            var client = GetWalClient(segmentId);
-            try
-            {
-                result = await client.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            }
-            catch (RequestFailedException exception) when (exception.Status is 404)
-            {
-                SetCurrentSegment(segmentId, exists: false, eTag: default, blockCount: 0);
-                consumer.Complete(metadata);
-                return;
-            }
-
-            stream = result.Value.Content;
-            await using (stream.ConfigureAwait(false))
-            {
-                var details = result.Value.Details;
-                var segmentFormat = GetFormatKeyMetadata(details.Metadata);
-                EnsureCompatibleFormat(expectedFormat, segmentFormat, segmentId);
-                metadata = segmentFormat is { Length: > 0 } ? new JournalFileMetadata(segmentFormat) : metadata;
-                if (offset > details.ContentLength)
-                {
-                    throw new InvalidOperationException(
-                        $"Azure Blob journal checkpoint points to offset {offset:N0} in segment {client.Name}, but the segment length is {details.ContentLength:N0}.");
-                }
-
-                if (offset > 0)
-                {
-                    await SkipExactlyAsync(stream, offset, cancellationToken).ConfigureAwait(false);
-                }
-
-                var bytesRead = await ReadStreamAsync(consumer, stream, metadata, complete: false, cancellationToken).ConfigureAwait(false);
-                LogRead(_shared.Logger, bytesRead, client.BlobContainerName, client.Name);
-
-                if (!details.IsSealed)
-                {
-                    SetCurrentSegment(segmentId, exists: true, details.ETag, details.BlobCommittedBlockCount);
-                    consumer.Complete(metadata);
-                    return;
-                }
-            }
-
-            segmentId = checked(segmentId + 1);
-            offset = 0;
-        }
-    }
-
-    private void SetCurrentSegment(uint segmentId, bool exists, ETag eTag, int blockCount)
-    {
-        _currentSegmentId = segmentId;
-        _currentSegmentETag = exists ? eTag : default;
+        _walETag = eTag;
         _numBlocks = blockCount;
-        _currentLogClient = GetLogClient(segmentId);
-        if (segmentId == 0)
-        {
-            _rootLogETag = exists ? eTag : default;
-        }
+        _walLength = length;
+        _checkpointName = checkpointName;
     }
 
-    private AppendBlobClient GetRootLogClient() => _currentSegmentId == 0 ? _currentLogClient : GetRootClient();
-
-    private AppendBlobClient GetLogClient(uint segmentId) => segmentId == 0 ? GetRootClient() : GetWalSegmentClient(segmentId);
-
-    private AppendBlobClient GetWalClient(uint segmentId)
+    private AppendBlobClient GetWalClient()
     {
-        if (segmentId == 0)
-        {
-            return GetRootLogClient();
-        }
-
-        return GetWalSegmentClient(segmentId);
-    }
-
-    private AppendBlobClient GetRootClient()
-    {
-        var client = _shared.BlobClientProvider.GetRootClient(_grainContext.GrainId);
-        return client ?? throw new InvalidOperationException("The configured Azure Blob journal root client provider returned null.");
-    }
-
-    private AppendBlobClient GetWalSegmentClient(uint segmentId)
-    {
-        var client = _shared.BlobClientProvider.GetWalClient(_grainContext.GrainId, _currentGeneration, checked(segmentId - 1));
+        var client = _shared.BlobClientProvider.GetWalClient(_grainContext.GrainId);
         return client ?? throw new InvalidOperationException("The configured Azure Blob journal WAL client provider returned null.");
     }
 
-    private AppendBlobCreateOptions CreateOptions(AppendBlobRequestConditions conditions) => new()
-    {
-        Conditions = conditions,
-        HttpHeaders = CreateHttpHeaders(_shared.MimeType),
-        Metadata = CreateSegmentMetadata(),
-    };
-
-    private async ValueTask<Response<BlobContentInfo>> CreateRootAsync(
-        uint generation,
+    private async ValueTask<Response<BlobContentInfo>> CreateWalAsync(
         string? checkpointName,
         AppendBlobRequestConditions conditions,
         CancellationToken cancellationToken)
-        => await GetRootLogClient().CreateAsync(
+        => await _walClient.CreateAsync(
             new AppendBlobCreateOptions
             {
                 Conditions = conditions,
                 HttpHeaders = CreateHttpHeaders(_shared.MimeType),
-                Metadata = CreateRootMetadata(generation, checkpointName),
+                Metadata = CreateWalMetadata(checkpointName, checkpointOffset: 0),
             },
             cancellationToken).ConfigureAwait(false);
 
     private static BlobHttpHeaders? CreateHttpHeaders(string? contentType)
         => contentType is { Length: > 0 } ? new BlobHttpHeaders { ContentType = contentType } : null;
 
-    private string GetCheckpointName(uint generation)
+    private string GetCheckpointName(string snapshotId)
     {
-        var checkpointName = _shared.BlobClientProvider.GetCheckpointName(_grainContext.GrainId, generation);
+        var checkpointName = _shared.BlobClientProvider.GetCheckpointName(_grainContext.GrainId, snapshotId);
         if (string.IsNullOrWhiteSpace(checkpointName))
         {
             throw new InvalidOperationException("The configured Azure Blob journal checkpoint client provider returned an empty blob name.");
@@ -488,12 +339,22 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         return client ?? throw new InvalidOperationException("The configured Azure Blob journal checkpoint client provider returned null.");
     }
 
-    private Dictionary<string, string> CreateMetadataDictionary(uint generation)
+    private async ValueTask DeleteCheckpointIfExistsAsync(string checkpointName, CancellationToken cancellationToken)
     {
-        var metadata = new Dictionary<string, string>
+        var checkpointClient = GetCheckpointClient(checkpointName);
+        try
         {
-            [GenerationMetadataKey] = FormatGeneration(generation),
-        };
+            await checkpointClient.DeleteIfExistsAsync(DeleteSnapshotsOption.None, conditions: null, cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException exception)
+        {
+            LogCheckpointCleanupFailure(_shared.Logger, checkpointClient.BlobContainerName, checkpointClient.Name, exception);
+        }
+    }
+
+    private Dictionary<string, string> CreateMetadataDictionary()
+    {
+        var metadata = new Dictionary<string, string>();
         if (_shared.JournalFormatKey is { Length: > 0 })
         {
             metadata[FormatMetadataKey] = _shared.JournalFormatKey;
@@ -502,16 +363,15 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         return metadata;
     }
 
-    private Dictionary<string, string> CreateSegmentMetadata() => CreateMetadataDictionary(_currentGeneration);
+    private Dictionary<string, string> CreateCheckpointBlobMetadata() => CreateMetadataDictionary();
 
-    private Dictionary<string, string> CreateCheckpointBlobMetadata(uint generation) => CreateMetadataDictionary(generation);
-
-    private Dictionary<string, string> CreateRootMetadata(uint generation, string? checkpointName)
+    private Dictionary<string, string> CreateWalMetadata(string? checkpointName, long checkpointOffset)
     {
-        var metadata = CreateMetadataDictionary(generation);
+        var metadata = CreateMetadataDictionary();
         if (checkpointName is not null)
         {
             metadata[CheckpointMetadataKey] = checkpointName;
+            metadata[CheckpointOffsetMetadataKey] = checkpointOffset.ToString(CultureInfo.InvariantCulture);
         }
 
         return metadata;
@@ -524,52 +384,30 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 ? storedKey
                 : null;
 
-    private static RootManifest CreateRootManifest(IDictionary<string, string>? metadata)
+    private static WalManifest CreateWalManifest(IDictionary<string, string>? metadata)
     {
-        if (!TryGetUInt32Metadata(metadata, GenerationMetadataKey, out var generation))
-        {
-            throw new InvalidOperationException(
-                $"Azure Blob journal root does not include valid '{GenerationMetadataKey}' metadata.");
-        }
-
         var fileMetadata = GetFormatKeyMetadata(metadata) is { } format
             ? new JournalFileMetadata(format)
             : JournalFileMetadata.Empty;
         if (metadata is null || !metadata.TryGetValue(CheckpointMetadataKey, out var checkpointName) || checkpointName is not { Length: > 0 })
         {
-            return new RootManifest(generation, fileMetadata, Checkpoint: null);
+            return new WalManifest(fileMetadata, Checkpoint: null);
         }
 
-        return new RootManifest(
-            generation,
-            fileMetadata,
-            new CheckpointReference(checkpointName, generation));
-    }
+        var checkpointOffset = 0L;
+        if (metadata.TryGetValue(CheckpointOffsetMetadataKey, out var checkpointOffsetValue)
+            && checkpointOffsetValue is { Length: > 0 }
+            && (!long.TryParse(checkpointOffsetValue, NumberStyles.None, CultureInfo.InvariantCulture, out checkpointOffset) || checkpointOffset < 0))
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal checkpoint offset metadata is invalid: '{checkpointOffsetValue}'.");
+        }
 
-    private async ValueTask<RootManifest?> ReadRootManifestForCollisionAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            var result = await GetRootLogClient().DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            await using (result.Value.Content.ConfigureAwait(false))
-            {
-                return CreateRootManifest(result.Value.Details.Metadata);
-            }
-        }
-        catch (RequestFailedException exception) when (exception.Status is 404)
-        {
-            return null;
-        }
+        return new WalManifest(fileMetadata, new CheckpointReference(checkpointName, checkpointOffset));
     }
 
     private static IJournalFileMetadata ValidateCheckpointMetadata(CheckpointReference checkpoint, BlobDownloadDetails checkpointDetails, string? expectedFormat)
     {
-        if (!TryGetUInt32Metadata(checkpointDetails.Metadata, GenerationMetadataKey, out var generation) || generation != checkpoint.Generation)
-        {
-            throw new InvalidOperationException(
-                $"Azure Blob journal checkpoint '{checkpoint.Name}' does not include the expected generation '{FormatGeneration(checkpoint.Generation)}'.");
-        }
-
         var checkpointBlobFormat = GetFormatKeyMetadata(checkpointDetails.Metadata);
         if (expectedFormat is { Length: > 0 })
         {
@@ -591,29 +429,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             : JournalFileMetadata.Empty;
     }
 
-    private static void EnsureCompatibleFormat(string? expectedFormat, string? segmentFormat, uint segmentId)
-    {
-        if (expectedFormat is null || segmentFormat is null || string.Equals(expectedFormat, segmentFormat, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        throw new InvalidOperationException(
-            $"Azure Blob journal WAL segment {FormatUInt32(segmentId)} format metadata is '{segmentFormat}', but recovery expected '{expectedFormat}'.");
-    }
-
-    private static bool TryGetUInt32Metadata(IDictionary<string, string>? metadata, string key, out uint value)
-    {
-        value = default;
-        return metadata is not null
-            && metadata.TryGetValue(key, out var text)
-            && uint.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value);
-    }
-
-    private static string FormatUInt32(uint value) => value.ToString("X8", CultureInfo.InvariantCulture);
-
-    private static string FormatGeneration(uint value) => value.ToString(CultureInfo.InvariantCulture);
-
     private static bool IsBlobSealed(RequestFailedException exception)
         => exception.Status == 409
             && (string.Equals(exception.ErrorCode, "BlobIsSealed", StringComparison.Ordinal)
@@ -624,7 +439,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             && (string.Equals(exception.ErrorCode, "BlobAlreadyExists", StringComparison.Ordinal)
                 || exception.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase));
 
-    private static bool IsRootMutationConflict(RequestFailedException exception)
+    private static bool IsWalMutationConflict(RequestFailedException exception)
         => exception.Status is 404 or 412
             || exception.Status == 409 && string.Equals(exception.ErrorCode, "ConditionNotMet", StringComparison.Ordinal);
 
@@ -663,20 +478,33 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
     }
 
-    private static async ValueTask SkipExactlyAsync(Stream stream, long bytesToSkip, CancellationToken cancellationToken)
+    private static async ValueTask SkipStreamAsync(Stream input, long length, CancellationToken cancellationToken)
     {
-        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+        if (length <= 0)
+        {
+            return;
+        }
+
+        if (input.CanSeek)
+        {
+            input.Seek(length, SeekOrigin.Current);
+            return;
+        }
+
+        var buffer = ArrayPool<byte>.Shared.Rent((int)Math.Min(81920, length));
         try
         {
-            while (bytesToSkip > 0)
+            while (length > 0)
             {
-                var bytesRead = await stream.ReadAsync(buffer.AsMemory(0, (int)Math.Min(buffer.Length, bytesToSkip)), cancellationToken).ConfigureAwait(false);
+                var bytesRead = await input.ReadAsync(
+                    buffer.AsMemory(0, (int)Math.Min(buffer.Length, length)),
+                    cancellationToken).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
-                    throw new InvalidOperationException("The stream ended before the requested WAL replay offset was reached.");
+                    throw new InvalidOperationException("Azure Blob journal WAL ended before the checkpoint offset was reached.");
                 }
 
-                bytesToSkip -= bytesRead;
+                length -= bytesRead;
             }
         }
         finally
@@ -706,9 +534,14 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         Message = "Wrote checkpoint blob \"{ContainerName}/{BlobName}\" containing {Length} bytes")]
     private static partial void LogReplace(ILogger logger, string containerName, string blobName, long length);
 
-    private sealed record RootManifest(uint Generation, IJournalFileMetadata Metadata, CheckpointReference? Checkpoint);
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Failed to delete obsolete Azure Blob journal checkpoint \"{ContainerName}/{BlobName}\"")]
+    private static partial void LogCheckpointCleanupFailure(ILogger logger, string containerName, string blobName, Exception exception);
 
-    private sealed record CheckpointReference(string Name, uint Generation);
+    private sealed record WalManifest(IJournalFileMetadata Metadata, CheckpointReference? Checkpoint);
+
+    private sealed record CheckpointReference(string Name, long WalOffset);
 
     internal sealed class SharedConfiguration
     {
@@ -738,11 +571,9 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     internal abstract class BlobClientProvider
     {
-        public abstract AppendBlobClient GetRootClient(GrainId grainId);
+        public abstract AppendBlobClient GetWalClient(GrainId grainId);
 
-        public abstract AppendBlobClient GetWalClient(GrainId grainId, uint generation, uint segmentId);
-
-        public abstract string GetCheckpointName(GrainId grainId, uint generation);
+        public abstract string GetCheckpointName(GrainId grainId, string snapshotId);
 
         public abstract BlockBlobClient GetCheckpointClient(GrainId grainId, string checkpointName);
     }
@@ -751,16 +582,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         IBlobContainerFactory containerFactory,
         AzureBlobJournalStorageOptions options) : BlobClientProvider
     {
-        public override AppendBlobClient GetRootClient(GrainId grainId)
+        public override AppendBlobClient GetWalClient(GrainId grainId)
             => containerFactory.GetBlobContainerClient(grainId).GetAppendBlobClient(
-                options.GetRootBlobNameForJournal(grainId, options.GetBlobNameForJournal(grainId)));
+                options.GetWalBlobNameForJournal(grainId, options.GetBlobNameForJournal(grainId)));
 
-        public override AppendBlobClient GetWalClient(GrainId grainId, uint generation, uint segmentId)
-            => containerFactory.GetBlobContainerClient(grainId).GetAppendBlobClient(
-                options.GetWalSegmentBlobNameForJournal(grainId, options.GetBlobNameForJournal(grainId), generation, segmentId));
-
-        public override string GetCheckpointName(GrainId grainId, uint generation)
-            => options.GetCheckpointBlobNameForJournal(grainId, options.GetBlobNameForJournal(grainId), generation);
+        public override string GetCheckpointName(GrainId grainId, string snapshotId)
+            => options.GetCheckpointBlobNameForJournal(grainId, options.GetBlobNameForJournal(grainId), snapshotId);
 
         public override BlockBlobClient GetCheckpointClient(GrainId grainId, string checkpointName)
             => containerFactory.GetBlobContainerClient(grainId).GetBlockBlobClient(checkpointName);

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -54,6 +54,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     {
         // Appends are written as one Azure append block, so validate blob limits before touching storage.
         ThrowIfBatchTooLarge(value.Length);
+
         // Ensure local state has the current WAL ETag and manifest before making a conditional append.
         await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
         ThrowIfCompactionRequired();
@@ -74,6 +75,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 cancellationToken).ConfigureAwait(false);
 
             LogAppend(_shared.Logger, stream.Length, _walClient.BlobContainerName, _walClient.Name);
+
             // Cache Azure's post-append state so the next mutation is guarded by the new ETag and block count.
             SetWal(result.Value.ETag, result.Value.BlobCommittedBlockCount, _walLength + stream.Length, _checkpointName);
         }
@@ -138,6 +140,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
         var walDetails = walResult.Value.Details;
         var manifest = CreateWalManifest(walDetails.Metadata);
+
         // Recovery refreshes the cached ETag, length, block count, and checkpoint pointer from the WAL manifest.
         SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount, walDetails.ContentLength, manifest.Checkpoint?.Name);
 
@@ -186,6 +189,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             complete: false,
             cancellationToken).ConfigureAwait(false);
         LogRead(_shared.Logger, totalWalBytes, _walClient.BlobContainerName, _walClient.Name);
+
         // Complete only after checkpoint and WAL tail have streamed as one logical journal.
         consumer.Complete(walMetadata);
     }
@@ -245,6 +249,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             }
 
             LogReplace(_shared.Logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
+
             // At this point the new checkpoint is reachable from WAL metadata and old state has been detached.
             return;
         }
@@ -317,6 +322,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         await using var content = walResult.Value.Content;
         var walDetails = walResult.Value.Details;
         var manifest = CreateWalManifest(walDetails.Metadata);
+
         // Cache the mutation preconditions and compaction signals without replaying journal bytes.
         SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount, walDetails.ContentLength, manifest.Checkpoint?.Name);
         return true;
@@ -342,8 +348,9 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         string? checkpointName,
         AppendBlobRequestConditions conditions,
         CancellationToken cancellationToken)
+    {
         // Creating an append blob is also how compaction publishes a fresh WAL manifest.
-        => await _walClient.CreateAsync(
+        return await _walClient.CreateAsync(
             new AppendBlobCreateOptions
             {
                 Conditions = conditions,
@@ -351,10 +358,13 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 Metadata = CreateWalMetadata(checkpointName, checkpointOffset: 0),
             },
             cancellationToken).ConfigureAwait(false);
+    }
 
     private static BlobHttpHeaders? CreateHttpHeaders(string? contentType)
+    {
         // Content type is optional transport metadata; journal format is carried separately in blob metadata.
-        => contentType is { Length: > 0 } ? new BlobHttpHeaders { ContentType = contentType } : null;
+        return contentType is { Length: > 0 } ? new BlobHttpHeaders { ContentType = contentType } : null;
+    }
 
     private string GetCheckpointName(string snapshotId)
     {
@@ -481,9 +491,11 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 || exception.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase));
 
     private static bool IsWalMutationConflict(RequestFailedException exception)
+    {
         // These failures mean our cached WAL view is stale or gone, so the caller must recover before retrying.
-        => exception.Status is 404 or 412
+        return exception.Status is 404 or 412
             || exception.Status == 409 && string.Equals(exception.ErrorCode, "ConditionNotMet", StringComparison.Ordinal);
+    }
 
     private static async ValueTask<long> ReadStreamAsync(
         IJournalStorageConsumer consumer,
@@ -518,6 +530,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
             buffer.AdvanceWriter(bytesRead);
             totalBytesRead += bytesRead;
+
             // Let the consumer drain incrementally so large blobs do not need to be buffered in full.
             ReadBuffer(consumer, buffer, metadata, isCompleted: false);
         }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -52,13 +52,16 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     public async ValueTask AppendAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
+        // Appends are written as one Azure append block, so validate blob limits before touching storage.
         ThrowIfBatchTooLarge(value.Length);
+        // Ensure local state has the current WAL ETag and manifest before making a conditional append.
         await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
         ThrowIfCompactionRequired();
 
         using var stream = new ReadOnlySequenceStream(value);
         try
         {
+            // Use the last observed WAL ETag so appends fail if the WAL changed since this instance recovered it.
             var result = await _walClient.AppendBlockAsync(
                 stream,
                 new AppendBlobAppendBlockOptions
@@ -71,6 +74,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 cancellationToken).ConfigureAwait(false);
 
             LogAppend(_shared.Logger, stream.Length, _walClient.BlobContainerName, _walClient.Name);
+            // Cache Azure's post-append state so the next mutation is guarded by the new ETag and block count.
             SetWal(result.Value.ETag, result.Value.BlobCommittedBlockCount, _walLength + stream.Length, _checkpointName);
         }
         catch (RequestFailedException exception) when (IsBlobSealed(exception))
@@ -85,14 +89,17 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     public async ValueTask DeleteAsync(CancellationToken cancellationToken)
     {
+        // Fresh storage instances load the WAL manifest first so delete knows whether a checkpoint is referenced.
         if (!WalExists && !await TryLoadWalStateAsync(cancellationToken).ConfigureAwait(false))
         {
             return;
         }
 
+        // Remember the checkpoint before clearing local WAL state so obsolete checkpoint cleanup can still run.
         var checkpointName = _checkpointName;
         try
         {
+            // Delete the WAL under its ETag before checkpoint cleanup so a racing WAL update cannot lose its checkpoint.
             await _walClient.DeleteIfExistsAsync(
                 DeleteSnapshotsOption.None,
                 new BlobRequestConditions { IfMatch = _walETag },
@@ -106,6 +113,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
         if (checkpointName is not null)
         {
+            // Checkpoint cleanup happens after WAL deletion because without the WAL manifest it is unreachable.
             await DeleteCheckpointIfExistsAsync(checkpointName, cancellationToken).ConfigureAwait(false);
         }
     }
@@ -117,10 +125,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         Response<BlobDownloadStreamingResult> walResult;
         try
         {
+            // Download the WAL first because its metadata is the manifest for any checkpoint that must be replayed.
             walResult = await _walClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         catch (RequestFailedException exception) when (exception.Status is 404)
         {
+            // A missing WAL is an empty journal; clear cached state before reporting completion.
             SetWal(eTag: default, blockCount: 0, length: 0, checkpointName: null);
             consumer.Complete(metadata: null);
             return;
@@ -128,6 +138,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
         var walDetails = walResult.Value.Details;
         var manifest = CreateWalManifest(walDetails.Metadata);
+        // Recovery refreshes the cached ETag, length, block count, and checkpoint pointer from the WAL manifest.
         SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount, walDetails.ContentLength, manifest.Checkpoint?.Name);
 
         await using var walStream = walResult.Value.Content;
@@ -138,6 +149,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             var checkpointResult = await checkpointClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             await using var checkpointStream = checkpointResult.Value.Content;
 
+            // Replay the immutable checkpoint first because it represents the compacted prefix before WAL entries.
             var checkpointMetadata = ValidateCheckpointMetadata(checkpoint, checkpointResult.Value.Details, expectedFormat);
             var totalCheckpointBytes = await ReadStreamAsync(
                 consumer,
@@ -157,9 +169,11 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                     $"Azure Blob journal checkpoint offset {checkpointOffset.WalOffset:N0} exceeds WAL length {walDetails.ContentLength:N0}.");
             }
 
+            // The checkpoint already contains WAL bytes through this offset, so replay only the WAL tail.
             await SkipStreamAsync(walStream, checkpointOffset.WalOffset, cancellationToken).ConfigureAwait(false);
         }
 
+        // Prefer WAL format metadata, falling back to the checkpoint when compaction recreated an empty WAL.
         var walMetadata = manifest.Metadata.Format is { Length: > 0 }
             ? manifest.Metadata
             : expectedFormat is { Length: > 0 }
@@ -172,22 +186,27 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             complete: false,
             cancellationToken).ConfigureAwait(false);
         LogRead(_shared.Logger, totalWalBytes, _walClient.BlobContainerName, _walClient.Name);
+        // Complete only after checkpoint and WAL tail have streamed as one logical journal.
         consumer.Complete(walMetadata);
     }
 
     public async ValueTask ReplaceAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
+        // Compaction publishes through WAL metadata, so first recover or create the WAL whose ETag will be checked.
         await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
 
+        // Snapshot the current publication state; the previous checkpoint is obsolete only after the new WAL wins.
         var walETag = _walETag;
         var previousCheckpointName = _checkpointName;
         using var checkpointStream = new ReadOnlySequenceStream(value);
         while (true)
         {
+            // The checkpoint blob is immutable and content-addressed by a random snapshot id for safe retry on collision.
             var checkpointName = GetCheckpointName(Guid.NewGuid().ToString("N"));
             var checkpointClient = GetCheckpointClient(checkpointName);
             try
             {
+                // Upload the checkpoint before publishing it from WAL metadata so upload failures leave recovery unchanged.
                 checkpointStream.Position = 0;
                 await checkpointClient.UploadAsync(
                     checkpointStream,
@@ -207,6 +226,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
             try
             {
+                // Recreate the WAL under its ETag to publish the checkpoint only if the existing WAL is unchanged.
                 var result = await CreateWalAsync(
                     checkpointName,
                     new AppendBlobRequestConditions { IfMatch = walETag },
@@ -220,16 +240,19 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
             if (previousCheckpointName is not null && !string.Equals(previousCheckpointName, checkpointName, StringComparison.Ordinal))
             {
+                // Keep the previous checkpoint until the new WAL is published so its manifest never points at a missing blob.
                 await DeleteCheckpointIfExistsAsync(previousCheckpointName, cancellationToken).ConfigureAwait(false);
             }
 
             LogReplace(_shared.Logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
+            // At this point the new checkpoint is reachable from WAL metadata and old state has been detached.
             return;
         }
     }
 
     private static void ThrowIfBatchTooLarge(long length)
     {
+        // Azure rejects oversize append blocks, so fail locally with the journal-specific guidance.
         if (length <= MaxAppendBlockBytes)
         {
             return;
@@ -242,6 +265,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private void ThrowIfCompactionRequired()
     {
+        // Stop before Azure's hard block cap so the caller can compact while there is still append headroom.
         if (_numBlocks < MaxBlocksPerBlob - HeadroomBlockCount)
         {
             return;
@@ -254,10 +278,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private async ValueTask EnsureWalAsync(CancellationToken cancellationToken)
     {
+        // Either create the initial WAL or load the WAL created by a racing instance, then loop until state is cached.
         while (!WalExists)
         {
             try
             {
+                // A newly-created WAL has no checkpoint pointer; existing WALs are handled by the conflict path.
                 var response = await CreateWalAsync(
                     checkpointName: null,
                     new AppendBlobRequestConditions { IfNoneMatch = ETag.All },
@@ -267,6 +293,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             }
             catch (RequestFailedException exception) when (IsBlobAlreadyExists(exception))
             {
+                // Another instance created the WAL first; read/discard it to recover its ETag and manifest before appending.
                 await ReadAsync(DiscardingJournalStorageConsumer.Instance, cancellationToken).ConfigureAwait(false);
             }
         }
@@ -277,10 +304,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         Response<BlobDownloadStreamingResult> walResult;
         try
         {
+            // Open the WAL just long enough to read properties and metadata; the content is discarded here.
             walResult = await _walClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
         }
         catch (RequestFailedException exception) when (exception.Status is 404)
         {
+            // Missing WAL means there is no durable state to delete or mutate.
             SetWal(eTag: default, blockCount: 0, length: 0, checkpointName: null);
             return false;
         }
@@ -288,12 +317,14 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         await using var content = walResult.Value.Content;
         var walDetails = walResult.Value.Details;
         var manifest = CreateWalManifest(walDetails.Metadata);
+        // Cache the mutation preconditions and compaction signals without replaying journal bytes.
         SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount, walDetails.ContentLength, manifest.Checkpoint?.Name);
         return true;
     }
 
     private void SetWal(ETag eTag, int blockCount, long length, string? checkpointName)
     {
+        // Keep the cached WAL mutation precondition, compaction counters, and checkpoint pointer in sync.
         _walETag = eTag;
         _numBlocks = blockCount;
         _walLength = length;
@@ -302,6 +333,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private AppendBlobClient GetWalClient()
     {
+        // Resolve the provider-specific WAL client once; checkpoint clients are resolved by published name.
         var client = _shared.BlobClientProvider.GetWalClient(_grainContext.GrainId);
         return client ?? throw new InvalidOperationException("The configured Azure Blob journal WAL client provider returned null.");
     }
@@ -310,6 +342,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         string? checkpointName,
         AppendBlobRequestConditions conditions,
         CancellationToken cancellationToken)
+        // Creating an append blob is also how compaction publishes a fresh WAL manifest.
         => await _walClient.CreateAsync(
             new AppendBlobCreateOptions
             {
@@ -320,10 +353,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             cancellationToken).ConfigureAwait(false);
 
     private static BlobHttpHeaders? CreateHttpHeaders(string? contentType)
+        // Content type is optional transport metadata; journal format is carried separately in blob metadata.
         => contentType is { Length: > 0 } ? new BlobHttpHeaders { ContentType = contentType } : null;
 
     private string GetCheckpointName(string snapshotId)
     {
+        // Let the configured provider own checkpoint naming so custom layouts stay consistent with WAL naming.
         var checkpointName = _shared.BlobClientProvider.GetCheckpointName(_grainContext.GrainId, snapshotId);
         if (string.IsNullOrWhiteSpace(checkpointName))
         {
@@ -335,6 +370,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private BlockBlobClient GetCheckpointClient(string checkpointName)
     {
+        // Resolve by the published checkpoint name so recovery can open checkpoints created by older instances.
         var client = _shared.BlobClientProvider.GetCheckpointClient(_grainContext.GrainId, checkpointName);
         return client ?? throw new InvalidOperationException("The configured Azure Blob journal checkpoint client provider returned null.");
     }
@@ -344,6 +380,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         var checkpointClient = GetCheckpointClient(checkpointName);
         try
         {
+            // Obsolete checkpoint cleanup is best-effort because the published WAL no longer references it.
             await checkpointClient.DeleteIfExistsAsync(DeleteSnapshotsOption.None, conditions: null, cancellationToken).ConfigureAwait(false);
         }
         catch (RequestFailedException exception)
@@ -354,6 +391,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private Dictionary<string, string> CreateMetadataDictionary()
     {
+        // Start with metadata common to WAL and checkpoint blobs so recovery can verify the journal format.
         var metadata = new Dictionary<string, string>();
         if (_shared.JournalFormatKey is { Length: > 0 })
         {
@@ -367,6 +405,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private Dictionary<string, string> CreateWalMetadata(string? checkpointName, long checkpointOffset)
     {
+        // WAL metadata is the recovery manifest: common format plus optional checkpoint pointer and WAL offset.
         var metadata = CreateMetadataDictionary();
         if (checkpointName is not null)
         {
@@ -386,6 +425,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private static WalManifest CreateWalManifest(IDictionary<string, string>? metadata)
     {
+        // Decode the WAL manifest, accepting non-compacted WALs that have no checkpoint pointer.
         var fileMetadata = GetFormatKeyMetadata(metadata) is { } format
             ? new JournalFileMetadata(format)
             : JournalFileMetadata.Empty;
@@ -408,6 +448,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private static IJournalFileMetadata ValidateCheckpointMetadata(CheckpointReference checkpoint, BlobDownloadDetails checkpointDetails, string? expectedFormat)
     {
+        // Refuse to stitch checkpoint and WAL data together if their declared journal formats differ.
         var checkpointBlobFormat = GetFormatKeyMetadata(checkpointDetails.Metadata);
         if (expectedFormat is { Length: > 0 })
         {
@@ -440,6 +481,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 || exception.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase));
 
     private static bool IsWalMutationConflict(RequestFailedException exception)
+        // These failures mean our cached WAL view is stale or gone, so the caller must recover before retrying.
         => exception.Status is 404 or 412
             || exception.Status == 409 && string.Equals(exception.ErrorCode, "ConditionNotMet", StringComparison.Ordinal);
 
@@ -450,6 +492,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         bool complete,
         CancellationToken cancellationToken)
     {
+        // Stream one blob through a reusable buffer; callers decide when the combined logical journal completes.
         metadata ??= JournalFileMetadata.Empty;
         using var buffer = new ArcBufferWriter();
         long totalBytesRead = 0;
@@ -459,6 +502,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             var bytesRead = await input.ReadAsync(memory, cancellationToken).ConfigureAwait(false);
             if (bytesRead == 0)
             {
+                // ReadAsync passes complete:false because checkpoint data and WAL tail are completed together later.
                 if (complete)
                 {
                     ReadBuffer(consumer, buffer, metadata, isCompleted: true);
@@ -474,12 +518,14 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
             buffer.AdvanceWriter(bytesRead);
             totalBytesRead += bytesRead;
+            // Let the consumer drain incrementally so large blobs do not need to be buffered in full.
             ReadBuffer(consumer, buffer, metadata, isCompleted: false);
         }
     }
 
     private static async ValueTask SkipStreamAsync(Stream input, long length, CancellationToken cancellationToken)
     {
+        // Used during recovery to consume checkpoint-covered WAL bytes without exposing them to the consumer.
         if (length <= 0)
         {
             return;
@@ -487,10 +533,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
         if (input.CanSeek)
         {
+            // Seeking is only used when supported; Azure response streams are often forward-only.
             input.Seek(length, SeekOrigin.Current);
             return;
         }
 
+        // Non-seekable streams can only advance by reading, so drain discarded bytes into a pooled buffer.
         var buffer = ArrayPool<byte>.Shared.Rent((int)Math.Min(81920, length));
         try
         {
@@ -515,6 +563,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private static void ReadBuffer(IJournalStorageConsumer consumer, ArcBufferWriter buffer, IJournalFileMetadata metadata, bool isCompleted)
     {
+        // The consumer advances the reader side of the buffer, leaving unread bytes to be detected by the caller.
         var reader = new JournalBufferReader(buffer.Reader, isCompleted);
         consumer.Read(reader, metadata);
     }
@@ -541,7 +590,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private sealed record WalManifest(IJournalFileMetadata Metadata, CheckpointReference? Checkpoint);
 
-    private sealed record CheckpointReference(string Name, long WalOffset);
+    private readonly record struct CheckpointReference(string Name, long WalOffset);
 
     internal sealed class SharedConfiguration
     {
@@ -600,96 +649,4 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         public void Read(JournalBufferReader buffer, IJournalFileMetadata? metadata) => buffer.Skip(buffer.Length);
     }
 
-    private sealed class ReadOnlySequenceStream(ReadOnlySequence<byte> sequence) : Stream
-    {
-        private readonly ReadOnlySequence<byte> _sequence = sequence;
-        private long _position;
-        private bool _disposed;
-
-        public override bool CanRead => !_disposed;
-
-        public override bool CanSeek => !_disposed;
-
-        public override bool CanWrite => false;
-
-        public override long Length
-        {
-            get
-            {
-                ObjectDisposedException.ThrowIf(_disposed, this);
-                return _sequence.Length;
-            }
-        }
-
-        public override long Position
-        {
-            get
-            {
-                ObjectDisposedException.ThrowIf(_disposed, this);
-                return _position;
-            }
-
-            set
-            {
-                ObjectDisposedException.ThrowIf(_disposed, this);
-                if (value < 0 || value > _sequence.Length)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(value));
-                }
-
-                _position = value;
-            }
-        }
-
-        public override void Flush() => ObjectDisposedException.ThrowIf(_disposed, this);
-
-        public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
-
-        public override int Read(Span<byte> buffer)
-        {
-            ObjectDisposedException.ThrowIf(_disposed, this);
-            if (buffer.IsEmpty || _position >= _sequence.Length)
-            {
-                return 0;
-            }
-
-            var length = (int)Math.Min(buffer.Length, _sequence.Length - _position);
-            _sequence.Slice(_position, length).CopyTo(buffer);
-            _position += length;
-            return length;
-        }
-
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return new ValueTask<int>(Read(buffer.Span));
-        }
-
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            ObjectDisposedException.ThrowIf(_disposed, this);
-            var newPosition = origin switch
-            {
-                SeekOrigin.Begin => offset,
-                SeekOrigin.Current => _position + offset,
-                SeekOrigin.End => _sequence.Length + offset,
-                _ => throw new ArgumentOutOfRangeException(nameof(origin))
-            };
-
-            Position = newPosition;
-            return _position;
-        }
-
-        public override void SetLength(long value) => throw new NotSupportedException("This stream is read-only.");
-
-        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException("This stream is read-only.");
-
-        public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException("This stream is read-only.");
-
-        protected override void Dispose(bool disposing)
-        {
-            _disposed = true;
-            base.Dispose(disposing);
-        }
-    }
 }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -4,36 +4,37 @@ using Azure;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
-using Orleans.Serialization.Buffers;
 
 namespace Orleans.Journaling;
 
 internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 {
+    // WAL and checkpoint blobs use this metadata key to declare which journal format their bytes contain.
     internal const string FormatMetadataKey = "format";
+
+    // WAL metadata uses this key to point recovery at the checkpoint blob holding the compacted journal prefix.
     internal const string CheckpointMetadataKey = "checkpoint";
+
+    // WAL metadata uses this key to record how many WAL bytes are already included in the checkpoint; recovery skips that prefix before replaying the WAL tail.
     internal const string CheckpointOffsetMetadataKey = "checkpoint_offset";
 
-    // Azure Append Blob hard limits documented at:
-    // https://learn.microsoft.com/azure/storage/blobs/scalability-targets#scale-targets-for-blob-storage
-    // The append-block size cap is 100 MiB for service version >= 2022-11-02.
+    // AppendAsync rejects batches above Azure's documented per-block cap before sending an append request.
     internal const long MaxAppendBlockBytes = 100L * 1024 * 1024;
 
-    // An append blob can hold up to 50,000 committed blocks. The compaction request
-    // (IsCompactionRequested) trips earlier, above 49,000 blocks, so this guard exists
-    // only to fail clearly before Azure rejects the append.
+    // ThrowIfCompactionRequired uses Azure's hard committed-block cap to fail clearly before Azure rejects an append.
     private const int MaxBlocksPerBlob = 50_000;
+
+    // ThrowIfCompactionRequired preserves this many blocks of append capacity after compaction becomes mandatory.
     private const int HeadroomBlockCount = 100;
+
+    // IsCompactionRequested trips at this block count so callers compact before the hard append-blob limit.
     private const int RequestCompactionBlockCount = 49_000;
-    private const int MaxSkipBufferBytes = 16 * 1024;
 
     private readonly SharedConfiguration _shared;
     private readonly IGrainContext _grainContext;
     private readonly AppendBlobClient _walClient;
     private int _numBlocks;
-    private long _walLength;
     private ETag _walETag;
-    private string? _checkpointName;
 
     private bool WalExists => _walETag != default;
 
@@ -57,7 +58,11 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         ThrowIfBatchTooLarge(value.Length);
 
         // Ensure local state has the current WAL ETag and manifest before making a conditional append.
-        await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
+        if (!WalExists)
+        {
+            await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
+        }
+
         ThrowIfCompactionRequired();
 
         using var stream = new ReadOnlySequenceStream(value);
@@ -78,7 +83,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             LogAppend(_shared.Logger, stream.Length, _walClient.BlobContainerName, _walClient.Name);
 
             // Cache Azure's post-append state so the next mutation is guarded by the new ETag and block count.
-            SetWal(result.Value.ETag, result.Value.BlobCommittedBlockCount, _walLength + stream.Length, _checkpointName);
+            SetWal(result.Value.ETag, result.Value.BlobCommittedBlockCount);
         }
         catch (RequestFailedException exception) when (IsBlobSealed(exception))
         {
@@ -92,22 +97,33 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     public async ValueTask DeleteAsync(CancellationToken cancellationToken)
     {
-        // Fresh storage instances load the WAL manifest first so delete knows whether a checkpoint is referenced.
-        if (!WalExists && !await TryLoadWalStateAsync(cancellationToken).ConfigureAwait(false))
+        var conditions = WalExists ? new BlobRequestConditions { IfMatch = _walETag } : null;
+        WalState? walState;
+        try
+        {
+            // Load the WAL manifest only when deletion needs to know which checkpoint may become unreachable.
+            walState = await TryLoadWalStateAsync(conditions, cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
+        {
+            throw new InvalidOperationException("Azure Blob journal WAL changed while deleting the journal; recovery is required.", exception);
+        }
+
+        if (walState is null)
         {
             return;
         }
 
         // Remember the checkpoint before clearing local WAL state so obsolete checkpoint cleanup can still run.
-        var checkpointName = _checkpointName;
+        var checkpointName = walState.Value.Manifest.Checkpoint?.Name;
         try
         {
             // Delete the WAL under its ETag before checkpoint cleanup so a racing WAL update cannot lose its checkpoint.
             await _walClient.DeleteIfExistsAsync(
                 DeleteSnapshotsOption.None,
-                new BlobRequestConditions { IfMatch = _walETag },
+                new BlobRequestConditions { IfMatch = walState.Value.ETag },
                 cancellationToken).ConfigureAwait(false);
-            SetWal(eTag: default, blockCount: 0, length: 0, checkpointName: null);
+            SetWal(eTag: default, blockCount: 0);
         }
         catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
         {
@@ -134,7 +150,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         catch (RequestFailedException exception) when (exception.Status is 404)
         {
             // A missing WAL is an empty journal; clear cached state before reporting completion.
-            SetWal(eTag: default, blockCount: 0, length: 0, checkpointName: null);
+            SetWal(eTag: default, blockCount: 0);
             consumer.Complete(metadata: null);
             return;
         }
@@ -142,8 +158,8 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         var walDetails = walResult.Value.Details;
         var manifest = CreateWalManifest(walDetails.Metadata);
 
-        // Recovery refreshes the cached ETag, length, block count, and checkpoint pointer from the WAL manifest.
-        SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount, walDetails.ContentLength, manifest.Checkpoint?.Name);
+        // Recovery refreshes the cached ETag and block count from the WAL manifest.
+        SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount);
 
         await using var walStream = walResult.Value.Content;
         var expectedFormat = manifest.Metadata.Format;
@@ -155,8 +171,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
             // Replay the immutable checkpoint first because it represents the compacted prefix before WAL entries.
             var checkpointMetadata = ValidateCheckpointMetadata(checkpoint, checkpointResult.Value.Details, expectedFormat);
-            var totalCheckpointBytes = await ReadStreamAsync(
-                consumer,
+            var totalCheckpointBytes = await consumer.ReadAsync(
                 checkpointStream,
                 checkpointMetadata,
                 complete: false,
@@ -174,7 +189,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             }
 
             // The checkpoint already contains WAL bytes through this offset, so replay only the WAL tail.
-            await SkipStreamAsync(walStream, checkpointOffset.WalOffset, cancellationToken).ConfigureAwait(false);
+            await AzureBlobJournalStorageStreamHelpers.SkipStreamAsync(walStream, checkpointOffset.WalOffset, cancellationToken).ConfigureAwait(false);
         }
 
         // Prefer WAL format metadata, falling back to the checkpoint when compaction recreated an empty WAL.
@@ -183,8 +198,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             : expectedFormat is { Length: > 0 }
                 ? new JournalFileMetadata(expectedFormat)
                 : JournalFileMetadata.Empty;
-        var totalWalBytes = await ReadStreamAsync(
-            consumer,
+        var totalWalBytes = await consumer.ReadAsync(
             walStream,
             walMetadata,
             complete: false,
@@ -200,9 +214,24 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         // Compaction publishes through WAL metadata, so first recover or create the WAL whose ETag will be checked.
         await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
 
-        // Snapshot the current publication state; the previous checkpoint is obsolete only after the new WAL wins.
+        // Snapshot the current WAL ETag, then read its manifest under that ETag before publishing a checkpoint.
         var walETag = _walETag;
-        var previousCheckpointName = _checkpointName;
+        WalState? walState;
+        try
+        {
+            walState = await TryLoadWalStateAsync(new BlobRequestConditions { IfMatch = walETag }, cancellationToken).ConfigureAwait(false);
+        }
+        catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
+        {
+            throw new InvalidOperationException("Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.", exception);
+        }
+
+        if (walState is null)
+        {
+            throw new InvalidOperationException("Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.");
+        }
+
+        var previousCheckpointName = walState.Value.Manifest.Checkpoint?.Name;
         using var checkpointStream = new ReadOnlySequenceStream(value);
         while (true)
         {
@@ -234,9 +263,9 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 // Recreate the WAL under its ETag to publish the checkpoint only if the existing WAL is unchanged.
                 var result = await CreateWalAsync(
                     checkpointName,
-                    new AppendBlobRequestConditions { IfMatch = walETag },
+                    new AppendBlobRequestConditions { IfMatch = walState.Value.ETag },
                     cancellationToken).ConfigureAwait(false);
-                SetWal(result.Value.ETag, blockCount: 0, length: 0, checkpointName);
+                SetWal(result.Value.ETag, blockCount: 0);
             }
             catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
             {
@@ -294,48 +323,45 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                     checkpointName: null,
                     new AppendBlobRequestConditions { IfNoneMatch = ETag.All },
                     cancellationToken).ConfigureAwait(false);
-                SetWal(response.Value.ETag, blockCount: 0, length: 0, checkpointName: null);
+                SetWal(response.Value.ETag, blockCount: 0);
                 return;
             }
             catch (RequestFailedException exception) when (IsBlobAlreadyExists(exception))
             {
-                // Another instance created the WAL first; read/discard it to recover its ETag and manifest before appending.
-                await ReadAsync(DiscardingJournalStorageConsumer.Instance, cancellationToken).ConfigureAwait(false);
+                // Another instance created the WAL first; load only the properties needed before appending.
+                await TryLoadWalStateAsync(conditions: null, cancellationToken).ConfigureAwait(false);
             }
         }
     }
 
-    private async ValueTask<bool> TryLoadWalStateAsync(CancellationToken cancellationToken)
+    private async ValueTask<WalState?> TryLoadWalStateAsync(BlobRequestConditions? conditions, CancellationToken cancellationToken)
     {
-        Response<BlobDownloadStreamingResult> walResult;
+        Response<BlobProperties> walProperties;
         try
         {
-            // Open the WAL just long enough to read properties and metadata; the content is discarded here.
-            walResult = await _walClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            // Read only WAL properties and metadata; no journal bytes are needed to cache mutation state.
+            walProperties = await _walClient.GetPropertiesAsync(conditions, cancellationToken).ConfigureAwait(false);
         }
         catch (RequestFailedException exception) when (exception.Status is 404)
         {
             // Missing WAL means there is no durable state to delete or mutate.
-            SetWal(eTag: default, blockCount: 0, length: 0, checkpointName: null);
-            return false;
+            SetWal(eTag: default, blockCount: 0);
+            return null;
         }
 
-        await using var content = walResult.Value.Content;
-        var walDetails = walResult.Value.Details;
+        var walDetails = walProperties.Value;
         var manifest = CreateWalManifest(walDetails.Metadata);
 
-        // Cache the mutation preconditions and compaction signals without replaying journal bytes.
-        SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount, walDetails.ContentLength, manifest.Checkpoint?.Name);
-        return true;
+        // Cache the mutation precondition and compaction signal without replaying journal bytes.
+        SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount);
+        return new WalState(walDetails.ETag, manifest);
     }
 
-    private void SetWal(ETag eTag, int blockCount, long length, string? checkpointName)
+    private void SetWal(ETag eTag, int blockCount)
     {
-        // Keep the cached WAL mutation precondition, compaction counters, and checkpoint pointer in sync.
+        // Keep the cached WAL mutation precondition and compaction counter in sync.
         _walETag = eTag;
         _numBlocks = blockCount;
-        _walLength = length;
-        _checkpointName = checkpointName;
     }
 
     private AppendBlobClient GetWalClient()
@@ -498,95 +524,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             || exception.Status == 409 && string.Equals(exception.ErrorCode, "ConditionNotMet", StringComparison.Ordinal);
     }
 
-    private static async ValueTask<long> ReadStreamAsync(
-        IJournalStorageConsumer consumer,
-        Stream input,
-        IJournalFileMetadata? metadata,
-        bool complete,
-        CancellationToken cancellationToken)
-    {
-        // Stream one blob through a reusable buffer; callers decide when the combined logical journal completes.
-        metadata ??= JournalFileMetadata.Empty;
-        using var buffer = new ArcBufferWriter();
-        long totalBytesRead = 0;
-        while (true)
-        {
-            var memory = buffer.GetMemory();
-            var bytesRead = await input.ReadAsync(memory, cancellationToken).ConfigureAwait(false);
-            if (bytesRead == 0)
-            {
-                // ReadAsync passes complete:false because checkpoint data and WAL tail are completed together later.
-                if (complete)
-                {
-                    ReadBuffer(consumer, buffer, metadata, isCompleted: true);
-                }
-
-                if (buffer.Length > 0)
-                {
-                    throw new InvalidOperationException("The journal storage consumer did not read all supplied journal data.");
-                }
-
-                return totalBytesRead;
-            }
-
-            buffer.AdvanceWriter(bytesRead);
-            totalBytesRead += bytesRead;
-
-            // Let the consumer drain incrementally so large blobs do not need to be buffered in full.
-            ReadBuffer(consumer, buffer, metadata, isCompleted: false);
-        }
-    }
-
-    private static async ValueTask SkipStreamAsync(Stream input, long length, CancellationToken cancellationToken)
-    {
-        // Used during recovery to consume checkpoint-covered WAL bytes without exposing them to the consumer.
-        if (length <= 0)
-        {
-            return;
-        }
-
-        if (input.CanSeek)
-        {
-            // Seeking is only used when supported; Azure response streams are often forward-only.
-            input.Seek(length, SeekOrigin.Current);
-            return;
-        }
-
-        // Non-seekable streams can only advance by reading, so drain discarded bytes into a pooled buffer.
-        var maxChunkSize = (int)Math.Min(MaxSkipBufferBytes, length);
-        var buffer = ArrayPool<byte>.Shared.Rent(maxChunkSize);
-
-        try
-        {
-            while (length > 0)
-            {
-                // ArrayPool can return a larger array, so slice it to keep each skip read capped.
-                var toRead = (int)Math.Min(maxChunkSize, length);
-
-                // ReadExactlyAsync guarantees the buffer slice is completely filled before returning,
-                // or it throws an EndOfStreamException if the stream ends early.
-                await input.ReadExactlyAsync(buffer.AsMemory(0, toRead), cancellationToken).ConfigureAwait(false);
-
-                length -= toRead;
-            }
-        }
-        catch (EndOfStreamException ex)
-        {
-            throw new InvalidOperationException("Azure Blob journal WAL ended before the checkpoint offset was reached.", ex);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
-    }
-
-    private static void ReadBuffer(IJournalStorageConsumer consumer, ArcBufferWriter buffer, IJournalFileMetadata metadata, bool isCompleted)
-    {
-        // The consumer advances the reader side of the buffer, leaving unread bytes to be detected by the caller.
-        var reader = new JournalBufferReader(buffer.Reader, isCompleted);
-        consumer.Read(reader, metadata);
-    }
-
     [LoggerMessage(
         Level = LogLevel.Debug,
         Message = "Appended {Length} bytes to blob \"{ContainerName}/{BlobName}\"")]
@@ -608,6 +545,8 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private static partial void LogCheckpointCleanupFailure(ILogger logger, string containerName, string blobName, Exception exception);
 
     private sealed record WalManifest(IJournalFileMetadata Metadata, CheckpointReference? Checkpoint);
+
+    private readonly record struct WalState(ETag ETag, WalManifest Manifest);
 
     private readonly record struct CheckpointReference(string Name, long WalOffset);
 
@@ -660,12 +599,4 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         public override BlockBlobClient GetCheckpointClient(GrainId grainId, string checkpointName)
             => containerFactory.GetBlobContainerClient(grainId).GetBlockBlobClient(checkpointName);
     }
-
-    private sealed class DiscardingJournalStorageConsumer : IJournalStorageConsumer
-    {
-        public static DiscardingJournalStorageConsumer Instance { get; } = new();
-
-        public void Read(JournalBufferReader buffer, IJournalFileMetadata? metadata) => buffer.Skip(buffer.Length);
-    }
-
 }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Globalization;
 using Azure;
 using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Blobs.Models;
@@ -9,6 +10,10 @@ namespace Orleans.Journaling;
 internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 {
     internal const string FormatMetadataKey = "format";
+    internal const string SnapshotMetadataKey = "snapshot";
+    internal const string SnapshotETagMetadataKey = "snapshot-etag";
+    internal const string SnapshotFormatMetadataKey = "snapshot-format";
+    internal const string SnapshotLengthMetadataKey = "snapshot-length";
 
     // Azure Append Blob hard limits documented at:
     // https://learn.microsoft.com/azure/storage/blobs/scalability-targets#scale-targets-for-blob-storage
@@ -22,6 +27,8 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private const int AppendBlobBlockCeilingHeadroom = 100;
 
     private readonly AppendBlobClient _client;
+    private readonly Func<string> _snapshotNameFactory;
+    private readonly Func<string, BlockBlobClient> _snapshotClientFactory;
     private readonly string? _mimeType;
     private readonly string? _journalFormatKey;
     private readonly ILogger<AzureBlobJournalStorage> _logger;
@@ -45,11 +52,15 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         AppendBlobClient client,
         string? mimeType,
         ILogger<AzureBlobJournalStorage> logger,
-        string? journalFormatKey = null)
+        string? journalFormatKey = null,
+        Func<string>? snapshotNameFactory = null,
+        Func<string, BlockBlobClient>? snapshotClientFactory = null)
     {
         ArgumentNullException.ThrowIfNull(client);
 
         _client = client;
+        _snapshotNameFactory = snapshotNameFactory ?? CreateDefaultSnapshotNameFactory(client);
+        _snapshotClientFactory = snapshotClientFactory ?? CreateDefaultSnapshotClientFactory(client);
         _mimeType = mimeType;
         _journalFormatKey = journalFormatKey;
         _logger = logger;
@@ -133,25 +144,69 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             return;
         }
 
-        var metadata = CreateFileMetadata(result.Value.Details.Metadata);
+        await using var appendStream = result.Value.Content;
+        var metadata = result.Value.Details.Metadata;
+        var fileMetadata = CreateFileMetadata(metadata);
 
         _numBlocks = result.Value.Details.BlobCommittedBlockCount;
         _appendOptions.Conditions.IfNoneMatch = default;
         _appendOptions.Conditions.IfMatch = result.Value.Details.ETag;
         _exists = true;
 
-        await using (var rawStream = result.Value.Content)
+        var snapshot = CreateSnapshotReference(metadata);
+        if (snapshot is null)
         {
-            var totalBytesRead = await consumer.ReadAsync(rawStream, metadata, cancellationToken).ConfigureAwait(false);
+            var totalBytesRead = await consumer.ReadAsync(appendStream, fileMetadata, cancellationToken).ConfigureAwait(false);
             LogRead(_logger, totalBytesRead, _client.BlobContainerName, _client.Name);
+            return;
         }
+
+        var snapshotClient = _snapshotClientFactory(snapshot.Name);
+        if (snapshotClient is null)
+        {
+            throw new InvalidOperationException("The configured Azure Blob journal snapshot client factory returned null.");
+        }
+
+        var snapshotResult = await snapshotClient.DownloadStreamingAsync(
+            new BlobDownloadOptions
+            {
+                Conditions = new BlobRequestConditions { IfMatch = snapshot.ETag }
+            },
+            cancellationToken).ConfigureAwait(false);
+        await using var snapshotStream = snapshotResult.Value.Content;
+
+        var readMetadata = ValidateSnapshotMetadata(snapshot, snapshotResult.Value.Details, metadata);
+        await using var combinedStream = new ConcatenatedReadStream(snapshotStream, appendStream);
+        var combinedBytesRead = await consumer.ReadAsync(combinedStream, readMetadata, cancellationToken).ConfigureAwait(false);
+        LogRead(_logger, combinedBytesRead, _client.BlobContainerName, _client.Name);
     }
 
     public async ValueTask ReplaceAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
-        ThrowIfBatchTooLarge(value.Length, isReplace: true);
+        var snapshotName = _snapshotNameFactory();
+        if (string.IsNullOrWhiteSpace(snapshotName))
+        {
+            throw new InvalidOperationException("The configured Azure Blob journal snapshot name factory returned an empty blob name.");
+        }
 
-        // Open the blob for writing, overwriting existing contents.
+        var snapshotClient = _snapshotClientFactory(snapshotName);
+        if (snapshotClient is null)
+        {
+            throw new InvalidOperationException("The configured Azure Blob journal snapshot client factory returned null.");
+        }
+
+        using var snapshotStream = new ReadOnlySequenceStream(value);
+        var snapshotResult = await snapshotClient.UploadAsync(
+            snapshotStream,
+            new BlobUploadOptions
+            {
+                Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All },
+                HttpHeaders = CreateHttpHeaders(),
+                Metadata = CreateMetadata(),
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        // Open the append blob for writing, atomically replacing it with an empty tail marker.
         var createOptions = new AppendBlobCreateOptions()
         {
             Conditions = new AppendBlobRequestConditions
@@ -159,21 +214,15 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 IfMatch = _appendOptions.Conditions.IfMatch,
                 IfNoneMatch = _appendOptions.Conditions.IfNoneMatch,
             },
-            Metadata = CreateMetadata(),
+            Metadata = CreateSnapshotMarkerMetadata(snapshotName, snapshotResult.Value.ETag, snapshotStream.Length),
             HttpHeaders = CreateHttpHeaders(),
         };
         var createResult = await _client.CreateAsync(createOptions, cancellationToken).ConfigureAwait(false);
         _appendOptions.Conditions.IfMatch = createResult.Value.ETag;
         _appendOptions.Conditions.IfNoneMatch = default;
-
-        // Write the compacted journal state.
-        using var stream = new ReadOnlySequenceStream(value);
-        var result = await _client.AppendBlockAsync(stream, _appendOptions, cancellationToken).ConfigureAwait(false);
-        LogReplace(_logger, _client.BlobContainerName, _client.Name, stream.Length);
-
-        _appendOptions.Conditions.IfNoneMatch = default;
-        _appendOptions.Conditions.IfMatch = result.Value.ETag;
-        _numBlocks = result.Value.BlobCommittedBlockCount;
+        _exists = true;
+        _numBlocks = 0;
+        LogReplace(_logger, _client.BlobContainerName, _client.Name, snapshotStream.Length);
     }
 
     private AppendBlobCreateOptions CreateOptions(AppendBlobRequestConditions conditions) => new()
@@ -188,8 +237,42 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private static BlobHttpHeaders? CreateHttpHeaders(string? contentType)
         => contentType is { Length: > 0 } ? new BlobHttpHeaders { ContentType = contentType } : null;
 
+    private static Func<string> CreateDefaultSnapshotNameFactory(AppendBlobClient client)
+        => () => $"{client.Name}.snapshots/{Guid.NewGuid():N}";
+
+    private static Func<string, BlockBlobClient> CreateDefaultSnapshotClientFactory(AppendBlobClient client)
+        => snapshotName => client.GetParentBlobContainerClient().GetBlockBlobClient(snapshotName);
+
+    private Dictionary<string, string> CreateMetadataDictionary()
+    {
+        var metadata = new Dictionary<string, string>();
+        if (_journalFormatKey is { Length: > 0 })
+        {
+            metadata[FormatMetadataKey] = _journalFormatKey;
+        }
+
+        return metadata;
+    }
+
     private Dictionary<string, string>? CreateMetadata()
-        => _journalFormatKey is { Length: > 0 } ? new Dictionary<string, string> { [FormatMetadataKey] = _journalFormatKey } : null;
+    {
+        var metadata = CreateMetadataDictionary();
+        return metadata.Count > 0 ? metadata : null;
+    }
+
+    private Dictionary<string, string> CreateSnapshotMarkerMetadata(string snapshotName, ETag snapshotETag, long snapshotLength)
+    {
+        var metadata = CreateMetadataDictionary();
+        metadata[SnapshotMetadataKey] = snapshotName;
+        metadata[SnapshotETagMetadataKey] = snapshotETag.ToString();
+        metadata[SnapshotLengthMetadataKey] = snapshotLength.ToString(CultureInfo.InvariantCulture);
+        if (_journalFormatKey is { Length: > 0 })
+        {
+            metadata[SnapshotFormatMetadataKey] = _journalFormatKey;
+        }
+
+        return metadata;
+    }
 
     private static string? GetFormatKeyMetadata(IDictionary<string, string>? metadata)
         => metadata is not null
@@ -203,6 +286,76 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             ? new JournalFileMetadata(format)
             : JournalFileMetadata.Empty;
 
+    private static SnapshotReference? CreateSnapshotReference(IDictionary<string, string>? metadata)
+    {
+        if (metadata is null || !metadata.TryGetValue(SnapshotMetadataKey, out var snapshotName) || snapshotName is not { Length: > 0 })
+        {
+            return null;
+        }
+
+        if (!metadata.TryGetValue(SnapshotETagMetadataKey, out var snapshotETag) || snapshotETag is not { Length: > 0 })
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal marker references snapshot blob '{snapshotName}' but does not include '{SnapshotETagMetadataKey}' metadata.");
+        }
+
+        if (!metadata.TryGetValue(SnapshotLengthMetadataKey, out var snapshotLengthValue)
+            || !long.TryParse(snapshotLengthValue, NumberStyles.None, CultureInfo.InvariantCulture, out var snapshotLength)
+            || snapshotLength < 0)
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal marker references snapshot blob '{snapshotName}' but does not include valid '{SnapshotLengthMetadataKey}' metadata.");
+        }
+
+        var snapshotFormat = metadata.TryGetValue(SnapshotFormatMetadataKey, out var storedSnapshotFormat)
+            && storedSnapshotFormat is { Length: > 0 }
+                ? storedSnapshotFormat
+                : null;
+
+        return new SnapshotReference(snapshotName, new ETag(snapshotETag), snapshotFormat, snapshotLength);
+    }
+
+    private static IJournalFileMetadata ValidateSnapshotMetadata(
+        SnapshotReference snapshot,
+        BlobDownloadDetails snapshotDetails,
+        IDictionary<string, string>? markerMetadata)
+    {
+        if (snapshotDetails.ContentLength != snapshot.Length)
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal snapshot '{snapshot.Name}' length is {snapshotDetails.ContentLength}, but marker metadata expected {snapshot.Length}.");
+        }
+
+        var markerFormat = GetFormatKeyMetadata(markerMetadata);
+        var snapshotBlobFormat = GetFormatKeyMetadata(snapshotDetails.Metadata);
+        if (snapshot.Format is { } markerSnapshotFormat
+            && snapshotBlobFormat is { }
+            && !string.Equals(markerSnapshotFormat, snapshotBlobFormat, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal snapshot '{snapshot.Name}' format metadata is '{snapshotBlobFormat}', but marker metadata expected '{markerSnapshotFormat}'.");
+        }
+
+        var effectiveSnapshotFormat = snapshot.Format ?? snapshotBlobFormat;
+        if (markerFormat is { } tailFormat
+            && effectiveSnapshotFormat is { }
+            && !string.Equals(tailFormat, effectiveSnapshotFormat, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal append tail format metadata is '{tailFormat}', but snapshot '{snapshot.Name}' uses format '{effectiveSnapshotFormat}'.");
+        }
+
+        if (markerFormat is { } && effectiveSnapshotFormat is null)
+        {
+            throw new InvalidOperationException(
+                $"Azure Blob journal snapshot '{snapshot.Name}' does not include format metadata.");
+        }
+
+        return effectiveSnapshotFormat is { } format
+            ? new JournalFileMetadata(format)
+            : JournalFileMetadata.Empty;
+    }
+
     [LoggerMessage(
         Level = LogLevel.Debug,
         Message = "Appended {Length} bytes to blob \"{ContainerName}/{BlobName}\"")]
@@ -215,8 +368,118 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     [LoggerMessage(
         Level = LogLevel.Debug,
-        Message = "Replaced blob \"{ContainerName}/{BlobName}\", writing {Length} bytes")]
+        Message = "Replaced blob \"{ContainerName}/{BlobName}\" with snapshot containing {Length} bytes")]
     private static partial void LogReplace(ILogger logger, string containerName, string blobName, long length);
+
+    private sealed record SnapshotReference(string Name, ETag ETag, string? Format, long Length);
+
+    private sealed class ConcatenatedReadStream(Stream first, Stream second) : Stream
+    {
+        // The caller owns and disposes the underlying streams.
+        private Stream? _current = first;
+        private Stream? _next = second;
+        private bool _disposed;
+
+        public override bool CanRead => !_disposed;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw GetSeekNotSupportedException();
+
+        public override long Position
+        {
+            get => throw GetSeekNotSupportedException();
+            set => throw GetSeekNotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            ThrowIfDisposed();
+            while (_current is not null)
+            {
+                var bytesRead = _current.Read(buffer);
+                if (bytesRead != 0 || _next is null)
+                {
+                    return bytesRead;
+                }
+
+                _current = _next;
+                _next = null;
+            }
+
+            return 0;
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            while (_current is not null)
+            {
+                var bytesRead = await _current.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                if (bytesRead != 0 || _next is null)
+                {
+                    return bytesRead;
+                }
+
+                _current = _next;
+                _next = null;
+            }
+
+            return 0;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw GetSeekNotSupportedException();
+
+        public override void SetLength(long value) => throw GetReadOnlyException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw GetReadOnlyException();
+
+        public override void Write(ReadOnlySpan<byte> buffer) => throw GetReadOnlyException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !_disposed)
+            {
+                _current = null;
+                _next = null;
+                _disposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            if (!_disposed)
+            {
+                _current = null;
+                _next = null;
+                _disposed = true;
+            }
+
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(ConcatenatedReadStream));
+            }
+        }
+
+        private static NotSupportedException GetSeekNotSupportedException() => new("This stream does not support seeking.");
+
+        private static NotSupportedException GetReadOnlyException() => new("This stream is read-only.");
+    }
 
     private sealed class ReadOnlySequenceStream(ReadOnlySequence<byte> sequence) : Stream
     {

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -25,9 +25,9 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     // to roll before hitting the hard Azure limit if a consumer ignores compaction requests.
     private const int AppendBlobBlockCeilingHeadroom = 100;
 
-    private AppendBlobClient _currentLogClient;
     private readonly SharedConfiguration _shared;
     private readonly IGrainContext _grainContext;
+    private AppendBlobClient _currentLogClient;
     private uint _currentGeneration;
     private uint _currentSegmentId;
     private int _numBlocks;

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -1,9 +1,11 @@
 using System.Buffers;
 using System.Globalization;
 using Azure;
+using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
 using Orleans.Serialization.Buffers;
 
 namespace Orleans.Journaling;
@@ -29,22 +31,21 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private const int AppendBlobBlockCeilingHeadroom = 100;
 
     private readonly AppendBlobClient _rootLogClient;
-    private readonly Func<ulong, uint, string> _walNameFactory;
-    private readonly Func<ulong, uint, AppendBlobClient> _walClientFactory;
-    private readonly Func<ulong, string> _checkpointNameFactory;
-    private readonly Func<string, BlockBlobClient> _checkpointClientFactory;
+    private readonly BlobClientProvider _blobClientProvider;
     private readonly string? _mimeType;
     private readonly string? _journalFormatKey;
     private readonly ILogger<AzureBlobJournalStorage> _logger;
     private AppendBlobClient _currentLogClient;
     private ulong _currentGeneration;
     private uint _currentSegmentId;
-    private bool _rootExists;
-    private bool _currentSegmentExists;
     private long _appendPosition;
     private int _numBlocks;
     private ETag _currentSegmentETag;
     private ETag _rootLogETag;
+
+    private bool CurrentSegmentExists => _currentSegmentETag != default;
+
+    private bool RootExists => _rootLogETag != default;
 
     public bool IsCompactionRequested => _numBlocks > 10;
 
@@ -63,19 +64,13 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         string? mimeType,
         ILogger<AzureBlobJournalStorage> logger,
         string? journalFormatKey = null,
-        Func<ulong, uint, string>? walNameFactory = null,
-        Func<ulong, uint, AppendBlobClient>? walClientFactory = null,
-        Func<ulong, string>? checkpointNameFactory = null,
-        Func<string, BlockBlobClient>? checkpointClientFactory = null)
+        BlobClientProvider? blobClientProvider = null)
     {
         ArgumentNullException.ThrowIfNull(client);
 
         _rootLogClient = client;
         _currentLogClient = client;
-        _walNameFactory = walNameFactory ?? CreateDefaultWalNameFactory(client);
-        _walClientFactory = walClientFactory ?? CreateDefaultWalClientFactory(client);
-        _checkpointNameFactory = checkpointNameFactory ?? CreateDefaultCheckpointNameFactory(client);
-        _checkpointClientFactory = checkpointClientFactory ?? CreateDefaultCheckpointClientFactory(client);
+        _blobClientProvider = blobClientProvider ?? DefaultBlobClientProvider.Instance;
         _mimeType = mimeType;
         _journalFormatKey = journalFormatKey;
         _logger = logger;
@@ -84,7 +79,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     public async ValueTask AppendAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
         ThrowIfBatchTooLarge(value.Length);
-        if (_currentSegmentExists && _numBlocks >= MaxAppendBlobBlocks - AppendBlobBlockCeilingHeadroom)
+        if (CurrentSegmentExists && _numBlocks >= MaxAppendBlobBlocks - AppendBlobBlockCeilingHeadroom)
         {
             await RollToNextSegmentAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -114,7 +109,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 if (_currentSegmentId == 0)
                 {
                     _rootLogETag = result.Value.ETag;
-                    _rootExists = true;
                 }
 
                 return;
@@ -140,12 +134,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     public async ValueTask DeleteAsync(CancellationToken cancellationToken)
     {
-        if (!_rootExists)
+        if (!RootExists)
         {
             return;
         }
 
-        if (_currentSegmentExists)
+        if (CurrentSegmentExists)
         {
             await SealCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -166,7 +160,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
 
         _currentGeneration = generation;
-        _rootExists = true;
         SetCurrentSegment(segmentId: 0, exists: true, response.Value.ETag, appendPosition: 0, blockCount: 0);
     }
 
@@ -182,7 +175,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         catch (RequestFailedException exception) when (exception.Status is 404)
         {
             _currentGeneration = 0;
-            _rootExists = false;
             SetCurrentSegment(segmentId: 0, exists: false, eTag: default, appendPosition: 0, blockCount: 0);
             _rootLogETag = default;
             consumer.Complete(metadata: null);
@@ -191,18 +183,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
         await using var rootStream = rootResult.Value.Content;
         _rootLogETag = rootResult.Value.Details.ETag;
-        _rootExists = true;
         var manifest = CreateRootManifest(rootResult.Value.Details.Metadata);
         _currentGeneration = manifest.Generation;
         var expectedFormat = manifest.Metadata.Format;
         if (manifest.Checkpoint is { } checkpoint)
         {
-            var checkpointClient = _checkpointClientFactory(checkpoint.Name);
-            if (checkpointClient is null)
-            {
-                throw new InvalidOperationException("The configured Azure Blob journal checkpoint client factory returned null.");
-            }
-
+            var checkpointClient = GetCheckpointClient(checkpoint.Name);
             var checkpointResult = await checkpointClient.DownloadStreamingAsync(
                 new BlobDownloadOptions
                 {
@@ -232,7 +218,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     public async ValueTask ReplaceAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
-        if (!_currentSegmentExists)
+        if (!CurrentSegmentExists)
         {
             await EnsureCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -242,18 +228,8 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         using var checkpointStream = new ReadOnlySequenceStream(value);
         while (true)
         {
-            var checkpointName = _checkpointNameFactory(generation);
-            if (string.IsNullOrWhiteSpace(checkpointName))
-            {
-                throw new InvalidOperationException("The configured Azure Blob journal checkpoint name factory returned an empty blob name.");
-            }
-
-            var checkpointClient = _checkpointClientFactory(checkpointName);
-            if (checkpointClient is null)
-            {
-                throw new InvalidOperationException("The configured Azure Blob journal checkpoint client factory returned null.");
-            }
-
+            var checkpointName = GetCheckpointName(generation);
+            var checkpointClient = GetCheckpointClient(checkpointName);
             try
             {
                 checkpointStream.Position = 0;
@@ -282,7 +258,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 }
 
                 _currentGeneration = generation;
-                _rootExists = true;
                 SetCurrentSegment(segmentId: 0, exists: true, rootResult.Value.ETag, appendPosition: 0, blockCount: 0);
                 LogReplace(_logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
                 return;
@@ -304,7 +279,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private async ValueTask EnsureCurrentSegmentAsync(CancellationToken cancellationToken)
     {
-        if (_currentSegmentExists)
+        if (CurrentSegmentExists)
         {
             return;
         }
@@ -323,7 +298,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             catch (RequestFailedException exception) when (IsBlobAlreadyExists(exception))
             {
                 await ReadAsync(DiscardingJournalStorageConsumer.Instance, cancellationToken).ConfigureAwait(false);
-                if (!_currentSegmentExists)
+                if (!CurrentSegmentExists)
                 {
                     await EnsureCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
                 }
@@ -331,7 +306,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 return;
             }
 
-            _rootExists = true;
         }
         else
         {
@@ -345,7 +319,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private async ValueTask RollToNextSegmentAsync(CancellationToken cancellationToken)
     {
-        if (_currentSegmentExists)
+        if (CurrentSegmentExists)
         {
             await SealCurrentSegmentAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -355,7 +329,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private async ValueTask SealCurrentSegmentAsync(CancellationToken cancellationToken)
     {
-        if (!_currentSegmentExists)
+        if (!CurrentSegmentExists)
         {
             return;
         }
@@ -367,7 +341,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         if (_currentSegmentId == 0)
         {
             _rootLogETag = response.Value.ETag;
-            _rootExists = true;
         }
     }
 
@@ -439,7 +412,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 if (offset > details.ContentLength)
                 {
                     throw new InvalidOperationException(
-                        $"Azure Blob journal checkpoint points to offset {offset:N0} in segment {GetWalName(segmentId)}, but the segment length is {details.ContentLength:N0}.");
+                        $"Azure Blob journal checkpoint points to offset {offset:N0} in segment {client.Name}, but the segment length is {details.ContentLength:N0}.");
                 }
 
                 if (offset > 0)
@@ -448,7 +421,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 }
 
                 var bytesRead = await ReadStreamAsync(consumer, stream, metadata, complete: false, cancellationToken).ConfigureAwait(false);
-                LogRead(_logger, bytesRead, _rootLogClient.BlobContainerName, GetWalName(segmentId));
+                LogRead(_logger, bytesRead, _rootLogClient.BlobContainerName, client.Name);
 
                 if (!details.IsSealed)
                 {
@@ -467,14 +440,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     {
         _currentSegmentId = segmentId;
         _currentLogClient = GetWalClient(segmentId);
-        _currentSegmentExists = exists;
-        _currentSegmentETag = eTag;
+        _currentSegmentETag = exists ? eTag : default;
         _appendPosition = appendPosition;
         _numBlocks = blockCount;
         if (segmentId == 0)
         {
-            _rootLogETag = eTag;
-            _rootExists = exists;
+            _rootLogETag = exists ? eTag : default;
         }
     }
 
@@ -485,12 +456,9 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             return _rootLogClient;
         }
 
-        var client = _walClientFactory(_currentGeneration, checked(segmentId - 1));
-        return client ?? throw new InvalidOperationException("The configured Azure Blob journal WAL client factory returned null.");
+        var client = _blobClientProvider.GetWalClient(_rootLogClient, _currentGeneration, checked(segmentId - 1));
+        return client ?? throw new InvalidOperationException("The configured Azure Blob journal WAL client provider returned null.");
     }
-
-    private string GetWalName(uint segmentId)
-        => segmentId == 0 ? _rootLogClient.Name : _walNameFactory(_currentGeneration, checked(segmentId - 1));
 
     private AppendBlobCreateOptions CreateOptions(AppendBlobRequestConditions conditions) => new()
     {
@@ -518,26 +486,22 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private static BlobHttpHeaders? CreateHttpHeaders(string? contentType)
         => contentType is { Length: > 0 } ? new BlobHttpHeaders { ContentType = contentType } : null;
 
-    private static Func<ulong, uint, string> CreateDefaultWalNameFactory(AppendBlobClient client)
+    private string GetCheckpointName(ulong generation)
     {
-        var journalId = GetJournalId(client.Name);
-        return (generation, segmentId) => $"{journalId}/{FormatGeneration(generation)}/seg.{segmentId:X8}";
+        var checkpointName = _blobClientProvider.GetCheckpointName(_rootLogClient, generation);
+        if (string.IsNullOrWhiteSpace(checkpointName))
+        {
+            throw new InvalidOperationException("The configured Azure Blob journal checkpoint client provider returned an empty blob name.");
+        }
+
+        return checkpointName;
     }
 
-    private static Func<ulong, uint, AppendBlobClient> CreateDefaultWalClientFactory(AppendBlobClient client)
+    private BlockBlobClient GetCheckpointClient(string checkpointName)
     {
-        var journalId = GetJournalId(client.Name);
-        return (generation, segmentId) => client.GetParentBlobContainerClient().GetAppendBlobClient($"{journalId}/{FormatGeneration(generation)}/seg.{segmentId:X8}");
+        var client = _blobClientProvider.GetCheckpointClient(_rootLogClient, checkpointName);
+        return client ?? throw new InvalidOperationException("The configured Azure Blob journal checkpoint client provider returned null.");
     }
-
-    private static Func<ulong, string> CreateDefaultCheckpointNameFactory(AppendBlobClient client)
-    {
-        var journalId = GetJournalId(client.Name);
-        return generation => $"{journalId}/{FormatGeneration(generation)}/chk";
-    }
-
-    private static Func<string, BlockBlobClient> CreateDefaultCheckpointClientFactory(AppendBlobClient client)
-        => checkpointName => client.GetParentBlobContainerClient().GetBlockBlobClient(checkpointName);
 
     private static string GetJournalId(string rootName)
         => rootName.EndsWith("/root", StringComparison.Ordinal)
@@ -814,6 +778,45 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private sealed record CheckpointReference(string Name, ETag ETag, ulong Generation, string? Format, long Length);
 
     private sealed record CheckpointPublication(string Name, ETag ETag, long Length);
+
+    internal abstract class BlobClientProvider
+    {
+        public abstract AppendBlobClient GetWalClient(AppendBlobClient rootLogClient, ulong generation, uint segmentId);
+
+        public abstract string GetCheckpointName(AppendBlobClient rootLogClient, ulong generation);
+
+        public abstract BlockBlobClient GetCheckpointClient(AppendBlobClient rootLogClient, string checkpointName);
+    }
+
+    internal sealed class OptionsBlobClientProvider(
+        BlobContainerClient containerClient,
+        AzureBlobJournalStorageOptions options,
+        GrainId grainId) : BlobClientProvider
+    {
+        public override AppendBlobClient GetWalClient(AppendBlobClient rootLogClient, ulong generation, uint segmentId)
+            => containerClient.GetAppendBlobClient(options.GetWalSegmentBlobNameForJournal(grainId, GetJournalId(rootLogClient.Name), generation, segmentId));
+
+        public override string GetCheckpointName(AppendBlobClient rootLogClient, ulong generation)
+            => options.GetCheckpointBlobNameForJournal(grainId, GetJournalId(rootLogClient.Name), generation);
+
+        public override BlockBlobClient GetCheckpointClient(AppendBlobClient rootLogClient, string checkpointName)
+            => containerClient.GetBlockBlobClient(checkpointName);
+    }
+
+    private sealed class DefaultBlobClientProvider : BlobClientProvider
+    {
+        public static DefaultBlobClientProvider Instance { get; } = new();
+
+        public override AppendBlobClient GetWalClient(AppendBlobClient rootLogClient, ulong generation, uint segmentId)
+            => rootLogClient.GetParentBlobContainerClient().GetAppendBlobClient(
+                AzureBlobJournalStorageOptions.GetDefaultWalSegmentBlobName(GetJournalId(rootLogClient.Name), generation, segmentId));
+
+        public override string GetCheckpointName(AppendBlobClient rootLogClient, ulong generation)
+            => AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName(GetJournalId(rootLogClient.Name), generation);
+
+        public override BlockBlobClient GetCheckpointClient(AppendBlobClient rootLogClient, string checkpointName)
+            => rootLogClient.GetParentBlobContainerClient().GetBlockBlobClient(checkpointName);
+    }
 
     private sealed class DiscardingJournalStorageConsumer : IJournalStorageConsumer
     {

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -32,7 +32,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     // IsCompactionRequested trips at this block count so callers compact before the hard append-blob limit.
     private const int RequestCompactionBlockCount = 49_000;
 
-    private readonly SharedConfiguration _shared;
+    private readonly AzureBlobJournalStorageShared _shared;
     private readonly JournalId _journalId;
     private readonly AppendBlobClient _walClient;
     private int _numBlocks;
@@ -43,7 +43,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     public bool IsCompactionRequested => _numBlocks > RequestCompactionBlockCount;
 
     internal AzureBlobJournalStorage(
-        SharedConfiguration shared,
+        AzureBlobJournalStorageShared shared,
         JournalId journalId)
     {
         ArgumentNullException.ThrowIfNull(shared);
@@ -596,9 +596,9 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     private readonly record struct CheckpointReference(string Name, long WalOffset);
 
-    internal sealed class SharedConfiguration
+    internal sealed class AzureBlobJournalStorageShared
     {
-        public SharedConfiguration(
+        public AzureBlobJournalStorageShared(
             ILogger<AzureBlobJournalStorage> logger,
             IOptions<AzureBlobJournalStorageOptions> options,
             BlobClientProvider blobClientProvider,

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -4,6 +4,8 @@ using Azure;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Storage;
 
 namespace Orleans.Journaling;
 
@@ -31,7 +33,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private const int RequestCompactionBlockCount = 49_000;
 
     private readonly SharedConfiguration _shared;
-    private readonly IGrainContext _grainContext;
+    private readonly JournalId _journalId;
     private readonly AppendBlobClient _walClient;
     private int _numBlocks;
     private ETag _walETag;
@@ -42,13 +44,16 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     internal AzureBlobJournalStorage(
         SharedConfiguration shared,
-        IGrainContext grainContext)
+        JournalId journalId)
     {
         ArgumentNullException.ThrowIfNull(shared);
-        ArgumentNullException.ThrowIfNull(grainContext);
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
 
         _shared = shared;
-        _grainContext = grainContext;
+        _journalId = journalId;
         _walClient = GetWalClient();
     }
 
@@ -87,11 +92,17 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
         catch (RequestFailedException exception) when (IsBlobSealed(exception))
         {
-            throw new InvalidOperationException("Azure Blob journal WAL is sealed; recovery is required before appending.", exception);
+            throw CreateInconsistentWalStateException(
+                "Azure Blob journal WAL is sealed; recovery is required before appending.",
+                _walETag,
+                exception);
         }
         catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
         {
-            throw new InvalidOperationException("Azure Blob journal WAL changed while appending; recovery is required.", exception);
+            throw CreateInconsistentWalStateException(
+                "Azure Blob journal WAL changed while appending; recovery is required.",
+                _walETag,
+                exception);
         }
     }
 
@@ -106,11 +117,21 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
         catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
         {
-            throw new InvalidOperationException("Azure Blob journal WAL changed while deleting the journal; recovery is required.", exception);
+            throw CreateInconsistentWalStateException(
+                "Azure Blob journal WAL changed while deleting the journal; recovery is required.",
+                _walETag,
+                exception);
         }
 
         if (walState is null)
         {
+            if (conditions is not null)
+            {
+                throw CreateInconsistentWalStateException(
+                    "Azure Blob journal WAL changed while deleting the journal; recovery is required.",
+                    _walETag);
+            }
+
             return;
         }
 
@@ -127,7 +148,10 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
         catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
         {
-            throw new InvalidOperationException("Azure Blob journal WAL changed while deleting the journal; recovery is required.", exception);
+            throw CreateInconsistentWalStateException(
+                "Azure Blob journal WAL changed while deleting the journal; recovery is required.",
+                walState.Value.ETag,
+                exception);
         }
 
         if (checkpointName is not null)
@@ -214,24 +238,35 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         // Compaction publishes through WAL metadata, so first recover or create the WAL whose ETag will be checked.
         await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
 
-        // Snapshot the current WAL ETag, then read its manifest under that ETag before publishing a checkpoint.
-        var walETag = _walETag;
-        WalState? walState;
-        try
+        var expectedWalETag = _walETag;
+        string? previousCheckpointName = null;
+        if (_shared.Options.DeleteOldCheckpoints)
         {
-            walState = await TryLoadWalStateAsync(new BlobRequestConditions { IfMatch = walETag }, cancellationToken).ConfigureAwait(false);
-        }
-        catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
-        {
-            throw new InvalidOperationException("Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.", exception);
+            // Read the WAL manifest only when cleanup needs the previous checkpoint name, and require the cached ETag to still match.
+            WalState? walState;
+            try
+            {
+                walState = await TryLoadWalStateAsync(new BlobRequestConditions { IfMatch = expectedWalETag }, cancellationToken).ConfigureAwait(false);
+
+                if (walState is null)
+                {
+                    throw CreateInconsistentWalStateException(
+                        "Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.",
+                        expectedWalETag);
+                }
+            }
+            catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
+            {
+                throw CreateInconsistentWalStateException(
+                    "Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.",
+                    expectedWalETag,
+                    exception);
+            }
+
+            expectedWalETag = walState.Value.ETag;
+            previousCheckpointName = walState.Value.Manifest.Checkpoint?.Name;
         }
 
-        if (walState is null)
-        {
-            throw new InvalidOperationException("Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.");
-        }
-
-        var previousCheckpointName = walState.Value.Manifest.Checkpoint?.Name;
         using var checkpointStream = new ReadOnlySequenceStream(value);
         while (true)
         {
@@ -263,13 +298,16 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 // Recreate the WAL under its ETag to publish the checkpoint only if the existing WAL is unchanged.
                 var result = await CreateWalAsync(
                     checkpointName,
-                    new AppendBlobRequestConditions { IfMatch = walState.Value.ETag },
+                    new AppendBlobRequestConditions { IfMatch = expectedWalETag },
                     cancellationToken).ConfigureAwait(false);
                 SetWal(result.Value.ETag, blockCount: 0);
             }
             catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
             {
-                throw new InvalidOperationException("Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.", exception);
+                throw CreateInconsistentWalStateException(
+                    "Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.",
+                    expectedWalETag,
+                    exception);
             }
 
             if (previousCheckpointName is not null && !string.Equals(previousCheckpointName, checkpointName, StringComparison.Ordinal))
@@ -367,7 +405,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private AppendBlobClient GetWalClient()
     {
         // Resolve the provider-specific WAL client once; checkpoint clients are resolved by published name.
-        var client = _shared.BlobClientProvider.GetWalClient(_grainContext.GrainId);
+        var client = _shared.BlobClientProvider.GetWalClient(_journalId);
         return client ?? throw new InvalidOperationException("The configured Azure Blob journal WAL client provider returned null.");
     }
 
@@ -396,7 +434,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private string GetCheckpointName(string snapshotId)
     {
         // Let the configured provider own checkpoint naming so custom layouts stay consistent with WAL naming.
-        var checkpointName = _shared.BlobClientProvider.GetCheckpointName(_grainContext.GrainId, snapshotId);
+        var checkpointName = _shared.BlobClientProvider.GetCheckpointName(_journalId, snapshotId);
         if (string.IsNullOrWhiteSpace(checkpointName))
         {
             throw new InvalidOperationException("The configured Azure Blob journal checkpoint client provider returned an empty blob name.");
@@ -408,7 +446,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     private BlockBlobClient GetCheckpointClient(string checkpointName)
     {
         // Resolve by the published checkpoint name so recovery can open checkpoints created by older instances.
-        var client = _shared.BlobClientProvider.GetCheckpointClient(_grainContext.GrainId, checkpointName);
+        var client = _shared.BlobClientProvider.GetCheckpointClient(_journalId, checkpointName);
         return client ?? throw new InvalidOperationException("The configured Azure Blob journal checkpoint client provider returned null.");
     }
 
@@ -524,6 +562,14 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             || exception.Status == 409 && string.Equals(exception.ErrorCode, "ConditionNotMet", StringComparison.Ordinal);
     }
 
+    private static InconsistentStateException CreateInconsistentWalStateException(string message, ETag expectedETag, Exception? exception = null)
+    {
+        var currentETag = expectedETag == default ? "Unknown" : expectedETag.ToString();
+        return exception is null
+            ? new InconsistentStateException(message, storedEtag: "Unknown", currentEtag: currentETag)
+            : new InconsistentStateException(message, storedEtag: "Unknown", currentEtag: currentETag, exception);
+    }
+
     [LoggerMessage(
         Level = LogLevel.Debug,
         Message = "Appended {Length} bytes to blob \"{ContainerName}/{BlobName}\"")]
@@ -554,20 +600,25 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     {
         public SharedConfiguration(
             ILogger<AzureBlobJournalStorage> logger,
+            IOptions<AzureBlobJournalStorageOptions> options,
             BlobClientProvider blobClientProvider,
             string? mimeType = null,
             string? journalFormatKey = null)
         {
             ArgumentNullException.ThrowIfNull(logger);
+            ArgumentNullException.ThrowIfNull(options);
             ArgumentNullException.ThrowIfNull(blobClientProvider);
 
             Logger = logger;
+            Options = options.Value;
             MimeType = mimeType;
             JournalFormatKey = journalFormatKey;
             BlobClientProvider = blobClientProvider;
         }
 
         public ILogger<AzureBlobJournalStorage> Logger { get; }
+
+        public AzureBlobJournalStorageOptions Options { get; }
 
         public string? MimeType { get; }
 
@@ -578,25 +629,25 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
     internal abstract class BlobClientProvider
     {
-        public abstract AppendBlobClient GetWalClient(GrainId grainId);
+        public abstract AppendBlobClient GetWalClient(JournalId journalId);
 
-        public abstract string GetCheckpointName(GrainId grainId, string snapshotId);
+        public abstract string GetCheckpointName(JournalId journalId, string snapshotId);
 
-        public abstract BlockBlobClient GetCheckpointClient(GrainId grainId, string checkpointName);
+        public abstract BlockBlobClient GetCheckpointClient(JournalId journalId, string checkpointName);
     }
 
     internal sealed class OptionsBlobClientProvider(
         IBlobContainerFactory containerFactory,
         AzureBlobJournalStorageOptions options) : BlobClientProvider
     {
-        public override AppendBlobClient GetWalClient(GrainId grainId)
-            => containerFactory.GetBlobContainerClient(grainId).GetAppendBlobClient(
-                options.GetWalBlobNameForJournal(grainId, options.GetBlobNameForJournal(grainId)));
+        public override AppendBlobClient GetWalClient(JournalId journalId)
+            => containerFactory.GetBlobContainerClient(journalId).GetAppendBlobClient(
+                AzureBlobJournalStorageOptions.GetWalBlobNameForJournal(journalId, options.GetBlobNameForJournal(journalId)));
 
-        public override string GetCheckpointName(GrainId grainId, string snapshotId)
-            => options.GetCheckpointBlobNameForJournal(grainId, options.GetBlobNameForJournal(grainId), snapshotId);
+        public override string GetCheckpointName(JournalId journalId, string snapshotId)
+            => AzureBlobJournalStorageOptions.GetCheckpointBlobNameForJournal(journalId, options.GetBlobNameForJournal(journalId), snapshotId);
 
-        public override BlockBlobClient GetCheckpointClient(GrainId grainId, string checkpointName)
-            => containerFactory.GetBlobContainerClient(grainId).GetBlockBlobClient(checkpointName);
+        public override BlockBlobClient GetCheckpointClient(JournalId journalId, string checkpointName)
+            => containerFactory.GetBlobContainerClient(journalId).GetBlockBlobClient(checkpointName);
     }
 }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -12,12 +12,12 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 {
     internal const string FormatMetadataKey = "format";
     internal const string CheckpointMetadataKey = "checkpoint";
-    internal const string CheckpointETagMetadataKey = "checkpoint-etag";
-    internal const string CheckpointFormatMetadataKey = "checkpoint-format";
-    internal const string CheckpointIdMetadataKey = "checkpoint-id";
-    internal const string CheckpointLengthMetadataKey = "checkpoint-length";
-    internal const string CheckpointReplaySegmentMetadataKey = "checkpoint-replay-segment";
-    internal const string CheckpointReplayOffsetMetadataKey = "checkpoint-replay-offset";
+    internal const string CheckpointETagMetadataKey = "checkpoint_etag";
+    internal const string CheckpointFormatMetadataKey = "checkpoint_format";
+    internal const string CheckpointIdMetadataKey = "checkpoint_id";
+    internal const string CheckpointLengthMetadataKey = "checkpoint_length";
+    internal const string CheckpointReplaySegmentMetadataKey = "checkpoint_replay_segment";
+    internal const string CheckpointReplayOffsetMetadataKey = "checkpoint_replay_offset";
 
     // Azure Append Blob hard limits documented at:
     // https://learn.microsoft.com/azure/storage/blobs/scalability-targets#scale-targets-for-blob-storage

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
@@ -1,7 +1,8 @@
+using System.Globalization;
 using Azure;
-using Azure.Storage.Blobs;
-using Azure.Storage;
 using Azure.Core;
+using Azure.Storage;
+using Azure.Storage.Blobs;
 using Orleans.Runtime;
 
 namespace Orleans.Journaling;
@@ -32,7 +33,7 @@ public sealed class AzureBlobJournalStorageOptions
     public Func<AzureBlobJournalWalSegmentNameContext, string> GetWalSegmentBlobName { get; set; } = DefaultGetWalSegmentBlobName;
 
     private static readonly Func<AzureBlobJournalWalSegmentNameContext, string> DefaultGetWalSegmentBlobName =
-        static context => $"{context.JournalBlobName}.log.{context.SegmentId:X8}";
+        static context => $"{context.JournalBlobName}/{context.Generation.ToString(CultureInfo.InvariantCulture)}/seg.{context.SegmentId:X8}";
 
     /// <summary>
     /// Gets or sets the delegate used to generate block blob names for immutable journal checkpoints.
@@ -40,7 +41,7 @@ public sealed class AzureBlobJournalStorageOptions
     public Func<AzureBlobJournalCheckpointNameContext, string> GetCheckpointBlobName { get; set; } = DefaultGetCheckpointBlobName;
 
     private static readonly Func<AzureBlobJournalCheckpointNameContext, string> DefaultGetCheckpointBlobName =
-        static context => $"{context.JournalBlobName}.checkpoint.{context.CheckpointId:X8}";
+        static context => $"{context.JournalBlobName}/{context.Generation.ToString(CultureInfo.InvariantCulture)}/chk";
 
     /// <summary>
     /// Options to be used when configuring the blob storage client, or <see langword="null"/> to use the default options.
@@ -73,16 +74,22 @@ public sealed class AzureBlobJournalStorageOptions
         return blobName;
     }
 
-    internal string GetWalSegmentBlobNameForJournal(GrainId grainId, string journalBlobName, uint segmentId)
+    internal string GetRootBlobNameForJournal(GrainId grainId, string journalBlobName)
     {
-        var blobName = GetWalSegmentBlobName(new AzureBlobJournalWalSegmentNameContext(grainId, journalBlobName, segmentId));
+        ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
+        return $"{journalBlobName}/root";
+    }
+
+    internal string GetWalSegmentBlobNameForJournal(GrainId grainId, string journalBlobName, ulong generation, uint segmentId)
+    {
+        var blobName = GetWalSegmentBlobName(new AzureBlobJournalWalSegmentNameContext(grainId, journalBlobName, generation, segmentId));
         ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
         return blobName;
     }
 
-    internal string GetCheckpointBlobNameForJournal(GrainId grainId, string journalBlobName, uint checkpointId)
+    internal string GetCheckpointBlobNameForJournal(GrainId grainId, string journalBlobName, ulong generation)
     {
-        var blobName = GetCheckpointBlobName(new AzureBlobJournalCheckpointNameContext(grainId, journalBlobName, checkpointId));
+        var blobName = GetCheckpointBlobName(new AzureBlobJournalCheckpointNameContext(grainId, journalBlobName, generation));
         ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
         return blobName;
     }
@@ -160,13 +167,15 @@ public sealed class AzureBlobJournalWalSegmentNameContext
     /// </summary>
     /// <param name="grainId">The grain id associated with the journal.</param>
     /// <param name="journalBlobName">The base blob name used for the journal.</param>
+    /// <param name="generation">The journal generation.</param>
     /// <param name="segmentId">The WAL segment id.</param>
-    public AzureBlobJournalWalSegmentNameContext(GrainId grainId, string journalBlobName, uint segmentId)
+    public AzureBlobJournalWalSegmentNameContext(GrainId grainId, string journalBlobName, ulong generation, uint segmentId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
 
         GrainId = grainId;
         JournalBlobName = journalBlobName;
+        Generation = generation;
         SegmentId = segmentId;
     }
 
@@ -179,6 +188,11 @@ public sealed class AzureBlobJournalWalSegmentNameContext
     /// Gets the base blob name used for the journal.
     /// </summary>
     public string JournalBlobName { get; }
+
+    /// <summary>
+    /// Gets the journal generation.
+    /// </summary>
+    public ulong Generation { get; }
 
     /// <summary>
     /// Gets the WAL segment id.
@@ -196,14 +210,14 @@ public sealed class AzureBlobJournalCheckpointNameContext
     /// </summary>
     /// <param name="grainId">The grain id associated with the journal.</param>
     /// <param name="journalBlobName">The base blob name used for the journal.</param>
-    /// <param name="checkpointId">The checkpoint id.</param>
-    public AzureBlobJournalCheckpointNameContext(GrainId grainId, string journalBlobName, uint checkpointId)
+    /// <param name="generation">The journal generation.</param>
+    public AzureBlobJournalCheckpointNameContext(GrainId grainId, string journalBlobName, ulong generation)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
 
         GrainId = grainId;
         JournalBlobName = journalBlobName;
-        CheckpointId = checkpointId;
+        Generation = generation;
     }
 
     /// <summary>
@@ -217,7 +231,7 @@ public sealed class AzureBlobJournalCheckpointNameContext
     public string JournalBlobName { get; }
 
     /// <summary>
-    /// Gets the checkpoint id.
+    /// Gets the journal generation.
     /// </summary>
-    public uint CheckpointId { get; }
+    public ulong Generation { get; }
 }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
@@ -10,8 +10,6 @@ namespace Orleans.Journaling;
 /// </summary>
 public sealed class AzureBlobJournalStorageOptions
 {
-    private BlobServiceClient? _blobServiceClient;
-
     /// <summary>
     /// Container name where state is stored.
     /// </summary>
@@ -19,11 +17,11 @@ public sealed class AzureBlobJournalStorageOptions
     public const string DEFAULT_CONTAINER_NAME = "state";
 
     /// <summary>
-    /// Gets or sets the delegate used to generate the blob name for a given grain.
+    /// Gets or sets the delegate used to generate the blob name for a journal.
     /// </summary>
-    public Func<GrainId, string> GetBlobName { get; set; } = DefaultGetBlobName;
+    public Func<JournalId, string> GetBlobName { get; set; } = DefaultGetBlobName;
 
-    private static readonly Func<GrainId, string> DefaultGetBlobName = static grainId => grainId.ToString();
+    private static readonly Func<JournalId, string> DefaultGetBlobName = static journalId => journalId.Value;
 
     /// <summary>
     /// Options to be used when configuring the blob storage client, or <see langword="null"/> to use the default options.
@@ -35,34 +33,44 @@ public sealed class AzureBlobJournalStorageOptions
     /// </summary>
     public BlobServiceClient? BlobServiceClient
     {
-        get => _blobServiceClient;
+        get;
         set
         {
             ArgumentNullException.ThrowIfNull(value);
-            _blobServiceClient = value;
+            field = value;
             CreateClient = ct => Task.FromResult(value);
         }
     }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether obsolete checkpoint blobs are deleted after a new checkpoint is published. Defaults to true.
+    /// </summary>
+    public bool DeleteOldCheckpoints { get; set; } = true;
 
     /// <summary>
     /// The optional delegate used to create a <see cref="BlobServiceClient"/> instance.
     /// </summary>
     internal Func<CancellationToken, Task<BlobServiceClient>>? CreateClient { get; private set; }
 
-    internal string GetBlobNameForJournal(GrainId grainId)
+    internal string GetBlobNameForJournal(JournalId journalId)
     {
-        var blobName = GetBlobName(grainId);
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
+
+        var blobName = GetBlobName(journalId);
         ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
         return blobName;
     }
 
-    internal string GetWalBlobNameForJournal(GrainId grainId, string journalBlobName)
+    internal static string GetWalBlobNameForJournal(JournalId journalId, string journalBlobName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
         return GetDefaultWalBlobName(journalBlobName);
     }
 
-    internal string GetCheckpointBlobNameForJournal(GrainId grainId, string journalBlobName, string snapshotId)
+    internal static string GetCheckpointBlobNameForJournal(JournalId journalId, string journalBlobName, string snapshotId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
         ArgumentException.ThrowIfNullOrWhiteSpace(snapshotId);

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Azure;
 using Azure.Core;
 using Azure.Storage;
@@ -25,22 +24,6 @@ public sealed class AzureBlobJournalStorageOptions
     public Func<GrainId, string> GetBlobName { get; set; } = DefaultGetBlobName;
 
     private static readonly Func<GrainId, string> DefaultGetBlobName = static grainId => grainId.ToString();
-
-    /// <summary>
-    /// Gets or sets the delegate used to generate append blob names for journal WAL segments.
-    /// </summary>
-    public Func<AzureBlobJournalWalSegmentNameContext, string> GetWalSegmentBlobName { get; set; } = DefaultGetWalSegmentBlobName;
-
-    private static readonly Func<AzureBlobJournalWalSegmentNameContext, string> DefaultGetWalSegmentBlobName =
-        static context => GetDefaultWalSegmentBlobName(context.JournalBlobName, context.Generation, context.SegmentId);
-
-    /// <summary>
-    /// Gets or sets the delegate used to generate block blob names for immutable journal checkpoints.
-    /// </summary>
-    public Func<AzureBlobJournalCheckpointNameContext, string> GetCheckpointBlobName { get; set; } = DefaultGetCheckpointBlobName;
-
-    private static readonly Func<AzureBlobJournalCheckpointNameContext, string> DefaultGetCheckpointBlobName =
-        static context => GetDefaultCheckpointBlobName(context.JournalBlobName, context.Generation);
 
     /// <summary>
     /// Options to be used when configuring the blob storage client, or <see langword="null"/> to use the default options.
@@ -73,35 +56,24 @@ public sealed class AzureBlobJournalStorageOptions
         return blobName;
     }
 
-    internal string GetRootBlobNameForJournal(GrainId grainId, string journalBlobName)
+    internal string GetWalBlobNameForJournal(GrainId grainId, string journalBlobName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
-        return $"{journalBlobName}/root";
+        return GetDefaultWalBlobName(journalBlobName);
     }
 
-    internal string GetWalSegmentBlobNameForJournal(GrainId grainId, string journalBlobName, ulong generation, uint segmentId)
+    internal string GetCheckpointBlobNameForJournal(GrainId grainId, string journalBlobName, string snapshotId)
     {
-        var blobName = ReferenceEquals(GetWalSegmentBlobName, DefaultGetWalSegmentBlobName)
-            ? GetDefaultWalSegmentBlobName(journalBlobName, generation, segmentId)
-            : GetWalSegmentBlobName(new AzureBlobJournalWalSegmentNameContext(grainId, journalBlobName, generation, segmentId));
-        ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
-        return blobName;
+        ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(snapshotId);
+        return GetDefaultCheckpointBlobName(journalBlobName, snapshotId);
     }
 
-    internal string GetCheckpointBlobNameForJournal(GrainId grainId, string journalBlobName, ulong generation)
-    {
-        var blobName = ReferenceEquals(GetCheckpointBlobName, DefaultGetCheckpointBlobName)
-            ? GetDefaultCheckpointBlobName(journalBlobName, generation)
-            : GetCheckpointBlobName(new AzureBlobJournalCheckpointNameContext(grainId, journalBlobName, generation));
-        ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
-        return blobName;
-    }
+    internal static string GetDefaultWalBlobName(string journalBlobName)
+        => $"{journalBlobName}/wal";
 
-    internal static string GetDefaultWalSegmentBlobName(string journalBlobName, ulong generation, uint segmentId)
-        => $"{journalBlobName}/{generation.ToString(CultureInfo.InvariantCulture)}/seg.{segmentId:X8}";
-
-    internal static string GetDefaultCheckpointBlobName(string journalBlobName, ulong generation)
-        => $"{journalBlobName}/{generation.ToString(CultureInfo.InvariantCulture)}/chk";
+    internal static string GetDefaultCheckpointBlobName(string journalBlobName, string snapshotId)
+        => $"{journalBlobName}/chk.{snapshotId}";
 
     /// <summary>
     /// A function for building container factory instances.
@@ -164,83 +136,4 @@ public sealed class AzureBlobJournalStorageOptions
         ArgumentNullException.ThrowIfNull(sharedKeyCredential);
         CreateClient = ct => Task.FromResult(new BlobServiceClient(serviceUri, sharedKeyCredential, ClientOptions));
     }
-}
-
-/// <summary>
-/// Context used to generate an Azure Blob journal WAL segment name.
-/// </summary>
-public sealed class AzureBlobJournalWalSegmentNameContext
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AzureBlobJournalWalSegmentNameContext"/> class.
-    /// </summary>
-    /// <param name="grainId">The grain id associated with the journal.</param>
-    /// <param name="journalBlobName">The base blob name used for the journal.</param>
-    /// <param name="generation">The journal generation.</param>
-    /// <param name="segmentId">The WAL segment id.</param>
-    public AzureBlobJournalWalSegmentNameContext(GrainId grainId, string journalBlobName, ulong generation, uint segmentId)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
-
-        GrainId = grainId;
-        JournalBlobName = journalBlobName;
-        Generation = generation;
-        SegmentId = segmentId;
-    }
-
-    /// <summary>
-    /// Gets the grain id associated with the journal.
-    /// </summary>
-    public GrainId GrainId { get; }
-
-    /// <summary>
-    /// Gets the base blob name used for the journal.
-    /// </summary>
-    public string JournalBlobName { get; }
-
-    /// <summary>
-    /// Gets the journal generation.
-    /// </summary>
-    public ulong Generation { get; }
-
-    /// <summary>
-    /// Gets the WAL segment id.
-    /// </summary>
-    public uint SegmentId { get; }
-}
-
-/// <summary>
-/// Context used to generate an Azure Blob journal checkpoint name.
-/// </summary>
-public sealed class AzureBlobJournalCheckpointNameContext
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AzureBlobJournalCheckpointNameContext"/> class.
-    /// </summary>
-    /// <param name="grainId">The grain id associated with the journal.</param>
-    /// <param name="journalBlobName">The base blob name used for the journal.</param>
-    /// <param name="generation">The journal generation.</param>
-    public AzureBlobJournalCheckpointNameContext(GrainId grainId, string journalBlobName, ulong generation)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
-
-        GrainId = grainId;
-        JournalBlobName = journalBlobName;
-        Generation = generation;
-    }
-
-    /// <summary>
-    /// Gets the grain id associated with the journal.
-    /// </summary>
-    public GrainId GrainId { get; }
-
-    /// <summary>
-    /// Gets the base blob name used for the journal.
-    /// </summary>
-    public string JournalBlobName { get; }
-
-    /// <summary>
-    /// Gets the journal generation.
-    /// </summary>
-    public ulong Generation { get; }
 }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
@@ -33,7 +33,7 @@ public sealed class AzureBlobJournalStorageOptions
     public Func<AzureBlobJournalWalSegmentNameContext, string> GetWalSegmentBlobName { get; set; } = DefaultGetWalSegmentBlobName;
 
     private static readonly Func<AzureBlobJournalWalSegmentNameContext, string> DefaultGetWalSegmentBlobName =
-        static context => $"{context.JournalBlobName}/{context.Generation.ToString(CultureInfo.InvariantCulture)}/seg.{context.SegmentId:X8}";
+        static context => GetDefaultWalSegmentBlobName(context.JournalBlobName, context.Generation, context.SegmentId);
 
     /// <summary>
     /// Gets or sets the delegate used to generate block blob names for immutable journal checkpoints.
@@ -41,7 +41,7 @@ public sealed class AzureBlobJournalStorageOptions
     public Func<AzureBlobJournalCheckpointNameContext, string> GetCheckpointBlobName { get; set; } = DefaultGetCheckpointBlobName;
 
     private static readonly Func<AzureBlobJournalCheckpointNameContext, string> DefaultGetCheckpointBlobName =
-        static context => $"{context.JournalBlobName}/{context.Generation.ToString(CultureInfo.InvariantCulture)}/chk";
+        static context => GetDefaultCheckpointBlobName(context.JournalBlobName, context.Generation);
 
     /// <summary>
     /// Options to be used when configuring the blob storage client, or <see langword="null"/> to use the default options.
@@ -82,17 +82,27 @@ public sealed class AzureBlobJournalStorageOptions
 
     internal string GetWalSegmentBlobNameForJournal(GrainId grainId, string journalBlobName, ulong generation, uint segmentId)
     {
-        var blobName = GetWalSegmentBlobName(new AzureBlobJournalWalSegmentNameContext(grainId, journalBlobName, generation, segmentId));
+        var blobName = ReferenceEquals(GetWalSegmentBlobName, DefaultGetWalSegmentBlobName)
+            ? GetDefaultWalSegmentBlobName(journalBlobName, generation, segmentId)
+            : GetWalSegmentBlobName(new AzureBlobJournalWalSegmentNameContext(grainId, journalBlobName, generation, segmentId));
         ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
         return blobName;
     }
 
     internal string GetCheckpointBlobNameForJournal(GrainId grainId, string journalBlobName, ulong generation)
     {
-        var blobName = GetCheckpointBlobName(new AzureBlobJournalCheckpointNameContext(grainId, journalBlobName, generation));
+        var blobName = ReferenceEquals(GetCheckpointBlobName, DefaultGetCheckpointBlobName)
+            ? GetDefaultCheckpointBlobName(journalBlobName, generation)
+            : GetCheckpointBlobName(new AzureBlobJournalCheckpointNameContext(grainId, journalBlobName, generation));
         ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
         return blobName;
     }
+
+    internal static string GetDefaultWalSegmentBlobName(string journalBlobName, ulong generation, uint segmentId)
+        => $"{journalBlobName}/{generation.ToString(CultureInfo.InvariantCulture)}/seg.{segmentId:X8}";
+
+    internal static string GetDefaultCheckpointBlobName(string journalBlobName, ulong generation)
+        => $"{journalBlobName}/{generation.ToString(CultureInfo.InvariantCulture)}/chk";
 
     /// <summary>
     /// A function for building container factory instances.

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
@@ -27,12 +27,20 @@ public sealed class AzureBlobJournalStorageOptions
     private static readonly Func<GrainId, string> DefaultGetBlobName = static grainId => grainId.ToString();
 
     /// <summary>
-    /// Gets or sets the delegate used to generate block blob names for compacted journal snapshots.
+    /// Gets or sets the delegate used to generate append blob names for journal WAL segments.
     /// </summary>
-    public Func<AzureBlobJournalSnapshotNameContext, string> GetSnapshotBlobName { get; set; } = DefaultGetSnapshotBlobName;
+    public Func<AzureBlobJournalWalSegmentNameContext, string> GetWalSegmentBlobName { get; set; } = DefaultGetWalSegmentBlobName;
 
-    private static readonly Func<AzureBlobJournalSnapshotNameContext, string> DefaultGetSnapshotBlobName =
-        static context => $"{context.JournalBlobName}.snapshots/{context.SnapshotId}";
+    private static readonly Func<AzureBlobJournalWalSegmentNameContext, string> DefaultGetWalSegmentBlobName =
+        static context => $"{context.JournalBlobName}.log.{context.SegmentId:X8}";
+
+    /// <summary>
+    /// Gets or sets the delegate used to generate block blob names for immutable journal checkpoints.
+    /// </summary>
+    public Func<AzureBlobJournalCheckpointNameContext, string> GetCheckpointBlobName { get; set; } = DefaultGetCheckpointBlobName;
+
+    private static readonly Func<AzureBlobJournalCheckpointNameContext, string> DefaultGetCheckpointBlobName =
+        static context => $"{context.JournalBlobName}.checkpoint.{context.CheckpointId:X8}";
 
     /// <summary>
     /// Options to be used when configuring the blob storage client, or <see langword="null"/> to use the default options.
@@ -65,9 +73,16 @@ public sealed class AzureBlobJournalStorageOptions
         return blobName;
     }
 
-    internal string GetSnapshotBlobNameForJournal(GrainId grainId, string journalBlobName, string snapshotId)
+    internal string GetWalSegmentBlobNameForJournal(GrainId grainId, string journalBlobName, uint segmentId)
     {
-        var blobName = GetSnapshotBlobName(new AzureBlobJournalSnapshotNameContext(grainId, journalBlobName, snapshotId));
+        var blobName = GetWalSegmentBlobName(new AzureBlobJournalWalSegmentNameContext(grainId, journalBlobName, segmentId));
+        ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
+        return blobName;
+    }
+
+    internal string GetCheckpointBlobNameForJournal(GrainId grainId, string journalBlobName, uint checkpointId)
+    {
+        var blobName = GetCheckpointBlobName(new AzureBlobJournalCheckpointNameContext(grainId, journalBlobName, checkpointId));
         ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
         return blobName;
     }
@@ -136,24 +151,23 @@ public sealed class AzureBlobJournalStorageOptions
 }
 
 /// <summary>
-/// Context used to generate an Azure Blob journal snapshot name.
+/// Context used to generate an Azure Blob journal WAL segment name.
 /// </summary>
-public sealed class AzureBlobJournalSnapshotNameContext
+public sealed class AzureBlobJournalWalSegmentNameContext
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="AzureBlobJournalSnapshotNameContext"/> class.
+    /// Initializes a new instance of the <see cref="AzureBlobJournalWalSegmentNameContext"/> class.
     /// </summary>
     /// <param name="grainId">The grain id associated with the journal.</param>
-    /// <param name="journalBlobName">The append blob name used for the journal marker and tail.</param>
-    /// <param name="snapshotId">A generated id which is unique to the current compaction attempt.</param>
-    public AzureBlobJournalSnapshotNameContext(GrainId grainId, string journalBlobName, string snapshotId)
+    /// <param name="journalBlobName">The base blob name used for the journal.</param>
+    /// <param name="segmentId">The WAL segment id.</param>
+    public AzureBlobJournalWalSegmentNameContext(GrainId grainId, string journalBlobName, uint segmentId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(snapshotId);
 
         GrainId = grainId;
         JournalBlobName = journalBlobName;
-        SnapshotId = snapshotId;
+        SegmentId = segmentId;
     }
 
     /// <summary>
@@ -162,12 +176,48 @@ public sealed class AzureBlobJournalSnapshotNameContext
     public GrainId GrainId { get; }
 
     /// <summary>
-    /// Gets the append blob name used for the journal marker and tail.
+    /// Gets the base blob name used for the journal.
     /// </summary>
     public string JournalBlobName { get; }
 
     /// <summary>
-    /// Gets a generated id which is unique to the current compaction attempt.
+    /// Gets the WAL segment id.
     /// </summary>
-    public string SnapshotId { get; }
+    public uint SegmentId { get; }
+}
+
+/// <summary>
+/// Context used to generate an Azure Blob journal checkpoint name.
+/// </summary>
+public sealed class AzureBlobJournalCheckpointNameContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureBlobJournalCheckpointNameContext"/> class.
+    /// </summary>
+    /// <param name="grainId">The grain id associated with the journal.</param>
+    /// <param name="journalBlobName">The base blob name used for the journal.</param>
+    /// <param name="checkpointId">The checkpoint id.</param>
+    public AzureBlobJournalCheckpointNameContext(GrainId grainId, string journalBlobName, uint checkpointId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
+
+        GrainId = grainId;
+        JournalBlobName = journalBlobName;
+        CheckpointId = checkpointId;
+    }
+
+    /// <summary>
+    /// Gets the grain id associated with the journal.
+    /// </summary>
+    public GrainId GrainId { get; }
+
+    /// <summary>
+    /// Gets the base blob name used for the journal.
+    /// </summary>
+    public string JournalBlobName { get; }
+
+    /// <summary>
+    /// Gets the checkpoint id.
+    /// </summary>
+    public uint CheckpointId { get; }
 }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
@@ -3,7 +3,6 @@ using Azure;
 using Azure.Core;
 using Azure.Storage;
 using Azure.Storage.Blobs;
-using Orleans.Runtime;
 
 namespace Orleans.Journaling;
 

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
@@ -27,6 +27,14 @@ public sealed class AzureBlobJournalStorageOptions
     private static readonly Func<GrainId, string> DefaultGetBlobName = static grainId => grainId.ToString();
 
     /// <summary>
+    /// Gets or sets the delegate used to generate block blob names for compacted journal snapshots.
+    /// </summary>
+    public Func<AzureBlobJournalSnapshotNameContext, string> GetSnapshotBlobName { get; set; } = DefaultGetSnapshotBlobName;
+
+    private static readonly Func<AzureBlobJournalSnapshotNameContext, string> DefaultGetSnapshotBlobName =
+        static context => $"{context.JournalBlobName}.snapshots/{context.SnapshotId}";
+
+    /// <summary>
     /// Options to be used when configuring the blob storage client, or <see langword="null"/> to use the default options.
     /// </summary>
     public BlobClientOptions? ClientOptions { get; set; }
@@ -53,6 +61,13 @@ public sealed class AzureBlobJournalStorageOptions
     internal string GetBlobNameForJournal(GrainId grainId)
     {
         var blobName = GetBlobName(grainId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
+        return blobName;
+    }
+
+    internal string GetSnapshotBlobNameForJournal(GrainId grainId, string journalBlobName, string snapshotId)
+    {
+        var blobName = GetSnapshotBlobName(new AzureBlobJournalSnapshotNameContext(grainId, journalBlobName, snapshotId));
         ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
         return blobName;
     }
@@ -118,4 +133,41 @@ public sealed class AzureBlobJournalStorageOptions
         ArgumentNullException.ThrowIfNull(sharedKeyCredential);
         CreateClient = ct => Task.FromResult(new BlobServiceClient(serviceUri, sharedKeyCredential, ClientOptions));
     }
+}
+
+/// <summary>
+/// Context used to generate an Azure Blob journal snapshot name.
+/// </summary>
+public sealed class AzureBlobJournalSnapshotNameContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureBlobJournalSnapshotNameContext"/> class.
+    /// </summary>
+    /// <param name="grainId">The grain id associated with the journal.</param>
+    /// <param name="journalBlobName">The append blob name used for the journal marker and tail.</param>
+    /// <param name="snapshotId">A generated id which is unique to the current compaction attempt.</param>
+    public AzureBlobJournalSnapshotNameContext(GrainId grainId, string journalBlobName, string snapshotId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(snapshotId);
+
+        GrainId = grainId;
+        JournalBlobName = journalBlobName;
+        SnapshotId = snapshotId;
+    }
+
+    /// <summary>
+    /// Gets the grain id associated with the journal.
+    /// </summary>
+    public GrainId GrainId { get; }
+
+    /// <summary>
+    /// Gets the append blob name used for the journal marker and tail.
+    /// </summary>
+    public string JournalBlobName { get; }
+
+    /// <summary>
+    /// Gets a generated id which is unique to the current compaction attempt.
+    /// </summary>
+    public string SnapshotId { get; }
 }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
@@ -41,15 +41,15 @@ internal sealed class AzureBlobJournalStorageProvider(
 
         var container = _containerFactory.GetBlobContainerClient(grainContext.GrainId);
         var blobName = _options.GetBlobNameForJournal(grainContext.GrainId);
-        var blobClient = container.GetAppendBlobClient(_options.GetWalSegmentBlobNameForJournal(grainContext.GrainId, blobName, segmentId: 0));
+        var blobClient = container.GetAppendBlobClient(_options.GetRootBlobNameForJournal(grainContext.GrainId, blobName));
         return new AzureBlobJournalStorage(
             blobClient,
             journalFormat.MimeType,
             logger,
             journalFormatKey: journalFormatKey,
-            walNameFactory: segmentId => _options.GetWalSegmentBlobNameForJournal(grainContext.GrainId, blobName, segmentId),
-            walClientFactory: segmentId => container.GetAppendBlobClient(_options.GetWalSegmentBlobNameForJournal(grainContext.GrainId, blobName, segmentId)),
-            checkpointNameFactory: checkpointId => _options.GetCheckpointBlobNameForJournal(grainContext.GrainId, blobName, checkpointId),
+            walNameFactory: (generation, segmentId) => _options.GetWalSegmentBlobNameForJournal(grainContext.GrainId, blobName, generation, segmentId),
+            walClientFactory: (generation, segmentId) => container.GetAppendBlobClient(_options.GetWalSegmentBlobNameForJournal(grainContext.GrainId, blobName, generation, segmentId)),
+            checkpointNameFactory: generation => _options.GetCheckpointBlobNameForJournal(grainContext.GrainId, blobName, generation),
             checkpointClientFactory: container.GetBlockBlobClient);
     }
 

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Orleans.Runtime;
 
 namespace Orleans.Journaling;
 

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
@@ -8,7 +8,7 @@ internal sealed class AzureBlobJournalStorageProvider : ILifecycleParticipant<IS
 {
     private readonly IBlobContainerFactory _containerFactory;
     private readonly AzureBlobJournalStorageOptions _options;
-    private readonly AzureBlobJournalStorage.SharedConfiguration _shared;
+    private readonly AzureBlobJournalStorage.AzureBlobJournalStorageShared _shared;
 
     public AzureBlobJournalStorageProvider(
         IOptions<AzureBlobJournalStorageOptions> options,
@@ -20,7 +20,7 @@ internal sealed class AzureBlobJournalStorageProvider : ILifecycleParticipant<IS
         _containerFactory = _options.BuildContainerFactory(serviceProvider, _options);
         var journalFormatKey = ValidateJournalFormatKey(managerOptions.Value.JournalFormatKey);
         var journalFormat = GetJournalFormat(serviceProvider, journalFormatKey);
-        _shared = new AzureBlobJournalStorage.SharedConfiguration(
+        _shared = new AzureBlobJournalStorage.AzureBlobJournalStorageShared(
             logger,
             options,
             new AzureBlobJournalStorage.OptionsBlobClientProvider(_containerFactory, _options),
@@ -49,10 +49,6 @@ internal sealed class AzureBlobJournalStorageProvider : ILifecycleParticipant<IS
 
         return new AzureBlobJournalStorage(_shared, journalId);
     }
-
-    public IJournalStorage Create(IGrainContext grainContext) => CreateStorage(grainContext);
-
-    public IJournalStorage Create(JournalId journalId) => CreateStorage(journalId);
 
     public void Participate(ISiloLifecycle observer)
     {

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
@@ -22,6 +22,7 @@ internal sealed class AzureBlobJournalStorageProvider : ILifecycleParticipant<IS
         var journalFormat = GetJournalFormat(serviceProvider, journalFormatKey);
         _shared = new AzureBlobJournalStorage.SharedConfiguration(
             logger,
+            options,
             new AzureBlobJournalStorage.OptionsBlobClientProvider(_containerFactory, _options),
             mimeType: journalFormat.MimeType,
             journalFormatKey: journalFormatKey);
@@ -33,9 +34,25 @@ internal sealed class AzureBlobJournalStorageProvider : ILifecycleParticipant<IS
         await _containerFactory.InitializeAsync(client, cancellationToken).ConfigureAwait(false);
     }
 
-    public IJournalStorage CreateStorage(IGrainContext grainContext) => new AzureBlobJournalStorage(_shared, grainContext);
+    public IJournalStorage CreateStorage(IGrainContext grainContext)
+    {
+        ArgumentNullException.ThrowIfNull(grainContext);
+        return CreateStorage(JournalId.FromGrainId(grainContext.GrainId));
+    }
+
+    public IJournalStorage CreateStorage(JournalId journalId)
+    {
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
+
+        return new AzureBlobJournalStorage(_shared, journalId);
+    }
 
     public IJournalStorage Create(IGrainContext grainContext) => CreateStorage(grainContext);
+
+    public IJournalStorage Create(JournalId journalId) => CreateStorage(journalId);
 
     public void Participate(ISiloLifecycle observer)
     {

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
@@ -47,10 +47,7 @@ internal sealed class AzureBlobJournalStorageProvider(
             journalFormat.MimeType,
             logger,
             journalFormatKey: journalFormatKey,
-            walNameFactory: (generation, segmentId) => _options.GetWalSegmentBlobNameForJournal(grainContext.GrainId, blobName, generation, segmentId),
-            walClientFactory: (generation, segmentId) => container.GetAppendBlobClient(_options.GetWalSegmentBlobNameForJournal(grainContext.GrainId, blobName, generation, segmentId)),
-            checkpointNameFactory: generation => _options.GetCheckpointBlobNameForJournal(grainContext.GrainId, blobName, generation),
-            checkpointClientFactory: container.GetBlockBlobClient);
+            blobClientProvider: new AzureBlobJournalStorage.OptionsBlobClientProvider(container, _options, grainContext.GrainId));
     }
 
     public IJournalStorage Create(IGrainContext grainContext) => CreateStorage(grainContext);

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
@@ -46,7 +46,9 @@ internal sealed class AzureBlobJournalStorageProvider(
             blobClient,
             journalFormat.MimeType,
             logger,
-            journalFormatKey: journalFormatKey);
+            journalFormatKey: journalFormatKey,
+            snapshotNameFactory: () => _options.GetSnapshotBlobNameForJournal(grainContext.GrainId, blobName, Guid.NewGuid().ToString("N")),
+            snapshotClientFactory: container.GetBlockBlobClient);
     }
 
     public void Participate(ISiloLifecycle observer)

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
@@ -1,20 +1,32 @@
-using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.Runtime;
 
 namespace Orleans.Journaling;
 
-internal sealed class AzureBlobJournalStorageProvider(
-    IOptions<AzureBlobJournalStorageOptions> options,
-    IOptions<JournaledStateManagerOptions> managerOptions,
-    IServiceProvider serviceProvider,
-    ILogger<AzureBlobJournalStorage> logger) : ILifecycleParticipant<ISiloLifecycle>, IJournalStorageProvider
+internal sealed class AzureBlobJournalStorageProvider : ILifecycleParticipant<ISiloLifecycle>, IJournalStorageProvider
 {
-    private readonly IBlobContainerFactory _containerFactory = options.Value.BuildContainerFactory(serviceProvider, options.Value);
-    private readonly string _journalFormatKey = ValidateJournalFormatKey(managerOptions.Value.JournalFormatKey);
-    private readonly AzureBlobJournalStorageOptions _options = options.Value;
+    private readonly IBlobContainerFactory _containerFactory;
+    private readonly AzureBlobJournalStorageOptions _options;
+    private readonly AzureBlobJournalStorage.SharedConfiguration _shared;
+
+    public AzureBlobJournalStorageProvider(
+        IOptions<AzureBlobJournalStorageOptions> options,
+        IOptions<JournaledStateManagerOptions> managerOptions,
+        IServiceProvider serviceProvider,
+        ILogger<AzureBlobJournalStorage> logger)
+    {
+        _options = options.Value;
+        _containerFactory = _options.BuildContainerFactory(serviceProvider, _options);
+        var journalFormatKey = ValidateJournalFormatKey(managerOptions.Value.JournalFormatKey);
+        var journalFormat = GetJournalFormat(serviceProvider, journalFormatKey);
+        _shared = new AzureBlobJournalStorage.SharedConfiguration(
+            logger,
+            new AzureBlobJournalStorage.OptionsBlobClientProvider(_containerFactory, _options),
+            mimeType: journalFormat.MimeType,
+            journalFormatKey: journalFormatKey);
+    }
 
     private async Task Initialize(CancellationToken cancellationToken)
     {
@@ -22,9 +34,20 @@ internal sealed class AzureBlobJournalStorageProvider(
         await _containerFactory.InitializeAsync(client, cancellationToken).ConfigureAwait(false);
     }
 
-    public IJournalStorage CreateStorage(IGrainContext grainContext)
+    public IJournalStorage CreateStorage(IGrainContext grainContext) => new AzureBlobJournalStorage(_shared, grainContext);
+
+    public IJournalStorage Create(IGrainContext grainContext) => CreateStorage(grainContext);
+
+    public void Participate(ISiloLifecycle observer)
     {
-        var journalFormatKey = _journalFormatKey;
+        observer.Subscribe(
+            nameof(AzureBlobJournalStorageProvider),
+            ServiceLifecycleStage.RuntimeInitialize,
+            onStart: Initialize);
+    }
+
+    private static IJournalFormat GetJournalFormat(IServiceProvider serviceProvider, string journalFormatKey)
+    {
         var journalFormat = serviceProvider.GetKeyedService<IJournalFormat>(journalFormatKey);
         if (journalFormat is null)
         {
@@ -39,25 +62,7 @@ internal sealed class AzureBlobJournalStorageProvider(
                 "Register the journal format using the same key it reports.");
         }
 
-        var container = _containerFactory.GetBlobContainerClient(grainContext.GrainId);
-        var blobName = _options.GetBlobNameForJournal(grainContext.GrainId);
-        var blobClient = container.GetAppendBlobClient(_options.GetRootBlobNameForJournal(grainContext.GrainId, blobName));
-        return new AzureBlobJournalStorage(
-            blobClient,
-            journalFormat.MimeType,
-            logger,
-            journalFormatKey: journalFormatKey,
-            blobClientProvider: new AzureBlobJournalStorage.OptionsBlobClientProvider(container, _options, grainContext.GrainId));
-    }
-
-    public IJournalStorage Create(IGrainContext grainContext) => CreateStorage(grainContext);
-
-    public void Participate(ISiloLifecycle observer)
-    {
-        observer.Subscribe(
-            nameof(AzureBlobJournalStorageProvider),
-            ServiceLifecycleStage.RuntimeInitialize,
-            onStart: Initialize);
+        return journalFormat;
     }
 
     private static string ValidateJournalFormatKey(string? journalFormatKey)

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
@@ -10,7 +10,7 @@ internal sealed class AzureBlobJournalStorageProvider(
     IOptions<AzureBlobJournalStorageOptions> options,
     IOptions<JournaledStateManagerOptions> managerOptions,
     IServiceProvider serviceProvider,
-    ILogger<AzureBlobJournalStorage> logger) : ILifecycleParticipant<ISiloLifecycle>
+    ILogger<AzureBlobJournalStorage> logger) : ILifecycleParticipant<ISiloLifecycle>, IJournalStorageProvider
 {
     private readonly IBlobContainerFactory _containerFactory = options.Value.BuildContainerFactory(serviceProvider, options.Value);
     private readonly string _journalFormatKey = ValidateJournalFormatKey(managerOptions.Value.JournalFormatKey);
@@ -22,7 +22,7 @@ internal sealed class AzureBlobJournalStorageProvider(
         await _containerFactory.InitializeAsync(client, cancellationToken).ConfigureAwait(false);
     }
 
-    public IJournalStorage Create(IGrainContext grainContext)
+    public IJournalStorage CreateStorage(IGrainContext grainContext)
     {
         var journalFormatKey = _journalFormatKey;
         var journalFormat = serviceProvider.GetKeyedService<IJournalFormat>(journalFormatKey);
@@ -41,15 +41,19 @@ internal sealed class AzureBlobJournalStorageProvider(
 
         var container = _containerFactory.GetBlobContainerClient(grainContext.GrainId);
         var blobName = _options.GetBlobNameForJournal(grainContext.GrainId);
-        var blobClient = container.GetAppendBlobClient(blobName);
+        var blobClient = container.GetAppendBlobClient(_options.GetWalSegmentBlobNameForJournal(grainContext.GrainId, blobName, segmentId: 0));
         return new AzureBlobJournalStorage(
             blobClient,
             journalFormat.MimeType,
             logger,
             journalFormatKey: journalFormatKey,
-            snapshotNameFactory: () => _options.GetSnapshotBlobNameForJournal(grainContext.GrainId, blobName, Guid.NewGuid().ToString("N")),
-            snapshotClientFactory: container.GetBlockBlobClient);
+            walNameFactory: segmentId => _options.GetWalSegmentBlobNameForJournal(grainContext.GrainId, blobName, segmentId),
+            walClientFactory: segmentId => container.GetAppendBlobClient(_options.GetWalSegmentBlobNameForJournal(grainContext.GrainId, blobName, segmentId)),
+            checkpointNameFactory: checkpointId => _options.GetCheckpointBlobNameForJournal(grainContext.GrainId, blobName, checkpointId),
+            checkpointClientFactory: container.GetBlockBlobClient);
     }
+
+    public IJournalStorage Create(IGrainContext grainContext) => CreateStorage(grainContext);
 
     public void Participate(ISiloLifecycle observer)
     {

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageStreamHelpers.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageStreamHelpers.cs
@@ -1,0 +1,52 @@
+using System.Buffers;
+
+namespace Orleans.Journaling;
+
+internal static class AzureBlobJournalStorageStreamHelpers
+{
+    // SkipStreamAsync caps each non-seekable drain read at this size instead of using larger pooled arrays.
+    private const int MaxSkipBufferBytes = 16 * 1024;
+
+    internal static async ValueTask SkipStreamAsync(Stream input, long length, CancellationToken cancellationToken)
+    {
+        // Used during recovery to consume checkpoint-covered WAL bytes without exposing them to the consumer.
+        if (length <= 0)
+        {
+            return;
+        }
+
+        if (input.CanSeek)
+        {
+            // Seeking is only used when supported; Azure response streams are often forward-only.
+            input.Seek(length, SeekOrigin.Current);
+            return;
+        }
+
+        // Non-seekable streams can only advance by reading, so drain discarded bytes into a pooled buffer.
+        var maxChunkSize = (int)Math.Min(MaxSkipBufferBytes, length);
+        var buffer = ArrayPool<byte>.Shared.Rent(maxChunkSize);
+
+        try
+        {
+            while (length > 0)
+            {
+                // ArrayPool can return a larger array, so slice it to keep each skip read capped.
+                var toRead = (int)Math.Min(maxChunkSize, length);
+
+                // ReadExactlyAsync guarantees the buffer slice is completely filled before returning,
+                // or it throws an EndOfStreamException if the stream ends early.
+                await input.ReadExactlyAsync(buffer.AsMemory(0, toRead), cancellationToken).ConfigureAwait(false);
+
+                length -= toRead;
+            }
+        }
+        catch (EndOfStreamException ex)
+        {
+            throw new InvalidOperationException("Azure Blob journal WAL ended before the checkpoint offset was reached.", ex);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobStorageGrainJournalingProviderBuilder.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobStorageGrainJournalingProviderBuilder.cs
@@ -1,8 +1,6 @@
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Orleans;
-using Orleans.Hosting;
 using Orleans.Journaling;
 using Orleans.Providers;
 

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobStorageHostingExtensions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobStorageHostingExtensions.cs
@@ -1,8 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.Configuration.Internal;
-using Orleans.Runtime;
-using Orleans.Hosting;
 
 namespace Orleans.Journaling;
 

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobStorageHostingExtensions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobStorageHostingExtensions.cs
@@ -24,11 +24,9 @@ public static class AzureBlobStorageHostingExtensions
         if (!services.Any(service => service.ServiceType.Equals(typeof(AzureBlobJournalStorageProvider))))
         {
             builder.Services.AddSingleton<AzureBlobJournalStorageProvider>();
+            builder.Services.AddFromExisting<IJournalStorageProvider, AzureBlobJournalStorageProvider>();
             builder.Services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, AzureBlobJournalStorageProvider>();
         }
-
-        builder.Services.TryAddScoped<IJournalStorage>(static sp =>
-            sp.GetRequiredService<AzureBlobJournalStorageProvider>().Create(sp.GetRequiredService<IGrainContext>()));
         return builder;
     }
 }

--- a/src/Azure/Orleans.Journaling.AzureStorage/DefaultBlobContainerFactory.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/DefaultBlobContainerFactory.cs
@@ -17,6 +17,9 @@ internal sealed class DefaultBlobContainerFactory(AzureBlobJournalStorageOptions
     public BlobContainerClient GetBlobContainerClient(GrainId grainId) => _defaultContainer;
 
     /// <inheritdoc/>
+    public BlobContainerClient GetBlobContainerClient(JournalId journalId) => _defaultContainer;
+
+    /// <inheritdoc/>
     public async Task InitializeAsync(BlobServiceClient client, CancellationToken cancellationToken)
     {
         _defaultContainer = client.GetBlobContainerClient(options.ContainerName);

--- a/src/Azure/Orleans.Journaling.AzureStorage/DefaultBlobContainerFactory.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/DefaultBlobContainerFactory.cs
@@ -1,5 +1,4 @@
 using Azure.Storage.Blobs;
-using Orleans.Runtime;
 
 namespace Orleans.Journaling;
 

--- a/src/Azure/Orleans.Journaling.AzureStorage/IBlobContainerFactory.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/IBlobContainerFactory.cs
@@ -3,10 +3,26 @@ using Azure.Storage.Blobs;
 namespace Orleans.Journaling;
 
 /// <summary>
-/// A factory for building container clients for blob storage using GrainId
+/// A factory for building container clients for blob storage.
 /// </summary>
 public interface IBlobContainerFactory
 {
+    /// <summary>
+    /// Gets the container which should be used for the specified journal.
+    /// </summary>
+    /// <param name="journalId">The journal id.</param>
+    /// <returns>A configured blob client.</returns>
+    public BlobContainerClient GetBlobContainerClient(JournalId journalId)
+    {
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
+
+        throw new NotSupportedException(
+            $"This blob container factory does not support grain-independent journals. Implement {nameof(GetBlobContainerClient)}({nameof(JournalId)}) to support on-demand journals.");
+    }
+
     /// <summary>
     /// Gets the container which should be used for the specified grain.
     /// </summary>

--- a/src/Azure/Orleans.Journaling.AzureStorage/IBlobContainerFactory.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/IBlobContainerFactory.cs
@@ -1,5 +1,4 @@
-﻿using Azure.Storage.Blobs;
-using Orleans.Runtime;
+using Azure.Storage.Blobs;
 
 namespace Orleans.Journaling;
 

--- a/src/Azure/Orleans.Journaling.AzureStorage/ReadOnlySequenceStream.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/ReadOnlySequenceStream.cs
@@ -1,0 +1,96 @@
+using System.Buffers;
+
+namespace Orleans.Journaling;
+
+internal sealed class ReadOnlySequenceStream(ReadOnlySequence<byte> sequence) : Stream
+{
+    private readonly ReadOnlySequence<byte> _sequence = sequence;
+    private long _position;
+    private bool _disposed;
+
+    public override bool CanRead => !_disposed;
+
+    public override bool CanSeek => !_disposed;
+
+    public override bool CanWrite => false;
+
+    public override long Length
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _sequence.Length;
+        }
+    }
+
+    public override long Position
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return _position;
+        }
+
+        set
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (value < 0 || value > _sequence.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            _position = value;
+        }
+    }
+
+    public override void Flush() => ObjectDisposedException.ThrowIf(_disposed, this);
+
+    public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+    public override int Read(Span<byte> buffer)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (buffer.IsEmpty || _position >= _sequence.Length)
+        {
+            return 0;
+        }
+
+        var length = (int)Math.Min(buffer.Length, _sequence.Length - _position);
+        _sequence.Slice(_position, length).CopyTo(buffer);
+        _position += length;
+        return length;
+    }
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ValueTask<int>(Read(buffer.Span));
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var newPosition = origin switch
+        {
+            SeekOrigin.Begin => offset,
+            SeekOrigin.Current => _position + offset,
+            SeekOrigin.End => _sequence.Length + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin))
+        };
+
+        Position = newPosition;
+        return _position;
+    }
+
+    public override void SetLength(long value) => throw new NotSupportedException("This stream is read-only.");
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException("This stream is read-only.");
+
+    public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException("This stream is read-only.");
+
+    protected override void Dispose(bool disposing)
+    {
+        _disposed = true;
+        base.Dispose(disposing);
+    }
+}

--- a/src/Orleans.Journaling/HostingExtensions.cs
+++ b/src/Orleans.Journaling/HostingExtensions.cs
@@ -11,6 +11,7 @@ public static class HostingExtensions
         builder.Services.AddOptions<JournaledStateManagerOptions>();
         builder.Services.TryAddScoped<JournaledStateManagerShared>();
         builder.Services.TryAddScoped<IJournaledStateManager, JournaledStateManager>();
+        builder.Services.TryAddScoped<IJournaledStateManagerFactory, JournaledStateManagerFactory>();
 
         // Register JSON as the default format family and keep Orleans binary available for existing data.
         builder.Services.AddJsonJournalFormat(new JsonJournalOptions().SerializerOptions, tryAdd: true);

--- a/src/Orleans.Journaling/IJournalStorage.cs
+++ b/src/Orleans.Journaling/IJournalStorage.cs
@@ -25,6 +25,9 @@ public interface IJournalStorage
     /// <summary>
     /// Replaces the journal with the provided value atomically.
     /// </summary>
+    /// <remarks>
+    /// Implementations should throw <see cref="Orleans.Storage.InconsistentStateException"/> when optimistic concurrency fails.
+    /// </remarks>
     /// <param name="value">The encoded journal bytes to write. The storage provider must not retain this buffer after the returned task completes.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="ValueTask"/> representing the operation.</returns>
@@ -33,6 +36,9 @@ public interface IJournalStorage
     /// <summary>
     /// Appends the provided segment to the journal atomically.
     /// </summary>
+    /// <remarks>
+    /// Implementations should throw <see cref="Orleans.Storage.InconsistentStateException"/> when optimistic concurrency fails.
+    /// </remarks>
     /// <param name="value">The encoded journal bytes to append. The storage provider must not retain this buffer after the returned task completes.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="ValueTask"/> representing the operation.</returns>
@@ -41,6 +47,9 @@ public interface IJournalStorage
     /// <summary>
     /// Deletes the journal atomically.
     /// </summary>
+    /// <remarks>
+    /// Implementations should throw <see cref="Orleans.Storage.InconsistentStateException"/> when optimistic concurrency fails.
+    /// </remarks>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="ValueTask"/> representing the operation.</returns>
     ValueTask DeleteAsync(CancellationToken cancellationToken);
@@ -52,14 +61,34 @@ public interface IJournalStorage
 }
 
 /// <summary>
-/// Creates journal storage for a grain activation.
+/// Creates journal storage.
 /// </summary>
 public interface IJournalStorageProvider
 {
+    /// <summary>
+    /// Creates journal storage for the provided journal id.
+    /// </summary>
+    /// <param name="journalId">The journal id.</param>
+    /// <returns>The journal storage instance.</returns>
+    IJournalStorage CreateStorage(JournalId journalId)
+    {
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
+
+        throw new NotSupportedException(
+            $"This journal storage provider does not support grain-independent journals. Implement {nameof(CreateStorage)}({nameof(JournalId)}) to support on-demand journals.");
+    }
+
     /// <summary>
     /// Creates journal storage for the provided grain context.
     /// </summary>
     /// <param name="grainContext">The grain context.</param>
     /// <returns>The journal storage instance.</returns>
-    IJournalStorage CreateStorage(IGrainContext grainContext);
+    IJournalStorage CreateStorage(IGrainContext grainContext)
+    {
+        ArgumentNullException.ThrowIfNull(grainContext);
+        return CreateStorage(JournalId.FromGrainId(grainContext.GrainId));
+    }
 }

--- a/src/Orleans.Journaling/IJournalStorage.cs
+++ b/src/Orleans.Journaling/IJournalStorage.cs
@@ -50,3 +50,16 @@ public interface IJournalStorage
     /// </summary>
     bool IsCompactionRequested { get; }
 }
+
+/// <summary>
+/// Creates journal storage for a grain activation.
+/// </summary>
+public interface IJournalStorageProvider
+{
+    /// <summary>
+    /// Creates journal storage for the provided grain context.
+    /// </summary>
+    /// <param name="grainContext">The grain context.</param>
+    /// <returns>The journal storage instance.</returns>
+    IJournalStorage CreateStorage(IGrainContext grainContext);
+}

--- a/src/Orleans.Journaling/IJournaledStateManager.cs
+++ b/src/Orleans.Journaling/IJournaledStateManager.cs
@@ -5,8 +5,11 @@ namespace Orleans.Journaling;
 /// <summary>
 /// Manages the states for a given grain.
 /// </summary>
-public interface IJournaledStateManager
+public interface IJournaledStateManager : IAsyncDisposable
 {
+    /// <inheritdoc/>
+    ValueTask IAsyncDisposable.DisposeAsync() => default;
+
     /// <summary>
     /// Initializes the state manager.
     /// </summary>

--- a/src/Orleans.Journaling/IJournaledStateManagerFactory.cs
+++ b/src/Orleans.Journaling/IJournaledStateManagerFactory.cs
@@ -1,0 +1,15 @@
+namespace Orleans.Journaling;
+
+/// <summary>
+/// Creates journaled state managers for journals identified independently of a grain activation.
+/// </summary>
+public interface IJournaledStateManagerFactory
+{
+    /// <summary>
+    /// Creates a journaled state manager for the provided journal id.
+    /// </summary>
+    /// <param name="journalId">The journal id.</param>
+    /// <returns>The journaled state manager.</returns>
+    IJournaledStateManager Create(JournalId journalId);
+}
+

--- a/src/Orleans.Journaling/JournalId.cs
+++ b/src/Orleans.Journaling/JournalId.cs
@@ -1,0 +1,70 @@
+namespace Orleans.Journaling;
+
+/// <summary>
+/// Identifies a journal independently of any grain activation.
+/// </summary>
+public readonly struct JournalId : IEquatable<JournalId>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JournalId"/> struct.
+    /// </summary>
+    /// <param name="value">The stable journal identifier.</param>
+    public JournalId(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        Value = value;
+    }
+
+    /// <summary>
+    /// Gets the stable journal identifier.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this instance is the default value.
+    /// </summary>
+    public bool IsDefault => Value is null;
+
+    /// <summary>
+    /// Creates a journal id from a grain id.
+    /// </summary>
+    /// <param name="grainId">The grain id.</param>
+    /// <returns>The journal id.</returns>
+    public static JournalId FromGrainId(GrainId grainId)
+    {
+        if (grainId.IsDefault)
+        {
+            throw new ArgumentException("The grain id must not be the default value.", nameof(grainId));
+        }
+
+        return new(grainId.ToString());
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => Value ?? string.Empty;
+
+    /// <inheritdoc/>
+    public bool Equals(JournalId other) => string.Equals(Value, other.Value, StringComparison.Ordinal);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is JournalId other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Value ?? string.Empty);
+
+    /// <summary>
+    /// Compares two journal ids for equality.
+    /// </summary>
+    /// <param name="left">The first journal id.</param>
+    /// <param name="right">The second journal id.</param>
+    /// <returns><see langword="true"/> if the journal ids are equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator ==(JournalId left, JournalId right) => left.Equals(right);
+
+    /// <summary>
+    /// Compares two journal ids for inequality.
+    /// </summary>
+    /// <param name="left">The first journal id.</param>
+    /// <param name="right">The second journal id.</param>
+    /// <returns><see langword="true"/> if the journal ids are not equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator !=(JournalId left, JournalId right) => !left.Equals(right);
+}

--- a/src/Orleans.Journaling/JournalStorageConsumerExtensions.cs
+++ b/src/Orleans.Journaling/JournalStorageConsumerExtensions.cs
@@ -121,6 +121,18 @@ public static class JournalStorageConsumerExtensions
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The number of bytes read from <paramref name="input"/>.</returns>
     public static async ValueTask<long> ReadAsync(this IJournalStorageConsumer consumer, Stream input, IJournalFileMetadata? metadata, CancellationToken cancellationToken)
+        => await consumer.ReadAsync(input, metadata, complete: true, cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Reads all bytes from <paramref name="input"/> and incrementally supplies them to <paramref name="consumer"/>.
+    /// </summary>
+    /// <param name="consumer">The journal storage consumer.</param>
+    /// <param name="input">The stream to read from.</param>
+    /// <param name="metadata">The metadata associated with the journal data being read, or <see langword="null"/> if no metadata is available.</param>
+    /// <param name="complete">Whether to notify the consumer that no more data will be supplied. If <see langword="false"/>, the consumer must read all supplied bytes.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The number of bytes read from <paramref name="input"/>.</returns>
+    public static async ValueTask<long> ReadAsync(this IJournalStorageConsumer consumer, Stream input, IJournalFileMetadata? metadata, bool complete, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(consumer);
         ArgumentNullException.ThrowIfNull(input);
@@ -134,12 +146,7 @@ public static class JournalStorageConsumerExtensions
             var bytesRead = await input.ReadAsync(memory, cancellationToken).ConfigureAwait(false);
             if (bytesRead == 0)
             {
-                ReadBuffer(consumer, buffer, metadata, isCompleted: true);
-                if (buffer.Length > 0)
-                {
-                    throw new InvalidOperationException("The journal storage consumer did not read all supplied journal data.");
-                }
-
+                CompleteOrThrowIfUnread(consumer, buffer, metadata, complete);
                 return totalBytesRead;
             }
 

--- a/src/Orleans.Journaling/JournaledStateManager.cs
+++ b/src/Orleans.Journaling/JournaledStateManager.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Orleans.Serialization.Buffers;
 using Orleans.Runtime.Internal;
+using Orleans.Storage;
 
 namespace Orleans.Journaling;
 
@@ -28,9 +29,15 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
     private Task? _workLoop;
     private ManagerState _state;
     private bool _migrationSnapshotRequired;
+    private int _disposed;
 
     public JournaledStateManager(JournaledStateManagerShared shared, IJournalStorageProvider storageProvider, IGrainContext grainContext)
         : this(shared, CreateStorage(storageProvider, grainContext))
+    {
+    }
+
+    public JournaledStateManager(JournaledStateManagerShared shared, IJournalStorageProvider storageProvider, JournalId journalId)
+        : this(shared, CreateStorage(storageProvider, journalId))
     {
     }
 
@@ -61,6 +68,17 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         ArgumentNullException.ThrowIfNull(storageProvider);
         ArgumentNullException.ThrowIfNull(grainContext);
         return storageProvider.CreateStorage(grainContext) ?? throw new InvalidOperationException("The configured journal storage provider returned null.");
+    }
+
+    private static IJournalStorage CreateStorage(IJournalStorageProvider storageProvider, JournalId journalId)
+    {
+        ArgumentNullException.ThrowIfNull(storageProvider);
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
+
+        return storageProvider.CreateStorage(journalId) ?? throw new InvalidOperationException("The configured journal storage provider returned null.");
     }
 
     internal string WriteJournalFormatKey => _shared.JournalFormatKey;
@@ -436,7 +454,10 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                     catch (Exception exception)
                     {
                         workItem.SetException(exception);
-                        needsRecovery = true;
+                        if (IsRecoverySignal(exception))
+                        {
+                            needsRecovery = true;
+                        }
                     }
                 }
             }
@@ -464,6 +485,19 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
             }
 
         }
+    }
+
+    private static bool IsRecoverySignal(Exception exception)
+    {
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is InconsistentStateException)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void RetireOrResurectStates()
@@ -746,7 +780,9 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
 
     void ILifecycleParticipant<IGrainLifecycle>.Participate(IGrainLifecycle observer) => observer.Subscribe(GrainLifecycleStage.SetupState, this);
     Task ILifecycleObserver.OnStart(CancellationToken cancellationToken) => InitializeAsync(cancellationToken).AsTask();
-    async Task ILifecycleObserver.OnStop(CancellationToken cancellationToken)
+    async Task ILifecycleObserver.OnStop(CancellationToken cancellationToken) => await StopAsync(cancellationToken).ConfigureAwait(false);
+
+    private async Task StopAsync(CancellationToken cancellationToken)
     {
         _shutdownCancellation.Cancel();
         _workSignal.Signal();
@@ -758,8 +794,21 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
 
     void IDisposable.Dispose()
     {
-        _shutdownCancellation.Dispose();
-        _journalWriter.Dispose();
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        {
+            _shutdownCancellation.Dispose();
+            _journalWriter.Dispose();
+        }
     }
 
     private abstract class WorkItem : TaskCompletionSource

--- a/src/Orleans.Journaling/JournaledStateManager.cs
+++ b/src/Orleans.Journaling/JournaledStateManager.cs
@@ -197,256 +197,256 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                         // We are ok sacrificing some code organization for performance in the inner loop.
                         switch (workItem)
                         {
-                        case AppendJournalWorkItem:
-                        case WriteSnapshotWorkItem:
-                        {
-                            // TODO: decide whether it's best to snapshot or append. Eg, by summing the size of the most recent snapshots and the current journal length.
-                            //       If the current journal length is greater than the snapshot size, then take a snapshot instead of appending more journal entries.
-                            var isSnapshot = workItem is WriteSnapshotWorkItem
-                                || _migrationSnapshotRequired
-                                || _storage.IsCompactionRequested;
-                            ArcBuffer committedBuffer = default;
-                            ArcBuffer bufferToConsume = default;
-                            var hasCommittedBuffer = false;
-                            var hasBufferToConsume = false;
-                            var bufferToConsumeIsCommittedBuffer = false;
-
-                            lock (_lock)
-                            {
-                                if (isSnapshot)
+                            case AppendJournalWorkItem:
+                            case WriteSnapshotWorkItem:
                                 {
-                                    using var snapshotWriter = _shared.JournalFormat.CreateWriter();
-                                    if (_retirementTracker.Count > 0)
-                                    {
-                                        RetireOrResurectStates();
-                                    }
+                                    // TODO: decide whether it's best to snapshot or append. Eg, by summing the size of the most recent snapshots and the current journal length.
+                                    //       If the current journal length is greater than the snapshot size, then take a snapshot instead of appending more journal entries.
+                                    var isSnapshot = workItem is WriteSnapshotWorkItem
+                                        || _migrationSnapshotRequired
+                                        || _storage.IsCompactionRequested;
+                                    ArcBuffer committedBuffer = default;
+                                    ArcBuffer bufferToConsume = default;
+                                    var hasCommittedBuffer = false;
+                                    var hasBufferToConsume = false;
+                                    var bufferToConsumeIsCommittedBuffer = false;
 
-                                    if (_migrationSnapshotRequired)
+                                    lock (_lock)
                                     {
-                                        ThrowIfMigrationBlockedByRetiredStates();
-                                    }
-
-                                    // The map of state ids is itself stored as a durable state with the id 0.
-                                    // This must be stored first, since it includes the identities of all other states, which are needed when replaying the journal.
-                                    // If we removed retired states, this snapshot will persist that change.
-                                    AppendUpdatesOrSnapshotState(snapshotWriter, isSnapshot: true, StateDirectory.Id, _journalStreamDirectory);
-
-                                    foreach (var (id, state) in _statesMap)
-                                    {
-                                        if (id is 0 || state is null)
+                                        if (isSnapshot)
                                         {
-                                            continue;
+                                            using var snapshotWriter = _shared.JournalFormat.CreateWriter();
+                                            if (_retirementTracker.Count > 0)
+                                            {
+                                                RetireOrResurectStates();
+                                            }
+
+                                            if (_migrationSnapshotRequired)
+                                            {
+                                                ThrowIfMigrationBlockedByRetiredStates();
+                                            }
+
+                                            // The map of state ids is itself stored as a durable state with the id 0.
+                                            // This must be stored first, since it includes the identities of all other states, which are needed when replaying the journal.
+                                            // If we removed retired states, this snapshot will persist that change.
+                                            AppendUpdatesOrSnapshotState(snapshotWriter, isSnapshot: true, StateDirectory.Id, _journalStreamDirectory);
+
+                                            foreach (var (id, state) in _statesMap)
+                                            {
+                                                if (id is 0 || state is null)
+                                                {
+                                                    continue;
+                                                }
+
+                                                AppendUpdatesOrSnapshotState(snapshotWriter, isSnapshot: true, id, state);
+                                            }
+
+                                            bufferToConsume = _journalWriter.GetCommittedBuffer();
+                                            if (bufferToConsume.Length > 0)
+                                            {
+                                                hasBufferToConsume = true;
+                                            }
+                                            else
+                                            {
+                                                bufferToConsume.Dispose();
+                                            }
+
+                                            committedBuffer = snapshotWriter.GetCommittedBuffer();
+                                        }
+                                        else
+                                        {
+                                            var flushCommittedOnly = _journalWriter.HasActiveEntry;
+                                            if (!flushCommittedOnly)
+                                            {
+                                                // The map of state ids is itself stored as a durable state with the id 0.
+                                                // This must be stored first, since it includes the identities of all other states, which are needed when replaying the journal.
+                                                AppendUpdatesOrSnapshotState(_journalWriter, isSnapshot: false, StateDirectory.Id, _journalStreamDirectory);
+
+                                                foreach (var (id, state) in _statesMap)
+                                                {
+                                                    if (id is 0 || state is null)
+                                                    {
+                                                        continue;
+                                                    }
+
+                                                    AppendUpdatesOrSnapshotState(_journalWriter, isSnapshot: false, id, state);
+                                                }
+                                            }
+
+                                            committedBuffer = _journalWriter.GetCommittedBuffer();
+                                            bufferToConsume = committedBuffer;
+                                            bufferToConsumeIsCommittedBuffer = true;
                                         }
 
-                                        AppendUpdatesOrSnapshotState(snapshotWriter, isSnapshot: true, id, state);
+                                        if (committedBuffer.Length == 0)
+                                        {
+                                            committedBuffer.Dispose();
+                                            if (bufferToConsumeIsCommittedBuffer)
+                                            {
+                                                bufferToConsume = default;
+                                            }
+                                        }
+                                        else
+                                        {
+                                            hasCommittedBuffer = true;
+                                            if (!isSnapshot)
+                                            {
+                                                hasBufferToConsume = true;
+                                            }
+                                        }
                                     }
 
-                                    bufferToConsume = _journalWriter.GetCommittedBuffer();
-                                    if (bufferToConsume.Length > 0)
-                                    {
-                                        hasBufferToConsume = true;
-                                    }
-                                    else
+                                    if (!hasCommittedBuffer && hasBufferToConsume && !bufferToConsumeIsCommittedBuffer)
                                     {
                                         bufferToConsume.Dispose();
                                     }
 
-                                    committedBuffer = snapshotWriter.GetCommittedBuffer();
-                                }
-                                else
-                                {
-                                    var flushCommittedOnly = _journalWriter.HasActiveEntry;
-                                    if (!flushCommittedOnly)
+                                    if (hasCommittedBuffer)
                                     {
-                                        // The map of state ids is itself stored as a durable state with the id 0.
-                                        // This must be stored first, since it includes the identities of all other states, which are needed when replaying the journal.
-                                        AppendUpdatesOrSnapshotState(_journalWriter, isSnapshot: false, StateDirectory.Id, _journalStreamDirectory);
-
-                                        foreach (var (id, state) in _statesMap)
-                                        {
-                                            if (id is 0 || state is null)
-                                            {
-                                                continue;
-                                            }
-
-                                            AppendUpdatesOrSnapshotState(_journalWriter, isSnapshot: false, id, state);
-                                        }
-                                    }
-
-                                    committedBuffer = _journalWriter.GetCommittedBuffer();
-                                    bufferToConsume = committedBuffer;
-                                    bufferToConsumeIsCommittedBuffer = true;
-                                }
-
-                                if (committedBuffer.Length == 0)
-                                {
-                                    committedBuffer.Dispose();
-                                    if (bufferToConsumeIsCommittedBuffer)
-                                    {
-                                        bufferToConsume = default;
-                                    }
-                                }
-                                else
-                                {
-                                    hasCommittedBuffer = true;
-                                    if (!isSnapshot)
-                                    {
-                                        hasBufferToConsume = true;
-                                    }
-                                }
-                            }
-
-                            if (!hasCommittedBuffer && hasBufferToConsume && !bufferToConsumeIsCommittedBuffer)
-                            {
-                                bufferToConsume.Dispose();
-                            }
-
-                            if (hasCommittedBuffer)
-                            {
-                                var writeSequence = committedBuffer.AsReadOnlySequence();
+                                        var writeSequence = committedBuffer.AsReadOnlySequence();
 #if DEBUG
-                                // Defensive: copy the sequence into a pooled buffer so we can poison it
-                                // after the storage call returns. Any IJournalStorage implementation that
-                                // retains the sequence past task completion (a violation of the documented
-                                // contract on AppendAsync/ReplaceAsync) will read 0x67 bytes when it next
-                                // touches the buffer, surfacing the bug loudly in tests instead of letting
-                                // recycled pool data hide it.
-                                var debugPoisonLength = checked((int)writeSequence.Length);
-                                var debugPoisonBuffer = ArrayPool<byte>.Shared.Rent(debugPoisonLength);
-                                writeSequence.CopyTo(debugPoisonBuffer);
-                                writeSequence = new ReadOnlySequence<byte>(debugPoisonBuffer, 0, debugPoisonLength);
+                                        // Defensive: copy the sequence into a pooled buffer so we can poison it
+                                        // after the storage call returns. Any IJournalStorage implementation that
+                                        // retains the sequence past task completion (a violation of the documented
+                                        // contract on AppendAsync/ReplaceAsync) will read 0x67 bytes when it next
+                                        // touches the buffer, surfacing the bug loudly in tests instead of letting
+                                        // recycled pool data hide it.
+                                        var debugPoisonLength = checked((int)writeSequence.Length);
+                                        var debugPoisonBuffer = ArrayPool<byte>.Shared.Rent(debugPoisonLength);
+                                        writeSequence.CopyTo(debugPoisonBuffer);
+                                        writeSequence = new ReadOnlySequence<byte>(debugPoisonBuffer, 0, debugPoisonLength);
 #endif
 
-                                var writeCompleted = false;
-                                try
-                                {
-                                    if (isSnapshot && hasBufferToConsume)
-                                    {
-                                        await _storage.AppendAsync(bufferToConsume.AsReadOnlySequence(), _shutdownCancellation.Token).ConfigureAwait(true);
+                                        var writeCompleted = false;
+                                        try
+                                        {
+                                            if (isSnapshot && hasBufferToConsume)
+                                            {
+                                                await _storage.AppendAsync(bufferToConsume.AsReadOnlySequence(), _shutdownCancellation.Token).ConfigureAwait(true);
+                                                lock (_lock)
+                                                {
+                                                    _journalWriter.Consume(bufferToConsume);
+                                                    foreach (var state in _states.Values)
+                                                    {
+                                                        state.OnWriteCompleted();
+                                                    }
+                                                }
+
+                                                bufferToConsume.Dispose();
+                                                hasBufferToConsume = false;
+                                            }
+
+                                            if (isSnapshot)
+                                            {
+                                                await _storage.ReplaceAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
+                                            }
+                                            else
+                                            {
+                                                await _storage.AppendAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
+                                            }
+
+                                            writeCompleted = true;
+                                        }
+                                        finally
+                                        {
+                                            try
+                                            {
+                                                if (writeCompleted)
+                                                {
+                                                    lock (_lock)
+                                                    {
+                                                        if (hasBufferToConsume)
+                                                        {
+                                                            _journalWriter.Consume(bufferToConsume);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            finally
+                                            {
+                                                committedBuffer.Dispose();
+                                                if (hasBufferToConsume && !bufferToConsumeIsCommittedBuffer)
+                                                {
+                                                    bufferToConsume.Dispose();
+                                                }
+#if DEBUG
+                                                debugPoisonBuffer.AsSpan(0, debugPoisonLength).Fill(0x67);
+                                                ArrayPool<byte>.Shared.Return(debugPoisonBuffer);
+#endif
+                                            }
+                                        }
+
+                                        // Notify all states that the operation completed.
                                         lock (_lock)
                                         {
-                                            _journalWriter.Consume(bufferToConsume);
                                             foreach (var state in _states.Values)
                                             {
                                                 state.OnWriteCompleted();
                                             }
-                                        }
 
-                                        bufferToConsume.Dispose();
-                                        hasBufferToConsume = false;
-                                    }
-
-                                    if (isSnapshot)
-                                    {
-                                        await _storage.ReplaceAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
-                                    }
-                                    else
-                                    {
-                                        await _storage.AppendAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
-                                    }
-
-                                    writeCompleted = true;
-                                }
-                                finally
-                                {
-                                    try
-                                    {
-                                        if (writeCompleted)
-                                        {
-                                            lock (_lock)
+                                            if (isSnapshot)
                                             {
-                                                if (hasBufferToConsume)
-                                                {
-                                                    _journalWriter.Consume(bufferToConsume);
-                                                }
+                                                _migrationSnapshotRequired = false;
                                             }
                                         }
                                     }
-                                    finally
+                                    break;
+                                }
+
+                            case DeleteStateWorkItem:
+                                {
+                                    // Clear storage.
+                                    await _storage.DeleteAsync(_shutdownCancellation.Token).ConfigureAwait(true);
+
+                                    lock (_lock)
                                     {
-                                        committedBuffer.Dispose();
-                                        if (hasBufferToConsume && !bufferToConsumeIsCommittedBuffer)
+                                        // Reset the state id collection.
+                                        _journalStreamDirectory.ResetVolatileState();
+
+                                        // Allocate new state ids for each state.
+                                        // Doing so will trigger a reset, since _journalStreamDirectory will bind the state in question.
+                                        foreach (var (name, state) in _states)
                                         {
-                                            bufferToConsume.Dispose();
+                                            var id = _journalStreamDirectory.GetNextJournalStreamId();
+                                            _journalStreamDirectory.Set(name, id);
                                         }
-#if DEBUG
-                                        debugPoisonBuffer.AsSpan(0, debugPoisonLength).Fill(0x67);
-                                        ArrayPool<byte>.Shared.Return(debugPoisonBuffer);
-#endif
                                     }
+                                    break;
                                 }
 
-                                // Notify all states that the operation completed.
-                                lock (_lock)
+                            case InitializeWorkItem:
                                 {
-                                    foreach (var state in _states.Values)
+                                    lock (_lock)
                                     {
-                                        state.OnWriteCompleted();
+                                        _state = ManagerState.Ready;
                                     }
+                                    break;
+                                }
 
-                                    if (isSnapshot)
+                            case RegisterStateWorkItem registerState:
+                                {
+                                    lock (_lock)
                                     {
-                                        _migrationSnapshotRequired = false;
+                                        if (_state is not ManagerState.Unknown)
+                                        {
+                                            throw new NotSupportedException("Registering a state after activation is not supported.");
+                                        }
+
+                                        var name = registerState.Name;
+                                        if (!_journalStreamDirectory.ContainsKey(name))
+                                        {
+                                            // Doing so will trigger a reset, since _journalStreamDirectory will bind the state in question.
+                                            _journalStreamDirectory.Set(name, _journalStreamDirectory.GetNextJournalStreamId());
+                                        }
                                     }
+                                    break;
                                 }
-                            }
-                            break;
-                        }
 
-                        case DeleteStateWorkItem:
-                        {
-                            // Clear storage.
-                            await _storage.DeleteAsync(_shutdownCancellation.Token).ConfigureAwait(true);
-
-                            lock (_lock)
-                            {
-                                // Reset the state id collection.
-                                _journalStreamDirectory.ResetVolatileState();
-
-                                // Allocate new state ids for each state.
-                                // Doing so will trigger a reset, since _journalStreamDirectory will bind the state in question.
-                                foreach (var (name, state) in _states)
+                            default:
                                 {
-                                    var id = _journalStreamDirectory.GetNextJournalStreamId();
-                                    _journalStreamDirectory.Set(name, id);
+                                    Debug.Fail($"The command {workItem.GetType().FullName} is unsupported");
+                                    break;
                                 }
-                            }
-                            break;
-                        }
-
-                        case InitializeWorkItem:
-                        {
-                            lock (_lock)
-                            {
-                                _state = ManagerState.Ready;
-                            }
-                            break;
-                        }
-
-                        case RegisterStateWorkItem registerState:
-                        {
-                            lock (_lock)
-                            {
-                                if (_state is not ManagerState.Unknown)
-                                {
-                                    throw new NotSupportedException("Registering a state after activation is not supported.");
-                                }
-
-                                var name = registerState.Name;
-                                if (!_journalStreamDirectory.ContainsKey(name))
-                                {
-                                    // Doing so will trigger a reset, since _journalStreamDirectory will bind the state in question.
-                                    _journalStreamDirectory.Set(name, _journalStreamDirectory.GetNextJournalStreamId());
-                                }
-                            }
-                            break;
-                        }
-
-                        default:
-                        {
-                            Debug.Fail($"The command {workItem.GetType().FullName} is unsupported");
-                            break;
-                        }
                         }
 
                         workItem.SetResult();

--- a/src/Orleans.Journaling/JournaledStateManager.cs
+++ b/src/Orleans.Journaling/JournaledStateManager.cs
@@ -18,6 +18,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
     private readonly Dictionary<string, IJournaledState> _states = new(StringComparer.Ordinal);
     private readonly Dictionary<uint, IJournaledState> _statesMap = [];
     private readonly JournaledStateManagerShared _shared;
+    private readonly IJournalStorage _storage;
     private readonly JournalBufferWriter _journalWriter;
     private readonly SingleWaiterAutoResetEvent _workSignal = new() { RunContinuationsAsynchronously = true };
     private readonly Queue<WorkItem> _workQueue = new();
@@ -28,10 +29,17 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
     private ManagerState _state;
     private bool _migrationSnapshotRequired;
 
-    public JournaledStateManager(JournaledStateManagerShared shared)
+    public JournaledStateManager(JournaledStateManagerShared shared, IJournalStorageProvider storageProvider, IGrainContext grainContext)
+        : this(shared, CreateStorage(storageProvider, grainContext))
+    {
+    }
+
+    internal JournaledStateManager(JournaledStateManagerShared shared, IJournalStorage storage)
     {
         ArgumentNullException.ThrowIfNull(shared);
+        ArgumentNullException.ThrowIfNull(storage);
         _shared = shared;
+        _storage = storage;
         _journalWriter = _shared.JournalFormat.CreateWriter();
         var serviceProvider = _shared.ServiceProvider;
         var journalStreamIdsCodec = JournalFormatServices.GetRequiredCommandCodec<IDurableDictionaryCommandCodec<string, uint>>(serviceProvider, WriteJournalFormatKey);
@@ -46,6 +54,13 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         // It is not stored in _journalStreamDirectory and does not participate in the general name->id mapping.
         _retirementTracker = new RetiredStateTracker(this, retirementTrackerCodec);
         _statesMap[RetiredStateTracker.Id] = _retirementTracker;
+    }
+
+    private static IJournalStorage CreateStorage(IJournalStorageProvider storageProvider, IGrainContext grainContext)
+    {
+        ArgumentNullException.ThrowIfNull(storageProvider);
+        ArgumentNullException.ThrowIfNull(grainContext);
+        return storageProvider.CreateStorage(grainContext) ?? throw new InvalidOperationException("The configured journal storage provider returned null.");
     }
 
     internal string WriteJournalFormatKey => _shared.JournalFormatKey;
@@ -171,7 +186,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                             //       If the current journal length is greater than the snapshot size, then take a snapshot instead of appending more journal entries.
                             var isSnapshot = workItem is WriteSnapshotWorkItem
                                 || _migrationSnapshotRequired
-                                || _shared.Storage.IsCompactionRequested;
+                                || _storage.IsCompactionRequested;
                             ArcBuffer committedBuffer = default;
                             ArcBuffer bufferToConsume = default;
                             var hasCommittedBuffer = false;
@@ -256,7 +271,10 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                                 else
                                 {
                                     hasCommittedBuffer = true;
-                                    hasBufferToConsume = true;
+                                    if (!isSnapshot)
+                                    {
+                                        hasBufferToConsume = true;
+                                    }
                                 }
                             }
 
@@ -284,13 +302,29 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                                 var writeCompleted = false;
                                 try
                                 {
+                                    if (isSnapshot && hasBufferToConsume)
+                                    {
+                                        await _storage.AppendAsync(bufferToConsume.AsReadOnlySequence(), _shutdownCancellation.Token).ConfigureAwait(true);
+                                        lock (_lock)
+                                        {
+                                            _journalWriter.Consume(bufferToConsume);
+                                            foreach (var state in _states.Values)
+                                            {
+                                                state.OnWriteCompleted();
+                                            }
+                                        }
+
+                                        bufferToConsume.Dispose();
+                                        hasBufferToConsume = false;
+                                    }
+
                                     if (isSnapshot)
                                     {
-                                        await _shared.Storage.ReplaceAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
+                                        await _storage.ReplaceAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
                                     }
                                     else
                                     {
-                                        await _shared.Storage.AppendAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
+                                        await _storage.AppendAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
                                     }
 
                                     writeCompleted = true;
@@ -344,7 +378,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                         case DeleteStateWorkItem:
                         {
                             // Clear storage.
-                            await _shared.Storage.DeleteAsync(_shutdownCancellation.Token).ConfigureAwait(true);
+                            await _storage.DeleteAsync(_shutdownCancellation.Token).ConfigureAwait(true);
 
                             lock (_lock)
                             {
@@ -518,7 +552,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
             ResetForRecovery();
         }
 
-        await _shared.Storage.ReadAsync(this, cancellationToken).ConfigureAwait(true);
+        await _storage.ReadAsync(this, cancellationToken).ConfigureAwait(true);
 
         lock (_lock)
         {
@@ -653,7 +687,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         bool didEnqueue;
         lock (_lock)
         {
-            pendingWrite = _migrationSnapshotRequired || _shared.Storage.IsCompactionRequested
+            pendingWrite = _migrationSnapshotRequired || _storage.IsCompactionRequested
                 ? EnqueueOrGetPendingWorkItem<WriteSnapshotWorkItem>(out didEnqueue)
                 : EnqueueOrGetPendingWorkItem<AppendJournalWorkItem>(out didEnqueue);
         }

--- a/src/Orleans.Journaling/JournaledStateManagerFactory.cs
+++ b/src/Orleans.Journaling/JournaledStateManagerFactory.cs
@@ -1,0 +1,17 @@
+namespace Orleans.Journaling;
+
+internal sealed class JournaledStateManagerFactory(
+    JournaledStateManagerShared shared,
+    IJournalStorageProvider storageProvider) : IJournaledStateManagerFactory
+{
+    public IJournaledStateManager Create(JournalId journalId)
+    {
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
+
+        return new JournaledStateManager(shared, storageProvider, journalId);
+    }
+}
+

--- a/src/Orleans.Journaling/JournaledStateManagerShared.cs
+++ b/src/Orleans.Journaling/JournaledStateManagerShared.cs
@@ -9,9 +9,8 @@ internal sealed class JournaledStateManagerShared
         ILogger<JournaledStateManager> logger,
         IOptions<JournaledStateManagerOptions> options,
         TimeProvider timeProvider,
-        IJournalStorage storage,
         IServiceProvider serviceProvider)
-        : this(logger, CreateOptions(options), timeProvider, storage, serviceProvider)
+        : this(logger, CreateOptions(options), timeProvider, serviceProvider)
     {
     }
 
@@ -19,19 +18,16 @@ internal sealed class JournaledStateManagerShared
         ILogger<JournaledStateManager> logger,
         JournaledStateManagerOptions options,
         TimeProvider timeProvider,
-        IJournalStorage storage,
         IServiceProvider serviceProvider)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(timeProvider);
-        ArgumentNullException.ThrowIfNull(storage);
         ArgumentNullException.ThrowIfNull(serviceProvider);
 
         Logger = logger;
         Options = options;
         TimeProvider = timeProvider;
-        Storage = storage;
         ServiceProvider = serviceProvider;
         JournalFormat = JournalFormatServices.GetRequiredJournalFormat(serviceProvider, options.JournalFormatKey);
     }
@@ -41,8 +37,6 @@ internal sealed class JournaledStateManagerShared
     public JournaledStateManagerOptions Options { get; }
 
     public TimeProvider TimeProvider { get; }
-
-    public IJournalStorage Storage { get; }
 
     public IServiceProvider ServiceProvider { get; }
 

--- a/src/Orleans.Journaling/VolatileJournalStorage.cs
+++ b/src/Orleans.Journaling/VolatileJournalStorage.cs
@@ -8,7 +8,7 @@ namespace Orleans.Journaling;
 public sealed class VolatileJournalStorageProvider : IJournalStorageProvider
 {
     private readonly IOptions<JournaledStateManagerOptions>? _options;
-    private readonly ConcurrentDictionary<GrainId, VolatileJournalStorage> _storage = new();
+    private readonly ConcurrentDictionary<JournalId, VolatileJournalStorage> _storage = new();
 
     public VolatileJournalStorageProvider()
     {
@@ -26,13 +26,22 @@ public sealed class VolatileJournalStorageProvider : IJournalStorageProvider
 
     public IJournalStorage CreateStorage(IGrainContext grainContext)
     {
+        ArgumentNullException.ThrowIfNull(grainContext);
+        return CreateStorage(JournalId.FromGrainId(grainContext.GrainId));
+    }
+
+    public IJournalStorage CreateStorage(JournalId journalId)
+    {
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
+
         var journalFormatKey = GetJournalFormatKey();
-        var storage = _storage.GetOrAdd(grainContext.GrainId, _ => new VolatileJournalStorage(journalFormatKey));
+        var storage = _storage.GetOrAdd(journalId, _ => new VolatileJournalStorage(journalFormatKey));
         storage.SetConfiguredJournalFormatKey(journalFormatKey);
         return storage;
     }
-
-    public IJournalStorage Create(IGrainContext grainContext) => CreateStorage(grainContext);
 
     private string GetJournalFormatKey()
         => JournalFormatServices.ValidateJournalFormatKey(_options?.Value.JournalFormatKey ?? JsonJournalExtensions.JournalFormatKey);

--- a/src/Orleans.Journaling/VolatileJournalStorage.cs
+++ b/src/Orleans.Journaling/VolatileJournalStorage.cs
@@ -5,7 +5,7 @@ using Orleans.Journaling.Json;
 
 namespace Orleans.Journaling;
 
-public sealed class VolatileJournalStorageProvider
+public sealed class VolatileJournalStorageProvider : IJournalStorageProvider
 {
     private readonly IOptions<JournaledStateManagerOptions>? _options;
     private readonly ConcurrentDictionary<GrainId, VolatileJournalStorage> _storage = new();
@@ -24,13 +24,15 @@ public sealed class VolatileJournalStorageProvider
         _options = options;
     }
 
-    public IJournalStorage Create(IGrainContext grainContext)
+    public IJournalStorage CreateStorage(IGrainContext grainContext)
     {
         var journalFormatKey = GetJournalFormatKey();
         var storage = _storage.GetOrAdd(grainContext.GrainId, _ => new VolatileJournalStorage(journalFormatKey));
         storage.SetConfiguredJournalFormatKey(journalFormatKey);
         return storage;
     }
+
+    public IJournalStorage Create(IGrainContext grainContext) => CreateStorage(grainContext);
 
     private string GetJournalFormatKey()
         => JournalFormatServices.ValidateJournalFormatKey(_options?.Value.JournalFormatKey ?? JsonJournalExtensions.JournalFormatKey);

--- a/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
@@ -19,7 +19,9 @@ namespace Orleans.Journaling
 
         public string ContainerName { get { throw null; } set { } }
 
-        public System.Func<Runtime.GrainId, string> GetBlobName { get { throw null; } set { } }
+        public bool DeleteOldCheckpoints { get { throw null; } set { } }
+
+        public System.Func<JournalId, string> GetBlobName { get { throw null; } set { } }
 
         public void ConfigureBlobServiceClient(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<Azure.Storage.Blobs.BlobServiceClient>> createClientCallback) { }
 
@@ -43,6 +45,7 @@ namespace Orleans.Journaling
 
     public partial interface IBlobContainerFactory
     {
+        Azure.Storage.Blobs.BlobContainerClient GetBlobContainerClient(JournalId journalId);
         Azure.Storage.Blobs.BlobContainerClient GetBlobContainerClient(Runtime.GrainId grainId);
         System.Threading.Tasks.Task InitializeAsync(Azure.Storage.Blobs.BlobServiceClient client, System.Threading.CancellationToken cancellationToken);
     }

--- a/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
@@ -40,9 +40,9 @@ namespace Orleans.Journaling
 
     public sealed partial class AzureBlobJournalCheckpointNameContext
     {
-        public AzureBlobJournalCheckpointNameContext(Runtime.GrainId grainId, string journalBlobName, uint checkpointId) { }
+        public AzureBlobJournalCheckpointNameContext(Runtime.GrainId grainId, string journalBlobName, ulong generation) { }
 
-        public uint CheckpointId { get { throw null; } }
+        public ulong Generation { get { throw null; } }
 
         public Runtime.GrainId GrainId { get { throw null; } }
 
@@ -51,7 +51,9 @@ namespace Orleans.Journaling
 
     public sealed partial class AzureBlobJournalWalSegmentNameContext
     {
-        public AzureBlobJournalWalSegmentNameContext(Runtime.GrainId grainId, string journalBlobName, uint segmentId) { }
+        public AzureBlobJournalWalSegmentNameContext(Runtime.GrainId grainId, string journalBlobName, ulong generation, uint segmentId) { }
+
+        public ulong Generation { get { throw null; } }
 
         public Runtime.GrainId GrainId { get { throw null; } }
 

--- a/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
@@ -21,7 +21,9 @@ namespace Orleans.Journaling
 
         public System.Func<Runtime.GrainId, string> GetBlobName { get { throw null; } set { } }
 
-        public System.Func<AzureBlobJournalSnapshotNameContext, string> GetSnapshotBlobName { get { throw null; } set { } }
+        public System.Func<AzureBlobJournalCheckpointNameContext, string> GetCheckpointBlobName { get { throw null; } set { } }
+
+        public System.Func<AzureBlobJournalWalSegmentNameContext, string> GetWalSegmentBlobName { get { throw null; } set { } }
 
         public void ConfigureBlobServiceClient(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<Azure.Storage.Blobs.BlobServiceClient>> createClientCallback) { }
 
@@ -36,15 +38,26 @@ namespace Orleans.Journaling
         public void ConfigureBlobServiceClient(System.Uri serviceUri) { }
     }
 
-    public sealed partial class AzureBlobJournalSnapshotNameContext
+    public sealed partial class AzureBlobJournalCheckpointNameContext
     {
-        public AzureBlobJournalSnapshotNameContext(Runtime.GrainId grainId, string journalBlobName, string snapshotId) { }
+        public AzureBlobJournalCheckpointNameContext(Runtime.GrainId grainId, string journalBlobName, uint checkpointId) { }
+
+        public uint CheckpointId { get { throw null; } }
+
+        public Runtime.GrainId GrainId { get { throw null; } }
+
+        public string JournalBlobName { get { throw null; } }
+    }
+
+    public sealed partial class AzureBlobJournalWalSegmentNameContext
+    {
+        public AzureBlobJournalWalSegmentNameContext(Runtime.GrainId grainId, string journalBlobName, uint segmentId) { }
 
         public Runtime.GrainId GrainId { get { throw null; } }
 
         public string JournalBlobName { get { throw null; } }
 
-        public string SnapshotId { get { throw null; } }
+        public uint SegmentId { get { throw null; } }
     }
 
     public static partial class AzureBlobStorageHostingExtensions

--- a/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
@@ -21,10 +21,6 @@ namespace Orleans.Journaling
 
         public System.Func<Runtime.GrainId, string> GetBlobName { get { throw null; } set { } }
 
-        public System.Func<AzureBlobJournalCheckpointNameContext, string> GetCheckpointBlobName { get { throw null; } set { } }
-
-        public System.Func<AzureBlobJournalWalSegmentNameContext, string> GetWalSegmentBlobName { get { throw null; } set { } }
-
         public void ConfigureBlobServiceClient(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<Azure.Storage.Blobs.BlobServiceClient>> createClientCallback) { }
 
         public void ConfigureBlobServiceClient(string connectionString) { }
@@ -36,30 +32,6 @@ namespace Orleans.Journaling
         public void ConfigureBlobServiceClient(System.Uri serviceUri, Azure.Storage.StorageSharedKeyCredential sharedKeyCredential) { }
 
         public void ConfigureBlobServiceClient(System.Uri serviceUri) { }
-    }
-
-    public sealed partial class AzureBlobJournalCheckpointNameContext
-    {
-        public AzureBlobJournalCheckpointNameContext(Runtime.GrainId grainId, string journalBlobName, ulong generation) { }
-
-        public ulong Generation { get { throw null; } }
-
-        public Runtime.GrainId GrainId { get { throw null; } }
-
-        public string JournalBlobName { get { throw null; } }
-    }
-
-    public sealed partial class AzureBlobJournalWalSegmentNameContext
-    {
-        public AzureBlobJournalWalSegmentNameContext(Runtime.GrainId grainId, string journalBlobName, ulong generation, uint segmentId) { }
-
-        public ulong Generation { get { throw null; } }
-
-        public Runtime.GrainId GrainId { get { throw null; } }
-
-        public string JournalBlobName { get { throw null; } }
-
-        public uint SegmentId { get { throw null; } }
     }
 
     public static partial class AzureBlobStorageHostingExtensions

--- a/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
@@ -21,6 +21,8 @@ namespace Orleans.Journaling
 
         public System.Func<Runtime.GrainId, string> GetBlobName { get { throw null; } set { } }
 
+        public System.Func<AzureBlobJournalSnapshotNameContext, string> GetSnapshotBlobName { get { throw null; } set { } }
+
         public void ConfigureBlobServiceClient(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<Azure.Storage.Blobs.BlobServiceClient>> createClientCallback) { }
 
         public void ConfigureBlobServiceClient(string connectionString) { }
@@ -32,6 +34,17 @@ namespace Orleans.Journaling
         public void ConfigureBlobServiceClient(System.Uri serviceUri, Azure.Storage.StorageSharedKeyCredential sharedKeyCredential) { }
 
         public void ConfigureBlobServiceClient(System.Uri serviceUri) { }
+    }
+
+    public sealed partial class AzureBlobJournalSnapshotNameContext
+    {
+        public AzureBlobJournalSnapshotNameContext(Runtime.GrainId grainId, string journalBlobName, string snapshotId) { }
+
+        public Runtime.GrainId GrainId { get { throw null; } }
+
+        public string JournalBlobName { get { throw null; } }
+
+        public string SnapshotId { get { throw null; } }
     }
 
     public static partial class AzureBlobStorageHostingExtensions

--- a/src/api/Orleans.Journaling/Orleans.Journaling.cs
+++ b/src/api/Orleans.Journaling/Orleans.Journaling.cs
@@ -495,8 +495,6 @@ namespace Orleans.Journaling
 
         public VolatileJournalStorageProvider(Microsoft.Extensions.Options.IOptions<JournaledStateManagerOptions> options) { }
 
-        public IJournalStorage Create(JournalId journalId) { throw null; }
-        public IJournalStorage Create(Runtime.IGrainContext grainContext) { throw null; }
         public IJournalStorage CreateStorage(JournalId journalId) { throw null; }
         public IJournalStorage CreateStorage(Runtime.IGrainContext grainContext) { throw null; }
     }

--- a/src/api/Orleans.Journaling/Orleans.Journaling.cs
+++ b/src/api/Orleans.Journaling/Orleans.Journaling.cs
@@ -170,6 +170,7 @@ namespace Orleans.Journaling
 
     public partial interface IJournalStorageProvider
     {
+        IJournalStorage CreateStorage(JournalId journalId);
         IJournalStorage CreateStorage(Runtime.IGrainContext grainContext);
     }
 
@@ -233,13 +234,18 @@ namespace Orleans.Journaling
         void Reset(int capacityHint);
     }
 
-    public partial interface IJournaledStateManager
+    public partial interface IJournaledStateManager : System.IAsyncDisposable
     {
         System.Threading.Tasks.ValueTask DeleteStateAsync(System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.ValueTask InitializeAsync(System.Threading.CancellationToken cancellationToken);
         void RegisterState(string name, IJournaledState state);
         bool TryGetState(string name, out IJournaledState? state);
         System.Threading.Tasks.ValueTask WriteStateAsync(System.Threading.CancellationToken cancellationToken);
+    }
+
+    public partial interface IJournaledStateManagerFactory
+    {
+        IJournaledStateManager Create(JournalId journalId);
     }
 
     public partial interface IPersistentStateCommandCodec<T>
@@ -441,6 +447,31 @@ namespace Orleans.Journaling
 
     }
 
+    public readonly partial struct JournalId : System.IEquatable<JournalId>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public JournalId(string value) { throw null; }
+
+        public bool IsDefault { get { throw null; } }
+
+        public string Value { get { throw null; } }
+
+        public bool Equals(JournalId other) { throw null; }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public static JournalId FromGrainId(Runtime.GrainId grainId) { throw null; }
+
+        public override int GetHashCode() { throw null; }
+
+        public override string ToString() { throw null; }
+
+        public static bool operator ==(JournalId left, JournalId right) { throw null; }
+
+        public static bool operator !=(JournalId left, JournalId right) { throw null; }
+    }
+
     public sealed partial class VolatileJournalStorage : IJournalStorage
     {
         public VolatileJournalStorage() { }
@@ -464,7 +495,9 @@ namespace Orleans.Journaling
 
         public VolatileJournalStorageProvider(Microsoft.Extensions.Options.IOptions<JournaledStateManagerOptions> options) { }
 
+        public IJournalStorage Create(JournalId journalId) { throw null; }
         public IJournalStorage Create(Runtime.IGrainContext grainContext) { throw null; }
+        public IJournalStorage CreateStorage(JournalId journalId) { throw null; }
         public IJournalStorage CreateStorage(Runtime.IGrainContext grainContext) { throw null; }
     }
 }

--- a/src/api/Orleans.Journaling/Orleans.Journaling.cs
+++ b/src/api/Orleans.Journaling/Orleans.Journaling.cs
@@ -400,6 +400,8 @@ namespace Orleans.Journaling
         public static void Read(this IJournalStorageConsumer consumer, System.ReadOnlyMemory<byte> input, IJournalFileMetadata? metadata, bool complete) { }
 
         public static System.Threading.Tasks.ValueTask<long> ReadAsync(this IJournalStorageConsumer consumer, System.IO.Stream input, IJournalFileMetadata? metadata, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.ValueTask<long> ReadAsync(this IJournalStorageConsumer consumer, System.IO.Stream input, IJournalFileMetadata? metadata, bool complete, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
 
     public readonly partial struct JournalStreamId : System.IEquatable<JournalStreamId>

--- a/src/api/Orleans.Journaling/Orleans.Journaling.cs
+++ b/src/api/Orleans.Journaling/Orleans.Journaling.cs
@@ -168,6 +168,11 @@ namespace Orleans.Journaling
         System.Threading.Tasks.ValueTask ReplaceAsync(System.Buffers.ReadOnlySequence<byte> value, System.Threading.CancellationToken cancellationToken);
     }
 
+    public partial interface IJournalStorageProvider
+    {
+        IJournalStorage CreateStorage(Runtime.IGrainContext grainContext);
+    }
+
     public partial interface IJournalStorageConsumer
     {
         void Read(JournalBufferReader buffer, IJournalFileMetadata? metadata);
@@ -451,13 +456,14 @@ namespace Orleans.Journaling
         public System.Threading.Tasks.ValueTask ReplaceAsync(System.Buffers.ReadOnlySequence<byte> snapshot, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
 
-    public sealed partial class VolatileJournalStorageProvider
+    public sealed partial class VolatileJournalStorageProvider : IJournalStorageProvider
     {
         public VolatileJournalStorageProvider() { }
 
         public VolatileJournalStorageProvider(Microsoft.Extensions.Options.IOptions<JournaledStateManagerOptions> options) { }
 
         public IJournalStorage Create(Runtime.IGrainContext grainContext) { throw null; }
+        public IJournalStorage CreateStorage(Runtime.IGrainContext grainContext) { throw null; }
     }
 }
 

--- a/test/Benchmarks/Journaling/JournalReplayContextFactory.cs
+++ b/test/Benchmarks/Journaling/JournalReplayContextFactory.cs
@@ -21,10 +21,9 @@ internal static class JournalReplayContextFactory
             NullLogger<JournaledStateManager>.Instance,
             Options.Create(new JournaledStateManagerOptions { JournalFormatKey = journalFormatKey }),
             TimeProvider.System,
-            new NullJournalStorage(),
             serviceProvider);
 
-        var manager = new JournaledStateManager(shared);
+        var manager = new JournaledStateManager(shared, new NullJournalStorage());
         manager.BindStateForReplay(streamId, state);
         return new(manager);
     }

--- a/test/Orleans.Journaling.Json.Tests/CodecRecoveryTests.cs
+++ b/test/Orleans.Journaling.Json.Tests/CodecRecoveryTests.cs
@@ -347,9 +347,8 @@ public class CodecRecoveryTests : JournalingTestBase
             serviceProvider.GetRequiredService<ILogger<JournaledStateManager>>(),
             Microsoft.Extensions.Options.Options.Create(managerOptions),
             TimeProvider.System,
-            storage,
             serviceProvider);
-        var manager = new JournaledStateManager(shared);
+        var manager = new JournaledStateManager(shared, storage);
         var lifecycle = new TestGrainLifecycle(serviceProvider.GetRequiredService<ILogger<TestGrainLifecycle>>());
         (manager as ILifecycleParticipant<IGrainLifecycle>)?.Participate(lifecycle);
         return (manager, storage, lifecycle);
@@ -406,10 +405,9 @@ public class CodecRecoveryTests : JournalingTestBase
             serviceProvider.GetRequiredService<ILogger<JournaledStateManager>>(),
             Microsoft.Extensions.Options.Options.Create(managerOptions),
             TimeProvider.System,
-            storage,
             serviceProvider);
 
-        var manager = new JournaledStateManager(shared);
+        var manager = new JournaledStateManager(shared, storage);
         var lifecycle = new TestGrainLifecycle(serviceProvider.GetRequiredService<ILogger<TestGrainLifecycle>>());
         (manager as ILifecycleParticipant<IGrainLifecycle>)?.Participate(lifecycle);
         return new(serviceProvider, manager, lifecycle);

--- a/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
@@ -168,10 +168,9 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
             LoggerFactory.CreateLogger<JournaledStateManager>(),
             Options.Create(ManagerOptions),
             TimeProvider.System,
-            storage,
             ServiceProvider);
 
-        return new(shared);
+        return new(shared, storage);
     }
 
     private IFieldCodec<T> ValueCodec<T>() => CodecProvider.GetCodec<T>();
@@ -229,10 +228,9 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
             serviceProvider.GetRequiredService<ILogger<JournaledStateManager>>(),
             Options.Create(new JournaledStateManagerOptions { JournalFormatKey = journalFormatKey }),
             TimeProvider.System,
-            storage,
             serviceProvider);
 
-        return new(shared);
+        return new(shared, storage);
     }
 
     private static DurableDictionary<string, int> CreateFormatAwareDictionary(IServiceProvider serviceProvider, JournaledStateManager manager, string journalFormatKey)

--- a/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -143,6 +144,35 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
         Assert.Equal(17, await recovered.Tcs.Task);
     }
 
+    [SkippableFact]
+    public async Task AzureBlobStorage_CheckpointAndWal_RecoverAcrossFreshProviderInstances()
+    {
+        var blobName = $"journaling-checkpoint-wal-recovery/{Guid.NewGuid():N}";
+        var grainId = GrainId.Create("journaling-checkpoint-wal-recovery", Guid.NewGuid().ToString("N"));
+        var checkpointBytes = new byte[] { 0x10, 0x20, 0x30, 0x40 };
+        var walBytes = new byte[] { 0x50, 0x60, 0x70 };
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        await using (var writerProvider = await CreateAzureProviderAsync(OrleansBinaryJournalFormat.JournalFormatKey, blobName, cts.Token))
+        {
+            var storage = writerProvider.StorageProvider.Create(new JournalBatchTests.TestGrainContext(grainId));
+            await storage.ReplaceAsync(new ReadOnlySequence<byte>(checkpointBytes), cts.Token);
+            await storage.AppendAsync(new ReadOnlySequence<byte>(walBytes), cts.Token);
+        }
+
+        await using var readerProvider = await CreateAzureProviderAsync(OrleansBinaryJournalFormat.JournalFormatKey, blobName, cts.Token);
+        var recoveredStorage = readerProvider.StorageProvider.Create(new JournalBatchTests.TestGrainContext(grainId));
+        var recovered = new RecordingJournalStorageConsumer();
+
+        await recoveredStorage.ReadAsync(recovered, cts.Token);
+
+        Assert.True(recovered.IsCompleted);
+        Assert.All(recovered.Formats, format => Assert.Equal(OrleansBinaryJournalFormat.JournalFormatKey, format));
+        Assert.Equal([.. checkpointBytes, .. walBytes], recovered.Bytes.ToArray());
+
+        await recoveredStorage.DeleteAsync(cts.Token);
+    }
+
     private DurableStates CreateStates(IJournalStorage storage)
     {
         var manager = CreateManager(storage);
@@ -255,6 +285,27 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             await lifecycle.OnStop(cts.Token);
             await ServiceProvider.DisposeAsync();
+        }
+    }
+
+    private sealed class RecordingJournalStorageConsumer : IJournalStorageConsumer
+    {
+        public List<byte> Bytes { get; } = [];
+
+        public List<string?> Formats { get; } = [];
+
+        public bool IsCompleted { get; private set; }
+
+        public void Read(JournalBufferReader buffer, IJournalFileMetadata? metadata)
+        {
+            if (buffer.Length > 0)
+            {
+                Bytes.AddRange(buffer.ToArray());
+                buffer.Skip(buffer.Length);
+                Formats.Add(metadata?.Format);
+            }
+
+            IsCompleted |= buffer.IsCompleted;
         }
     }
 

--- a/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
@@ -59,7 +59,7 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
 
         await using (var binaryProvider = await CreateAzureProviderAsync(OrleansBinaryJournalFormat.JournalFormatKey, blobName, cts.Token))
         {
-            var storage = binaryProvider.StorageProvider.Create(new JournalBatchTests.TestGrainContext(grainId));
+            var storage = binaryProvider.StorageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
             var manager = CreateFormatAwareManager(binaryProvider.ServiceProvider, storage, OrleansBinaryJournalFormat.JournalFormatKey);
             var dict = CreateFormatAwareDictionary(binaryProvider.ServiceProvider, manager, OrleansBinaryJournalFormat.JournalFormatKey);
             await manager.InitializeAsync(cts.Token);
@@ -70,7 +70,7 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
         }
 
         await using var jsonProvider = await CreateAzureProviderAsync(JsonJournalExtensions.JournalFormatKey, blobName, cts.Token);
-        var migratedStorage = jsonProvider.StorageProvider.Create(new JournalBatchTests.TestGrainContext(grainId));
+        var migratedStorage = jsonProvider.StorageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
         var migratedManager = CreateFormatAwareManager(jsonProvider.ServiceProvider, migratedStorage, JsonJournalExtensions.JournalFormatKey);
         var migratedDict = CreateFormatAwareDictionary(jsonProvider.ServiceProvider, migratedManager, JsonJournalExtensions.JournalFormatKey);
         await migratedManager.InitializeAsync(cts.Token);
@@ -81,7 +81,7 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
         await migratedManager.WriteStateAsync(cts.Token);
         ((IDisposable)migratedManager).Dispose();
 
-        var recoveredStorage = jsonProvider.StorageProvider.Create(new JournalBatchTests.TestGrainContext(grainId));
+        var recoveredStorage = jsonProvider.StorageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
         var recoveredManager = CreateFormatAwareManager(jsonProvider.ServiceProvider, recoveredStorage, JsonJournalExtensions.JournalFormatKey);
         var recoveredDict = CreateFormatAwareDictionary(jsonProvider.ServiceProvider, recoveredManager, JsonJournalExtensions.JournalFormatKey);
         await recoveredManager.InitializeAsync(cts.Token);
@@ -107,7 +107,7 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
     public async Task AzureBlobStorage_AllDurableTypes_RecoverWithBinaryCodec()
     {
         var grainId = GrainId.Create("journaling-codec-recovery", Guid.NewGuid().ToString("N"));
-        var storage = _storageProvider.Create(new JournalBatchTests.TestGrainContext(grainId));
+        var storage = _storageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
         var first = CreateStates(storage);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         await first.Manager.InitializeAsync(cts.Token);
@@ -125,7 +125,7 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
         Assert.True(first.Tcs.TrySetResult(17));
         await first.Manager.WriteStateAsync(cts.Token);
 
-        var recoveredStorage = _storageProvider.Create(new JournalBatchTests.TestGrainContext(grainId));
+        var recoveredStorage = _storageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
         var recovered = CreateStates(recoveredStorage);
         await recovered.Manager.InitializeAsync(cts.Token);
 
@@ -155,13 +155,13 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
 
         await using (var writerProvider = await CreateAzureProviderAsync(OrleansBinaryJournalFormat.JournalFormatKey, blobName, cts.Token))
         {
-            var storage = writerProvider.StorageProvider.Create(new JournalBatchTests.TestGrainContext(grainId));
+            var storage = writerProvider.StorageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
             await storage.ReplaceAsync(new ReadOnlySequence<byte>(checkpointBytes), cts.Token);
             await storage.AppendAsync(new ReadOnlySequence<byte>(walBytes), cts.Token);
         }
 
         await using var readerProvider = await CreateAzureProviderAsync(OrleansBinaryJournalFormat.JournalFormatKey, blobName, cts.Token);
-        var recoveredStorage = readerProvider.StorageProvider.Create(new JournalBatchTests.TestGrainContext(grainId));
+        var recoveredStorage = readerProvider.StorageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
         var recovered = new RecordingJournalStorageConsumer();
 
         await recoveredStorage.ReadAsync(recovered, cts.Token);

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -97,6 +97,7 @@ public sealed class AzureBlobJournalStorageTests
 
         var metadata = appendBlobs.SetMetadataCalls.Single();
         Assert.Equal("blob.log.00000000", metadata.Name);
+        Assert.Equal(new ETag("\"seal-1\""), metadata.IfMatch);
         AssertAzureMetadataKeys(metadata.Metadata);
         Assert.Equal("blob.checkpoint.00000000", metadata.Metadata[AzureBlobJournalStorage.CheckpointMetadataKey]);
         Assert.Equal("\"checkpoint-1\"", metadata.Metadata[AzureBlobJournalStorage.CheckpointETagMetadataKey]);
@@ -422,6 +423,7 @@ public sealed class AzureBlobJournalStorageTests
         private readonly Dictionary<string, StoredAppendBlob> _blobs = [];
         private int _createCount;
         private int _appendCount;
+        private int _sealCount;
 
         public bool FailNextAppend { get; set; }
 
@@ -531,6 +533,8 @@ public sealed class AzureBlobJournalStorageTests
 
             ThrowIfAppendConditionsFail(name, conditions);
             blob.IsSealed = true;
+            _sealCount++;
+            blob.ETag = new ETag($"\"seal-{_sealCount}\"");
             return Task.FromResult(Response.FromValue(BlobsModelFactory.BlobInfo(blob.ETag, default), TestResponse.Instance));
         }
 

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -343,7 +343,7 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
-    public async Task AppendAsync_WhenAppendFails_DoesNotAdvanceAppendPosition()
+    public async Task AppendAsync_WhenAppendFails_ReusesLastObservedETag()
     {
         var appendBlobs = new FakeAppendBlobStore();
         var storage = CreateStorage(appendBlobs);
@@ -355,8 +355,8 @@ public sealed class AzureBlobJournalStorageTests
             () => storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
         await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
 
-        Assert.Equal(1, appendBlobs.AppendCalls[1].AppendPosition);
-        Assert.Equal(1, appendBlobs.AppendCalls[2].AppendPosition);
+        Assert.Equal(new ETag("\"append-1\""), appendBlobs.AppendCalls[1].IfMatch);
+        Assert.Equal(new ETag("\"append-1\""), appendBlobs.AppendCalls[2].IfMatch);
         Assert.Equal([3], appendBlobs.AppendCalls[2].Payload);
     }
 
@@ -398,14 +398,15 @@ public sealed class AzureBlobJournalStorageTests
     {
         checkpoints ??= new FakeBlockBlobStore();
         return new AzureBlobJournalStorage(
-            appendBlobs.GetAppendBlobClient("blob/root"),
-            mimeType,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            journalFormatKey,
-            blobClientProvider: new FakeBlobClientProvider(appendBlobs, checkpoints));
+            new AzureBlobJournalStorage.SharedConfiguration(
+                NullLogger<AzureBlobJournalStorage>.Instance,
+                new FakeBlobClientProvider(appendBlobs, checkpoints),
+                mimeType,
+                journalFormatKey),
+            new JournalBatchTests.TestGrainContext(GrainId.Create("test-grain", "0")));
     }
 
-    private static Dictionary<string, string> RootMetadata(ulong generation, string? format = null)
+    private static Dictionary<string, string> RootMetadata(uint generation, string? format = null)
     {
         var result = new Dictionary<string, string>
         {
@@ -422,7 +423,7 @@ public sealed class AzureBlobJournalStorageTests
     private static Dictionary<string, string> CheckpointMarkerMetadata(
         string checkpointName,
         string format,
-        ulong generation) => new()
+        uint generation) => new()
     {
         [AzureBlobJournalStorage.GenerationMetadataKey] = generation.ToString(System.Globalization.CultureInfo.InvariantCulture),
         [AzureBlobJournalStorage.FormatMetadataKey] = format,
@@ -491,19 +492,19 @@ public sealed class AzureBlobJournalStorageTests
 
     private sealed class FakeBlobClientProvider(FakeAppendBlobStore appendBlobs, FakeBlockBlobStore blockBlobs) : AzureBlobJournalStorage.BlobClientProvider
     {
-        public override AppendBlobClient GetWalClient(AppendBlobClient rootLogClient, ulong generation, uint segmentId)
-            => appendBlobs.GetAppendBlobClient(AzureBlobJournalStorageOptions.GetDefaultWalSegmentBlobName(GetJournalId(rootLogClient), generation, segmentId));
+        private const string JournalBlobName = "blob";
 
-        public override string GetCheckpointName(AppendBlobClient rootLogClient, ulong generation)
-            => AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName(GetJournalId(rootLogClient), generation);
+        public override AppendBlobClient GetRootClient(GrainId grainId)
+            => appendBlobs.GetAppendBlobClient($"{JournalBlobName}/root");
 
-        public override BlockBlobClient GetCheckpointClient(AppendBlobClient rootLogClient, string checkpointName)
+        public override AppendBlobClient GetWalClient(GrainId grainId, uint generation, uint segmentId)
+            => appendBlobs.GetAppendBlobClient(AzureBlobJournalStorageOptions.GetDefaultWalSegmentBlobName(JournalBlobName, generation, segmentId));
+
+        public override string GetCheckpointName(GrainId grainId, uint generation)
+            => AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName(JournalBlobName, generation);
+
+        public override BlockBlobClient GetCheckpointClient(GrainId grainId, string checkpointName)
             => blockBlobs.GetBlockBlobClient(checkpointName);
-
-        private static string GetJournalId(AppendBlobClient rootLogClient)
-            => rootLogClient.Name.EndsWith("/root", StringComparison.Ordinal)
-                ? rootLogClient.Name[..^"/root".Length]
-                : rootLogClient.Name;
     }
 
     private sealed class FakeAppendBlobStore
@@ -592,7 +593,6 @@ public sealed class AzureBlobJournalStorageTests
                 name,
                 options.Conditions?.IfMatch ?? default,
                 options.Conditions?.IfNoneMatch ?? default,
-                options.Conditions?.IfAppendPositionEqual,
                 payload));
 
             if (blob.IsSealed)
@@ -713,11 +713,6 @@ public sealed class AzureBlobJournalStorageTests
             if (conditions.IfMatch is { } ifMatch && ifMatch != default && (!exists || ifMatch != blob!.ETag))
             {
                 throw new RequestFailedException(412, "ETag mismatch.");
-            }
-
-            if (conditions.IfAppendPositionEqual is { } appendPosition && (!exists || appendPosition != blob!.Content.Length))
-            {
-                throw new RequestFailedException(412, "Append position mismatch.");
             }
         }
 
@@ -842,7 +837,7 @@ public sealed class AzureBlobJournalStorageTests
 
     private sealed record CreateCall(string Name, ETag IfMatch, ETag IfNoneMatch, string? ContentType, IDictionary<string, string> Metadata);
 
-    private sealed record AppendCall(string Name, ETag IfMatch, ETag IfNoneMatch, long? AppendPosition, byte[] Payload);
+    private sealed record AppendCall(string Name, ETag IfMatch, ETag IfNoneMatch, byte[] Payload);
 
     private sealed record SealCall(string Name, ETag IfMatch);
 

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -401,10 +401,7 @@ public sealed class AzureBlobJournalStorageTests
             mimeType,
             NullLogger<AzureBlobJournalStorage>.Instance,
             journalFormatKey,
-            walNameFactory: (generation, segmentId) => $"blob/{generation}/seg.{segmentId:X8}",
-            walClientFactory: (generation, segmentId) => appendBlobs.GetAppendBlobClient($"blob/{generation}/seg.{segmentId:X8}"),
-            checkpointNameFactory: generation => $"blob/{generation}/chk",
-            checkpointClientFactory: checkpoints.GetBlockBlobClient);
+            blobClientProvider: new FakeBlobClientProvider(appendBlobs, checkpoints));
     }
 
     private static Dictionary<string, string> RootMetadata(ulong generation, string? format = null)
@@ -494,6 +491,23 @@ public sealed class AzureBlobJournalStorageTests
                 Bytes.Write(chunk);
             }
         }
+    }
+
+    private sealed class FakeBlobClientProvider(FakeAppendBlobStore appendBlobs, FakeBlockBlobStore blockBlobs) : AzureBlobJournalStorage.BlobClientProvider
+    {
+        public override AppendBlobClient GetWalClient(AppendBlobClient rootLogClient, ulong generation, uint segmentId)
+            => appendBlobs.GetAppendBlobClient(AzureBlobJournalStorageOptions.GetDefaultWalSegmentBlobName(GetJournalId(rootLogClient), generation, segmentId));
+
+        public override string GetCheckpointName(AppendBlobClient rootLogClient, ulong generation)
+            => AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName(GetJournalId(rootLogClient), generation);
+
+        public override BlockBlobClient GetCheckpointClient(AppendBlobClient rootLogClient, string checkpointName)
+            => blockBlobs.GetBlockBlobClient(checkpointName);
+
+        private static string GetJournalId(AppendBlobClient rootLogClient)
+            => rootLogClient.Name.EndsWith("/root", StringComparison.Ordinal)
+                ? rootLogClient.Name[..^"/root".Length]
+                : rootLogClient.Name;
     }
 
     private sealed class FakeAppendBlobStore

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -239,7 +239,7 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
-    public async Task ReplaceAsync_WhenWalETagChanges_DoesNotPublishStaleCheckpoint()
+    public async Task ReplaceAsync_WhenWalETagChanges_DoesNotUploadStaleCheckpoint()
     {
         var appendBlobs = new FakeAppendBlobStore();
         var checkpoints = new FakeBlockBlobStore();
@@ -253,7 +253,7 @@ public sealed class AzureBlobJournalStorageTests
 
         var requestFailed = Assert.IsType<RequestFailedException>(exception.InnerException);
         Assert.Equal(412, requestFailed.Status);
-        Assert.Single(checkpoints.UploadCalls);
+        Assert.Empty(checkpoints.UploadCalls);
 
         var consumer = new CapturingJournalStorageConsumer();
         await CreateStorage(appendBlobs, checkpoints).ReadAsync(consumer, CancellationToken.None);
@@ -448,7 +448,7 @@ public sealed class AzureBlobJournalStorageTests
         await second.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
 
         Assert.Equal([1, 2], appendBlobs.GetContent("blob/wal"));
-        Assert.Contains(appendBlobs.DownloadCalls, static call => call.Name == "blob/wal");
+        Assert.Contains(appendBlobs.PropertiesCalls, static call => call.Name == "blob/wal");
     }
 
     [Fact]
@@ -668,6 +668,8 @@ public sealed class AzureBlobJournalStorageTests
 
         public List<DownloadCall> DownloadCalls { get; } = [];
 
+        public List<GetPropertiesCall> PropertiesCalls { get; } = [];
+
         public AppendBlobClient GetAppendBlobClient(string name) => new FakeAppendBlobClient(this, name);
 
         public byte[] GetContent(string name) => _blobs[name].Content;
@@ -838,6 +840,31 @@ public sealed class AzureBlobJournalStorageTests
             return Task.FromResult(Response.FromValue(result, TestResponse.Instance));
         }
 
+        private Task<Response<BlobProperties>> GetPropertiesAsync(string name, BlobRequestConditions? conditions, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            PropertiesCalls.Add(new(name, conditions?.IfMatch ?? default, conditions?.IfNoneMatch ?? default));
+            if (!_blobs.TryGetValue(name, out var blob))
+            {
+                throw new RequestFailedException(404, "Blob does not exist.");
+            }
+
+            ThrowIfConditionsFail(name, conditions);
+
+            var result = BlobsModelFactory.BlobProperties(
+                contentLength: blob.Content.Length,
+                contentType: blob.ContentType,
+                eTag: blob.ETag,
+                blobCommittedBlockCount: blob.CommittedBlockCount,
+                blobCopyStatus: default(CopyStatus?),
+                blobType: BlobType.Append,
+                metadata: blob.Metadata,
+                isSealed: blob.IsSealed,
+                immutabilityPolicy: null,
+                hasLegalHold: false);
+            return Task.FromResult(Response.FromValue(result, TestResponse.Instance));
+        }
+
         private void ThrowIfConditionsFail(string name, BlobRequestConditions? conditions)
         {
             if (conditions is null)
@@ -884,6 +911,9 @@ public sealed class AzureBlobJournalStorageTests
 
             public override Task<Response<BlobDownloadStreamingResult>> DownloadStreamingAsync(BlobDownloadOptions? options = null, CancellationToken cancellationToken = default)
                 => store.DownloadStreamingAsync(name, options, cancellationToken);
+
+            public override Task<Response<BlobProperties>> GetPropertiesAsync(BlobRequestConditions conditions = default!, CancellationToken cancellationToken = default)
+                => store.GetPropertiesAsync(name, conditions, cancellationToken);
         }
     }
 
@@ -1017,6 +1047,8 @@ public sealed class AzureBlobJournalStorageTests
     private sealed record DeleteCall(string Name, ETag IfMatch, ETag IfNoneMatch);
 
     private sealed record DownloadCall(string Name);
+
+    private sealed record GetPropertiesCall(string Name, ETag IfMatch, ETag IfNoneMatch);
 
     private sealed record BlockUploadCall(string Name, ETag IfMatch, ETag IfNoneMatch, string? ContentType, IDictionary<string, string> Metadata, byte[] Payload);
 

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -722,6 +722,10 @@ public sealed class AzureBlobJournalStorageTests
 
             public override string Name => name;
 
+            public override int AppendBlobMaxAppendBlockBytes => (int)AzureBlobJournalStorage.MaxAppendBlockBytes;
+
+            public override int AppendBlobMaxBlocks => 50_000;
+
             public override Task<Response<BlobContentInfo>> CreateAsync(AppendBlobCreateOptions options, CancellationToken cancellationToken = default)
                 => store.CreateAsync(name, options, cancellationToken);
 

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -12,39 +12,28 @@ namespace Orleans.Journaling.Tests;
 public sealed class AzureBlobJournalStorageTests
 {
     [Fact]
-    public async Task DeleteAsync_AllowsNextAppendToRecreateBlob()
+    public async Task DeleteAsync_AllowsNextAppendToRecreateRootWal()
     {
-        var client = new FakeAppendBlobClient();
-        var storage = new AzureBlobJournalStorage(client, NullLogger<AzureBlobJournalStorage>.Instance);
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
         await storage.DeleteAsync(CancellationToken.None);
         await storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
 
-        Assert.Equal(2, client.CreateCallCount);
-        Assert.Equal(2, client.AppendCallCount);
+        Assert.Equal(2, appendBlobs.CreateCalls.Count(call => call.Name == "blob.log.00000000"));
+        Assert.Equal(2, appendBlobs.AppendCalls.Count(call => call.Name == "blob.log.00000000"));
     }
 
     [Fact]
     public async Task AppendAsync_WhenMimeTypeConfigured_SetsBlobContentType()
     {
-        var client = new FakeAppendBlobClient();
-        var storage = new AzureBlobJournalStorage(client, "application/jsonl", NullLogger<AzureBlobJournalStorage>.Instance);
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs, mimeType: "application/jsonl");
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
 
-        Assert.Equal("application/jsonl", client.CreateCalls.Single().ContentType);
-    }
-
-    [Fact]
-    public async Task AppendAsync_WhenMimeTypeUnavailable_LeavesBlobContentTypeUnset()
-    {
-        var client = new FakeAppendBlobClient();
-        var storage = new AzureBlobJournalStorage(client, mimeType: null, NullLogger<AzureBlobJournalStorage>.Instance);
-
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-
-        Assert.Null(client.CreateCalls.Single().ContentType);
+        Assert.Equal("application/jsonl", appendBlobs.CreateCalls.Single().ContentType);
     }
 
     [Fact]
@@ -61,193 +50,153 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
-    public void GetBlobNameForJournal_ReturnsConfiguredBlobNameVerbatim()
+    public void DefaultWalAndCheckpointNames_UseFixedWidthHexIds()
     {
-        var options = new AzureBlobJournalStorageOptions
-        {
-            GetBlobName = _ => "journals/test-grain.jsonl"
-        };
+        var options = new AzureBlobJournalStorageOptions();
+        var grainId = GrainId.Create("test-grain", "0");
 
-        var blobName = options.GetBlobNameForJournal(GrainId.Create("test-grain", "0"));
-
-        Assert.Equal("journals/test-grain.jsonl", blobName);
+        Assert.Equal("journals/test.log.0000000A", options.GetWalSegmentBlobName(new(grainId, "journals/test", 10)));
+        Assert.Equal("journals/test.checkpoint.0000000B", options.GetCheckpointBlobName(new(grainId, "journals/test", 11)));
     }
 
     [Fact]
-    public async Task ReplaceAsync_UploadsSnapshotThenReplacesAppendBlobMarker()
+    public async Task AppendAsync_WhenCurrentWalIsSealed_RollsToNextWalSegment()
     {
-        var client = new FakeAppendBlobClient();
-        var snapshots = new FakeBlockBlobStore(client.Operations);
-        var storage = new AzureBlobJournalStorage(
-            client,
-            "application/jsonl",
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            snapshotNameFactory: () => "blob.snapshots/1",
-            snapshotClientFactory: snapshots.GetBlockBlobClient);
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        appendBlobs.Seal("blob.log.00000000");
+        await storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+
+        Assert.Equal(["create:blob.log.00000000", "append:blob.log.00000000", "seal:blob.log.00000000", "append:blob.log.00000000", "seal:blob.log.00000000", "create:blob.log.00000001", "append:blob.log.00000001"], appendBlobs.Operations);
+        Assert.Equal([2], appendBlobs.GetContent("blob.log.00000001"));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_SealsWalUploadsImmutableCheckpointAndPublishesRootMetadata()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints, mimeType: "application/jsonl", journalFormatKey: "json-lines");
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
         await storage.ReplaceAsync(new ReadOnlySequence<byte>([2, 3]), CancellationToken.None);
 
-        Assert.Equal(2, client.CreateCallCount);
-        Assert.Equal(1, client.AppendCallCount);
-        Assert.Single(snapshots.UploadCalls);
-        Assert.Equal(["append-create", "append-block", "snapshot-upload", "append-create"], client.Operations);
+        Assert.Contains("seal:blob.log.00000000", appendBlobs.Operations);
+        var upload = checkpoints.UploadCalls.Single();
+        Assert.Equal("blob.checkpoint.00000000", upload.Name);
+        Assert.Equal(ETag.All, upload.IfNoneMatch);
+        Assert.Equal([2, 3], upload.Payload);
+        Assert.Equal("application/jsonl", upload.ContentType);
+        Assert.Equal("json-lines", upload.Metadata[AzureBlobJournalStorage.FormatMetadataKey]);
+        Assert.Equal("00000000", upload.Metadata[AzureBlobJournalStorage.CheckpointIdMetadataKey]);
+        Assert.Equal("00000001", upload.Metadata[AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey]);
+        Assert.Equal("0", upload.Metadata[AzureBlobJournalStorage.CheckpointReplayOffsetMetadataKey]);
 
-        var snapshotUpload = snapshots.UploadCalls.Single();
-        Assert.Equal("blob.snapshots/1", snapshotUpload.Name);
-        Assert.Equal(ETag.All, snapshotUpload.IfNoneMatch);
-        Assert.Equal([2, 3], snapshotUpload.Payload);
-        Assert.Equal("application/jsonl", snapshotUpload.ContentType);
-
-        var replaceCreate = client.CreateCalls[1];
-        Assert.Equal(new ETag("\"append-1\""), replaceCreate.IfMatch);
-        Assert.Equal(default, replaceCreate.IfNoneMatch);
-        Assert.Equal("blob.snapshots/1", replaceCreate.Metadata[AzureBlobJournalStorage.SnapshotMetadataKey]);
-        Assert.Equal("\"snapshot-1\"", replaceCreate.Metadata[AzureBlobJournalStorage.SnapshotETagMetadataKey]);
-        Assert.Equal("2", replaceCreate.Metadata[AzureBlobJournalStorage.SnapshotLengthMetadataKey]);
-        Assert.Equal("application/jsonl", replaceCreate.ContentType);
+        var metadata = appendBlobs.SetMetadataCalls.Single();
+        Assert.Equal("blob.log.00000000", metadata.Name);
+        Assert.Equal("blob.checkpoint.00000000", metadata.Metadata[AzureBlobJournalStorage.CheckpointMetadataKey]);
+        Assert.Equal("\"checkpoint-1\"", metadata.Metadata[AzureBlobJournalStorage.CheckpointETagMetadataKey]);
+        Assert.Equal("2", metadata.Metadata[AzureBlobJournalStorage.CheckpointLengthMetadataKey]);
+        Assert.Equal("json-lines", metadata.Metadata[AzureBlobJournalStorage.CheckpointFormatMetadataKey]);
     }
 
     [Fact]
-    public async Task ReadAsync_WhenSnapshotMetadataPresent_ReadsSnapshotThenAppendTail()
+    public async Task ReadAsync_WhenNoCheckpointMetadata_ReadsRootWalOnly()
     {
-        var client = new FakeAppendBlobClient();
-        var snapshots = new FakeBlockBlobStore(client.Operations);
-        snapshots.Add(
-            "snapshot-1",
+        var appendBlobs = new FakeAppendBlobStore();
+        appendBlobs.Add("blob.log.00000000", [1, 2], metadata: new Dictionary<string, string>(), isSealed: false);
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints);
+
+        var consumer = new CapturingJournalStorageConsumer();
+        await storage.ReadAsync(consumer, CancellationToken.None);
+
+        Assert.Equal([1, 2], consumer.Bytes.ToArray());
+        Assert.Single(appendBlobs.DownloadCalls);
+        Assert.Empty(checkpoints.DownloadCalls);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenCheckpointMetadataPresent_ReadsCheckpointThenWalTail()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        appendBlobs.Add(
+            "blob.log.00000000",
+            [9, 9],
+            CheckpointMarkerMetadata("blob.checkpoint.00000000", new ETag("\"checkpoint-etag\""), "json-lines", 2, checkpointId: 0, replaySegment: 1, replayOffset: 0),
+            isSealed: true);
+        appendBlobs.Add("blob.log.00000001", [3, 4], new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines" }, isSealed: false);
+        var checkpoints = new FakeBlockBlobStore();
+        checkpoints.Add(
+            "blob.checkpoint.00000000",
             [1, 2],
-            new ETag("\"snapshot-etag\""),
-            new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines" });
-        client.Downloads.Enqueue(new DownloadResult(
-            [3, 4],
-            new ETag("\"read\""),
+            new ETag("\"checkpoint-etag\""),
             new Dictionary<string, string>
             {
-                [AzureBlobJournalStorage.SnapshotMetadataKey] = "snapshot-1",
-                [AzureBlobJournalStorage.SnapshotETagMetadataKey] = "\"snapshot-etag\"",
-                [AzureBlobJournalStorage.SnapshotFormatMetadataKey] = "json-lines",
-                [AzureBlobJournalStorage.SnapshotLengthMetadataKey] = "2",
-                [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines"
-            },
-            BlobCommittedBlockCount: 1));
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            snapshotClientFactory: snapshots.GetBlockBlobClient);
+                [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines",
+                [AzureBlobJournalStorage.CheckpointIdMetadataKey] = "00000000",
+                [AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey] = "00000001",
+                [AzureBlobJournalStorage.CheckpointReplayOffsetMetadataKey] = "0"
+            });
+        var storage = CreateStorage(appendBlobs, checkpoints);
 
         var consumer = new CapturingJournalStorageConsumer();
         await storage.ReadAsync(consumer, CancellationToken.None);
 
         Assert.Equal("json-lines", consumer.JournalFormatKey);
         Assert.Equal([1, 2, 3, 4], consumer.Bytes.ToArray());
-        Assert.Empty(client.CreateCalls);
-        Assert.Empty(client.AppendCalls);
-        Assert.Single(snapshots.DownloadCalls);
-        Assert.Equal(new ETag("\"snapshot-etag\""), snapshots.DownloadCalls.Single().IfMatch);
+        Assert.Equal(["blob.log.00000000", "blob.log.00000001"], appendBlobs.DownloadCalls.Select(static call => call.Name));
+        Assert.Single(checkpoints.DownloadCalls);
+        Assert.Equal(new ETag("\"checkpoint-etag\""), checkpoints.DownloadCalls.Single().IfMatch);
     }
 
     [Fact]
-    public async Task ReplaceAsync_WhenSnapshotUploadFails_DoesNotReplaceAppendBlobMarker()
+    public async Task ReplaceAsync_WhenCheckpointUploadFails_DoesNotPublishRootMetadata()
     {
-        var client = new FakeAppendBlobClient();
-        var snapshots = new FakeBlockBlobStore(client.Operations) { FailNextUpload = true };
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            snapshotNameFactory: () => "blob.snapshots/fail-upload",
-            snapshotClientFactory: snapshots.GetBlockBlobClient);
+        var appendBlobs = new FakeAppendBlobStore();
+        var checkpoints = new FakeBlockBlobStore { FailNextUpload = true };
+        var storage = CreateStorage(appendBlobs, checkpoints);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-
         await Assert.ThrowsAsync<RequestFailedException>(
             () => storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
 
-        Assert.Equal(1, client.CreateCallCount);
-        Assert.Single(snapshots.UploadCalls);
+        Assert.Empty(appendBlobs.SetMetadataCalls);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
-        Assert.Equal(new ETag("\"append-1\""), client.AppendCalls[1].IfMatch);
-        Assert.Equal([3], client.AppendCalls[1].Payload);
+        Assert.Equal([3], appendBlobs.GetContent("blob.log.00000001"));
     }
 
     [Fact]
-    public async Task ReplaceAsync_WhenMarkerUpdateFails_DoesNotAdvanceAppendCondition()
+    public async Task ReplaceAsync_WhenRootMetadataUpdateFails_DoesNotPublishCheckpoint()
     {
-        var client = new FakeAppendBlobClient();
-        var snapshots = new FakeBlockBlobStore(client.Operations);
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            snapshotNameFactory: () => "blob.snapshots/marker-fail",
-            snapshotClientFactory: snapshots.GetBlockBlobClient);
+        var appendBlobs = new FakeAppendBlobStore { FailNextSetMetadata = true };
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        client.FailNextCreate = true;
-
         await Assert.ThrowsAsync<RequestFailedException>(
             () => storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
 
-        Assert.Single(snapshots.UploadCalls);
-        Assert.Equal(2, client.CreateCallCount);
+        Assert.Single(checkpoints.UploadCalls);
+        Assert.Single(appendBlobs.SetMetadataCalls);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
-        Assert.Equal(new ETag("\"append-1\""), client.AppendCalls[1].IfMatch);
-        Assert.Equal([3], client.AppendCalls[1].Payload);
+        Assert.Equal([3], appendBlobs.GetContent("blob.log.00000001"));
     }
 
     [Fact]
-    public async Task ReplaceAsync_WithStaleMarkerETag_ThrowsAndDoesNotRetry()
+    public async Task ReadAsync_WhenCheckpointIsMissing_Throws()
     {
-        var client = new FakeAppendBlobClient();
-        var snapshots = new FakeBlockBlobStore(client.Operations);
-        var storageA = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            snapshotNameFactory: () => "blob.snapshots/a",
-            snapshotClientFactory: snapshots.GetBlockBlobClient);
-        var storageB = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            snapshotNameFactory: () => "blob.snapshots/b",
-            snapshotClientFactory: snapshots.GetBlockBlobClient);
-
-        await storageA.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        await storageB.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None);
-        await storageA.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
-
-        var replaceException = await Assert.ThrowsAsync<RequestFailedException>(
-            () => storageB.ReplaceAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None).AsTask());
-        Assert.Equal(412, replaceException.Status);
-
-        var appendException = await Assert.ThrowsAsync<RequestFailedException>(
-            () => storageB.AppendAsync(new ReadOnlySequence<byte>([4]), CancellationToken.None).AsTask());
-        Assert.Equal(412, appendException.Status);
-        Assert.Equal(new ETag("\"append-1\""), client.CreateCalls.Last().IfMatch);
-        Assert.Equal(new ETag("\"append-1\""), client.AppendCalls.Last().IfMatch);
-        Assert.Equal(2, client.CreateCallCount);
-        Assert.Single(snapshots.UploadCalls);
-    }
-
-    [Fact]
-    public async Task ReadAsync_WhenSnapshotIsMissing_Throws()
-    {
-        var client = new FakeAppendBlobClient();
-        var snapshots = new FakeBlockBlobStore(client.Operations);
-        client.Downloads.Enqueue(new DownloadResult(
+        var appendBlobs = new FakeAppendBlobStore();
+        appendBlobs.Add(
+            "blob.log.00000000",
             [],
-            new ETag("\"read\""),
-            SnapshotMarkerMetadata("missing-snapshot", new ETag("\"missing-etag\""), "json-lines", 1),
-            BlobCommittedBlockCount: 0));
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            snapshotClientFactory: snapshots.GetBlockBlobClient);
+            CheckpointMarkerMetadata("missing-checkpoint", new ETag("\"missing\""), "json-lines", 1, checkpointId: 0, replaySegment: 1, replayOffset: 0),
+            isSealed: true);
+        var storage = CreateStorage(appendBlobs, new FakeBlockBlobStore());
 
         var exception = await Assert.ThrowsAsync<RequestFailedException>(
             () => storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None).AsTask());
@@ -255,51 +204,55 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
-    public async Task ReadAsync_WhenSnapshotLengthMismatchesMarker_Throws()
+    public async Task ReadAsync_WhenCheckpointReplayOffsetExceedsWalLength_Throws()
     {
-        var client = new FakeAppendBlobClient();
-        var snapshots = new FakeBlockBlobStore(client.Operations);
-        snapshots.Add(
-            "snapshot-1",
-            [1, 2],
-            new ETag("\"snapshot-etag\""),
-            new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines" });
-        client.Downloads.Enqueue(new DownloadResult(
+        var appendBlobs = new FakeAppendBlobStore();
+        appendBlobs.Add(
+            "blob.log.00000000",
             [],
-            new ETag("\"read\""),
-            SnapshotMarkerMetadata("snapshot-1", new ETag("\"snapshot-etag\""), "json-lines", 3),
-            BlobCommittedBlockCount: 0));
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            snapshotClientFactory: snapshots.GetBlockBlobClient);
+            CheckpointMarkerMetadata("blob.checkpoint.00000000", new ETag("\"checkpoint-etag\""), "json-lines", 1, checkpointId: 0, replaySegment: 1, replayOffset: 5),
+            isSealed: true);
+        appendBlobs.Add("blob.log.00000001", [1], new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines" }, isSealed: false);
+        var checkpoints = new FakeBlockBlobStore();
+        checkpoints.Add(
+            "blob.checkpoint.00000000",
+            [2],
+            new ETag("\"checkpoint-etag\""),
+            new Dictionary<string, string>
+            {
+                [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines",
+                [AzureBlobJournalStorage.CheckpointIdMetadataKey] = "00000000",
+                [AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey] = "00000001",
+                [AzureBlobJournalStorage.CheckpointReplayOffsetMetadataKey] = "5"
+            });
+        var storage = CreateStorage(appendBlobs, checkpoints);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
             () => storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None).AsTask());
-        Assert.Contains("length", exception.Message);
+        Assert.Contains("offset", exception.Message);
     }
 
     [Fact]
-    public async Task ReadAsync_WhenSnapshotFormatDiffersFromTail_Throws()
+    public async Task ReadAsync_WhenCheckpointFormatMetadataIsMissing_Throws()
     {
-        var client = new FakeAppendBlobClient();
-        var snapshots = new FakeBlockBlobStore(client.Operations);
-        snapshots.Add(
-            "snapshot-1",
-            [1],
-            new ETag("\"snapshot-etag\""),
-            new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "orleans-binary" });
-        client.Downloads.Enqueue(new DownloadResult(
+        var appendBlobs = new FakeAppendBlobStore();
+        appendBlobs.Add(
+            "blob.log.00000000",
             [],
-            new ETag("\"read\""),
-            SnapshotMarkerMetadata("snapshot-1", new ETag("\"snapshot-etag\""), "json-lines", 1),
-            BlobCommittedBlockCount: 0));
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            snapshotClientFactory: snapshots.GetBlockBlobClient);
+            CheckpointMarkerMetadata("blob.checkpoint.00000000", new ETag("\"checkpoint-etag\""), "json-lines", 1, checkpointId: 0, replaySegment: 1, replayOffset: 0),
+            isSealed: true);
+        var checkpoints = new FakeBlockBlobStore();
+        checkpoints.Add(
+            "blob.checkpoint.00000000",
+            [2],
+            new ETag("\"checkpoint-etag\""),
+            new Dictionary<string, string>
+            {
+                [AzureBlobJournalStorage.CheckpointIdMetadataKey] = "00000000",
+                [AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey] = "00000001",
+                [AzureBlobJournalStorage.CheckpointReplayOffsetMetadataKey] = "0"
+            });
+        var storage = CreateStorage(appendBlobs, checkpoints);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
             () => storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None).AsTask());
@@ -309,148 +262,51 @@ public sealed class AzureBlobJournalStorageTests
     [Fact]
     public async Task ReadAsync_UpdatesCompactionRequestFromCommittedBlockCount()
     {
-        var client = new FakeAppendBlobClient();
-        var snapshots = new FakeBlockBlobStore(client.Operations);
-        client.Downloads.Enqueue(new DownloadResult([1], new ETag("\"read\""), new Dictionary<string, string>(), BlobCommittedBlockCount: 11));
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            snapshotNameFactory: () => "blob.snapshots/compaction-request",
-            snapshotClientFactory: snapshots.GetBlockBlobClient);
+        var appendBlobs = new FakeAppendBlobStore();
+        appendBlobs.Add("blob.log.00000000", [1], metadata: new Dictionary<string, string>(), isSealed: false, committedBlockCount: 11);
+        var storage = CreateStorage(appendBlobs);
 
         await storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None);
 
         Assert.True(storage.IsCompactionRequested);
-
-        await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
-
-        Assert.False(storage.IsCompactionRequested);
     }
 
     [Fact]
-    public async Task AppendAsync_WhenJournalFormatKeyConfigured_StampsBlobMetadata()
+    public async Task AppendAsync_WhenJournalFormatKeyConfigured_StampsWalMetadata()
     {
-        var client = new FakeAppendBlobClient();
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            journalFormatKey: "json-lines");
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs, journalFormatKey: "json-lines");
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
 
-        var create = client.CreateCalls.Single();
+        var create = appendBlobs.CreateCalls.Single();
         Assert.True(create.Metadata.TryGetValue(AzureBlobJournalStorage.FormatMetadataKey, out var stamped));
         Assert.Equal("json-lines", stamped);
     }
 
     [Fact]
-    public async Task ReplaceAsync_WhenJournalFormatKeyConfigured_PreservesFormatKeyMetadata()
+    public async Task AppendAsync_WhenAppendFails_DoesNotAdvanceAppendPosition()
     {
-        var client = new FakeAppendBlobClient();
-        var snapshots = new FakeBlockBlobStore(client.Operations);
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            journalFormatKey: "json-lines",
-            snapshotNameFactory: () => "blob.snapshots/format",
-            snapshotClientFactory: snapshots.GetBlockBlobClient);
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
-
-        var snapshotUpload = snapshots.UploadCalls.Single();
-        Assert.Equal("json-lines", snapshotUpload.Metadata[AzureBlobJournalStorage.FormatMetadataKey]);
-
-        var replaceCreate = client.CreateCalls[1];
-        Assert.Equal("json-lines", replaceCreate.Metadata[AzureBlobJournalStorage.FormatMetadataKey]);
-        Assert.Equal("json-lines", replaceCreate.Metadata[AzureBlobJournalStorage.SnapshotFormatMetadataKey]);
-    }
-
-    [Fact]
-    public async Task ReadAsync_WhenStoredFormatKeyDiffersFromConfigured_ReportsStoredFormatKey()
-    {
-        var client = new FakeAppendBlobClient();
-        client.Downloads.Enqueue(new DownloadResult(
-            [1, 2, 3],
-            new ETag("\"read\""),
-            new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "orleans-binary" },
-            BlobCommittedBlockCount: 1));
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            journalFormatKey: "json-lines");
-
-        var consumer = new CapturingJournalStorageConsumer();
-        await storage.ReadAsync(consumer, CancellationToken.None);
-
-        Assert.Equal("orleans-binary", consumer.JournalFormatKey);
-    }
-
-    [Fact]
-    public async Task ReadAsync_WhenStoredFormatKeyMatchesConfigured_Succeeds()
-    {
-        var client = new FakeAppendBlobClient();
-        client.Downloads.Enqueue(new DownloadResult(
-            [1, 2, 3],
-            new ETag("\"read\""),
-            new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines" },
-            BlobCommittedBlockCount: 1));
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            journalFormatKey: "json-lines");
-
-        var consumer = new CapturingJournalStorageConsumer();
-        await storage.ReadAsync(consumer, CancellationToken.None);
-
-        Assert.Equal("json-lines", consumer.JournalFormatKey);
-    }
-
-    [Fact]
-    public async Task ReadAsync_WhenLegacyBlobHasNoFormatKeyMetadata_AllowsReadForBackCompat()
-    {
-        var client = new FakeAppendBlobClient();
-        client.Downloads.Enqueue(new DownloadResult([1, 2, 3], new ETag("\"read\""), new Dictionary<string, string>(), BlobCommittedBlockCount: 1));
-        var storage = new AzureBlobJournalStorage(
-            client,
-            mimeType: null,
-            NullLogger<AzureBlobJournalStorage>.Instance,
-            journalFormatKey: "json-lines");
-
-        var consumer = new CapturingJournalStorageConsumer();
-        await storage.ReadAsync(consumer, CancellationToken.None);
-
-        Assert.Null(consumer.JournalFormatKey);
-    }
-
-    [Fact]
-    public async Task AppendAsync_WhenAppendFails_DoesNotAdvanceAppendCondition()
-    {
-        var client = new FakeAppendBlobClient();
-        var storage = new AzureBlobJournalStorage(client, NullLogger<AzureBlobJournalStorage>.Instance);
-
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        client.FailNextAppend = true;
+        appendBlobs.FailNextAppend = true;
 
         await Assert.ThrowsAsync<RequestFailedException>(
             () => storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
         await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
 
-        Assert.Equal(new ETag("\"append-1\""), client.AppendCalls[1].IfMatch);
-        Assert.Equal(new ETag("\"append-1\""), client.AppendCalls[2].IfMatch);
-        Assert.Equal([3], client.AppendCalls[2].Payload);
+        Assert.Equal(1, appendBlobs.AppendCalls[1].AppendPosition);
+        Assert.Equal(1, appendBlobs.AppendCalls[2].AppendPosition);
+        Assert.Equal([3], appendBlobs.AppendCalls[2].Payload);
     }
 
     [Fact]
     public async Task AppendAsync_WhenBatchExceedsMaxAppendBlockBytes_ThrowsBeforeRoundTrip()
     {
-        var client = new FakeAppendBlobClient();
-        var storage = new AzureBlobJournalStorage(client, NullLogger<AzureBlobJournalStorage>.Instance);
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs);
 
         var oversize = OversizedSequence(AzureBlobJournalStorage.MaxAppendBlockBytes + 1);
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -458,29 +314,49 @@ public sealed class AzureBlobJournalStorageTests
 
         Assert.Contains("100 MiB", ex.Message);
         Assert.Contains("journal batch", ex.Message);
-        Assert.Equal(0, client.CreateCallCount);
-        Assert.Equal(0, client.AppendCallCount);
+        Assert.Empty(appendBlobs.CreateCalls);
+        Assert.Empty(appendBlobs.AppendCalls);
     }
 
-    [Fact]
-    public async Task AppendAsync_WhenApproachingBlockCeiling_Throws()
+    private static AzureBlobJournalStorage CreateStorage(
+        FakeAppendBlobStore appendBlobs,
+        FakeBlockBlobStore? checkpoints = null,
+        string? mimeType = null,
+        string? journalFormatKey = null)
     {
-        var client = new FakeAppendBlobClient { OverrideCommittedBlockCount = AzureBlobJournalStorage.MaxAppendBlobBlocks - 50 };
-        var storage = new AzureBlobJournalStorage(client, NullLogger<AzureBlobJournalStorage>.Instance);
-
-        // Prime the block counter via a successful append.
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
-
-        Assert.Contains("maximum", ex.Message);
-        Assert.Contains("50,000", ex.Message);
+        checkpoints ??= new FakeBlockBlobStore();
+        return new AzureBlobJournalStorage(
+            appendBlobs.GetAppendBlobClient("blob.log.00000000"),
+            mimeType,
+            NullLogger<AzureBlobJournalStorage>.Instance,
+            journalFormatKey,
+            walNameFactory: segmentId => $"blob.log.{segmentId:X8}",
+            walClientFactory: segmentId => appendBlobs.GetAppendBlobClient($"blob.log.{segmentId:X8}"),
+            checkpointNameFactory: checkpointId => $"blob.checkpoint.{checkpointId:X8}",
+            checkpointClientFactory: checkpoints.GetBlockBlobClient);
     }
+
+    private static Dictionary<string, string> CheckpointMarkerMetadata(
+        string checkpointName,
+        ETag checkpointETag,
+        string format,
+        long checkpointLength,
+        uint checkpointId,
+        uint replaySegment,
+        long replayOffset) => new()
+    {
+        [AzureBlobJournalStorage.FormatMetadataKey] = format,
+        [AzureBlobJournalStorage.CheckpointMetadataKey] = checkpointName,
+        [AzureBlobJournalStorage.CheckpointETagMetadataKey] = checkpointETag.ToString(),
+        [AzureBlobJournalStorage.CheckpointFormatMetadataKey] = format,
+        [AzureBlobJournalStorage.CheckpointIdMetadataKey] = checkpointId.ToString("X8", System.Globalization.CultureInfo.InvariantCulture),
+        [AzureBlobJournalStorage.CheckpointLengthMetadataKey] = checkpointLength.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        [AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey] = replaySegment.ToString("X8", System.Globalization.CultureInfo.InvariantCulture),
+        [AzureBlobJournalStorage.CheckpointReplayOffsetMetadataKey] = replayOffset.ToString(System.Globalization.CultureInfo.InvariantCulture),
+    };
 
     private static ReadOnlySequence<byte> OversizedSequence(long length)
     {
-        // Build a multi-segment sequence that reports the given Length without allocating a single contiguous array.
         var segmentSize = 1 << 20;
         var first = new ChunkSegment(new byte[segmentSize], 0);
         var current = first;
@@ -495,16 +371,7 @@ public sealed class AzureBlobJournalStorageTests
         return new ReadOnlySequence<byte>(first, 0, current, current.Memory.Length);
     }
 
-    private static Dictionary<string, string> SnapshotMarkerMetadata(string snapshotName, ETag snapshotETag, string format, long snapshotLength) => new()
-    {
-        [AzureBlobJournalStorage.FormatMetadataKey] = format,
-        [AzureBlobJournalStorage.SnapshotMetadataKey] = snapshotName,
-        [AzureBlobJournalStorage.SnapshotETagMetadataKey] = snapshotETag.ToString(),
-        [AzureBlobJournalStorage.SnapshotFormatMetadataKey] = format,
-        [AzureBlobJournalStorage.SnapshotLengthMetadataKey] = snapshotLength.ToString(System.Globalization.CultureInfo.InvariantCulture),
-    };
-
-    private sealed class ChunkSegment : System.Buffers.ReadOnlySequenceSegment<byte>
+    private sealed class ChunkSegment : ReadOnlySequenceSegment<byte>
     {
         public ChunkSegment(byte[] buffer, long runningIndex)
         {
@@ -545,35 +412,15 @@ public sealed class AzureBlobJournalStorageTests
         }
     }
 
-    private sealed class FakeAppendBlobClient : AppendBlobClient
+    private sealed class FakeAppendBlobStore
     {
-        private readonly FakeAppendBlobClient _root;
-        private bool _exists;
-        private ETag _eTag = new("\"initial\"");
-        private int _successfulAppendCount;
-        private int _committedBlockCount;
-        private byte[] _content = [];
-        private Dictionary<string, string> _metadata = [];
-        private string? _contentType;
-
-        public FakeAppendBlobClient()
-        {
-            _root = this;
-        }
-
-        public override string BlobContainerName => "container";
-
-        public override string Name => "blob";
-
-        public int CreateCallCount => CreateCalls.Count;
-
-        public int AppendCallCount => AppendCalls.Count;
+        private readonly Dictionary<string, StoredAppendBlob> _blobs = [];
+        private int _createCount;
+        private int _appendCount;
 
         public bool FailNextAppend { get; set; }
 
-        public bool FailNextCreate { get; set; }
-
-        public int? OverrideCommittedBlockCount { get; set; }
+        public bool FailNextSetMetadata { get; set; }
 
         public List<string> Operations { get; } = [];
 
@@ -581,132 +428,222 @@ public sealed class AzureBlobJournalStorageTests
 
         public List<AppendCall> AppendCalls { get; } = [];
 
-        public Queue<DownloadResult> Downloads { get; } = new();
+        public List<SealCall> SealCalls { get; } = [];
 
-        public override Task<Response<BlobContentInfo>> CreateAsync(AppendBlobCreateOptions options, CancellationToken cancellationToken = default)
+        public List<SetMetadataCall> SetMetadataCalls { get; } = [];
+
+        public List<DownloadCall> DownloadCalls { get; } = [];
+
+        public AppendBlobClient GetAppendBlobClient(string name) => new FakeAppendBlobClient(this, name);
+
+        public byte[] GetContent(string name) => _blobs[name].Content;
+
+        public void Add(string name, byte[] content, IDictionary<string, string> metadata, bool isSealed, int? committedBlockCount = null)
+            => _blobs[name] = new StoredAppendBlob(content, new ETag($"\"{name}-etag\""), new Dictionary<string, string>(metadata), ContentType: null, committedBlockCount ?? (content.Length == 0 ? 0 : 1), isSealed);
+
+        public void Seal(string name)
+        {
+            Operations.Add($"seal:{name}");
+            var blob = _blobs[name];
+            blob.IsSealed = true;
+        }
+
+        private Task<Response<BlobContentInfo>> CreateAsync(string name, AppendBlobCreateOptions options, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            _root.Operations.Add("append-create");
-            _root.CreateCalls.Add(new(
+            Operations.Add($"create:{name}");
+            CreateCalls.Add(new(
+                name,
                 options.Conditions?.IfMatch ?? default,
                 options.Conditions?.IfNoneMatch ?? default,
                 options.HttpHeaders?.ContentType,
                 options.Metadata is null ? new Dictionary<string, string>() : new Dictionary<string, string>(options.Metadata)));
-            _root.ThrowIfConditionsFail(options.Conditions);
-            if (_root.FailNextCreate)
-            {
-                _root.FailNextCreate = false;
-                throw new RequestFailedException(500, "Create failed.");
-            }
+            ThrowIfAppendConditionsFail(name, options.Conditions);
 
-            _root._exists = true;
-            _root._content = [];
-            _root._metadata = options.Metadata is null ? [] : new Dictionary<string, string>(options.Metadata);
-            _root._contentType = options.HttpHeaders?.ContentType;
-            _root._committedBlockCount = 0;
-            _root._eTag = new ETag($"\"create-{_root.CreateCallCount}\"");
+            _createCount++;
+            var eTag = new ETag($"\"create-{_createCount}\"");
+            _blobs[name] = new StoredAppendBlob(
+                [],
+                eTag,
+                options.Metadata is null ? [] : new Dictionary<string, string>(options.Metadata),
+                options.HttpHeaders?.ContentType,
+                CommittedBlockCount: 0,
+                IsSealed: false);
             return Task.FromResult(Response.FromValue(
-                BlobsModelFactory.BlobContentInfo(_root._eTag, default, null, null, null, null, 0),
+                BlobsModelFactory.BlobContentInfo(eTag, default, null, null, null, null, 0),
                 TestResponse.Instance));
         }
 
-        public override async Task<Response<BlobAppendInfo>> AppendBlockAsync(Stream content, AppendBlobAppendBlockOptions options, CancellationToken cancellationToken = default)
+        private async Task<Response<BlobAppendInfo>> AppendBlockAsync(string name, Stream content, AppendBlobAppendBlockOptions options, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!_root._exists)
+            if (!_blobs.TryGetValue(name, out var blob))
             {
                 throw new RequestFailedException(404, "Blob does not exist.");
             }
 
             using var buffer = new MemoryStream();
             await content.CopyToAsync(buffer, cancellationToken);
-            _root.Operations.Add("append-block");
-            _root.AppendCalls.Add(new(
+            var payload = buffer.ToArray();
+            Operations.Add($"append:{name}");
+            AppendCalls.Add(new(
+                name,
                 options.Conditions?.IfMatch ?? default,
                 options.Conditions?.IfNoneMatch ?? default,
-                buffer.ToArray()));
-            _root.ThrowIfConditionsFail(options.Conditions);
-            if (_root.FailNextAppend)
+                options.Conditions?.IfAppendPositionEqual,
+                payload));
+
+            if (blob.IsSealed)
             {
-                _root.FailNextAppend = false;
+                throw new RequestFailedException(409, "The specified blob is sealed.", "BlobIsSealed", null);
+            }
+
+            ThrowIfAppendConditionsFail(name, options.Conditions);
+            if (FailNextAppend)
+            {
+                FailNextAppend = false;
                 throw new RequestFailedException(500, "Append failed.");
             }
 
-            _root._successfulAppendCount++;
-            _root._committedBlockCount++;
-            _root._content = [.. _root._content, .. buffer.ToArray()];
-            _root._eTag = new ETag($"\"append-{_root._successfulAppendCount}\"");
-            var committedBlocks = _root.OverrideCommittedBlockCount ?? _root._committedBlockCount;
+            _appendCount++;
+            blob.Content = [.. blob.Content, .. payload];
+            blob.CommittedBlockCount++;
+            blob.ETag = new ETag($"\"append-{_appendCount}\"");
             return Response.FromValue(
-                BlobsModelFactory.BlobAppendInfo(_root._eTag, default, null, null, "0", committedBlocks, false, null, null),
+                BlobsModelFactory.BlobAppendInfo(blob.ETag, default, null, null, "0", blob.CommittedBlockCount, false, null, null),
                 TestResponse.Instance);
         }
 
-        public override Task<Response> DeleteAsync(DeleteSnapshotsOption snapshotsOption = DeleteSnapshotsOption.None, BlobRequestConditions? conditions = null, CancellationToken cancellationToken = default)
+        private Task<Response<BlobInfo>> SealAsync(string name, AppendBlobRequestConditions? conditions, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (conditions?.IfMatch is { } ifMatch && ifMatch != default && ifMatch != _root._eTag)
-            {
-                throw new RequestFailedException(412, "ETag mismatch.");
-            }
-
-            _root._exists = false;
-            return Task.FromResult<Response>(TestResponse.Instance);
-        }
-
-        public override Task<Response<BlobDownloadStreamingResult>> DownloadStreamingAsync(BlobDownloadOptions? options = null, CancellationToken cancellationToken = default)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (!_root._exists && _root.Downloads.Count == 0)
+            Operations.Add($"seal:{name}");
+            SealCalls.Add(new(name, conditions?.IfMatch ?? default));
+            if (!_blobs.TryGetValue(name, out var blob))
             {
                 throw new RequestFailedException(404, "Blob does not exist.");
             }
 
-            var download = _root.Downloads.Count > 0
-                ? _root.Downloads.Dequeue()
-                : new DownloadResult(
-                    _root._content,
-                    _root._eTag,
-                    _root._metadata,
-                    _root.OverrideCommittedBlockCount ?? _root._committedBlockCount,
-                    _root._contentType);
-            _root._exists = true;
-            _root._eTag = download.ETag;
-            _root._content = download.Content;
-            _root._metadata = new Dictionary<string, string>(download.Metadata);
-            _root._contentType = download.ContentType;
-            _root._committedBlockCount = download.BlobCommittedBlockCount;
+            ThrowIfAppendConditionsFail(name, conditions);
+            blob.IsSealed = true;
+            return Task.FromResult(Response.FromValue(BlobsModelFactory.BlobInfo(blob.ETag, default), TestResponse.Instance));
+        }
+
+        private Task<Response<BlobInfo>> SetMetadataAsync(string name, IDictionary<string, string> metadata, BlobRequestConditions? conditions, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Operations.Add($"set-metadata:{name}");
+            SetMetadataCalls.Add(new(name, conditions?.IfMatch ?? default, new Dictionary<string, string>(metadata)));
+            if (!_blobs.TryGetValue(name, out var blob))
+            {
+                throw new RequestFailedException(404, "Blob does not exist.");
+            }
+
+            if (conditions?.IfMatch is { } ifMatch && ifMatch != default && ifMatch != blob.ETag)
+            {
+                throw new RequestFailedException(412, "ETag mismatch.");
+            }
+
+            if (FailNextSetMetadata)
+            {
+                FailNextSetMetadata = false;
+                throw new RequestFailedException(500, "Set metadata failed.");
+            }
+
+            blob.Metadata = new Dictionary<string, string>(metadata);
+            blob.ETag = new ETag($"\"metadata-{SetMetadataCalls.Count}\"");
+            return Task.FromResult(Response.FromValue(BlobsModelFactory.BlobInfo(blob.ETag, default), TestResponse.Instance));
+        }
+
+        private Task<Response> DeleteAsync(string name, BlobRequestConditions? conditions, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!_blobs.TryGetValue(name, out var blob))
+            {
+                throw new RequestFailedException(404, "Blob does not exist.");
+            }
+
+            if (conditions?.IfMatch is { } ifMatch && ifMatch != default && ifMatch != blob.ETag)
+            {
+                throw new RequestFailedException(412, "ETag mismatch.");
+            }
+
+            _blobs.Remove(name);
+            return Task.FromResult<Response>(TestResponse.Instance);
+        }
+
+        private Task<Response<BlobDownloadStreamingResult>> DownloadStreamingAsync(string name, BlobDownloadOptions? options, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DownloadCalls.Add(new(name));
+            if (!_blobs.TryGetValue(name, out var blob))
+            {
+                throw new RequestFailedException(404, "Blob does not exist.");
+            }
+
             var details = BlobsModelFactory.BlobDownloadDetails(
                 blobType: BlobType.Append,
-                contentLength: download.Content.Length,
-                contentType: download.ContentType,
-                metadata: download.Metadata,
-                blobCommittedBlockCount: download.BlobCommittedBlockCount,
-                eTag: download.ETag);
-            var result = BlobsModelFactory.BlobDownloadStreamingResult(new MemoryStream(download.Content), details);
+                contentLength: blob.Content.Length,
+                contentType: blob.ContentType,
+                metadata: blob.Metadata,
+                blobCommittedBlockCount: blob.CommittedBlockCount,
+                isSealed: blob.IsSealed,
+                eTag: blob.ETag);
+            var result = BlobsModelFactory.BlobDownloadStreamingResult(new MemoryStream(blob.Content), details);
             return Task.FromResult(Response.FromValue(result, TestResponse.Instance));
         }
 
-        private void ThrowIfConditionsFail(AppendBlobRequestConditions? conditions)
+        private void ThrowIfAppendConditionsFail(string name, AppendBlobRequestConditions? conditions)
         {
             if (conditions is null)
             {
                 return;
             }
 
-            if (conditions.IfNoneMatch == ETag.All && _root._exists)
+            var exists = _blobs.TryGetValue(name, out var blob);
+            if (conditions.IfNoneMatch == ETag.All && exists)
             {
                 throw new RequestFailedException(409, "Blob already exists.");
             }
 
-            if (conditions.IfMatch is { } ifMatch && ifMatch != default && ifMatch != _root._eTag)
+            if (conditions.IfMatch is { } ifMatch && ifMatch != default && (!exists || ifMatch != blob!.ETag))
             {
                 throw new RequestFailedException(412, "ETag mismatch.");
             }
+
+            if (conditions.IfAppendPositionEqual is { } appendPosition && (!exists || appendPosition != blob!.Content.Length))
+            {
+                throw new RequestFailedException(412, "Append position mismatch.");
+            }
+        }
+
+        private sealed class FakeAppendBlobClient(FakeAppendBlobStore store, string name) : AppendBlobClient
+        {
+            public override string BlobContainerName => "container";
+
+            public override string Name => name;
+
+            public override Task<Response<BlobContentInfo>> CreateAsync(AppendBlobCreateOptions options, CancellationToken cancellationToken = default)
+                => store.CreateAsync(name, options, cancellationToken);
+
+            public override Task<Response<BlobAppendInfo>> AppendBlockAsync(Stream content, AppendBlobAppendBlockOptions options, CancellationToken cancellationToken = default)
+                => store.AppendBlockAsync(name, content, options, cancellationToken);
+
+            public override Task<Response<BlobInfo>> SealAsync(AppendBlobRequestConditions conditions = default!, CancellationToken cancellationToken = default)
+                => store.SealAsync(name, conditions, cancellationToken);
+
+            public override Task<Response<BlobInfo>> SetMetadataAsync(IDictionary<string, string> metadata, BlobRequestConditions? conditions = null, CancellationToken cancellationToken = default)
+                => store.SetMetadataAsync(name, metadata, conditions, cancellationToken);
+
+            public override Task<Response> DeleteAsync(DeleteSnapshotsOption snapshotsOption = DeleteSnapshotsOption.None, BlobRequestConditions? conditions = null, CancellationToken cancellationToken = default)
+                => store.DeleteAsync(name, conditions, cancellationToken);
+
+            public override Task<Response<BlobDownloadStreamingResult>> DownloadStreamingAsync(BlobDownloadOptions? options = null, CancellationToken cancellationToken = default)
+                => store.DownloadStreamingAsync(name, options, cancellationToken);
         }
     }
 
-    private sealed class FakeBlockBlobStore(List<string> operations)
+    private sealed class FakeBlockBlobStore
     {
         private readonly Dictionary<string, StoredBlockBlob> _blobs = [];
         private int _uploadCount;
@@ -725,7 +662,6 @@ public sealed class AzureBlobJournalStorageTests
         private async Task<Response<BlobContentInfo>> UploadAsync(string name, Stream content, BlobUploadOptions options, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            operations.Add("snapshot-upload");
             using var buffer = new MemoryStream();
             await content.CopyToAsync(buffer, cancellationToken);
             var payload = buffer.ToArray();
@@ -745,11 +681,11 @@ public sealed class AzureBlobJournalStorageTests
             if (FailNextUpload)
             {
                 FailNextUpload = false;
-                throw new RequestFailedException(500, "Snapshot upload failed.");
+                throw new RequestFailedException(500, "Checkpoint upload failed.");
             }
 
             _uploadCount++;
-            var eTag = new ETag($"\"snapshot-{_uploadCount}\"");
+            var eTag = new ETag($"\"checkpoint-{_uploadCount}\"");
             _blobs[name] = new StoredBlockBlob(
                 payload,
                 eTag,
@@ -768,12 +704,12 @@ public sealed class AzureBlobJournalStorageTests
 
             if (!_blobs.TryGetValue(name, out var blob))
             {
-                throw new RequestFailedException(404, "Snapshot does not exist.");
+                throw new RequestFailedException(404, "Checkpoint does not exist.");
             }
 
             if (ifMatch != default && ifMatch != blob.ETag)
             {
-                throw new RequestFailedException(412, "Snapshot ETag mismatch.");
+                throw new RequestFailedException(412, "Checkpoint ETag mismatch.");
             }
 
             var details = BlobsModelFactory.BlobDownloadDetails(
@@ -800,33 +736,40 @@ public sealed class AzureBlobJournalStorageTests
         }
     }
 
-    private sealed record DownloadResult(
-        byte[] Content,
-        ETag ETag,
-        IDictionary<string, string> Metadata,
-        int BlobCommittedBlockCount = 0,
-        string? ContentType = null);
+    private sealed record CreateCall(string Name, ETag IfMatch, ETag IfNoneMatch, string? ContentType, IDictionary<string, string> Metadata);
 
-    private sealed record CreateCall(
-        ETag IfMatch,
-        ETag IfNoneMatch,
-        string? ContentType,
-        IDictionary<string, string> Metadata);
+    private sealed record AppendCall(string Name, ETag IfMatch, ETag IfNoneMatch, long? AppendPosition, byte[] Payload);
 
-    private sealed record AppendCall(
-        ETag IfMatch,
-        ETag IfNoneMatch,
-        byte[] Payload);
+    private sealed record SealCall(string Name, ETag IfMatch);
 
-    private sealed record BlockUploadCall(
-        string Name,
-        ETag IfMatch,
-        ETag IfNoneMatch,
-        string? ContentType,
-        IDictionary<string, string> Metadata,
-        byte[] Payload);
+    private sealed record SetMetadataCall(string Name, ETag IfMatch, IDictionary<string, string> Metadata);
+
+    private sealed record DownloadCall(string Name);
+
+    private sealed record BlockUploadCall(string Name, ETag IfMatch, ETag IfNoneMatch, string? ContentType, IDictionary<string, string> Metadata, byte[] Payload);
 
     private sealed record BlockDownloadCall(string Name, ETag IfMatch);
+
+    private sealed class StoredAppendBlob(
+        byte[] content,
+        ETag eTag,
+        IDictionary<string, string> metadata,
+        string? ContentType,
+        int CommittedBlockCount,
+        bool IsSealed)
+    {
+        public byte[] Content { get; set; } = content;
+
+        public ETag ETag { get; set; } = eTag;
+
+        public IDictionary<string, string> Metadata { get; set; } = metadata;
+
+        public string? ContentType { get; } = ContentType;
+
+        public int CommittedBlockCount { get; set; } = CommittedBlockCount;
+
+        public bool IsSealed { get; set; } = IsSealed;
+    }
 
     private sealed record StoredBlockBlob(byte[] Content, ETag ETag, IDictionary<string, string> Metadata, string? ContentType);
 
@@ -862,5 +805,4 @@ public sealed class AzureBlobJournalStorageTests
             return false;
         }
     }
-
 }

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -74,57 +74,250 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
-    public async Task ReplaceAsync_RecreatesAppendBlobAndAppendsCompactedState()
+    public async Task ReplaceAsync_UploadsSnapshotThenReplacesAppendBlobMarker()
     {
         var client = new FakeAppendBlobClient();
-        var storage = new AzureBlobJournalStorage(client, "application/jsonl", NullLogger<AzureBlobJournalStorage>.Instance);
+        var snapshots = new FakeBlockBlobStore(client.Operations);
+        var storage = new AzureBlobJournalStorage(
+            client,
+            "application/jsonl",
+            NullLogger<AzureBlobJournalStorage>.Instance,
+            snapshotNameFactory: () => "blob.snapshots/1",
+            snapshotClientFactory: snapshots.GetBlockBlobClient);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
         await storage.ReplaceAsync(new ReadOnlySequence<byte>([2, 3]), CancellationToken.None);
 
         Assert.Equal(2, client.CreateCallCount);
-        Assert.Equal(2, client.AppendCallCount);
+        Assert.Equal(1, client.AppendCallCount);
+        Assert.Single(snapshots.UploadCalls);
+        Assert.Equal(["append-create", "append-block", "snapshot-upload", "append-create"], client.Operations);
+
+        var snapshotUpload = snapshots.UploadCalls.Single();
+        Assert.Equal("blob.snapshots/1", snapshotUpload.Name);
+        Assert.Equal(ETag.All, snapshotUpload.IfNoneMatch);
+        Assert.Equal([2, 3], snapshotUpload.Payload);
+        Assert.Equal("application/jsonl", snapshotUpload.ContentType);
 
         var replaceCreate = client.CreateCalls[1];
         Assert.Equal(new ETag("\"append-1\""), replaceCreate.IfMatch);
         Assert.Equal(default, replaceCreate.IfNoneMatch);
-        Assert.Empty(replaceCreate.Metadata);
+        Assert.Equal("blob.snapshots/1", replaceCreate.Metadata[AzureBlobJournalStorage.SnapshotMetadataKey]);
+        Assert.Equal("\"snapshot-1\"", replaceCreate.Metadata[AzureBlobJournalStorage.SnapshotETagMetadataKey]);
+        Assert.Equal("2", replaceCreate.Metadata[AzureBlobJournalStorage.SnapshotLengthMetadataKey]);
         Assert.Equal("application/jsonl", replaceCreate.ContentType);
-
-        var replaceAppend = client.AppendCalls[1];
-        Assert.Equal(new ETag("\"create-2\""), replaceAppend.IfMatch);
-        Assert.Equal([2, 3], replaceAppend.Payload);
     }
 
     [Fact]
-    public async Task ReadAsync_DoesNotPerformSnapshotRecovery()
+    public async Task ReadAsync_WhenSnapshotMetadataPresent_ReadsSnapshotThenAppendTail()
     {
         var client = new FakeAppendBlobClient();
+        var snapshots = new FakeBlockBlobStore(client.Operations);
+        snapshots.Add(
+            "snapshot-1",
+            [1, 2],
+            new ETag("\"snapshot-etag\""),
+            new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines" });
         client.Downloads.Enqueue(new DownloadResult(
-            [1, 2, 3],
+            [3, 4],
             new ETag("\"read\""),
             new Dictionary<string, string>
             {
-                ["snapshot"] = "snapshot-1",
+                [AzureBlobJournalStorage.SnapshotMetadataKey] = "snapshot-1",
+                [AzureBlobJournalStorage.SnapshotETagMetadataKey] = "\"snapshot-etag\"",
+                [AzureBlobJournalStorage.SnapshotFormatMetadataKey] = "json-lines",
+                [AzureBlobJournalStorage.SnapshotLengthMetadataKey] = "2",
                 [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines"
             },
             BlobCommittedBlockCount: 1));
-        var storage = new AzureBlobJournalStorage(client, NullLogger<AzureBlobJournalStorage>.Instance);
+        var storage = new AzureBlobJournalStorage(
+            client,
+            mimeType: null,
+            NullLogger<AzureBlobJournalStorage>.Instance,
+            snapshotClientFactory: snapshots.GetBlockBlobClient);
 
         var consumer = new CapturingJournalStorageConsumer();
         await storage.ReadAsync(consumer, CancellationToken.None);
 
         Assert.Equal("json-lines", consumer.JournalFormatKey);
+        Assert.Equal([1, 2, 3, 4], consumer.Bytes.ToArray());
         Assert.Empty(client.CreateCalls);
         Assert.Empty(client.AppendCalls);
+        Assert.Single(snapshots.DownloadCalls);
+        Assert.Equal(new ETag("\"snapshot-etag\""), snapshots.DownloadCalls.Single().IfMatch);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenSnapshotUploadFails_DoesNotReplaceAppendBlobMarker()
+    {
+        var client = new FakeAppendBlobClient();
+        var snapshots = new FakeBlockBlobStore(client.Operations) { FailNextUpload = true };
+        var storage = new AzureBlobJournalStorage(
+            client,
+            mimeType: null,
+            NullLogger<AzureBlobJournalStorage>.Instance,
+            snapshotNameFactory: () => "blob.snapshots/fail-upload",
+            snapshotClientFactory: snapshots.GetBlockBlobClient);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+
+        await Assert.ThrowsAsync<RequestFailedException>(
+            () => storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
+
+        Assert.Equal(1, client.CreateCallCount);
+        Assert.Single(snapshots.UploadCalls);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
+        Assert.Equal(new ETag("\"append-1\""), client.AppendCalls[1].IfMatch);
+        Assert.Equal([3], client.AppendCalls[1].Payload);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenMarkerUpdateFails_DoesNotAdvanceAppendCondition()
+    {
+        var client = new FakeAppendBlobClient();
+        var snapshots = new FakeBlockBlobStore(client.Operations);
+        var storage = new AzureBlobJournalStorage(
+            client,
+            mimeType: null,
+            NullLogger<AzureBlobJournalStorage>.Instance,
+            snapshotNameFactory: () => "blob.snapshots/marker-fail",
+            snapshotClientFactory: snapshots.GetBlockBlobClient);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        client.FailNextCreate = true;
+
+        await Assert.ThrowsAsync<RequestFailedException>(
+            () => storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
+
+        Assert.Single(snapshots.UploadCalls);
+        Assert.Equal(2, client.CreateCallCount);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
+        Assert.Equal(new ETag("\"append-1\""), client.AppendCalls[1].IfMatch);
+        Assert.Equal([3], client.AppendCalls[1].Payload);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WithStaleMarkerETag_ThrowsAndDoesNotRetry()
+    {
+        var client = new FakeAppendBlobClient();
+        var snapshots = new FakeBlockBlobStore(client.Operations);
+        var storageA = new AzureBlobJournalStorage(
+            client,
+            mimeType: null,
+            NullLogger<AzureBlobJournalStorage>.Instance,
+            snapshotNameFactory: () => "blob.snapshots/a",
+            snapshotClientFactory: snapshots.GetBlockBlobClient);
+        var storageB = new AzureBlobJournalStorage(
+            client,
+            mimeType: null,
+            NullLogger<AzureBlobJournalStorage>.Instance,
+            snapshotNameFactory: () => "blob.snapshots/b",
+            snapshotClientFactory: snapshots.GetBlockBlobClient);
+
+        await storageA.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        await storageB.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None);
+        await storageA.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+
+        var replaceException = await Assert.ThrowsAsync<RequestFailedException>(
+            () => storageB.ReplaceAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None).AsTask());
+        Assert.Equal(412, replaceException.Status);
+
+        var appendException = await Assert.ThrowsAsync<RequestFailedException>(
+            () => storageB.AppendAsync(new ReadOnlySequence<byte>([4]), CancellationToken.None).AsTask());
+        Assert.Equal(412, appendException.Status);
+        Assert.Equal(new ETag("\"append-1\""), client.CreateCalls.Last().IfMatch);
+        Assert.Equal(new ETag("\"append-1\""), client.AppendCalls.Last().IfMatch);
+        Assert.Equal(2, client.CreateCallCount);
+        Assert.Single(snapshots.UploadCalls);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenSnapshotIsMissing_Throws()
+    {
+        var client = new FakeAppendBlobClient();
+        var snapshots = new FakeBlockBlobStore(client.Operations);
+        client.Downloads.Enqueue(new DownloadResult(
+            [],
+            new ETag("\"read\""),
+            SnapshotMarkerMetadata("missing-snapshot", new ETag("\"missing-etag\""), "json-lines", 1),
+            BlobCommittedBlockCount: 0));
+        var storage = new AzureBlobJournalStorage(
+            client,
+            mimeType: null,
+            NullLogger<AzureBlobJournalStorage>.Instance,
+            snapshotClientFactory: snapshots.GetBlockBlobClient);
+
+        var exception = await Assert.ThrowsAsync<RequestFailedException>(
+            () => storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None).AsTask());
+        Assert.Equal(404, exception.Status);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenSnapshotLengthMismatchesMarker_Throws()
+    {
+        var client = new FakeAppendBlobClient();
+        var snapshots = new FakeBlockBlobStore(client.Operations);
+        snapshots.Add(
+            "snapshot-1",
+            [1, 2],
+            new ETag("\"snapshot-etag\""),
+            new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines" });
+        client.Downloads.Enqueue(new DownloadResult(
+            [],
+            new ETag("\"read\""),
+            SnapshotMarkerMetadata("snapshot-1", new ETag("\"snapshot-etag\""), "json-lines", 3),
+            BlobCommittedBlockCount: 0));
+        var storage = new AzureBlobJournalStorage(
+            client,
+            mimeType: null,
+            NullLogger<AzureBlobJournalStorage>.Instance,
+            snapshotClientFactory: snapshots.GetBlockBlobClient);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None).AsTask());
+        Assert.Contains("length", exception.Message);
+    }
+
+    [Fact]
+    public async Task ReadAsync_WhenSnapshotFormatDiffersFromTail_Throws()
+    {
+        var client = new FakeAppendBlobClient();
+        var snapshots = new FakeBlockBlobStore(client.Operations);
+        snapshots.Add(
+            "snapshot-1",
+            [1],
+            new ETag("\"snapshot-etag\""),
+            new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "orleans-binary" });
+        client.Downloads.Enqueue(new DownloadResult(
+            [],
+            new ETag("\"read\""),
+            SnapshotMarkerMetadata("snapshot-1", new ETag("\"snapshot-etag\""), "json-lines", 1),
+            BlobCommittedBlockCount: 0));
+        var storage = new AzureBlobJournalStorage(
+            client,
+            mimeType: null,
+            NullLogger<AzureBlobJournalStorage>.Instance,
+            snapshotClientFactory: snapshots.GetBlockBlobClient);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None).AsTask());
+        Assert.Contains("format", exception.Message);
     }
 
     [Fact]
     public async Task ReadAsync_UpdatesCompactionRequestFromCommittedBlockCount()
     {
         var client = new FakeAppendBlobClient();
+        var snapshots = new FakeBlockBlobStore(client.Operations);
         client.Downloads.Enqueue(new DownloadResult([1], new ETag("\"read\""), new Dictionary<string, string>(), BlobCommittedBlockCount: 11));
-        var storage = new AzureBlobJournalStorage(client, NullLogger<AzureBlobJournalStorage>.Instance);
+        var storage = new AzureBlobJournalStorage(
+            client,
+            mimeType: null,
+            NullLogger<AzureBlobJournalStorage>.Instance,
+            snapshotNameFactory: () => "blob.snapshots/compaction-request",
+            snapshotClientFactory: snapshots.GetBlockBlobClient);
 
         await storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None);
 
@@ -156,17 +349,24 @@ public sealed class AzureBlobJournalStorageTests
     public async Task ReplaceAsync_WhenJournalFormatKeyConfigured_PreservesFormatKeyMetadata()
     {
         var client = new FakeAppendBlobClient();
+        var snapshots = new FakeBlockBlobStore(client.Operations);
         var storage = new AzureBlobJournalStorage(
             client,
             mimeType: null,
             NullLogger<AzureBlobJournalStorage>.Instance,
-            journalFormatKey: "json-lines");
+            journalFormatKey: "json-lines",
+            snapshotNameFactory: () => "blob.snapshots/format",
+            snapshotClientFactory: snapshots.GetBlockBlobClient);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
         await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
 
+        var snapshotUpload = snapshots.UploadCalls.Single();
+        Assert.Equal("json-lines", snapshotUpload.Metadata[AzureBlobJournalStorage.FormatMetadataKey]);
+
         var replaceCreate = client.CreateCalls[1];
         Assert.Equal("json-lines", replaceCreate.Metadata[AzureBlobJournalStorage.FormatMetadataKey]);
+        Assert.Equal("json-lines", replaceCreate.Metadata[AzureBlobJournalStorage.SnapshotFormatMetadataKey]);
     }
 
     [Fact]
@@ -263,27 +463,6 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
-    public async Task ReplaceAsync_WhenBatchExceedsMaxAppendBlockBytes_ThrowsBeforeRoundTrip()
-    {
-        var client = new FakeAppendBlobClient();
-        var storage = new AzureBlobJournalStorage(client, NullLogger<AzureBlobJournalStorage>.Instance);
-
-        // Establish a successful create + append baseline before testing the replacement size guard.
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        var baselineCreates = client.CreateCallCount;
-        var baselineAppends = client.AppendCallCount;
-
-        var oversize = OversizedSequence(AzureBlobJournalStorage.MaxAppendBlockBytes + 1);
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => storage.ReplaceAsync(oversize, CancellationToken.None).AsTask());
-
-        Assert.Contains("100 MiB", ex.Message);
-        Assert.Contains("compacted journal", ex.Message);
-        Assert.Equal(baselineCreates, client.CreateCallCount);
-        Assert.Equal(baselineAppends, client.AppendCallCount);
-    }
-
-    [Fact]
     public async Task AppendAsync_WhenApproachingBlockCeiling_Throws()
     {
         var client = new FakeAppendBlobClient { OverrideCommittedBlockCount = AzureBlobJournalStorage.MaxAppendBlobBlocks - 50 };
@@ -316,6 +495,15 @@ public sealed class AzureBlobJournalStorageTests
         return new ReadOnlySequence<byte>(first, 0, current, current.Memory.Length);
     }
 
+    private static Dictionary<string, string> SnapshotMarkerMetadata(string snapshotName, ETag snapshotETag, string format, long snapshotLength) => new()
+    {
+        [AzureBlobJournalStorage.FormatMetadataKey] = format,
+        [AzureBlobJournalStorage.SnapshotMetadataKey] = snapshotName,
+        [AzureBlobJournalStorage.SnapshotETagMetadataKey] = snapshotETag.ToString(),
+        [AzureBlobJournalStorage.SnapshotFormatMetadataKey] = format,
+        [AzureBlobJournalStorage.SnapshotLengthMetadataKey] = snapshotLength.ToString(System.Globalization.CultureInfo.InvariantCulture),
+    };
+
     private sealed class ChunkSegment : System.Buffers.ReadOnlySequenceSegment<byte>
     {
         public ChunkSegment(byte[] buffer, long runningIndex)
@@ -343,10 +531,17 @@ public sealed class AzureBlobJournalStorageTests
     {
         public string? JournalFormatKey { get; private set; }
 
+        public MemoryStream Bytes { get; } = new();
+
         public void Read(JournalBufferReader buffer, IJournalFileMetadata? metadata)
         {
             JournalFormatKey = metadata?.Format;
-            buffer.Skip(buffer.Length);
+            while (buffer.Length > 0)
+            {
+                var chunk = new byte[buffer.Length];
+                buffer.Read(chunk);
+                Bytes.Write(chunk);
+            }
         }
     }
 
@@ -356,6 +551,10 @@ public sealed class AzureBlobJournalStorageTests
         private bool _exists;
         private ETag _eTag = new("\"initial\"");
         private int _successfulAppendCount;
+        private int _committedBlockCount;
+        private byte[] _content = [];
+        private Dictionary<string, string> _metadata = [];
+        private string? _contentType;
 
         public FakeAppendBlobClient()
         {
@@ -372,7 +571,11 @@ public sealed class AzureBlobJournalStorageTests
 
         public bool FailNextAppend { get; set; }
 
+        public bool FailNextCreate { get; set; }
+
         public int? OverrideCommittedBlockCount { get; set; }
+
+        public List<string> Operations { get; } = [];
 
         public List<CreateCall> CreateCalls { get; } = [];
 
@@ -383,12 +586,24 @@ public sealed class AzureBlobJournalStorageTests
         public override Task<Response<BlobContentInfo>> CreateAsync(AppendBlobCreateOptions options, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            _root.Operations.Add("append-create");
             _root.CreateCalls.Add(new(
                 options.Conditions?.IfMatch ?? default,
                 options.Conditions?.IfNoneMatch ?? default,
                 options.HttpHeaders?.ContentType,
                 options.Metadata is null ? new Dictionary<string, string>() : new Dictionary<string, string>(options.Metadata)));
+            _root.ThrowIfConditionsFail(options.Conditions);
+            if (_root.FailNextCreate)
+            {
+                _root.FailNextCreate = false;
+                throw new RequestFailedException(500, "Create failed.");
+            }
+
             _root._exists = true;
+            _root._content = [];
+            _root._metadata = options.Metadata is null ? [] : new Dictionary<string, string>(options.Metadata);
+            _root._contentType = options.HttpHeaders?.ContentType;
+            _root._committedBlockCount = 0;
             _root._eTag = new ETag($"\"create-{_root.CreateCallCount}\"");
             return Task.FromResult(Response.FromValue(
                 BlobsModelFactory.BlobContentInfo(_root._eTag, default, null, null, null, null, 0),
@@ -405,10 +620,12 @@ public sealed class AzureBlobJournalStorageTests
 
             using var buffer = new MemoryStream();
             await content.CopyToAsync(buffer, cancellationToken);
+            _root.Operations.Add("append-block");
             _root.AppendCalls.Add(new(
                 options.Conditions?.IfMatch ?? default,
                 options.Conditions?.IfNoneMatch ?? default,
                 buffer.ToArray()));
+            _root.ThrowIfConditionsFail(options.Conditions);
             if (_root.FailNextAppend)
             {
                 _root.FailNextAppend = false;
@@ -416,8 +633,10 @@ public sealed class AzureBlobJournalStorageTests
             }
 
             _root._successfulAppendCount++;
+            _root._committedBlockCount++;
+            _root._content = [.. _root._content, .. buffer.ToArray()];
             _root._eTag = new ETag($"\"append-{_root._successfulAppendCount}\"");
-            var committedBlocks = _root.OverrideCommittedBlockCount ?? _root._successfulAppendCount;
+            var committedBlocks = _root.OverrideCommittedBlockCount ?? _root._committedBlockCount;
             return Response.FromValue(
                 BlobsModelFactory.BlobAppendInfo(_root._eTag, default, null, null, "0", committedBlocks, false, null, null),
                 TestResponse.Instance);
@@ -426,6 +645,11 @@ public sealed class AzureBlobJournalStorageTests
         public override Task<Response> DeleteAsync(DeleteSnapshotsOption snapshotsOption = DeleteSnapshotsOption.None, BlobRequestConditions? conditions = null, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (conditions?.IfMatch is { } ifMatch && ifMatch != default && ifMatch != _root._eTag)
+            {
+                throw new RequestFailedException(412, "ETag mismatch.");
+            }
+
             _root._exists = false;
             return Task.FromResult<Response>(TestResponse.Instance);
         }
@@ -433,7 +657,25 @@ public sealed class AzureBlobJournalStorageTests
         public override Task<Response<BlobDownloadStreamingResult>> DownloadStreamingAsync(BlobDownloadOptions? options = null, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var download = _root.Downloads.Dequeue();
+            if (!_root._exists && _root.Downloads.Count == 0)
+            {
+                throw new RequestFailedException(404, "Blob does not exist.");
+            }
+
+            var download = _root.Downloads.Count > 0
+                ? _root.Downloads.Dequeue()
+                : new DownloadResult(
+                    _root._content,
+                    _root._eTag,
+                    _root._metadata,
+                    _root.OverrideCommittedBlockCount ?? _root._committedBlockCount,
+                    _root._contentType);
+            _root._exists = true;
+            _root._eTag = download.ETag;
+            _root._content = download.Content;
+            _root._metadata = new Dictionary<string, string>(download.Metadata);
+            _root._contentType = download.ContentType;
+            _root._committedBlockCount = download.BlobCommittedBlockCount;
             var details = BlobsModelFactory.BlobDownloadDetails(
                 blobType: BlobType.Append,
                 contentLength: download.Content.Length,
@@ -445,6 +687,117 @@ public sealed class AzureBlobJournalStorageTests
             return Task.FromResult(Response.FromValue(result, TestResponse.Instance));
         }
 
+        private void ThrowIfConditionsFail(AppendBlobRequestConditions? conditions)
+        {
+            if (conditions is null)
+            {
+                return;
+            }
+
+            if (conditions.IfNoneMatch == ETag.All && _root._exists)
+            {
+                throw new RequestFailedException(409, "Blob already exists.");
+            }
+
+            if (conditions.IfMatch is { } ifMatch && ifMatch != default && ifMatch != _root._eTag)
+            {
+                throw new RequestFailedException(412, "ETag mismatch.");
+            }
+        }
+    }
+
+    private sealed class FakeBlockBlobStore(List<string> operations)
+    {
+        private readonly Dictionary<string, StoredBlockBlob> _blobs = [];
+        private int _uploadCount;
+
+        public bool FailNextUpload { get; set; }
+
+        public List<BlockUploadCall> UploadCalls { get; } = [];
+
+        public List<BlockDownloadCall> DownloadCalls { get; } = [];
+
+        public BlockBlobClient GetBlockBlobClient(string name) => new FakeBlockBlobClient(this, name);
+
+        public void Add(string name, byte[] content, ETag eTag, IDictionary<string, string> metadata)
+            => _blobs[name] = new StoredBlockBlob(content, eTag, new Dictionary<string, string>(metadata), ContentType: null);
+
+        private async Task<Response<BlobContentInfo>> UploadAsync(string name, Stream content, BlobUploadOptions options, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            operations.Add("snapshot-upload");
+            using var buffer = new MemoryStream();
+            await content.CopyToAsync(buffer, cancellationToken);
+            var payload = buffer.ToArray();
+            UploadCalls.Add(new(
+                name,
+                options.Conditions?.IfMatch ?? default,
+                options.Conditions?.IfNoneMatch ?? default,
+                options.HttpHeaders?.ContentType,
+                options.Metadata is null ? new Dictionary<string, string>() : new Dictionary<string, string>(options.Metadata),
+                payload));
+
+            if (options.Conditions?.IfNoneMatch == ETag.All && _blobs.ContainsKey(name))
+            {
+                throw new RequestFailedException(409, "Blob already exists.");
+            }
+
+            if (FailNextUpload)
+            {
+                FailNextUpload = false;
+                throw new RequestFailedException(500, "Snapshot upload failed.");
+            }
+
+            _uploadCount++;
+            var eTag = new ETag($"\"snapshot-{_uploadCount}\"");
+            _blobs[name] = new StoredBlockBlob(
+                payload,
+                eTag,
+                options.Metadata is null ? [] : new Dictionary<string, string>(options.Metadata),
+                options.HttpHeaders?.ContentType);
+            return Response.FromValue(
+                BlobsModelFactory.BlobContentInfo(eTag, default, null, null, null, null, payload.Length),
+                TestResponse.Instance);
+        }
+
+        private Task<Response<BlobDownloadStreamingResult>> DownloadStreamingAsync(string name, BlobDownloadOptions? options, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var ifMatch = options?.Conditions?.IfMatch ?? default;
+            DownloadCalls.Add(new(name, ifMatch));
+
+            if (!_blobs.TryGetValue(name, out var blob))
+            {
+                throw new RequestFailedException(404, "Snapshot does not exist.");
+            }
+
+            if (ifMatch != default && ifMatch != blob.ETag)
+            {
+                throw new RequestFailedException(412, "Snapshot ETag mismatch.");
+            }
+
+            var details = BlobsModelFactory.BlobDownloadDetails(
+                blobType: BlobType.Block,
+                contentLength: blob.Content.Length,
+                contentType: blob.ContentType,
+                metadata: blob.Metadata,
+                eTag: blob.ETag);
+            var result = BlobsModelFactory.BlobDownloadStreamingResult(new MemoryStream(blob.Content), details);
+            return Task.FromResult(Response.FromValue(result, TestResponse.Instance));
+        }
+
+        private sealed class FakeBlockBlobClient(FakeBlockBlobStore store, string name) : BlockBlobClient
+        {
+            public override string BlobContainerName => "container";
+
+            public override string Name => name;
+
+            public override Task<Response<BlobContentInfo>> UploadAsync(Stream content, BlobUploadOptions options, CancellationToken cancellationToken = default)
+                => store.UploadAsync(name, content, options, cancellationToken);
+
+            public override Task<Response<BlobDownloadStreamingResult>> DownloadStreamingAsync(BlobDownloadOptions? options = null, CancellationToken cancellationToken = default)
+                => store.DownloadStreamingAsync(name, options, cancellationToken);
+        }
     }
 
     private sealed record DownloadResult(
@@ -464,6 +817,18 @@ public sealed class AzureBlobJournalStorageTests
         ETag IfMatch,
         ETag IfNoneMatch,
         byte[] Payload);
+
+    private sealed record BlockUploadCall(
+        string Name,
+        ETag IfMatch,
+        ETag IfNoneMatch,
+        string? ContentType,
+        IDictionary<string, string> Metadata,
+        byte[] Payload);
+
+    private sealed record BlockDownloadCall(string Name, ETag IfMatch);
+
+    private sealed record StoredBlockBlob(byte[] Content, ETag ETag, IDictionary<string, string> Metadata, string? ContentType);
 
     private sealed class TestResponse : Response
     {

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -21,8 +21,8 @@ public sealed class AzureBlobJournalStorageTests
         await storage.DeleteAsync(CancellationToken.None);
         await storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
 
-        Assert.Equal(2, appendBlobs.CreateCalls.Count(call => call.Name == "blob.log.00000000"));
-        Assert.Equal(2, appendBlobs.AppendCalls.Count(call => call.Name == "blob.log.00000000"));
+        Assert.Equal(2, appendBlobs.CreateCalls.Count(call => call.Name == "blob/root"));
+        Assert.Equal(2, appendBlobs.AppendCalls.Count(call => call.Name == "blob/root"));
     }
 
     [Fact]
@@ -55,8 +55,8 @@ public sealed class AzureBlobJournalStorageTests
         var options = new AzureBlobJournalStorageOptions();
         var grainId = GrainId.Create("test-grain", "0");
 
-        Assert.Equal("journals/test.log.0000000A", options.GetWalSegmentBlobName(new(grainId, "journals/test", 10)));
-        Assert.Equal("journals/test.checkpoint.0000000B", options.GetCheckpointBlobName(new(grainId, "journals/test", 11)));
+        Assert.Equal("journals/test/2/seg.0000000A", options.GetWalSegmentBlobName(new(grainId, "journals/test", generation: 2, segmentId: 10)));
+        Assert.Equal("journals/test/2/chk", options.GetCheckpointBlobName(new(grainId, "journals/test", generation: 2)));
     }
 
     [Fact]
@@ -66,11 +66,11 @@ public sealed class AzureBlobJournalStorageTests
         var storage = CreateStorage(appendBlobs);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        appendBlobs.Seal("blob.log.00000000");
+        appendBlobs.Seal("blob/root");
         await storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
 
-        Assert.Equal(["create:blob.log.00000000", "append:blob.log.00000000", "seal:blob.log.00000000", "append:blob.log.00000000", "seal:blob.log.00000000", "create:blob.log.00000001", "append:blob.log.00000001"], appendBlobs.Operations);
-        Assert.Equal([2], appendBlobs.GetContent("blob.log.00000001"));
+        Assert.Equal(["create:blob/root", "append:blob/root", "seal:blob/root", "append:blob/root", "seal:blob/root", "create:blob/0/seg.00000000", "append:blob/0/seg.00000000"], appendBlobs.Operations);
+        Assert.Equal([2], appendBlobs.GetContent("blob/0/seg.00000000"));
     }
 
     [Fact]
@@ -83,33 +83,31 @@ public sealed class AzureBlobJournalStorageTests
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
         await storage.ReplaceAsync(new ReadOnlySequence<byte>([2, 3]), CancellationToken.None);
 
-        Assert.Contains("seal:blob.log.00000000", appendBlobs.Operations);
         var upload = checkpoints.UploadCalls.Single();
-        Assert.Equal("blob.checkpoint.00000000", upload.Name);
+        Assert.Equal("blob/1/chk", upload.Name);
         Assert.Equal(ETag.All, upload.IfNoneMatch);
         Assert.Equal([2, 3], upload.Payload);
         Assert.Equal("application/jsonl", upload.ContentType);
         AssertAzureMetadataKeys(upload.Metadata);
         Assert.Equal("json-lines", upload.Metadata[AzureBlobJournalStorage.FormatMetadataKey]);
-        Assert.Equal("00000000", upload.Metadata[AzureBlobJournalStorage.CheckpointIdMetadataKey]);
-        Assert.Equal("00000001", upload.Metadata[AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey]);
-        Assert.Equal("0", upload.Metadata[AzureBlobJournalStorage.CheckpointReplayOffsetMetadataKey]);
+        Assert.Equal("1", upload.Metadata[AzureBlobJournalStorage.GenerationMetadataKey]);
 
-        var metadata = appendBlobs.SetMetadataCalls.Single();
-        Assert.Equal("blob.log.00000000", metadata.Name);
-        Assert.Equal(new ETag("\"seal-1\""), metadata.IfMatch);
-        AssertAzureMetadataKeys(metadata.Metadata);
-        Assert.Equal("blob.checkpoint.00000000", metadata.Metadata[AzureBlobJournalStorage.CheckpointMetadataKey]);
-        Assert.Equal("\"checkpoint-1\"", metadata.Metadata[AzureBlobJournalStorage.CheckpointETagMetadataKey]);
-        Assert.Equal("2", metadata.Metadata[AzureBlobJournalStorage.CheckpointLengthMetadataKey]);
-        Assert.Equal("json-lines", metadata.Metadata[AzureBlobJournalStorage.CheckpointFormatMetadataKey]);
+        var rootReplace = appendBlobs.CreateCalls.Last();
+        Assert.Equal("blob/root", rootReplace.Name);
+        Assert.Equal(new ETag("\"append-1\""), rootReplace.IfMatch);
+        AssertAzureMetadataKeys(rootReplace.Metadata);
+        Assert.Equal("1", rootReplace.Metadata[AzureBlobJournalStorage.GenerationMetadataKey]);
+        Assert.Equal("blob/1/chk", rootReplace.Metadata[AzureBlobJournalStorage.CheckpointMetadataKey]);
+        Assert.Equal("\"checkpoint-1\"", rootReplace.Metadata[AzureBlobJournalStorage.CheckpointETagMetadataKey]);
+        Assert.Equal("2", rootReplace.Metadata[AzureBlobJournalStorage.CheckpointLengthMetadataKey]);
+        Assert.Equal("json-lines", rootReplace.Metadata[AzureBlobJournalStorage.CheckpointFormatMetadataKey]);
     }
 
     [Fact]
     public async Task ReadAsync_WhenNoCheckpointMetadata_ReadsRootWalOnly()
     {
         var appendBlobs = new FakeAppendBlobStore();
-        appendBlobs.Add("blob.log.00000000", [1, 2], metadata: new Dictionary<string, string>(), isSealed: false);
+        appendBlobs.Add("blob/root", [1, 2], metadata: RootMetadata(generation: 0), isSealed: false);
         var checkpoints = new FakeBlockBlobStore();
         var storage = CreateStorage(appendBlobs, checkpoints);
 
@@ -126,22 +124,19 @@ public sealed class AzureBlobJournalStorageTests
     {
         var appendBlobs = new FakeAppendBlobStore();
         appendBlobs.Add(
-            "blob.log.00000000",
-            [9, 9],
-            CheckpointMarkerMetadata("blob.checkpoint.00000000", new ETag("\"checkpoint-etag\""), "json-lines", 2, checkpointId: 0, replaySegment: 1, replayOffset: 0),
-            isSealed: true);
-        appendBlobs.Add("blob.log.00000001", [3, 4], new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines" }, isSealed: false);
+            "blob/root",
+            [3, 4],
+            CheckpointMarkerMetadata("blob/1/chk", new ETag("\"checkpoint-etag\""), "json-lines", 2, generation: 1),
+            isSealed: false);
         var checkpoints = new FakeBlockBlobStore();
         checkpoints.Add(
-            "blob.checkpoint.00000000",
+            "blob/1/chk",
             [1, 2],
             new ETag("\"checkpoint-etag\""),
             new Dictionary<string, string>
             {
                 [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines",
-                [AzureBlobJournalStorage.CheckpointIdMetadataKey] = "00000000",
-                [AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey] = "00000001",
-                [AzureBlobJournalStorage.CheckpointReplayOffsetMetadataKey] = "0"
+                [AzureBlobJournalStorage.GenerationMetadataKey] = "1",
             });
         var storage = CreateStorage(appendBlobs, checkpoints);
 
@@ -150,7 +145,7 @@ public sealed class AzureBlobJournalStorageTests
 
         Assert.Equal("json-lines", consumer.JournalFormatKey);
         Assert.Equal([1, 2, 3, 4], consumer.Bytes.ToArray());
-        Assert.Equal(["blob.log.00000000", "blob.log.00000001"], appendBlobs.DownloadCalls.Select(static call => call.Name));
+        Assert.Equal(["blob/root"], appendBlobs.DownloadCalls.Select(static call => call.Name));
         Assert.Single(checkpoints.DownloadCalls);
         Assert.Equal(new ETag("\"checkpoint-etag\""), checkpoints.DownloadCalls.Single().IfMatch);
     }
@@ -169,25 +164,89 @@ public sealed class AzureBlobJournalStorageTests
         Assert.Empty(appendBlobs.SetMetadataCalls);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
-        Assert.Equal([3], appendBlobs.GetContent("blob.log.00000001"));
+        Assert.Equal([1, 3], appendBlobs.GetContent("blob/root"));
     }
 
     [Fact]
     public async Task ReplaceAsync_WhenRootMetadataUpdateFails_DoesNotPublishCheckpoint()
     {
-        var appendBlobs = new FakeAppendBlobStore { FailNextSetMetadata = true };
+        var appendBlobs = new FakeAppendBlobStore();
         var checkpoints = new FakeBlockBlobStore();
         var storage = CreateStorage(appendBlobs, checkpoints);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        appendBlobs.FailNextCreate = true;
         await Assert.ThrowsAsync<RequestFailedException>(
             () => storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
 
         Assert.Single(checkpoints.UploadCalls);
-        Assert.Single(appendBlobs.SetMetadataCalls);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
-        Assert.Equal([3], appendBlobs.GetContent("blob.log.00000001"));
+        Assert.Equal([1, 3], appendBlobs.GetContent("blob/root"));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenCheckpointGenerationExistsButRootDoesNotReferenceIt_BumpsGeneration()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        checkpoints.Add(
+            "blob/1/chk",
+            [9],
+            new ETag("\"orphan\""),
+            new Dictionary<string, string> { [AzureBlobJournalStorage.GenerationMetadataKey] = "1" });
+
+        await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+
+        Assert.Equal(["blob/1/chk", "blob/2/chk"], checkpoints.UploadCalls.Select(static call => call.Name));
+        var rootReplace = appendBlobs.CreateCalls.Last();
+        Assert.Equal("2", rootReplace.Metadata[AzureBlobJournalStorage.GenerationMetadataKey]);
+        Assert.Equal("blob/2/chk", rootReplace.Metadata[AzureBlobJournalStorage.CheckpointMetadataKey]);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenCheckpointGenerationExistsAndRootReferencesIt_RequiresRecovery()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        checkpoints.Add(
+            "blob/1/chk",
+            [2],
+            new ETag("\"checkpoint-etag\""),
+            new Dictionary<string, string> { [AzureBlobJournalStorage.GenerationMetadataKey] = "1" });
+        appendBlobs.Add(
+            "blob/root",
+            [],
+            CheckpointMarkerMetadata("blob/1/chk", new ETag("\"checkpoint-etag\""), "json-lines", 1, generation: 1),
+            isSealed: false);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
+
+        Assert.Contains("recovery", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenRootETagConflicts_RequiresRecovery()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        appendBlobs.Add("blob/root", [1], RootMetadata(generation: 0), isSealed: false);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
+
+        var requestFailed = Assert.IsType<RequestFailedException>(exception.InnerException);
+        Assert.Equal(412, requestFailed.Status);
     }
 
     [Fact]
@@ -195,9 +254,9 @@ public sealed class AzureBlobJournalStorageTests
     {
         var appendBlobs = new FakeAppendBlobStore();
         appendBlobs.Add(
-            "blob.log.00000000",
+            "blob/root",
             [],
-            CheckpointMarkerMetadata("missing-checkpoint", new ETag("\"missing\""), "json-lines", 1, checkpointId: 0, replaySegment: 1, replayOffset: 0),
+            CheckpointMarkerMetadata("missing-checkpoint", new ETag("\"missing\""), "json-lines", 1, generation: 1),
             isSealed: true);
         var storage = CreateStorage(appendBlobs, new FakeBlockBlobStore());
 
@@ -207,32 +266,29 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
-    public async Task ReadAsync_WhenCheckpointReplayOffsetExceedsWalLength_Throws()
+    public async Task ReadAsync_WhenCheckpointGenerationDoesNotMatch_Throws()
     {
         var appendBlobs = new FakeAppendBlobStore();
         appendBlobs.Add(
-            "blob.log.00000000",
+            "blob/root",
             [],
-            CheckpointMarkerMetadata("blob.checkpoint.00000000", new ETag("\"checkpoint-etag\""), "json-lines", 1, checkpointId: 0, replaySegment: 1, replayOffset: 5),
-            isSealed: true);
-        appendBlobs.Add("blob.log.00000001", [1], new Dictionary<string, string> { [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines" }, isSealed: false);
+            CheckpointMarkerMetadata("blob/1/chk", new ETag("\"checkpoint-etag\""), "json-lines", 1, generation: 1),
+            isSealed: false);
         var checkpoints = new FakeBlockBlobStore();
         checkpoints.Add(
-            "blob.checkpoint.00000000",
+            "blob/1/chk",
             [2],
             new ETag("\"checkpoint-etag\""),
             new Dictionary<string, string>
             {
                 [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines",
-                [AzureBlobJournalStorage.CheckpointIdMetadataKey] = "00000000",
-                [AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey] = "00000001",
-                [AzureBlobJournalStorage.CheckpointReplayOffsetMetadataKey] = "5"
+                [AzureBlobJournalStorage.GenerationMetadataKey] = "2",
             });
         var storage = CreateStorage(appendBlobs, checkpoints);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
             () => storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None).AsTask());
-        Assert.Contains("offset", exception.Message);
+        Assert.Contains("generation", exception.Message);
     }
 
     [Fact]
@@ -240,20 +296,18 @@ public sealed class AzureBlobJournalStorageTests
     {
         var appendBlobs = new FakeAppendBlobStore();
         appendBlobs.Add(
-            "blob.log.00000000",
+            "blob/root",
             [],
-            CheckpointMarkerMetadata("blob.checkpoint.00000000", new ETag("\"checkpoint-etag\""), "json-lines", 1, checkpointId: 0, replaySegment: 1, replayOffset: 0),
+            CheckpointMarkerMetadata("blob/1/chk", new ETag("\"checkpoint-etag\""), "json-lines", 1, generation: 1),
             isSealed: true);
         var checkpoints = new FakeBlockBlobStore();
         checkpoints.Add(
-            "blob.checkpoint.00000000",
+            "blob/1/chk",
             [2],
             new ETag("\"checkpoint-etag\""),
             new Dictionary<string, string>
             {
-                [AzureBlobJournalStorage.CheckpointIdMetadataKey] = "00000000",
-                [AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey] = "00000001",
-                [AzureBlobJournalStorage.CheckpointReplayOffsetMetadataKey] = "0"
+                [AzureBlobJournalStorage.GenerationMetadataKey] = "1",
             });
         var storage = CreateStorage(appendBlobs, checkpoints);
 
@@ -266,7 +320,7 @@ public sealed class AzureBlobJournalStorageTests
     public async Task ReadAsync_UpdatesCompactionRequestFromCommittedBlockCount()
     {
         var appendBlobs = new FakeAppendBlobStore();
-        appendBlobs.Add("blob.log.00000000", [1], metadata: new Dictionary<string, string>(), isSealed: false, committedBlockCount: 11);
+        appendBlobs.Add("blob/root", [1], metadata: RootMetadata(generation: 0), isSealed: false, committedBlockCount: 11);
         var storage = CreateStorage(appendBlobs);
 
         await storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None);
@@ -306,6 +360,20 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
+    public async Task AppendAsync_WithoutPriorRead_LoadsExistingRootGeneration()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var first = CreateStorage(appendBlobs);
+        await first.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+
+        var second = CreateStorage(appendBlobs);
+        await second.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+
+        Assert.Equal([1, 2], appendBlobs.GetContent("blob/root"));
+        Assert.Contains(appendBlobs.DownloadCalls, static call => call.Name == "blob/root");
+    }
+
+    [Fact]
     public async Task AppendAsync_WhenBatchExceedsMaxAppendBlockBytes_ThrowsBeforeRoundTrip()
     {
         var appendBlobs = new FakeAppendBlobStore();
@@ -329,14 +397,28 @@ public sealed class AzureBlobJournalStorageTests
     {
         checkpoints ??= new FakeBlockBlobStore();
         return new AzureBlobJournalStorage(
-            appendBlobs.GetAppendBlobClient("blob.log.00000000"),
+            appendBlobs.GetAppendBlobClient("blob/root"),
             mimeType,
             NullLogger<AzureBlobJournalStorage>.Instance,
             journalFormatKey,
-            walNameFactory: segmentId => $"blob.log.{segmentId:X8}",
-            walClientFactory: segmentId => appendBlobs.GetAppendBlobClient($"blob.log.{segmentId:X8}"),
-            checkpointNameFactory: checkpointId => $"blob.checkpoint.{checkpointId:X8}",
+            walNameFactory: (generation, segmentId) => $"blob/{generation}/seg.{segmentId:X8}",
+            walClientFactory: (generation, segmentId) => appendBlobs.GetAppendBlobClient($"blob/{generation}/seg.{segmentId:X8}"),
+            checkpointNameFactory: generation => $"blob/{generation}/chk",
             checkpointClientFactory: checkpoints.GetBlockBlobClient);
+    }
+
+    private static Dictionary<string, string> RootMetadata(ulong generation, string? format = null)
+    {
+        var result = new Dictionary<string, string>
+        {
+            [AzureBlobJournalStorage.GenerationMetadataKey] = generation.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        };
+        if (format is not null)
+        {
+            result[AzureBlobJournalStorage.FormatMetadataKey] = format;
+        }
+
+        return result;
     }
 
     private static Dictionary<string, string> CheckpointMarkerMetadata(
@@ -344,18 +426,14 @@ public sealed class AzureBlobJournalStorageTests
         ETag checkpointETag,
         string format,
         long checkpointLength,
-        uint checkpointId,
-        uint replaySegment,
-        long replayOffset) => new()
+        ulong generation) => new()
     {
+        [AzureBlobJournalStorage.GenerationMetadataKey] = generation.ToString(System.Globalization.CultureInfo.InvariantCulture),
         [AzureBlobJournalStorage.FormatMetadataKey] = format,
         [AzureBlobJournalStorage.CheckpointMetadataKey] = checkpointName,
         [AzureBlobJournalStorage.CheckpointETagMetadataKey] = checkpointETag.ToString(),
         [AzureBlobJournalStorage.CheckpointFormatMetadataKey] = format,
-        [AzureBlobJournalStorage.CheckpointIdMetadataKey] = checkpointId.ToString("X8", System.Globalization.CultureInfo.InvariantCulture),
         [AzureBlobJournalStorage.CheckpointLengthMetadataKey] = checkpointLength.ToString(System.Globalization.CultureInfo.InvariantCulture),
-        [AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey] = replaySegment.ToString("X8", System.Globalization.CultureInfo.InvariantCulture),
-        [AzureBlobJournalStorage.CheckpointReplayOffsetMetadataKey] = replayOffset.ToString(System.Globalization.CultureInfo.InvariantCulture),
     };
 
     private static void AssertAzureMetadataKeys(IDictionary<string, string> metadata)
@@ -427,6 +505,8 @@ public sealed class AzureBlobJournalStorageTests
 
         public bool FailNextAppend { get; set; }
 
+        public bool FailNextCreate { get; set; }
+
         public bool FailNextSetMetadata { get; set; }
 
         public List<string> Operations { get; } = [];
@@ -466,6 +546,11 @@ public sealed class AzureBlobJournalStorageTests
                 options.HttpHeaders?.ContentType,
                 options.Metadata is null ? new Dictionary<string, string>() : new Dictionary<string, string>(options.Metadata)));
             ThrowIfAppendConditionsFail(name, options.Conditions);
+            if (FailNextCreate)
+            {
+                FailNextCreate = false;
+                throw new RequestFailedException(500, "Create failed.");
+            }
 
             _createCount++;
             var eTag = new ETag($"\"create-{_createCount}\"");

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Globalization;
 using Azure;
 using Azure.Core;
 using Azure.Storage.Blobs.Models;
@@ -12,7 +13,7 @@ namespace Orleans.Journaling.Tests;
 public sealed class AzureBlobJournalStorageTests
 {
     [Fact]
-    public async Task DeleteAsync_AllowsNextAppendToRecreateRootWal()
+    public async Task DeleteAsync_AllowsNextAppendToRecreateWal()
     {
         var appendBlobs = new FakeAppendBlobStore();
         var storage = CreateStorage(appendBlobs);
@@ -21,8 +22,37 @@ public sealed class AzureBlobJournalStorageTests
         await storage.DeleteAsync(CancellationToken.None);
         await storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
 
-        Assert.Equal(2, appendBlobs.CreateCalls.Count(call => call.Name == "blob/root"));
-        Assert.Equal(2, appendBlobs.AppendCalls.Count(call => call.Name == "blob/root"));
+        Assert.Equal(2, appendBlobs.CreateCalls.Count(call => call.Name == "blob/wal"));
+        Assert.Equal(2, appendBlobs.AppendCalls.Count(call => call.Name == "blob/wal"));
+        Assert.Equal([2], appendBlobs.GetContent("blob/wal"));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenWalETagChanges_DoesNotDeleteUpdatedWal()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        appendBlobs.BeforeDelete = (name, conditions) =>
+        {
+            if (name == "blob/wal" && conditions?.IfMatch == new ETag("\"append-1\""))
+            {
+                appendBlobs.BeforeDelete = null;
+                appendBlobs.Add("blob/wal", [1, 2], WalMetadata(), isSealed: false);
+            }
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.DeleteAsync(CancellationToken.None).AsTask());
+
+        var requestFailed = Assert.IsType<RequestFailedException>(exception.InnerException);
+        Assert.Equal(412, requestFailed.Status);
+
+        var consumer = new CapturingJournalStorageConsumer();
+        await CreateStorage(appendBlobs).ReadAsync(consumer, CancellationToken.None);
+
+        Assert.Equal([1, 2], consumer.Bytes.ToArray());
     }
 
     [Fact]
@@ -50,31 +80,30 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
-    public void DefaultWalAndCheckpointNames_UseFixedWidthHexIds()
+    public void DefaultWalAndCheckpointNames_UseFixedWalAndSnapshotPrefix()
     {
-        var options = new AzureBlobJournalStorageOptions();
-        var grainId = GrainId.Create("test-grain", "0");
-
-        Assert.Equal("journals/test/2/seg.0000000A", options.GetWalSegmentBlobName(new(grainId, "journals/test", generation: 2, segmentId: 10)));
-        Assert.Equal("journals/test/2/chk", options.GetCheckpointBlobName(new(grainId, "journals/test", generation: 2)));
+        Assert.Equal("journals/test/wal", AzureBlobJournalStorageOptions.GetDefaultWalBlobName("journals/test"));
+        Assert.Equal("journals/test/chk.snapshot", AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName("journals/test", "snapshot"));
     }
 
     [Fact]
-    public async Task AppendAsync_WhenCurrentWalIsSealed_RollsToNextWalSegment()
+    public async Task AppendAsync_WhenCurrentWalIsSealed_RequiresRecovery()
     {
         var appendBlobs = new FakeAppendBlobStore();
         var storage = CreateStorage(appendBlobs);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        appendBlobs.Seal("blob/root");
-        await storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+        appendBlobs.Seal("blob/wal");
 
-        Assert.Equal(["create:blob/root", "append:blob/root", "seal:blob/root", "append:blob/root", "seal:blob/root", "create:blob/0/seg.00000000", "append:blob/0/seg.00000000"], appendBlobs.Operations);
-        Assert.Equal([2], appendBlobs.GetContent("blob/0/seg.00000000"));
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
+
+        Assert.Contains("recovery", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(appendBlobs.Operations, static operation => operation.Contains("seg.", StringComparison.Ordinal));
     }
 
     [Fact]
-    public async Task ReplaceAsync_SealsWalUploadsImmutableCheckpointAndPublishesRootMetadata()
+    public async Task ReplaceAsync_UploadsImmutableCheckpointAndPublishesWalMetadata()
     {
         var appendBlobs = new FakeAppendBlobStore();
         var checkpoints = new FakeBlockBlobStore();
@@ -84,31 +113,38 @@ public sealed class AzureBlobJournalStorageTests
         await storage.ReplaceAsync(new ReadOnlySequence<byte>([2, 3]), CancellationToken.None);
 
         var upload = checkpoints.UploadCalls.Single();
-        Assert.Equal("blob/1/chk", upload.Name);
+        Assert.StartsWith("blob/chk.", upload.Name);
         Assert.Equal(ETag.All, upload.IfNoneMatch);
         Assert.Equal([2, 3], upload.Payload);
         Assert.Equal("application/jsonl", upload.ContentType);
         AssertAzureMetadataKeys(upload.Metadata);
         Assert.Equal("json-lines", upload.Metadata[AzureBlobJournalStorage.FormatMetadataKey]);
-        Assert.Equal("1", upload.Metadata[AzureBlobJournalStorage.GenerationMetadataKey]);
+        Assert.DoesNotContain("generation", upload.Metadata.Keys);
 
-        var rootReplace = appendBlobs.CreateCalls.Last();
-        Assert.Equal("blob/root", rootReplace.Name);
-        Assert.Equal(new ETag("\"append-1\""), rootReplace.IfMatch);
-        AssertAzureMetadataKeys(rootReplace.Metadata);
-        Assert.Equal("1", rootReplace.Metadata[AzureBlobJournalStorage.GenerationMetadataKey]);
-        Assert.Equal("json-lines", rootReplace.Metadata[AzureBlobJournalStorage.FormatMetadataKey]);
-        Assert.Equal("blob/1/chk", rootReplace.Metadata[AzureBlobJournalStorage.CheckpointMetadataKey]);
-        Assert.DoesNotContain("checkpoint_etag", rootReplace.Metadata.Keys);
-        Assert.DoesNotContain("checkpoint_length", rootReplace.Metadata.Keys);
-        Assert.DoesNotContain("checkpoint_format", rootReplace.Metadata.Keys);
+        var walPublish = appendBlobs.CreateCalls.Last();
+        Assert.Equal("blob/wal", walPublish.Name);
+        Assert.Equal(new ETag("\"append-1\""), walPublish.IfMatch);
+        AssertAzureMetadataKeys(walPublish.Metadata);
+        Assert.Equal("json-lines", walPublish.Metadata[AzureBlobJournalStorage.FormatMetadataKey]);
+        Assert.Equal(upload.Name, walPublish.Metadata[AzureBlobJournalStorage.CheckpointMetadataKey]);
+        Assert.Equal("0", walPublish.Metadata[AzureBlobJournalStorage.CheckpointOffsetMetadataKey]);
+        Assert.DoesNotContain("generation", walPublish.Metadata.Keys);
+        Assert.DoesNotContain("checkpoint_etag", walPublish.Metadata.Keys);
+        Assert.DoesNotContain("checkpoint_length", walPublish.Metadata.Keys);
+        Assert.DoesNotContain("checkpoint_format", walPublish.Metadata.Keys);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([4]), CancellationToken.None);
+        var consumer = new CapturingJournalStorageConsumer();
+        await CreateStorage(appendBlobs, checkpoints).ReadAsync(consumer, CancellationToken.None);
+
+        Assert.Equal([2, 3, 4], consumer.Bytes.ToArray());
     }
 
     [Fact]
-    public async Task ReadAsync_WhenNoCheckpointMetadata_ReadsRootWalOnly()
+    public async Task ReadAsync_WhenNoCheckpointMetadata_ReadsWalOnly()
     {
         var appendBlobs = new FakeAppendBlobStore();
-        appendBlobs.Add("blob/root", [1, 2], metadata: RootMetadata(generation: 0), isSealed: false);
+        appendBlobs.Add("blob/wal", [1, 2], metadata: WalMetadata(), isSealed: false);
         var checkpoints = new FakeBlockBlobStore();
         var storage = CreateStorage(appendBlobs, checkpoints);
 
@@ -116,7 +152,7 @@ public sealed class AzureBlobJournalStorageTests
         await storage.ReadAsync(consumer, CancellationToken.None);
 
         Assert.Equal([1, 2], consumer.Bytes.ToArray());
-        Assert.Single(appendBlobs.DownloadCalls);
+        Assert.Equal(["blob/wal"], appendBlobs.DownloadCalls.Select(static call => call.Name));
         Assert.Empty(checkpoints.DownloadCalls);
     }
 
@@ -125,19 +161,18 @@ public sealed class AzureBlobJournalStorageTests
     {
         var appendBlobs = new FakeAppendBlobStore();
         appendBlobs.Add(
-            "blob/root",
-            [3, 4],
-            CheckpointMarkerMetadata("blob/1/chk", "json-lines", generation: 1),
+            "blob/wal",
+            [9, 8, 3, 4],
+            CheckpointMarkerMetadata("blob/chk.snapshot", "json-lines", checkpointOffset: 2),
             isSealed: false);
         var checkpoints = new FakeBlockBlobStore();
         checkpoints.Add(
-            "blob/1/chk",
+            "blob/chk.snapshot",
             [1, 2],
             new ETag("\"checkpoint-etag\""),
             new Dictionary<string, string>
             {
                 [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines",
-                [AzureBlobJournalStorage.GenerationMetadataKey] = "1",
             });
         var storage = CreateStorage(appendBlobs, checkpoints);
 
@@ -146,13 +181,13 @@ public sealed class AzureBlobJournalStorageTests
 
         Assert.Equal("json-lines", consumer.JournalFormatKey);
         Assert.Equal([1, 2, 3, 4], consumer.Bytes.ToArray());
-        Assert.Equal(["blob/root"], appendBlobs.DownloadCalls.Select(static call => call.Name));
+        Assert.Equal(["blob/wal"], appendBlobs.DownloadCalls.Select(static call => call.Name));
         Assert.Single(checkpoints.DownloadCalls);
         Assert.Equal(default(ETag), checkpoints.DownloadCalls.Single().IfMatch);
     }
 
     [Fact]
-    public async Task ReplaceAsync_WhenCheckpointUploadFails_DoesNotPublishRootMetadata()
+    public async Task ReplaceAsync_WhenCheckpointUploadFails_DoesNotPublishWalMetadata()
     {
         var appendBlobs = new FakeAppendBlobStore();
         var checkpoints = new FakeBlockBlobStore { FailNextUpload = true };
@@ -162,14 +197,13 @@ public sealed class AzureBlobJournalStorageTests
         await Assert.ThrowsAsync<RequestFailedException>(
             () => storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
 
-        Assert.Empty(appendBlobs.SetMetadataCalls);
-
         await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
-        Assert.Equal([1, 3], appendBlobs.GetContent("blob/root"));
+        Assert.Equal([1, 3], appendBlobs.GetContent("blob/wal"));
+        Assert.Empty(appendBlobs.SetMetadataCalls);
     }
 
     [Fact]
-    public async Task ReplaceAsync_WhenRootMetadataUpdateFails_DoesNotPublishCheckpoint()
+    public async Task ReplaceAsync_WhenWalPublishFails_DoesNotResetWal()
     {
         var appendBlobs = new FakeAppendBlobStore();
         var checkpoints = new FakeBlockBlobStore();
@@ -183,71 +217,115 @@ public sealed class AzureBlobJournalStorageTests
         Assert.Single(checkpoints.UploadCalls);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
-        Assert.Equal([1, 3], appendBlobs.GetContent("blob/root"));
+        Assert.Equal([1, 3], appendBlobs.GetContent("blob/wal"));
     }
 
     [Fact]
-    public async Task ReplaceAsync_WhenCheckpointGenerationExistsButRootDoesNotReferenceIt_BumpsGeneration()
+    public async Task ReplaceAsync_WhenWalETagConflicts_RequiresRecovery()
     {
         var appendBlobs = new FakeAppendBlobStore();
         var checkpoints = new FakeBlockBlobStore();
         var storage = CreateStorage(appendBlobs, checkpoints);
 
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        checkpoints.Add(
-            "blob/1/chk",
-            [9],
-            new ETag("\"orphan\""),
-            new Dictionary<string, string> { [AzureBlobJournalStorage.GenerationMetadataKey] = "1" });
-
-        await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
-
-        Assert.Equal(["blob/1/chk", "blob/2/chk"], checkpoints.UploadCalls.Select(static call => call.Name));
-        var rootReplace = appendBlobs.CreateCalls.Last();
-        Assert.Equal("2", rootReplace.Metadata[AzureBlobJournalStorage.GenerationMetadataKey]);
-        Assert.Equal("blob/2/chk", rootReplace.Metadata[AzureBlobJournalStorage.CheckpointMetadataKey]);
-    }
-
-    [Fact]
-    public async Task ReplaceAsync_WhenCheckpointGenerationExistsAndRootReferencesIt_RequiresRecovery()
-    {
-        var appendBlobs = new FakeAppendBlobStore();
-        var checkpoints = new FakeBlockBlobStore();
-        var storage = CreateStorage(appendBlobs, checkpoints);
-
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        checkpoints.Add(
-            "blob/1/chk",
-            [2],
-            new ETag("\"checkpoint-etag\""),
-            new Dictionary<string, string> { [AzureBlobJournalStorage.GenerationMetadataKey] = "1" });
-        appendBlobs.Add(
-            "blob/root",
-            [],
-            CheckpointMarkerMetadata("blob/1/chk", "json-lines", generation: 1),
-            isSealed: false);
-
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
-
-        Assert.Contains("recovery", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task ReplaceAsync_WhenRootETagConflicts_RequiresRecovery()
-    {
-        var appendBlobs = new FakeAppendBlobStore();
-        var checkpoints = new FakeBlockBlobStore();
-        var storage = CreateStorage(appendBlobs, checkpoints);
-
-        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
-        appendBlobs.Add("blob/root", [1], RootMetadata(generation: 0), isSealed: false);
+        appendBlobs.Add("blob/wal", [1], WalMetadata(), isSealed: false);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
             () => storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
 
         var requestFailed = Assert.IsType<RequestFailedException>(exception.InnerException);
         Assert.Equal(412, requestFailed.Status);
+        Assert.Contains("recovery", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenWalETagChanges_DoesNotPublishStaleCheckpoint()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        appendBlobs.Add("blob/wal", [1, 2], WalMetadata(), isSealed: false);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.ReplaceAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None).AsTask());
+
+        var requestFailed = Assert.IsType<RequestFailedException>(exception.InnerException);
+        Assert.Equal(412, requestFailed.Status);
+        Assert.Single(checkpoints.UploadCalls);
+
+        var consumer = new CapturingJournalStorageConsumer();
+        await CreateStorage(appendBlobs, checkpoints).ReadAsync(consumer, CancellationToken.None);
+
+        Assert.Equal([1, 2], consumer.Bytes.ToArray());
+        Assert.Empty(checkpoints.DownloadCalls);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenWalNearBlockLimit_ResetsBlockBudgetAndAllowsMoreAppends()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        appendBlobs.Add("blob/wal", [1], metadata: WalMetadata(), isSealed: false, committedBlockCount: 49_900);
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints);
+
+        await storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None);
+        Assert.True(storage.IsCompactionRequested);
+
+        await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+        await storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
+
+        Assert.False(storage.IsCompactionRequested);
+        Assert.Equal([3], appendBlobs.GetContent("blob/wal"));
+        var consumer = new CapturingJournalStorageConsumer();
+        await CreateStorage(appendBlobs, checkpoints).ReadAsync(consumer, CancellationToken.None);
+        Assert.Equal([2, 3], consumer.Bytes.ToArray());
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenReplacingExistingCheckpoint_DeletesPreviousCheckpointAfterPublishingNewWal()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+        var previousCheckpoint = checkpoints.UploadCalls.Single().Name;
+
+        await storage.ReplaceAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
+
+        var currentCheckpoint = checkpoints.UploadCalls.Last().Name;
+        Assert.NotEqual(previousCheckpoint, currentCheckpoint);
+        Assert.False(checkpoints.Exists(previousCheckpoint));
+        Assert.True(checkpoints.Exists(currentCheckpoint));
+        Assert.Equal([previousCheckpoint], checkpoints.DeleteCalls.Select(static call => call.Name));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenWalExistsOnFreshStorage_DeletesWalAndReferencedCheckpoint()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        appendBlobs.Add(
+            "blob/wal",
+            [1],
+            CheckpointMarkerMetadata("blob/chk.snapshot", "json-lines"),
+            isSealed: false);
+        var checkpoints = new FakeBlockBlobStore();
+        checkpoints.Add(
+            "blob/chk.snapshot",
+            [2],
+            new ETag("\"checkpoint-etag\""),
+            new Dictionary<string, string>
+            {
+                [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines",
+            });
+
+        await CreateStorage(appendBlobs, checkpoints).DeleteAsync(CancellationToken.None);
+
+        Assert.False(appendBlobs.Exists("blob/wal"));
+        Assert.False(checkpoints.Exists("blob/chk.snapshot"));
     }
 
     [Fact]
@@ -255,10 +333,10 @@ public sealed class AzureBlobJournalStorageTests
     {
         var appendBlobs = new FakeAppendBlobStore();
         appendBlobs.Add(
-            "blob/root",
+            "blob/wal",
             [],
-            CheckpointMarkerMetadata("missing-checkpoint", "json-lines", generation: 1),
-            isSealed: true);
+            CheckpointMarkerMetadata("missing-checkpoint", "json-lines"),
+            isSealed: false);
         var storage = CreateStorage(appendBlobs, new FakeBlockBlobStore());
 
         var exception = await Assert.ThrowsAsync<RequestFailedException>(
@@ -267,49 +345,20 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
-    public async Task ReadAsync_WhenCheckpointGenerationDoesNotMatch_Throws()
-    {
-        var appendBlobs = new FakeAppendBlobStore();
-        appendBlobs.Add(
-            "blob/root",
-            [],
-            CheckpointMarkerMetadata("blob/1/chk", "json-lines", generation: 1),
-            isSealed: false);
-        var checkpoints = new FakeBlockBlobStore();
-        checkpoints.Add(
-            "blob/1/chk",
-            [2],
-            new ETag("\"checkpoint-etag\""),
-            new Dictionary<string, string>
-            {
-                [AzureBlobJournalStorage.FormatMetadataKey] = "json-lines",
-                [AzureBlobJournalStorage.GenerationMetadataKey] = "2",
-            });
-        var storage = CreateStorage(appendBlobs, checkpoints);
-
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None).AsTask());
-        Assert.Contains("generation", exception.Message);
-    }
-
-    [Fact]
     public async Task ReadAsync_WhenCheckpointFormatMetadataIsMissing_Throws()
     {
         var appendBlobs = new FakeAppendBlobStore();
         appendBlobs.Add(
-            "blob/root",
+            "blob/wal",
             [],
-            CheckpointMarkerMetadata("blob/1/chk", "json-lines", generation: 1),
-            isSealed: true);
+            CheckpointMarkerMetadata("blob/chk.snapshot", "json-lines"),
+            isSealed: false);
         var checkpoints = new FakeBlockBlobStore();
         checkpoints.Add(
-            "blob/1/chk",
+            "blob/chk.snapshot",
             [2],
             new ETag("\"checkpoint-etag\""),
-            new Dictionary<string, string>
-            {
-                [AzureBlobJournalStorage.GenerationMetadataKey] = "1",
-            });
+            new Dictionary<string, string>());
         var storage = CreateStorage(appendBlobs, checkpoints);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -318,10 +367,38 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
+    public async Task ReadAsync_WhenCheckpointFormatDiffersFromWal_Throws()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        appendBlobs.Add(
+            "blob/wal",
+            [],
+            CheckpointMarkerMetadata("blob/chk.snapshot", "json-lines"),
+            isSealed: false);
+        var checkpoints = new FakeBlockBlobStore();
+        checkpoints.Add(
+            "blob/chk.snapshot",
+            [1, 2],
+            new ETag("\"checkpoint-etag\""),
+            new Dictionary<string, string>
+            {
+                [AzureBlobJournalStorage.FormatMetadataKey] = "binary",
+            });
+        var storage = CreateStorage(appendBlobs, checkpoints);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None).AsTask());
+
+        Assert.Contains("format", exception.Message);
+        Assert.Contains("binary", exception.Message);
+        Assert.Contains("json-lines", exception.Message);
+    }
+
+    [Fact]
     public async Task ReadAsync_UpdatesCompactionRequestFromCommittedBlockCount()
     {
         var appendBlobs = new FakeAppendBlobStore();
-        appendBlobs.Add("blob/root", [1], metadata: RootMetadata(generation: 0), isSealed: false, committedBlockCount: 49_001);
+        appendBlobs.Add("blob/wal", [1], metadata: WalMetadata(), isSealed: false, committedBlockCount: 49_001);
         var storage = CreateStorage(appendBlobs);
 
         await storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None);
@@ -361,7 +438,7 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
-    public async Task AppendAsync_WithoutPriorRead_LoadsExistingRootGeneration()
+    public async Task AppendAsync_WithoutPriorRead_LoadsExistingWal()
     {
         var appendBlobs = new FakeAppendBlobStore();
         var first = CreateStorage(appendBlobs);
@@ -370,8 +447,41 @@ public sealed class AzureBlobJournalStorageTests
         var second = CreateStorage(appendBlobs);
         await second.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
 
-        Assert.Equal([1, 2], appendBlobs.GetContent("blob/root"));
-        Assert.Contains(appendBlobs.DownloadCalls, static call => call.Name == "blob/root");
+        Assert.Equal([1, 2], appendBlobs.GetContent("blob/wal"));
+        Assert.Contains(appendBlobs.DownloadCalls, static call => call.Name == "blob/wal");
+    }
+
+    [Fact]
+    public async Task AppendAsync_WhenWalETagConflicts_RequiresRecovery()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        appendBlobs.Add("blob/wal", [1, 2], WalMetadata(), isSealed: false);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None).AsTask());
+
+        var requestFailed = Assert.IsType<RequestFailedException>(exception.InnerException);
+        Assert.Equal(412, requestFailed.Status);
+        Assert.Contains("recovery", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AppendAsync_WhenWalNearBlockLimit_RequiresCompactionInsteadOfRolling()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        appendBlobs.Add("blob/wal", [1], metadata: WalMetadata(), isSealed: false, committedBlockCount: 49_900);
+        var storage = CreateStorage(appendBlobs);
+
+        await storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None);
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
+
+        Assert.Contains("compacted", exception.Message);
+        Assert.Empty(appendBlobs.AppendCalls);
+        Assert.DoesNotContain(appendBlobs.Operations, static operation => operation.Contains("seg.", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -390,6 +500,20 @@ public sealed class AzureBlobJournalStorageTests
         Assert.Empty(appendBlobs.AppendCalls);
     }
 
+    [Fact]
+    public async Task ReadAsync_WhenWalDoesNotExist_CompletesEmpty()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints);
+
+        var consumer = new CapturingJournalStorageConsumer();
+        await storage.ReadAsync(consumer, CancellationToken.None);
+
+        Assert.Empty(consumer.Bytes.ToArray());
+        Assert.Empty(checkpoints.DownloadCalls);
+    }
+
     private static AzureBlobJournalStorage CreateStorage(
         FakeAppendBlobStore appendBlobs,
         FakeBlockBlobStore? checkpoints = null,
@@ -406,12 +530,9 @@ public sealed class AzureBlobJournalStorageTests
             new JournalBatchTests.TestGrainContext(GrainId.Create("test-grain", "0")));
     }
 
-    private static Dictionary<string, string> RootMetadata(uint generation, string? format = null)
+    private static Dictionary<string, string> WalMetadata(string? format = null)
     {
-        var result = new Dictionary<string, string>
-        {
-            [AzureBlobJournalStorage.GenerationMetadataKey] = generation.ToString(System.Globalization.CultureInfo.InvariantCulture),
-        };
+        var result = new Dictionary<string, string>();
         if (format is not null)
         {
             result[AzureBlobJournalStorage.FormatMetadataKey] = format;
@@ -423,12 +544,21 @@ public sealed class AzureBlobJournalStorageTests
     private static Dictionary<string, string> CheckpointMarkerMetadata(
         string checkpointName,
         string format,
-        uint generation) => new()
+        long? checkpointOffset = null)
     {
-        [AzureBlobJournalStorage.GenerationMetadataKey] = generation.ToString(System.Globalization.CultureInfo.InvariantCulture),
-        [AzureBlobJournalStorage.FormatMetadataKey] = format,
-        [AzureBlobJournalStorage.CheckpointMetadataKey] = checkpointName,
-    };
+        var result = new Dictionary<string, string>
+        {
+            [AzureBlobJournalStorage.FormatMetadataKey] = format,
+            [AzureBlobJournalStorage.CheckpointMetadataKey] = checkpointName,
+        };
+
+        if (checkpointOffset is { } offset)
+        {
+            result[AzureBlobJournalStorage.CheckpointOffsetMetadataKey] = offset.ToString(CultureInfo.InvariantCulture);
+        }
+
+        return result;
+    }
 
     private static void AssertAzureMetadataKeys(IDictionary<string, string> metadata)
         => Assert.All(metadata.Keys, key => Assert.Matches("^[A-Za-z_][A-Za-z0-9_]*$", key));
@@ -494,14 +624,11 @@ public sealed class AzureBlobJournalStorageTests
     {
         private const string JournalBlobName = "blob";
 
-        public override AppendBlobClient GetRootClient(GrainId grainId)
-            => appendBlobs.GetAppendBlobClient($"{JournalBlobName}/root");
+        public override AppendBlobClient GetWalClient(GrainId grainId)
+            => appendBlobs.GetAppendBlobClient(AzureBlobJournalStorageOptions.GetDefaultWalBlobName(JournalBlobName));
 
-        public override AppendBlobClient GetWalClient(GrainId grainId, uint generation, uint segmentId)
-            => appendBlobs.GetAppendBlobClient(AzureBlobJournalStorageOptions.GetDefaultWalSegmentBlobName(JournalBlobName, generation, segmentId));
-
-        public override string GetCheckpointName(GrainId grainId, uint generation)
-            => AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName(JournalBlobName, generation);
+        public override string GetCheckpointName(GrainId grainId, string snapshotId)
+            => AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName(JournalBlobName, snapshotId);
 
         public override BlockBlobClient GetCheckpointClient(GrainId grainId, string checkpointName)
             => blockBlobs.GetBlockBlobClient(checkpointName);
@@ -513,12 +640,19 @@ public sealed class AzureBlobJournalStorageTests
         private int _createCount;
         private int _appendCount;
         private int _sealCount;
+        private int _metadataCount;
 
         public bool FailNextAppend { get; set; }
 
         public bool FailNextCreate { get; set; }
 
         public bool FailNextSetMetadata { get; set; }
+
+        public Action<string, AppendBlobCreateOptions>? BeforeCreate { get; set; }
+
+        public Action<string, IDictionary<string, string>, BlobRequestConditions?>? BeforeSetMetadata { get; set; }
+
+        public Action<string, BlobRequestConditions?>? BeforeDelete { get; set; }
 
         public List<string> Operations { get; } = [];
 
@@ -530,11 +664,15 @@ public sealed class AzureBlobJournalStorageTests
 
         public List<SetMetadataCall> SetMetadataCalls { get; } = [];
 
+        public List<DeleteCall> DeleteCalls { get; } = [];
+
         public List<DownloadCall> DownloadCalls { get; } = [];
 
         public AppendBlobClient GetAppendBlobClient(string name) => new FakeAppendBlobClient(this, name);
 
         public byte[] GetContent(string name) => _blobs[name].Content;
+
+        public bool Exists(string name) => _blobs.ContainsKey(name);
 
         public void Add(string name, byte[] content, IDictionary<string, string> metadata, bool isSealed, int? committedBlockCount = null)
             => _blobs[name] = new StoredAppendBlob(content, new ETag($"\"{name}-etag\""), new Dictionary<string, string>(metadata), ContentType: null, committedBlockCount ?? (content.Length == 0 ? 0 : 1), isSealed);
@@ -556,7 +694,9 @@ public sealed class AzureBlobJournalStorageTests
                 options.Conditions?.IfNoneMatch ?? default,
                 options.HttpHeaders?.ContentType,
                 options.Metadata is null ? new Dictionary<string, string>() : new Dictionary<string, string>(options.Metadata)));
-            ThrowIfAppendConditionsFail(name, options.Conditions);
+            BeforeCreate?.Invoke(name, options);
+            ThrowIfConditionsFail(name, options.Conditions);
+
             if (FailNextCreate)
             {
                 FailNextCreate = false;
@@ -600,7 +740,7 @@ public sealed class AzureBlobJournalStorageTests
                 throw new RequestFailedException(409, "The specified blob is sealed.", "BlobIsSealed", null);
             }
 
-            ThrowIfAppendConditionsFail(name, options.Conditions);
+            ThrowIfConditionsFail(name, options.Conditions);
             if (FailNextAppend)
             {
                 FailNextAppend = false;
@@ -626,7 +766,7 @@ public sealed class AzureBlobJournalStorageTests
                 throw new RequestFailedException(404, "Blob does not exist.");
             }
 
-            ThrowIfAppendConditionsFail(name, conditions);
+            ThrowIfConditionsFail(name, conditions);
             blob.IsSealed = true;
             _sealCount++;
             blob.ETag = new ETag($"\"seal-{_sealCount}\"");
@@ -636,44 +776,45 @@ public sealed class AzureBlobJournalStorageTests
         private Task<Response<BlobInfo>> SetMetadataAsync(string name, IDictionary<string, string> metadata, BlobRequestConditions? conditions, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            Operations.Add($"set-metadata:{name}");
-            SetMetadataCalls.Add(new(name, conditions?.IfMatch ?? default, new Dictionary<string, string>(metadata)));
+            Operations.Add($"setMetadata:{name}");
+            SetMetadataCalls.Add(new(
+                name,
+                conditions?.IfMatch ?? default,
+                conditions?.IfNoneMatch ?? default,
+                new Dictionary<string, string>(metadata)));
+            BeforeSetMetadata?.Invoke(name, metadata, conditions);
             if (!_blobs.TryGetValue(name, out var blob))
             {
                 throw new RequestFailedException(404, "Blob does not exist.");
             }
 
-            if (conditions?.IfMatch is { } ifMatch && ifMatch != default && ifMatch != blob.ETag)
-            {
-                throw new RequestFailedException(412, "ETag mismatch.");
-            }
-
+            ThrowIfConditionsFail(name, conditions);
             if (FailNextSetMetadata)
             {
                 FailNextSetMetadata = false;
                 throw new RequestFailedException(500, "Set metadata failed.");
             }
 
+            _metadataCount++;
             blob.Metadata = new Dictionary<string, string>(metadata);
-            blob.ETag = new ETag($"\"metadata-{SetMetadataCalls.Count}\"");
+            blob.ETag = new ETag($"\"metadata-{_metadataCount}\"");
             return Task.FromResult(Response.FromValue(BlobsModelFactory.BlobInfo(blob.ETag, default), TestResponse.Instance));
         }
 
-        private Task<Response> DeleteAsync(string name, BlobRequestConditions? conditions, CancellationToken cancellationToken)
+        private Task<Response<bool>> DeleteIfExistsAsync(string name, BlobRequestConditions? conditions, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (!_blobs.TryGetValue(name, out var blob))
+            Operations.Add($"delete:{name}");
+            DeleteCalls.Add(new(name, conditions?.IfMatch ?? default, conditions?.IfNoneMatch ?? default));
+            BeforeDelete?.Invoke(name, conditions);
+            if (!_blobs.TryGetValue(name, out _))
             {
-                throw new RequestFailedException(404, "Blob does not exist.");
+                return Task.FromResult(Response.FromValue(false, TestResponse.Instance));
             }
 
-            if (conditions?.IfMatch is { } ifMatch && ifMatch != default && ifMatch != blob.ETag)
-            {
-                throw new RequestFailedException(412, "ETag mismatch.");
-            }
-
+            ThrowIfConditionsFail(name, conditions);
             _blobs.Remove(name);
-            return Task.FromResult<Response>(TestResponse.Instance);
+            return Task.FromResult(Response.FromValue(true, TestResponse.Instance));
         }
 
         private Task<Response<BlobDownloadStreamingResult>> DownloadStreamingAsync(string name, BlobDownloadOptions? options, CancellationToken cancellationToken)
@@ -697,7 +838,7 @@ public sealed class AzureBlobJournalStorageTests
             return Task.FromResult(Response.FromValue(result, TestResponse.Instance));
         }
 
-        private void ThrowIfAppendConditionsFail(string name, AppendBlobRequestConditions? conditions)
+        private void ThrowIfConditionsFail(string name, BlobRequestConditions? conditions)
         {
             if (conditions is null)
             {
@@ -735,11 +876,11 @@ public sealed class AzureBlobJournalStorageTests
             public override Task<Response<BlobInfo>> SealAsync(AppendBlobRequestConditions conditions = default!, CancellationToken cancellationToken = default)
                 => store.SealAsync(name, conditions, cancellationToken);
 
-            public override Task<Response<BlobInfo>> SetMetadataAsync(IDictionary<string, string> metadata, BlobRequestConditions? conditions = null, CancellationToken cancellationToken = default)
+            public override Task<Response<BlobInfo>> SetMetadataAsync(IDictionary<string, string> metadata, BlobRequestConditions conditions = default!, CancellationToken cancellationToken = default)
                 => store.SetMetadataAsync(name, metadata, conditions, cancellationToken);
 
-            public override Task<Response> DeleteAsync(DeleteSnapshotsOption snapshotsOption = DeleteSnapshotsOption.None, BlobRequestConditions? conditions = null, CancellationToken cancellationToken = default)
-                => store.DeleteAsync(name, conditions, cancellationToken);
+            public override Task<Response<bool>> DeleteIfExistsAsync(DeleteSnapshotsOption snapshotsOption = DeleteSnapshotsOption.None, BlobRequestConditions conditions = default!, CancellationToken cancellationToken = default)
+                => store.DeleteIfExistsAsync(name, conditions, cancellationToken);
 
             public override Task<Response<BlobDownloadStreamingResult>> DownloadStreamingAsync(BlobDownloadOptions? options = null, CancellationToken cancellationToken = default)
                 => store.DownloadStreamingAsync(name, options, cancellationToken);
@@ -757,10 +898,14 @@ public sealed class AzureBlobJournalStorageTests
 
         public List<BlockDownloadCall> DownloadCalls { get; } = [];
 
+        public List<BlockDeleteCall> DeleteCalls { get; } = [];
+
         public BlockBlobClient GetBlockBlobClient(string name) => new FakeBlockBlobClient(this, name);
 
         public void Add(string name, byte[] content, ETag eTag, IDictionary<string, string> metadata)
             => _blobs[name] = new StoredBlockBlob(content, eTag, new Dictionary<string, string>(metadata), ContentType: null);
+
+        public bool Exists(string name) => _blobs.ContainsKey(name);
 
         private async Task<Response<BlobContentInfo>> UploadAsync(string name, Stream content, BlobUploadOptions options, CancellationToken cancellationToken)
         {
@@ -825,6 +970,25 @@ public sealed class AzureBlobJournalStorageTests
             return Task.FromResult(Response.FromValue(result, TestResponse.Instance));
         }
 
+        private Task<Response<bool>> DeleteIfExistsAsync(string name, BlobRequestConditions? conditions, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DeleteCalls.Add(new(name, conditions?.IfMatch ?? default, conditions?.IfNoneMatch ?? default));
+
+            if (!_blobs.TryGetValue(name, out var blob))
+            {
+                return Task.FromResult(Response.FromValue(false, TestResponse.Instance));
+            }
+
+            if (conditions?.IfMatch is { } ifMatch && ifMatch != default && ifMatch != blob.ETag)
+            {
+                throw new RequestFailedException(412, "Checkpoint ETag mismatch.");
+            }
+
+            _blobs.Remove(name);
+            return Task.FromResult(Response.FromValue(true, TestResponse.Instance));
+        }
+
         private sealed class FakeBlockBlobClient(FakeBlockBlobStore store, string name) : BlockBlobClient
         {
             public override string BlobContainerName => "container";
@@ -836,6 +1000,9 @@ public sealed class AzureBlobJournalStorageTests
 
             public override Task<Response<BlobDownloadStreamingResult>> DownloadStreamingAsync(BlobDownloadOptions? options = null, CancellationToken cancellationToken = default)
                 => store.DownloadStreamingAsync(name, options, cancellationToken);
+
+            public override Task<Response<bool>> DeleteIfExistsAsync(DeleteSnapshotsOption snapshotsOption = DeleteSnapshotsOption.None, BlobRequestConditions conditions = default!, CancellationToken cancellationToken = default)
+                => store.DeleteIfExistsAsync(name, conditions, cancellationToken);
         }
     }
 
@@ -845,13 +1012,17 @@ public sealed class AzureBlobJournalStorageTests
 
     private sealed record SealCall(string Name, ETag IfMatch);
 
-    private sealed record SetMetadataCall(string Name, ETag IfMatch, IDictionary<string, string> Metadata);
+    private sealed record SetMetadataCall(string Name, ETag IfMatch, ETag IfNoneMatch, IDictionary<string, string> Metadata);
+
+    private sealed record DeleteCall(string Name, ETag IfMatch, ETag IfNoneMatch);
 
     private sealed record DownloadCall(string Name);
 
     private sealed record BlockUploadCall(string Name, ETag IfMatch, ETag IfNoneMatch, string? ContentType, IDictionary<string, string> Metadata, byte[] Payload);
 
     private sealed record BlockDownloadCall(string Name, ETag IfMatch);
+
+    private sealed record BlockDeleteCall(string Name, ETag IfMatch, ETag IfNoneMatch);
 
     private sealed class StoredAppendBlob(
         byte[] content,

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -5,6 +5,8 @@ using Azure.Core;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Storage;
 using Xunit;
 
 namespace Orleans.Journaling.Tests;
@@ -43,7 +45,7 @@ public sealed class AzureBlobJournalStorageTests
             }
         };
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        var exception = await Assert.ThrowsAsync<InconsistentStateException>(
             () => storage.DeleteAsync(CancellationToken.None).AsTask());
 
         var requestFailed = Assert.IsType<RequestFailedException>(exception.InnerException);
@@ -74,9 +76,19 @@ public sealed class AzureBlobJournalStorageTests
             GetBlobName = _ => "journals/test-grain"
         };
 
-        var blobName = options.GetBlobNameForJournal(GrainId.Create("test-grain", "0"));
+        var blobName = options.GetBlobNameForJournal(JournalId.FromGrainId(GrainId.Create("test-grain", "0")));
 
         Assert.Equal("journals/test-grain", blobName);
+    }
+
+    [Fact]
+    public void GetBlobNameForJournal_UsesJournalIdOutsideGrain()
+    {
+        var options = new AzureBlobJournalStorageOptions();
+
+        var blobName = options.GetBlobNameForJournal(new JournalId("journals/on-demand"));
+
+        Assert.Equal("journals/on-demand", blobName);
     }
 
     [Fact]
@@ -95,7 +107,7 @@ public sealed class AzureBlobJournalStorageTests
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
         appendBlobs.Seal("blob/wal");
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        var exception = await Assert.ThrowsAsync<InconsistentStateException>(
             () => storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
 
         Assert.Contains("recovery", exception.Message, StringComparison.OrdinalIgnoreCase);
@@ -230,7 +242,7 @@ public sealed class AzureBlobJournalStorageTests
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
         appendBlobs.Add("blob/wal", [1], WalMetadata(), isSealed: false);
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        var exception = await Assert.ThrowsAsync<InconsistentStateException>(
             () => storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
 
         var requestFailed = Assert.IsType<RequestFailedException>(exception.InnerException);
@@ -248,7 +260,7 @@ public sealed class AzureBlobJournalStorageTests
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
         appendBlobs.Add("blob/wal", [1, 2], WalMetadata(), isSealed: false);
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        var exception = await Assert.ThrowsAsync<InconsistentStateException>(
             () => storage.ReplaceAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None).AsTask());
 
         var requestFailed = Assert.IsType<RequestFailedException>(exception.InnerException);
@@ -301,6 +313,25 @@ public sealed class AzureBlobJournalStorageTests
         Assert.False(checkpoints.Exists(previousCheckpoint));
         Assert.True(checkpoints.Exists(currentCheckpoint));
         Assert.Equal([previousCheckpoint], checkpoints.DeleteCalls.Select(static call => call.Name));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenOldCheckpointCleanupDisabled_DoesNotReadWalManifestOrDeletePreviousCheckpoint()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints, deleteOldCheckpoints: false);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+        var previousCheckpoint = checkpoints.UploadCalls.Single().Name;
+        appendBlobs.PropertiesCalls.Clear();
+
+        await storage.ReplaceAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None);
+
+        Assert.Empty(appendBlobs.PropertiesCalls);
+        Assert.True(checkpoints.Exists(previousCheckpoint));
+        Assert.Empty(checkpoints.DeleteCalls);
     }
 
     [Fact]
@@ -460,7 +491,7 @@ public sealed class AzureBlobJournalStorageTests
         await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
         appendBlobs.Add("blob/wal", [1, 2], WalMetadata(), isSealed: false);
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        var exception = await Assert.ThrowsAsync<InconsistentStateException>(
             () => storage.AppendAsync(new ReadOnlySequence<byte>([3]), CancellationToken.None).AsTask());
 
         var requestFailed = Assert.IsType<RequestFailedException>(exception.InnerException);
@@ -518,16 +549,18 @@ public sealed class AzureBlobJournalStorageTests
         FakeAppendBlobStore appendBlobs,
         FakeBlockBlobStore? checkpoints = null,
         string? mimeType = null,
-        string? journalFormatKey = null)
+        string? journalFormatKey = null,
+        bool deleteOldCheckpoints = true)
     {
         checkpoints ??= new FakeBlockBlobStore();
         return new AzureBlobJournalStorage(
             new AzureBlobJournalStorage.SharedConfiguration(
                 NullLogger<AzureBlobJournalStorage>.Instance,
+                Options.Create(new AzureBlobJournalStorageOptions { DeleteOldCheckpoints = deleteOldCheckpoints }),
                 new FakeBlobClientProvider(appendBlobs, checkpoints),
                 mimeType,
                 journalFormatKey),
-            new JournalBatchTests.TestGrainContext(GrainId.Create("test-grain", "0")));
+            JournalId.FromGrainId(GrainId.Create("test-grain", "0")));
     }
 
     private static Dictionary<string, string> WalMetadata(string? format = null)
@@ -624,13 +657,13 @@ public sealed class AzureBlobJournalStorageTests
     {
         private const string JournalBlobName = "blob";
 
-        public override AppendBlobClient GetWalClient(GrainId grainId)
+        public override AppendBlobClient GetWalClient(JournalId journalId)
             => appendBlobs.GetAppendBlobClient(AzureBlobJournalStorageOptions.GetDefaultWalBlobName(JournalBlobName));
 
-        public override string GetCheckpointName(GrainId grainId, string snapshotId)
+        public override string GetCheckpointName(JournalId journalId, string snapshotId)
             => AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName(JournalBlobName, snapshotId);
 
-        public override BlockBlobClient GetCheckpointClient(GrainId grainId, string checkpointName)
+        public override BlockBlobClient GetCheckpointClient(JournalId journalId, string checkpointName)
             => blockBlobs.GetBlockBlobClient(checkpointName);
     }
 

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -554,7 +554,7 @@ public sealed class AzureBlobJournalStorageTests
     {
         checkpoints ??= new FakeBlockBlobStore();
         return new AzureBlobJournalStorage(
-            new AzureBlobJournalStorage.SharedConfiguration(
+            new AzureBlobJournalStorage.AzureBlobJournalStorageShared(
                 NullLogger<AzureBlobJournalStorage>.Instance,
                 Options.Create(new AzureBlobJournalStorageOptions { DeleteOldCheckpoints = deleteOldCheckpoints }),
                 new FakeBlobClientProvider(appendBlobs, checkpoints),

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -89,6 +89,7 @@ public sealed class AzureBlobJournalStorageTests
         Assert.Equal(ETag.All, upload.IfNoneMatch);
         Assert.Equal([2, 3], upload.Payload);
         Assert.Equal("application/jsonl", upload.ContentType);
+        AssertAzureMetadataKeys(upload.Metadata);
         Assert.Equal("json-lines", upload.Metadata[AzureBlobJournalStorage.FormatMetadataKey]);
         Assert.Equal("00000000", upload.Metadata[AzureBlobJournalStorage.CheckpointIdMetadataKey]);
         Assert.Equal("00000001", upload.Metadata[AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey]);
@@ -96,6 +97,7 @@ public sealed class AzureBlobJournalStorageTests
 
         var metadata = appendBlobs.SetMetadataCalls.Single();
         Assert.Equal("blob.log.00000000", metadata.Name);
+        AssertAzureMetadataKeys(metadata.Metadata);
         Assert.Equal("blob.checkpoint.00000000", metadata.Metadata[AzureBlobJournalStorage.CheckpointMetadataKey]);
         Assert.Equal("\"checkpoint-1\"", metadata.Metadata[AzureBlobJournalStorage.CheckpointETagMetadataKey]);
         Assert.Equal("2", metadata.Metadata[AzureBlobJournalStorage.CheckpointLengthMetadataKey]);
@@ -354,6 +356,9 @@ public sealed class AzureBlobJournalStorageTests
         [AzureBlobJournalStorage.CheckpointReplaySegmentMetadataKey] = replaySegment.ToString("X8", System.Globalization.CultureInfo.InvariantCulture),
         [AzureBlobJournalStorage.CheckpointReplayOffsetMetadataKey] = replayOffset.ToString(System.Globalization.CultureInfo.InvariantCulture),
     };
+
+    private static void AssertAzureMetadataKeys(IDictionary<string, string> metadata)
+        => Assert.All(metadata.Keys, key => Assert.Matches("^[A-Za-z_][A-Za-z0-9_]*$", key));
 
     private static ReadOnlySequence<byte> OversizedSequence(long length)
     {

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -97,10 +97,11 @@ public sealed class AzureBlobJournalStorageTests
         Assert.Equal(new ETag("\"append-1\""), rootReplace.IfMatch);
         AssertAzureMetadataKeys(rootReplace.Metadata);
         Assert.Equal("1", rootReplace.Metadata[AzureBlobJournalStorage.GenerationMetadataKey]);
+        Assert.Equal("json-lines", rootReplace.Metadata[AzureBlobJournalStorage.FormatMetadataKey]);
         Assert.Equal("blob/1/chk", rootReplace.Metadata[AzureBlobJournalStorage.CheckpointMetadataKey]);
-        Assert.Equal("\"checkpoint-1\"", rootReplace.Metadata[AzureBlobJournalStorage.CheckpointETagMetadataKey]);
-        Assert.Equal("2", rootReplace.Metadata[AzureBlobJournalStorage.CheckpointLengthMetadataKey]);
-        Assert.Equal("json-lines", rootReplace.Metadata[AzureBlobJournalStorage.CheckpointFormatMetadataKey]);
+        Assert.DoesNotContain("checkpoint_etag", rootReplace.Metadata.Keys);
+        Assert.DoesNotContain("checkpoint_length", rootReplace.Metadata.Keys);
+        Assert.DoesNotContain("checkpoint_format", rootReplace.Metadata.Keys);
     }
 
     [Fact]
@@ -126,7 +127,7 @@ public sealed class AzureBlobJournalStorageTests
         appendBlobs.Add(
             "blob/root",
             [3, 4],
-            CheckpointMarkerMetadata("blob/1/chk", new ETag("\"checkpoint-etag\""), "json-lines", 2, generation: 1),
+            CheckpointMarkerMetadata("blob/1/chk", "json-lines", generation: 1),
             isSealed: false);
         var checkpoints = new FakeBlockBlobStore();
         checkpoints.Add(
@@ -147,7 +148,7 @@ public sealed class AzureBlobJournalStorageTests
         Assert.Equal([1, 2, 3, 4], consumer.Bytes.ToArray());
         Assert.Equal(["blob/root"], appendBlobs.DownloadCalls.Select(static call => call.Name));
         Assert.Single(checkpoints.DownloadCalls);
-        Assert.Equal(new ETag("\"checkpoint-etag\""), checkpoints.DownloadCalls.Single().IfMatch);
+        Assert.Equal(default(ETag), checkpoints.DownloadCalls.Single().IfMatch);
     }
 
     [Fact]
@@ -223,7 +224,7 @@ public sealed class AzureBlobJournalStorageTests
         appendBlobs.Add(
             "blob/root",
             [],
-            CheckpointMarkerMetadata("blob/1/chk", new ETag("\"checkpoint-etag\""), "json-lines", 1, generation: 1),
+            CheckpointMarkerMetadata("blob/1/chk", "json-lines", generation: 1),
             isSealed: false);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -256,7 +257,7 @@ public sealed class AzureBlobJournalStorageTests
         appendBlobs.Add(
             "blob/root",
             [],
-            CheckpointMarkerMetadata("missing-checkpoint", new ETag("\"missing\""), "json-lines", 1, generation: 1),
+            CheckpointMarkerMetadata("missing-checkpoint", "json-lines", generation: 1),
             isSealed: true);
         var storage = CreateStorage(appendBlobs, new FakeBlockBlobStore());
 
@@ -272,7 +273,7 @@ public sealed class AzureBlobJournalStorageTests
         appendBlobs.Add(
             "blob/root",
             [],
-            CheckpointMarkerMetadata("blob/1/chk", new ETag("\"checkpoint-etag\""), "json-lines", 1, generation: 1),
+            CheckpointMarkerMetadata("blob/1/chk", "json-lines", generation: 1),
             isSealed: false);
         var checkpoints = new FakeBlockBlobStore();
         checkpoints.Add(
@@ -298,7 +299,7 @@ public sealed class AzureBlobJournalStorageTests
         appendBlobs.Add(
             "blob/root",
             [],
-            CheckpointMarkerMetadata("blob/1/chk", new ETag("\"checkpoint-etag\""), "json-lines", 1, generation: 1),
+            CheckpointMarkerMetadata("blob/1/chk", "json-lines", generation: 1),
             isSealed: true);
         var checkpoints = new FakeBlockBlobStore();
         checkpoints.Add(
@@ -420,17 +421,12 @@ public sealed class AzureBlobJournalStorageTests
 
     private static Dictionary<string, string> CheckpointMarkerMetadata(
         string checkpointName,
-        ETag checkpointETag,
         string format,
-        long checkpointLength,
         ulong generation) => new()
     {
         [AzureBlobJournalStorage.GenerationMetadataKey] = generation.ToString(System.Globalization.CultureInfo.InvariantCulture),
         [AzureBlobJournalStorage.FormatMetadataKey] = format,
         [AzureBlobJournalStorage.CheckpointMetadataKey] = checkpointName,
-        [AzureBlobJournalStorage.CheckpointETagMetadataKey] = checkpointETag.ToString(),
-        [AzureBlobJournalStorage.CheckpointFormatMetadataKey] = format,
-        [AzureBlobJournalStorage.CheckpointLengthMetadataKey] = checkpointLength.ToString(System.Globalization.CultureInfo.InvariantCulture),
     };
 
     private static void AssertAzureMetadataKeys(IDictionary<string, string> metadata)

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -321,7 +321,7 @@ public sealed class AzureBlobJournalStorageTests
     public async Task ReadAsync_UpdatesCompactionRequestFromCommittedBlockCount()
     {
         var appendBlobs = new FakeAppendBlobStore();
-        appendBlobs.Add("blob/root", [1], metadata: RootMetadata(generation: 0), isSealed: false, committedBlockCount: 11);
+        appendBlobs.Add("blob/root", [1], metadata: RootMetadata(generation: 0), isSealed: false, committedBlockCount: 49_001);
         var storage = CreateStorage(appendBlobs);
 
         await storage.ReadAsync(DiscardingJournalStorageConsumer.Instance, CancellationToken.None);

--- a/test/Orleans.Journaling.Tests/FormatMigrationClusterTests.cs
+++ b/test/Orleans.Journaling.Tests/FormatMigrationClusterTests.cs
@@ -29,8 +29,8 @@ public sealed class FormatMigrationClusterTests
                     : JsonJournalExtensions.JournalFormatKey;
             });
             siloBuilder.Services.AddSingleton(storageProvider);
-            siloBuilder.Services.AddScoped<IJournalStorage>(sp => storageProvider.Create(
-                sp.GetRequiredService<IGrainContext>(),
+            siloBuilder.Services.AddScoped<IJournalStorageProvider>(sp => new SharedVolatileJournalStorageProviderAdapter(
+                storageProvider,
                 sp.GetRequiredService<IOptions<JournaledStateManagerOptions>>()));
         });
         var cluster = builder.Build();
@@ -87,5 +87,12 @@ public sealed class FormatMigrationClusterTests
             return storage;
         }
 
+    }
+
+    private sealed class SharedVolatileJournalStorageProviderAdapter(
+        SharedVolatileJournalStorageProvider provider,
+        IOptions<JournaledStateManagerOptions> options) : IJournalStorageProvider
+    {
+        public IJournalStorage CreateStorage(IGrainContext grainContext) => provider.Create(grainContext, options);
     }
 }

--- a/test/Orleans.Journaling.Tests/IntegrationTestFixture.cs
+++ b/test/Orleans.Journaling.Tests/IntegrationTestFixture.cs
@@ -24,7 +24,7 @@ public class IntegrationTestFixture : IAsyncLifetime
             siloBuilder.AddJournalStorage();
             siloBuilder.UseJsonJournalFormat(JournalingTestsJsonContext.Default);
             siloBuilder.Services.AddSingleton(storageProvider);
-            siloBuilder.Services.AddScoped<IJournalStorage>(sp => storageProvider.Create(sp.GetRequiredService<IGrainContext>()));
+            siloBuilder.Services.AddSingleton<IJournalStorageProvider>(storageProvider);
         });
         ConfigureTestCluster(builder);
         Cluster = builder.Build();

--- a/test/Orleans.Journaling.Tests/JournalBatchTests.cs
+++ b/test/Orleans.Journaling.Tests/JournalBatchTests.cs
@@ -58,12 +58,11 @@ public abstract class JournalBatchTests : IAsyncLifetime
         JournalFormatKey = OrleansBinaryJournalFormat.JournalFormatKey
     });
 
-    private JournaledStateManagerShared CreateShared(IJournalStorage storage)
+    private JournaledStateManagerShared CreateShared()
         => new(
             _serviceProvider.GetRequiredService<ILogger<JournaledStateManager>>(),
             ManagerOptions,
             TimeProvider.System,
-            storage,
             _serviceProvider);
 
     public virtual async Task InitializeAsync()
@@ -117,7 +116,7 @@ public abstract class JournalBatchTests : IAsyncLifetime
         var codecProvider = _serviceProvider.GetRequiredService<ICodecProvider>();
         var grainContext = new TestGrainContext(grainId); // Use provided GrainId
         var storage = CreateStorage(_serviceProvider, grainContext);
-        var manager = new JournaledStateManager(CreateShared(storage));
+        var manager = new JournaledStateManager(CreateShared(), storage);
         var list = new DurableList<T>(listName, manager, new OrleansBinaryDurableListCommandCodec<T>(codecProvider.GetCodec<T>(), sessionPool));
         return (manager, list, storage);
     }
@@ -175,7 +174,7 @@ public abstract class JournalBatchTests : IAsyncLifetime
 
         var sessionPool = _serviceProvider.GetRequiredService<SerializerSessionPool>();
         var codecProvider = _serviceProvider.GetRequiredService<ICodecProvider>();
-        var manager2 = new JournaledStateManager(CreateShared(storage));
+        var manager2 = new JournaledStateManager(CreateShared(), storage);
         var list2 = new DurableList<string>(listName, manager2, new OrleansBinaryDurableListCommandCodec<string>(codecProvider.GetCodec<string>(), sessionPool));
         await manager2.InitializeAsync(cts.Token);
 
@@ -374,7 +373,7 @@ public abstract class JournalBatchTests : IAsyncLifetime
         // Test recovery (potentially from snapshot)
         var sessionPool = _serviceProvider.GetRequiredService<SerializerSessionPool>();
         var codecProvider = _serviceProvider.GetRequiredService<ICodecProvider>();
-        var manager2 = new JournaledStateManager(CreateShared(storage)); // Reuses the storage object linked via grainId
+        var manager2 = new JournaledStateManager(CreateShared(), storage); // Reuses the storage object linked via grainId
         var list2 = new DurableList<int>(listName, manager2, new OrleansBinaryDurableListCommandCodec<int>(codecProvider.GetCodec<int>(), sessionPool));
         await manager2.InitializeAsync(cts.Token);
 

--- a/test/Orleans.Journaling.Tests/JournalBatchTests.cs
+++ b/test/Orleans.Journaling.Tests/JournalBatchTests.cs
@@ -29,7 +29,7 @@ public sealed class AzureStorageJournalBatchTests : JournalBatchTests
     }
 
     protected override IJournalStorage CreateStorage(IServiceProvider serviceProvider, IGrainContext grainContext) =>
-        serviceProvider.GetRequiredService<AzureBlobJournalStorageProvider>().Create(grainContext);
+        serviceProvider.GetRequiredService<AzureBlobJournalStorageProvider>().CreateStorage(grainContext);
 }
 
 public sealed class InMemoryJournalBatchTests : JournalBatchTests
@@ -40,7 +40,7 @@ public sealed class InMemoryJournalBatchTests : JournalBatchTests
     }
 
     protected override IJournalStorage CreateStorage(IServiceProvider serviceProvider, IGrainContext grainContext) =>
-        serviceProvider.GetRequiredService<VolatileJournalStorageProvider>().Create(grainContext);
+        serviceProvider.GetRequiredService<VolatileJournalStorageProvider>().CreateStorage(grainContext);
 }
 
 /// <summary>

--- a/test/Orleans.Journaling.Tests/JournalSnapshotInfrastructure.cs
+++ b/test/Orleans.Journaling.Tests/JournalSnapshotInfrastructure.cs
@@ -282,10 +282,9 @@ public static class JournalTestReplayContext
             NullLogger<JournaledStateManager>.Instance,
             Options.Create(new JournaledStateManagerOptions { JournalFormatKey = journalFormatKey }),
             TimeProvider.System,
-            new NullJournalStorage(),
             serviceProvider);
 
-        return new JournaledStateManager(shared);
+        return new JournaledStateManager(shared, new NullJournalStorage());
     }
 
     private sealed class TestJournalFormat(string journalFormatKey) : IJournalFormat

--- a/test/Orleans.Journaling.Tests/JournalingTestBase.cs
+++ b/test/Orleans.Journaling.Tests/JournalingTestBase.cs
@@ -65,9 +65,8 @@ public abstract class JournalingTestBase
             serviceProvider.GetRequiredService<ILogger<JournaledStateManager>>(),
             Options.Create(options),
             provider,
-            storage,
             serviceProvider);
-        var manager = new JournaledStateManager(shared);
+        var manager = new JournaledStateManager(shared, storage);
         var lifecycle = new GrainLifecycle(serviceProvider.GetRequiredService<ILogger<GrainLifecycle>>());
         (manager as ILifecycleParticipant<IGrainLifecycle>)?.Participate(lifecycle);
         return (manager, storage, lifecycle);

--- a/test/Orleans.Journaling.Tests/KeyedJournalingRegistrationTests.cs
+++ b/test/Orleans.Journaling.Tests/KeyedJournalingRegistrationTests.cs
@@ -52,10 +52,9 @@ public sealed class KeyedJournalingRegistrationTests : JournalingTestBase
                 logger,
                 Options.Create(options),
                 TimeProvider.System,
-                storage,
                 serviceProvider);
 
-            _ = new JournaledStateManager(shared);
+            _ = new JournaledStateManager(shared, storage);
         });
 
         Assert.Contains(CustomFormatKey, exception.Message);
@@ -71,7 +70,8 @@ public sealed class KeyedJournalingRegistrationTests : JournalingTestBase
         services.AddLogging();
         services.AddOptions();
         services.AddSingleton(TimeProvider.System);
-        services.AddScoped<IJournalStorage>(_ => storage);
+        services.AddScoped<IGrainContext>(_ => new JournalBatchTests.TestGrainContext(GrainId.Create("test-grain", "keyed")));
+        services.AddScoped<IJournalStorageProvider>(_ => new TestJournalStorageProvider(storage));
         services.Configure<JournaledStateManagerOptions>(options => options.JournalFormatKey = CustomFormatKey);
         services.AddScoped<JournaledStateManagerShared>();
         services.AddScoped<IJournaledStateManager, JournaledStateManager>();
@@ -91,6 +91,11 @@ public sealed class KeyedJournalingRegistrationTests : JournalingTestBase
         _ = scope.ServiceProvider.GetRequiredKeyedService<IDurableValue<int>>("value");
 
         Assert.True(wasUsed);
+    }
+
+    private sealed class TestJournalStorageProvider(IJournalStorage storage) : IJournalStorageProvider
+    {
+        public IJournalStorage CreateStorage(IGrainContext grainContext) => storage;
     }
 
     private sealed class TestSiloBuilder : ISiloBuilder

--- a/test/Orleans.Journaling.Tests/KeyedJournalingRegistrationTests.cs
+++ b/test/Orleans.Journaling.Tests/KeyedJournalingRegistrationTests.cs
@@ -7,6 +7,8 @@ using Orleans.Hosting;
 using Orleans.Journaling.Json;
 using Orleans.Serialization;
 using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Serializers;
+using Orleans.Serialization.Session;
 using Xunit;
 
 namespace Orleans.Journaling.Tests;
@@ -93,9 +95,44 @@ public sealed class KeyedJournalingRegistrationTests : JournalingTestBase
         Assert.True(wasUsed);
     }
 
+    [Fact]
+    public async Task StateManagerFactory_CreatesManagerForJournalId()
+    {
+        var storage = new VolatileJournalStorage(OrleansBinaryJournalFormat.JournalFormatKey);
+        var builder = new TestSiloBuilder();
+        builder.Services.AddSerializer();
+        builder.Services.AddLogging();
+        builder.Services.AddSingleton(TimeProvider.System);
+        builder.AddJournalStorage();
+        builder.Services.Configure<JournaledStateManagerOptions>(options => options.JournalFormatKey = OrleansBinaryJournalFormat.JournalFormatKey);
+        builder.Services.AddScoped<IJournalStorageProvider>(_ => new TestJournalStorageProvider(storage));
+
+        using var serviceProvider = builder.Services.BuildServiceProvider();
+        using var scope = serviceProvider.CreateScope();
+        var manager = scope.ServiceProvider.GetRequiredService<IJournaledStateManagerFactory>()
+            .Create(new JournalId("on-demand-journal"));
+        await using (manager.ConfigureAwait(false))
+        {
+            var codecProvider = scope.ServiceProvider.GetRequiredService<ICodecProvider>();
+            var sessionPool = scope.ServiceProvider.GetRequiredService<SerializerSessionPool>();
+            var value = new DurableValue<int>(
+                "value",
+                manager,
+                new OrleansBinaryDurableValueCommandCodec<int>(codecProvider.GetCodec<int>(), sessionPool));
+
+            await manager.InitializeAsync(CancellationToken.None);
+            value.Value = 42;
+            await manager.WriteStateAsync(CancellationToken.None);
+        }
+
+        Assert.NotEmpty(storage.Segments);
+    }
+
     private sealed class TestJournalStorageProvider(IJournalStorage storage) : IJournalStorageProvider
     {
         public IJournalStorage CreateStorage(IGrainContext grainContext) => storage;
+
+        public IJournalStorage CreateStorage(JournalId journalId) => storage;
     }
 
     private sealed class TestSiloBuilder : ISiloBuilder

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -254,7 +254,7 @@ public class StateManagerTests : JournalingTestBase
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
         var replacement = Assert.Single(storage.Replaces);
-        Assert.Empty(storage.Appends);
+        Assert.Single(storage.Appends);
         AssertContainsRuntimeAndApplicationEntries(ReadBinaryEntries(replacement));
     }
 
@@ -319,7 +319,7 @@ public class StateManagerTests : JournalingTestBase
         dictionary.Add("key", 1);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
-        Assert.Empty(storage.Appends);
+        Assert.Single(storage.Appends);
         Assert.Single(storage.Replaces);
 
         var recovered = CreateTestSystem(storage: storage, journalFormat: new TrackingJournalFormat(SessionPool));
@@ -499,11 +499,13 @@ public class StateManagerTests : JournalingTestBase
         await writeTask.WaitAsync(TimeSpan.FromSeconds(10));
         var replacement = Assert.Single(storage.Replaces);
         Assert.DoesNotContain(ReadBinaryEntries(replacement), entry => entry.StreamId.Value >= 8);
+        Assert.Single(storage.Appends);
 
         storage.IsCompactionRequested = false;
         await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
 
-        var append = Assert.Single(storage.Appends);
+        Assert.Equal(2, storage.Appends.Count);
+        var append = storage.Appends[^1];
         Assert.Contains(ReadBinaryEntries(append), entry => entry.StreamId.Value >= 8);
 
         Task StartSnapshotAndCommitActiveEntry()

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Time.Testing;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Buffers.Adaptors;
 using Orleans.Serialization.Session;
+using Orleans.Storage;
 using Xunit;
 
 namespace Orleans.Journaling.Tests;
@@ -375,7 +376,7 @@ public class StateManagerTests : JournalingTestBase
     }
 
     [Fact]
-    public async Task StateManager_WriteStateAsync_RecoversAfterStorageWriteFailure()
+    public async Task StateManager_WriteStateAsync_RecoversAfterInconsistentStateException()
     {
         var storage = new CapturingStorage();
         var sut = CreateTestSystem(storage: storage);
@@ -385,11 +386,11 @@ public class StateManagerTests : JournalingTestBase
         dictionary.Add("first", 1);
         await sut.Manager.WriteStateAsync(CancellationToken.None);
 
-        var expected = new InvalidOperationException("Expected storage write failure.");
+        var expected = new InconsistentStateException("Expected storage write conflict.");
         storage.NextAppendException = expected;
         dictionary.Add("second", 2);
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+        var exception = await Assert.ThrowsAsync<InconsistentStateException>(
             () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
         Assert.Same(expected, exception);
 
@@ -404,6 +405,39 @@ public class StateManagerTests : JournalingTestBase
 
         Assert.Equal(1, recoveredDictionary["first"]);
         Assert.False(recoveredDictionary.ContainsKey("second"));
+    }
+
+    [Fact]
+    public async Task StateManager_WriteStateAsync_PreservesPendingStateAfterTransientStorageWriteFailure()
+    {
+        var storage = new CapturingStorage();
+        var sut = CreateTestSystem(storage: storage);
+        var dictionary = new DurableDictionary<string, int>("dict", sut.Manager, CreateDictionaryCodec<string, int>());
+
+        await sut.Lifecycle.OnStart();
+        dictionary.Add("first", 1);
+        await sut.Manager.WriteStateAsync(CancellationToken.None);
+        storage.ResetReadConsumeCount();
+
+        var expected = new IOException("Expected storage write failure.");
+        storage.NextAppendException = expected;
+        dictionary.Add("second", 2);
+
+        var exception = await Assert.ThrowsAsync<IOException>(
+            () => sut.Manager.WriteStateAsync(CancellationToken.None).AsTask());
+        Assert.Same(expected, exception);
+
+        await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(0, storage.ReadConsumeCount);
+        Assert.Equal(2, dictionary["second"]);
+
+        var recovered = CreateTestSystem(storage: storage);
+        var recoveredDictionary = new DurableDictionary<string, int>("dict", recovered.Manager, CreateDictionaryCodec<string, int>());
+        await recovered.Lifecycle.OnStart();
+
+        Assert.Equal(1, recoveredDictionary["first"]);
+        Assert.Equal(2, recoveredDictionary["second"]);
     }
 
     [Fact]
@@ -1353,6 +1387,8 @@ public class StateManagerTests : JournalingTestBase
         public Exception? NextAppendException { get; set; }
 
         public int ReadConsumeCount { get; private set; }
+
+        public void ResetReadConsumeCount() => ReadConsumeCount = 0;
 
         public bool IsCompactionRequested { get; set; }
 

--- a/test/Orleans.Journaling.Tests/UpstreamMainCompatibilityTests.cs
+++ b/test/Orleans.Journaling.Tests/UpstreamMainCompatibilityTests.cs
@@ -106,10 +106,9 @@ public sealed class UpstreamMainCompatibilityTests : JournalingTestBase
             LoggerFactory.CreateLogger<JournaledStateManager>(),
             Options.Create(ManagerOptions),
             TimeProvider.System,
-            storage,
             ServiceProvider);
 
-        return new(shared);
+        return new(shared, storage);
     }
 
     private IFieldCodec<T> ValueCodec<T>() => CodecProvider.GetCodec<T>();


### PR DESCRIPTION
## Problem
Azure Blob journal compaction needs crash-safe checkpoint publication and atomic logical delete semantics while allowing old blobs to remain for asynchronous cleanup.

## Solution
This PR uses `<id>/root` as the root manifest and hot tail segment, with generation-scoped auxiliary blobs under `<id>/<generation>/`. Checkpoints are written to `<id>/<generation>/chk`, auxiliary segments use `<id>/<generation>/seg.XXXXXXXX`, and checkpoint publication advances the generation by uploading the checkpoint first and then conditionally replacing `root` to point at it.

Checkpoint collisions now re-read `root` to decide whether recovery is required or whether to retry with a higher generation, and root replacement conflicts from Azure conditional failures are treated as recovery-required races. Delete seals the current segment, advances generation, and replaces `root` with empty content and no checkpoint marker, leaving old generation blobs untouched.

## Notes for reviewers
Please focus on the recovery paths around checkpoint upload conflicts, root replacement 409/412 handling, and the root-as-tail replay order: checkpoint, root tail, then generation segments only when root is sealed.
