### PR TITLE
Add interface collection codecs

### DIFF
--- a/src/Orleans.Serialization.TestKit/CopierTester.cs
+++ b/src/Orleans.Serialization.TestKit/CopierTester.cs
@@ -26,12 +26,12 @@ namespace Orleans.Serialization.TestKit
         /// </summary>
         protected CopierTester(ITestOutputHelper output)
         {
+            _ = output;
 #if NET6_0_OR_GREATER
             var seed = Random.Shared.Next();
 #else
             var seed = new Random().Next();
 #endif
-            output.WriteLine($"Random seed: {seed}");
             Random = new(seed);
             var services = new ServiceCollection();
             _ = services.AddSerializer(builder => builder.Configure(config => config.Copiers.Add(typeof(TCopier))));

--- a/src/Orleans.Serialization.TestKit/CopierTester.cs
+++ b/src/Orleans.Serialization.TestKit/CopierTester.cs
@@ -25,6 +25,7 @@ namespace Orleans.Serialization.TestKit
         /// </summary>
         protected CopierTester(ITestOutputHelper output) : base(output)
         {
+            output.WriteLine($"Random seed: {RandomSeed}");
             _codecProvider = ServiceProvider.GetRequiredService<CodecProvider>();
         }
 
@@ -33,6 +34,7 @@ namespace Orleans.Serialization.TestKit
         /// </summary>
         protected CopierTester(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
         {
+            output.WriteLine($"Random seed: {RandomSeed}");
             _codecProvider = ServiceProvider.GetRequiredService<CodecProvider>();
         }
 

--- a/src/Orleans.Serialization.TestKit/CopierTester.cs
+++ b/src/Orleans.Serialization.TestKit/CopierTester.cs
@@ -16,23 +16,32 @@ namespace Orleans.Serialization.TestKit
     /// </summary>
     [Trait("Category", "BVT")]
     [ExcludeFromCodeCoverage]
-    public abstract class CopierTester<TValue, TCopier> where TCopier : class, IDeepCopier<TValue>
+    public abstract class CopierTester<TValue, TCopier> : SerializationTester where TCopier : class, IDeepCopier<TValue>
     {
-        private readonly IServiceProvider _serviceProvider;
         private readonly CodecProvider _codecProvider;
 
         /// <summary>
         /// Initializes a new <see cref="CopierTester{TValue, TCopier}"/> instance.
         /// </summary>
-        protected CopierTester(ITestOutputHelper output)
+        protected CopierTester(ITestOutputHelper output) : base(output)
         {
-            _ = output;
-#if NET6_0_OR_GREATER
-            var seed = Random.Shared.Next();
-#else
-            var seed = new Random().Next();
-#endif
-            Random = new(seed);
+            _codecProvider = ServiceProvider.GetRequiredService<CodecProvider>();
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="CopierTester{TValue, TCopier}"/> instance.
+        /// </summary>
+        protected CopierTester(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
+        {
+            _codecProvider = ServiceProvider.GetRequiredService<CodecProvider>();
+        }
+
+        /// <inheritdoc/>
+        protected override IServiceProvider CreateServiceProvider()
+            => CreateServiceProviderCore(Configure);
+
+        internal static IServiceProvider CreateServiceProviderCore(Action<ISerializerBuilder> configure)
+        {
             var services = new ServiceCollection();
             _ = services.AddSerializer(builder => builder.Configure(config => config.Copiers.Add(typeof(TCopier))));
 
@@ -41,21 +50,10 @@ namespace Orleans.Serialization.TestKit
                 _ = services.AddSingleton<TCopier>();
             }
 
-            _ = services.AddSerializer(Configure);
+            _ = services.AddSerializer(configure);
 
-            _serviceProvider = services.BuildServiceProvider();
-            _codecProvider = _serviceProvider.GetRequiredService<CodecProvider>();
+            return services.BuildServiceProvider();
         }
-
-        /// <summary>
-        /// Gets the random number generator.
-        /// </summary>
-        protected Random Random { get; }
-
-        /// <summary>
-        /// Gets the service provider.
-        /// </summary>
-        protected IServiceProvider ServiceProvider => _serviceProvider;
 
         /// <summary>
         /// Gets a value indicating whether the type copied by this codec is immutable.
@@ -77,7 +75,7 @@ namespace Orleans.Serialization.TestKit
         /// <summary>
         /// Creates a copier instance for testing.
         /// </summary>
-        protected virtual TCopier CreateCopier() => _serviceProvider.GetRequiredService<TCopier>();
+        protected virtual TCopier CreateCopier() => ServiceProvider.GetRequiredService<TCopier>();
 
         /// <summary>
         /// Creates a value to copy.
@@ -139,7 +137,7 @@ namespace Orleans.Serialization.TestKit
 
             var value = CreateValue();
             var array = new TValue[] { value, value };
-            var arrayCopier = _serviceProvider.GetRequiredService<DeepCopier<TValue[]>>();
+            var arrayCopier = ServiceProvider.GetRequiredService<DeepCopier<TValue[]>>();
             var arrayCopy = arrayCopier.Copy(array);
             Assert.Same(arrayCopy[0], arrayCopy[1]);
 
@@ -159,7 +157,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanCopyTupleViaSerializer()
         {
-            var copier = _serviceProvider.GetRequiredService<DeepCopier<(string, TValue, TValue, string)>>();
+            var copier = ServiceProvider.GetRequiredService<DeepCopier<(string, TValue, TValue, string)>>();
 
             var original = (Guid.NewGuid().ToString(), CreateValue(), CreateValue(), Guid.NewGuid().ToString());
 
@@ -189,7 +187,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanCopyUntypedTupleViaSerializer()
         {
-            var copier = _serviceProvider.GetRequiredService<DeepCopier<(string, object, object, string)>>();
+            var copier = ServiceProvider.GetRequiredService<DeepCopier<(string, object, object, string)>>();
             var value = ((IEnumerable<TValue>)TestValues).Reverse().Concat(new[] { CreateValue(), CreateValue() }).Take(2).ToArray();
 
             var original = (Guid.NewGuid().ToString(), (object)value[0], (object)value[1], Guid.NewGuid().ToString());
@@ -220,7 +218,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanCopyCollectionViaSerializer()
         {
-            var copier = _serviceProvider.GetRequiredService<DeepCopier<List<TValue>>>();
+            var copier = ServiceProvider.GetRequiredService<DeepCopier<List<TValue>>>();
 
             var original = new List<TValue>();
             original.AddRange(TestValues);
@@ -247,7 +245,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanCopyCollectionViaUntypedSerializer()
         {
-            var copier = _serviceProvider.GetRequiredService<DeepCopier<List<object>>>();
+            var copier = ServiceProvider.GetRequiredService<DeepCopier<List<object>>>();
 
             var original = new List<object>();
             foreach (var value in TestValues)
@@ -272,4 +270,5 @@ namespace Orleans.Serialization.TestKit
             }
         }
     }
+
 }

--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -33,6 +33,7 @@ namespace Orleans.Serialization.TestKit
         /// </summary>
         protected FieldCodecTester(ITestOutputHelper output) : base(output)
         {
+            output.WriteLine($"Random seed: {RandomSeed}");
             _sessionPool = ServiceProvider.GetRequiredService<SerializerSessionPool>();
         }
 
@@ -41,6 +42,7 @@ namespace Orleans.Serialization.TestKit
         /// </summary>
         protected FieldCodecTester(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
         {
+            output.WriteLine($"Random seed: {RandomSeed}");
             _sessionPool = ServiceProvider.GetRequiredService<SerializerSessionPool>();
         }
 

--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -34,12 +34,12 @@ namespace Orleans.Serialization.TestKit
         /// </summary>
         protected FieldCodecTester(ITestOutputHelper output)
         {
+            _ = output;
 #if NET6_0_OR_GREATER
             var seed = Random.Shared.Next();
 #else
             var seed = new Random().Next();
 #endif
-            output.WriteLine($"Random seed: {seed}");
             Random = new(seed);
             var services = new ServiceCollection();
             _ = services.AddSerializer(builder => builder.Configure(config => config.FieldCodecs.Add(typeof(TCodec))));

--- a/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/FieldCodecTester.cs
@@ -24,23 +24,32 @@ namespace Orleans.Serialization.TestKit
     /// </summary>
     [Trait("Category", "BVT")]
     [ExcludeFromCodeCoverage]
-    public abstract class FieldCodecTester<TValue, TCodec> : IDisposable where TCodec : class, IFieldCodec<TValue>
+    public abstract class FieldCodecTester<TValue, TCodec> : SerializationTester where TCodec : class, IFieldCodec<TValue>
     {
-        private readonly IServiceProvider _serviceProvider;
         private readonly SerializerSessionPool _sessionPool;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FieldCodecTester{TValue, TCodec}"/> class.
         /// </summary>
-        protected FieldCodecTester(ITestOutputHelper output)
+        protected FieldCodecTester(ITestOutputHelper output) : base(output)
         {
-            _ = output;
-#if NET6_0_OR_GREATER
-            var seed = Random.Shared.Next();
-#else
-            var seed = new Random().Next();
-#endif
-            Random = new(seed);
+            _sessionPool = ServiceProvider.GetRequiredService<SerializerSessionPool>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FieldCodecTester{TValue, TCodec}"/> class.
+        /// </summary>
+        protected FieldCodecTester(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
+        {
+            _sessionPool = ServiceProvider.GetRequiredService<SerializerSessionPool>();
+        }
+
+        /// <inheritdoc/>
+        protected override IServiceProvider CreateServiceProvider()
+            => CreateServiceProviderCore(Configure);
+
+        internal static IServiceProvider CreateServiceProviderCore(Action<ISerializerBuilder> configure)
+        {
             var services = new ServiceCollection();
             _ = services.AddSerializer(builder => builder.Configure(config => config.FieldCodecs.Add(typeof(TCodec))));
 
@@ -49,21 +58,10 @@ namespace Orleans.Serialization.TestKit
                 _ = services.AddSingleton<TCodec>();
             }
 
-            _ = services.AddSerializer(Configure);
+            _ = services.AddSerializer(configure);
 
-            _serviceProvider = services.BuildServiceProvider();
-            _sessionPool = _serviceProvider.GetService<SerializerSessionPool>();
+            return services.BuildServiceProvider();
         }
-
-        /// <summary>
-        /// Gets the random number generator.
-        /// </summary>
-        protected Random Random { get; }
-
-        /// <summary>
-        /// Gets the service provider.
-        /// </summary>
-        protected IServiceProvider ServiceProvider => _serviceProvider;
 
         /// <summary>
         /// Gets the session pool.
@@ -85,7 +83,7 @@ namespace Orleans.Serialization.TestKit
         /// <summary>
         /// Creates a codec.
         /// </summary>
-        protected virtual TCodec CreateCodec() => _serviceProvider.GetRequiredService<TCodec>();
+        protected virtual TCodec CreateCodec() => ServiceProvider.GetRequiredService<TCodec>();
 
         /// <summary>
         /// Creates a value.
@@ -106,9 +104,6 @@ namespace Orleans.Serialization.TestKit
         /// Gets a value provider delegate.
         /// </summary>
         protected virtual Action<Action<TValue>> ValueProvider { get; }
-
-        /// <inheritdoc/>
-        void IDisposable.Dispose() => (_serviceProvider as IDisposable)?.Dispose();
 
         protected virtual TValue GetWriteCopy(TValue input) => input;
 
@@ -221,7 +216,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanRoundTripViaSerializer_StreamPooled()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<TValue>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<TValue>>();
 
             foreach (var original in TestValues)
             {
@@ -259,7 +254,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanRoundTripViaSerializer_Span()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<TValue>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<TValue>>();
 
             foreach (var original in TestValues)
             {
@@ -295,7 +290,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanRoundTripViaSerializer_Array()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<TValue>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<TValue>>();
 
             foreach (var original in TestValues)
             {
@@ -331,7 +326,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanRoundTripViaSerializer_Memory()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<TValue>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<TValue>>();
 
             foreach (var original in TestValues)
             {
@@ -367,7 +362,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanRoundTripViaSerializer_MemoryStream()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<TValue>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<TValue>>();
 
             foreach (var original in TestValues)
             {
@@ -410,7 +405,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanRoundTripViaSerializer_ReadByteByByte()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<TValue>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<TValue>>();
 
             foreach (var original in TestValues)
             {
@@ -449,7 +444,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void ProducesValidBitStream()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<TValue>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<TValue>>();
             foreach (var value in TestValues)
             {
                 Test(value);
@@ -484,7 +479,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void WritersProduceSameResults()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<TValue>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<TValue>>();
 
             foreach (var original in TestValues)
             {
@@ -590,7 +585,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanRoundTripCollectionViaSerializer()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<List<TValue>>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<List<TValue>>>();
 
             var original = new List<TValue>();
             var originalCopy = new List<TValue>();
@@ -634,7 +629,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanRoundTripWeaklyTypedCollectionViaSerializer()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<List<object>>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<List<object>>>();
 
             var original = new List<object>();
             var originalCopy = new List<object>();
@@ -682,7 +677,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanRoundTripTupleViaSerializer()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<(string, TValue, TValue, string)>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<(string, TValue, TValue, string)>>();
 
             var original = (Guid.NewGuid().ToString(), CreateValue(), CreateValue(), Guid.NewGuid().ToString());
             var originalCopy = (original.Item1, GetWriteCopy(original.Item2), GetWriteCopy(original.Item3), original.Item4);
@@ -721,7 +716,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanRoundTripViaSerializer()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<TValue>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<TValue>>();
 
             foreach (var original in TestValues)
             {
@@ -759,7 +754,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CanRoundTripViaObjectSerializer()
         {
-            var serializer = _serviceProvider.GetRequiredService<Serializer<object>>();
+            var serializer = ServiceProvider.GetRequiredService<Serializer<object>>();
 
             var buffer = new byte[10240];
 
@@ -830,7 +825,7 @@ namespace Orleans.Serialization.TestKit
         [Fact]
         public void CorrectlyHandlesBuffers()
         {
-            var testers = BufferTestHelper<TValue>.GetTestSerializers(_serviceProvider, MaxSegmentSizes);
+            var testers = BufferTestHelper<TValue>.GetTestSerializers(ServiceProvider, MaxSegmentSizes);
 
             foreach (var tester in testers)
             {
@@ -998,4 +993,5 @@ namespace Orleans.Serialization.TestKit
             return result;
         }
     }
+
 }

--- a/src/Orleans.Serialization.TestKit/SerializationTester.cs
+++ b/src/Orleans.Serialization.TestKit/SerializationTester.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Xunit.Abstractions;
+
+#nullable disable
+namespace Orleans.Serialization.TestKit
+{
+    /// <summary>
+    /// Base class for serialization test helpers.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public abstract class SerializationTester : IDisposable
+    {
+        private readonly bool _ownsServiceProvider;
+
+        /// <summary>
+        /// Initializes a new <see cref="SerializationTester"/> instance.
+        /// </summary>
+        protected SerializationTester(ITestOutputHelper output)
+        {
+            _ = output;
+            Random = CreateRandom();
+            ServiceProvider = CreateServiceProvider();
+            _ownsServiceProvider = true;
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="SerializationTester"/> instance.
+        /// </summary>
+        protected SerializationTester(ITestOutputHelper output, SerializationTesterFixture fixture)
+        {
+            _ = output;
+            if (fixture is null)
+            {
+                throw new ArgumentNullException(nameof(fixture));
+            }
+
+            Random = CreateRandom();
+            ServiceProvider = fixture.GetOrCreateServiceProvider(CreateServiceProvider);
+        }
+
+        private static Random CreateRandom()
+        {
+#if NET6_0_OR_GREATER
+            var seed = Random.Shared.Next();
+#else
+            var seed = new Random().Next();
+#endif
+            return new(seed);
+        }
+
+        /// <summary>
+        /// Gets the random number generator.
+        /// </summary>
+        protected Random Random { get; }
+
+        /// <summary>
+        /// Gets the service provider.
+        /// </summary>
+        protected IServiceProvider ServiceProvider { get; }
+
+        /// <summary>
+        /// Creates the serializer service provider for this test class.
+        /// </summary>
+        protected abstract IServiceProvider CreateServiceProvider();
+
+        /// <summary>
+        /// Releases resources used by this instance.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing && _ownsServiceProvider)
+            {
+                (ServiceProvider as IDisposable)?.Dispose();
+            }
+        }
+
+        /// <inheritdoc/>
+        void IDisposable.Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    /// <summary>
+    /// Fixture which owns a serializer service provider shared by all instances of a test class.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class SerializationTesterFixture : IDisposable
+    {
+        private readonly object _lock = new();
+        private IServiceProvider _serviceProvider;
+
+        /// <summary>
+        /// Initializes a new <see cref="SerializationTesterFixture"/> instance.
+        /// </summary>
+        public SerializationTesterFixture()
+        {
+        }
+
+        /// <summary>
+        /// Gets the service provider.
+        /// </summary>
+        public IServiceProvider ServiceProvider => _serviceProvider ?? throw new InvalidOperationException("The service provider has not been initialized.");
+
+        internal IServiceProvider GetOrCreateServiceProvider(Func<IServiceProvider> factory)
+        {
+            if (_serviceProvider is { } serviceProvider)
+            {
+                return serviceProvider;
+            }
+
+            lock (_lock)
+            {
+                return _serviceProvider ??= factory();
+            }
+        }
+
+        /// <summary>
+        /// Releases resources used by this instance.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                (_serviceProvider as IDisposable)?.Dispose();
+            }
+        }
+
+        /// <inheritdoc/>
+        void IDisposable.Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Orleans.Serialization.TestKit/SerializationTester.cs
+++ b/src/Orleans.Serialization.TestKit/SerializationTester.cs
@@ -19,7 +19,8 @@ namespace Orleans.Serialization.TestKit
         protected SerializationTester(ITestOutputHelper output)
         {
             _ = output;
-            Random = CreateRandom();
+            RandomSeed = CreateRandomSeed();
+            Random = new(RandomSeed);
             ServiceProvider = CreateServiceProvider();
             _ownsServiceProvider = true;
         }
@@ -35,24 +36,26 @@ namespace Orleans.Serialization.TestKit
                 throw new ArgumentNullException(nameof(fixture));
             }
 
-            Random = CreateRandom();
+            RandomSeed = CreateRandomSeed();
+            Random = new(RandomSeed);
             ServiceProvider = fixture.GetOrCreateServiceProvider(CreateServiceProvider);
         }
 
-        private static Random CreateRandom()
+        private static int CreateRandomSeed()
         {
 #if NET6_0_OR_GREATER
-            var seed = Random.Shared.Next();
+            return Random.Shared.Next();
 #else
-            var seed = new Random().Next();
+            return new Random().Next();
 #endif
-            return new(seed);
         }
 
         /// <summary>
         /// Gets the random number generator.
         /// </summary>
         protected Random Random { get; }
+
+        internal int RandomSeed { get; }
 
         /// <summary>
         /// Gets the service provider.

--- a/src/Orleans.Serialization.TestKit/ValueTypeFieldCodecTester.cs
+++ b/src/Orleans.Serialization.TestKit/ValueTypeFieldCodecTester.cs
@@ -14,6 +14,10 @@ namespace Orleans.Serialization.TestKit
         {
         }
 
+        protected ValueTypeFieldCodecTester(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
+        {
+        }
+
         [Fact]
         public void ValueSerializerRoundTrip()
         {

--- a/src/Orleans.Serialization/Cloning/IDeepCopier.cs
+++ b/src/Orleans.Serialization/Cloning/IDeepCopier.cs
@@ -364,7 +364,7 @@ namespace Orleans.Serialization.Cloning
     /// <summary>
     /// Object pool for <see cref="CopyContext"/> instances.
     /// </summary>
-    public sealed class CopyContextPool
+    public sealed class CopyContextPool : IDisposable
     {
         private readonly ConcurrentObjectPool<CopyContext, PoolPolicy> _pool;
 
@@ -383,6 +383,9 @@ namespace Orleans.Serialization.Cloning
         /// </summary>
         /// <returns>A <see cref="CopyContext"/>.</returns>
         public CopyContext GetContext() => _pool.Get();
+
+        /// <inheritdoc/>
+        public void Dispose() => _pool.Dispose();
 
         /// <summary>
         /// Returns the specified copy context to the pool.

--- a/src/Orleans.Serialization/Codecs/InterfaceCollectionCodecs.cs
+++ b/src/Orleans.Serialization/Codecs/InterfaceCollectionCodecs.cs
@@ -1,7 +1,9 @@
 using System.Buffers;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.GeneratedCodeHelpers;
+using Orleans.Serialization.Serializers;
 using Orleans.Serialization.WireProtocol;
 
 #nullable disable
@@ -36,6 +38,7 @@ internal static class InterfaceCollectionCodecHelpers
         ref Reader<TInput> reader,
         Field field,
         Type fallbackType,
+        Type codecType,
         out TField result)
     {
         if (field.WireType == WireType.Reference)
@@ -48,6 +51,7 @@ internal static class InterfaceCollectionCodecHelpers
         if (fieldType is not null
             && fieldType != typeof(TField)
             && fieldType != fallbackType
+            && fieldType != codecType
             && reader.Session.CodecProvider.TryGetCodec(fieldType) is { } specificCodec)
         {
             result = (TField)specificCodec.ReadValue(ref reader, field);
@@ -115,6 +119,101 @@ internal static class InterfaceCollectionCodecHelpers
         UInt32Codec.WriteField(ref writer, fieldIdDelta, (uint)capacityHint);
         return true;
     }
+
+    public static bool TryGetInterfaceTypeForCodecType(Type type, out Type interfaceType)
+    {
+        if (type is null || !type.IsConstructedGenericType)
+        {
+            interfaceType = null;
+            return false;
+        }
+
+        var genericTypeDefinition = type.GetGenericTypeDefinition();
+        var arguments = type.GetGenericArguments();
+        if (genericTypeDefinition == typeof(EnumerableCodec<>))
+        {
+            interfaceType = typeof(IEnumerable<>).MakeGenericType(arguments);
+            return true;
+        }
+
+        if (genericTypeDefinition == typeof(ReadOnlyCollectionInterfaceCodec<>))
+        {
+            interfaceType = typeof(IReadOnlyCollection<>).MakeGenericType(arguments);
+            return true;
+        }
+
+        if (genericTypeDefinition == typeof(ReadOnlyListInterfaceCodec<>))
+        {
+            interfaceType = typeof(IReadOnlyList<>).MakeGenericType(arguments);
+            return true;
+        }
+
+        if (genericTypeDefinition == typeof(CollectionInterfaceCodec<>))
+        {
+            interfaceType = typeof(ICollection<>).MakeGenericType(arguments);
+            return true;
+        }
+
+        if (genericTypeDefinition == typeof(ListInterfaceCodec<>))
+        {
+            interfaceType = typeof(IList<>).MakeGenericType(arguments);
+            return true;
+        }
+
+        if (genericTypeDefinition == typeof(SetInterfaceCodec<>))
+        {
+            interfaceType = typeof(ISet<>).MakeGenericType(arguments);
+            return true;
+        }
+
+#if NET5_0_OR_GREATER
+        if (genericTypeDefinition == typeof(ReadOnlySetInterfaceCodec<>))
+        {
+            interfaceType = typeof(IReadOnlySet<>).MakeGenericType(arguments);
+            return true;
+        }
+#endif
+
+        if (genericTypeDefinition == typeof(DictionaryInterfaceCodec<,>))
+        {
+            interfaceType = typeof(IDictionary<,>).MakeGenericType(arguments);
+            return true;
+        }
+
+        if (genericTypeDefinition == typeof(ReadOnlyDictionaryInterfaceCodec<,>))
+        {
+            interfaceType = typeof(IReadOnlyDictionary<,>).MakeGenericType(arguments);
+            return true;
+        }
+
+        interfaceType = null;
+        return false;
+    }
+}
+
+internal sealed class InterfaceCollectionCodecResolver(IServiceProvider serviceProvider) : IGeneralizedCodec
+{
+    public bool IsSupportedType(Type type) => InterfaceCollectionCodecHelpers.TryGetInterfaceTypeForCodecType(type, out _);
+
+    public object ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        if (!InterfaceCollectionCodecHelpers.TryGetInterfaceTypeForCodecType(field.FieldType, out var interfaceType))
+        {
+            throw new InvalidOperationException($"Type {field.FieldType} is not a supported interface collection codec type.");
+        }
+
+        return serviceProvider.GetRequiredService<ICodecProvider>().GetCodec(interfaceType).ReadValue(ref reader, field);
+    }
+
+    public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, object value) where TBufferWriter : IBufferWriter<byte>
+    {
+        if (!InterfaceCollectionCodecHelpers.TryGetInterfaceTypeForCodecType(expectedType, out var interfaceType))
+        {
+            throw new InvalidOperationException($"Type {expectedType} is not a supported interface collection codec type.");
+        }
+
+        serviceProvider.GetRequiredService<ICodecProvider>().GetCodec(interfaceType).WriteField(ref writer, fieldIdDelta, interfaceType, value);
+    }
 }
 
 internal abstract class ListInterfaceCodec<TInterface, T> : IFieldCodec<TInterface> where TInterface : class, IEnumerable<T>
@@ -135,12 +234,13 @@ internal abstract class ListInterfaceCodec<TInterface, T> : IFieldCodec<TInterfa
             return;
         }
 
-        if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, FallbackType, value))
+        var codecType = GetType();
+        if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, codecType, value))
         {
             return;
         }
 
-        writer.WriteFieldHeader(fieldIdDelta, expectedType, FallbackType, WireType.TagDelimited);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, codecType, WireType.TagDelimited);
         if (InterfaceCollectionCodecHelpers.TryGetCount(value, out var count))
         {
             WriteElements(ref writer, value, count);
@@ -161,7 +261,7 @@ internal abstract class ListInterfaceCodec<TInterface, T> : IFieldCodec<TInterfa
 
     public TInterface ReadValue<TInput>(ref Reader<TInput> reader, Field field)
     {
-        if (InterfaceCollectionCodecHelpers.TryReadReferenceOrSpecificCodec<TInterface, TInput>(ref reader, field, FallbackType, out var result))
+        if (InterfaceCollectionCodecHelpers.TryReadReferenceOrSpecificCodec<TInterface, TInput>(ref reader, field, FallbackType, GetType(), out var result))
         {
             return result;
         }
@@ -251,12 +351,13 @@ internal abstract class SetInterfaceCodec<TInterface, T> : IFieldCodec<TInterfac
             return;
         }
 
-        if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, FallbackType, value))
+        var codecType = GetType();
+        if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, codecType, value))
         {
             return;
         }
 
-        writer.WriteFieldHeader(fieldIdDelta, expectedType, FallbackType, WireType.TagDelimited);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, codecType, WireType.TagDelimited);
         if (InterfaceCollectionCodecHelpers.TryGetCount(value, out var count))
         {
             WriteElements(ref writer, value, count);
@@ -277,7 +378,7 @@ internal abstract class SetInterfaceCodec<TInterface, T> : IFieldCodec<TInterfac
 
     public TInterface ReadValue<TInput>(ref Reader<TInput> reader, Field field)
     {
-        if (InterfaceCollectionCodecHelpers.TryReadReferenceOrSpecificCodec<TInterface, TInput>(ref reader, field, FallbackType, out var result))
+        if (InterfaceCollectionCodecHelpers.TryReadReferenceOrSpecificCodec<TInterface, TInput>(ref reader, field, FallbackType, GetType(), out var result))
         {
             return result;
         }
@@ -379,12 +480,13 @@ internal abstract class DictionaryInterfaceCodec<TInterface, TKey, TValue> : IFi
             return;
         }
 
-        if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, FallbackType, value))
+        var codecType = GetType();
+        if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, codecType, value))
         {
             return;
         }
 
-        writer.WriteFieldHeader(fieldIdDelta, expectedType, FallbackType, WireType.TagDelimited);
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, codecType, WireType.TagDelimited);
         if (InterfaceCollectionCodecHelpers.TryGetCount(value, out var count))
         {
             WriteEntries(ref writer, value, count);
@@ -405,7 +507,7 @@ internal abstract class DictionaryInterfaceCodec<TInterface, TKey, TValue> : IFi
 
     public TInterface ReadValue<TInput>(ref Reader<TInput> reader, Field field)
     {
-        if (InterfaceCollectionCodecHelpers.TryReadReferenceOrSpecificCodec<TInterface, TInput>(ref reader, field, FallbackType, out var result))
+        if (InterfaceCollectionCodecHelpers.TryReadReferenceOrSpecificCodec<TInterface, TInput>(ref reader, field, FallbackType, GetType(), out var result))
         {
             return result;
         }
@@ -580,6 +682,7 @@ internal abstract class DictionaryInterfaceCopier<TInterface, TKey, TValue>(
 }
 
 [RegisterSerializer]
+[Alias("EnumerableCodec`1")]
 internal sealed class EnumerableCodec<T>(IFieldCodec<T> elementCodec)
     : ListInterfaceCodec<IEnumerable<T>, T>(elementCodec)
 {
@@ -592,6 +695,7 @@ internal sealed class EnumerableCopier<T>(IDeepCopierProvider copierProvider, ID
 }
 
 [RegisterSerializer]
+[Alias("ReadOnlyCollectionInterfaceCodec`1")]
 internal sealed class ReadOnlyCollectionInterfaceCodec<T>(IFieldCodec<T> elementCodec)
     : ListInterfaceCodec<IReadOnlyCollection<T>, T>(elementCodec)
 {
@@ -604,6 +708,7 @@ internal sealed class ReadOnlyCollectionInterfaceCopier<T>(IDeepCopierProvider c
 }
 
 [RegisterSerializer]
+[Alias("ReadOnlyListInterfaceCodec`1")]
 internal sealed class ReadOnlyListInterfaceCodec<T>(IFieldCodec<T> elementCodec)
     : ListInterfaceCodec<IReadOnlyList<T>, T>(elementCodec)
 {
@@ -616,6 +721,7 @@ internal sealed class ReadOnlyListInterfaceCopier<T>(IDeepCopierProvider copierP
 }
 
 [RegisterSerializer]
+[Alias("CollectionInterfaceCodec`1")]
 internal sealed class CollectionInterfaceCodec<T>(IFieldCodec<T> elementCodec)
     : ListInterfaceCodec<ICollection<T>, T>(elementCodec)
 {
@@ -628,6 +734,7 @@ internal sealed class CollectionInterfaceCopier<T>(IDeepCopierProvider copierPro
 }
 
 [RegisterSerializer]
+[Alias("ListInterfaceCodec`1")]
 internal sealed class ListInterfaceCodec<T>(IFieldCodec<T> elementCodec)
     : ListInterfaceCodec<IList<T>, T>(elementCodec)
 {
@@ -640,6 +747,7 @@ internal sealed class ListInterfaceCopier<T>(IDeepCopierProvider copierProvider,
 }
 
 [RegisterSerializer]
+[Alias("SetInterfaceCodec`1")]
 internal sealed class SetInterfaceCodec<T>(IFieldCodec<T> elementCodec, IFieldCodec<IEqualityComparer<T>> comparerCodec)
     : SetInterfaceCodec<ISet<T>, T>(elementCodec, comparerCodec)
 {
@@ -653,6 +761,7 @@ internal sealed class SetInterfaceCopier<T>(IDeepCopierProvider copierProvider, 
 
 #if NET5_0_OR_GREATER
 [RegisterSerializer]
+[Alias("ReadOnlySetInterfaceCodec`1")]
 internal sealed class ReadOnlySetInterfaceCodec<T>(IFieldCodec<T> elementCodec, IFieldCodec<IEqualityComparer<T>> comparerCodec)
     : SetInterfaceCodec<IReadOnlySet<T>, T>(elementCodec, comparerCodec)
 {
@@ -666,6 +775,7 @@ internal sealed class ReadOnlySetInterfaceCopier<T>(IDeepCopierProvider copierPr
 #endif
 
 [RegisterSerializer]
+[Alias("DictionaryInterfaceCodec`2")]
 internal sealed class DictionaryInterfaceCodec<TKey, TValue>(
     IFieldCodec<TKey> keyCodec,
     IFieldCodec<TValue> valueCodec,
@@ -686,6 +796,7 @@ internal sealed class DictionaryInterfaceCopier<TKey, TValue>(
 }
 
 [RegisterSerializer]
+[Alias("ReadOnlyDictionaryInterfaceCodec`2")]
 internal sealed class ReadOnlyDictionaryInterfaceCodec<TKey, TValue>(
     IFieldCodec<TKey> keyCodec,
     IFieldCodec<TValue> valueCodec,

--- a/src/Orleans.Serialization/Codecs/InterfaceCollectionCodecs.cs
+++ b/src/Orleans.Serialization/Codecs/InterfaceCollectionCodecs.cs
@@ -1,0 +1,706 @@
+using System.Buffers;
+using Orleans.Serialization.Buffers;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.GeneratedCodeHelpers;
+using Orleans.Serialization.WireProtocol;
+
+#nullable disable
+namespace Orleans.Serialization.Codecs;
+
+internal static class InterfaceCollectionCodecHelpers
+{
+    private const int MaxCapacityHint = 16 * 1024;
+
+    public static bool TryWriteRuntimeCodec<TBufferWriter, TField>(
+        ref Writer<TBufferWriter> writer,
+        uint fieldIdDelta,
+        Type expectedType,
+        TField value) where TBufferWriter : IBufferWriter<byte>
+    {
+        if (value is null)
+        {
+            ReferenceCodec.WriteNullReference(ref writer, fieldIdDelta);
+            return true;
+        }
+
+        if (writer.Session.CodecProvider.TryGetCodec(value.GetType()) is not { } codec)
+        {
+            return false;
+        }
+
+        codec.WriteField(ref writer, fieldIdDelta, expectedType, value);
+        return true;
+    }
+
+    public static bool TryReadReferenceOrSpecificCodec<TField, TInput>(
+        ref Reader<TInput> reader,
+        Field field,
+        Type fallbackType,
+        out TField result)
+    {
+        if (field.WireType == WireType.Reference)
+        {
+            result = ReferenceCodec.ReadReference<TField, TInput>(ref reader, field);
+            return true;
+        }
+
+        var fieldType = field.FieldType;
+        if (fieldType is not null
+            && fieldType != typeof(TField)
+            && fieldType != fallbackType
+            && reader.Session.CodecProvider.TryGetCodec(fieldType) is { } specificCodec)
+        {
+            result = (TField)specificCodec.ReadValue(ref reader, field);
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    public static bool TryCopyRuntime<TField>(
+        IDeepCopierProvider copierProvider,
+        TField input,
+        CopyContext context,
+        out TField result) where TField : class
+    {
+        if (input is null)
+        {
+            result = null;
+            return true;
+        }
+
+        if (copierProvider.TryGetDeepCopier(input.GetType()) is not { } copier)
+        {
+            result = null;
+            return false;
+        }
+
+        result = (TField)copier.DeepCopy(input, context);
+        return true;
+    }
+
+    public static bool TryGetCount<T>(IEnumerable<T> value, out int count)
+    {
+        switch (value)
+        {
+            case ICollection<T> collection:
+                count = collection.Count;
+                return true;
+            case IReadOnlyCollection<T> collection:
+                count = collection.Count;
+                return true;
+            default:
+                count = 0;
+                return false;
+        }
+    }
+
+    public static int GetCapacityHint(int count) => count <= 0 ? 0 : Math.Min(count, MaxCapacityHint);
+
+    public static int ReadCapacityHint<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        var capacityHint = UInt32Codec.ReadValue(ref reader, field);
+        return capacityHint > MaxCapacityHint ? MaxCapacityHint : (int)capacityHint;
+    }
+
+    public static bool TryWriteCapacityHint<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, int count) where TBufferWriter : IBufferWriter<byte>
+    {
+        var capacityHint = GetCapacityHint(count);
+        if (capacityHint <= 0)
+        {
+            return false;
+        }
+
+        UInt32Codec.WriteField(ref writer, fieldIdDelta, (uint)capacityHint);
+        return true;
+    }
+}
+
+internal abstract class ListInterfaceCodec<TInterface, T> : IFieldCodec<TInterface> where TInterface : class, IEnumerable<T>
+{
+    private static readonly Type FallbackType = typeof(List<T>);
+    private static readonly Type ElementType = typeof(T);
+    private readonly IFieldCodec<T> _elementCodec;
+
+    protected ListInterfaceCodec(IFieldCodec<T> elementCodec)
+    {
+        _elementCodec = OrleansGeneratedCodeHelper.UnwrapService(this, elementCodec);
+    }
+
+    public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TInterface value) where TBufferWriter : IBufferWriter<byte>
+    {
+        if (InterfaceCollectionCodecHelpers.TryWriteRuntimeCodec(ref writer, fieldIdDelta, expectedType, value))
+        {
+            return;
+        }
+
+        if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, FallbackType, value))
+        {
+            return;
+        }
+
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, FallbackType, WireType.TagDelimited);
+        if (InterfaceCollectionCodecHelpers.TryGetCount(value, out var count))
+        {
+            WriteElements(ref writer, value, count);
+        }
+        else
+        {
+            var snapshot = new List<T>();
+            foreach (var element in value)
+            {
+                snapshot.Add(element);
+            }
+
+            WriteElements(ref writer, snapshot, snapshot.Count);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    public TInterface ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        if (InterfaceCollectionCodecHelpers.TryReadReferenceOrSpecificCodec<TInterface, TInput>(ref reader, field, FallbackType, out var result))
+        {
+            return result;
+        }
+
+        return (TInterface)(object)ReadFallback(ref reader, field);
+    }
+
+    private void WriteElements<TBufferWriter>(ref Writer<TBufferWriter> writer, IEnumerable<T> value, int count) where TBufferWriter : IBufferWriter<byte>
+    {
+        if (!InterfaceCollectionCodecHelpers.TryWriteCapacityHint(ref writer, 0, count))
+        {
+            return;
+        }
+
+        uint innerFieldIdDelta = 1;
+        foreach (var element in value)
+        {
+            _elementCodec.WriteField(ref writer, innerFieldIdDelta, ElementType, element);
+            innerFieldIdDelta = 0;
+        }
+    }
+
+    private List<T> ReadFallback<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        field.EnsureWireTypeTagDelimited();
+
+        var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
+        List<T> result = null;
+        uint fieldId = 0;
+        while (true)
+        {
+            var header = reader.ReadFieldHeader();
+            if (header.IsEndBaseOrEndObject)
+            {
+                break;
+            }
+
+            fieldId += header.FieldIdDelta;
+            switch (fieldId)
+            {
+                case 0:
+                    result = new(InterfaceCollectionCodecHelpers.ReadCapacityHint(ref reader, header));
+                    ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
+                    break;
+                case 1:
+                    if (result is null)
+                    {
+                        result = [];
+                        ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
+                    }
+
+                    result.Add(_elementCodec.ReadValue(ref reader, header));
+                    break;
+                default:
+                    reader.ConsumeUnknownField(header);
+                    break;
+            }
+        }
+
+        if (result is null)
+        {
+            result = [];
+            ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
+        }
+
+        return result;
+    }
+}
+
+internal abstract class SetInterfaceCodec<TInterface, T> : IFieldCodec<TInterface> where TInterface : class, IEnumerable<T>
+{
+    private static readonly Type FallbackType = typeof(HashSet<T>);
+    private static readonly Type ElementType = typeof(T);
+    private readonly IFieldCodec<T> _elementCodec;
+    private readonly IFieldCodec<IEqualityComparer<T>> _comparerCodec;
+
+    protected SetInterfaceCodec(IFieldCodec<T> elementCodec, IFieldCodec<IEqualityComparer<T>> comparerCodec)
+    {
+        _elementCodec = OrleansGeneratedCodeHelper.UnwrapService(this, elementCodec);
+        _comparerCodec = OrleansGeneratedCodeHelper.UnwrapService(this, comparerCodec);
+    }
+
+    public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TInterface value) where TBufferWriter : IBufferWriter<byte>
+    {
+        if (InterfaceCollectionCodecHelpers.TryWriteRuntimeCodec(ref writer, fieldIdDelta, expectedType, value))
+        {
+            return;
+        }
+
+        if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, FallbackType, value))
+        {
+            return;
+        }
+
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, FallbackType, WireType.TagDelimited);
+        if (InterfaceCollectionCodecHelpers.TryGetCount(value, out var count))
+        {
+            WriteElements(ref writer, value, count);
+        }
+        else
+        {
+            var snapshot = new List<T>();
+            foreach (var element in value)
+            {
+                snapshot.Add(element);
+            }
+
+            WriteElements(ref writer, snapshot, snapshot.Count);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    public TInterface ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        if (InterfaceCollectionCodecHelpers.TryReadReferenceOrSpecificCodec<TInterface, TInput>(ref reader, field, FallbackType, out var result))
+        {
+            return result;
+        }
+
+        return (TInterface)(object)ReadFallback(ref reader, field);
+    }
+
+    private void WriteElements<TBufferWriter>(ref Writer<TBufferWriter> writer, IEnumerable<T> value, int count) where TBufferWriter : IBufferWriter<byte>
+    {
+        if (!InterfaceCollectionCodecHelpers.TryWriteCapacityHint(ref writer, 1, count))
+        {
+            return;
+        }
+
+        uint innerFieldIdDelta = 1;
+        foreach (var element in value)
+        {
+            _elementCodec.WriteField(ref writer, innerFieldIdDelta, ElementType, element);
+            innerFieldIdDelta = 0;
+        }
+    }
+
+    private HashSet<T> ReadFallback<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        field.EnsureWireTypeTagDelimited();
+
+        var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
+        HashSet<T> result = null;
+        IEqualityComparer<T> comparer = null;
+        uint fieldId = 0;
+        while (true)
+        {
+            var header = reader.ReadFieldHeader();
+            if (header.IsEndBaseOrEndObject)
+            {
+                break;
+            }
+
+            fieldId += header.FieldIdDelta;
+            switch (fieldId)
+            {
+                case 0:
+                    comparer = _comparerCodec.ReadValue(ref reader, header);
+                    break;
+                case 1:
+                    result = new(InterfaceCollectionCodecHelpers.ReadCapacityHint(ref reader, header), comparer);
+                    ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
+                    break;
+                case 2:
+                    if (result is null)
+                    {
+                        result = new(comparer);
+                        ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
+                    }
+
+                    result.Add(_elementCodec.ReadValue(ref reader, header));
+                    break;
+                default:
+                    reader.ConsumeUnknownField(header);
+                    break;
+            }
+        }
+
+        if (result is null)
+        {
+            result = new(comparer);
+            ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
+        }
+
+        return result;
+    }
+}
+
+internal abstract class DictionaryInterfaceCodec<TInterface, TKey, TValue> : IFieldCodec<TInterface>
+    where TInterface : class, IEnumerable<KeyValuePair<TKey, TValue>>
+    where TKey : notnull
+{
+    private static readonly Type FallbackType = typeof(Dictionary<TKey, TValue>);
+    private static readonly Type KeyType = typeof(TKey);
+    private static readonly Type ValueType = typeof(TValue);
+    private readonly IFieldCodec<TKey> _keyCodec;
+    private readonly IFieldCodec<TValue> _valueCodec;
+    private readonly IFieldCodec<IEqualityComparer<TKey>> _comparerCodec;
+
+    protected DictionaryInterfaceCodec(
+        IFieldCodec<TKey> keyCodec,
+        IFieldCodec<TValue> valueCodec,
+        IFieldCodec<IEqualityComparer<TKey>> comparerCodec)
+    {
+        _keyCodec = OrleansGeneratedCodeHelper.UnwrapService(this, keyCodec);
+        _valueCodec = OrleansGeneratedCodeHelper.UnwrapService(this, valueCodec);
+        _comparerCodec = OrleansGeneratedCodeHelper.UnwrapService(this, comparerCodec);
+    }
+
+    public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TInterface value) where TBufferWriter : IBufferWriter<byte>
+    {
+        if (InterfaceCollectionCodecHelpers.TryWriteRuntimeCodec(ref writer, fieldIdDelta, expectedType, value))
+        {
+            return;
+        }
+
+        if (ReferenceCodec.TryWriteReferenceField(ref writer, fieldIdDelta, expectedType, FallbackType, value))
+        {
+            return;
+        }
+
+        writer.WriteFieldHeader(fieldIdDelta, expectedType, FallbackType, WireType.TagDelimited);
+        if (InterfaceCollectionCodecHelpers.TryGetCount(value, out var count))
+        {
+            WriteEntries(ref writer, value, count);
+        }
+        else
+        {
+            var snapshot = new List<KeyValuePair<TKey, TValue>>();
+            foreach (var entry in value)
+            {
+                snapshot.Add(entry);
+            }
+
+            WriteEntries(ref writer, snapshot, snapshot.Count);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    public TInterface ReadValue<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        if (InterfaceCollectionCodecHelpers.TryReadReferenceOrSpecificCodec<TInterface, TInput>(ref reader, field, FallbackType, out var result))
+        {
+            return result;
+        }
+
+        return (TInterface)(object)ReadFallback(ref reader, field);
+    }
+
+    private void WriteEntries<TBufferWriter>(ref Writer<TBufferWriter> writer, IEnumerable<KeyValuePair<TKey, TValue>> value, int count) where TBufferWriter : IBufferWriter<byte>
+    {
+        if (!InterfaceCollectionCodecHelpers.TryWriteCapacityHint(ref writer, 1, count))
+        {
+            return;
+        }
+
+        uint innerFieldIdDelta = 1;
+        foreach (var entry in value)
+        {
+            _keyCodec.WriteField(ref writer, innerFieldIdDelta, KeyType, entry.Key);
+            _valueCodec.WriteField(ref writer, 0, ValueType, entry.Value);
+            innerFieldIdDelta = 0;
+        }
+    }
+
+    private Dictionary<TKey, TValue> ReadFallback<TInput>(ref Reader<TInput> reader, Field field)
+    {
+        field.EnsureWireTypeTagDelimited();
+
+        var placeholderReferenceId = ReferenceCodec.CreateRecordPlaceholder(reader.Session);
+        Dictionary<TKey, TValue> result = null;
+        IEqualityComparer<TKey> comparer = null;
+        TKey key = default;
+        var valueExpected = false;
+        uint fieldId = 0;
+        while (true)
+        {
+            var header = reader.ReadFieldHeader();
+            if (header.IsEndBaseOrEndObject)
+            {
+                break;
+            }
+
+            fieldId += header.FieldIdDelta;
+            switch (fieldId)
+            {
+                case 0:
+                    comparer = _comparerCodec.ReadValue(ref reader, header);
+                    break;
+                case 1:
+                    result = new(InterfaceCollectionCodecHelpers.ReadCapacityHint(ref reader, header), comparer);
+                    ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
+                    break;
+                case 2:
+                    if (result is null)
+                    {
+                        result = new(comparer);
+                        ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
+                    }
+
+                    if (!valueExpected)
+                    {
+                        key = _keyCodec.ReadValue(ref reader, header);
+                        valueExpected = true;
+                    }
+                    else
+                    {
+                        result.Add(key, _valueCodec.ReadValue(ref reader, header));
+                        valueExpected = false;
+                    }
+
+                    break;
+                default:
+                    reader.ConsumeUnknownField(header);
+                    break;
+            }
+        }
+
+        if (result is null)
+        {
+            result = new(comparer);
+            ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
+        }
+
+        return result;
+    }
+}
+
+internal abstract class ListInterfaceCopier<TInterface, T>(IDeepCopierProvider copierProvider, IDeepCopier<T> elementCopier)
+    : IDeepCopier<TInterface> where TInterface : class, IEnumerable<T>
+{
+    public TInterface DeepCopy(TInterface input, CopyContext context)
+    {
+        if (InterfaceCollectionCodecHelpers.TryCopyRuntime(copierProvider, input, context, out var runtimeResult))
+        {
+            return runtimeResult;
+        }
+
+        if (context.TryGetCopy<TInterface>(input, out var result))
+        {
+            return result;
+        }
+
+        var copy = InterfaceCollectionCodecHelpers.TryGetCount(input, out var count)
+            ? new List<T>(InterfaceCollectionCodecHelpers.GetCapacityHint(count))
+            : new List<T>();
+        context.RecordCopy(input, copy);
+        foreach (var element in input)
+        {
+            copy.Add(elementCopier.DeepCopy(element, context));
+        }
+
+        return (TInterface)(object)copy;
+    }
+}
+
+internal abstract class SetInterfaceCopier<TInterface, T>(IDeepCopierProvider copierProvider, IDeepCopier<T> elementCopier) : IDeepCopier<TInterface> where TInterface : class, IEnumerable<T>
+{
+    public TInterface DeepCopy(TInterface input, CopyContext context)
+    {
+        if (InterfaceCollectionCodecHelpers.TryCopyRuntime(copierProvider, input, context, out var runtimeResult))
+        {
+            return runtimeResult;
+        }
+
+        if (context.TryGetCopy<TInterface>(input, out var result))
+        {
+            return result;
+        }
+
+        var copy = InterfaceCollectionCodecHelpers.TryGetCount(input, out var count)
+            ? new HashSet<T>(InterfaceCollectionCodecHelpers.GetCapacityHint(count))
+            : [];
+        context.RecordCopy(input, copy);
+        foreach (var element in input)
+        {
+            copy.Add(elementCopier.DeepCopy(element, context));
+        }
+
+        return (TInterface)(object)copy;
+    }
+}
+
+internal abstract class DictionaryInterfaceCopier<TInterface, TKey, TValue>(
+    IDeepCopierProvider copierProvider,
+    IDeepCopier<TKey> keyCopier,
+    IDeepCopier<TValue> valueCopier) : IDeepCopier<TInterface>
+    where TInterface : class, IEnumerable<KeyValuePair<TKey, TValue>>
+    where TKey : notnull
+{
+    public TInterface DeepCopy(TInterface input, CopyContext context)
+    {
+        if (InterfaceCollectionCodecHelpers.TryCopyRuntime(copierProvider, input, context, out var runtimeResult))
+        {
+            return runtimeResult;
+        }
+
+        if (context.TryGetCopy<TInterface>(input, out var result))
+        {
+            return result;
+        }
+
+        var copy = InterfaceCollectionCodecHelpers.TryGetCount(input, out var count)
+            ? new Dictionary<TKey, TValue>(InterfaceCollectionCodecHelpers.GetCapacityHint(count))
+            : [];
+        context.RecordCopy(input, copy);
+        foreach (var entry in input)
+        {
+            copy[keyCopier.DeepCopy(entry.Key, context)] = valueCopier.DeepCopy(entry.Value, context);
+        }
+
+        return (TInterface)(object)copy;
+    }
+}
+
+[RegisterSerializer]
+internal sealed class EnumerableCodec<T>(IFieldCodec<T> elementCodec)
+    : ListInterfaceCodec<IEnumerable<T>, T>(elementCodec)
+{
+}
+
+[RegisterCopier]
+internal sealed class EnumerableCopier<T>(IDeepCopierProvider copierProvider, IDeepCopier<T> elementCopier)
+    : ListInterfaceCopier<IEnumerable<T>, T>(copierProvider, elementCopier)
+{
+}
+
+[RegisterSerializer]
+internal sealed class ReadOnlyCollectionInterfaceCodec<T>(IFieldCodec<T> elementCodec)
+    : ListInterfaceCodec<IReadOnlyCollection<T>, T>(elementCodec)
+{
+}
+
+[RegisterCopier]
+internal sealed class ReadOnlyCollectionInterfaceCopier<T>(IDeepCopierProvider copierProvider, IDeepCopier<T> elementCopier)
+    : ListInterfaceCopier<IReadOnlyCollection<T>, T>(copierProvider, elementCopier)
+{
+}
+
+[RegisterSerializer]
+internal sealed class ReadOnlyListInterfaceCodec<T>(IFieldCodec<T> elementCodec)
+    : ListInterfaceCodec<IReadOnlyList<T>, T>(elementCodec)
+{
+}
+
+[RegisterCopier]
+internal sealed class ReadOnlyListInterfaceCopier<T>(IDeepCopierProvider copierProvider, IDeepCopier<T> elementCopier)
+    : ListInterfaceCopier<IReadOnlyList<T>, T>(copierProvider, elementCopier)
+{
+}
+
+[RegisterSerializer]
+internal sealed class CollectionInterfaceCodec<T>(IFieldCodec<T> elementCodec)
+    : ListInterfaceCodec<ICollection<T>, T>(elementCodec)
+{
+}
+
+[RegisterCopier]
+internal sealed class CollectionInterfaceCopier<T>(IDeepCopierProvider copierProvider, IDeepCopier<T> elementCopier)
+    : ListInterfaceCopier<ICollection<T>, T>(copierProvider, elementCopier)
+{
+}
+
+[RegisterSerializer]
+internal sealed class ListInterfaceCodec<T>(IFieldCodec<T> elementCodec)
+    : ListInterfaceCodec<IList<T>, T>(elementCodec)
+{
+}
+
+[RegisterCopier]
+internal sealed class ListInterfaceCopier<T>(IDeepCopierProvider copierProvider, IDeepCopier<T> elementCopier)
+    : ListInterfaceCopier<IList<T>, T>(copierProvider, elementCopier)
+{
+}
+
+[RegisterSerializer]
+internal sealed class SetInterfaceCodec<T>(IFieldCodec<T> elementCodec, IFieldCodec<IEqualityComparer<T>> comparerCodec)
+    : SetInterfaceCodec<ISet<T>, T>(elementCodec, comparerCodec)
+{
+}
+
+[RegisterCopier]
+internal sealed class SetInterfaceCopier<T>(IDeepCopierProvider copierProvider, IDeepCopier<T> elementCopier)
+    : SetInterfaceCopier<ISet<T>, T>(copierProvider, elementCopier)
+{
+}
+
+#if NET5_0_OR_GREATER
+[RegisterSerializer]
+internal sealed class ReadOnlySetInterfaceCodec<T>(IFieldCodec<T> elementCodec, IFieldCodec<IEqualityComparer<T>> comparerCodec)
+    : SetInterfaceCodec<IReadOnlySet<T>, T>(elementCodec, comparerCodec)
+{
+}
+
+[RegisterCopier]
+internal sealed class ReadOnlySetInterfaceCopier<T>(IDeepCopierProvider copierProvider, IDeepCopier<T> elementCopier)
+    : SetInterfaceCopier<IReadOnlySet<T>, T>(copierProvider, elementCopier)
+{
+}
+#endif
+
+[RegisterSerializer]
+internal sealed class DictionaryInterfaceCodec<TKey, TValue>(
+    IFieldCodec<TKey> keyCodec,
+    IFieldCodec<TValue> valueCodec,
+    IFieldCodec<IEqualityComparer<TKey>> comparerCodec)
+    : DictionaryInterfaceCodec<IDictionary<TKey, TValue>, TKey, TValue>(keyCodec, valueCodec, comparerCodec)
+    where TKey : notnull
+{
+}
+
+[RegisterCopier]
+internal sealed class DictionaryInterfaceCopier<TKey, TValue>(
+    IDeepCopierProvider copierProvider,
+    IDeepCopier<TKey> keyCopier,
+    IDeepCopier<TValue> valueCopier)
+    : DictionaryInterfaceCopier<IDictionary<TKey, TValue>, TKey, TValue>(copierProvider, keyCopier, valueCopier)
+    where TKey : notnull
+{
+}
+
+[RegisterSerializer]
+internal sealed class ReadOnlyDictionaryInterfaceCodec<TKey, TValue>(
+    IFieldCodec<TKey> keyCodec,
+    IFieldCodec<TValue> valueCodec,
+    IFieldCodec<IEqualityComparer<TKey>> comparerCodec)
+    : DictionaryInterfaceCodec<IReadOnlyDictionary<TKey, TValue>, TKey, TValue>(keyCodec, valueCodec, comparerCodec)
+    where TKey : notnull
+{
+}
+
+[RegisterCopier]
+internal sealed class ReadOnlyDictionaryInterfaceCopier<TKey, TValue>(
+    IDeepCopierProvider copierProvider,
+    IDeepCopier<TKey> keyCopier,
+    IDeepCopier<TValue> valueCopier)
+    : DictionaryInterfaceCopier<IReadOnlyDictionary<TKey, TValue>, TKey, TValue>(copierProvider, keyCopier, valueCopier)
+    where TKey : notnull
+{
+}

--- a/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
+++ b/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@ namespace Orleans.Serialization
                 services.TryAddSingleton<CopyContextPool>();
 
                 services.AddSingleton<IGeneralizedCodec, WellKnownStringComparerCodec>();
+                services.AddSingleton<IGeneralizedCodec, InterfaceCollectionCodecResolver>();
 
                 services.AddSingleton<ExceptionCodec>();
                 services.AddSingleton<IGeneralizedCodec>(sp => sp.GetRequiredService<ExceptionCodec>());

--- a/src/Orleans.Serialization/Invocation/Pools/ConcurrentObjectPool.cs
+++ b/src/Orleans.Serialization/Invocation/Pools/ConcurrentObjectPool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Extensions.ObjectPool;
@@ -12,11 +13,12 @@ namespace Orleans.Serialization.Invocation
         }
     }
 
-    internal class ConcurrentObjectPool<T, TPoolPolicy> : ObjectPool<T> where T : class where TPoolPolicy : IPooledObjectPolicy<T>
+    internal class ConcurrentObjectPool<T, TPoolPolicy> : ObjectPool<T>, IDisposable where T : class where TPoolPolicy : IPooledObjectPolicy<T>
     {
         private readonly ThreadLocal<Stack<T>> _objects = new(() => new());
 
         private readonly TPoolPolicy _policy;
+        private int _disposed;
 
         public ConcurrentObjectPool(TPoolPolicy policy) => _policy = policy;
 
@@ -24,6 +26,7 @@ namespace Orleans.Serialization.Invocation
 
         public override T Get()
         {
+            ThrowIfDisposed();
             var stack = _objects.Value;
             if (stack.TryPop(out var result))
             {
@@ -37,11 +40,42 @@ namespace Orleans.Serialization.Invocation
         {
             if (_policy.Return(obj))
             {
-                var stack = _objects.Value;
+                if (Volatile.Read(ref _disposed) != 0)
+                {
+                    return;
+                }
+
+                Stack<T> stack;
+                try
+                {
+                    stack = _objects.Value;
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+
                 if (stack.Count < MaxPoolSize)
                 {
                     stack.Push(obj);
                 }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                // Clear per-thread stacks so pooled objects do not keep their owning service provider alive.
+                _objects.Dispose();
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                throw new ObjectDisposedException(typeof(ConcurrentObjectPool<T, TPoolPolicy>).FullName);
             }
         }
     }

--- a/src/Orleans.Serialization/Session/SerializerSessionPool.cs
+++ b/src/Orleans.Serialization/Session/SerializerSessionPool.cs
@@ -1,17 +1,17 @@
+using System;
 using Microsoft.Extensions.ObjectPool;
 using Orleans.Serialization.Invocation;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.TypeSystem;
-using System;
 
 namespace Orleans.Serialization.Session
 {
     /// <summary>
     /// Pool for <see cref="SerializerSession"/> objects.
     /// </summary>
-    public sealed class SerializerSessionPool
+    public sealed class SerializerSessionPool : IDisposable
     {
-        private readonly ObjectPool<SerializerSession> _sessionPool;
+        private readonly ConcurrentObjectPool<SerializerSession, SerializerSessionPoolPolicy> _sessionPool;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SerializerSessionPool"/> class.
@@ -36,6 +36,9 @@ namespace Orleans.Serialization.Session
         /// </summary>
         /// <returns>A serializer session.</returns>
         public SerializerSession GetSession() => _sessionPool.Get();
+
+        /// <inheritdoc/>
+        public void Dispose() => _sessionPool.Dispose();
 
         /// <summary>
         /// Returns a session to the pool.

--- a/src/api/Orleans.Serialization.TestKit/Orleans.Serialization.TestKit.cs
+++ b/src/api/Orleans.Serialization.TestKit/Orleans.Serialization.TestKit.cs
@@ -10,18 +10,15 @@ namespace Orleans.Serialization.TestKit
 {
     [Xunit.Trait("Category", "BVT")]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public abstract partial class CopierTester<TValue, TCopier>
+    public abstract partial class CopierTester<TValue, TCopier> : SerializationTester
         where TCopier : class, Cloning.IDeepCopier<TValue>
     {
         protected CopierTester(Xunit.Abstractions.ITestOutputHelper output) { }
+        protected CopierTester(Xunit.Abstractions.ITestOutputHelper output, SerializationTesterFixture fixture) { }
 
         protected virtual bool IsImmutable { get { throw null; } }
 
         protected virtual bool IsPooled { get { throw null; } }
-
-        protected System.Random Random { get { throw null; } }
-
-        protected System.IServiceProvider ServiceProvider { get { throw null; } }
 
         protected abstract TValue[] TestValues { get; }
 
@@ -40,6 +37,7 @@ namespace Orleans.Serialization.TestKit
         public void CanCopyUntypedTupleViaSerializer() { }
 
         protected virtual void Configure(ISerializerBuilder builder) { }
+        protected override System.IServiceProvider CreateServiceProvider() { throw null; }
 
         [Xunit.Fact]
         public void CopiedValuesAreEqual() { }
@@ -55,15 +53,12 @@ namespace Orleans.Serialization.TestKit
 
     [Xunit.Trait("Category", "BVT")]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public abstract partial class FieldCodecTester<TValue, TCodec> : System.IDisposable where TCodec : class, Codecs.IFieldCodec<TValue>
+    public abstract partial class FieldCodecTester<TValue, TCodec> : SerializationTester where TCodec : class, Codecs.IFieldCodec<TValue>
     {
         protected FieldCodecTester(Xunit.Abstractions.ITestOutputHelper output) { }
+        protected FieldCodecTester(Xunit.Abstractions.ITestOutputHelper output, SerializationTesterFixture fixture) { }
 
         protected virtual int[] MaxSegmentSizes { get { throw null; } }
-
-        protected System.Random Random { get { throw null; } }
-
-        protected System.IServiceProvider ServiceProvider { get { throw null; } }
 
         protected Session.SerializerSessionPool SessionPool { get { throw null; } }
 
@@ -114,6 +109,7 @@ namespace Orleans.Serialization.TestKit
         public void CanSkipValue() { }
 
         protected virtual void Configure(ISerializerBuilder builder) { }
+        protected override System.IServiceProvider CreateServiceProvider() { throw null; }
 
         [Xunit.Fact]
         public void CorrectlyAdvancesReferenceCounter() { }
@@ -141,10 +137,36 @@ namespace Orleans.Serialization.TestKit
 
         protected object RoundTripThroughUntypedSerializer(object original, out string formattedBitStream) { throw null; }
 
-        void System.IDisposable.Dispose() { }
-
         [Xunit.Fact]
         public void WritersProduceSameResults() { }
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public abstract partial class SerializationTester : System.IDisposable
+    {
+        protected SerializationTester(Xunit.Abstractions.ITestOutputHelper output) { }
+        protected SerializationTester(Xunit.Abstractions.ITestOutputHelper output, SerializationTesterFixture fixture) { }
+
+        protected System.Random Random { get { throw null; } }
+
+        protected System.IServiceProvider ServiceProvider { get { throw null; } }
+
+        protected abstract System.IServiceProvider CreateServiceProvider();
+        protected virtual void Dispose(bool disposing) { }
+
+        void System.IDisposable.Dispose() { }
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public partial class SerializationTesterFixture : System.IDisposable
+    {
+        public SerializationTesterFixture() { }
+
+        public System.IServiceProvider ServiceProvider { get { throw null; } }
+
+        protected virtual void Dispose(bool disposing) { }
+
+        void System.IDisposable.Dispose() { }
     }
 
     public partial interface IOutputBuffer
@@ -199,6 +221,7 @@ namespace Orleans.Serialization.TestKit
     public abstract partial class ValueTypeFieldCodecTester<TField, TCodec> : FieldCodecTester<TField, TCodec> where TField : struct where TCodec : class, Codecs.IFieldCodec<TField>
     {
         protected ValueTypeFieldCodecTester(Xunit.Abstractions.ITestOutputHelper output) : base(default!) { }
+        protected ValueTypeFieldCodecTester(Xunit.Abstractions.ITestOutputHelper output, SerializationTesterFixture fixture) : base(default!) { }
 
         [Xunit.Fact]
         public void DirectAccessValueSerializerRoundTrip() { }

--- a/src/api/Orleans.Serialization/Orleans.Serialization.cs
+++ b/src/api/Orleans.Serialization/Orleans.Serialization.cs
@@ -1281,9 +1281,11 @@ namespace Orleans.Serialization.Cloning
             where T : class { throw null; }
     }
 
-    public sealed partial class CopyContextPool
+    public sealed partial class CopyContextPool : System.IDisposable
     {
         public CopyContextPool(Serializers.CodecProvider codecProvider) { }
+
+        public void Dispose() { }
 
         public CopyContext GetContext() { throw null; }
     }
@@ -3806,11 +3808,13 @@ namespace Orleans.Serialization.Session
         public void Reset() { }
     }
 
-    public sealed partial class SerializerSessionPool
+    public sealed partial class SerializerSessionPool : System.IDisposable
     {
         public SerializerSessionPool(TypeSystem.TypeCodec typeCodec, WellKnownTypeCollection wellKnownTypes, Serializers.CodecProvider codecProvider) { }
 
         public Serializers.CodecProvider CodecProvider { get { throw null; } }
+
+        public void Dispose() { }
 
         public SerializerSession GetSession() { throw null; }
     }

--- a/test/Grains/TestGrainInterfaces/IValueTypeTestGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IValueTypeTestGrain.cs
@@ -154,6 +154,24 @@ namespace UnitTests.GrainInterfaces
         Task<RetVal> GetRetValForParamVal(ParamVal param);
     }
 
+    /// <summary>
+    /// Grain interface for testing that collection expressions returned from grain methods
+    /// serialize and deserialize correctly when the declared return type is a collection interface.
+    /// Covers the scenario fixed by the interface collection codecs (issue #8934 / PR #10104).
+    /// </summary>
+    public interface ICollectionExpressionGrain : IGrainWithIntegerKey
+    {
+        Task<IEnumerable<int>> GetEnumerable();
+        Task<IReadOnlyList<int>> GetReadOnlyList();
+        Task<IList<int>> GetList();
+        Task<IReadOnlyCollection<int>> GetReadOnlyCollection();
+        Task<ICollection<int>> GetCollection();
+        Task<ISet<int>> GetSet();
+        Task<IReadOnlySet<int>> GetReadOnlySet();
+        Task<IDictionary<string, int>> GetDictionary();
+        Task<IReadOnlyDictionary<string, int>> GetReadOnlyDictionary();
+    }
+
     [GenerateSerializer]
     public record ParamVal([field: Id(0)] int Value);
 

--- a/test/Grains/TestGrains/CollectionExpressionGrain.cs
+++ b/test/Grains/TestGrains/CollectionExpressionGrain.cs
@@ -1,0 +1,49 @@
+using UnitTests.GrainInterfaces;
+
+namespace UnitTests.Grains;
+
+public class CollectionExpressionGrain : Grain, ICollectionExpressionGrain
+{
+    public Task<IEnumerable<int>> GetEnumerable()
+        => Task.FromResult<IEnumerable<int>>([1, 2, 3]);
+
+    public Task<IReadOnlyList<int>> GetReadOnlyList()
+        => Task.FromResult<IReadOnlyList<int>>([10, 20, 30]);
+
+    public Task<IList<int>> GetList()
+        => Task.FromResult<IList<int>>([100, 200, 300]);
+
+    public Task<IReadOnlyCollection<int>> GetReadOnlyCollection()
+        => Task.FromResult<IReadOnlyCollection<int>>([4, 5, 6]);
+
+    public Task<ICollection<int>> GetCollection()
+        => Task.FromResult<ICollection<int>>([40, 50, 60]);
+
+    public Task<ISet<int>> GetSet()
+    {
+        HashSet<int> result = [7, 8, 9];
+        return Task.FromResult<ISet<int>>(result);
+    }
+
+    public Task<IReadOnlySet<int>> GetReadOnlySet()
+    {
+        HashSet<int> result = [70, 80, 90];
+        return Task.FromResult<IReadOnlySet<int>>(result);
+    }
+
+    public Task<IDictionary<string, int>> GetDictionary()
+        => Task.FromResult<IDictionary<string, int>>(new Dictionary<string, int>
+        {
+            ["alpha"] = 1,
+            ["beta"] = 2,
+            ["gamma"] = 3
+        });
+
+    public Task<IReadOnlyDictionary<string, int>> GetReadOnlyDictionary()
+        => Task.FromResult<IReadOnlyDictionary<string, int>>(new Dictionary<string, int>
+        {
+            ["x"] = 10,
+            ["y"] = 20,
+            ["z"] = 30
+        });
+}

--- a/test/Orleans.DefaultCluster.Tests/SerializationTests/CollectionExpressionGrainTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/SerializationTests/CollectionExpressionGrainTests.cs
@@ -1,0 +1,111 @@
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace DefaultCluster.Tests.Serialization;
+
+[TestCategory("Serialization"), TestCategory("BVT")]
+public class CollectionExpressionGrainTests : HostedTestClusterEnsureDefaultStarted
+{
+    public CollectionExpressionGrainTests(DefaultClusterFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task CollectionExpression_IEnumerable_RoundTrips()
+    {
+        var grain = GetGrain();
+
+        var result = await grain.GetEnumerable();
+
+        Assert.Equal([1, 2, 3], result);
+    }
+
+    [Fact]
+    public async Task CollectionExpression_IReadOnlyList_RoundTrips()
+    {
+        var grain = GetGrain();
+
+        var result = await grain.GetReadOnlyList();
+
+        Assert.Equal([10, 20, 30], result);
+    }
+
+    [Fact]
+    public async Task CollectionExpression_IList_RoundTrips()
+    {
+        var grain = GetGrain();
+
+        var result = await grain.GetList();
+
+        Assert.Equal([100, 200, 300], result);
+    }
+
+    [Fact]
+    public async Task CollectionExpression_IReadOnlyCollection_RoundTrips()
+    {
+        var grain = GetGrain();
+
+        var result = await grain.GetReadOnlyCollection();
+
+        Assert.Equal([4, 5, 6], result);
+    }
+
+    [Fact]
+    public async Task CollectionExpression_ICollection_RoundTrips()
+    {
+        var grain = GetGrain();
+
+        var result = await grain.GetCollection();
+
+        Assert.Equal([40, 50, 60], result);
+    }
+
+    [Fact]
+    public async Task CollectionExpression_ISet_RoundTrips()
+    {
+        var grain = GetGrain();
+
+        var result = await grain.GetSet();
+
+        Assert.True(result.SetEquals([7, 8, 9]));
+    }
+
+    [Fact]
+    public async Task CollectionExpression_IReadOnlySet_RoundTrips()
+    {
+        var grain = GetGrain();
+
+        var result = await grain.GetReadOnlySet();
+
+        Assert.True(result.SetEquals([70, 80, 90]));
+    }
+
+    [Fact]
+    public async Task CollectionExpression_IDictionary_RoundTrips()
+    {
+        var grain = GetGrain();
+
+        var result = await grain.GetDictionary();
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(1, result["alpha"]);
+        Assert.Equal(2, result["beta"]);
+        Assert.Equal(3, result["gamma"]);
+    }
+
+    [Fact]
+    public async Task CollectionExpression_IReadOnlyDictionary_RoundTrips()
+    {
+        var grain = GetGrain();
+
+        var result = await grain.GetReadOnlyDictionary();
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(10, result["x"]);
+        Assert.Equal(20, result["y"]);
+        Assert.Equal(30, result["z"]);
+    }
+
+    private ICollectionExpressionGrain GetGrain() => GrainFactory.GetGrain<ICollectionExpressionGrain>(GetRandomGrainId());
+}

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -178,7 +178,7 @@ namespace Orleans.Serialization.UnitTests
     /// Enums in Orleans are serialized efficiently as their underlying type values,
     /// ensuring compact representation and support for undefined enum values.
     /// </summary>
-    public class EnumTests(ITestOutputHelper output) : FieldCodecTester<MyEnum, IFieldCodec<MyEnum>>(output)
+    public class EnumTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<MyEnum, IFieldCodec<MyEnum>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override IFieldCodec<MyEnum> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<MyEnum>();
         protected override MyEnum CreateValue() => (MyEnum)Random.Next((int)MyEnum.None, (int)MyEnum.Two);
@@ -191,7 +191,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<MyEnum>> ValueProvider => Gen.Int.Select(v => (MyEnum)v).ToValueProvider();
     }
 
-    public class EnumCopierTests(ITestOutputHelper output) : CopierTester<MyEnum, IDeepCopier<MyEnum>>(output)
+    public class EnumCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<MyEnum, IDeepCopier<MyEnum>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override IDeepCopier<MyEnum> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<MyEnum>();
         protected override MyEnum CreateValue() => (MyEnum)Random.Next((int)MyEnum.None, (int)MyEnum.Two);
@@ -204,7 +204,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<MyEnum>> ValueProvider => Gen.Int.Select(v => (MyEnum)v).ToValueProvider();
     }
 
-    public class DateTimeKindTests(ITestOutputHelper output) : FieldCodecTester<DateTimeKind, IFieldCodec<DateTimeKind>>(output)
+    public class DateTimeKindTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<DateTimeKind, IFieldCodec<DateTimeKind>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override IFieldCodec<DateTimeKind> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<DateTimeKind>();
         protected override DateTimeKind CreateValue() => (DateTimeKind)Random.Next((int)DateTimeKind.Unspecified, (int)DateTimeKind.Local + 1);
@@ -213,7 +213,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<DateTimeKind>> ValueProvider => Gen.Int.Select(v => (DateTimeKind)v).ToValueProvider();
     }
 
-    public class DateTimeKindCopierTests(ITestOutputHelper output) : CopierTester<DateTimeKind, IDeepCopier<DateTimeKind>>(output)
+    public class DateTimeKindCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<DateTimeKind, IDeepCopier<DateTimeKind>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override IDeepCopier<DateTimeKind> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<DateTimeKind>();
         protected override DateTimeKind CreateValue() => (DateTimeKind)Random.Next((int)DateTimeKind.Unspecified, (int)DateTimeKind.Local + 1);
@@ -222,7 +222,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<DateTimeKind>> ValueProvider => Gen.Int.Select(v => (DateTimeKind)v).ToValueProvider();
     }
 
-    public class DayOfWeekTests(ITestOutputHelper output) : FieldCodecTester<DayOfWeek, IFieldCodec<DayOfWeek>>(output)
+    public class DayOfWeekTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<DayOfWeek, IFieldCodec<DayOfWeek>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override IFieldCodec<DayOfWeek> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<DayOfWeek>();
         protected override DayOfWeek CreateValue() => (DayOfWeek)Random.Next((int)DayOfWeek.Sunday, (int)DayOfWeek.Saturday + 1);
@@ -231,7 +231,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<DayOfWeek>> ValueProvider => Gen.Int.Select(v => (DayOfWeek)v).ToValueProvider();
     }
 
-    public class DayOfWeekCopierTests(ITestOutputHelper output) : CopierTester<DayOfWeek, IDeepCopier<DayOfWeek>>(output)
+    public class DayOfWeekCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<DayOfWeek, IDeepCopier<DayOfWeek>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override IDeepCopier<DayOfWeek> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<DayOfWeek>();
         protected override DayOfWeek CreateValue() => (DayOfWeek)Random.Next((int)DayOfWeek.Sunday, (int)DayOfWeek.Saturday);
@@ -240,28 +240,28 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<DayOfWeek>> ValueProvider => Gen.Int.Select(v => (DayOfWeek)v).ToValueProvider();
     }
 
-    public class NullableIntTests(ITestOutputHelper output) : FieldCodecTester<int?, IFieldCodec<int?>>(output)
+    public class NullableIntTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<int?, IFieldCodec<int?>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override IFieldCodec<int?> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<int?>();
         protected override int? CreateValue() => TestValues[Random.Next(TestValues.Length)];
         protected override int?[] TestValues => [null, 1, 2, -3];
     }
 
-    public class NullableIntCopierTests(ITestOutputHelper output) : CopierTester<int?, IDeepCopier<int?>>(output)
+    public class NullableIntCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<int?, IDeepCopier<int?>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override IDeepCopier<int?> CreateCopier() => ServiceProvider.GetRequiredService<ICodecProvider>().GetDeepCopier<int?>();
         protected override int? CreateValue() => TestValues[Random.Next(TestValues.Length)];
         protected override int?[] TestValues => [null, 1, 2, -3];
     }
 
-    public class DateTimeTests(ITestOutputHelper output) : FieldCodecTester<DateTime, DateTimeCodec>(output)
+    public class DateTimeTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<DateTime, DateTimeCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override DateTime CreateValue() => DateTime.UtcNow;
         protected override DateTime[] TestValues => [DateTime.MinValue, DateTime.MaxValue, new DateTime(1970, 1, 1, 0, 0, 0)];
         protected override Action<Action<DateTime>> ValueProvider => Gen.DateTime.ToValueProvider();
     }
 
-    public class DateTimeCopierTests(ITestOutputHelper output) : CopierTester<DateTime, IDeepCopier<DateTime>>(output)
+    public class DateTimeCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<DateTime, IDeepCopier<DateTime>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override DateTime CreateValue() => DateTime.UtcNow;
         protected override DateTime[] TestValues => [DateTime.MinValue, DateTime.MaxValue, new DateTime(1970, 1, 1, 0, 0, 0)];
@@ -269,28 +269,28 @@ namespace Orleans.Serialization.UnitTests
     }
 
 #if NET6_0_OR_GREATER
-    public class DateOnlyTests(ITestOutputHelper output) : FieldCodecTester<DateOnly, DateOnlyCodec>(output)
+    public class DateOnlyTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<DateOnly, DateOnlyCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override DateOnly CreateValue() => DateOnly.FromDateTime(DateTime.UtcNow);
         protected override DateOnly[] TestValues => [DateOnly.MinValue, DateOnly.MaxValue, new DateOnly(1970, 1, 1), CreateValue()];
         protected override Action<Action<DateOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(DateOnly.FromDateTime(dt)));
     }
 
-    public class TimeOnlyTests(ITestOutputHelper output) : FieldCodecTester<TimeOnly, TimeOnlyCodec>(output)
+    public class TimeOnlyTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<TimeOnly, TimeOnlyCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override TimeOnly CreateValue() => TimeOnly.FromDateTime(DateTime.UtcNow);
         protected override TimeOnly[] TestValues => [TimeOnly.MinValue, TimeOnly.MaxValue, TimeOnly.FromTimeSpan(TimeSpan.Zero), CreateValue()];
         protected override Action<Action<TimeOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(TimeOnly.FromDateTime(dt)));
     }
 
