### PR TITLE
Clean up journaling storage provider APIs

### DIFF
--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
@@ -34,12 +34,6 @@ internal sealed class AzureBlobJournalStorageProvider : ILifecycleParticipant<IS
         await _containerFactory.InitializeAsync(client, cancellationToken).ConfigureAwait(false);
     }
 
-    public IJournalStorage CreateStorage(IGrainContext grainContext)
-    {
-        ArgumentNullException.ThrowIfNull(grainContext);
-        return CreateStorage(JournalId.FromGrainId(grainContext.GrainId));
-    }
-
     public IJournalStorage CreateStorage(JournalId journalId)
     {
         if (journalId.IsDefault)

--- a/src/Azure/Orleans.Journaling.AzureStorage/DefaultBlobContainerFactory.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/DefaultBlobContainerFactory.cs
@@ -14,10 +14,15 @@ internal sealed class DefaultBlobContainerFactory(AzureBlobJournalStorageOptions
     private BlobContainerClient _defaultContainer = null!;
 
     /// <inheritdoc/>
-    public BlobContainerClient GetBlobContainerClient(GrainId grainId) => _defaultContainer;
+    public BlobContainerClient GetBlobContainerClient(JournalId journalId)
+    {
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
 
-    /// <inheritdoc/>
-    public BlobContainerClient GetBlobContainerClient(JournalId journalId) => _defaultContainer;
+        return _defaultContainer;
+    }
 
     /// <inheritdoc/>
     public async Task InitializeAsync(BlobServiceClient client, CancellationToken cancellationToken)

--- a/src/Azure/Orleans.Journaling.AzureStorage/IBlobContainerFactory.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/IBlobContainerFactory.cs
@@ -12,23 +12,7 @@ public interface IBlobContainerFactory
     /// </summary>
     /// <param name="journalId">The journal id.</param>
     /// <returns>A configured blob client.</returns>
-    public BlobContainerClient GetBlobContainerClient(JournalId journalId)
-    {
-        if (journalId.IsDefault)
-        {
-            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
-        }
-
-        throw new NotSupportedException(
-            $"This blob container factory does not support grain-independent journals. Implement {nameof(GetBlobContainerClient)}({nameof(JournalId)}) to support on-demand journals.");
-    }
-
-    /// <summary>
-    /// Gets the container which should be used for the specified grain.
-    /// </summary>
-    /// <param name="grainId">The grain id</param>
-    /// <returns>A configured blob client</returns>
-    public BlobContainerClient GetBlobContainerClient(GrainId grainId);
+    public BlobContainerClient GetBlobContainerClient(JournalId journalId);
 
     /// <summary>
     /// Initialize any required dependencies using the provided client and options.

--- a/src/Orleans.Journaling/IJournalStorage.cs
+++ b/src/Orleans.Journaling/IJournalStorage.cs
@@ -70,25 +70,5 @@ public interface IJournalStorageProvider
     /// </summary>
     /// <param name="journalId">The journal id.</param>
     /// <returns>The journal storage instance.</returns>
-    IJournalStorage CreateStorage(JournalId journalId)
-    {
-        if (journalId.IsDefault)
-        {
-            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
-        }
-
-        throw new NotSupportedException(
-            $"This journal storage provider does not support grain-independent journals. Implement {nameof(CreateStorage)}({nameof(JournalId)}) to support on-demand journals.");
-    }
-
-    /// <summary>
-    /// Creates journal storage for the provided grain context.
-    /// </summary>
-    /// <param name="grainContext">The grain context.</param>
-    /// <returns>The journal storage instance.</returns>
-    IJournalStorage CreateStorage(IGrainContext grainContext)
-    {
-        ArgumentNullException.ThrowIfNull(grainContext);
-        return CreateStorage(JournalId.FromGrainId(grainContext.GrainId));
-    }
+    IJournalStorage CreateStorage(JournalId journalId);
 }

--- a/src/Orleans.Journaling/JournaledStateManager.cs
+++ b/src/Orleans.Journaling/JournaledStateManager.cs
@@ -32,7 +32,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
     private int _disposed;
 
     public JournaledStateManager(JournaledStateManagerShared shared, IJournalStorageProvider storageProvider, IGrainContext grainContext)
-        : this(shared, CreateStorage(storageProvider, grainContext))
+        : this(shared, CreateStorage(storageProvider, CreateJournalId(grainContext)))
     {
     }
 
@@ -63,11 +63,10 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         _statesMap[RetiredStateTracker.Id] = _retirementTracker;
     }
 
