### PR TITLE
Fix activation collector memory pressure safety

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -327,6 +327,13 @@ namespace Orleans.Runtime
             var stats = _environmentStatisticsProvider.GetEnvironmentStatistics();
             var limit = _grainCollectionOptions.MemoryUsageLimitPercentage / 100f;
 
+            var activationCount = _activationCount;
+            if (activationCount == 0)
+            {
+                surplusActivationCount = 0;
+                return false;
+            }
+
             var usage = stats.NormalizedMemoryUsage;
             if (usage <= limit)
             {
@@ -336,7 +343,6 @@ namespace Orleans.Runtime
             }
 
             // Calculate the surplus activations based the memory usage target.
-            var activationCount = _activationCount;
             var target = _grainCollectionOptions.MemoryUsageTargetPercentage / 100f;
             surplusActivationCount = (int)Math.Max(0, activationCount - Math.Floor(activationCount * target / usage));
             if (surplusActivationCount <= 0)
@@ -375,6 +381,13 @@ namespace Orleans.Runtime
                     }
 
                     var activation = item.Value;
+                    lock (activation)
+                    {
+                        if (!activation.IsValid || !activation.IsInactive)
+                        {
+                            continue;
+                        }
+                    }
 
                     candidates.Add(activation);
                 }

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -324,15 +324,15 @@ namespace Orleans.Runtime
         // Internal for testing. It's expected that when this returns true, activation shedding will occur.
         internal bool IsMemoryOverloaded(out int surplusActivationCount)
         {
-            var stats = _environmentStatisticsProvider.GetEnvironmentStatistics();
-            var limit = _grainCollectionOptions.MemoryUsageLimitPercentage / 100f;
-
             var activationCount = _activationCount;
             if (activationCount == 0)
             {
                 surplusActivationCount = 0;
                 return false;
             }
+
+            var stats = _environmentStatisticsProvider.GetEnvironmentStatistics();
+            var limit = _grainCollectionOptions.MemoryUsageLimitPercentage / 100f;
 
             var usage = stats.NormalizedMemoryUsage;
             if (usage <= limit)

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -105,6 +105,7 @@ namespace UnitTests.Runtime
         [InlineData(80.0, 70.0, 1000, 100, 200, true, 155)] // More activations, smaller per-activation size
         [InlineData(80.0, 70.0, 1000, 800, 100, false, 0)] // Well below threshold
         [InlineData(80.0, 70.0, 1000, 50,  10,  true, 7)] // Few activations, large per-activation size
+        [InlineData(80.0, 70.0, 1000, 100, 0, false, 0)] // No activations
         public void IsMemoryOverloaded_WorksAsExpected(
             double memoryLoadThreshold,
             double targetMemoryLoad,
@@ -155,6 +156,10 @@ namespace UnitTests.Runtime
             if (overloaded)
             {
                 Assert.Equal(expectedActivationsTarget, activationCount - surplusActivations);
+            }
+            else
+            {
+                Assert.Equal(0, surplusActivations);
             }
         }
 
@@ -302,6 +307,51 @@ namespace UnitTests.Runtime
 
             // Verify no exceptions occurred during deactivation
             Assert.Empty(exceptions);
+        }
+
+        [Fact]
+        public async Task DeactivateInDueTimeOrder_SkipsActiveAndInvalidActivations()
+        {
+            var grainCollectionOptions = Options.Create(new GrainCollectionOptions());
+
+            var logger = NullLogger<ActivationCollector>.Instance;
+            var statsProvider = Substitute.For<IEnvironmentStatisticsProvider>();
+            var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+
+            var collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, statsProvider);
+            var timer = Substitute.For<IAsyncTimer>();
+            timer.NextTick().Returns(Task.FromResult(false));
+            var timerFactory = Substitute.For<IAsyncTimerFactory>();
+            timerFactory.Create(Arg.Any<TimeSpan>(), Arg.Any<string>()).Returns(timer);
+
+            var wsLogger = NullLogger<ActivationWorkingSet>.Instance;
+            var workingSet = new ActivationWorkingSet(timerFactory, wsLogger, new[] { collector });
+
+            var inactiveActivation1 = PrepareActivation(1, collector);
+            var activeActivation = PrepareActivation(1, collector);
+            var invalidActivation = PrepareActivation(1, collector);
+            var inactiveActivation2 = PrepareActivation(1, collector);
+
+            inactiveActivation1.IsCandidateForRemoval(Arg.Any<bool>()).Returns(true);
+            activeActivation.IsCandidateForRemoval(Arg.Any<bool>()).Returns(true);
+            invalidActivation.IsCandidateForRemoval(Arg.Any<bool>()).Returns(true);
+            inactiveActivation2.IsCandidateForRemoval(Arg.Any<bool>()).Returns(true);
+
+            workingSet.OnActivated(inactiveActivation1);
+            workingSet.OnActivated(activeActivation);
+            workingSet.OnActivated(invalidActivation);
+            workingSet.OnActivated(inactiveActivation2);
+
+            ((ICollectibleGrainContext)activeActivation).IsInactive.Returns(false);
+            ((ICollectibleGrainContext)invalidActivation).IsValid.Returns(false);
+
+            await collector.DeactivateInDueTimeOrder(4, CancellationToken.None);
+
+            ((ICollectibleGrainContext)inactiveActivation1).Received(1).Deactivate(Arg.Any<DeactivationReason>(), Arg.Any<CancellationToken>());
+            ((ICollectibleGrainContext)inactiveActivation2).Received(1).Deactivate(Arg.Any<DeactivationReason>(), Arg.Any<CancellationToken>());
+            ((ICollectibleGrainContext)activeActivation).DidNotReceive().Deactivate(Arg.Any<DeactivationReason>(), Arg.Any<CancellationToken>());
+            ((ICollectibleGrainContext)invalidActivation).DidNotReceive().Deactivate(Arg.Any<DeactivationReason>(), Arg.Any<CancellationToken>());
+            Assert.Equal(2, collector._activationCount);
         }
 
         private IActivationWorkingSetMember PrepareActivation(int collectionAgeLimitMinutes, ActivationCollector collector)

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -164,6 +164,23 @@ namespace UnitTests.Runtime
         }
 
         [Fact]