-    public class DateOnlyCopierTests(ITestOutputHelper output) : CopierTester<DateOnly, IDeepCopier<DateOnly>>(output)
+    public class DateOnlyCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<DateOnly, IDeepCopier<DateOnly>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override DateOnly CreateValue() => DateOnly.FromDateTime(DateTime.UtcNow);
         protected override DateOnly[] TestValues => [DateOnly.MinValue, DateOnly.MaxValue, new DateOnly(1970, 1, 1), CreateValue()];
         protected override Action<Action<DateOnly>> ValueProvider => assert => Gen.Date.Sample(dt => assert(DateOnly.FromDateTime(dt)));
     }
 
-    public class TimeOnlyCopierTests(ITestOutputHelper output) : CopierTester<TimeOnly, IDeepCopier<TimeOnly>>(output)
+    public class TimeOnlyCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<TimeOnly, IDeepCopier<TimeOnly>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override TimeOnly CreateValue() => TimeOnly.FromDateTime(DateTime.UtcNow);
         protected override TimeOnly[] TestValues => [TimeOnly.MinValue, TimeOnly.MaxValue, TimeOnly.FromTimeSpan(TimeSpan.Zero), CreateValue()];
@@ -298,21 +298,21 @@ namespace Orleans.Serialization.UnitTests
     }
 #endif
 
