### PR TITLE
Add cancellable grain cancellation overload

### DIFF
--- a/src/Orleans.Core.Abstractions/Cancellation/GrainCancellationToken.cs
+++ b/src/Orleans.Core.Abstractions/Cancellation/GrainCancellationToken.cs
@@ -88,13 +88,25 @@ namespace Orleans
         /// </returns>
         internal Task Cancel()
         {
+            return Cancel(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Cancels the cancellation token.
+        /// </summary>
+        /// <param name="cancellationToken">The token used to cancel waiting for cancellation propagation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the operation.
+        /// </returns>
+        internal Task Cancel(CancellationToken cancellationToken)
+        {
             if (_cancellationTokenRuntime == null)
             {
                 // Wrap in task
                 try
                 {
                     _cancellationTokenSource.Cancel();
-                    return Task.CompletedTask;
+                    return cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) : Task.CompletedTask;
                 }
                 catch (Exception exception)
                 {
@@ -104,7 +116,7 @@ namespace Orleans
                 }
             }
 
-            return _cancellationTokenRuntime.Cancel(Id, _cancellationTokenSource, _targetGrainReferences);
+            return _cancellationTokenRuntime.Cancel(Id, _cancellationTokenSource, _targetGrainReferences, cancellationToken);
         }
 
         /// <summary>

--- a/src/Orleans.Core.Abstractions/Cancellation/GrainCancellationTokenSource.cs
+++ b/src/Orleans.Core.Abstractions/Cancellation/GrainCancellationTokenSource.cs
@@ -61,7 +61,7 @@ namespace Orleans
         /// <see cref="CancellationToken" /> will be executed.
         /// </para>
         /// <para>
-        /// Cancelable operations and callbacks registered with the token should not <see langword="throw"/> exceptions. However, this overload of <see cref="Cancel"/> will aggregate any exceptions thrown into a
+        /// Cancelable operations and callbacks registered with the token should not <see langword="throw"/> exceptions. However, this overload of <see cref="Cancel()"/> will aggregate any exceptions thrown into a
         /// <see cref="AggregateException" /> , such that one callback throwing an exception will not prevent other registered callbacks from being executed.
         /// </para>
         /// <para>The <see cref="System.Threading.ExecutionContext" /> that was captured when each callback was registered will be reestablished when the callback is invoked.</para>
@@ -70,7 +70,35 @@ namespace Orleans
         /// <exception cref="ObjectDisposedException">This <see cref="GrainCancellationTokenSource" /> has been disposed.</exception>
         public Task Cancel()
         {
-            return _grainCancellationToken.Cancel();
+            return _grainCancellationToken.Cancel(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Communicates a request for cancellation.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The associated <see cref="GrainCancellationToken" /> will be notified of the cancellation and will transition to a state where
+        /// <see cref="GrainCancellationToken.CancellationToken"><see cref="IsCancellationRequested"/></see> returns true. Any callbacks or cancelable operations registered with the
+        /// <see cref="CancellationToken" /> will be executed.
+        /// </para>
+        /// <para>
+        /// The <paramref name="cancellationToken"/> cancels waiting for cancellation to be propagated to remote observers. The associated
+        /// <see cref="GrainCancellationToken" /> remains canceled once cancellation has been requested.
+        /// </para>
+        /// <para>
+        /// Cancelable operations and callbacks registered with the token should not <see langword="throw"/> exceptions. However, this overload of <see cref="Cancel(CancellationToken)"/> will aggregate any exceptions thrown into a
+        /// <see cref="AggregateException" /> , such that one callback throwing an exception will not prevent other registered callbacks from being executed.
+        /// </para>
+        /// <para>The <see cref="System.Threading.ExecutionContext" /> that was captured when each callback was registered will be reestablished when the callback is invoked.</para>
+        /// </remarks>
+        /// <param name="cancellationToken">The token used to cancel waiting for cancellation propagation.</param>
+        /// <exception cref="AggregateException">An aggregate exception containing all the exceptions thrown by the registered callbacks on the associated <see cref="GrainCancellationToken" /> .</exception>
+        /// <exception cref="ObjectDisposedException">This <see cref="GrainCancellationTokenSource" /> has been disposed.</exception>
+        /// <exception cref="OperationCanceledException">The <paramref name="cancellationToken"/> was canceled.</exception>
+        public Task Cancel(CancellationToken cancellationToken)
+        {
+            return _grainCancellationToken.Cancel(cancellationToken);
         }
 
         /// <summary>

--- a/src/Orleans.Core.Abstractions/Runtime/IGrainCancellationTokenRuntime.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/IGrainCancellationTokenRuntime.cs
@@ -18,5 +18,15 @@ namespace Orleans.Runtime
         /// <param name="grainReferences">The grain references which are observing the cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the operation.</returns>
         Task Cancel(Guid id, CancellationTokenSource tokenSource, ConcurrentDictionary<GrainId, GrainReference> grainReferences);
+
+        /// <summary>
+        /// Cancels the <see cref="GrainCancellationToken"/> with the provided id.
+        /// </summary>
+        /// <param name="id">The grain cancellation token id.</param>
+        /// <param name="tokenSource">The grain cancellation token source being canceled.</param>
+        /// <param name="grainReferences">The grain references which are observing the cancellation token.</param>
+        /// <param name="cancellationToken">The token used to cancel waiting for cancellation propagation.</param>
+        /// <returns>A <see cref="Task"/> representing the operation.</returns>
+        Task Cancel(Guid id, CancellationTokenSource tokenSource, ConcurrentDictionary<GrainId, GrainReference> grainReferences, CancellationToken cancellationToken);
     }
 }

--- a/src/Orleans.Core/Runtime/GrainCancellationTokenRuntime.cs
+++ b/src/Orleans.Core/Runtime/GrainCancellationTokenRuntime.cs
@@ -20,23 +20,30 @@ namespace Orleans.Runtime
 
         public Task Cancel(Guid id, CancellationTokenSource tokenSource, ConcurrentDictionary<GrainId, GrainReference> grainReferences)
         {
-            if (tokenSource.IsCancellationRequested)
-            {
-                // This token has already been canceled.
-                return Task.CompletedTask;
-            }
+            return Cancel(id, tokenSource, grainReferences, CancellationToken.None);
+        }
 
+        public Task Cancel(Guid id, CancellationTokenSource tokenSource, ConcurrentDictionary<GrainId, GrainReference> grainReferences, CancellationToken cancellationToken)
+        {
             // propagate the exception from the _cancellationTokenSource.Cancel back to the caller
             // but also cancel _targetGrainReferences.
             Task localTask = null;
-            try
+            if (!tokenSource.IsCancellationRequested)
             {
-                // Cancel the token now, preventing recursion.
-                tokenSource.Cancel();
+                try
+                {
+                    // Cancel the token now, preventing recursion.
+                    tokenSource.Cancel();
+                }
+                catch (Exception exception)
+                {
+                    localTask = Task.FromException(exception);
+                }
             }
-            catch (Exception exception)
+
+            if (cancellationToken.IsCancellationRequested)
             {
-                localTask = Task.FromException(exception);
+                return localTask ?? Task.FromCanceled(cancellationToken);
             }
 
             List<Task> tasks = null;
@@ -47,24 +54,40 @@ namespace Orleans.Runtime
                     tasks = new();
                     if (localTask != null) tasks.Add(localTask);
                 }
-                tasks.Add(CancelTokenWithRetries(id, grainReferences, reference.Key, reference.Value.AsReference<ICancellationSourcesExtension>()));
+                tasks.Add(CancelTokenWithRetries(id, grainReferences, reference.Key, reference.Value.AsReference<ICancellationSourcesExtension>(), cancellationToken));
             }
 
             return tasks is null ? localTask ?? Task.CompletedTask : Task.WhenAll(tasks);
         }
 
