### PR TITLE
Add concrete interface collection codec snapshots

### DIFF
--- a/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
@@ -384,6 +384,44 @@ public class InterfaceCollectionRegressionTests
     [Fact]
     public Task ReadOnlyDictionaryInterfaceFallback_Formatted_MatchesSnapshot()
         => VerifyFallbackBitStream<IReadOnlyDictionary<string, int>>(new UnknownDictionary<string, int>(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }), ReadOnlyDictionaryCodecAlias);
+
+    [Fact]
+    public Task EnumerableInterfaceConcreteList_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IEnumerable<int>>(new List<int> { 2, 4, 6 }, EnumerableCodecAlias);
+
+    [Fact]
+    public Task ReadOnlyCollectionInterfaceConcreteList_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IReadOnlyCollection<int>>(new List<int> { 2, 4, 6 }, ReadOnlyCollectionCodecAlias);
+
+    [Fact]
+    public Task ReadOnlyListInterfaceConcreteList_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IReadOnlyList<int>>(new List<int> { 2, 4, 6 }, ReadOnlyListCodecAlias);
+
+    [Fact]
+    public Task CollectionInterfaceConcreteList_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<ICollection<int>>(new List<int> { 2, 4, 6 }, CollectionCodecAlias);
+
+    [Fact]
+    public Task ListInterfaceConcreteList_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IList<int>>(new List<int> { 2, 4, 6 }, ListCodecAlias);
+
+    [Fact]
+    public Task SetInterfaceConcreteHashSet_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<ISet<string>>(new HashSet<string> { "a", "b" }, SetCodecAlias);
+
+#if NET5_0_OR_GREATER
+    [Fact]
+    public Task ReadOnlySetInterfaceConcreteHashSet_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IReadOnlySet<string>>(new HashSet<string> { "a", "b" }, ReadOnlySetCodecAlias);
+#endif
+
+    [Fact]
+    public Task DictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IDictionary<string, int>>(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }, DictionaryCodecAlias);
+
+    [Fact]
+    public Task ReadOnlyDictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot()
+        => VerifyConcreteRuntimeBitStream<IReadOnlyDictionary<string, int>>(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }, ReadOnlyDictionaryCodecAlias);
 #endif
 
     private static T RoundTrip<T>(T value)