-    public class TimeSpanTests(ITestOutputHelper output) : FieldCodecTester<TimeSpan, TimeSpanCodec>(output)
+    public class TimeSpanTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<TimeSpan, TimeSpanCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override TimeSpan CreateValue() => TimeSpan.FromMilliseconds(Guid.NewGuid().GetHashCode());
         protected override TimeSpan[] TestValues => [TimeSpan.MinValue, TimeSpan.MaxValue, TimeSpan.Zero, TimeSpan.FromSeconds(12345)];
         protected override Action<Action<TimeSpan>> ValueProvider => Gen.TimeSpan.ToValueProvider();
     }
 
-    public class TimeSpanCopierTests(ITestOutputHelper output) : CopierTester<TimeSpan, IDeepCopier<TimeSpan>>(output)
+    public class TimeSpanCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<TimeSpan, IDeepCopier<TimeSpan>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override TimeSpan CreateValue() => TimeSpan.FromMilliseconds(Guid.NewGuid().GetHashCode());
         protected override TimeSpan[] TestValues => [TimeSpan.MinValue, TimeSpan.MaxValue, TimeSpan.Zero, TimeSpan.FromSeconds(12345)];
         protected override Action<Action<TimeSpan>> ValueProvider => Gen.TimeSpan.ToValueProvider();
     }
 
-    public class DateTimeOffsetTests(ITestOutputHelper output) : FieldCodecTester<DateTimeOffset, DateTimeOffsetCodec>(output)
+    public class DateTimeOffsetTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<DateTimeOffset, DateTimeOffsetCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override DateTimeOffset CreateValue() => DateTime.UtcNow;
         protected override DateTimeOffset[] TestValues =>
@@ -326,7 +326,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<DateTimeOffset>> ValueProvider => Gen.DateTimeOffset.ToValueProvider();
     }
 
-    public class DateTimeOffsetCopierTests(ITestOutputHelper output) : CopierTester<DateTimeOffset, IDeepCopier<DateTimeOffset>>(output)
+    public class DateTimeOffsetCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<DateTimeOffset, IDeepCopier<DateTimeOffset>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override DateTimeOffset CreateValue() => DateTime.UtcNow;
         protected override DateTimeOffset[] TestValues =>
@@ -340,7 +340,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<DateTimeOffset>> ValueProvider => Gen.DateTimeOffset.ToValueProvider();
     }
 
-    public class VersionTests(ITestOutputHelper output) : FieldCodecTester<Version, VersionCodec>(output)
+    public class VersionTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Version, VersionCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Version CreateValue() => new();
         protected override Version[] TestValues =>
@@ -357,7 +357,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(Version left, Version right) => left == right && (left is null || left.GetHashCode() == right.GetHashCode());
     }
 
-    public class VersionCopierTests(ITestOutputHelper output) : CopierTester<Version, IDeepCopier<Version>>(output)
+    public class VersionCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Version, IDeepCopier<Version>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Version CreateValue() => new();
         protected override Version[] TestValues =>
@@ -376,7 +376,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class BitVector32Tests(ITestOutputHelper output) : FieldCodecTester<BitVector32, BitVector32Codec>(output)
+    public class BitVector32Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<BitVector32, BitVector32Codec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override BitVector32 CreateValue() => new(Random.Next());
 
@@ -393,7 +393,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(BitVector32 left, BitVector32 right) => left.Equals(right) && left.GetHashCode() == right.GetHashCode();
     }
 
-    public class BitVector32CopierTests(ITestOutputHelper output) : CopierTester<BitVector32, IDeepCopier<BitVector32>>(output)
+    public class BitVector32CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<BitVector32, IDeepCopier<BitVector32>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override BitVector32 CreateValue() => new(Random.Next());
 
@@ -410,7 +410,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(BitVector32 left, BitVector32 right) => left.Equals(right) && left.GetHashCode() == right.GetHashCode();
     }
 
-    public class KeyValuePairTests(ITestOutputHelper output) : FieldCodecTester<KeyValuePair<string, string>, KeyValuePairCodec<string, string>>(output)
+    public class KeyValuePairTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<KeyValuePair<string, string>, KeyValuePairCodec<string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override KeyValuePair<string, string> CreateValue() => KeyValuePair.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
@@ -424,7 +424,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class KeyValuePairCopierTests(ITestOutputHelper output) : CopierTester<KeyValuePair<string, string>, KeyValuePairCopier<string, string>>(output)
+    public class KeyValuePairCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<KeyValuePair<string, string>, KeyValuePairCopier<string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override KeyValuePair<string, string> CreateValue() => KeyValuePair.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
@@ -438,7 +438,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class Tuple1Tests(ITestOutputHelper output) : FieldCodecTester<Tuple<string>, TupleCodec<string>>(output)
+    public class Tuple1Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Tuple<string>, TupleCodec<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string> CreateValue() => Tuple.Create(Guid.NewGuid().ToString());
 
@@ -451,7 +451,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class Tuple1CopierTests(ITestOutputHelper output) : CopierTester<Tuple<string>, TupleCopier<string>>(output)
+    public class Tuple1CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Tuple<string>, TupleCopier<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string> CreateValue() => Tuple.Create(Guid.NewGuid().ToString());
 