-         private async Task CancelTokenWithRetries(
-             Guid id,
-             ConcurrentDictionary<GrainId, GrainReference> grainReferences,
-             GrainId key,
-             ICancellationSourcesExtension tokenExtension)
+        private async Task CancelTokenWithRetries(
+            Guid id,
+            ConcurrentDictionary<GrainId, GrainReference> grainReferences,
+            GrainId key,
+            ICancellationSourcesExtension tokenExtension,
+            CancellationToken cancellationToken)
         {
-            await AsyncExecutorWithRetries.ExecuteWithRetries(
-                i => tokenExtension.CancelRemoteToken(id),
+            await AsyncExecutorWithRetries.ExecuteWithRetries<bool>(
+                async i =>
+                {
+                    var cancelTask = tokenExtension.CancelRemoteToken(id);
+                    try
+                    {
+                        await cancelTask.WaitAsync(cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        cancelTask.Ignore();
+                        throw;
+                    }
+
+                    return true;
+                },
                 MaxNumCancelErrorTries,
                 _cancelCallRetryExceptionFilter,
                 _cancelCallMaxWaitTime,
-                _cancelCallBackoffProvider);
+                _cancelCallBackoffProvider,
+                cancellationToken);
             grainReferences.TryRemove(key, out _);
         }
     }

--- a/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
+++ b/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
@@ -1129,6 +1129,8 @@ namespace Orleans
 
         public System.Threading.Tasks.Task Cancel() { throw null; }
 
+        public System.Threading.Tasks.Task Cancel(System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public void Dispose() { }
     }
 

--- a/test/Orleans.Runtime.Tests/CancellationTests/GrainCancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/GrainCancellationTokenTests.cs
@@ -1,3 +1,7 @@
+using System.Collections.Concurrent;
+using Orleans.CodeGeneration;
+using Orleans.Runtime;
+using Orleans.Serialization.Invocation;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime.Placement;
 using Orleans.TestingHost;
@@ -131,6 +135,64 @@ namespace UnitTests.CancellationTests
             var grainTask = grain.LongWaitGrainCancellation(cts.Token, TimeSpan.FromSeconds(10), callId);
             await Assert.ThrowsAsync<TaskCanceledException>(() => grainTask);
             await WaitForCallCancellation(grain, callId);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