-    private static IJournalStorage CreateStorage(IJournalStorageProvider storageProvider, IGrainContext grainContext)
+    private static JournalId CreateJournalId(IGrainContext grainContext)
     {
-        ArgumentNullException.ThrowIfNull(storageProvider);
         ArgumentNullException.ThrowIfNull(grainContext);
-        return storageProvider.CreateStorage(grainContext) ?? throw new InvalidOperationException("The configured journal storage provider returned null.");
+        return JournalId.FromGrainId(grainContext.GrainId);
     }
 
     private static IJournalStorage CreateStorage(IJournalStorageProvider storageProvider, JournalId journalId)

--- a/src/Orleans.Journaling/VolatileJournalStorage.cs
+++ b/src/Orleans.Journaling/VolatileJournalStorage.cs
@@ -24,12 +24,6 @@ public sealed class VolatileJournalStorageProvider : IJournalStorageProvider
         _options = options;
     }
 
-    public IJournalStorage CreateStorage(IGrainContext grainContext)
-    {
-        ArgumentNullException.ThrowIfNull(grainContext);
-        return CreateStorage(JournalId.FromGrainId(grainContext.GrainId));
-    }
-
     public IJournalStorage CreateStorage(JournalId journalId)
     {
         if (journalId.IsDefault)

--- a/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
@@ -46,7 +46,6 @@ namespace Orleans.Journaling
     public partial interface IBlobContainerFactory
     {
         Azure.Storage.Blobs.BlobContainerClient GetBlobContainerClient(JournalId journalId);
-        Azure.Storage.Blobs.BlobContainerClient GetBlobContainerClient(Runtime.GrainId grainId);
         System.Threading.Tasks.Task InitializeAsync(Azure.Storage.Blobs.BlobServiceClient client, System.Threading.CancellationToken cancellationToken);
     }
 }

--- a/src/api/Orleans.Journaling/Orleans.Journaling.cs
+++ b/src/api/Orleans.Journaling/Orleans.Journaling.cs
@@ -171,7 +171,6 @@ namespace Orleans.Journaling
     public partial interface IJournalStorageProvider
     {
         IJournalStorage CreateStorage(JournalId journalId);
-        IJournalStorage CreateStorage(Runtime.IGrainContext grainContext);
     }
 
     public partial interface IJournalStorageConsumer
@@ -496,7 +495,6 @@ namespace Orleans.Journaling
         public VolatileJournalStorageProvider(Microsoft.Extensions.Options.IOptions<JournaledStateManagerOptions> options) { }
 
         public IJournalStorage CreateStorage(JournalId journalId) { throw null; }
-        public IJournalStorage CreateStorage(Runtime.IGrainContext grainContext) { throw null; }
     }
 }
 

--- a/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
@@ -59,7 +59,7 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
 
         await using (var binaryProvider = await CreateAzureProviderAsync(OrleansBinaryJournalFormat.JournalFormatKey, blobName, cts.Token))
         {
-            var storage = binaryProvider.StorageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
+            var storage = binaryProvider.StorageProvider.CreateStorage(JournalId.FromGrainId(grainId));
             var manager = CreateFormatAwareManager(binaryProvider.ServiceProvider, storage, OrleansBinaryJournalFormat.JournalFormatKey);
             var dict = CreateFormatAwareDictionary(binaryProvider.ServiceProvider, manager, OrleansBinaryJournalFormat.JournalFormatKey);
             await manager.InitializeAsync(cts.Token);
@@ -70,7 +70,7 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
         }
 
         await using var jsonProvider = await CreateAzureProviderAsync(JsonJournalExtensions.JournalFormatKey, blobName, cts.Token);