@@ -466,7 +466,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class Tuple2Tests(ITestOutputHelper output) : FieldCodecTester<Tuple<string, string>, TupleCodec<string, string>>(output)
+    public class Tuple2Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Tuple<string, string>, TupleCodec<string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string> CreateValue() => Tuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
@@ -480,7 +480,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class Tuple2CopierTests(ITestOutputHelper output) : CopierTester<Tuple<string, string>, TupleCopier<string, string>>(output)
+    public class Tuple2CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Tuple<string, string>, TupleCopier<string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string> CreateValue() => Tuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
@@ -496,7 +496,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class Tuple3Tests(ITestOutputHelper output) : FieldCodecTester<Tuple<string, string, string>, TupleCodec<string, string, string>>(output)
+    public class Tuple3Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Tuple<string, string, string>, TupleCodec<string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
@@ -513,7 +513,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class Tuple3CopierTests(ITestOutputHelper output) : CopierTester<Tuple<string, string, string>, TupleCopier<string, string, string>>(output)
+    public class Tuple3CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Tuple<string, string, string>, TupleCopier<string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
@@ -532,7 +532,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class Tuple4Tests(ITestOutputHelper output) : FieldCodecTester<Tuple<string, string, string, string>, TupleCodec<string, string, string, string>>(output)
+    public class Tuple4Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Tuple<string, string, string, string>, TupleCodec<string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
@@ -550,7 +550,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class Tuple4CopierTests(ITestOutputHelper output) : CopierTester<Tuple<string, string, string, string>, TupleCopier<string, string, string, string>>(output)
+    public class Tuple4CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Tuple<string, string, string, string>, TupleCopier<string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
@@ -570,7 +570,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class Tuple5Tests(ITestOutputHelper output) : FieldCodecTester<Tuple<string, string, string, string, string>, TupleCodec<string, string, string, string, string>>(output)
+    public class Tuple5Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Tuple<string, string, string, string, string>, TupleCodec<string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
@@ -589,7 +589,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class Tuple5CopierTests(ITestOutputHelper output) : CopierTester<Tuple<string, string, string, string, string>, TupleCopier<string, string, string, string, string>>(output)
+    public class Tuple5CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Tuple<string, string, string, string, string>, TupleCopier<string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
@@ -610,7 +610,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class Tuple6Tests(ITestOutputHelper output) : FieldCodecTester<Tuple<string, string,string, string, string, string>, TupleCodec<string, string, string, string, string, string>>(output)
+    public class Tuple6Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Tuple<string, string,string, string, string, string>, TupleCodec<string, string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
@@ -630,7 +630,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class Tuple6CopierTests(ITestOutputHelper output) : CopierTester<Tuple<string, string,string, string, string, string>, TupleCopier<string, string, string, string, string, string>>(output)
+    public class Tuple6CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Tuple<string, string,string, string, string, string>, TupleCopier<string, string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
@@ -652,7 +652,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class Tuple7Tests(ITestOutputHelper output) : FieldCodecTester<Tuple<string, string, string, string, string, string, string>, TupleCodec<string, string, string, string, string, string, string>>(output)
+    public class Tuple7Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Tuple<string, string, string, string, string, string, string>, TupleCodec<string, string, string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
@@ -673,7 +673,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class Tuple7CopierTests(ITestOutputHelper output) : CopierTester<Tuple<string, string, string, string, string, string, string>, TupleCopier<string, string, string, string, string, string, string>>(output)
+    public class Tuple7CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Tuple<string, string, string, string, string, string, string>, TupleCopier<string, string, string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string, string, string, string, string> CreateValue() => Tuple.Create(
             Guid.NewGuid().ToString(),
@@ -696,7 +696,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class Tuple8Tests(ITestOutputHelper output) : FieldCodecTester<Tuple<string, string, string, string, string, string, string, Tuple<string>>, TupleCodec<string, string, string, string, string, string, string, Tuple<string>>>(output)
+    public class Tuple8Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Tuple<string, string, string, string, string, string, string, Tuple<string>>, TupleCodec<string, string, string, string, string, string, string, Tuple<string>>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string, string, string, string, string, Tuple<string>> CreateValue() => new(
             Guid.NewGuid().ToString(),
@@ -718,7 +718,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class Tuple8CopierTests(ITestOutputHelper output) : CopierTester<Tuple<string, string, string, string, string, string, string, Tuple<string>>, TupleCopier<string, string, string, string, string, string, string, Tuple<string>>>(output)
+    public class Tuple8CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Tuple<string, string, string, string, string, string, string, Tuple<string>>, TupleCopier<string, string, string, string, string, string, string, Tuple<string>>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Tuple<string, string, string, string, string, string, string, Tuple<string>> CreateValue() => new(
             Guid.NewGuid().ToString(),
@@ -742,21 +742,21 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class ValueTupleTests(ITestOutputHelper output) : FieldCodecTester<ValueTuple, ValueTupleCodec>(output)
+    public class ValueTupleTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ValueTuple, ValueTupleCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple CreateValue() => default;
 
         protected override ValueTuple[] TestValues => [ default ];
     }
 
-    public class ValueTupleCopierTests(ITestOutputHelper output) : CopierTester<ValueTuple, ValueTupleCopier>(output)
+    public class ValueTupleCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ValueTuple, ValueTupleCopier>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple CreateValue() => default;
 
         protected override ValueTuple[] TestValues => [ default ];
     }
 
-    public class ValueTuple1Tests(ITestOutputHelper output) : FieldCodecTester<ValueTuple<string>, ValueTupleCodec<string>>(output)
+    public class ValueTuple1Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ValueTuple<string>, ValueTupleCodec<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string> CreateValue() => ValueTuple.Create(Guid.NewGuid().ToString());
 
@@ -769,7 +769,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple1CopierTests(ITestOutputHelper output) : CopierTester<ValueTuple<string>, ValueTupleCopier<string>>(output)
+    public class ValueTuple1CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ValueTuple<string>, ValueTupleCopier<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string> CreateValue() => ValueTuple.Create(Guid.NewGuid().ToString());
 
@@ -782,7 +782,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple2Tests(ITestOutputHelper output) : FieldCodecTester<ValueTuple<string, string>, ValueTupleCodec<string, string>>(output)
+    public class ValueTuple2Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ValueTuple<string, string>, ValueTupleCodec<string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string> CreateValue() => ValueTuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
@@ -796,7 +796,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple2CopierTests(ITestOutputHelper output) : CopierTester<ValueTuple<string, string>, ValueTupleCopier<string, string>>(output)
+    public class ValueTuple2CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ValueTuple<string, string>, ValueTupleCopier<string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string> CreateValue() => ValueTuple.Create(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
 
@@ -810,7 +810,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple3Tests(ITestOutputHelper output) : FieldCodecTester<ValueTuple<string, string, string>, ValueTupleCodec<string, string, string>>(output)
+    public class ValueTuple3Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ValueTuple<string, string, string>, ValueTupleCodec<string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
@@ -827,7 +827,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple3CopierTests(ITestOutputHelper output) : CopierTester<ValueTuple<string, string, string>, ValueTupleCopier<string, string, string>>(output)
+    public class ValueTuple3CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ValueTuple<string, string, string>, ValueTupleCopier<string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
@@ -844,7 +844,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple4Tests(ITestOutputHelper output) : FieldCodecTester<ValueTuple<string, string, string, string>, ValueTupleCodec<string, string, string, string>>(output)
+    public class ValueTuple4Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ValueTuple<string, string, string, string>, ValueTupleCodec<string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
@@ -862,7 +862,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple4CopierTests(ITestOutputHelper output) : CopierTester<ValueTuple<string, string, string, string>, ValueTupleCopier<string, string, string, string>>(output)
+    public class ValueTuple4CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ValueTuple<string, string, string, string>, ValueTupleCopier<string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
@@ -880,7 +880,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple5Tests(ITestOutputHelper output) : FieldCodecTester<ValueTuple<string, string, string, string, string>, ValueTupleCodec<string, string, string, string, string>>(output)
+    public class ValueTuple5Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ValueTuple<string, string, string, string, string>, ValueTupleCodec<string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
@@ -899,7 +899,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple5CopierTests(ITestOutputHelper output) : CopierTester<ValueTuple<string, string, string, string, string>, ValueTupleCopier<string, string, string, string, string>>(output)
+    public class ValueTuple5CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ValueTuple<string, string, string, string, string>, ValueTupleCopier<string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
@@ -918,7 +918,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple6Tests(ITestOutputHelper output) : FieldCodecTester<ValueTuple<string, string,string, string, string, string>, ValueTupleCodec<string, string, string, string, string, string>>(output)
+    public class ValueTuple6Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ValueTuple<string, string,string, string, string, string>, ValueTupleCodec<string, string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
@@ -938,7 +938,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple6CopierTests(ITestOutputHelper output) : CopierTester<ValueTuple<string, string,string, string, string, string>, ValueTupleCopier<string, string, string, string, string, string>>(output)
+    public class ValueTuple6CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ValueTuple<string, string,string, string, string, string>, ValueTupleCopier<string, string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
@@ -958,7 +958,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple7Tests(ITestOutputHelper output) : FieldCodecTester<ValueTuple<string, string, string, string, string, string, string>, ValueTupleCodec<string, string, string, string, string, string, string>>(output)
+    public class ValueTuple7Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ValueTuple<string, string, string, string, string, string, string>, ValueTupleCodec<string, string, string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
@@ -979,7 +979,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple7opierTests(ITestOutputHelper output) : CopierTester<ValueTuple<string, string, string, string, string, string, string>, ValueTupleCopier<string, string, string, string, string, string, string>>(output)
+    public class ValueTuple7opierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ValueTuple<string, string, string, string, string, string, string>, ValueTupleCopier<string, string, string, string, string, string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string, string, string, string, string> CreateValue() => ValueTuple.Create(
             Guid.NewGuid().ToString(),
@@ -1000,7 +1000,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple8Tests(ITestOutputHelper output) : FieldCodecTester<ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>, ValueTupleCodec<string, string, string, string, string, string, string, ValueTuple<string>>>(output)
+    public class ValueTuple8Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>, ValueTupleCodec<string, string, string, string, string, string, string, ValueTuple<string>>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>> CreateValue() => new(
             Guid.NewGuid().ToString(),
@@ -1022,7 +1022,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ValueTuple8CopierTests(ITestOutputHelper output) : CopierTester<ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>, ValueTupleCopier<string, string, string, string, string, string, string, ValueTuple<string>>>(output)
+    public class ValueTuple8CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>>, ValueTupleCopier<string, string, string, string, string, string, string, ValueTuple<string>>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ValueTuple<string, string, string, string, string, string, string, ValueTuple<string>> CreateValue() => new(
             Guid.NewGuid().ToString(),
@@ -1044,28 +1044,28 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class BoolCodecTests(ITestOutputHelper output) : FieldCodecTester<bool, BoolCodec>(output)
+    public class BoolCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<bool, BoolCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool CreateValue() => true;
         protected override bool Equals(bool left, bool right) => left == right;
         protected override bool[] TestValues => [false, true];
     }
 
-    public class BoolCopierTests(ITestOutputHelper output) : CopierTester<bool, IDeepCopier<bool>>(output)
+    public class BoolCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<bool, IDeepCopier<bool>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool CreateValue() => true;
         protected override bool Equals(bool left, bool right) => left == right;
         protected override bool[] TestValues => [false, true];
     }
 
-    public class StringCodecTests(ITestOutputHelper output) : FieldCodecTester<string, StringCodec>(output)
+    public class StringCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<string, StringCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override string CreateValue() => Guid.NewGuid().ToString();
         protected override bool Equals(string left, string right) => StringComparer.Ordinal.Equals(left, right);
         protected override string[] TestValues => [null, string.Empty, new string('*', 6), new string('x', 4097), "Hello, World!"];
     }
 
-    public class StringCopierTests(ITestOutputHelper output) : CopierTester<string, IDeepCopier<string>>(output)
+    public class StringCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<string, IDeepCopier<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override string CreateValue() => Guid.NewGuid().ToString();
         protected override bool Equals(string left, string right) => StringComparer.Ordinal.Equals(left, right);
@@ -1074,14 +1074,14 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class ObjectCodecTests(ITestOutputHelper output) : FieldCodecTester<object, ObjectCodec>(output)
+    public class ObjectCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<object, ObjectCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override object CreateValue() => new();
         protected override bool Equals(object left, object right) => ReferenceEquals(left, right) || typeof(object) == left?.GetType() && typeof(object) == right?.GetType();
         protected override object[] TestValues => [null, new object()];
     }
 
-    public class ObjectCopierTests(ITestOutputHelper output) : CopierTester<object, ObjectCopier>(output)
+    public class ObjectCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<object, ObjectCopier>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override object CreateValue() => new();
         protected override bool Equals(object left, object right) => ReferenceEquals(left, right) || typeof(object) == left?.GetType() && typeof(object) == right?.GetType();
@@ -1089,7 +1089,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class BitArrayCodecTests(ITestOutputHelper output) : FieldCodecTester<BitArray, BitArrayCodec>(output)
+    public class BitArrayCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<BitArray, BitArrayCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override BitArray CreateValue() => new BitArray(Guid.NewGuid().ToByteArray());
 
@@ -1104,7 +1104,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class BitArrayCopierTests(ITestOutputHelper output) : CopierTester<BitArray, BitArrayCopier>(output)
+    public class BitArrayCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<BitArray, BitArrayCopier>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override BitArray CreateValue() => new BitArray(Guid.NewGuid().ToByteArray());
 
@@ -1119,7 +1119,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ByteArrayCodecTests(ITestOutputHelper output) : FieldCodecTester<byte[], ByteArrayCodec>(output)
+    public class ByteArrayCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<byte[], ByteArrayCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override byte[] CreateValue() => Guid.NewGuid().ToByteArray();
 
@@ -1133,7 +1133,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class ByteArrayCopierTests(ITestOutputHelper output) : CopierTester<byte[], ByteArrayCopier>(output)
+    public class ByteArrayCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<byte[], ByteArrayCopier>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override byte[] CreateValue() => Guid.NewGuid().ToByteArray();
 
@@ -1147,7 +1147,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class MemoryCodecTests(ITestOutputHelper output) : FieldCodecTester<Memory<int>, MemoryCodec<int>>(output)
+    public class MemoryCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Memory<int>, MemoryCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Memory<int> CreateValue()
         {
@@ -1161,7 +1161,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Memory<int>[] TestValues => [default, new Memory<int>([], 0, 0), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class MemoryCopierTests(ITestOutputHelper output) : CopierTester<Memory<int>, MemoryCopier<int>>(output)
+    public class MemoryCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Memory<int>, MemoryCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Memory<int> CreateValue()
         {
@@ -1175,7 +1175,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Memory<int>[] TestValues => [default, new Memory<int>([], 0, 0), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ReadOnlyMemoryCodecTests(ITestOutputHelper output) : FieldCodecTester<ReadOnlyMemory<int>, ReadOnlyMemoryCodec<int>>(output)
+    public class ReadOnlyMemoryCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ReadOnlyMemory<int>, ReadOnlyMemoryCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ReadOnlyMemory<int> CreateValue()
         {
@@ -1189,7 +1189,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ReadOnlyMemory<int>[] TestValues => [default, new ReadOnlyMemory<int>([], 0, 0), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ReadOnlyMemoryCopierTests(ITestOutputHelper output) : CopierTester<ReadOnlyMemory<int>, ReadOnlyMemoryCopier<int>>(output)
+    public class ReadOnlyMemoryCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ReadOnlyMemory<int>, ReadOnlyMemoryCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ReadOnlyMemory<int> CreateValue()
         {
@@ -1203,7 +1203,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ReadOnlyMemory<int>[] TestValues => [default, new ReadOnlyMemory<int>([], 0, 0), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ArraySegmentCodecTests(ITestOutputHelper output) : FieldCodecTester<ArraySegment<int>, ArraySegmentCodec<int>>(output)
+    public class ArraySegmentCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ArraySegment<int>, ArraySegmentCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ArraySegment<int> CreateValue()
         {
@@ -1217,7 +1217,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ArraySegment<int>[] TestValues => [default, new ArraySegment<int>([], 0, 0), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ArraySegmentCopierTests(ITestOutputHelper output) : CopierTester<ArraySegment<int>, ArraySegmentCopier<int>>(output)
+    public class ArraySegmentCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ArraySegment<int>, ArraySegmentCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ArraySegment<int> CreateValue()
         {
@@ -1231,35 +1231,35 @@ namespace Orleans.Serialization.UnitTests
         protected override ArraySegment<int>[] TestValues => [default, new ArraySegment<int>([], 0, 0), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ArrayCodecTests(ITestOutputHelper output) : FieldCodecTester<int[], ArrayCodec<int>>(output)
+    public class ArrayCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<int[], ArrayCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override int[] CreateValue() => Enumerable.Range(0, Random.Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToArray();
         protected override bool Equals(int[] left, int[] right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
         protected override int[][] TestValues => [null, [], CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ArrayCopierTests(ITestOutputHelper output) : CopierTester<int[], ArrayCopier<int>>(output)
+    public class ArrayCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<int[], ArrayCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override int[] CreateValue() => Enumerable.Range(0, Random.Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToArray();
         protected override bool Equals(int[] left, int[] right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
         protected override int[][] TestValues => [null, [], CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ImmutableArrayCodecTests(ITestOutputHelper output) : FieldCodecTester<ImmutableArray<int>, ImmutableArrayCodec<int>>(output)
+    public class ImmutableArrayCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ImmutableArray<int>, ImmutableArrayCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ImmutableArray<int> CreateValue() => Enumerable.Range(0, Random.Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToImmutableArray();
         protected override bool Equals(ImmutableArray<int> left, ImmutableArray<int> right) => (left.IsDefault && right.IsDefault) || left.SequenceEqual(right);
         protected override ImmutableArray<int>[] TestValues => [default, [], CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ImmutableArrayCopierTests(ITestOutputHelper output) : CopierTester<ImmutableArray<int>, ImmutableArrayCopier<int>>(output)
+    public class ImmutableArrayCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ImmutableArray<int>, ImmutableArrayCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ImmutableArray<int> CreateValue() => Enumerable.Range(0, Random.Next(120) + 50).Select(_ => Guid.NewGuid().GetHashCode()).ToImmutableArray();
         protected override bool Equals(ImmutableArray<int> left, ImmutableArray<int> right) => (left.IsDefault && right.IsDefault) || left.SequenceEqual(right);
         protected override ImmutableArray<int>[] TestValues => [default, [], CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class PooledBufferCodecTests(ITestOutputHelper output) : FieldCodecTester<PooledBuffer, PooledBufferCodec>(output)
+    public class PooledBufferCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<PooledBuffer, PooledBufferCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override PooledBuffer CreateValue()
         {
@@ -1288,7 +1288,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class PooledBufferCopierTests(ITestOutputHelper output) : CopierTester<PooledBuffer, PooledBufferCopier>(output)
+    public class PooledBufferCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<PooledBuffer, PooledBufferCopier>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
 
@@ -1317,7 +1317,7 @@ namespace Orleans.Serialization.UnitTests
     }
 
 #if NET7_0_OR_GREATER
-    public class UInt128CodecTests(ITestOutputHelper output) : FieldCodecTester<UInt128, UInt128Codec>(output)
+    public class UInt128CodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<UInt128, UInt128Codec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override UInt128 CreateValue() => new (unchecked((ulong)Random.NextInt64()), unchecked((ulong)Random.NextInt64()));
 
@@ -1340,7 +1340,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<UInt128>> ValueProvider => assert => Gen.ULong.Select(Gen.ULong).Sample(value => assert(new (value.Item1, value.Item2)));
     }
 
-    public class UInt128CopierTests(ITestOutputHelper output) : CopierTester<UInt128, IDeepCopier<UInt128>>(output)
+    public class UInt128CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<UInt128, IDeepCopier<UInt128>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override UInt128 CreateValue() => new (unchecked((ulong)Random.NextInt64()), unchecked((ulong)Random.NextInt64()));
 
@@ -1364,7 +1364,7 @@ namespace Orleans.Serialization.UnitTests
     }
 #endif
 
-    public class BigIntegerCodecTests(ITestOutputHelper output) : FieldCodecTester<BigInteger, BigIntegerCodec>(output)
+    public class BigIntegerCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<BigInteger, BigIntegerCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         // New behavior in .NET 9: https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/biginteger-limit#new-behavior
         protected override int[] MaxSegmentSizes => [(2^31)-1];
@@ -1417,7 +1417,7 @@ namespace Orleans.Serialization.UnitTests
         };
     }
 
-    public class BigIntegerCopierTests(ITestOutputHelper output) : CopierTester<BigInteger, ShallowCopier<BigInteger>>(output)
+    public class BigIntegerCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<BigInteger, ShallowCopier<BigInteger>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
 
@@ -1471,7 +1471,7 @@ namespace Orleans.Serialization.UnitTests
         };
     }
 
-    public class UInt64CodecTests(ITestOutputHelper output) : FieldCodecTester<ulong, UInt64Codec>(output)
+    public class UInt64CodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ulong, UInt64Codec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ulong CreateValue()
         {
@@ -1502,7 +1502,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<ulong>> ValueProvider => Gen.ULong.ToValueProvider();
     }
 
-    public class UInt64CopierTests(ITestOutputHelper output) : CopierTester<ulong, IDeepCopier<ulong>>(output)
+    public class UInt64CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ulong, IDeepCopier<ulong>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ulong CreateValue()
         {
@@ -1530,7 +1530,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<ulong>> ValueProvider => Gen.ULong.ToValueProvider();
     }
 
-    public class UInt32CodecTests(ITestOutputHelper output) : FieldCodecTester<uint, UInt32Codec>(output)
+    public class UInt32CodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<uint, UInt32Codec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override uint CreateValue() => (uint)Guid.NewGuid().GetHashCode();
 
@@ -1552,7 +1552,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<uint>> ValueProvider => Gen.UInt.ToValueProvider();
     }
 
-    public class UInt32CopierTests(ITestOutputHelper output) : CopierTester<uint, IDeepCopier<uint>>(output)
+    public class UInt32CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<uint, IDeepCopier<uint>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override uint CreateValue() => (uint)Guid.NewGuid().GetHashCode();
 
@@ -1572,7 +1572,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<uint>> ValueProvider => Gen.UInt.ToValueProvider();
     }
 
-    public class UInt16CodecTests(ITestOutputHelper output) : FieldCodecTester<ushort, UInt16Codec>(output)
+    public class UInt16CodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ushort, UInt16Codec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ushort CreateValue() => (ushort)Guid.NewGuid().GetHashCode();
         protected override ushort[] TestValues =>
@@ -1589,7 +1589,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<ushort>> ValueProvider => Gen.UShort.ToValueProvider();
     }
 
-    public class UInt16CopierTests(ITestOutputHelper output) : CopierTester<ushort, IDeepCopier<ushort>>(output)
+    public class UInt16CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ushort, IDeepCopier<ushort>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ushort CreateValue() => (ushort)Guid.NewGuid().GetHashCode();
         protected override ushort[] TestValues =>
@@ -1606,7 +1606,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<ushort>> ValueProvider => Gen.UShort.ToValueProvider();
     }
 
-    public class ByteCodecTests(ITestOutputHelper output) : FieldCodecTester<byte, ByteCodec>(output)
+    public class ByteCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<byte, ByteCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override byte CreateValue() => (byte)Guid.NewGuid().GetHashCode();
         protected override byte[] TestValues => [0, 1, byte.MaxValue - 1, byte.MaxValue];
@@ -1614,7 +1614,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<byte>> ValueProvider => Gen.Byte.ToValueProvider();
     }
 
-    public class ByteCopierTests(ITestOutputHelper output) : CopierTester<byte, IDeepCopier<byte>>(output)
+    public class ByteCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<byte, IDeepCopier<byte>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override byte CreateValue() => (byte)Guid.NewGuid().GetHashCode();
         protected override byte[] TestValues => [0, 1, byte.MaxValue - 1, byte.MaxValue];
@@ -1623,7 +1623,7 @@ namespace Orleans.Serialization.UnitTests
     }
 
 #if NET7_0_OR_GREATER
-    public class Int128CodecTests(ITestOutputHelper output) : FieldCodecTester<Int128, Int128Codec>(output)
+    public class Int128CodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Int128, Int128Codec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Int128 CreateValue() => new (unchecked((ulong)Random.NextInt64()), unchecked((ulong)Random.NextInt64()));
 
@@ -1646,7 +1646,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<Int128>> ValueProvider => assert => Gen.ULong.Select(Gen.ULong).Sample(value => assert(new (value.Item1, value.Item2)));
     }
 
-    public class Int128CopierTests(ITestOutputHelper output) : CopierTester<Int128, IDeepCopier<Int128>>(output)
+    public class Int128CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Int128, IDeepCopier<Int128>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Int128 CreateValue() => new Int128(unchecked((ulong)Random.NextInt64()), unchecked((ulong)Random.NextInt64()));
 
@@ -1670,7 +1670,7 @@ namespace Orleans.Serialization.UnitTests
     }
 #endif
 
-    public class Int64CodecTests(ITestOutputHelper output) : FieldCodecTester<long, Int64Codec>(output)
+    public class Int64CodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<long, Int64Codec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override long CreateValue()
         {
@@ -1700,7 +1700,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<long>> ValueProvider => Gen.Long.ToValueProvider();
     }
 
-    public class Int64CopierTests(ITestOutputHelper output) : CopierTester<long, IDeepCopier<long>>(output)
+    public class Int64CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<long, IDeepCopier<long>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override long CreateValue()
         {
@@ -1730,7 +1730,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<long>> ValueProvider => Gen.Long.ToValueProvider();
     }
 
-    public class Int32CodecTests(ITestOutputHelper output) : FieldCodecTester<int, Int32Codec>(output)
+    public class Int32CodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<int, Int32Codec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override int CreateValue() => Guid.NewGuid().GetHashCode();
 
@@ -1781,7 +1781,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class Int32CopierTests(ITestOutputHelper output) : CopierTester<int, IDeepCopier<int>>(output)
+    public class Int32CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<int, IDeepCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override int CreateValue() => Guid.NewGuid().GetHashCode();
 
@@ -1804,7 +1804,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<int>> ValueProvider => Gen.Int.ToValueProvider();
     }
 
-    public class Int16CodecTests(ITestOutputHelper output) : FieldCodecTester<short, Int16Codec>(output)
+    public class Int16CodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<short, Int16Codec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override short CreateValue() => (short)Guid.NewGuid().GetHashCode();
 
@@ -1824,7 +1824,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<short>> ValueProvider => Gen.Short.ToValueProvider();
     }
 
-    public class Int16CopierTests(ITestOutputHelper output) : CopierTester<short, IDeepCopier<short>>(output)
+    public class Int16CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<short, IDeepCopier<short>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override short CreateValue() => (short)Guid.NewGuid().GetHashCode();
 
@@ -1844,7 +1844,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<short>> ValueProvider => Gen.Short.ToValueProvider();
     }
 
-    public class SByteCodecTests(ITestOutputHelper output) : FieldCodecTester<sbyte, SByteCodec>(output)
+    public class SByteCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<sbyte, SByteCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override sbyte CreateValue() => (sbyte)Guid.NewGuid().GetHashCode();
 
@@ -1861,7 +1861,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<sbyte>> ValueProvider => Gen.SByte.ToValueProvider();
     }
 
-    public class SByteCopierTests(ITestOutputHelper output) : CopierTester<sbyte, IDeepCopier<sbyte>>(output)
+    public class SByteCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<sbyte, IDeepCopier<sbyte>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override sbyte CreateValue() => (sbyte)Guid.NewGuid().GetHashCode();
 
@@ -1878,7 +1878,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<sbyte>> ValueProvider => Gen.SByte.ToValueProvider();
     }
 
-    public class CharCodecTests(ITestOutputHelper output) : FieldCodecTester<char, CharCodec>(output)
+    public class CharCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<char, CharCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         private int _createValueCount;
 
@@ -1897,7 +1897,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<char>> ValueProvider => Gen.Char.ToValueProvider();
     }
 
-    public class CharCopierTests(ITestOutputHelper output) : CopierTester<char, IDeepCopier<char>>(output)
+    public class CharCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<char, IDeepCopier<char>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         private int _createValueCount;
 
@@ -1916,7 +1916,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<char>> ValueProvider => Gen.Char.ToValueProvider();
     }
 
-    public class GuidCodecTests(ITestOutputHelper output) : FieldCodecTester<Guid, GuidCodec>(output)
+    public class GuidCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Guid, GuidCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Guid CreateValue() => Guid.NewGuid();
         protected override Guid[] TestValues =>
@@ -1929,7 +1929,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<Guid>> ValueProvider => Gen.Guid.ToValueProvider();
     }
 
-    public class GuidCopierTests(ITestOutputHelper output) : CopierTester<Guid, IDeepCopier<Guid>>(output)
+    public class GuidCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Guid, IDeepCopier<Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Guid CreateValue() => Guid.NewGuid();
         protected override Guid[] TestValues =>
@@ -1942,7 +1942,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<Guid>> ValueProvider => Gen.Guid.ToValueProvider();
     }
 
-    public class TypeCodecTests(ITestOutputHelper output) : FieldCodecTester<Type, TypeSerializerCodec>(output)
+    public class TypeCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Type, TypeSerializerCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         private readonly Type[] _values =
         [
@@ -1966,7 +1966,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Type[] TestValues => _values;
     }
 
-    public class TypeCopierTests(ITestOutputHelper output) : CopierTester<Type, IDeepCopier<Type>>(output)
+    public class TypeCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Type, IDeepCopier<Type>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         private readonly Type[] _values =
         [
@@ -1992,7 +1992,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class FloatCodecTests(ITestOutputHelper output) : FieldCodecTester<float, FloatCodec>(output)
+    public class FloatCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<float, FloatCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override float CreateValue() => float.MaxValue * (float)Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override float[] TestValues => [float.MinValue, 0, 1.0f, float.MaxValue];
@@ -2000,7 +2000,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<float>> ValueProvider => Gen.Float.ToValueProvider();
     }
 
-    public class FloatCopierTests(ITestOutputHelper output) : CopierTester<float, IDeepCopier<float>>(output)
+    public class FloatCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<float, IDeepCopier<float>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override float CreateValue() => float.MaxValue * (float)Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override float[] TestValues => [float.MinValue, 0, 1.0f, float.MaxValue];
@@ -2009,7 +2009,7 @@ namespace Orleans.Serialization.UnitTests
     }
 
 #if NET5_0_OR_GREATER
-    public class HalfCodecTests(ITestOutputHelper output) : FieldCodecTester<Half, HalfCodec>(output)
+    public class HalfCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Half, HalfCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Half CreateValue() => (Half)BitConverter.UInt16BitsToHalf((ushort)Random.Next(ushort.MinValue, ushort.MaxValue));
         protected override Half[] TestValues => [Half.MinValue, (Half)0, (Half)1.0f, Half.Tau, Half.E, Half.Epsilon, Half.MaxValue];
@@ -2017,7 +2017,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<Half>> ValueProvider => assert => Gen.UShort.Sample(value => assert(BitConverter.UInt16BitsToHalf(value)));
     }
 
-    public class HalfCopierTests(ITestOutputHelper output) : CopierTester<Half, IDeepCopier<Half>>(output)
+    public class HalfCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Half, IDeepCopier<Half>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Half CreateValue() => (Half)BitConverter.UInt16BitsToHalf((ushort)Random.Next(ushort.MinValue, ushort.MaxValue));
         protected override Half[] TestValues => [Half.MinValue, (Half)0, (Half)1.0f, Half.Tau, Half.E, Half.Epsilon, Half.MaxValue];
@@ -2026,7 +2026,7 @@ namespace Orleans.Serialization.UnitTests
     }
 #endif
 
-    public class DoubleCodecTests(ITestOutputHelper output) : FieldCodecTester<double, DoubleCodec>(output)
+    public class DoubleCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<double, DoubleCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override double CreateValue() => double.MaxValue * Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override double[] TestValues => [double.MinValue, 0, 1.0, double.MaxValue];
@@ -2034,7 +2034,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<double>> ValueProvider => Gen.Double.ToValueProvider();
     }
 
-    public class DoubleCopierTests(ITestOutputHelper output) : CopierTester<double, IDeepCopier<double>>(output)
+    public class DoubleCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<double, IDeepCopier<double>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override double CreateValue() => double.MaxValue * Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override double[] TestValues => [double.MinValue, 0, 1.0, double.MaxValue];
@@ -2042,21 +2042,21 @@ namespace Orleans.Serialization.UnitTests
         protected override Action<Action<double>> ValueProvider => Gen.Double.ToValueProvider();
     }
 
-    public class DecimalCodecTests(ITestOutputHelper output) : FieldCodecTester<decimal, DecimalCodec>(output)
+    public class DecimalCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<decimal, DecimalCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override decimal CreateValue() => decimal.MaxValue * (decimal)Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override decimal[] TestValues => [decimal.MinValue, 0, 1.0M, decimal.MaxValue];
         protected override Action<Action<decimal>> ValueProvider => Gen.Decimal.ToValueProvider();
     }
 
-    public class DecimalCopierTests(ITestOutputHelper output) : CopierTester<decimal, IDeepCopier<decimal>>(output)
+    public class DecimalCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<decimal, IDeepCopier<decimal>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override decimal CreateValue() => decimal.MaxValue * (decimal)Random.NextDouble() * Math.Sign(Guid.NewGuid().GetHashCode());
         protected override decimal[] TestValues => [decimal.MinValue, 0, 1.0M, decimal.MaxValue];
         protected override Action<Action<decimal>> ValueProvider => Gen.Decimal.ToValueProvider();
     }
 
-    public class ListCodecTests(ITestOutputHelper output) : FieldCodecTester<List<int>, ListCodec<int>>(output)
+    public class ListCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<List<int>, ListCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override List<int> CreateValue()
         {
@@ -2092,7 +2092,7 @@ namespace Orleans.Serialization.UnitTests
         public override string ToString() => $"[OtherProperty: {OtherProperty}, Values: [{string.Join(", ", this)}]]";
     }
 
-    public class ListBaseCodecTests(ITestOutputHelper output) : FieldCodecTester<TypeWithListBase, IFieldCodec<TypeWithListBase>>(output)
+    public class ListBaseCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<TypeWithListBase, IFieldCodec<TypeWithListBase>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         private static TypeWithListBase AddValues(TypeWithListBase value)
         {
@@ -2108,7 +2108,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(TypeWithListBase left, TypeWithListBase right) => ReferenceEquals(left, right) || left.SequenceEqual(right) && left.OtherProperty == right.OtherProperty;
     }
 
-    public class ListBaseCopierTests(ITestOutputHelper output) : CopierTester<TypeWithListBase, IDeepCopier<TypeWithListBase>>(output)
+    public class ListBaseCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<TypeWithListBase, IDeepCopier<TypeWithListBase>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         private static TypeWithListBase AddValues(TypeWithListBase value)
         {
@@ -2124,7 +2124,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(TypeWithListBase left, TypeWithListBase right) => ReferenceEquals(left, right) || left.SequenceEqual(right) && left.OtherProperty == right.OtherProperty;
     }
 