+        public void IsMemoryOverloaded_DoesNotQueryStats_WhenNoActivations()
+        {
+            var grainCollectionOptions = Options.Create(new GrainCollectionOptions());
+            var statsProvider = Substitute.For<IEnvironmentStatisticsProvider>();
+            var logger = NullLogger<ActivationCollector>.Instance;
+            var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+            var collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, statsProvider);
+
+            collector._activationCount = 0;
+            var overloaded = collector.IsMemoryOverloaded(out var surplusActivations);
+
+            Assert.False(overloaded);
+            Assert.Equal(0, surplusActivations);
+            statsProvider.DidNotReceive().GetEnvironmentStatistics();
+        }
+
+        [Fact]
         public async Task DeactivateInDueTimeOrder_OnlyOldestAndEligibleAreDeactivated()
         {
             var grainCollectionOptions = Options.Create(new GrainCollectionOptions());


### PR DESCRIPTION
## Summary
- Guard memory-pressure collection when the silo has zero activations.
- Re-check activation validity and inactivity while selecting memory-pressure deactivation candidates.
- Add regression coverage for zero-activation and active/invalid candidate cases.

## Validation
- `dotnet build test\Orleans.Core.Tests\Orleans.Core.Tests.csproj --no-restore --nologo --verbosity minimal -property:UseSharedCompilation=false`
- `dotnet test test\Orleans.Core.Tests\Orleans.Core.Tests.csproj --no-build --nologo --verbosity minimal --filter FullyQualifiedName~ActivationCollectorTests -property:UseSharedCompilation=false`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10113)