@@ -404,6 +442,17 @@ public class InterfaceCollectionRegressionTests
     {
         var formatted = FormatSerializedPayload(value);
         Assert.Contains($"TypeName \"{codecAlias}", formatted);
+        return Verify(formatted, extension: "txt").UseDirectory("snapshots");
+    }
+
+    private static Task VerifyConcreteRuntimeBitStream<T>(T value, params string[] fallbackCodecAliases)
+    {
+        var formatted = FormatSerializedPayload(value);
+        foreach (var codecAlias in fallbackCodecAliases)
+        {
+            Assert.DoesNotContain($"TypeName \"{codecAlias}", formatted);
+        }
+
         return Verify(formatted, extension: "txt").UseDirectory("snapshots");
     }
 

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.CollectionInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.CollectionInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x002F [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.List`1[System.Int32] (name: Encoded "TypeName "System.Collections.Generic.List`1[[int]]" (hash 77903B0D)" (System.Collections.Generic.List`1[[System.Int32]]))] Value: {
+0x0030  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0032  [#3 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0034  [#4 VarInt Id: 1 SchemaType: Expected] Value: 8 (0x8)
+0x0036  [#5 VarInt Id: 1 SchemaType: Expected] Value: 12 (0xC)
+0x0038 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.DictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.DictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,7 @@
+﻿0x003E [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.Dictionary`2[System.String,System.Int32] (name: Encoded "TypeName "System.Collections.Generic.Dictionary`2[[string],[int]]" (hash ABFDFCFE)" (System.Collections.Generic.Dictionary`2[[System.String],[System.Int32]]))] Value: {
+0x003F  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0041  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x0044  [#4 VarInt Id: 2 SchemaType: Expected] Value: 2 (0x2)
+0x0046  [#5 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x0049  [#6 VarInt Id: 2 SchemaType: Expected] Value: 4 (0x4)
+0x004B }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.EnumerableInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.EnumerableInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x002F [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.List`1[System.Int32] (name: Encoded "TypeName "System.Collections.Generic.List`1[[int]]" (hash 77903B0D)" (System.Collections.Generic.List`1[[System.Int32]]))] Value: {
+0x0030  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0032  [#3 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0034  [#4 VarInt Id: 1 SchemaType: Expected] Value: 8 (0x8)
+0x0036  [#5 VarInt Id: 1 SchemaType: Expected] Value: 12 (0xC)
+0x0038 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ListInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ListInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x002F [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.List`1[System.Int32] (name: Encoded "TypeName "System.Collections.Generic.List`1[[int]]" (hash 77903B0D)" (System.Collections.Generic.List`1[[System.Int32]]))] Value: {
+0x0030  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0032  [#3 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0034  [#4 VarInt Id: 1 SchemaType: Expected] Value: 8 (0x8)
+0x0036  [#5 VarInt Id: 1 SchemaType: Expected] Value: 12 (0xC)
+0x0038 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyCollectionInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyCollectionInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x002F [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.List`1[System.Int32] (name: Encoded "TypeName "System.Collections.Generic.List`1[[int]]" (hash 77903B0D)" (System.Collections.Generic.List`1[[System.Int32]]))] Value: {
+0x0030  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0032  [#3 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0034  [#4 VarInt Id: 1 SchemaType: Expected] Value: 8 (0x8)
+0x0036  [#5 VarInt Id: 1 SchemaType: Expected] Value: 12 (0xC)
+0x0038 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyDictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyDictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,7 @@
+﻿0x003E [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.Dictionary`2[System.String,System.Int32] (name: Encoded "TypeName "System.Collections.Generic.Dictionary`2[[string],[int]]" (hash ABFDFCFE)" (System.Collections.Generic.Dictionary`2[[System.String],[System.Int32]]))] Value: {
+0x003F  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0041  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x0044  [#4 VarInt Id: 2 SchemaType: Expected] Value: 2 (0x2)
+0x0046  [#5 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x0049  [#6 VarInt Id: 2 SchemaType: Expected] Value: 4 (0x4)
+0x004B }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyListInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlyListInterfaceConcreteList_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,6 @@
+﻿0x002F [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.List`1[System.Int32] (name: Encoded "TypeName "System.Collections.Generic.List`1[[int]]" (hash 77903B0D)" (System.Collections.Generic.List`1[[System.Int32]]))] Value: {
+0x0030  [#2 VarInt Id: 0 SchemaType: Expected] Value: 3 (0x3)
+0x0032  [#3 VarInt Id: 1 SchemaType: Expected] Value: 4 (0x4)
+0x0034  [#4 VarInt Id: 1 SchemaType: Expected] Value: 8 (0x8)
+0x0036  [#5 VarInt Id: 1 SchemaType: Expected] Value: 12 (0xC)
+0x0038 }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlySetInterfaceConcreteHashSet_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.ReadOnlySetInterfaceConcreteHashSet_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,5 @@
+﻿0x0035 [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.HashSet`1[System.String] (name: Encoded "TypeName "System.Collections.Generic.HashSet`1[[string]]" (hash DCA1FD98)" (System.Collections.Generic.HashSet`1[[System.String]]))] Value: {
+0x0036  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0038  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x003B  [#4 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x003E }

--- a/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.SetInterfaceConcreteHashSet_Formatted_MatchesSnapshot.verified.txt
+++ b/test/Orleans.Serialization.UnitTests/snapshots/InterfaceCollectionRegressionTests.SetInterfaceConcreteHashSet_Formatted_MatchesSnapshot.verified.txt
@@ -1,0 +1,5 @@
+﻿0x0035 [#1 TagDelimited Id: 0 SchemaType: Encoded RuntimeType: System.Collections.Generic.HashSet`1[System.String] (name: Encoded "TypeName "System.Collections.Generic.HashSet`1[[string]]" (hash DCA1FD98)" (System.Collections.Generic.HashSet`1[[System.String]]))] Value: {
+0x0036  [#2 VarInt Id: 1 SchemaType: Expected] Value: 2 (0x2)
+0x0038  [#3 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["a"]
+0x003B  [#4 LengthPrefixed Id: 2 SchemaType: Expected] Value: (length: 1b) ["b"]
+0x003E }


### PR DESCRIPTION
## Reason

The original interface collection codec PR was merged before the final concrete runtime codec snapshot coverage landed in the merge commit.

## Solution

This follow-up adds focused BitStreamFormatter snapshot tests which serialize concrete `List<T>`, `HashSet<T>`, and `Dictionary<TKey,TValue>` instances through interface-typed serializers. The tests assert that interface fallback codec aliases are not used when a concrete runtime codec exists, and the snapshots capture the concrete runtime codec payloads reviewers should expect.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10106)