-    public class ListCopierTests(ITestOutputHelper output) : CopierTester<List<int>, ListCopier<int>>(output)
+    public class ListCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<List<int>, ListCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override List<int> CreateValue()
         {
@@ -2142,7 +2142,7 @@ namespace Orleans.Serialization.UnitTests
         protected override List<int>[] TestValues => [null, new List<int>(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ImmutableListCodecTests(ITestOutputHelper output) : FieldCodecTester<ImmutableList<int>, ImmutableListCodec<int>>(output)
+    public class ImmutableListCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ImmutableList<int>, ImmutableListCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ImmutableList<int> CreateValue()
         {
@@ -2160,7 +2160,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ImmutableList<int>[] TestValues => [null, ImmutableList<int>.Empty, CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ImmutableListCopierTests(ITestOutputHelper output) : CopierTester<ImmutableList<int>, ImmutableListCopier<int>>(output)
+    public class ImmutableListCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ImmutableList<int>, ImmutableListCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override ImmutableList<int> CreateValue()
@@ -2179,7 +2179,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ImmutableList<int>[] TestValues => [null, ImmutableList<int>.Empty, CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class SortedListCodecTests(ITestOutputHelper output) : FieldCodecTester<SortedList<int, string>, SortedListCodec<int, string>>(output)
+    public class SortedListCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<SortedList<int, string>, SortedListCodec<int, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override SortedList<int, string> CreateValue()
         {
@@ -2198,7 +2198,7 @@ namespace Orleans.Serialization.UnitTests
         protected override SortedList<int, string>[] TestValues => [null, new SortedList<int, string>(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class SortedListCopierTests(ITestOutputHelper output) : CopierTester<SortedList<int, string>, SortedListCopier<int, string>>(output)
+    public class SortedListCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<SortedList<int, string>, SortedListCopier<int, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override SortedList<int, string> CreateValue()
         {
@@ -2217,7 +2217,7 @@ namespace Orleans.Serialization.UnitTests
         protected override SortedList<int, string>[] TestValues => [null, new SortedList<int, string>(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class SortedSetCodecTests(ITestOutputHelper output) : FieldCodecTester<SortedSet<int>, SortedSetCodec<int>>(output)
+    public class SortedSetCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<SortedSet<int>, SortedSetCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override SortedSet<int> CreateValue()
         {
@@ -2236,7 +2236,7 @@ namespace Orleans.Serialization.UnitTests
         protected override SortedSet<int>[] TestValues => [null, [], CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class SortedSetCopierTests(ITestOutputHelper output) : CopierTester<SortedSet<int>, SortedSetCopier<int>>(output)
+    public class SortedSetCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<SortedSet<int>, SortedSetCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override SortedSet<int> CreateValue()
         {
@@ -2255,7 +2255,7 @@ namespace Orleans.Serialization.UnitTests
         protected override SortedSet<int>[] TestValues => [null, [], CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ImmutableSortedSetCodecTests(ITestOutputHelper output) : FieldCodecTester<ImmutableSortedSet<int>, ImmutableSortedSetCodec<int>>(output)
+    public class ImmutableSortedSetCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ImmutableSortedSet<int>, ImmutableSortedSetCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ImmutableSortedSet<int> CreateValue()
         {
@@ -2274,7 +2274,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ImmutableSortedSet<int>[] TestValues => [null, [], CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ImmutableSortedSetCopierTests(ITestOutputHelper output) : CopierTester<ImmutableSortedSet<int>, ImmutableSortedSetCopier<int>>(output)
+    public class ImmutableSortedSetCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ImmutableSortedSet<int>, ImmutableSortedSetCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override ImmutableSortedSet<int> CreateValue()
@@ -2294,7 +2294,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ImmutableSortedSet<int>[] TestValues => [null, [], CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ArrayListCodecTests(ITestOutputHelper output) : FieldCodecTester<ArrayList, ArrayListCodec>(output)
+    public class ArrayListCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ArrayList, ArrayListCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ArrayList CreateValue()
         {
@@ -2312,7 +2312,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ArrayList[] TestValues => [null, new ArrayList(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ArrayListCopierTests(ITestOutputHelper output) : CopierTester<ArrayList, ArrayListCopier>(output)
+    public class ArrayListCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ArrayList, ArrayListCopier>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ArrayList CreateValue()
         {
@@ -2330,7 +2330,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ArrayList[] TestValues => [null, new ArrayList(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class CollectionCodecTests(ITestOutputHelper output) : FieldCodecTester<Collection<int>, CollectionCodec<int>>(output)
+    public class CollectionCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Collection<int>, CollectionCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Collection<int> CreateValue()
         {
@@ -2348,7 +2348,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Collection<int>[] TestValues => [null, new Collection<int>(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class CollectionCopierTests(ITestOutputHelper output) : CopierTester<Collection<int>, CollectionCopier<int>>(output)
+    public class CollectionCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Collection<int>, CollectionCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Collection<int> CreateValue()
         {
@@ -2384,7 +2384,7 @@ namespace Orleans.Serialization.UnitTests
         public override string ToString() => $"[OtherProperty: {OtherProperty}, Values: [{string.Join(", ", this)}]]";
     }
 
-    public class CollectionBaseCodecTests(ITestOutputHelper output) : FieldCodecTester<TypeWithCollectionBase, IFieldCodec<TypeWithCollectionBase>>(output)
+    public class CollectionBaseCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<TypeWithCollectionBase, IFieldCodec<TypeWithCollectionBase>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         private static TypeWithCollectionBase AddValues(TypeWithCollectionBase value)
         {
@@ -2400,7 +2400,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(TypeWithCollectionBase left, TypeWithCollectionBase right) => ReferenceEquals(left, right) || left.SequenceEqual(right) && left.OtherProperty == right.OtherProperty;
     }
 
-    public class CollectionBaseCopierTests(ITestOutputHelper output) : CopierTester<TypeWithCollectionBase, IDeepCopier<TypeWithCollectionBase>>(output)
+    public class CollectionBaseCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<TypeWithCollectionBase, IDeepCopier<TypeWithCollectionBase>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         private static TypeWithCollectionBase AddValues(TypeWithCollectionBase value)
         {
@@ -2416,7 +2416,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(TypeWithCollectionBase left, TypeWithCollectionBase right) => ReferenceEquals(left, right) || left.SequenceEqual(right) && left.OtherProperty == right.OtherProperty;
     }
 
-    public class ReadOnlyCollectionCodecTests(ITestOutputHelper output) : FieldCodecTester<ReadOnlyCollection<int>, ReadOnlyCollectionCodec<int>>(output)
+    public class ReadOnlyCollectionCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ReadOnlyCollection<int>, ReadOnlyCollectionCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ReadOnlyCollection<int> CreateValue()
         {
@@ -2434,7 +2434,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ReadOnlyCollection<int>[] TestValues => [null, new ReadOnlyCollection<int>([]), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ReadOnlyCollectionCopierTests(ITestOutputHelper output) : CopierTester<ReadOnlyCollection<int>, ReadOnlyCollectionCopier<int>>(output)
+    public class ReadOnlyCollectionCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ReadOnlyCollection<int>, ReadOnlyCollectionCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ReadOnlyCollection<int> CreateValue()
         {
@@ -2452,7 +2452,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ReadOnlyCollection<int>[] TestValues => [null, new ReadOnlyCollection<int>([]), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class StackCodecTests(ITestOutputHelper output) : FieldCodecTester<Stack<int>, StackCodec<int>>(output)
+    public class StackCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Stack<int>, StackCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Stack<int> CreateValue()
         {
@@ -2470,7 +2470,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Stack<int>[] TestValues => [null, new Stack<int>(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class StackCopierTests(ITestOutputHelper output) : CopierTester<Stack<int>, StackCopier<int>>(output)
+    public class StackCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Stack<int>, StackCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Stack<int> CreateValue()
         {
@@ -2488,7 +2488,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Stack<int>[] TestValues => [null, new Stack<int>(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ImmutableStackCodecTests(ITestOutputHelper output) : FieldCodecTester<ImmutableStack<int>, ImmutableStackCodec<int>>(output)
+    public class ImmutableStackCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ImmutableStack<int>, ImmutableStackCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ImmutableStack<int> CreateValue()
         {
@@ -2506,7 +2506,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ImmutableStack<int>[] TestValues => [null, ImmutableStack<int>.Empty, CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ImmutableStackCopierTests(ITestOutputHelper output) : CopierTester<ImmutableStack<int>, ImmutableStackCopier<int>>(output)
+    public class ImmutableStackCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ImmutableStack<int>, ImmutableStackCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override ImmutableStack<int> CreateValue()
@@ -2525,7 +2525,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ImmutableStack<int>[] TestValues => [null, ImmutableStack<int>.Empty, CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class QueueCodecTests(ITestOutputHelper output) : FieldCodecTester<Queue<int>, QueueCodec<int>>(output)
+    public class QueueCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Queue<int>, QueueCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Queue<int> CreateValue()
         {
@@ -2543,7 +2543,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Queue<int>[] TestValues => [null, new Queue<int>(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class QueueCopierTests(ITestOutputHelper output) : CopierTester<Queue<int>, QueueCopier<int>>(output)
+    public class QueueCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Queue<int>, QueueCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Queue<int> CreateValue()
         {
@@ -2561,7 +2561,7 @@ namespace Orleans.Serialization.UnitTests
         protected override Queue<int>[] TestValues => [null, new Queue<int>(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ConcurrentQueueCodecTests(ITestOutputHelper output) : FieldCodecTester<ConcurrentQueue<int>, ConcurrentQueueCodec<int>>(output)
+    public class ConcurrentQueueCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ConcurrentQueue<int>, ConcurrentQueueCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ConcurrentQueue<int> CreateValue()
         {
@@ -2579,7 +2579,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ConcurrentQueue<int>[] TestValues => [null, new ConcurrentQueue<int>(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ConcurrentQueueCopierTests(ITestOutputHelper output) : CopierTester<ConcurrentQueue<int>, ConcurrentQueueCopier<int>>(output)
+    public class ConcurrentQueueCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ConcurrentQueue<int>, ConcurrentQueueCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ConcurrentQueue<int> CreateValue()
         {
@@ -2597,7 +2597,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ConcurrentQueue<int>[] TestValues => [null, new ConcurrentQueue<int>(), CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ImmutableQueueCodecTests(ITestOutputHelper output) : FieldCodecTester<ImmutableQueue<int>, ImmutableQueueCodec<int>>(output)
+    public class ImmutableQueueCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ImmutableQueue<int>, ImmutableQueueCodec<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ImmutableQueue<int> CreateValue()
         {
@@ -2615,7 +2615,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ImmutableQueue<int>[] TestValues => [null, ImmutableQueue<int>.Empty, CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class ImmutableQueueCopierTests(ITestOutputHelper output) : CopierTester<ImmutableQueue<int>, ImmutableQueueCopier<int>>(output)
+    public class ImmutableQueueCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ImmutableQueue<int>, ImmutableQueueCopier<int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override ImmutableQueue<int> CreateValue()
@@ -2634,7 +2634,7 @@ namespace Orleans.Serialization.UnitTests
         protected override ImmutableQueue<int>[] TestValues => [null, ImmutableQueue<int>.Empty, CreateValue(), CreateValue(), CreateValue()];
     }
 
-    public class DictionaryCodecTests(ITestOutputHelper output) : FieldCodecTester<Dictionary<string, int>, DictionaryCodec<string, int>>(output)
+    public class DictionaryCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Dictionary<string, int>, DictionaryCodec<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Dictionary<string, int> CreateValue()
         {
@@ -2652,7 +2652,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(Dictionary<string, int> left, Dictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class DictionaryCopierTests(ITestOutputHelper output) : CopierTester<Dictionary<string, int>, DictionaryCopier<string, int>>(output)
+    public class DictionaryCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Dictionary<string, int>, DictionaryCopier<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Dictionary<string, int> CreateValue()
         {
@@ -2690,7 +2690,7 @@ namespace Orleans.Serialization.UnitTests
         public override string ToString() => $"[OtherProperty: {OtherProperty}, Values: [{string.Join(", ", this.Select(kvp => $"[{kvp.Key}] = '{kvp.Value}'"))}]]";
     }
 
-    public class DictionaryBaseCodecTests(ITestOutputHelper output) : FieldCodecTester<TypeWithDictionaryBase, IFieldCodec<TypeWithDictionaryBase>>(output)
+    public class DictionaryBaseCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<TypeWithDictionaryBase, IFieldCodec<TypeWithDictionaryBase>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override TypeWithDictionaryBase[] TestValues =>
         [
@@ -2711,7 +2711,7 @@ namespace Orleans.Serialization.UnitTests
             && left.Comparer?.GetType() == right.Comparer?.GetType();
     }
 
-    public class DictionaryBaseCopierTests(ITestOutputHelper output) : CopierTester<TypeWithDictionaryBase, IDeepCopier<TypeWithDictionaryBase>>(output)
+    public class DictionaryBaseCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<TypeWithDictionaryBase, IDeepCopier<TypeWithDictionaryBase>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override TypeWithDictionaryBase[] TestValues => [null, new(), new(addDefaultValue: false), new() { ["foo"] = 15 }, new() { ["foo"] = 15, OtherProperty = 123 }];
 
@@ -2719,7 +2719,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(TypeWithDictionaryBase left, TypeWithDictionaryBase right) => ReferenceEquals(left, right) || left.SequenceEqual(right) && left.OtherProperty == right.OtherProperty;
     }
 
-    public class DictionaryWithComparerCodecTests(ITestOutputHelper output) : FieldCodecTester<Dictionary<string, int>, DictionaryCodec<string, int>>(output)
+    public class DictionaryWithComparerCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Dictionary<string, int>, DictionaryCodec<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override int[] MaxSegmentSizes => [1024];
         private int _nextComparer;
@@ -2796,7 +2796,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class DictionaryWithComparerCopierTests(ITestOutputHelper output) : CopierTester<Dictionary<string, int>, DictionaryCopier<string, int>>(output)
+    public class DictionaryWithComparerCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Dictionary<string, int>, DictionaryCopier<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Dictionary<string, int> CreateValue()
         {
@@ -2816,7 +2816,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(Dictionary<string, int> left, Dictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right) && left.Comparer?.GetType() == right.Comparer?.GetType();
     }
 
-    public class ConcurrentDictionaryCodecTests(ITestOutputHelper output) : FieldCodecTester<ConcurrentDictionary<string, int>, ConcurrentDictionaryCodec<string, int>>(output)
+    public class ConcurrentDictionaryCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ConcurrentDictionary<string, int>, ConcurrentDictionaryCodec<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ConcurrentDictionary<string, int> CreateValue()
         {
@@ -2856,7 +2856,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class ConcurrentDictionaryCopierTests(ITestOutputHelper output) : CopierTester<ConcurrentDictionary<string, int>, ConcurrentDictionaryCopier<string, int>>(output)
+    public class ConcurrentDictionaryCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ConcurrentDictionary<string, int>, ConcurrentDictionaryCopier<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ConcurrentDictionary<string, int> CreateValue()
         {
@@ -2896,7 +2896,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class ReadOnlyDictionaryCodecTests(ITestOutputHelper output) : FieldCodecTester<ReadOnlyDictionary<string, int>, ReadOnlyDictionaryCodec<string, int>>(output)
+    public class ReadOnlyDictionaryCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ReadOnlyDictionary<string, int>, ReadOnlyDictionaryCodec<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ReadOnlyDictionary<string, int> CreateValue()
         {
@@ -2914,7 +2914,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(ReadOnlyDictionary<string, int> left, ReadOnlyDictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class ReadOnlyDictionaryCopierTests(ITestOutputHelper output) : CopierTester<ReadOnlyDictionary<string, int>, ReadOnlyDictionaryCopier<string, int>>(output)
+    public class ReadOnlyDictionaryCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ReadOnlyDictionary<string, int>, ReadOnlyDictionaryCopier<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ReadOnlyDictionary<string, int> CreateValue()
         {
@@ -2932,7 +2932,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(ReadOnlyDictionary<string, int> left, ReadOnlyDictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class ImmutableDictionaryCodecTests(ITestOutputHelper output) : FieldCodecTester<ImmutableDictionary<string, int>, ImmutableDictionaryCodec<string, int>>(output)
+    public class ImmutableDictionaryCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ImmutableDictionary<string, int>, ImmutableDictionaryCodec<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ImmutableDictionary<string, int> CreateValue()
         {
@@ -2950,7 +2950,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(ImmutableDictionary<string, int> left, ImmutableDictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class ImmutableDictionaryCopierTests(ITestOutputHelper output) : CopierTester<ImmutableDictionary<string, int>, ImmutableDictionaryCopier<string, int>>(output)
+    public class ImmutableDictionaryCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ImmutableDictionary<string, int>, ImmutableDictionaryCopier<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override ImmutableDictionary<string, int> CreateValue()
@@ -2969,7 +2969,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(ImmutableDictionary<string, int> left, ImmutableDictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class SortedDictionaryCodecTests(ITestOutputHelper output) : FieldCodecTester<SortedDictionary<string, int>, SortedDictionaryCodec<string, int>>(output)
+    public class SortedDictionaryCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<SortedDictionary<string, int>, SortedDictionaryCodec<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override SortedDictionary<string, int> CreateValue()
         {
@@ -2987,7 +2987,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(SortedDictionary<string, int> left, SortedDictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class SortedDictionaryCopierTests(ITestOutputHelper output) : CopierTester<SortedDictionary<string, int>, SortedDictionaryCopier<string, int>>(output)
+    public class SortedDictionaryCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<SortedDictionary<string, int>, SortedDictionaryCopier<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override SortedDictionary<string, int> CreateValue()
         {
@@ -3005,7 +3005,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(SortedDictionary<string, int> left, SortedDictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class ImmutableSortedDictionaryCodecTests(ITestOutputHelper output) : FieldCodecTester<ImmutableSortedDictionary<string, int>, ImmutableSortedDictionaryCodec<string, int>>(output)
+    public class ImmutableSortedDictionaryCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ImmutableSortedDictionary<string, int>, ImmutableSortedDictionaryCodec<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ImmutableSortedDictionary<string, int> CreateValue()
         {
@@ -3023,7 +3023,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(ImmutableSortedDictionary<string, int> left, ImmutableSortedDictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class ImmutableSortedDictionaryCopierTests(ITestOutputHelper output) : CopierTester<ImmutableSortedDictionary<string, int>, ImmutableSortedDictionaryCopier<string, int>>(output)
+    public class ImmutableSortedDictionaryCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ImmutableSortedDictionary<string, int>, ImmutableSortedDictionaryCopier<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
 
@@ -3043,7 +3043,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(ImmutableSortedDictionary<string, int> left, ImmutableSortedDictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class NameValueCollectionCodecTests(ITestOutputHelper output) : FieldCodecTester<NameValueCollection, NameValueCollectionCodec>(output)
+    public class NameValueCollectionCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<NameValueCollection, NameValueCollectionCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override NameValueCollection CreateValue()
         {
@@ -3062,7 +3062,7 @@ namespace Orleans.Serialization.UnitTests
             || (left.AllKeys.OrderBy(key => key).SequenceEqual(right.AllKeys.OrderBy(key => key)) && left.AllKeys.All(key => string.Equals(left[key], right[key], StringComparison.Ordinal)));
     }
 
-    public class NameValueCollectionCopierTests(ITestOutputHelper output) : CopierTester<NameValueCollection, NameValueCollectionCopier>(output)
+    public class NameValueCollectionCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<NameValueCollection, NameValueCollectionCopier>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override NameValueCollection CreateValue()
         {
@@ -3081,7 +3081,7 @@ namespace Orleans.Serialization.UnitTests
             || (left.AllKeys.OrderBy(key => key).SequenceEqual(right.AllKeys.OrderBy(key => key)) && left.AllKeys.All(key => string.Equals(left[key], right[key], StringComparison.Ordinal)));
     }
 
-    public class IPAddressTests(ITestOutputHelper output) : FieldCodecTester<IPAddress, IPAddressCodec>(output)
+    public class IPAddressTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<IPAddress, IPAddressCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override int[] MaxSegmentSizes => [32];
 
@@ -3103,7 +3103,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class IPAddressCopierTests(ITestOutputHelper output) : CopierTester<IPAddress, IDeepCopier<IPAddress>>(output)
+    public class IPAddressCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<IPAddress, IDeepCopier<IPAddress>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override IPAddress[] TestValues => [null, IPAddress.Any, IPAddress.IPv6Any, IPAddress.IPv6Loopback, IPAddress.IPv6None, IPAddress.Loopback, IPAddress.Parse("123.123.10.3"), CreateValue()];
 
@@ -3125,7 +3125,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class IPEndPointTests(ITestOutputHelper output) : FieldCodecTester<IPEndPoint, IPEndPointCodec>(output)
+    public class IPEndPointTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<IPEndPoint, IPEndPointCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override int[] MaxSegmentSizes => [32];
 
@@ -3155,7 +3155,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class IPEndPointCopierTests(ITestOutputHelper output) : CopierTester<IPEndPoint, IDeepCopier<IPEndPoint>>(output)
+    public class IPEndPointCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<IPEndPoint, IDeepCopier<IPEndPoint>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override IPEndPoint[] TestValues =>
            [null,
@@ -3185,7 +3185,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class HashSetTests(ITestOutputHelper output) : FieldCodecTester<HashSet<string>, HashSetCodec<string>>(output)
+    public class HashSetTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<HashSet<string>, HashSetCodec<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override HashSet<string> CreateValue()
         {
@@ -3204,7 +3204,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(HashSet<string> left, HashSet<string> right) => ReferenceEquals(left, right) || left.SetEquals(right);
     }
 
-    public class HashSetCopierTests(ITestOutputHelper output) : CopierTester<HashSet<string>, HashSetCopier<string>>(output)
+    public class HashSetCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<HashSet<string>, HashSetCopier<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override HashSet<string> CreateValue()
         {
@@ -3244,7 +3244,7 @@ namespace Orleans.Serialization.UnitTests
         public override string ToString() => $"[OtherProperty: {OtherProperty}, Values: [{string.Join(", ", this)}]]";
     }
 
-    public class HashSetBaseCodecTests(ITestOutputHelper output) : FieldCodecTester<TypeWithHashSetBase, IFieldCodec<TypeWithHashSetBase>>(output)
+    public class HashSetBaseCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<TypeWithHashSetBase, IFieldCodec<TypeWithHashSetBase>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         private static TypeWithHashSetBase AddValues(TypeWithHashSetBase value)
         {
@@ -3274,7 +3274,7 @@ namespace Orleans.Serialization.UnitTests
             && left?.Comparer == right?.Comparer;
     }
 
-    public class HashSetBaseCopierTests(ITestOutputHelper output) : CopierTester<TypeWithHashSetBase, IDeepCopier<TypeWithHashSetBase>>(output)
+    public class HashSetBaseCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<TypeWithHashSetBase, IDeepCopier<TypeWithHashSetBase>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         private static TypeWithHashSetBase AddValues(TypeWithHashSetBase value)
         {
@@ -3305,7 +3305,7 @@ namespace Orleans.Serialization.UnitTests
             && left?.Comparer == right?.Comparer;
     }
 
-    public class ImmutableHashSetTests(ITestOutputHelper output) : FieldCodecTester<ImmutableHashSet<string>, ImmutableHashSetCodec<string>>(output)
+    public class ImmutableHashSetTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ImmutableHashSet<string>, ImmutableHashSetCodec<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ImmutableHashSet<string> CreateValue()
         {
@@ -3324,7 +3324,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(ImmutableHashSet<string> left, ImmutableHashSet<string> right) => ReferenceEquals(left, right) || left.SetEquals(right);
     }
 
-    public class ImmutableHashSetCopierTests(ITestOutputHelper output) : CopierTester<ImmutableHashSet<string>, ImmutableHashSetCopier<string>>(output)
+    public class ImmutableHashSetCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ImmutableHashSet<string>, ImmutableHashSetCopier<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ImmutableHashSet<string> CreateValue()
         {
@@ -3345,7 +3345,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public sealed class ImmutableHashSetMutableCopierTests(ITestOutputHelper output) : CopierTester<ImmutableHashSet<object>, ImmutableHashSetCopier<object>>(output)
+    public sealed class ImmutableHashSetMutableCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ImmutableHashSet<object>, ImmutableHashSetCopier<object>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override ImmutableHashSet<object> CreateValue()
         {
@@ -3366,7 +3366,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => false;
     }
 
-    public class UriTests(ITestOutputHelper output) : FieldCodecTester<Uri, UriCodec>(output)
+    public class UriTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Uri, UriCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override int[] MaxSegmentSizes => [128];
         protected override Uri CreateValue() => new Uri($"http://www.{Guid.NewGuid()}.com/");
@@ -3376,7 +3376,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(Uri left, Uri right) => ReferenceEquals(left, right) || left == right;
     }
 
-    public class UriCopierTests(ITestOutputHelper output) : CopierTester<Uri, IDeepCopier<Uri>>(output)
+    public class UriCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Uri, IDeepCopier<Uri>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Uri CreateValue() => new Uri($"http://www.{Guid.NewGuid()}.com/");
 
@@ -3387,27 +3387,27 @@ namespace Orleans.Serialization.UnitTests
         protected override bool IsImmutable => true;
     }
 
-    public class FSharpUnitTests(ITestOutputHelper output) : FieldCodecTester<Unit, FSharpUnitCodec>(output)
+    public class FSharpUnitTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Unit, FSharpUnitCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Unit CreateValue() => null;
         protected override Unit[] TestValues => [null];
     }
 
-    public class FSharpUnitCopierTests(ITestOutputHelper output) : CopierTester<Unit, FSharpUnitCopier>(output)
+    public class FSharpUnitCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Unit, FSharpUnitCopier>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override Unit CreateValue() => null;
         protected override Unit[] TestValues => [null];
     }
 
-    public class FSharpOptionTests(ITestOutputHelper output) : FieldCodecTester<FSharpOption<Guid>, FSharpOptionCodec<Guid>>(output)
+    public class FSharpOptionTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpOption<Guid>, FSharpOptionCodec<Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpOption<Guid>[] TestValues => [null, FSharpOption<Guid>.None, FSharpOption<Guid>.Some(Guid.Empty), FSharpOption<Guid>.Some(Guid.NewGuid())];
 
         protected override FSharpOption<Guid> CreateValue() => FSharpOption<Guid>.Some(Guid.NewGuid());
     }
 
-    public class FSharpOptionCopierTests(ITestOutputHelper output) : CopierTester<FSharpOption<Guid>, FSharpOptionCopier<Guid>>(output)
+    public class FSharpOptionCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FSharpOption<Guid>, FSharpOptionCopier<Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpOption<Guid>[] TestValues => [null, FSharpOption<Guid>.None, FSharpOption<Guid>.Some(Guid.Empty), FSharpOption<Guid>.Some(Guid.NewGuid())];
 
@@ -3416,14 +3416,14 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(FSharpOption<Guid> left, FSharpOption<Guid> right) => ReferenceEquals(left, right) || left.GetType() == right.GetType() && left.Value.Equals(right.Value);
     }
 
-    public class FSharpOptionTests2(ITestOutputHelper output) : FieldCodecTester<FSharpOption<object>, FSharpOptionCodec<object>>(output)
+    public class FSharpOptionTests2(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpOption<object>, FSharpOptionCodec<object>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpOption<object>[] TestValues => [null, FSharpOption<object>.Some(null), FSharpOption<object>.None, FSharpOption<object>.Some(Guid.Empty), FSharpOption<object>.Some(Guid.NewGuid())];
 
         protected override FSharpOption<object> CreateValue() => FSharpOption<object>.Some(Guid.NewGuid());
     }
 
-    public class FSharpRefTests(ITestOutputHelper output) : FieldCodecTester<FSharpRef<Guid>, FSharpRefCodec<Guid>>(output)
+    public class FSharpRefTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpRef<Guid>, FSharpRefCodec<Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpRef<Guid>[] TestValues => [null, new FSharpRef<Guid>(default), new FSharpRef<Guid>(Guid.Empty), new FSharpRef<Guid>(Guid.NewGuid())];
 
@@ -3432,7 +3432,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(FSharpRef<Guid> left, FSharpRef<Guid> right) => ReferenceEquals(left, right) || EqualityComparer<Guid>.Default.Equals(left.Value, right.Value);
     }
 
-    public class FSharpRefCopierTests(ITestOutputHelper output) : CopierTester<FSharpRef<Guid>, FSharpRefCopier<Guid>>(output)
+    public class FSharpRefCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FSharpRef<Guid>, FSharpRefCopier<Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpRef<Guid>[] TestValues => [null, new FSharpRef<Guid>(default), new FSharpRef<Guid>(Guid.Empty), new FSharpRef<Guid>(Guid.NewGuid())];
 
@@ -3441,14 +3441,14 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(FSharpRef<Guid> left, FSharpRef<Guid> right) => ReferenceEquals(left, right) || left.GetType() == right.GetType() && left.Value.Equals(right.Value);
     }
 
-    public class FSharpValueOptionTests(ITestOutputHelper output) : FieldCodecTester<FSharpValueOption<Guid>, FSharpValueOptionCodec<Guid>>(output)
+    public class FSharpValueOptionTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpValueOption<Guid>, FSharpValueOptionCodec<Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpValueOption<Guid>[] TestValues => [default, FSharpValueOption<Guid>.None, FSharpValueOption<Guid>.Some(Guid.Empty), FSharpValueOption<Guid>.Some(Guid.NewGuid())];
 
         protected override FSharpValueOption<Guid> CreateValue() => FSharpValueOption<Guid>.Some(Guid.NewGuid());
     }
 
-    public class FSharpValueOptionCopierTests(ITestOutputHelper output) : CopierTester<FSharpValueOption<Guid>, FSharpValueOptionCopier<Guid>>(output)
+    public class FSharpValueOptionCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FSharpValueOption<Guid>, FSharpValueOptionCopier<Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpValueOption<Guid>[] TestValues => [default, FSharpValueOption<Guid>.None, FSharpValueOption<Guid>.Some(Guid.Empty), FSharpValueOption<Guid>.Some(Guid.NewGuid())];
 
@@ -3457,84 +3457,84 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(FSharpValueOption<Guid> left, FSharpValueOption<Guid> right) => left.IsNone && right.IsNone || left.IsSome && right.IsSome && left.Value.Equals(right.Value);
     }
 
-    public class FSharpResultTests(ITestOutputHelper output) : FieldCodecTester<FSharpResult<int, Guid>, FSharpResultCodec<int, Guid>>(output)
+    public class FSharpResultTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpResult<int, Guid>, FSharpResultCodec<int, Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpResult<int, Guid>[] TestValues => [FSharpResult<int, Guid>.NewOk(-1), FSharpResult<int, Guid>.NewError(Guid.NewGuid())];
 
         protected override FSharpResult<int, Guid> CreateValue() => FSharpResult<int, Guid>.NewOk(0);
     }
 
-    public class FSharpChoice2Tests(ITestOutputHelper output) : FieldCodecTester<FSharpChoice<int, Guid>, FSharpChoiceCodec<int, Guid>>(output)
+    public class FSharpChoice2Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpChoice<int, Guid>, FSharpChoiceCodec<int, Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpChoice<int, Guid>[] TestValues => [FSharpChoice<int, Guid>.NewChoice1Of2(-1), FSharpChoice<int, Guid>.NewChoice2Of2(Guid.NewGuid())];
 
         protected override FSharpChoice<int, Guid> CreateValue() => FSharpChoice<int, Guid>.NewChoice1Of2(0);
     }
 
-    public class FSharpChoice2CopierTests(ITestOutputHelper output) : CopierTester<FSharpChoice<int, Guid>, FSharpChoiceCopier<int, Guid>>(output)
+    public class FSharpChoice2CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FSharpChoice<int, Guid>, FSharpChoiceCopier<int, Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpChoice<int, Guid>[] TestValues => [FSharpChoice<int, Guid>.NewChoice1Of2(-1), FSharpChoice<int, Guid>.NewChoice2Of2(Guid.NewGuid())];
 
         protected override FSharpChoice<int, Guid> CreateValue() => FSharpChoice<int, Guid>.NewChoice1Of2(0);
     }
 
-    public class FSharpChoice3Tests(ITestOutputHelper output) : FieldCodecTester<FSharpChoice<int, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid>>(output)
+    public class FSharpChoice3Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpChoice<int, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpChoice<int, Guid, Guid>[] TestValues => [FSharpChoice<int, Guid, Guid>.NewChoice1Of3(-1), FSharpChoice<int, Guid, Guid>.NewChoice3Of3(Guid.NewGuid())];
 
         protected override FSharpChoice<int, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid>.NewChoice1Of3(0);
     }
 
-    public class FSharpChoice3CopierTests(ITestOutputHelper output) : CopierTester<FSharpChoice<int, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid>>(output)
+    public class FSharpChoice3CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FSharpChoice<int, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpChoice<int, Guid, Guid>[] TestValues => [FSharpChoice<int, Guid, Guid>.NewChoice1Of3(-1), FSharpChoice<int, Guid, Guid>.NewChoice3Of3(Guid.NewGuid())];
 
         protected override FSharpChoice<int, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid>.NewChoice1Of3(0);
     }
 
-    public class FSharpChoice4Tests(ITestOutputHelper output) : FieldCodecTester<FSharpChoice<int, Guid, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid, Guid>>(output)
+    public class FSharpChoice4Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpChoice<int, Guid, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid, Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpChoice<int, Guid, Guid, Guid>[] TestValues => [FSharpChoice<int, Guid, Guid, Guid>.NewChoice1Of4(-1), FSharpChoice<int, Guid, Guid, Guid>.NewChoice4Of4(Guid.NewGuid())];
 
         protected override FSharpChoice<int, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid>.NewChoice1Of4(0);
     }
 
-    public class FSharpChoice4CopierTests(ITestOutputHelper output) : CopierTester<FSharpChoice<int, Guid, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid, Guid>>(output)
+    public class FSharpChoice4CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FSharpChoice<int, Guid, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid, Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpChoice<int, Guid, Guid, Guid>[] TestValues => [FSharpChoice<int, Guid, Guid, Guid>.NewChoice1Of4(-1), FSharpChoice<int, Guid, Guid, Guid>.NewChoice4Of4(Guid.NewGuid())];
 
         protected override FSharpChoice<int, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid>.NewChoice1Of4(0);
     }
 
-    public class FSharpChoice5Tests(ITestOutputHelper output) : FieldCodecTester<FSharpChoice<int, Guid, Guid, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid, Guid, Guid>>(output)
+    public class FSharpChoice5Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpChoice<int, Guid, Guid, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid, Guid, Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid>[] TestValues => [FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice1Of5(-1), FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice5Of5(Guid.NewGuid())];
 
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice1Of5(0);
     }
 
-    public class FSharpChoice5CopierTests(ITestOutputHelper output) : CopierTester<FSharpChoice<int, Guid, Guid, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid, Guid, Guid>>(output)
+    public class FSharpChoice5CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FSharpChoice<int, Guid, Guid, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid, Guid, Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid>[] TestValues => [FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice1Of5(-1), FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice5Of5(Guid.NewGuid())];
 
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid, Guid>.NewChoice1Of5(0);
     }
 
-    public class FSharpChoice6Tests(ITestOutputHelper output) : FieldCodecTester<FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid, Guid, Guid, Guid>>(output)
+    public class FSharpChoice6Tests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>, FSharpChoiceCodec<int, Guid, Guid, Guid, Guid, Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>[] TestValues => [FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice1Of6(-1), FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice6Of6(Guid.NewGuid())];
 
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice1Of6(0);
     }
 
-    public class FSharpChoice6CopierTests(ITestOutputHelper output) : CopierTester<FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid, Guid, Guid, Guid>>(output)
+    public class FSharpChoice6CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>, FSharpChoiceCopier<int, Guid, Guid, Guid, Guid, Guid>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>[] TestValues => [FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice1Of6(-1), FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice6Of6(Guid.NewGuid())];
 
         protected override FSharpChoice<int, Guid, Guid, Guid, Guid, Guid> CreateValue() => FSharpChoice<int, Guid, Guid, Guid, Guid, Guid>.NewChoice1Of6(0);
     }
 
-    public class FSharpSetTests(ITestOutputHelper output) : FieldCodecTester<FSharpSet<string>, FSharpSetCodec<string>>(output)
+    public class FSharpSetTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpSet<string>, FSharpSetCodec<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpSet<string> CreateValue()
         {
@@ -3553,7 +3553,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(FSharpSet<string> left, FSharpSet<string> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class FSharpSetCopierTests(ITestOutputHelper output) : CopierTester<FSharpSet<string>, FSharpSetCopier<string>>(output)
+    public class FSharpSetCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FSharpSet<string>, FSharpSetCopier<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpSet<string> CreateValue()
         {
@@ -3572,7 +3572,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(FSharpSet<string> left, FSharpSet<string> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class FSharpMapTests(ITestOutputHelper output) : FieldCodecTester<FSharpMap<string, string>, FSharpMapCodec<string, string>>(output)
+    public class FSharpMapTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpMap<string, string>, FSharpMapCodec<string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override int[] MaxSegmentSizes => [128];
 
@@ -3593,7 +3593,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(FSharpMap<string, string> left, FSharpMap<string, string> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class FSharpMapCopierTests(ITestOutputHelper output) : CopierTester<FSharpMap<string, string>, FSharpMapCopier<string, string>>(output)
+    public class FSharpMapCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FSharpMap<string, string>, FSharpMapCopier<string, string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpMap<string, string> CreateValue()
         {
@@ -3612,7 +3612,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(FSharpMap<string, string> left, FSharpMap<string, string> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class FSharpListTests(ITestOutputHelper output) : FieldCodecTester<FSharpList<string>, FSharpListCodec<string>>(output)
+    public class FSharpListTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FSharpList<string>, FSharpListCodec<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpList<string> CreateValue()
         {
@@ -3631,7 +3631,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(FSharpList<string> left, FSharpList<string> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class FSharpListCopierTests(ITestOutputHelper output) : CopierTester<FSharpList<string>, FSharpListCopier<string>>(output)
+    public class FSharpListCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FSharpList<string>, FSharpListCopier<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override FSharpList<string> CreateValue()
         {
@@ -3650,7 +3650,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(FSharpList<string> left, FSharpList<string> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
     }
 
-    public class CultureInfoTests(ITestOutputHelper output) : FieldCodecTester<CultureInfo, CultureInfoCodec>(output)
+    public class CultureInfoTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<CultureInfo, CultureInfoCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override CultureInfo CreateValue() => TestValues[Random.Next(TestValues.Length)];
 
@@ -3659,7 +3659,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(CultureInfo left, CultureInfo right) => ReferenceEquals(left, right) || left.Equals(right);
     }
 
-    public class CultureInfoCopierTests(ITestOutputHelper output) : CopierTester<CultureInfo, IDeepCopier<CultureInfo>>(output)
+    public class CultureInfoCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<CultureInfo, IDeepCopier<CultureInfo>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override CultureInfo CreateValue() => TestValues[Random.Next(TestValues.Length)];
@@ -3669,7 +3669,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(CultureInfo left, CultureInfo right) => ReferenceEquals(left, right) || left.Equals(right);
     }
 
-    public class CompareInfoTests(ITestOutputHelper output) : FieldCodecTester<CompareInfo, CompareInfoCodec>(output)
+    public class CompareInfoTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<CompareInfo, CompareInfoCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override CompareInfo CreateValue() => TestValues[Random.Next(TestValues.Length)];
 
@@ -3678,7 +3678,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(CompareInfo left, CompareInfo right) => ReferenceEquals(left, right) || left.Equals(right);
     }
 
-    public class CompareInfoCopierTests(ITestOutputHelper output) : CopierTester<CompareInfo, IDeepCopier<CompareInfo>>(output)
+    public class CompareInfoCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<CompareInfo, IDeepCopier<CompareInfo>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override CompareInfo CreateValue() => TestValues[Random.Next(TestValues.Length)];
@@ -3688,7 +3688,7 @@ namespace Orleans.Serialization.UnitTests
         protected override bool Equals(CompareInfo left, CompareInfo right) => ReferenceEquals(left, right) || left.Equals(right);
     }
 
-    public class ResponseCodecTests(ITestOutputHelper output) : FieldCodecTester<Response, IFieldCodec<Response>>(output)
+    public class ResponseCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Response, IFieldCodec<Response>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Response CreateValue() => Response.FromResult(Guid.NewGuid());
 
@@ -3734,7 +3734,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class ResponseCopierTests(ITestOutputHelper output) : CopierTester<Response, IDeepCopier<Response>>(output)
+    public class ResponseCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Response, IDeepCopier<Response>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override bool IsPooled => true;
@@ -3784,7 +3784,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class Response1CodecTests(ITestOutputHelper output) : FieldCodecTester<Response<int>, IFieldCodec<Response<int>>>(output)
+    public class Response1CodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Response<int>, IFieldCodec<Response<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Response<int> CreateValue() => (Response<int>)Response.FromResult(Random.Next());
 
@@ -3828,7 +3828,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class Response1CopierTests(ITestOutputHelper output) : CopierTester<Response<int>, IDeepCopier<Response<int>>>(output)
+    public class Response1CopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Response<int>, IDeepCopier<Response<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override bool IsPooled => true;
@@ -3875,7 +3875,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class ExceptionCodecTests(ITestOutputHelper output) : FieldCodecTester<Exception, ExceptionCodec>(output)
+    public class ExceptionCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Exception, ExceptionCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override Exception[] TestValues => [null, new Exception("hi"), CreateValue()];
         protected override int[] MaxSegmentSizes => [8096];
@@ -3908,7 +3908,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class ExceptionCopierTests(ITestOutputHelper output) : CopierTester<Exception, IDeepCopier<Exception>>(output)
+    public class ExceptionCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<Exception, IDeepCopier<Exception>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override Exception[] TestValues => [null, new Exception("hi"), CreateValue()];
@@ -3941,7 +3941,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class AggregateExceptionCodecTests(ITestOutputHelper output) : FieldCodecTester<AggregateException, IFieldCodec<AggregateException>>(output)
+    public class AggregateExceptionCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<AggregateException, IFieldCodec<AggregateException>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override AggregateException[] TestValues => [null, new AggregateException("hi"), CreateValue()];
         protected override int[] MaxSegmentSizes => [8096];
@@ -3981,7 +3981,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class AggregateExceptionCopierTests(ITestOutputHelper output) : CopierTester<AggregateException, IDeepCopier<AggregateException>>(output)
+    public class AggregateExceptionCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<AggregateException, IDeepCopier<AggregateException>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
         protected override AggregateException[] TestValues => [null, new AggregateException("hi"), CreateValue()];
@@ -4034,7 +4034,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class CancellationTokenCopierTests(ITestOutputHelper output) : CopierTester<CancellationToken, IDeepCopier<CancellationToken>>(output)
+    public class CancellationTokenCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<CancellationToken, IDeepCopier<CancellationToken>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override CancellationToken CreateValue() => default;
         protected override CancellationToken[] TestValues =>
@@ -4045,7 +4045,7 @@ namespace Orleans.Serialization.UnitTests
     }
 
 #if NET8_0_OR_GREATER
-    public class GrainCancellationTokenCodecTests(ITestOutputHelper output) : FieldCodecTester<GrainCancellationToken, IFieldCodec<GrainCancellationToken>>(output)
+    public class GrainCancellationTokenCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<GrainCancellationToken, IFieldCodec<GrainCancellationToken>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         private static readonly PropertyInfo TokenIdProperty = typeof(GrainCancellationToken).GetProperty("Id", BindingFlags.Instance | BindingFlags.NonPublic)
             ?? throw new InvalidOperationException("Unable to locate GrainCancellationToken.Id property.");
@@ -4102,7 +4102,7 @@ namespace Orleans.Serialization.UnitTests
             => (Guid)TokenIdProperty.GetValue(token)!;
     }
 
-    public class IdSpanCodecTests(ITestOutputHelper output) : FieldCodecTester<IdSpan, IdSpanCodec>(output)
+    public class IdSpanCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<IdSpan, IdSpanCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override IdSpan CreateValue() => IdSpan.Create(Guid.NewGuid().ToString("N"));
 
@@ -4115,7 +4115,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class SiloAddressCodecTests(ITestOutputHelper output) : FieldCodecTester<SiloAddress, SiloAddressCodec>(output)
+    public class SiloAddressCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<SiloAddress, SiloAddressCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override int[] MaxSegmentSizes => [256];
 
@@ -4131,7 +4131,7 @@ namespace Orleans.Serialization.UnitTests
         ];
     }
 
-    public class IAddressableCodecTests(ITestOutputHelper output) : FieldCodecTester<IAddressable, IFieldCodec<IAddressable>>(output)
+    public class IAddressableCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<IAddressable, IFieldCodec<IAddressable>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override void Configure(ISerializerBuilder builder)
         {
@@ -4177,7 +4177,7 @@ namespace Orleans.Serialization.UnitTests
         }
     }
 
-    public class XDocumentCodecTests(ITestOutputHelper output) : FieldCodecTester<XDocument, IFieldCodec<XDocument>>(output)
+    public class XDocumentCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<XDocument, IFieldCodec<XDocument>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override int[] MaxSegmentSizes => [256];
 
@@ -4209,7 +4209,7 @@ namespace Orleans.Serialization.UnitTests
             => new(new XElement("root", new XAttribute("id", Guid.NewGuid()), new XElement("value", Guid.NewGuid().ToString("N"))));
     }
 
-    public class XDocumentCopierTests(ITestOutputHelper output) : CopierTester<XDocument, IDeepCopier<XDocument>>(output)
+    public class XDocumentCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<XDocument, IDeepCopier<XDocument>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsPooled => true;
 
@@ -4240,7 +4240,7 @@ namespace Orleans.Serialization.UnitTests
             => new(new XElement("root", new XAttribute("id", Guid.NewGuid()), new XElement("value", Guid.NewGuid().ToString("N"))));
     }
 
-    public class GrainReferenceCopierTests(ITestOutputHelper output) : CopierTester<GrainReference, IDeepCopier<GrainReference>>(output)
+    public class GrainReferenceCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<GrainReference, IDeepCopier<GrainReference>>(output, fixture), IClassFixture<SerializationTesterFixture>
     {
         protected override bool IsImmutable => true;
 

--- a/test/Orleans.Serialization.UnitTests/ConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ConverterTests.cs
@@ -2,6 +2,7 @@ using System;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Codecs;
 using Orleans.Serialization.TestKit;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Orleans.Serialization.UnitTests;
@@ -19,9 +20,9 @@ namespace Orleans.Serialization.UnitTests;
 /// This approach enables Orleans to maintain its high-performance serialization while
 /// integrating with third-party libraries and legacy code.
 /// </summary>
-public class ConverterCodecTests : FieldCodecTester<MyForeignLibraryType, IFieldCodec<MyForeignLibraryType>>
+public class ConverterCodecTests : FieldCodecTester<MyForeignLibraryType, IFieldCodec<MyForeignLibraryType>>, IClassFixture<SerializationTesterFixture>
 {
-    public ConverterCodecTests(ITestOutputHelper output) : base(output)
+    public ConverterCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -30,9 +31,9 @@ public class ConverterCodecTests : FieldCodecTester<MyForeignLibraryType, IField
     protected override MyForeignLibraryType[] TestValues => new MyForeignLibraryType[] { null, CreateValue() };
 }
 
-public class ConverterCopierTests : CopierTester<MyForeignLibraryType, IDeepCopier<MyForeignLibraryType>>
+public class ConverterCopierTests : CopierTester<MyForeignLibraryType, IDeepCopier<MyForeignLibraryType>>, IClassFixture<SerializationTesterFixture>
 {
-    public ConverterCopierTests(ITestOutputHelper output) : base(output)
+    public ConverterCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -41,9 +42,9 @@ public class ConverterCopierTests : CopierTester<MyForeignLibraryType, IDeepCopi
     protected override MyForeignLibraryType[] TestValues => new MyForeignLibraryType[] { null, CreateValue() };
 }
 
-public class WrappedConverterCodecTests : FieldCodecTester<WrapsMyForeignLibraryType, IFieldCodec<WrapsMyForeignLibraryType>>
+public class WrappedConverterCodecTests : FieldCodecTester<WrapsMyForeignLibraryType, IFieldCodec<WrapsMyForeignLibraryType>>, IClassFixture<SerializationTesterFixture>
 {
-    public WrappedConverterCodecTests(ITestOutputHelper output) : base(output)
+    public WrappedConverterCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -52,9 +53,9 @@ public class WrappedConverterCodecTests : FieldCodecTester<WrapsMyForeignLibrary
     protected override WrapsMyForeignLibraryType[] TestValues => new WrapsMyForeignLibraryType[] { default, CreateValue() };
 }
 
-public class WrappedConverterCopierTests : CopierTester<WrapsMyForeignLibraryType, IDeepCopier<WrapsMyForeignLibraryType>>
+public class WrappedConverterCopierTests : CopierTester<WrapsMyForeignLibraryType, IDeepCopier<WrapsMyForeignLibraryType>>, IClassFixture<SerializationTesterFixture>
 {
-    public WrappedConverterCopierTests(ITestOutputHelper output) : base(output)
+    public WrappedConverterCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -63,9 +64,9 @@ public class WrappedConverterCopierTests : CopierTester<WrapsMyForeignLibraryTyp
     protected override WrapsMyForeignLibraryType[] TestValues => new WrapsMyForeignLibraryType[] { default, CreateValue() };
 }
 
-public class StructConverterCodecTests : ValueTypeFieldCodecTester<MyForeignLibraryValueType, IFieldCodec<MyForeignLibraryValueType>>
+public class StructConverterCodecTests : ValueTypeFieldCodecTester<MyForeignLibraryValueType, IFieldCodec<MyForeignLibraryValueType>>, IClassFixture<SerializationTesterFixture>
 {
-    public StructConverterCodecTests(ITestOutputHelper output) : base(output)
+    public StructConverterCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -74,9 +75,9 @@ public class StructConverterCodecTests : ValueTypeFieldCodecTester<MyForeignLibr
     protected override MyForeignLibraryValueType[] TestValues => new MyForeignLibraryValueType[] { default, CreateValue() };
 }
 
-public class StructConverterCopierTests : CopierTester<MyForeignLibraryValueType, IDeepCopier<MyForeignLibraryValueType>>
+public class StructConverterCopierTests : CopierTester<MyForeignLibraryValueType, IDeepCopier<MyForeignLibraryValueType>>, IClassFixture<SerializationTesterFixture>
 {
-    public StructConverterCopierTests(ITestOutputHelper output) : base(output)
+    public StructConverterCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -85,9 +86,9 @@ public class StructConverterCopierTests : CopierTester<MyForeignLibraryValueType
     protected override MyForeignLibraryValueType[] TestValues => new MyForeignLibraryValueType[] { default, CreateValue() };
 }
 
-public class WrappedStructConverterCodecTests : ValueTypeFieldCodecTester<WrapsMyForeignLibraryValueType, IFieldCodec<WrapsMyForeignLibraryValueType>>
+public class WrappedStructConverterCodecTests : ValueTypeFieldCodecTester<WrapsMyForeignLibraryValueType, IFieldCodec<WrapsMyForeignLibraryValueType>>, IClassFixture<SerializationTesterFixture>
 {
-    public WrappedStructConverterCodecTests(ITestOutputHelper output) : base(output)
+    public WrappedStructConverterCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -96,9 +97,9 @@ public class WrappedStructConverterCodecTests : ValueTypeFieldCodecTester<WrapsM
     protected override WrapsMyForeignLibraryValueType[] TestValues => new WrapsMyForeignLibraryValueType[] { default, CreateValue() };
 }
 
-public class WrappedStructConverterCopierTests : CopierTester<WrapsMyForeignLibraryValueType, IDeepCopier<WrapsMyForeignLibraryValueType>>
+public class WrappedStructConverterCopierTests : CopierTester<WrapsMyForeignLibraryValueType, IDeepCopier<WrapsMyForeignLibraryValueType>>, IClassFixture<SerializationTesterFixture>
 {
-    public WrappedStructConverterCopierTests(ITestOutputHelper output) : base(output)
+    public WrappedStructConverterCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -107,9 +108,9 @@ public class WrappedStructConverterCopierTests : CopierTester<WrapsMyForeignLibr
     protected override WrapsMyForeignLibraryValueType[] TestValues => new WrapsMyForeignLibraryValueType[] { default, CreateValue() };
 }
 
-public class DerivedConverterCodecTests : FieldCodecTester<DerivedFromMyForeignLibraryType, IFieldCodec<DerivedFromMyForeignLibraryType>>
+public class DerivedConverterCodecTests : FieldCodecTester<DerivedFromMyForeignLibraryType, IFieldCodec<DerivedFromMyForeignLibraryType>>, IClassFixture<SerializationTesterFixture>
 {
-    public DerivedConverterCodecTests(ITestOutputHelper output) : base(output)
+    public DerivedConverterCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -118,9 +119,9 @@ public class DerivedConverterCodecTests : FieldCodecTester<DerivedFromMyForeignL
     protected override DerivedFromMyForeignLibraryType[] TestValues => new DerivedFromMyForeignLibraryType[] { null, CreateValue() };
 }
 
-public class DerivedConverterCopierTests : CopierTester<DerivedFromMyForeignLibraryType, IDeepCopier<DerivedFromMyForeignLibraryType>>
+public class DerivedConverterCopierTests : CopierTester<DerivedFromMyForeignLibraryType, IDeepCopier<DerivedFromMyForeignLibraryType>>, IClassFixture<SerializationTesterFixture>
 {
-    public DerivedConverterCopierTests(ITestOutputHelper output) : base(output)
+    public DerivedConverterCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -130,9 +131,9 @@ public class DerivedConverterCopierTests : CopierTester<DerivedFromMyForeignLibr
 }
 
 
-public class CombinedConverterCopierTests : CopierTester<MyFirstForeignLibraryType, IDeepCopier<MyFirstForeignLibraryType>>
+public class CombinedConverterCopierTests : CopierTester<MyFirstForeignLibraryType, IDeepCopier<MyFirstForeignLibraryType>>, IClassFixture<SerializationTesterFixture>
 {
-    public CombinedConverterCopierTests(ITestOutputHelper output) : base(output)
+    public CombinedConverterCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 

--- a/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
@@ -384,6 +384,44 @@ public class InterfaceCollectionRegressionTests
     [Fact]
     public Task ReadOnlyDictionaryInterfaceFallback_Formatted_MatchesSnapshot()
         => VerifyFallbackBitStream<IReadOnlyDictionary<string, int>>(new UnknownDictionary<string, int>(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }), ReadOnlyDictionaryCodecAlias);
+
+    [Fact]
+    public Task EnumerableInterfaceConcreteList_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IEnumerable<int>>(new List<int> { 2, 4, 6 }, EnumerableCodecAlias);
+
+    [Fact]
+    public Task ReadOnlyCollectionInterfaceConcreteList_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IReadOnlyCollection<int>>(new List<int> { 2, 4, 6 }, ReadOnlyCollectionCodecAlias);
+
+    [Fact]
+    public Task ReadOnlyListInterfaceConcreteList_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IReadOnlyList<int>>(new List<int> { 2, 4, 6 }, ReadOnlyListCodecAlias);
+
+    [Fact]
+    public Task CollectionInterfaceConcreteList_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<ICollection<int>>(new List<int> { 2, 4, 6 }, CollectionCodecAlias);
+
+    [Fact]
+    public Task ListInterfaceConcreteList_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IList<int>>(new List<int> { 2, 4, 6 }, ListCodecAlias);
+
+    [Fact]
+    public Task SetInterfaceConcreteHashSet_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<ISet<string>>(new HashSet<string> { "a", "b" }, SetCodecAlias);
+
+#if NET5_0_OR_GREATER
+    [Fact]
+    public Task ReadOnlySetInterfaceConcreteHashSet_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IReadOnlySet<string>>(new HashSet<string> { "a", "b" }, ReadOnlySetCodecAlias);
+#endif
+
+    [Fact]
+    public Task DictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IDictionary<string, int>>(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }, DictionaryCodecAlias);
+
+    [Fact]
+    public Task ReadOnlyDictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IReadOnlyDictionary<string, int>>(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }, ReadOnlyDictionaryCodecAlias);
 #endif
 
     private static T RoundTrip<T>(T value)
@@ -404,6 +442,17 @@ public class InterfaceCollectionRegressionTests
     {
         var formatted = FormatSerializedPayload(value);
         Assert.Contains($"TypeName \"{codecAlias}", formatted);
+        return Verify(formatted, extension: "txt").UseDirectory("snapshots");
+    }
+
+    private static Task VerifyConcreteRuntimeBitStream<T>(T value, params string[] fallbackCodecAliases)
+    {
+        var formatted = FormatSerializedPayload(value);
+        foreach (var codecAlias in fallbackCodecAliases)
+        {
+            Assert.DoesNotContain($"TypeName \"{codecAlias}", formatted);
+        }
+
         return Verify(formatted, extension: "txt").UseDirectory("snapshots");
     }
 

--- a/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
@@ -586,7 +586,7 @@ internal static class InterfaceCollectionTestHelpers
 
 internal sealed class UnknownList<T>(IEnumerable<T> values) : IList<T>, IReadOnlyList<T>
 {
-    private readonly List<T> _values = [with(values)];
+    private readonly List<T> _values = [.. values];
 
     public int Count => _values.Count;
 

--- a/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
@@ -1,0 +1,480 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Orleans.Serialization;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.Serializers;
+using Orleans.Serialization.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Serialization.UnitTests;
+
+public class EnumerableInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IEnumerable<int>, IFieldCodec<IEnumerable<int>>>(output)
+{
+    protected override IFieldCodec<IEnumerable<int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IEnumerable<int>>();
+    protected override IEnumerable<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
+    protected override IEnumerable<int>[] TestValues => [null, Array.Empty<int>(), new List<int> { 1, 2, 3 }, CreateValue()];
+    protected override bool Equals(IEnumerable<int> left, IEnumerable<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
+}
+
+public class EnumerableInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IEnumerable<int>, IDeepCopier<IEnumerable<int>>>(output)
+{
+    protected override IDeepCopier<IEnumerable<int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IEnumerable<int>>();
+    protected override IEnumerable<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
+    protected override IEnumerable<int>[] TestValues => [null, Array.Empty<int>(), new List<int> { 1, 2, 3 }, CreateValue()];
+    protected override bool Equals(IEnumerable<int> left, IEnumerable<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
+}
+
+public class ReadOnlyCollectionInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IReadOnlyCollection<int>, IFieldCodec<IReadOnlyCollection<int>>>(output)
+{
+    protected override IFieldCodec<IReadOnlyCollection<int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IReadOnlyCollection<int>>();
+    protected override IReadOnlyCollection<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
+    protected override IReadOnlyCollection<int>[] TestValues => [null, Array.Empty<int>(), new List<int> { 1, 2, 3 }, CreateValue()];
+    protected override bool Equals(IReadOnlyCollection<int> left, IReadOnlyCollection<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
+}
+
+public class ReadOnlyCollectionInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IReadOnlyCollection<int>, IDeepCopier<IReadOnlyCollection<int>>>(output)
+{
+    protected override IDeepCopier<IReadOnlyCollection<int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IReadOnlyCollection<int>>();
+    protected override IReadOnlyCollection<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
+    protected override IReadOnlyCollection<int>[] TestValues => [null, Array.Empty<int>(), new List<int> { 1, 2, 3 }, CreateValue()];
+    protected override bool Equals(IReadOnlyCollection<int> left, IReadOnlyCollection<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
+}
+
+public class ReadOnlyListInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IReadOnlyList<int>, IFieldCodec<IReadOnlyList<int>>>(output)
+{
+    protected override IFieldCodec<IReadOnlyList<int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IReadOnlyList<int>>();
+    protected override IReadOnlyList<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
+    protected override IReadOnlyList<int>[] TestValues => [null, Array.Empty<int>(), new List<int> { 1, 2, 3 }, CreateValue()];
+    protected override bool Equals(IReadOnlyList<int> left, IReadOnlyList<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
+}
+
+public class ReadOnlyListInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IReadOnlyList<int>, IDeepCopier<IReadOnlyList<int>>>(output)
+{
+    protected override IDeepCopier<IReadOnlyList<int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IReadOnlyList<int>>();
+    protected override IReadOnlyList<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
+    protected override IReadOnlyList<int>[] TestValues => [null, Array.Empty<int>(), new List<int> { 1, 2, 3 }, CreateValue()];
+    protected override bool Equals(IReadOnlyList<int> left, IReadOnlyList<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
+}
+
+public class CollectionInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<ICollection<int>, IFieldCodec<ICollection<int>>>(output)
+{
+    protected override IFieldCodec<ICollection<int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<ICollection<int>>();
+    protected override ICollection<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
+    protected override ICollection<int>[] TestValues => [null, new List<int>(), new List<int> { 1, 2, 3 }, CreateValue()];
+    protected override bool Equals(ICollection<int> left, ICollection<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
+}
+
+public class CollectionInterfaceCopierTests(ITestOutputHelper output) : CopierTester<ICollection<int>, IDeepCopier<ICollection<int>>>(output)
+{
+    protected override IDeepCopier<ICollection<int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<ICollection<int>>();
+    protected override ICollection<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
+    protected override ICollection<int>[] TestValues => [null, new List<int>(), new List<int> { 1, 2, 3 }, CreateValue()];
+    protected override bool Equals(ICollection<int> left, ICollection<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
+}
+
+public class ListInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IList<int>, IFieldCodec<IList<int>>>(output)
+{
+    protected override IFieldCodec<IList<int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IList<int>>();
+    protected override IList<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
+    protected override IList<int>[] TestValues => [null, new List<int>(), new List<int> { 1, 2, 3 }, CreateValue()];
+    protected override bool Equals(IList<int> left, IList<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
+}
+
+public class ListInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IList<int>, IDeepCopier<IList<int>>>(output)
+{
+    protected override IDeepCopier<IList<int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IList<int>>();
+    protected override IList<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
+    protected override IList<int>[] TestValues => [null, new List<int>(), new List<int> { 1, 2, 3 }, CreateValue()];
+    protected override bool Equals(IList<int> left, IList<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
+}
+
+public class SetInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<ISet<string>, IFieldCodec<ISet<string>>>(output)
+{
+    protected override IFieldCodec<ISet<string>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<ISet<string>>();
+    protected override ISet<string> CreateValue() => InterfaceCollectionTestHelpers.CreateSet(Random);
+    protected override ISet<string>[] TestValues => [null, new HashSet<string>(), new HashSet<string> { "a", "b" }, CreateValue()];
+    protected override bool Equals(ISet<string> left, ISet<string> right) => InterfaceCollectionTestHelpers.SetEqual(left, right);
+}
+
+public class SetInterfaceCopierTests(ITestOutputHelper output) : CopierTester<ISet<string>, IDeepCopier<ISet<string>>>(output)
+{
+    protected override IDeepCopier<ISet<string>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<ISet<string>>();
+    protected override ISet<string> CreateValue() => InterfaceCollectionTestHelpers.CreateSet(Random);
+    protected override ISet<string>[] TestValues => [null, new HashSet<string>(), new HashSet<string> { "a", "b" }, CreateValue()];
+    protected override bool Equals(ISet<string> left, ISet<string> right) => InterfaceCollectionTestHelpers.SetEqual(left, right);
+}
+
+#if NET5_0_OR_GREATER
+public class ReadOnlySetInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IReadOnlySet<string>, IFieldCodec<IReadOnlySet<string>>>(output)
+{
+    protected override IFieldCodec<IReadOnlySet<string>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IReadOnlySet<string>>();
+    protected override IReadOnlySet<string> CreateValue() => InterfaceCollectionTestHelpers.CreateSet(Random);
+    protected override IReadOnlySet<string>[] TestValues => [null, new HashSet<string>(), new HashSet<string> { "a", "b" }, CreateValue()];
+    protected override bool Equals(IReadOnlySet<string> left, IReadOnlySet<string> right) => InterfaceCollectionTestHelpers.SetEqual(left, right);
+}
+
+public class ReadOnlySetInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IReadOnlySet<string>, IDeepCopier<IReadOnlySet<string>>>(output)
+{
+    protected override IDeepCopier<IReadOnlySet<string>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IReadOnlySet<string>>();
+    protected override IReadOnlySet<string> CreateValue() => InterfaceCollectionTestHelpers.CreateSet(Random);
+    protected override IReadOnlySet<string>[] TestValues => [null, new HashSet<string>(), new HashSet<string> { "a", "b" }, CreateValue()];
+    protected override bool Equals(IReadOnlySet<string> left, IReadOnlySet<string> right) => InterfaceCollectionTestHelpers.SetEqual(left, right);
+}
+#endif
+
+public class DictionaryInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IDictionary<string, int>, IFieldCodec<IDictionary<string, int>>>(output)
+{
+    protected override IFieldCodec<IDictionary<string, int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IDictionary<string, int>>();
+    protected override IDictionary<string, int> CreateValue() => InterfaceCollectionTestHelpers.CreateDictionary(Random);
+    protected override IDictionary<string, int>[] TestValues => [null, new Dictionary<string, int>(), new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }, CreateValue()];
+    protected override bool Equals(IDictionary<string, int> left, IDictionary<string, int> right) => InterfaceCollectionTestHelpers.DictionaryEqual(left, right);
+}
+
+public class DictionaryInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IDictionary<string, int>, IDeepCopier<IDictionary<string, int>>>(output)
+{
+    protected override IDeepCopier<IDictionary<string, int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IDictionary<string, int>>();
+    protected override IDictionary<string, int> CreateValue() => InterfaceCollectionTestHelpers.CreateDictionary(Random);
+    protected override IDictionary<string, int>[] TestValues => [null, new Dictionary<string, int>(), new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }, CreateValue()];
+    protected override bool Equals(IDictionary<string, int> left, IDictionary<string, int> right) => InterfaceCollectionTestHelpers.DictionaryEqual(left, right);
+}
+
+public class ReadOnlyDictionaryInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IReadOnlyDictionary<string, int>, IFieldCodec<IReadOnlyDictionary<string, int>>>(output)
+{
+    protected override IFieldCodec<IReadOnlyDictionary<string, int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IReadOnlyDictionary<string, int>>();
+    protected override IReadOnlyDictionary<string, int> CreateValue() => InterfaceCollectionTestHelpers.CreateDictionary(Random);
+    protected override IReadOnlyDictionary<string, int>[] TestValues => [null, new Dictionary<string, int>(), new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }, CreateValue()];
+    protected override bool Equals(IReadOnlyDictionary<string, int> left, IReadOnlyDictionary<string, int> right) => InterfaceCollectionTestHelpers.DictionaryEqual(left, right);
+}
+
+public class ReadOnlyDictionaryInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IReadOnlyDictionary<string, int>, IDeepCopier<IReadOnlyDictionary<string, int>>>(output)
+{
+    protected override IDeepCopier<IReadOnlyDictionary<string, int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IReadOnlyDictionary<string, int>>();
+    protected override IReadOnlyDictionary<string, int> CreateValue() => InterfaceCollectionTestHelpers.CreateDictionary(Random);
+    protected override IReadOnlyDictionary<string, int>[] TestValues => [null, new Dictionary<string, int>(), new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }, CreateValue()];
+    protected override bool Equals(IReadOnlyDictionary<string, int> left, IReadOnlyDictionary<string, int> right) => InterfaceCollectionTestHelpers.DictionaryEqual(left, right);
+}
+
+[Trait("Category", "BVT")]
+public class InterfaceCollectionRegressionTests
+{
+    private const int MaxInterfaceCollectionCapacityHint = 16 * 1024;
+    private static readonly int[] ExpectedArray = [1, 2, 3];
+
+    [Fact]
+    public void CanSerializeCollectionExpressionReadOnlyList()
+    {
+        var original = new ReadOnlyListContainer { Values = ["a", "b"] };
+
+        var result = RoundTrip(original);
+
+        Assert.Collection(result.Values, value => Assert.Equal("a", value), value => Assert.Equal("b", value));
+    }
+
+    [Fact]
+    public void CanCopyCollectionExpressionReadOnlyList()
+    {
+        var original = new ReadOnlyListContainer { Values = ["a", "b"] };
+
+        var result = Copy(original);
+
+        Assert.NotSame(original, result);
+        Assert.Collection(result.Values, value => Assert.Equal("a", value), value => Assert.Equal("b", value));
+    }
+
+    [Fact]
+    public void CanSerializeLinqEnumerableAsDeclaredInterface()
+    {
+        IEnumerable<int> original = Enumerable.Range(0, 10).Where(value => value % 2 == 0);
+
+        var result = RoundTrip(original);
+
+        Assert.Equal([0, 2, 4, 6, 8], result);
+    }
+
+    [Fact]
+    public void CanCopyUnsupportedReadOnlyListAsDeclaredInterface()
+    {
+        IReadOnlyList<int> original = [1, 2, 3];
+
+        var result = Copy(original);
+
+        Assert.IsType<List<int>>(result);
+        Assert.Equal(original, result);
+    }
+
+    [Fact]
+    public void FallbackSerializationCapsCapacityHint()
+    {
+        IReadOnlyCollection<int> original = new MisreportedReadOnlyCollection<int>(
+            [1, 2, 3],
+            MaxInterfaceCollectionCapacityHint + 1);
+
+        var result = RoundTrip(original);
+
+        var list = Assert.IsType<List<int>>(result);
+        Assert.Equal(ExpectedArray, list);
+        Assert.Equal(MaxInterfaceCollectionCapacityHint, list.Capacity);
+    }
+
+    [Fact]
+    public void FallbackCopyCapsCapacityHint()
+    {
+        IReadOnlyCollection<int> original = new MisreportedReadOnlyCollection<int>(
+            [1, 2, 3],
+            MaxInterfaceCollectionCapacityHint + 1);
+
+        var result = Copy(original);
+
+        var list = Assert.IsType<List<int>>(result);
+        Assert.Equal(ExpectedArray, list);
+        Assert.Equal(MaxInterfaceCollectionCapacityHint, list.Capacity);
+    }
+
+    [Fact]
+    public void RuntimeConcreteCodecIsPreservedWhenAvailable()
+    {
+        var original = new IntReadOnlyListContainer
+        {
+            Values = new GeneratedReadOnlyList { Values = [1, 2, 3], Marker = "preserved" }
+        };
+
+        var result = RoundTrip(original);
+
+        var concrete = Assert.IsType<GeneratedReadOnlyList>(result.Values);
+        Assert.Equal("preserved", concrete.Marker);
+        Assert.Equal([1, 2, 3], concrete);
+    }
+
+    [Fact]
+    public void RuntimeConcreteSetComparerIsPreservedWhenAvailable()
+    {
+        var original = new SetContainer
+        {
+            Values = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "key" }
+        };
+
+        var result = RoundTrip(original);
+
+        var set = Assert.IsType<HashSet<string>>(result.Values);
+        Assert.Contains("KEY", set);
+    }
+
+#if NET8_0_OR_GREATER
+    [Fact]
+    public void CanSerializeFrozenCollectionsAsDeclaredInterfaces()
+    {
+        var original = new FrozenCollectionContainer
+        {
+            Set = new HashSet<string> { "a", "b" }.ToFrozenSet(),
+            Dictionary = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }.ToFrozenDictionary()
+        };
+
+        var result = RoundTrip(original);
+
+        Assert.True(result.Set.SetEquals(["a", "b"]));
+        Assert.Equal(1, result.Dictionary["a"]);
+        Assert.Equal(2, result.Dictionary["b"]);
+    }
+#endif
+
+    private static T RoundTrip<T>(T value)
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        return serializer.Deserialize<T>(serializer.SerializeToArray(value));
+    }
+
+    private static T Copy<T>(T value)
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        return serviceProvider.GetRequiredService<DeepCopier<T>>().Copy(value);
+    }
+
+    [GenerateSerializer]
+    [Alias("Orleans.Serialization.UnitTests.InterfaceCollectionRegressionTests.ReadOnlyListContainer")]
+    public sealed class ReadOnlyListContainer
+    {
+        [Id(0)]
+        public IReadOnlyList<string> Values { get; set; }
+    }
+
+    [GenerateSerializer]
+    [Alias("Orleans.Serialization.UnitTests.InterfaceCollectionRegressionTests.IntReadOnlyListContainer")]
+    public sealed class IntReadOnlyListContainer
+    {
+        [Id(0)]
+        public IReadOnlyList<int> Values { get; set; }
+    }
+
+    [GenerateSerializer]
+    [Alias("Orleans.Serialization.UnitTests.InterfaceCollectionRegressionTests.SetContainer")]
+    public sealed class SetContainer
+    {
+        [Id(0)]
+        public ISet<string> Values { get; set; }
+    }
+
+    [GenerateSerializer]
+    [Alias("Orleans.Serialization.UnitTests.InterfaceCollectionRegressionTests.GeneratedReadOnlyList")]
+    public sealed class GeneratedReadOnlyList : IReadOnlyList<int>
+    {
+        [Id(0)]
+        public List<int> Values { get; set; } = [];
+
+        [Id(1)]
+        public string Marker { get; set; }
+
+        public int Count => Values.Count;
+
+        public int this[int index] => Values[index];
+
+        public IEnumerator<int> GetEnumerator() => Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+#if NET8_0_OR_GREATER
+    [GenerateSerializer]
+    [Alias("Orleans.Serialization.UnitTests.InterfaceCollectionRegressionTests.FrozenCollectionContainer")]
+    public sealed class FrozenCollectionContainer
+    {
+        [Id(0)]
+        public IReadOnlySet<string> Set { get; set; }
+
+        [Id(1)]
+        public IReadOnlyDictionary<string, int> Dictionary { get; set; }
+    }
+#endif
+}
+
+internal static class InterfaceCollectionTestHelpers
+{
+    public static List<int> CreateList(Random random)
+    {
+        var result = new List<int>();
+        var length = random.Next(17) + 5;
+        for (var i = 0; i < length; i++)
+        {
+            result.Add(random.Next());
+        }
+
+        return result;
+    }
+
+    public static HashSet<string> CreateSet(Random random)
+    {
+        var result = new HashSet<string>();
+        var length = random.Next(17) + 5;
+        for (var i = 0; i < length; i++)
+        {
+            result.Add(random.Next().ToString(CultureInfo.InvariantCulture));
+        }
+
+        return result;
+    }
+
+    public static Dictionary<string, int> CreateDictionary(Random random)
+    {
+        var result = new Dictionary<string, int>();
+        var length = random.Next(17) + 5;
+        for (var i = 0; i < length; i++)
+        {
+            result[random.Next().ToString(CultureInfo.InvariantCulture)] = random.Next();
+        }
+
+        return result;
+    }
+
+    public static bool SequenceEqual<T>(IEnumerable<T> left, IEnumerable<T> right) =>
+        ReferenceEquals(left, right) || left is not null && right is not null && left.SequenceEqual(right);
+
+    public static bool SetEqual<T>(IEnumerable<T> left, IEnumerable<T> right) =>
+        ReferenceEquals(left, right) || left is not null && right is not null && left.ToHashSet().SetEquals(right);
+
+    public static bool DictionaryEqual<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> left, IEnumerable<KeyValuePair<TKey, TValue>> right) where TKey : notnull
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        var rightDictionary = new Dictionary<TKey, TValue>();
+        foreach (var (key, value) in right)
+        {
+            rightDictionary[key] = value;
+        }
+
+        var count = 0;
+        foreach (var (key, value) in left)
+        {
+            count++;
+            if (!rightDictionary.TryGetValue(key, out var result) || !EqualityComparer<TValue>.Default.Equals(value, result))
+            {
+                return false;
+            }
+        }
+
+        return count == rightDictionary.Count;
+    }
+}
+
+internal sealed class UnknownList<T>(IEnumerable<T> values) : IList<T>, IReadOnlyList<T>
+{
+    private readonly List<T> _values = [with(values)];
+
+    public int Count => _values.Count;
+
+    public bool IsReadOnly => false;
+
+    public T this[int index]
+    {
+        get => _values[index];
+        set => _values[index] = value;
+    }
+
+    public void Add(T item) => _values.Add(item);
+
+    public void Clear() => _values.Clear();
+
+    public bool Contains(T item) => _values.Contains(item);
+
+    public void CopyTo(T[] array, int arrayIndex) => _values.CopyTo(array, arrayIndex);
+
+    public IEnumerator<T> GetEnumerator() => _values.GetEnumerator();
+
+    public int IndexOf(T item) => _values.IndexOf(item);
+
+    public void Insert(int index, T item) => _values.Insert(index, item);
+
+    public bool Remove(T item) => _values.Remove(item);
+
+    public void RemoveAt(int index) => _values.RemoveAt(index);
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+internal sealed class MisreportedReadOnlyCollection<T>(IEnumerable<T> values, int count) : IReadOnlyCollection<T>
+{
+    private readonly IReadOnlyList<T> _values = [.. values];
+
+    public int Count { get; } = count;
+
+    public IEnumerator<T> GetEnumerator() => _values.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
@@ -24,7 +24,7 @@ using static VerifyXunit.Verifier;
 
 namespace Orleans.Serialization.UnitTests;
 
-public class EnumerableInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IEnumerable<int>, IFieldCodec<IEnumerable<int>>>(output)
+public class EnumerableInterfaceCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<IEnumerable<int>, IFieldCodec<IEnumerable<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IFieldCodec<IEnumerable<int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IEnumerable<int>>();
     protected override IEnumerable<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
@@ -32,7 +32,7 @@ public class EnumerableInterfaceCodecTests(ITestOutputHelper output) : FieldCode
     protected override bool Equals(IEnumerable<int> left, IEnumerable<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
 }
 
-public class EnumerableInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IEnumerable<int>, IDeepCopier<IEnumerable<int>>>(output)
+public class EnumerableInterfaceCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<IEnumerable<int>, IDeepCopier<IEnumerable<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IDeepCopier<IEnumerable<int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IEnumerable<int>>();
     protected override IEnumerable<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
@@ -40,7 +40,7 @@ public class EnumerableInterfaceCopierTests(ITestOutputHelper output) : CopierTe
     protected override bool Equals(IEnumerable<int> left, IEnumerable<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
 }
 
-public class ReadOnlyCollectionInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IReadOnlyCollection<int>, IFieldCodec<IReadOnlyCollection<int>>>(output)
+public class ReadOnlyCollectionInterfaceCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<IReadOnlyCollection<int>, IFieldCodec<IReadOnlyCollection<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IFieldCodec<IReadOnlyCollection<int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IReadOnlyCollection<int>>();
     protected override IReadOnlyCollection<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
@@ -48,7 +48,7 @@ public class ReadOnlyCollectionInterfaceCodecTests(ITestOutputHelper output) : F
     protected override bool Equals(IReadOnlyCollection<int> left, IReadOnlyCollection<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
 }
 
-public class ReadOnlyCollectionInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IReadOnlyCollection<int>, IDeepCopier<IReadOnlyCollection<int>>>(output)
+public class ReadOnlyCollectionInterfaceCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<IReadOnlyCollection<int>, IDeepCopier<IReadOnlyCollection<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IDeepCopier<IReadOnlyCollection<int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IReadOnlyCollection<int>>();
     protected override IReadOnlyCollection<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
@@ -56,7 +56,7 @@ public class ReadOnlyCollectionInterfaceCopierTests(ITestOutputHelper output) : 
     protected override bool Equals(IReadOnlyCollection<int> left, IReadOnlyCollection<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
 }
 
-public class ReadOnlyListInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IReadOnlyList<int>, IFieldCodec<IReadOnlyList<int>>>(output)
+public class ReadOnlyListInterfaceCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<IReadOnlyList<int>, IFieldCodec<IReadOnlyList<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IFieldCodec<IReadOnlyList<int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IReadOnlyList<int>>();
     protected override IReadOnlyList<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
@@ -64,7 +64,7 @@ public class ReadOnlyListInterfaceCodecTests(ITestOutputHelper output) : FieldCo
     protected override bool Equals(IReadOnlyList<int> left, IReadOnlyList<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
 }
 
-public class ReadOnlyListInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IReadOnlyList<int>, IDeepCopier<IReadOnlyList<int>>>(output)
+public class ReadOnlyListInterfaceCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<IReadOnlyList<int>, IDeepCopier<IReadOnlyList<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IDeepCopier<IReadOnlyList<int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IReadOnlyList<int>>();
     protected override IReadOnlyList<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
@@ -72,7 +72,7 @@ public class ReadOnlyListInterfaceCopierTests(ITestOutputHelper output) : Copier
     protected override bool Equals(IReadOnlyList<int> left, IReadOnlyList<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
 }
 
-public class CollectionInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<ICollection<int>, IFieldCodec<ICollection<int>>>(output)
+public class CollectionInterfaceCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ICollection<int>, IFieldCodec<ICollection<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IFieldCodec<ICollection<int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<ICollection<int>>();
     protected override ICollection<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
@@ -80,7 +80,7 @@ public class CollectionInterfaceCodecTests(ITestOutputHelper output) : FieldCode
     protected override bool Equals(ICollection<int> left, ICollection<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
 }
 
-public class CollectionInterfaceCopierTests(ITestOutputHelper output) : CopierTester<ICollection<int>, IDeepCopier<ICollection<int>>>(output)
+public class CollectionInterfaceCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ICollection<int>, IDeepCopier<ICollection<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IDeepCopier<ICollection<int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<ICollection<int>>();
     protected override ICollection<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
@@ -88,7 +88,7 @@ public class CollectionInterfaceCopierTests(ITestOutputHelper output) : CopierTe
     protected override bool Equals(ICollection<int> left, ICollection<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
 }
 
-public class ListInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IList<int>, IFieldCodec<IList<int>>>(output)
+public class ListInterfaceCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<IList<int>, IFieldCodec<IList<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IFieldCodec<IList<int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IList<int>>();
     protected override IList<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
@@ -96,7 +96,7 @@ public class ListInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTeste
     protected override bool Equals(IList<int> left, IList<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
 }
 
-public class ListInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IList<int>, IDeepCopier<IList<int>>>(output)
+public class ListInterfaceCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<IList<int>, IDeepCopier<IList<int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IDeepCopier<IList<int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IList<int>>();
     protected override IList<int> CreateValue() => InterfaceCollectionTestHelpers.CreateList(Random);
@@ -104,7 +104,7 @@ public class ListInterfaceCopierTests(ITestOutputHelper output) : CopierTester<I
     protected override bool Equals(IList<int> left, IList<int> right) => InterfaceCollectionTestHelpers.SequenceEqual(left, right);
 }
 
-public class SetInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<ISet<string>, IFieldCodec<ISet<string>>>(output)
+public class SetInterfaceCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<ISet<string>, IFieldCodec<ISet<string>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IFieldCodec<ISet<string>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<ISet<string>>();
     protected override ISet<string> CreateValue() => InterfaceCollectionTestHelpers.CreateSet(Random);
@@ -112,7 +112,7 @@ public class SetInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester
     protected override bool Equals(ISet<string> left, ISet<string> right) => InterfaceCollectionTestHelpers.SetEqual(left, right);
 }
 
-public class SetInterfaceCopierTests(ITestOutputHelper output) : CopierTester<ISet<string>, IDeepCopier<ISet<string>>>(output)
+public class SetInterfaceCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ISet<string>, IDeepCopier<ISet<string>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IDeepCopier<ISet<string>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<ISet<string>>();
     protected override ISet<string> CreateValue() => InterfaceCollectionTestHelpers.CreateSet(Random);
@@ -121,7 +121,7 @@ public class SetInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IS
 }
 
 #if NET5_0_OR_GREATER
-public class ReadOnlySetInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IReadOnlySet<string>, IFieldCodec<IReadOnlySet<string>>>(output)
+public class ReadOnlySetInterfaceCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<IReadOnlySet<string>, IFieldCodec<IReadOnlySet<string>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IFieldCodec<IReadOnlySet<string>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IReadOnlySet<string>>();
     protected override IReadOnlySet<string> CreateValue() => InterfaceCollectionTestHelpers.CreateSet(Random);
@@ -129,7 +129,7 @@ public class ReadOnlySetInterfaceCodecTests(ITestOutputHelper output) : FieldCod
     protected override bool Equals(IReadOnlySet<string> left, IReadOnlySet<string> right) => InterfaceCollectionTestHelpers.SetEqual(left, right);
 }
 
-public class ReadOnlySetInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IReadOnlySet<string>, IDeepCopier<IReadOnlySet<string>>>(output)
+public class ReadOnlySetInterfaceCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<IReadOnlySet<string>, IDeepCopier<IReadOnlySet<string>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IDeepCopier<IReadOnlySet<string>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IReadOnlySet<string>>();
     protected override IReadOnlySet<string> CreateValue() => InterfaceCollectionTestHelpers.CreateSet(Random);
@@ -138,7 +138,7 @@ public class ReadOnlySetInterfaceCopierTests(ITestOutputHelper output) : CopierT
 }
 #endif
 
-public class DictionaryInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IDictionary<string, int>, IFieldCodec<IDictionary<string, int>>>(output)
+public class DictionaryInterfaceCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<IDictionary<string, int>, IFieldCodec<IDictionary<string, int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IFieldCodec<IDictionary<string, int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IDictionary<string, int>>();
     protected override IDictionary<string, int> CreateValue() => InterfaceCollectionTestHelpers.CreateDictionary(Random);
@@ -146,7 +146,7 @@ public class DictionaryInterfaceCodecTests(ITestOutputHelper output) : FieldCode
     protected override bool Equals(IDictionary<string, int> left, IDictionary<string, int> right) => InterfaceCollectionTestHelpers.DictionaryEqual(left, right);
 }
 
-public class DictionaryInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IDictionary<string, int>, IDeepCopier<IDictionary<string, int>>>(output)
+public class DictionaryInterfaceCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<IDictionary<string, int>, IDeepCopier<IDictionary<string, int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IDeepCopier<IDictionary<string, int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IDictionary<string, int>>();
     protected override IDictionary<string, int> CreateValue() => InterfaceCollectionTestHelpers.CreateDictionary(Random);
@@ -154,7 +154,7 @@ public class DictionaryInterfaceCopierTests(ITestOutputHelper output) : CopierTe
     protected override bool Equals(IDictionary<string, int> left, IDictionary<string, int> right) => InterfaceCollectionTestHelpers.DictionaryEqual(left, right);
 }
 
-public class ReadOnlyDictionaryInterfaceCodecTests(ITestOutputHelper output) : FieldCodecTester<IReadOnlyDictionary<string, int>, IFieldCodec<IReadOnlyDictionary<string, int>>>(output)
+public class ReadOnlyDictionaryInterfaceCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<IReadOnlyDictionary<string, int>, IFieldCodec<IReadOnlyDictionary<string, int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IFieldCodec<IReadOnlyDictionary<string, int>> CreateCodec() => ServiceProvider.GetRequiredService<ICodecProvider>().GetCodec<IReadOnlyDictionary<string, int>>();
     protected override IReadOnlyDictionary<string, int> CreateValue() => InterfaceCollectionTestHelpers.CreateDictionary(Random);
@@ -162,7 +162,7 @@ public class ReadOnlyDictionaryInterfaceCodecTests(ITestOutputHelper output) : F
     protected override bool Equals(IReadOnlyDictionary<string, int> left, IReadOnlyDictionary<string, int> right) => InterfaceCollectionTestHelpers.DictionaryEqual(left, right);
 }
 
-public class ReadOnlyDictionaryInterfaceCopierTests(ITestOutputHelper output) : CopierTester<IReadOnlyDictionary<string, int>, IDeepCopier<IReadOnlyDictionary<string, int>>>(output)
+public class ReadOnlyDictionaryInterfaceCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<IReadOnlyDictionary<string, int>, IDeepCopier<IReadOnlyDictionary<string, int>>>(output, fixture), IClassFixture<SerializationTesterFixture>
 {
     protected override IDeepCopier<IReadOnlyDictionary<string, int>> CreateCopier() => ServiceProvider.GetRequiredService<IDeepCopierProvider>().GetDeepCopier<IReadOnlyDictionary<string, int>>();
     protected override IReadOnlyDictionary<string, int> CreateValue() => InterfaceCollectionTestHelpers.CreateDictionary(Random);

--- a/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading.Tasks;
 #if NET8_0_OR_GREATER
 using System.Collections.Frozen;
 #endif
@@ -11,10 +12,15 @@ using Orleans;
 using Orleans.Serialization;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.Codecs;
+using Orleans.Serialization.Session;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.TestKit;
+using Orleans.Serialization.Utilities;
 using Xunit;
 using Xunit.Abstractions;
+#if !NETCOREAPP3_1
+using static VerifyXunit.Verifier;
+#endif
 
 namespace Orleans.Serialization.UnitTests;
 
@@ -168,6 +174,15 @@ public class ReadOnlyDictionaryInterfaceCopierTests(ITestOutputHelper output) : 
 public class InterfaceCollectionRegressionTests
 {
     private const int MaxInterfaceCollectionCapacityHint = 16 * 1024;
+    private const string EnumerableCodecAlias = "EnumerableCodec`1";
+    private const string ReadOnlyCollectionCodecAlias = "ReadOnlyCollectionInterfaceCodec`1";
+    private const string ReadOnlyListCodecAlias = "ReadOnlyListInterfaceCodec`1";
+    private const string CollectionCodecAlias = "CollectionInterfaceCodec`1";
+    private const string ListCodecAlias = "ListInterfaceCodec`1";
+    private const string SetCodecAlias = "SetInterfaceCodec`1";
+    private const string ReadOnlySetCodecAlias = "ReadOnlySetInterfaceCodec`1";
+    private const string DictionaryCodecAlias = "DictionaryInterfaceCodec`2";
+    private const string ReadOnlyDictionaryCodecAlias = "ReadOnlyDictionaryInterfaceCodec`2";
     private static readonly int[] ExpectedArray = [1, 2, 3];
 
     [Fact]
@@ -287,6 +302,90 @@ public class InterfaceCollectionRegressionTests
     }
 #endif
 
+    [Fact]
+    public void CanSerializeGenericInterfaceFieldsUsingFallbackCodecTypes()
+    {
+        var original = new GenericInterfaceCollectionContainer
+        {
+            Enumerable = new UnknownList<int>(ExpectedArray),
+            ReadOnlyCollection = new MisreportedReadOnlyCollection<int>(ExpectedArray, ExpectedArray.Length),
+            ReadOnlyList = new UnknownList<int>(ExpectedArray),
+            Collection = new UnknownList<int>(ExpectedArray),
+            List = new UnknownList<int>(ExpectedArray),
+            Set = new UnknownSet<string>(["a", "b"]),
+#if NET5_0_OR_GREATER
+            ReadOnlySet = new UnknownSet<string>(["c", "d"]),
+#endif
+            Dictionary = new UnknownDictionary<string, int>(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }),
+            ReadOnlyDictionary = new UnknownDictionary<string, int>(new Dictionary<string, int> { ["c"] = 3, ["d"] = 4 }),
+        };
+
+        var result = RoundTrip(original);
+
+        var enumerable = Assert.IsType<List<int>>(result.Enumerable);
+        Assert.Equal(ExpectedArray, enumerable);
+        var readOnlyCollection = Assert.IsType<List<int>>(result.ReadOnlyCollection);
+        Assert.Equal(ExpectedArray, readOnlyCollection);
+        var readOnlyList = Assert.IsType<List<int>>(result.ReadOnlyList);
+        Assert.Equal(ExpectedArray, readOnlyList);
+        var collection = Assert.IsType<List<int>>(result.Collection);
+        Assert.Equal(ExpectedArray, collection);
+        var list = Assert.IsType<List<int>>(result.List);
+        Assert.Equal(ExpectedArray, list);
+        var set = Assert.IsType<HashSet<string>>(result.Set);
+        Assert.True(set.SetEquals(["a", "b"]));
+#if NET5_0_OR_GREATER
+        var readOnlySet = Assert.IsType<HashSet<string>>(result.ReadOnlySet);
+        Assert.True(readOnlySet.SetEquals(["c", "d"]));
+#endif
+        var dictionary = Assert.IsType<Dictionary<string, int>>(result.Dictionary);
+        Assert.Equal(1, dictionary["a"]);
+        Assert.Equal(2, dictionary["b"]);
+        var readOnlyDictionary = Assert.IsType<Dictionary<string, int>>(result.ReadOnlyDictionary);
+        Assert.Equal(3, readOnlyDictionary["c"]);
+        Assert.Equal(4, readOnlyDictionary["d"]);
+    }
+
+#if !NETCOREAPP3_1
+    [Fact]
+    public Task EnumerableInterfaceFallback_Formatted_MatchesSnapshot()
+        => VerifyFallbackBitStream<IEnumerable<int>>(new UnknownList<int>(ExpectedArray), EnumerableCodecAlias);
+
+    [Fact]
+    public Task ReadOnlyCollectionInterfaceFallback_Formatted_MatchesSnapshot()
+        => VerifyFallbackBitStream<IReadOnlyCollection<int>>(new MisreportedReadOnlyCollection<int>(ExpectedArray, ExpectedArray.Length), ReadOnlyCollectionCodecAlias);
+
+    [Fact]
+    public Task ReadOnlyListInterfaceFallback_Formatted_MatchesSnapshot()
+        => VerifyFallbackBitStream<IReadOnlyList<int>>(new UnknownList<int>(ExpectedArray), ReadOnlyListCodecAlias);
+
+    [Fact]
+    public Task CollectionInterfaceFallback_Formatted_MatchesSnapshot()
+        => VerifyFallbackBitStream<ICollection<int>>(new UnknownList<int>(ExpectedArray), CollectionCodecAlias);
+
+    [Fact]
+    public Task ListInterfaceFallback_Formatted_MatchesSnapshot()
+        => VerifyFallbackBitStream<IList<int>>(new UnknownList<int>(ExpectedArray), ListCodecAlias);
+
+    [Fact]
+    public Task SetInterfaceFallback_Formatted_MatchesSnapshot()
+        => VerifyFallbackBitStream<ISet<string>>(new UnknownSet<string>(["a", "b"]), SetCodecAlias);
+
+#if NET5_0_OR_GREATER
+    [Fact]
+    public Task ReadOnlySetInterfaceFallback_Formatted_MatchesSnapshot()
+        => VerifyFallbackBitStream<IReadOnlySet<string>>(new UnknownSet<string>(["a", "b"]), ReadOnlySetCodecAlias);
+#endif
+
+    [Fact]
+    public Task DictionaryInterfaceFallback_Formatted_MatchesSnapshot()
+        => VerifyFallbackBitStream<IDictionary<string, int>>(new UnknownDictionary<string, int>(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }), DictionaryCodecAlias);
+
+    [Fact]
+    public Task ReadOnlyDictionaryInterfaceFallback_Formatted_MatchesSnapshot()
+        => VerifyFallbackBitStream<IReadOnlyDictionary<string, int>>(new UnknownDictionary<string, int>(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }), ReadOnlyDictionaryCodecAlias);
+#endif
+
     private static T RoundTrip<T>(T value)
     {
         using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
@@ -299,6 +398,24 @@ public class InterfaceCollectionRegressionTests
         using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
         return serviceProvider.GetRequiredService<DeepCopier<T>>().Copy(value);
     }
+
+#if !NETCOREAPP3_1
+    private static Task VerifyFallbackBitStream<T>(T value, string codecAlias)
+    {
+        var formatted = FormatSerializedPayload(value);
+        Assert.Contains($"TypeName \"{codecAlias}", formatted);
+        return Verify(formatted, extension: "txt").UseDirectory("snapshots");
+    }
+
+    private static string FormatSerializedPayload<T>(T value)
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer<T>>();
+        var payload = serializer.SerializeToArray(value);
+        using var session = serviceProvider.GetRequiredService<SerializerSessionPool>().GetSession();
+        return BitStreamFormatter.Format(payload, session);
+    }
+#endif
 
     [GenerateSerializer]
     [Alias("Orleans.Serialization.UnitTests.InterfaceCollectionRegressionTests.ReadOnlyListContainer")]
@@ -355,6 +472,40 @@ public class InterfaceCollectionRegressionTests
         public IReadOnlyDictionary<string, int> Dictionary { get; set; }
     }
 #endif
+
+    [GenerateSerializer]
+    [Alias("Orleans.Serialization.UnitTests.InterfaceCollectionRegressionTests.GenericInterfaceCollectionContainer")]
+    public sealed class GenericInterfaceCollectionContainer
+    {
+        [Id(0)]
+        public IEnumerable<int> Enumerable { get; set; }
+
+        [Id(1)]
+        public IReadOnlyCollection<int> ReadOnlyCollection { get; set; }
+
+        [Id(2)]
+        public IReadOnlyList<int> ReadOnlyList { get; set; }
+
+        [Id(3)]
+        public ICollection<int> Collection { get; set; }
+
+        [Id(4)]
+        public IList<int> List { get; set; }
+
+        [Id(5)]
+        public ISet<string> Set { get; set; }
+
+#if NET5_0_OR_GREATER
+        [Id(6)]
+        public IReadOnlySet<string> ReadOnlySet { get; set; }
+#endif
+
+        [Id(7)]
+        public IDictionary<string, int> Dictionary { get; set; }
+
+        [Id(8)]
+        public IReadOnlyDictionary<string, int> ReadOnlyDictionary { get; set; }
+    }
 }
 
 internal static class InterfaceCollectionTestHelpers
@@ -464,6 +615,99 @@ internal sealed class UnknownList<T>(IEnumerable<T> values) : IList<T>, IReadOnl
     public bool Remove(T item) => _values.Remove(item);
 
     public void RemoveAt(int index) => _values.RemoveAt(index);
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+internal sealed class UnknownSet<T>(IEnumerable<T> values) : ISet<T>
+#if NET5_0_OR_GREATER
+    , IReadOnlySet<T>
+#endif
+{
+    private readonly HashSet<T> _values = [.. values];
+
+    public int Count => _values.Count;
+
+    public bool IsReadOnly => false;
+
+    public bool Add(T item) => _values.Add(item);
+
+    void ICollection<T>.Add(T item) => Add(item);
+
+    public void ExceptWith(IEnumerable<T> other) => _values.ExceptWith(other);
+
+    public IEnumerator<T> GetEnumerator() => _values.GetEnumerator();
+
+    public void IntersectWith(IEnumerable<T> other) => _values.IntersectWith(other);
+
+    public bool IsProperSubsetOf(IEnumerable<T> other) => _values.IsProperSubsetOf(other);
+
+    public bool IsProperSupersetOf(IEnumerable<T> other) => _values.IsProperSupersetOf(other);
+
+    public bool IsSubsetOf(IEnumerable<T> other) => _values.IsSubsetOf(other);
+
+    public bool IsSupersetOf(IEnumerable<T> other) => _values.IsSupersetOf(other);
+
+    public bool Overlaps(IEnumerable<T> other) => _values.Overlaps(other);
+
+    public bool SetEquals(IEnumerable<T> other) => _values.SetEquals(other);
+
+    public void SymmetricExceptWith(IEnumerable<T> other) => _values.SymmetricExceptWith(other);
+
+    public void UnionWith(IEnumerable<T> other) => _values.UnionWith(other);
+
+    public void Clear() => _values.Clear();
+
+    public bool Contains(T item) => _values.Contains(item);
+
+    public void CopyTo(T[] array, int arrayIndex) => _values.CopyTo(array, arrayIndex);
+
+    public bool Remove(T item) => _values.Remove(item);
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+internal sealed class UnknownDictionary<TKey, TValue>(IDictionary<TKey, TValue> values) : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>
+{
+    private readonly Dictionary<TKey, TValue> _values = new(values);
+
+    public int Count => _values.Count;
+
+    public bool IsReadOnly => false;
+
+    public ICollection<TKey> Keys => _values.Keys;
+
+    public ICollection<TValue> Values => _values.Values;
+
+    IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => _values.Keys;
+
+    IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => _values.Values;
+
+    public TValue this[TKey key]
+    {
+        get => _values[key];
+        set => _values[key] = value;
+    }
+
+    public void Add(TKey key, TValue value) => _values.Add(key, value);
+
+    public void Add(KeyValuePair<TKey, TValue> item) => ((ICollection<KeyValuePair<TKey, TValue>>)_values).Add(item);
+
+    public void Clear() => _values.Clear();
+
+    public bool Contains(KeyValuePair<TKey, TValue> item) => ((ICollection<KeyValuePair<TKey, TValue>>)_values).Contains(item);
+
+    public bool ContainsKey(TKey key) => _values.ContainsKey(key);
+
+    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) => ((ICollection<KeyValuePair<TKey, TValue>>)_values).CopyTo(array, arrayIndex);
+
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _values.GetEnumerator();
+
+    public bool Remove(TKey key) => _values.Remove(key);
+
+    public bool Remove(KeyValuePair<TKey, TValue> item) => ((ICollection<KeyValuePair<TKey, TValue>>)_values).Remove(item);
+
+    public bool TryGetValue(TKey key, out TValue value) => _values.TryGetValue(key, out value);
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/test/Orleans.Serialization.UnitTests/MemoryPackSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/MemoryPackSerializerTests.cs
@@ -30,9 +30,9 @@ namespace Orleans.Serialization.UnitTests;
 /// - Needing better performance than JSON but more portability than Orleans' native format
 /// </summary>
 [Trait("Category", "BVT")]
-public class MemoryPackCodecTests : FieldCodecTester<MyMemoryPackClass?, IFieldCodec<MyMemoryPackClass?>>
+public class MemoryPackCodecTests : FieldCodecTester<MyMemoryPackClass?, IFieldCodec<MyMemoryPackClass?>>, IClassFixture<SerializationTesterFixture>
 {
-    public MemoryPackCodecTests(ITestOutputHelper output) : base(output)
+    public MemoryPackCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -101,9 +101,9 @@ public class MemoryPackCodecTests : FieldCodecTester<MyMemoryPackClass?, IFieldC
 
 
 [Trait("Category", "BVT")]
-public class MemoryPackUnionCodecTests : FieldCodecTester<IMyMemoryPackUnion?, IFieldCodec<IMyMemoryPackUnion?>>
+public class MemoryPackUnionCodecTests : FieldCodecTester<IMyMemoryPackUnion?, IFieldCodec<IMyMemoryPackUnion?>>, IClassFixture<SerializationTesterFixture>
 {
-    public MemoryPackUnionCodecTests(ITestOutputHelper output) : base(output)
+    public MemoryPackUnionCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -124,9 +124,9 @@ public class MemoryPackUnionCodecTests : FieldCodecTester<IMyMemoryPackUnion?, I
 
 
 [Trait("Category", "BVT")]
-public class MemoryPackCodecCopierTests : CopierTester<MyMemoryPackClass?, IDeepCopier<MyMemoryPackClass?>>
+public class MemoryPackCodecCopierTests : CopierTester<MyMemoryPackClass?, IDeepCopier<MyMemoryPackClass?>>, IClassFixture<SerializationTesterFixture>
 {
-    public MemoryPackCodecCopierTests(ITestOutputHelper output) : base(output)
+    public MemoryPackCodecCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 

--- a/test/Orleans.Serialization.UnitTests/MessagePackSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/MessagePackSerializerTests.cs
@@ -30,9 +30,9 @@ namespace Orleans.Serialization.UnitTests;
 /// - Needing better performance than JSON but more portability than Orleans' native format
 /// </summary>
 [Trait("Category", "BVT")]
-public class MessagePackCodecTests : FieldCodecTester<MyMessagePackClass?, IFieldCodec<MyMessagePackClass?>>
+public class MessagePackCodecTests : FieldCodecTester<MyMessagePackClass?, IFieldCodec<MyMessagePackClass?>>, IClassFixture<SerializationTesterFixture>
 {
-    public MessagePackCodecTests(ITestOutputHelper output) : base(output)
+    public MessagePackCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -101,9 +101,9 @@ public class MessagePackCodecTests : FieldCodecTester<MyMessagePackClass?, IFiel
 
 
 [Trait("Category", "BVT")]
-public class MessagePackUnionCodecTests : FieldCodecTester<IMyMessagePackUnion?, IFieldCodec<IMyMessagePackUnion?>>
+public class MessagePackUnionCodecTests : FieldCodecTester<IMyMessagePackUnion?, IFieldCodec<IMyMessagePackUnion?>>, IClassFixture<SerializationTesterFixture>
 {
-    public MessagePackUnionCodecTests(ITestOutputHelper output) : base(output)
+    public MessagePackUnionCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -124,9 +124,9 @@ public class MessagePackUnionCodecTests : FieldCodecTester<IMyMessagePackUnion?,
 
 
 [Trait("Category", "BVT")]
-public class MessagePackCodecCopierTests : CopierTester<MyMessagePackClass?, IDeepCopier<MyMessagePackClass?>>
+public class MessagePackCodecCopierTests : CopierTester<MyMessagePackClass?, IDeepCopier<MyMessagePackClass?>>, IClassFixture<SerializationTesterFixture>
 {
-    public MessagePackCodecCopierTests(ITestOutputHelper output) : base(output)
+    public MessagePackCodecCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 

--- a/test/Orleans.Serialization.UnitTests/NewtonsoftJsonCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/NewtonsoftJsonCodecTests.cs
@@ -28,9 +28,9 @@ namespace Orleans.Serialization.UnitTests
     /// to Orleans that already have complex Newtonsoft.Json configurations.
     /// </summary>
     [Trait("Category", "BVT")]
-    public class NewtonsoftJsonCodecTests : FieldCodecTester<MyNewtonsoftJsonClass, IFieldCodec<MyNewtonsoftJsonClass>>
+    public class NewtonsoftJsonCodecTests : FieldCodecTester<MyNewtonsoftJsonClass, IFieldCodec<MyNewtonsoftJsonClass>>, IClassFixture<SerializationTesterFixture>
     {
-        public NewtonsoftJsonCodecTests(ITestOutputHelper output) : base(output)
+        public NewtonsoftJsonCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
         {
         }
 
@@ -119,9 +119,9 @@ namespace Orleans.Serialization.UnitTests
     }
 
     [Trait("Category", "BVT")]
-    public class NewtonsoftJsonCodecCopierTests : CopierTester<MyNewtonsoftJsonClass, IDeepCopier<MyNewtonsoftJsonClass>>
+    public class NewtonsoftJsonCodecCopierTests : CopierTester<MyNewtonsoftJsonClass, IDeepCopier<MyNewtonsoftJsonClass>>, IClassFixture<SerializationTesterFixture>
     {
-        public NewtonsoftJsonCodecCopierTests(ITestOutputHelper output) : base(output)
+        public NewtonsoftJsonCodecCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
         {
         }
 

--- a/test/Orleans.Serialization.UnitTests/ProtobufSerializerTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ProtobufSerializerTests.cs
@@ -35,9 +35,9 @@ namespace Orleans.Serialization.UnitTests;
 /// - Needing highly optimized wire format
 /// </summary>
 [Trait("Category", "BVT")]
-public class ProtobufSerializerTests : FieldCodecTester<MyProtobufClass?, IFieldCodec<MyProtobufClass?>>
+public class ProtobufSerializerTests : FieldCodecTester<MyProtobufClass?, IFieldCodec<MyProtobufClass?>>, IClassFixture<SerializationTesterFixture>
 {
-    public ProtobufSerializerTests(ITestOutputHelper output) : base(output)
+    public ProtobufSerializerTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -101,9 +101,9 @@ public class ProtobufSerializerTests : FieldCodecTester<MyProtobufClass?, IField
 }
 
 [Trait("Category", "BVT")]
-public class ProtobufCodecCopierTests : CopierTester<MyProtobufClass?, IDeepCopier<MyProtobufClass?>>
+public class ProtobufCodecCopierTests : CopierTester<MyProtobufClass?, IDeepCopier<MyProtobufClass?>>, IClassFixture<SerializationTesterFixture>
 {
-    public ProtobufCodecCopierTests(ITestOutputHelper output) : base(output)
+    public ProtobufCodecCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -125,9 +125,9 @@ public class ProtobufCodecCopierTests : CopierTester<MyProtobufClass?, IDeepCopi
 }
 
 [Trait("Category", "BVT")]
-public class ProtobufRepeatedFieldCodecTests : FieldCodecTester<RepeatedField<int>, RepeatedFieldCodec<int>>
+public class ProtobufRepeatedFieldCodecTests : FieldCodecTester<RepeatedField<int>, RepeatedFieldCodec<int>>, IClassFixture<SerializationTesterFixture>
 {
-    public ProtobufRepeatedFieldCodecTests(ITestOutputHelper output) : base(output)
+    public ProtobufRepeatedFieldCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -147,9 +147,9 @@ public class ProtobufRepeatedFieldCodecTests : FieldCodecTester<RepeatedField<in
 }
 
 [Trait("Category", "BVT")]
-public class ProtobufRepeatedFieldCopierTests : CopierTester<RepeatedField<int>, IDeepCopier<RepeatedField<int>>>
+public class ProtobufRepeatedFieldCopierTests : CopierTester<RepeatedField<int>, IDeepCopier<RepeatedField<int>>>, IClassFixture<SerializationTesterFixture>
 {
-    public ProtobufRepeatedFieldCopierTests(ITestOutputHelper output) : base(output)
+    public ProtobufRepeatedFieldCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -171,9 +171,9 @@ public class ProtobufRepeatedFieldCopierTests : CopierTester<RepeatedField<int>,
 }
 
 [Trait("Category", "BVT")]
-public class MapFieldCodecTests : FieldCodecTester<MapField<string, int>, MapFieldCodec<string, int>>
+public class MapFieldCodecTests : FieldCodecTester<MapField<string, int>, MapFieldCodec<string, int>>, IClassFixture<SerializationTesterFixture>
 {
-    public MapFieldCodecTests(ITestOutputHelper output) : base(output)
+    public MapFieldCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -193,9 +193,9 @@ public class MapFieldCodecTests : FieldCodecTester<MapField<string, int>, MapFie
 }
 
 [Trait("Category", "BVT")]
-public class MapFieldCopierTests : CopierTester<MapField<string, int>, MapFieldCopier<string, int>>
+public class MapFieldCopierTests : CopierTester<MapField<string, int>, MapFieldCopier<string, int>>, IClassFixture<SerializationTesterFixture>
 {
-    public MapFieldCopierTests(ITestOutputHelper output) : base(output)
+    public MapFieldCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -215,9 +215,9 @@ public class MapFieldCopierTests : CopierTester<MapField<string, int>, MapFieldC
 }
 
 [Trait("Category", "BVT")]
-public class ByteStringCodecTests : FieldCodecTester<ByteString, ByteStringCodec>
+public class ByteStringCodecTests : FieldCodecTester<ByteString, ByteStringCodec>, IClassFixture<SerializationTesterFixture>
 {
-    public ByteStringCodecTests(ITestOutputHelper output) : base(output)
+    public ByteStringCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 
@@ -234,9 +234,9 @@ public class ByteStringCodecTests : FieldCodecTester<ByteString, ByteStringCodec
 }
 
 [Trait("Category", "BVT")]
-public class ByteStringCopierTests : CopierTester<ByteString, ByteStringCopier>
+public class ByteStringCopierTests : CopierTester<ByteString, ByteStringCopier>, IClassFixture<SerializationTesterFixture>
 {
-    public ByteStringCopierTests(ITestOutputHelper output) : base(output)
+    public ByteStringCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : base(output, fixture)
     {
     }
 

--- a/test/Orleans.Serialization.UnitTests/SerializerServiceProviderLifetimeTests.cs
+++ b/test/Orleans.Serialization.UnitTests/SerializerServiceProviderLifetimeTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Serializers;
+using Orleans.Serialization.Session;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+public sealed class SerializerServiceProviderLifetimeTests
+{
+    [Fact]
+    public void DisposingServiceProviderReleasesPooledSerializerState()
+    {
+        var codecProvider = CreateWeakReferenceToPooledCodecProvider();
+
+        Collect();
+
+        Assert.False(codecProvider.IsAlive);
+    }
+
+    [Fact]
+    public void PooledSerializerStateCanBeReturnedAfterServiceProviderDisposal()
+    {
+        using var serviceProvider = new ServiceCollection()
+            .AddSerializer()
+            .BuildServiceProvider();
+        var session = serviceProvider.GetRequiredService<SerializerSessionPool>().GetSession();
+        var context = serviceProvider.GetRequiredService<CopyContextPool>().GetContext();
+
+        serviceProvider.Dispose();
+
+        session.Dispose();
+        context.Dispose();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateWeakReferenceToPooledCodecProvider()
+    {
+        var serviceProvider = new ServiceCollection()
+            .AddSerializer()
+            .BuildServiceProvider();
+        var codecProvider = serviceProvider.GetRequiredService<CodecProvider>();
+
+        using (serviceProvider.GetRequiredService<SerializerSessionPool>().GetSession())
+        {
+        }
+
+        using (serviceProvider.GetRequiredService<CopyContextPool>().GetContext())
+        {
+        }
+
+        var result = new WeakReference(codecProvider);
+        serviceProvider.Dispose();
+        return result;
+    }
+
+    private static void Collect()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+        }
+    }
+}

--- a/test/Orleans.Serialization.UnitTests/SerializerServiceProviderLifetimeTests.cs
+++ b/test/Orleans.Serialization.UnitTests/SerializerServiceProviderLifetimeTests.cs
@@ -24,7 +24,7 @@ public sealed class SerializerServiceProviderLifetimeTests
     [Fact]
     public void PooledSerializerStateCanBeReturnedAfterServiceProviderDisposal()
     {
-        using var serviceProvider = new ServiceCollection()
+        var serviceProvider = new ServiceCollection()
             .AddSerializer()
             .BuildServiceProvider();
         var session = serviceProvider.GetRequiredService<SerializerSessionPool>().GetSession();

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.CollectionInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.CollectionInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x002F [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.List`1[System.Int32] (name: Encoded "TypeName "System.Collections.Generic.List`1[[int]]" (hash 77903B0D)" (System.Collections.Generic.List`1[[System.Int32]]))] Value: {
+0x0030  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0032  [#3 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0034  [#4 VarInt Id: 1 SchemaType: Expected] Value: 8 (0x8)
+0x0036  [#5 VarInt Id: 1 SchemaType: Expected] Value: 12 (0xC)
+0x0038 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.CollectionInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.CollectionInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x0028 [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: Orleans.Serialization.Codecs.CollectionInterfaceCodec`1[System.Int32] (name: Encoded "TypeName "CollectionInterfaceCodec`1[[int]]" (hash 3F7E3DBD)" (Orleans.Serialization.Codecs.CollectionInterfaceCodec`1[[System.Int32]],Orleans.Serialization))] Value: {
+0x0029  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x002B  [#3 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x002D  [#4 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x002F  [#5 VarInt Id: 1 SchemaType: Expected] Value: 6 (0x6)
+0x0031 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.DictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.DictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,7 @@
+﻿0x003E [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.Dictionary`2[System.String,System.Int32] (name: Encoded "TypeName "System.Collections.Generic.Dictionary`2[[string],[int]]" (hash ABFDFCFE)" (System.Collections.Generic.Dictionary`2[[System.String],[System.Int32]]))] Value: {
+0x003F  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0041  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x0044  [#4 VarInt Id: 2 SchemaType: Expected] Value: 2 (0x2)
+0x0046  [#5 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x0049  [#6 VarInt Id: 2 SchemaType: Expected] Value: 4 (0x4)
+0x004B }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.DictionaryInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.DictionaryInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,7 @@
+﻿0x0031 [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: Orleans.Serialization.Codecs.DictionaryInterfaceCodec`2[System.String,System.Int32] (name: Encoded "TypeName "DictionaryInterfaceCodec`2[[string],[int]]" (hash 1D6FD9D8)" (Orleans.Serialization.Codecs.DictionaryInterfaceCodec`2[[System.String],[System.Int32]],Orleans.Serialization))] Value: {
+0x0032  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0034  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x0037  [#4 VarInt Id: 2 SchemaType: Expected] Value: 2 (0x2)
+0x0039  [#5 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x003C  [#6 VarInt Id: 2 SchemaType: Expected] Value: 4 (0x4)
+0x003E }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.EnumerableInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.EnumerableInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x002F [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.List`1[System.Int32] (name: Encoded "TypeName "System.Collections.Generic.List`1[[int]]" (hash 77903B0D)" (System.Collections.Generic.List`1[[System.Int32]]))] Value: {
+0x0030  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0032  [#3 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0034  [#4 VarInt Id: 1 SchemaType: Expected] Value: 8 (0x8)
+0x0036  [#5 VarInt Id: 1 SchemaType: Expected] Value: 12 (0xC)
+0x0038 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.EnumerableInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.EnumerableInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x001F [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: Orleans.Serialization.Codecs.EnumerableCodec`1[System.Int32] (name: Encoded "TypeName "EnumerableCodec`1[[int]]" (hash 036AAE6C)" (Orleans.Serialization.Codecs.EnumerableCodec`1[[System.Int32]],Orleans.Serialization))] Value: {
+0x0020  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0022  [#3 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0024  [#4 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0026  [#5 VarInt Id: 1 SchemaType: Expected] Value: 6 (0x6)
+0x0028 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ListInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ListInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x002F [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.List`1[System.Int32] (name: Encoded "TypeName "System.Collections.Generic.List`1[[int]]" (hash 77903B0D)" (System.Collections.Generic.List`1[[System.Int32]]))] Value: {
+0x0030  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0032  [#3 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0034  [#4 VarInt Id: 1 SchemaType: Expected] Value: 8 (0x8)
+0x0036  [#5 VarInt Id: 1 SchemaType: Expected] Value: 12 (0xC)
+0x0038 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ListInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ListInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x0022 [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: Orleans.Serialization.Codecs.ListInterfaceCodec`1[System.Int32] (name: Encoded "TypeName "ListInterfaceCodec`1[[int]]" (hash 043128D8)" (Orleans.Serialization.Codecs.ListInterfaceCodec`1[[System.Int32]],Orleans.Serialization))] Value: {
+0x0023  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0025  [#3 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0027  [#4 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0029  [#5 VarInt Id: 1 SchemaType: Expected] Value: 6 (0x6)
+0x002B }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyCollectionInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyCollectionInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x002F [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.List`1[System.Int32] (name: Encoded "TypeName "System.Collections.Generic.List`1[[int]]" (hash 77903B0D)" (System.Collections.Generic.List`1[[System.Int32]]))] Value: {
+0x0030  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0032  [#3 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0034  [#4 VarInt Id: 1 SchemaType: Expected] Value: 8 (0x8)
+0x0036  [#5 VarInt Id: 1 SchemaType: Expected] Value: 12 (0xC)
+0x0038 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyCollectionInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyCollectionInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x0030 [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: Orleans.Serialization.Codecs.ReadOnlyCollectionInterfaceCodec`1[System.Int32] (name: Encoded "TypeName "ReadOnlyCollectionInterfaceCodec`1[[int]]" (hash F2F01844)" (Orleans.Serialization.Codecs.ReadOnlyCollectionInterfaceCodec`1[[System.Int32]],Orleans.Serialization))] Value: {
+0x0031  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0033  [#3 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0035  [#4 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0037  [#5 VarInt Id: 1 SchemaType: Expected] Value: 6 (0x6)
+0x0039 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyDictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyDictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,7 @@
+﻿0x003E [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.Dictionary`2[System.String,System.Int32] (name: Encoded "TypeName "System.Collections.Generic.Dictionary`2[[string],[int]]" (hash ABFDFCFE)" (System.Collections.Generic.Dictionary`2[[System.String],[System.Int32]]))] Value: {
+0x003F  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0041  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x0044  [#4 VarInt Id: 2 SchemaType: Expected] Value: 2 (0x2)
+0x0046  [#5 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x0049  [#6 VarInt Id: 2 SchemaType: Expected] Value: 4 (0x4)
+0x004B }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyDictionaryInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyDictionaryInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,7 @@
+﻿0x0039 [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: Orleans.Serialization.Codecs.ReadOnlyDictionaryInterfaceCodec`2[System.String,System.Int32] (name: Encoded "TypeName "ReadOnlyDictionaryInterfaceCodec`2[[string],[int]]" (hash 11AF9B94)" (Orleans.Serialization.Codecs.ReadOnlyDictionaryInterfaceCodec`2[[System.String],[System.Int32]],Orleans.Serialization))] Value: {
+0x003A  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x003C  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x003F  [#4 VarInt Id: 2 SchemaType: Expected] Value: 2 (0x2)
+0x0041  [#5 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x0044  [#6 VarInt Id: 2 SchemaType: Expected] Value: 4 (0x4)
+0x0046 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyListInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyListInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x002F [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.List`1[System.Int32] (name: Encoded "TypeName "System.Collections.Generic.List`1[[int]]" (hash 77903B0D)" (System.Collections.Generic.List`1[[System.Int32]]))] Value: {
+0x0030  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0032  [#3 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0034  [#4 VarInt Id: 1 SchemaType: Expected] Value: 8 (0x8)
+0x0036  [#5 VarInt Id: 1 SchemaType: Expected] Value: 12 (0xC)
+0x0038 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyListInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyListInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x002A [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: Orleans.Serialization.Codecs.ReadOnlyListInterfaceCodec`1[System.Int32] (name: Encoded "TypeName "ReadOnlyListInterfaceCodec`1[[int]]" (hash EFB8BAFD)" (Orleans.Serialization.Codecs.ReadOnlyListInterfaceCodec`1[[System.Int32]],Orleans.Serialization))] Value: {
+0x002B  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x002D  [#3 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x002F  [#4 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0031  [#5 VarInt Id: 1 SchemaType: Expected] Value: 6 (0x6)
+0x0033 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlySetInterfaceConcreteHashSet_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlySetInterfaceConcreteHashSet_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,5 @@
+﻿0x0035 [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.HashSet`1[System.String] (name: Encoded "TypeName "System.Collections.Generic.HashSet`1[[string]]" (hash DCA1FD98)" (System.Collections.Generic.HashSet`1[[System.String]]))] Value: {
+0x0036  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0038  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x003B  [#4 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x003E }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlySetInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlySetInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,5 @@
+﻿0x002C [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: Orleans.Serialization.Codecs.ReadOnlySetInterfaceCodec`1[System.String] (name: Encoded "TypeName "ReadOnlySetInterfaceCodec`1[[string]]" (hash 428A07BE)" (Orleans.Serialization.Codecs.ReadOnlySetInterfaceCodec`1[[System.String]],Orleans.Serialization))] Value: {
+0x002D  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x002F  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x0032  [#4 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x0035 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.SetInterfaceConcreteHashSet_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.SetInterfaceConcreteHashSet_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,5 @@
+﻿0x0035 [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.HashSet`1[System.String] (name: Encoded "TypeName "System.Collections.Generic.HashSet`1[[string]]" (hash DCA1FD98)" (System.Collections.Generic.HashSet`1[[System.String]]))] Value: {
+0x0036  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0038  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x003B  [#4 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x003E }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.SetInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.SetInterfaceFallback_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,5 @@
+﻿0x0024 [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: Orleans.Serialization.Codecs.SetInterfaceCodec`1[System.String] (name: Encoded "TypeName "SetInterfaceCodec`1[[string]]" (hash 3284CBF8)" (Orleans.Serialization.Codecs.SetInterfaceCodec`1[[System.String]],Orleans.Serialization))] Value: {
+0x0025  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0027  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x002A  [#4 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x002D }


### PR DESCRIPTION
Fixes #8934

## Problem

Issue #8934 reports failures when interface-typed collection fields are assigned runtime collection implementations which Orleans does not have concrete codecs for, such as collection-expression generated types. Those fields currently fall through to runtime-type serialization and can fail with `CodecNotFoundException`.

## Solution

This adds regular open-generic codecs and copiers for common generic collection interfaces, including enumerable/list-like, set-like, and dictionary-like interfaces. The codecs preserve existing concrete runtime serialization when a concrete codec exists, and otherwise fall back to concrete BCL collection shapes (`List<T>`, `HashSet<T>`, and `Dictionary<TKey, TValue>`). The fallback writes bounded capacity hints, capped at 16K elements, so deserialization can preallocate efficiently without trusting accidentally huge reported counts.

The accompanying tests cover the issue regression, copy behavior, frozen collections, capacity-hint capping, and preservation of known concrete runtime behavior.

## Notes

Non-generic collection interfaces and lookup/query/streaming interfaces remain out of scope for this change.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10104)