+        public async Task CancelWithCanceledOperationToken_CancelsLocalToken()
+        {
+            using var cts = new GrainCancellationTokenSource();
+            using var operationCts = new CancellationTokenSource();
+            operationCts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cts.Cancel(operationCts.Token));
+
+            Assert.True(cts.IsCancellationRequested);
+            Assert.True(cts.Token.CancellationToken.IsCancellationRequested);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
+        public async Task CancelWithCanceledOperationToken_CanRetryRemotePropagation()
+        {
+            var grain = this.fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
+            using var cts = new GrainCancellationTokenSource();
+            var callId = Guid.NewGuid();
+            var grainTask = grain.LongWaitGrainCancellation(cts.Token, TimeSpan.FromSeconds(10), callId);
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            using var operationCts = new CancellationTokenSource();
+            operationCts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cts.Cancel(operationCts.Token));
+
+            Assert.True(cts.IsCancellationRequested);
+            Assert.False(grainTask.IsCompleted);
+
+            await cts.Cancel();
+            await Assert.ThrowsAsync<TaskCanceledException>(() => grainTask);
+            await WaitForCallCancellation(grain, callId);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
+        public async Task CancelWithShutdownToken_StopsWaitingForRemotePropagation()
+        {
+            var runtime = new GrainCancellationTokenRuntime();
+            var tokenSource = new CancellationTokenSource();
+            var extension = new ControllableCancellationSourcesExtension();
+            var grainId = GrainId.Create(GrainType.Create("shutdown-test"), IdSpan.Create(Guid.NewGuid().ToString("N")));
+            var grainReferences = new ConcurrentDictionary<GrainId, GrainReference>();
+            grainReferences[grainId] = CreateGrainReference(grainId, extension);
+            using var shutdownCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => runtime.Cancel(Guid.NewGuid(), tokenSource, grainReferences, shutdownCts.Token));
+
+            Assert.True(tokenSource.IsCancellationRequested);
+            Assert.Single(grainReferences);
+
+            extension.CompleteSynchronously = true;
+
+            await runtime.Cancel(Guid.NewGuid(), tokenSource, grainReferences);
+
+            Assert.Empty(grainReferences);
+            Assert.True(extension.CancelCallCount >= 2);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Cancellation")]
@@ -329,6 +391,54 @@ namespace UnitTests.CancellationTests
             }
 
             Assert.Fail("Did not encounter the expected call id");
+        }
+
+        private static GrainReference CreateGrainReference(GrainId grainId, ICancellationSourcesExtension extension)
+        {
+            var runtime = new TestGrainReferenceRuntime(extension);
+            var shared = new GrainReferenceShared(
+                grainId.Type,
+                GrainInterfaceType.Create("shutdown-test"),
+                interfaceVersion: 0,
+                runtime,
+                InvokeMethodOptions.None,
+                codecProvider: null,
+                copyContextPool: null,
+                serviceProvider: null);
+
+            return GrainReference.FromGrainId(shared, grainId);
+        }
+
+        private sealed class TestGrainReferenceRuntime(ICancellationSourcesExtension extension) : IGrainReferenceRuntime
+        {
+            private readonly ICancellationSourcesExtension _extension = extension;
+
+            public object Cast(IAddressable grain, Type interfaceType)
+                => interfaceType == typeof(ICancellationSourcesExtension) ? _extension : throw new NotSupportedException();
+
+            public ValueTask<T> InvokeMethodAsync<T>(GrainReference reference, IInvokable request, InvokeMethodOptions options)
+                => throw new NotSupportedException();
+
+            public ValueTask InvokeMethodAsync(GrainReference reference, IInvokable request, InvokeMethodOptions options)
+                => throw new NotSupportedException();
+
+            public void InvokeMethod(GrainReference reference, IInvokable request, InvokeMethodOptions options)
+                => throw new NotSupportedException();
+        }
+
+        private sealed class ControllableCancellationSourcesExtension : ICancellationSourcesExtension
+        {
+            private readonly TaskCompletionSource _pendingCancellation = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public int CancelCallCount { get; private set; }
+
+            public bool CompleteSynchronously { get; set; }
+
+            public Task CancelRemoteToken(Guid tokenId)
+            {
+                ++CancelCallCount;
+                return CompleteSynchronously ? Task.CompletedTask : _pendingCancellation.Task;
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem
GrainCancellationTokenSource.Cancel() waits for cancellation propagation to known remote observers, which can hold shutdown paths open while remote cancellation acknowledgements are delayed.

Fixes #8634.

## Solution
Add an explicit Cancel(CancellationToken) overload which uses the provided token to stop waiting for propagation while still requesting local grain cancellation. Remote observers are only removed from tracking after propagation succeeds, so a later Cancel() can retry any observer that did not acknowledge before the wait was canceled.

## Notes
The change keeps the existing Cancel() API and naming convention intact, updates the public API surface, and adds focused tests including a shutdown-token scenario where remote propagation stalls.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10111)