-        var migratedStorage = jsonProvider.StorageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
+        var migratedStorage = jsonProvider.StorageProvider.CreateStorage(JournalId.FromGrainId(grainId));
         var migratedManager = CreateFormatAwareManager(jsonProvider.ServiceProvider, migratedStorage, JsonJournalExtensions.JournalFormatKey);
         var migratedDict = CreateFormatAwareDictionary(jsonProvider.ServiceProvider, migratedManager, JsonJournalExtensions.JournalFormatKey);
         await migratedManager.InitializeAsync(cts.Token);
@@ -81,7 +81,7 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
         await migratedManager.WriteStateAsync(cts.Token);
         ((IDisposable)migratedManager).Dispose();
 
-        var recoveredStorage = jsonProvider.StorageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
+        var recoveredStorage = jsonProvider.StorageProvider.CreateStorage(JournalId.FromGrainId(grainId));
         var recoveredManager = CreateFormatAwareManager(jsonProvider.ServiceProvider, recoveredStorage, JsonJournalExtensions.JournalFormatKey);
         var recoveredDict = CreateFormatAwareDictionary(jsonProvider.ServiceProvider, recoveredManager, JsonJournalExtensions.JournalFormatKey);
         await recoveredManager.InitializeAsync(cts.Token);
@@ -107,7 +107,7 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
     public async Task AzureBlobStorage_AllDurableTypes_RecoverWithBinaryCodec()
     {
         var grainId = GrainId.Create("journaling-codec-recovery", Guid.NewGuid().ToString("N"));
-        var storage = _storageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
+        var storage = _storageProvider.CreateStorage(JournalId.FromGrainId(grainId));
         var first = CreateStates(storage);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         await first.Manager.InitializeAsync(cts.Token);
@@ -125,7 +125,7 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
         Assert.True(first.Tcs.TrySetResult(17));
         await first.Manager.WriteStateAsync(cts.Token);
 
-        var recoveredStorage = _storageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
+        var recoveredStorage = _storageProvider.CreateStorage(JournalId.FromGrainId(grainId));
         var recovered = CreateStates(recoveredStorage);
         await recovered.Manager.InitializeAsync(cts.Token);
 
@@ -155,13 +155,13 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
 
         await using (var writerProvider = await CreateAzureProviderAsync(OrleansBinaryJournalFormat.JournalFormatKey, blobName, cts.Token))
         {
-            var storage = writerProvider.StorageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
+            var storage = writerProvider.StorageProvider.CreateStorage(JournalId.FromGrainId(grainId));
             await storage.ReplaceAsync(new ReadOnlySequence<byte>(checkpointBytes), cts.Token);
             await storage.AppendAsync(new ReadOnlySequence<byte>(walBytes), cts.Token);
         }
 
         await using var readerProvider = await CreateAzureProviderAsync(OrleansBinaryJournalFormat.JournalFormatKey, blobName, cts.Token);
-        var recoveredStorage = readerProvider.StorageProvider.CreateStorage(new JournalBatchTests.TestGrainContext(grainId));
+        var recoveredStorage = readerProvider.StorageProvider.CreateStorage(JournalId.FromGrainId(grainId));
         var recovered = new RecordingJournalStorageConsumer();
 
         await recoveredStorage.ReadAsync(recovered, cts.Token);

--- a/test/Orleans.Journaling.Tests/FormatMigrationClusterTests.cs
+++ b/test/Orleans.Journaling.Tests/FormatMigrationClusterTests.cs
@@ -75,14 +75,14 @@ public sealed class FormatMigrationClusterTests
 
     private sealed class SharedVolatileJournalStorageProvider
     {
-        private readonly ConcurrentDictionary<GrainId, VolatileJournalStorage> _storage = new();
+        private readonly ConcurrentDictionary<JournalId, VolatileJournalStorage> _storage = new();
 
         public IEnumerable<string?> StoredFormatKeys => _storage.Values.Select(static storage => storage.StoredJournalFormatKey);
 
-        public IJournalStorage Create(IGrainContext grainContext, IOptions<JournaledStateManagerOptions> options)
+        public IJournalStorage Create(JournalId journalId, IOptions<JournaledStateManagerOptions> options)
         {
             var journalFormatKey = JournalFormatServices.ValidateJournalFormatKey(options.Value.JournalFormatKey);
-            var storage = _storage.GetOrAdd(grainContext.GrainId, _ => new VolatileJournalStorage(journalFormatKey));
+            var storage = _storage.GetOrAdd(journalId, _ => new VolatileJournalStorage(journalFormatKey));
             storage.SetConfiguredJournalFormatKey(journalFormatKey);
             return storage;
         }
@@ -93,6 +93,6 @@ public sealed class FormatMigrationClusterTests
         SharedVolatileJournalStorageProvider provider,
         IOptions<JournaledStateManagerOptions> options) : IJournalStorageProvider
     {
-        public IJournalStorage CreateStorage(IGrainContext grainContext) => provider.Create(grainContext, options);
+        public IJournalStorage CreateStorage(JournalId journalId) => provider.Create(journalId, options);
     }
 }

