### PR TITLE
Enable nullable in memory storage provider builder

### DIFF
--- a/src/Orleans.Persistence.Memory/Hosting/MemoryGrainStorageProviderBuilder.cs
+++ b/src/Orleans.Persistence.Memory/Hosting/MemoryGrainStorageProviderBuilder.cs
@@ -9,14 +9,13 @@ using Orleans.Providers;
 using Orleans.Runtime.Hosting.ProviderConfiguration;
 using Orleans.Storage;
 
-#nullable disable
 [assembly: RegisterProvider("Memory", "GrainStorage", "Silo", typeof(MemoryGrainStorageProviderBuilder))]
 
 namespace Orleans.Runtime.Hosting.ProviderConfiguration;
 
 internal sealed class MemoryGrainStorageProviderBuilder : IProviderBuilder<ISiloBuilder>
 {
-    public void Configure(ISiloBuilder builder, string name, IConfigurationSection configurationSection)
+    public void Configure(ISiloBuilder builder, string? name, IConfigurationSection configurationSection)
     {
         builder.AddMemoryGrainStorage(name, (OptionsBuilder<MemoryGrainStorageOptions> optionsBuilder) => optionsBuilder.Configure<IServiceProvider>((options, services) =>
         {


### PR DESCRIPTION
This removes a small `#nullable disable` usage from an internal memory storage provider builder without changing its runtime behavior.

The provider builder now matches `IProviderBuilder<ISiloBuilder>` by accepting `string? name`, allowing nullable analysis to remain enabled while preserving the existing null-name flow through the registration helpers.

Validation:
- `dotnet build src\Orleans.Persistence.Memory\Orleans.Persistence.Memory.csproj --verbosity minimal`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10110)