### PR TITLE
Limit deserialized cache invalidation headers

### DIFF
--- a/src/Orleans.Core/Messaging/MessageSerializer.cs
+++ b/src/Orleans.Core/Messaging/MessageSerializer.cs
@@ -301,13 +301,18 @@ namespace Orleans.Runtime.Messaging
 
         internal List<GrainAddressCacheUpdate> ReadCacheInvalidationHeaders<TInput>(ref Reader<TInput> reader)
         {
-            var n = (int)reader.ReadVarUInt32();
+            var n = reader.ReadVarUInt32();
             if (n > 0)
             {
-                var list = new List<GrainAddressCacheUpdate>(n);
-                for (int i = 0; i < n; i++)
+                var count = Math.Min(n, (uint)Message.MaxCacheInvalidationHeaderEntries);
+                var list = new List<GrainAddressCacheUpdate>((int)count);
+                for (uint i = 0; i < n; i++)
                 {
-                    list.Add(_grainAddressCacheUpdateCodec.ReadValue(ref reader, reader.ReadFieldHeader()));
+                    var update = _grainAddressCacheUpdateCodec.ReadValue(ref reader, reader.ReadFieldHeader());
+                    if (i < count)
+                    {
+                        list.Add(update);
+                    }
                 }
 
                 return list;

--- a/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
+++ b/test/Orleans.Core.Tests/Serialization/MessageSerializerTests.cs
@@ -276,6 +276,40 @@ namespace UnitTests.Serialization
             }
         }
 
+        [Fact, TestCategory("BVT")]
+        public void MessageTest_CacheInvalidationHeader_DeserializeCapsHeaderCount()
+        {
+            var fromNew = new List<GrainAddressCacheUpdate>();
+            for (var i = 0; i < Message.MaxCacheInvalidationHeaderEntries + 1; i++)
+            {
+                var grainId = GrainId.Create("test", i.ToString());
+                fromNew.Add(new GrainAddressCacheUpdate(
+                    GrainAddress.NewActivationAddress(SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 11_000 + i), 11_000 + i), grainId),
+                    GrainAddress.NewActivationAddress(SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 22_000 + i), 22_000 + i), grainId)));
+            }
+
+            using var writer1Session = _serializerSessionPool.GetSession();
+            var writer = Writer.CreatePooled(writer1Session);
+            var message = new Message { CacheInvalidationHeader = fromNew };
+            messageSerializer.WriteCacheInvalidationHeaders(ref writer, message);
+            writer.WriteVarUInt32(42);
+            writer.Commit();
+
+            using var reader1Session = _serializerSessionPool.GetSession();
+            var reader = Reader.Create(writer.Output.AsReadOnlySequence(), reader1Session);
+            var toNew = messageSerializer.ReadCacheInvalidationHeaders(ref reader);
+            Assert.NotNull(toNew);
+            Assert.Equal(Message.MaxCacheInvalidationHeaderEntries, toNew.Count);
+            for (var i = 0; i < Message.MaxCacheInvalidationHeaderEntries; i++)
+            {
+                Assert.Equal(fromNew[i].InvalidGrainAddress, toNew[i].InvalidGrainAddress);
+                Assert.Equal(fromNew[i].ValidGrainAddress, toNew[i].ValidGrainAddress);
+            }
+
+            Assert.Equal(42u, reader.ReadVarUInt32());
+            writer.Dispose();
+        }
+
         private class MessageSerializerBackwardsCompatibilityStub
         {
             private readonly IFieldCodec<GrainAddress> _grainAddressCodec;


### PR DESCRIPTION
## Problem

Message deserialization accepted any number of cache invalidation headers, even though `Message` caps internally-created cache invalidation headers at 16 entries.

## Solution

Cap deserialized cache invalidation headers at `Message.MaxCacheInvalidationHeaderEntries` while still consuming all serialized entries so the reader remains aligned. Added regression coverage for over-limit deserialization.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10105)