--- a/test/Orleans.Journaling.Tests/JournalBatchTests.cs
+++ b/test/Orleans.Journaling.Tests/JournalBatchTests.cs
@@ -29,7 +29,8 @@ public sealed class AzureStorageJournalBatchTests : JournalBatchTests
     }
 
     protected override IJournalStorage CreateStorage(IServiceProvider serviceProvider, IGrainContext grainContext) =>
-        serviceProvider.GetRequiredService<AzureBlobJournalStorageProvider>().CreateStorage(grainContext);
+        serviceProvider.GetRequiredService<AzureBlobJournalStorageProvider>()
+            .CreateStorage(JournalId.FromGrainId(grainContext.GrainId));
 }
 
 public sealed class InMemoryJournalBatchTests : JournalBatchTests
@@ -40,7 +41,8 @@ public sealed class InMemoryJournalBatchTests : JournalBatchTests
     }
 
     protected override IJournalStorage CreateStorage(IServiceProvider serviceProvider, IGrainContext grainContext) =>
-        serviceProvider.GetRequiredService<VolatileJournalStorageProvider>().CreateStorage(grainContext);
+        serviceProvider.GetRequiredService<VolatileJournalStorageProvider>()
+            .CreateStorage(JournalId.FromGrainId(grainContext.GrainId));
 }
 
 /// <summary>

--- a/test/Orleans.Journaling.Tests/KeyedJournalingRegistrationTests.cs
+++ b/test/Orleans.Journaling.Tests/KeyedJournalingRegistrationTests.cs
@@ -130,8 +130,6 @@ public sealed class KeyedJournalingRegistrationTests : JournalingTestBase
 
     private sealed class TestJournalStorageProvider(IJournalStorage storage) : IJournalStorageProvider
     {
-        public IJournalStorage CreateStorage(IGrainContext grainContext) => storage;
-
         public IJournalStorage CreateStorage(JournalId journalId) => storage;
     }
 


### PR DESCRIPTION
## Problem
The journaling storage abstractions still expose grain-specific overloads even though journals are now identified by JournalId. This leaves two ways to select storage and leaks grain activation details into provider APIs.

## Solution
Remove the IGrainContext overload from IJournalStorageProvider and require storage providers to accept JournalId. Apply the same cleanup to the Azure journaling blob container factory by removing the GrainId overload and making DefaultBlobContainerFactory implement only the JournalId-based method. Grain-based journal creation now converts to JournalId at the manager boundary, keeping provider APIs consistent with on-demand journals.

Reviewers should focus on the public API shape and the conversion points from grain context to JournalId.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10112)