### PR TITLE
perf(scheduler): use activation-specific work signal

### DIFF
--- a/src/Orleans.Core/Core/GrainFactory.cs
+++ b/src/Orleans.Core/Core/GrainFactory.cs
@@ -9,7 +9,11 @@ namespace Orleans
     /// <summary>
     /// Factory for accessing grains.
     /// </summary>
-    internal class GrainFactory : IInternalGrainFactory
+    internal class GrainFactory(
+        IRuntimeClient runtimeClient,
+        GrainReferenceActivator referenceActivator,
+        GrainInterfaceTypeResolver interfaceTypeResolver,
+        GrainInterfaceTypeToGrainTypeResolver interfaceToTypeResolver) : IInternalGrainFactory
     {
         private GrainReferenceRuntime? grainReferenceRuntime;
 
@@ -18,24 +22,7 @@ namespace Orleans
         /// </summary>
         private readonly Dictionary<(GrainId, Type), ISystemTarget> typedSystemTargetReferenceCache = new Dictionary<(GrainId, Type), ISystemTarget>();
 
-        private readonly GrainReferenceActivator referenceActivator;
-        private readonly GrainInterfaceTypeResolver interfaceTypeResolver;
-        private readonly GrainInterfaceTypeToGrainTypeResolver interfaceTypeToGrainTypeResolver;
-        private readonly IRuntimeClient runtimeClient;
-
-        public GrainFactory(
-            IRuntimeClient runtimeClient,
-            GrainReferenceActivator referenceActivator,
-            GrainInterfaceTypeResolver interfaceTypeResolver,
-            GrainInterfaceTypeToGrainTypeResolver interfaceToTypeResolver)
-        {
-            this.runtimeClient = runtimeClient;
-            this.referenceActivator = referenceActivator;
-            this.interfaceTypeResolver = interfaceTypeResolver;
-            this.interfaceTypeToGrainTypeResolver = interfaceToTypeResolver;
-        }
-
-        private GrainReferenceRuntime GrainReferenceRuntime => this.grainReferenceRuntime ??= (GrainReferenceRuntime)this.runtimeClient.GrainReferenceRuntime;
+        private GrainReferenceRuntime GrainReferenceRuntime => this.grainReferenceRuntime ??= (GrainReferenceRuntime)runtimeClient.GrainReferenceRuntime;
 
         /// <inheritdoc />
         public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string? grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey
@@ -92,7 +79,7 @@ namespace Orleans
         public void DeleteObjectReference<TGrainObserverInterface>(
             IGrainObserver obj) where TGrainObserverInterface : IGrainObserver
         {
-            this.runtimeClient.DeleteObjectReference(obj);
+            runtimeClient.DeleteObjectReference(obj);
         }
 
         /// <inheritdoc />
@@ -146,7 +133,7 @@ namespace Orleans
         }
 
         /// <inheritdoc />
-        public IAddressable GetGrain(GrainId grainId) => this.referenceActivator.CreateReference(grainId, default);
+        public IAddressable GetGrain(GrainId grainId) => referenceActivator.CreateReference(grainId, default);
 
         /// <inheritdoc />
         public IGrain GetGrain(Type grainInterfaceType, Guid key)
@@ -187,7 +174,7 @@ namespace Orleans
         /// <inheritdoc />
         public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType)
         {
-            return this.referenceActivator.CreateReference(grainId, interfaceType);
+            return referenceActivator.CreateReference(grainId, interfaceType);
         }
 
         /// <inheritdoc />
@@ -208,20 +195,20 @@ namespace Orleans
         {
             ArgumentNullException.ThrowIfNull(interfaceType);
 
-            var grainInterfaceType = this.interfaceTypeResolver.GetGrainInterfaceType(interfaceType);
+            var grainInterfaceType = interfaceTypeResolver.GetGrainInterfaceType(interfaceType);
 
             GrainType grainType;
             if (!string.IsNullOrWhiteSpace(grainClassNamePrefix))
             {
-                grainType = this.interfaceTypeToGrainTypeResolver.GetGrainType(grainInterfaceType, grainClassNamePrefix);
+                grainType = interfaceToTypeResolver.GetGrainType(grainInterfaceType, grainClassNamePrefix);
             }
             else
             {
-                grainType = this.interfaceTypeToGrainTypeResolver.GetGrainType(grainInterfaceType);
+                grainType = interfaceToTypeResolver.GetGrainType(grainInterfaceType);
             }
 
             var grainId = GrainId.Create(grainType, grainKey);
-            var grain = this.referenceActivator.CreateReference(grainId, grainInterfaceType);
+            var grain = referenceActivator.CreateReference(grainId, grainInterfaceType);
             return grain;
         }
 
@@ -233,8 +220,8 @@ namespace Orleans
         /// <returns>A grain reference.</returns>
         private object CreateGrainReference(Type interfaceType, GrainId grainId)
         {
-            var grainInterfaceType = this.interfaceTypeResolver.GetGrainInterfaceType(interfaceType);
-            return this.referenceActivator.CreateReference(grainId, grainInterfaceType);
+            var grainInterfaceType = interfaceTypeResolver.GetGrainInterfaceType(interfaceType);
+            return referenceActivator.CreateReference(grainId, grainInterfaceType);
         }
 
         /// <summary>
@@ -256,7 +243,7 @@ namespace Orleans
                 throw new ArgumentException($"The provided object must implement '{interfaceType.FullName}'.", nameof(obj));
             }
 
-            return this.Cast(this.runtimeClient.CreateObjectReference(obj), interfaceType);
+            return this.Cast(runtimeClient.CreateObjectReference(obj), interfaceType);
         }
 
         /// <summary>

--- a/src/Orleans.Core/Core/GrainInterfaceTypeToGrainTypeResolver.cs
+++ b/src/Orleans.Core/Core/GrainInterfaceTypeToGrainTypeResolver.cs
@@ -30,10 +30,7 @@ namespace Orleans
         /// Creates a new instance of the <see cref="GrainInterfaceTypeToGrainTypeResolver"/> class.
         /// </summary>
         /// <param name="clusterManifestProvider">The cluster manifest provider.</param>
-        public GrainInterfaceTypeToGrainTypeResolver(IClusterManifestProvider clusterManifestProvider)
-        {
-            _clusterManifestProvider = clusterManifestProvider;
-        }
+        public GrainInterfaceTypeToGrainTypeResolver(IClusterManifestProvider clusterManifestProvider) => _clusterManifestProvider = clusterManifestProvider;
 
         /// <summary>
         /// Returns the <see cref="GrainType"/> which supports the provided <see cref="GrainInterfaceType"/> and which has an implementing type name beginning with the provided prefix string.

--- a/src/Orleans.Core/Core/GrainMethodInvoker.cs
+++ b/src/Orleans.Core/Core/GrainMethodInvoker.cs
@@ -12,40 +12,24 @@ namespace Orleans.Runtime
     /// <summary>
     /// Invokes a request on a grain.
     /// </summary>
-    internal sealed class GrainMethodInvoker : IIncomingGrainCallContext
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="GrainMethodInvoker"/> class.
+    /// </remarks>
+    /// <param name="message">The message.</param>
+    /// <param name="grainContext">The grain.</param>
+    /// <param name="request">The request.</param>
+    /// <param name="filters">The invocation interceptors.</param>
+    /// <param name="interfaceToImplementationMapping">The implementation map.</param>
+    /// <param name="responseCopier">The response copier.</param>
+    internal sealed class GrainMethodInvoker(
+        Message message,
+        IGrainContext grainContext,
+        IInvokable request,
+        List<IIncomingGrainCallFilter> filters,
+        InterfaceToImplementationMappingCache interfaceToImplementationMapping,
+        DeepCopier<Response> responseCopier) : IIncomingGrainCallContext
     {
-        private readonly Message message;
-        private readonly IInvokable request;
-        private readonly List<IIncomingGrainCallFilter> filters;
-        private readonly InterfaceToImplementationMappingCache interfaceToImplementationMapping;
-        private readonly DeepCopier<Response> responseCopier;
-        private readonly IGrainContext grainContext;
         private int stage;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GrainMethodInvoker"/> class.
-        /// </summary>
-        /// <param name="message">The message.</param>
-        /// <param name="grainContext">The grain.</param>
-        /// <param name="request">The request.</param>
-        /// <param name="filters">The invocation interceptors.</param>
-        /// <param name="interfaceToImplementationMapping">The implementation map.</param>
-        /// <param name="responseCopier">The response copier.</param>
-        public GrainMethodInvoker(
-            Message message,
-            IGrainContext grainContext,
-            IInvokable request,
-            List<IIncomingGrainCallFilter> filters,
-            InterfaceToImplementationMappingCache interfaceToImplementationMapping,
-            DeepCopier<Response> responseCopier)
-        {
-            this.message = message;
-            this.request = request;
-            this.grainContext = grainContext;
-            this.filters = filters;
-            this.interfaceToImplementationMapping = interfaceToImplementationMapping;
-            this.responseCopier = responseCopier;
-        }
 
         public IInvokable Request => request;
 
@@ -89,7 +73,7 @@ namespace Orleans.Runtime
                 if (stage < numFilters)
                 {
                     // Call each of the specified interceptors.
-                    var systemWideFilter = this.filters[stage];
+                    var systemWideFilter = filters[stage];
                     stage++;
                     await systemWideFilter.Invoke(this);
 
@@ -132,7 +116,7 @@ namespace Orleans.Runtime
                         ExceptionDispatchInfo.Capture(exception).Throw();
                     }
 
-                    this.Response = this.responseCopier.Copy(this.Response);
+                    this.Response = responseCopier.Copy(this.Response);
 
                     return;
                 }
@@ -160,8 +144,8 @@ namespace Orleans.Runtime
 
         private (MethodInfo ImplementationMethod, MethodInfo InterfaceMethod) GetMethodEntry()
         {
-            var interfaceType = this.request.GetInterfaceType();
-            var implementationType = this.request.GetTarget()!.GetType();
+            var interfaceType = request.GetInterfaceType();
+            var implementationType = request.GetTarget()!.GetType();
 
             // Get or create the implementation map for this object.
             var implementationMap = interfaceToImplementationMapping.GetOrCreate(

--- a/src/Orleans.Core/Diagnostics/Metrics/Aggregators/AggregatorKey.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/Aggregators/AggregatorKey.cs
@@ -4,15 +4,10 @@ using System.Linq;
 
 namespace Orleans.Runtime;
 
-internal readonly struct AggregatorKey : IEquatable<AggregatorKey>
+internal readonly struct AggregatorKey(string instrumentName, KeyValuePair<string, object?>[] tags) : IEquatable<AggregatorKey>
 {
-    public AggregatorKey(string instrumentName, KeyValuePair<string, object?>[] tags)
-    {
-        InstrumentName = instrumentName;
-        Tags = tags;
-    }
-    public string InstrumentName { get; }
-    public KeyValuePair<string, object?>[] Tags { get; }
+    public string InstrumentName { get; } = instrumentName;
+    public KeyValuePair<string, object?>[] Tags { get; } = tags;
 
     public override int GetHashCode() => HashCode.Combine(InstrumentName, Tags);
     public bool Equals(AggregatorKey other) => InstrumentName == other.InstrumentName && Tags.SequenceEqual(other.Tags);

--- a/src/Orleans.Core/Diagnostics/Metrics/Aggregators/CounterAggregator.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/Aggregators/CounterAggregator.cs
@@ -9,10 +9,7 @@ internal sealed class CounterAggregator
 {
     private readonly KeyValuePair<string, object?>[] _tags;
     private long _value = 0;
-    public CounterAggregator()
-    {
-        _tags = Array.Empty<KeyValuePair<string, object?>>();
-    }
+    public CounterAggregator() => _tags = Array.Empty<KeyValuePair<string, object?>>();
 
     public CounterAggregator(in TagList tagList)
     {

--- a/src/Orleans.Core/Diagnostics/Metrics/Aggregators/HistogramBucketAggregator.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/Aggregators/HistogramBucketAggregator.cs
@@ -6,17 +6,11 @@ using System.Threading;
 
 namespace Orleans.Runtime;
 
-internal class HistogramBucketAggregator
+internal class HistogramBucketAggregator(KeyValuePair<string, object?>[] tags, long bound, KeyValuePair<string, object?> label)
 {
     private long _value = 0;
-    private readonly KeyValuePair<string, object?>[] _tags;
-    public long Bound { get; }
-
-    public HistogramBucketAggregator(KeyValuePair<string, object?>[] tags, long bound, KeyValuePair<string, object?> label)
-    {
-        _tags = tags.Concat(new[] { label }).ToArray();
-        Bound = bound;
-    }
+    private readonly KeyValuePair<string, object?>[] _tags = tags.Concat(new[] { label }).ToArray();
+    public long Bound { get; } = bound;
 
     public ReadOnlySpan<KeyValuePair<string, object?>> Tags => _tags;
 

--- a/src/Orleans.Core/GrainReferences/GrainReferenceActivator.cs
+++ b/src/Orleans.Core/GrainReferences/GrainReferenceActivator.cs
@@ -22,29 +22,23 @@ namespace Orleans.GrainReferences
     /// <summary>
     /// The central point for creating <see cref="GrainReference"/> instances.
     /// </summary>
-    public sealed class GrainReferenceActivator
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="GrainReferenceActivator"/> class.
+    /// </remarks>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <param name="providers">The collection of grain reference activator providers.</param>
+    public sealed class GrainReferenceActivator(
+        IServiceProvider serviceProvider,
+        IEnumerable<IGrainReferenceActivatorProvider> providers)
     {
 #if NET9_0_OR_GREATER
         private readonly Lock _lockObj = new();
 #else
         private readonly object _lockObj = new();
 #endif
-        private readonly IServiceProvider _serviceProvider;
-        private readonly IGrainReferenceActivatorProvider[] _providers;
+        private readonly IServiceProvider _serviceProvider = serviceProvider;
+        private readonly IGrainReferenceActivatorProvider[] _providers = providers.ToArray();
         private Dictionary<(GrainType, GrainInterfaceType), IGrainReferenceActivator> _activators = new();
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GrainReferenceActivator"/> class.
-        /// </summary>
-        /// <param name="serviceProvider">The service provider.</param>
-        /// <param name="providers">The collection of grain reference activator providers.</param>
-        public GrainReferenceActivator(
-            IServiceProvider serviceProvider,
-            IEnumerable<IGrainReferenceActivatorProvider> providers)
-        {
-            _serviceProvider = serviceProvider;
-            _providers = providers.ToArray();
-        }
 
         /// <summary>
         /// Creates a grain reference pointing to the specified grain id and implementing the specified grain interface type.

--- a/src/Orleans.Core/Lifecycle/MigrationContext.cs
+++ b/src/Orleans.Core/Lifecycle/MigrationContext.cs
@@ -27,10 +27,7 @@ internal sealed class MigrationContext : IDehydrationContext, IRehydrationContex
     internal readonly SerializerSessionPool _sessionPool;
 
     [GeneratedActivatorConstructor]
-    public MigrationContext(SerializerSessionPool sessionPool)
-    {
-        _sessionPool = sessionPool;
-    }
+    public MigrationContext(SerializerSessionPool sessionPool) => _sessionPool = sessionPool;
 
     [Id(0), Immutable]
     private Dictionary<string, (int Offset, int Length)> _indices = new(StringComparer.Ordinal);

--- a/src/Orleans.Core/Manifest/GrainBindings.cs
+++ b/src/Orleans.Core/Manifest/GrainBindings.cs
@@ -13,28 +13,23 @@ namespace Orleans.Metadata
     /// <remarks>
     /// Bindings are a way to declaratively connect grains with other resources.
     /// </remarks>
-    public class GrainBindings
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="GrainBindings"/> class.
+    /// </remarks>
+    /// <param name="grainType">The grain type.</param>
+    /// <param name="bindings">The bindings for the specified grain type.</param>
+    public class GrainBindings(GrainType grainType, ImmutableArray<ImmutableDictionary<string, string>> bindings)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GrainBindings"/> class.
-        /// </summary>
-        /// <param name="grainType">The grain type.</param>
-        /// <param name="bindings">The bindings for the specified grain type.</param>
-        public GrainBindings(GrainType grainType, ImmutableArray<ImmutableDictionary<string, string>> bindings)
-        {
-            this.GrainType = grainType;
-            this.Bindings = bindings;
-        }
 
         /// <summary>
         /// Gets the grain type.
         /// </summary>
-        public GrainType GrainType { get; }
+        public GrainType GrainType { get; } = grainType;
 
         /// <summary>
         /// Gets the bindings for the specified grain type.
         /// </summary>
-        public ImmutableArray<ImmutableDictionary<string, string>> Bindings { get; }
+        public ImmutableArray<ImmutableDictionary<string, string>> Bindings { get; } = bindings;
     }
 
     /// <summary>

--- a/src/Orleans.Core/Manifest/GrainInterfaceTypeResolver.cs
+++ b/src/Orleans.Core/Manifest/GrainInterfaceTypeResolver.cs
@@ -9,27 +9,20 @@ namespace Orleans.Metadata
     /// <summary>
     /// Associates a <see cref="GrainInterfaceType"/> with a <see cref="Type" />.
     /// </summary>
-    public class GrainInterfaceTypeResolver
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="GrainInterfaceTypeResolver"/> class.
+    /// </remarks>
+    /// <param name="providers">
+    /// The collection of grain interface type providers.
+    /// </param>
+    /// <param name="typeConverter">
+    /// The type converter, used for generic parameter names.
+    /// </param>
+    public class GrainInterfaceTypeResolver(
+        IEnumerable<IGrainInterfaceTypeProvider> providers,
+        TypeConverter typeConverter)
     {
-        private readonly IGrainInterfaceTypeProvider[] _providers;
-        private readonly TypeConverter _typeConverter;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GrainInterfaceTypeResolver"/> class.
-        /// </summary>
-        /// <param name="providers">
-        /// The collection of grain interface type providers.
-        /// </param>
-        /// <param name="typeConverter">
-        /// The type converter, used for generic parameter names.
-        /// </param>
-        public GrainInterfaceTypeResolver(
-            IEnumerable<IGrainInterfaceTypeProvider> providers,
-            TypeConverter typeConverter)
-        {
-            _providers = providers.ToArray();
-            _typeConverter = typeConverter;
-        }
+        private readonly IGrainInterfaceTypeProvider[] _providers = providers.ToArray();
 
         /// <summary>
         /// Returns the <see cref="GrainInterfaceType"/> for the provided interface.
@@ -64,7 +57,7 @@ namespace Orleans.Metadata
         /// <returns>The grain interface type name.</returns>
         public GrainInterfaceType GetGrainInterfaceTypeByConvention(Type type)
         {
-            var result = GrainInterfaceType.Create(_typeConverter.Format(type, input => input switch
+            var result = GrainInterfaceType.Create(typeConverter.Format(type, input => input switch
             {
                 AssemblyQualifiedTypeSpec asm => asm.Type, // drop outer assembly qualification
                 _ => input
@@ -81,7 +74,7 @@ namespace Orleans.Metadata
                 && !type.ContainsGenericParameters
                 && !genericGrainType.IsConstructed)
             {
-                result = genericGrainType.Construct(_typeConverter, type.GetGenericArguments()).Value;
+                result = genericGrainType.Construct(typeConverter, type.GetGenericArguments()).Value;
             }
 
             return result;

--- a/src/Orleans.Core/Manifest/GrainPropertiesResolver.cs
+++ b/src/Orleans.Core/Manifest/GrainPropertiesResolver.cs
@@ -8,20 +8,14 @@ namespace Orleans.Metadata
     /// <summary>
     /// Responsible for resolving <see cref="GrainProperties"/> for <see cref="GrainType"/> values.
     /// </summary>
-    public class GrainPropertiesResolver
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="GrainPropertiesResolver"/> class.
+    /// </remarks>
+    /// <param name="clusterManifestProvider">
+    /// The cluster manifest provider.
+    /// </param>
+    public class GrainPropertiesResolver(IClusterManifestProvider clusterManifestProvider)
     {
-        private readonly IClusterManifestProvider _clusterManifestProvider;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GrainPropertiesResolver"/> class.
-        /// </summary>
-        /// <param name="clusterManifestProvider">
-        /// The cluster manifest provider.
-        /// </param>
-        public GrainPropertiesResolver(IClusterManifestProvider clusterManifestProvider)
-        {
-            _clusterManifestProvider = clusterManifestProvider;
-        }
 
         /// <summary>
         /// Gets the grain properties for the provided type.
@@ -57,7 +51,7 @@ namespace Orleans.Metadata
         /// </returns>
         public bool TryGetGrainProperties(GrainType grainType, [NotNullWhen(true)] out GrainProperties? properties)
         {
-            var clusterManifest = _clusterManifestProvider.Current;
+            var clusterManifest = clusterManifestProvider.Current;
             if (clusterManifest is null)
             {
                 properties = default;

--- a/src/Orleans.Core/Manifest/GrainTypeResolver.cs
+++ b/src/Orleans.Core/Manifest/GrainTypeResolver.cs
@@ -9,28 +9,21 @@ namespace Orleans.Metadata
     /// <summary>
     /// Associates a <see cref="GrainType"/> with a grain class.
     /// </summary>
-    public class GrainTypeResolver
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="GrainTypeResolver"/> class.
+    /// </remarks>
+    /// <param name="resolvers">
+    /// The grain type name providers.
+    /// </param>
+    /// <param name="argumentFormatter">
+    /// The type converter, used to format generic parameters.
+    /// </param>
+    public class GrainTypeResolver(
+        IEnumerable<IGrainTypeProvider> resolvers,
+        TypeConverter argumentFormatter)
     {
         private const string GrainSuffix = "grain";
-        private readonly IGrainTypeProvider[] _providers;
-        private readonly TypeConverter _typeConverter;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GrainTypeResolver"/> class.
-        /// </summary>
-        /// <param name="resolvers">
-        /// The grain type name providers.
-        /// </param>
-        /// <param name="argumentFormatter">
-        /// The type converter, used to format generic parameters.
-        /// </param>
-        public GrainTypeResolver(
-            IEnumerable<IGrainTypeProvider> resolvers,
-            TypeConverter argumentFormatter)
-        {
-            _providers = resolvers.ToArray();
-            _typeConverter = argumentFormatter;
-        }
+        private readonly IGrainTypeProvider[] _providers = resolvers.ToArray();
 
         /// <summary>
         /// Returns the grain type for the provided class.
@@ -96,7 +89,7 @@ namespace Orleans.Metadata
                 && !genericGrainType.IsConstructed)
             {
                 var typeArguments = type.GetGenericArguments();
-                grainType = genericGrainType.Construct(_typeConverter, typeArguments).GrainType;
+                grainType = genericGrainType.Construct(argumentFormatter, typeArguments).GrainType;
             }
 
             return grainType;

--- a/src/Orleans.Core/Manifest/GrainVersionManifest.cs
+++ b/src/Orleans.Core/Manifest/GrainVersionManifest.cs
@@ -4,200 +4,233 @@ using System.Collections.Generic;
 using System.Threading;
 using Orleans.Metadata;
 
-namespace Orleans.Runtime.Versions
+namespace Orleans.Runtime.Versions;
+
+/// <summary>
+/// Functionality for querying the declared version of grain interfaces.
+/// </summary>
+internal sealed class GrainVersionManifest
 {
-    /// <summary>
-    /// Functionality for querying the declared version of grain interfaces.
-    /// </summary>
-    internal sealed class GrainVersionManifest
-    {
 #if NET9_0_OR_GREATER
-        private readonly Lock _lockObj = new();
+    private readonly Lock _lockObj = new();
 #else
-        private readonly object _lockObj = new();
+    private readonly object _lockObj = new();
 #endif
-        private readonly ConcurrentDictionary<GrainInterfaceType, GrainInterfaceType> _genericInterfaceMapping = new ConcurrentDictionary<GrainInterfaceType, GrainInterfaceType>();
-        private readonly ConcurrentDictionary<GrainType, GrainType> _genericGrainTypeMapping = new ConcurrentDictionary<GrainType, GrainType>();
-        private readonly IClusterManifestProvider _clusterManifestProvider;
-        private readonly Dictionary<GrainInterfaceType, ushort> _localVersions;
-        private Cache _cache;
+    private readonly ConcurrentDictionary<GrainInterfaceType, GrainInterfaceType> _genericInterfaceMapping = new ConcurrentDictionary<GrainInterfaceType, GrainInterfaceType>();
+    private readonly ConcurrentDictionary<GrainType, GrainType> _genericGrainTypeMapping = new ConcurrentDictionary<GrainType, GrainType>();
+    private readonly IClusterManifestProvider _clusterManifestProvider;
+    private readonly Dictionary<GrainInterfaceType, ushort> _localVersions;
+    private Cache _cache;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GrainVersionManifest"/> class.
-        /// </summary>
-        /// <param name="clusterManifestProvider">The cluster manifest provider.</param>
-        public GrainVersionManifest(IClusterManifestProvider clusterManifestProvider)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GrainVersionManifest"/> class.
+    /// </summary>
+    /// <param name="clusterManifestProvider">The cluster manifest provider.</param>
+    public GrainVersionManifest(IClusterManifestProvider clusterManifestProvider)
+    {
+        _clusterManifestProvider = clusterManifestProvider;
+        _cache = BuildCache(clusterManifestProvider.Current);
+        _localVersions = BuildLocalVersionMap(clusterManifestProvider.LocalGrainManifest);
+    }
+
+    /// <summary>
+    /// Gets the local version for a specified grain interface type.
+    /// </summary>
+    /// <param name="interfaceType">The grain interface type name.</param>
+    /// <returns>The version of the specified grain interface.</returns>
+    public ushort GetLocalVersion(GrainInterfaceType interfaceType)
+    {
+        if (_localVersions.TryGetValue(interfaceType, out var result))
         {
-            _clusterManifestProvider = clusterManifestProvider;
-            _cache = BuildCache(clusterManifestProvider.Current);
-            _localVersions = BuildLocalVersionMap(clusterManifestProvider.LocalGrainManifest);
+            return result;
         }
 
-        /// <summary>
-        /// Gets the local version for a specified grain interface type.
-        /// </summary>
-        /// <param name="interfaceType">The grain interface type name.</param>
-        /// <returns>The version of the specified grain interface.</returns>
-        public ushort GetLocalVersion(GrainInterfaceType interfaceType)
+        if (_genericInterfaceMapping.TryGetValue(interfaceType, out var genericInterfaceId))
         {
-            if (_localVersions.TryGetValue(interfaceType, out var result))
-            {
-                return result;
-            }
-
-            if (_genericInterfaceMapping.TryGetValue(interfaceType, out var genericInterfaceId))
-            {
-                return GetLocalVersion(genericInterfaceId);
-            }
-
-            if (GenericGrainInterfaceType.TryParse(interfaceType, out var generic) && generic.IsConstructed)
-            {
-                var genericId = _genericInterfaceMapping[interfaceType] = generic.GetGenericGrainType().Value;
-                return GetLocalVersion(genericId);
-            }
-
-            return 0;
+            return GetLocalVersion(genericInterfaceId);
         }
 
-        /// <summary>
-        /// Gets a collection of all known versions for a grain interface.
-        /// </summary>
-        /// <param name="interfaceType">The grain interface type name.</param>
-        /// <returns>All known versions for the specified grain interface.</returns>
-        public (MajorMinorVersion Version, ushort[] Result) GetAvailableVersions(GrainInterfaceType interfaceType)
+        if (GenericGrainInterfaceType.TryParse(interfaceType, out var generic) && generic.IsConstructed)
         {
-            var snapshot = Capture();
-            return (snapshot.Version, snapshot.GetAvailableVersions(interfaceType));
+            var genericId = _genericInterfaceMapping[interfaceType] = generic.GetGenericGrainType().Value;
+            return GetLocalVersion(genericId);
         }
 
-        /// <summary>
-        /// Gets the set of supported silos for a specified grain interface and version.
-        /// </summary>
-        /// <param name="interfaceType">The grain interface type name.</param>
-        /// <param name="version">The grain interface version.</param>
-        /// <returns>The set of silos which support the specified grain interface type and version.</returns>
-        public (MajorMinorVersion Version, SiloAddress[] Result) GetSupportedSilos(GrainInterfaceType interfaceType, ushort version)
+        return 0;
+    }
+
+    /// <summary>
+    /// Gets a collection of all known versions for a grain interface.
+    /// </summary>
+    /// <param name="interfaceType">The grain interface type name.</param>
+    /// <returns>All known versions for the specified grain interface.</returns>
+    public (MajorMinorVersion Version, ushort[] Result) GetAvailableVersions(GrainInterfaceType interfaceType)
+    {
+        var snapshot = Capture();
+        return (snapshot.Version, snapshot.GetAvailableVersions(interfaceType));
+    }
+
+    /// <summary>
+    /// Gets the set of supported silos for a specified grain interface and version.
+    /// </summary>
+    /// <param name="interfaceType">The grain interface type name.</param>
+    /// <param name="version">The grain interface version.</param>
+    /// <returns>The set of silos which support the specified grain interface type and version.</returns>
+    public (MajorMinorVersion Version, SiloAddress[] Result) GetSupportedSilos(GrainInterfaceType interfaceType, ushort version)
+    {
+        var snapshot = Capture();
+        return (snapshot.Version, snapshot.GetSupportedSilos(interfaceType, version));
+    }
+
+    /// <summary>
+    /// Gets the set of supported silos for the specified grain type.
+    /// </summary>
+    /// <param name="grainType">The grain type.</param>
+    /// <returns>The silos which support the specified grain type.</returns>
+    public (MajorMinorVersion Version, SiloAddress[] Result) GetSupportedSilos(GrainType grainType)
+    {
+        var snapshot = Capture();
+        return (snapshot.Version, snapshot.GetSupportedSilos(grainType));
+    }
+
+    /// <summary>
+    /// Gets the set of supported silos for the specified combination of grain type, interface type, and version.
+    /// </summary>
+    /// <param name="grainType">The grain type.</param>
+    /// <param name="interfaceType">The grain interface type name.</param>
+    /// <param name="versions">The grain interface version.</param>
+    /// <returns>The set of silos which support the specified grain.</returns>
+    public (MajorMinorVersion Version, Dictionary<ushort, SiloAddress[]> Result) GetSupportedSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort[] versions)
+    {
+        var snapshot = Capture();
+        return (snapshot.Version, snapshot.GetSupportedSilos(grainType, interfaceType, versions));
+    }
+
+    internal Snapshot Capture() => new(this, GetCache());
+
+    private ushort[] GetAvailableVersions(Cache cache, GrainInterfaceType interfaceType)
+    {
+        if (cache.AvailableVersions.TryGetValue(interfaceType, out var result))
         {
-            var snapshot = Capture();
-            return (snapshot.Version, snapshot.GetSupportedSilos(interfaceType, version));
+            return result;
         }
 
-        /// <summary>
-        /// Gets the set of supported silos for the specified grain type.
-        /// </summary>
-        /// <param name="grainType">The grain type.</param>
-        /// <returns>The silos which support the specified grain type.</returns>
-        public (MajorMinorVersion Version, SiloAddress[] Result) GetSupportedSilos(GrainType grainType)
+        if (_genericInterfaceMapping.TryGetValue(interfaceType, out var genericInterfaceId))
         {
-            var snapshot = Capture();
-            return (snapshot.Version, snapshot.GetSupportedSilos(grainType));
+            return GetAvailableVersions(cache, genericInterfaceId);
         }
 
-        /// <summary>
-        /// Gets the set of supported silos for the specified combination of grain type, interface type, and version.
-        /// </summary>
-        /// <param name="grainType">The grain type.</param>
-        /// <param name="interfaceType">The grain interface type name.</param>
-        /// <param name="versions">The grain interface version.</param>
-        /// <returns>The set of silos which support the specified grain.</returns>
-        public (MajorMinorVersion Version, Dictionary<ushort, SiloAddress[]> Result) GetSupportedSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort[] versions)
+        if (GenericGrainInterfaceType.TryParse(interfaceType, out var generic) && generic.IsConstructed)
         {
-            var snapshot = Capture();
-            return (snapshot.Version, snapshot.GetSupportedSilos(grainType, interfaceType, versions));
+            var genericId = _genericInterfaceMapping[interfaceType] = generic.GetGenericGrainType().Value;
+            return GetAvailableVersions(cache, genericId);
         }
 
-        internal Snapshot Capture() => new(this, GetCache());
+        return Array.Empty<ushort>();
+    }
 
-        private ushort[] GetAvailableVersions(Cache cache, GrainInterfaceType interfaceType)
+    private SiloAddress[] GetSupportedSilos(Cache cache, GrainInterfaceType interfaceType, ushort version)
+    {
+        if (cache.SupportedSilosByInterface.TryGetValue((interfaceType, version), out var result))
         {
-            if (cache.AvailableVersions.TryGetValue(interfaceType, out var result))
-            {
-                return result;
-            }
-
-            if (_genericInterfaceMapping.TryGetValue(interfaceType, out var genericInterfaceId))
-            {
-                return GetAvailableVersions(cache, genericInterfaceId);
-            }
-
-            if (GenericGrainInterfaceType.TryParse(interfaceType, out var generic) && generic.IsConstructed)
-            {
-                var genericId = _genericInterfaceMapping[interfaceType] = generic.GetGenericGrainType().Value;
-                return GetAvailableVersions(cache, genericId);
-            }
-
-            return Array.Empty<ushort>();
+            return result;
         }
 
-        private SiloAddress[] GetSupportedSilos(Cache cache, GrainInterfaceType interfaceType, ushort version)
+        if (_genericInterfaceMapping.TryGetValue(interfaceType, out var genericInterfaceId))
         {
-            if (cache.SupportedSilosByInterface.TryGetValue((interfaceType, version), out var result))
-            {
-                return result;
-            }
-
-            if (_genericInterfaceMapping.TryGetValue(interfaceType, out var genericInterfaceId))
-            {
-                return GetSupportedSilos(cache, genericInterfaceId, version);
-            }
-
-            if (GenericGrainInterfaceType.TryParse(interfaceType, out var generic) && generic.IsConstructed)
-            {
-                var genericId = _genericInterfaceMapping[interfaceType] = generic.GetGenericGrainType().Value;
-                return GetSupportedSilos(cache, genericId, version);
-            }
-
-            return Array.Empty<SiloAddress>();
+            return GetSupportedSilos(cache, genericInterfaceId, version);
         }
 
-        private SiloAddress[] GetSupportedSilos(Cache cache, GrainType grainType)
+        if (GenericGrainInterfaceType.TryParse(interfaceType, out var generic) && generic.IsConstructed)
         {
-            if (cache.SupportedSilosByGrainType.TryGetValue(grainType, out var result))
-            {
-                return result;
-            }
-
-            if (_genericGrainTypeMapping.TryGetValue(grainType, out var genericGrainType))
-            {
-                return GetSupportedSilos(cache, genericGrainType);
-            }
-
-            if (GenericGrainType.TryParse(grainType, out var generic) && generic.IsConstructed)
-            {
-                var genericId = _genericGrainTypeMapping[grainType] = generic.GetUnconstructedGrainType().GrainType;
-                return GetSupportedSilos(cache, genericId);
-            }
-
-            return Array.Empty<SiloAddress>();
+            var genericId = _genericInterfaceMapping[interfaceType] = generic.GetGenericGrainType().Value;
+            return GetSupportedSilos(cache, genericId, version);
         }
 
-        private Cache GetCache()
+        return Array.Empty<SiloAddress>();
+    }
+
+    private SiloAddress[] GetSupportedSilos(Cache cache, GrainType grainType)
+    {
+        if (cache.SupportedSilosByGrainType.TryGetValue(grainType, out var result))
         {
-            var cache = Volatile.Read(ref _cache);
-            var manifest = _clusterManifestProvider.Current;
+            return result;
+        }
+
+        if (_genericGrainTypeMapping.TryGetValue(grainType, out var genericGrainType))
+        {
+            return GetSupportedSilos(cache, genericGrainType);
+        }
+
+        if (GenericGrainType.TryParse(grainType, out var generic) && generic.IsConstructed)
+        {
+            var genericId = _genericGrainTypeMapping[grainType] = generic.GetUnconstructedGrainType().GrainType;
+            return GetSupportedSilos(cache, genericId);
+        }
+
+        return Array.Empty<SiloAddress>();
+    }
+
+    private Cache GetCache()
+    {
+        var cache = Volatile.Read(ref _cache);
+        var manifest = _clusterManifestProvider.Current;
+        if (manifest.Version == cache.Version)
+        {
+            return cache;
+        }
+
+        lock (_lockObj)
+        {
+            cache = Volatile.Read(ref _cache);
+            manifest = _clusterManifestProvider.Current;
             if (manifest.Version == cache.Version)
             {
                 return cache;
             }
 
-            lock (_lockObj)
-            {
-                cache = Volatile.Read(ref _cache);
-                manifest = _clusterManifestProvider.Current;
-                if (manifest.Version == cache.Version)
-                {
-                    return cache;
-                }
+            cache = BuildCache(manifest);
+            Volatile.Write(ref _cache, cache);
+            return cache;
+        }
+    }
 
-                cache = BuildCache(manifest);
-                Volatile.Write(ref _cache, cache);
-                return cache;
+    private static Dictionary<GrainInterfaceType, ushort> BuildLocalVersionMap(GrainManifest manifest)
+    {
+        var result = new Dictionary<GrainInterfaceType, ushort>();
+        foreach (var grainInterface in manifest.Interfaces)
+        {
+            var id = grainInterface.Key;
+
+            if (!grainInterface.Value.Properties.TryGetValue(WellKnownGrainInterfaceProperties.Version, out var versionString)
+                || !ushort.TryParse(versionString, out var version))
+            {
+                version = 0;
             }
+
+            result[id] = version;
         }
 
-        private static Dictionary<GrainInterfaceType, ushort> BuildLocalVersionMap(GrainManifest manifest)
+        return result;
+    }
+
+    private static Cache BuildCache(ClusterManifest clusterManifest)
+    {
+        var available = new Dictionary<GrainInterfaceType, List<ushort>>();
+        var supportedInterfaces = new Dictionary<(GrainInterfaceType, ushort), List<SiloAddress>>();
+        var supportedGrains = new Dictionary<GrainType, List<SiloAddress>>();
+
+        foreach (var entry in clusterManifest.Silos)
         {
-            var result = new Dictionary<GrainInterfaceType, ushort>();
+            var silo = entry.Key;
+
+            // Since clients are not eligible for placement, we exclude them here.
+            if (silo.IsClient)
+            {
+                continue;
+            }
+
+            var manifest = entry.Value;
             foreach (var grainInterface in manifest.Interfaces)
             {
                 var id = grainInterface.Key;
@@ -208,255 +241,221 @@ namespace Orleans.Runtime.Versions
                     version = 0;
                 }
 
-                result[id] = version;
+                if (!available.TryGetValue(id, out var versions))
+                {
+                    available[id] = new List<ushort> { version };
+                }
+                else if (!versions.Contains(version))
+                {
+                    versions.Add(version);
+                }
+
+                if (!supportedInterfaces.TryGetValue((id, version), out var supportedSilos))
+                {
+                    supportedInterfaces[(id, version)] = new List<SiloAddress> { silo };
+                }
+                else
+                {
+                    supportedSilos.Add(silo);
+                }
+            }
+
+            foreach (var grainType in manifest.Grains)
+            {
+                var id = grainType.Key;
+                if (!supportedGrains.TryGetValue(id, out var supportedSilos))
+                {
+                    supportedGrains[id] = new List<SiloAddress> { silo };
+                }
+                else
+                {
+                    supportedSilos.Add(silo);
+                }
+            }
+        }
+
+        var resultAvailable = new Dictionary<GrainInterfaceType, ushort[]>();
+        foreach (var entry in available)
+        {
+            entry.Value.Sort();
+            resultAvailable[entry.Key] = entry.Value.ToArray();
+        }
+
+        var resultSupportedByInterface = new Dictionary<(GrainInterfaceType, ushort), SiloAddress[]>();
+        foreach (var entry in supportedInterfaces)
+        {
+            entry.Value.Sort();
+            resultSupportedByInterface[entry.Key] = entry.Value.ToArray();
+        }
+
+        var resultSupportedSilosByGrainType = new Dictionary<GrainType, SiloAddress[]>();
+        foreach (var entry in supportedGrains)
+        {
+            entry.Value.Sort();
+            resultSupportedSilosByGrainType[entry.Key] = entry.Value.ToArray();
+        }
+
+        return new Cache(clusterManifest.Version, resultAvailable, resultSupportedByInterface, resultSupportedSilosByGrainType);
+    }
+
+    internal readonly struct Snapshot
+    {
+        private readonly GrainVersionManifest _owner;
+        private readonly Cache _cache;
+
+        internal Snapshot(GrainVersionManifest owner, Cache cache)
+        {
+            _owner = owner;
+            _cache = cache;
+        }
+
+        public MajorMinorVersion Version => _cache.Version;
+
+        public ushort[] GetAvailableVersions(GrainInterfaceType interfaceType) =>
+            _owner.GetAvailableVersions(_cache, interfaceType);
+
+        public SiloAddress[] GetSupportedSilos(GrainInterfaceType interfaceType, ushort version) =>
+            _owner.GetSupportedSilos(_cache, interfaceType, version);
+
+        public SiloAddress[] GetSupportedSilos(GrainType grainType) =>
+            _owner.GetSupportedSilos(_cache, grainType);
+
+        public Dictionary<ushort, SiloAddress[]> GetSupportedSilos(
+            GrainType grainType,
+            GrainInterfaceType interfaceType,
+            ushort[] versions) =>
+            GetSupportedSilos(grainType, interfaceType, versions, out _);
+
+        public Dictionary<ushort, SiloAddress[]> GetSupportedSilos(
+            GrainType grainType,
+            GrainInterfaceType interfaceType,
+            ushort[] versions,
+            out SiloAddress[] allSupportedSilos)
+        {
+            var result = new Dictionary<ushort, SiloAddress[]>(versions.Length);
+            var silosWithGrain = GetSupportedSilos(grainType);
+            allSupportedSilos = Array.Empty<SiloAddress>();
+            foreach (var version in versions)
+            {
+                var supportedSilos = IntersectSorted(
+                    silosWithGrain,
+                    GetSupportedSilos(interfaceType, version));
+                result[version] = supportedSilos;
+                allSupportedSilos = UnionSorted(allSupportedSilos, supportedSilos);
             }
 
             return result;
         }
 
-        private static Cache BuildCache(ClusterManifest clusterManifest)
+        private static SiloAddress[] UnionSorted(SiloAddress[] left, SiloAddress[] right)
         {
-            var available = new Dictionary<GrainInterfaceType, List<ushort>>();
-            var supportedInterfaces = new Dictionary<(GrainInterfaceType, ushort), List<SiloAddress>>();
-            var supportedGrains = new Dictionary<GrainType, List<SiloAddress>>();
-
-            foreach (var entry in clusterManifest.Silos)
+            if (left.Length == 0)
             {
-                var silo = entry.Key;
-
-                // Since clients are not eligible for placement, we exclude them here.
-                if (silo.IsClient)
-                {
-                    continue;
-                }
-
-                var manifest = entry.Value;
-                foreach (var grainInterface in manifest.Interfaces)
-                {
-                    var id = grainInterface.Key;
-
-                    if (!grainInterface.Value.Properties.TryGetValue(WellKnownGrainInterfaceProperties.Version, out var versionString)
-                        || !ushort.TryParse(versionString, out var version))
-                    {
-                        version = 0;
-                    }
-
-                    if (!available.TryGetValue(id, out var versions))
-                    {
-                        available[id] = new List<ushort> { version };
-                    }
-                    else if (!versions.Contains(version))
-                    {
-                        versions.Add(version);
-                    }
-
-                    if (!supportedInterfaces.TryGetValue((id, version), out var supportedSilos))
-                    {
-                        supportedInterfaces[(id, version)] = new List<SiloAddress> { silo };
-                    }
-                    else
-                    {
-                        supportedSilos.Add(silo);
-                    }
-                }
-
-                foreach (var grainType in manifest.Grains)
-                {
-                    var id = grainType.Key;
-                    if (!supportedGrains.TryGetValue(id, out var supportedSilos))
-                    {
-                        supportedGrains[id] = new List<SiloAddress> { silo };
-                    }
-                    else
-                    {
-                        supportedSilos.Add(silo);
-                    }
-                }
+                return right;
             }
 
-            var resultAvailable = new Dictionary<GrainInterfaceType, ushort[]>();
-            foreach (var entry in available)
+            if (right.Length == 0)
             {
-                entry.Value.Sort();
-                resultAvailable[entry.Key] = entry.Value.ToArray();
+                return left;
             }
 
-            var resultSupportedByInterface = new Dictionary<(GrainInterfaceType, ushort), SiloAddress[]>();
-            foreach (var entry in supportedInterfaces)
+            var result = new SiloAddress[left.Length + right.Length];
+            var leftIndex = 0;
+            var rightIndex = 0;
+            var resultIndex = 0;
+            while (leftIndex < left.Length && rightIndex < right.Length)
             {
-                entry.Value.Sort();
-                resultSupportedByInterface[entry.Key] = entry.Value.ToArray();
-            }
-
-            var resultSupportedSilosByGrainType = new Dictionary<GrainType, SiloAddress[]>();
-            foreach (var entry in supportedGrains)
-            {
-                entry.Value.Sort();
-                resultSupportedSilosByGrainType[entry.Key] = entry.Value.ToArray();
-            }
-
-            return new Cache(clusterManifest.Version, resultAvailable, resultSupportedByInterface, resultSupportedSilosByGrainType);
-        }
-
-        internal readonly struct Snapshot
-        {
-            private readonly GrainVersionManifest _owner;
-            private readonly Cache _cache;
-
-            internal Snapshot(GrainVersionManifest owner, Cache cache)
-            {
-                _owner = owner;
-                _cache = cache;
-            }
-
-            public MajorMinorVersion Version => _cache.Version;
-
-            public ushort[] GetAvailableVersions(GrainInterfaceType interfaceType) =>
-                _owner.GetAvailableVersions(_cache, interfaceType);
-
-            public SiloAddress[] GetSupportedSilos(GrainInterfaceType interfaceType, ushort version) =>
-                _owner.GetSupportedSilos(_cache, interfaceType, version);
-
-            public SiloAddress[] GetSupportedSilos(GrainType grainType) =>
-                _owner.GetSupportedSilos(_cache, grainType);
-
-            public Dictionary<ushort, SiloAddress[]> GetSupportedSilos(
-                GrainType grainType,
-                GrainInterfaceType interfaceType,
-                ushort[] versions) =>
-                GetSupportedSilos(grainType, interfaceType, versions, out _);
-
-            public Dictionary<ushort, SiloAddress[]> GetSupportedSilos(
-                GrainType grainType,
-                GrainInterfaceType interfaceType,
-                ushort[] versions,
-                out SiloAddress[] allSupportedSilos)
-            {
-                var result = new Dictionary<ushort, SiloAddress[]>(versions.Length);
-                var silosWithGrain = GetSupportedSilos(grainType);
-                allSupportedSilos = Array.Empty<SiloAddress>();
-                foreach (var version in versions)
-                {
-                    var supportedSilos = IntersectSorted(
-                        silosWithGrain,
-                        GetSupportedSilos(interfaceType, version));
-                    result[version] = supportedSilos;
-                    allSupportedSilos = UnionSorted(allSupportedSilos, supportedSilos);
-                }
-
-                return result;
-            }
-
-            private static SiloAddress[] UnionSorted(SiloAddress[] left, SiloAddress[] right)
-            {
-                if (left.Length == 0)
-                {
-                    return right;
-                }
-
-                if (right.Length == 0)
-                {
-                    return left;
-                }
-
-                var result = new SiloAddress[left.Length + right.Length];
-                var leftIndex = 0;
-                var rightIndex = 0;
-                var resultIndex = 0;
-                while (leftIndex < left.Length && rightIndex < right.Length)
-                {
-                    var comparison = left[leftIndex].CompareTo(right[rightIndex]);
-                    if (comparison < 0)
-                    {
-                        result[resultIndex++] = left[leftIndex++];
-                    }
-                    else if (comparison > 0)
-                    {
-                        result[resultIndex++] = right[rightIndex++];
-                    }
-                    else
-                    {
-                        result[resultIndex++] = left[leftIndex++];
-                        ++rightIndex;
-                    }
-                }
-
-                while (leftIndex < left.Length)
+                var comparison = left[leftIndex].CompareTo(right[rightIndex]);
+                if (comparison < 0)
                 {
                     result[resultIndex++] = left[leftIndex++];
                 }
-
-                while (rightIndex < right.Length)
+                else if (comparison > 0)
                 {
                     result[resultIndex++] = right[rightIndex++];
                 }
-
-                if (resultIndex != result.Length)
+                else
                 {
-                    Array.Resize(ref result, resultIndex);
+                    result[resultIndex++] = left[leftIndex++];
+                    ++rightIndex;
                 }
-
-                return result;
             }
 
-            private static SiloAddress[] IntersectSorted(SiloAddress[] left, SiloAddress[] right)
+            while (leftIndex < left.Length)
             {
-                if (left.Length == 0 || right.Length == 0)
-                {
-                    return Array.Empty<SiloAddress>();
-                }
+                result[resultIndex++] = left[leftIndex++];
+            }
 
-                var result = new SiloAddress[Math.Min(left.Length, right.Length)];
-                var leftIndex = 0;
-                var rightIndex = 0;
-                var resultIndex = 0;
-                while (leftIndex < left.Length && rightIndex < right.Length)
-                {
-                    var comparison = left[leftIndex].CompareTo(right[rightIndex]);
-                    if (comparison < 0)
-                    {
-                        ++leftIndex;
-                    }
-                    else if (comparison > 0)
-                    {
-                        ++rightIndex;
-                    }
-                    else
-                    {
-                        result[resultIndex++] = left[leftIndex];
-                        ++leftIndex;
-                        ++rightIndex;
-                    }
-                }
+            while (rightIndex < right.Length)
+            {
+                result[resultIndex++] = right[rightIndex++];
+            }
 
-                if (resultIndex == result.Length)
-                {
-                    return result;
-                }
-
+            if (resultIndex != result.Length)
+            {
                 Array.Resize(ref result, resultIndex);
+            }
+
+            return result;
+        }
+
+        private static SiloAddress[] IntersectSorted(SiloAddress[] left, SiloAddress[] right)
+        {
+            if (left.Length == 0 || right.Length == 0)
+            {
+                return Array.Empty<SiloAddress>();
+            }
+
+            var result = new SiloAddress[Math.Min(left.Length, right.Length)];
+            var leftIndex = 0;
+            var rightIndex = 0;
+            var resultIndex = 0;
+            while (leftIndex < left.Length && rightIndex < right.Length)
+            {
+                var comparison = left[leftIndex].CompareTo(right[rightIndex]);
+                if (comparison < 0)
+                {
+                    ++leftIndex;
+                }
+                else if (comparison > 0)
+                {
+                    ++rightIndex;
+                }
+                else
+                {
+                    result[resultIndex++] = left[leftIndex];
+                    ++leftIndex;
+                    ++rightIndex;
+                }
+            }
+
+            if (resultIndex == result.Length)
+            {
                 return result;
             }
-        }
 
-        internal sealed class Cache
+            Array.Resize(ref result, resultIndex);
+            return result;
+        }
+    }
+
+    internal sealed class Cache
+    {
+        public Cache(
+            MajorMinorVersion version,
+            Dictionary<GrainInterfaceType, ushort[]> availableVersions,
+            Dictionary<(GrainInterfaceType, ushort), SiloAddress[]> supportedSilosByInterface,
+            Dictionary<GrainType, SiloAddress[]> supportedSilosByGrainType)
         {
-            public Cache(
-                MajorMinorVersion version,
-                Dictionary<GrainInterfaceType, ushort[]> availableVersions,
-                Dictionary<(GrainInterfaceType, ushort), SiloAddress[]> supportedSilosByInterface,
-                Dictionary<GrainType, SiloAddress[]> supportedSilosByGrainType)
-            {
-                this.Version = version;
-                this.AvailableVersions = availableVersions;
-                this.SupportedSilosByGrainType = supportedSilosByGrainType;
-                this.SupportedSilosByInterface = supportedSilosByInterface;
-            }
-
-            public MajorMinorVersion Version { get; }
-            public Dictionary<GrainInterfaceType, ushort[]> AvailableVersions { get; }
-            public Dictionary<(GrainInterfaceType, ushort), SiloAddress[]> SupportedSilosByInterface { get; }
-            public Dictionary<GrainType, SiloAddress[]> SupportedSilosByGrainType { get; }
+            this.Version = version;
+            this.AvailableVersions = availableVersions;
+            this.SupportedSilosByGrainType = supportedSilosByGrainType;
+            this.SupportedSilosByInterface = supportedSilosByInterface;
         }
+
+        public MajorMinorVersion Version { get; }
+        public Dictionary<GrainInterfaceType, ushort[]> AvailableVersions { get; }
+        public Dictionary<(GrainInterfaceType, ushort), SiloAddress[]> SupportedSilosByInterface { get; }
+        public Dictionary<GrainType, SiloAddress[]> SupportedSilosByGrainType { get; }
     }
 }

--- a/src/Orleans.Core/Manifest/ImplementedInterfaceProvider.cs
+++ b/src/Orleans.Core/Manifest/ImplementedInterfaceProvider.cs
@@ -7,19 +7,13 @@ namespace Orleans.Metadata
     /// <summary>
     /// Populates grain interface properties with the grain interfaces implemented by a grain class.
     /// </summary>
-    internal sealed class ImplementedInterfaceProvider : IGrainPropertiesProvider
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="ImplementedInterfaceProvider"/> class.
+    /// </remarks>
+    /// <param name="interfaceTypeResolver">The interface type resolver.</param>
+    internal sealed class ImplementedInterfaceProvider(GrainInterfaceTypeResolver interfaceTypeResolver) : IGrainPropertiesProvider
     {
-        private readonly GrainInterfaceTypeResolver interfaceTypeResolver;
         private readonly string[] _cachedKeys = new string[16];
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ImplementedInterfaceProvider"/> class.
-        /// </summary>
-        /// <param name="interfaceTypeResolver">The interface type resolver.</param>
-        public ImplementedInterfaceProvider(GrainInterfaceTypeResolver interfaceTypeResolver)
-        {
-            this.interfaceTypeResolver = interfaceTypeResolver;
-        }
 
         /// <inheritdoc/>
         public void Populate(Type grainClass, GrainType grainType, Dictionary<string, string> properties)
@@ -34,7 +28,7 @@ namespace Orleans.Metadata
                     { IsGenericType: true } when grainClass is { IsGenericType: true } => @interface.GetGenericTypeDefinition(),
                     _ => @interface
                 };
-                var interfaceId = this.interfaceTypeResolver.GetGrainInterfaceType(type);
+                var interfaceId = interfaceTypeResolver.GetGrainInterfaceType(type);
                 var key = (uint)counter < (uint)_cachedKeys.Length ? (_cachedKeys[counter] ??= GetKey(counter)) : GetKey(counter);
                 properties[key] = interfaceId.ToString();
                 ++counter;

--- a/src/Orleans.Core/Messaging/CachingIdSpanCodec.cs
+++ b/src/Orleans.Core/Messaging/CachingIdSpanCodec.cs
@@ -24,10 +24,7 @@ namespace Orleans.Runtime.Messaging
         private readonly Dictionary<int, (byte[] Value, long LastSeen)> _cache = new();
         private long _lastGarbageCollectionTimestamp;
 
-        public CachingIdSpanCodec()
-        {
-            _lastGarbageCollectionTimestamp = Environment.TickCount64;
-        }
+        public CachingIdSpanCodec() => _lastGarbageCollectionTimestamp = Environment.TickCount64;
 
         public IdSpan ReadRaw<TInput>(ref Reader<TInput> reader)
         {

--- a/src/Orleans.Core/Messaging/CachingSiloAddressCodec.cs
+++ b/src/Orleans.Core/Messaging/CachingSiloAddressCodec.cs
@@ -25,10 +25,7 @@ namespace Orleans.Runtime.Messaging
         private readonly Dictionary<int, (byte[] Encoded, SiloAddress Value, long LastSeen)> _cache = new();
         private long _lastGarbageCollectionTimestamp;
 
-        public CachingSiloAddressCodec()
-        {
-            _lastGarbageCollectionTimestamp = Environment.TickCount64;
-        }
+        public CachingSiloAddressCodec() => _lastGarbageCollectionTimestamp = Environment.TickCount64;
 
         public SiloAddress? ReadRaw<TInput>(ref Reader<TInput> reader)
         {

--- a/src/Orleans.Core/Messaging/StaticGatewayListProvider.cs
+++ b/src/Orleans.Core/Messaging/StaticGatewayListProvider.cs
@@ -9,21 +9,15 @@ namespace Orleans.Messaging
     /// <summary>
     /// <see cref="IGatewayListProvider"/> implementation which returns a static list, configured via <see cref="StaticGatewayListProviderOptions"/>.
     /// </summary>
-    public class StaticGatewayListProvider : IGatewayListProvider
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="StaticGatewayListProvider"/> class.
+    /// </remarks>
+    /// <param name="options">The specific options.</param>
+    /// <param name="gatewayOptions">The general gateway options.</param>
+    public class StaticGatewayListProvider(IOptions<StaticGatewayListProviderOptions> options, IOptions<GatewayOptions> gatewayOptions) : IGatewayListProvider
     {
-        private readonly StaticGatewayListProviderOptions options;
-        private readonly TimeSpan maxStaleness;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StaticGatewayListProvider"/> class.
-        /// </summary>
-        /// <param name="options">The specific options.</param>
-        /// <param name="gatewayOptions">The general gateway options.</param>
-        public StaticGatewayListProvider(IOptions<StaticGatewayListProviderOptions> options, IOptions<GatewayOptions> gatewayOptions)
-        {
-            this.options = options.Value;
-            this.maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
-        }
+        private readonly StaticGatewayListProviderOptions options = options.Value;
+        private readonly TimeSpan maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
 
         /// <inheritdoc />
         public Task InitializeGatewayListProvider() => Task.CompletedTask;

--- a/src/Orleans.Core/Messaging/StaticGatewayListProvider.cs
+++ b/src/Orleans.Core/Messaging/StaticGatewayListProvider.cs
@@ -9,15 +9,21 @@ namespace Orleans.Messaging
     /// <summary>
     /// <see cref="IGatewayListProvider"/> implementation which returns a static list, configured via <see cref="StaticGatewayListProviderOptions"/>.
     /// </summary>
-    /// <remarks>
-    /// Initializes a new instance of the <see cref="StaticGatewayListProvider"/> class.
-    /// </remarks>
-    /// <param name="optionsAccessor">The specific options.</param>
-    /// <param name="gatewayOptions">The general gateway options.</param>
-    public class StaticGatewayListProvider(IOptions<StaticGatewayListProviderOptions> optionsAccessor, IOptions<GatewayOptions> gatewayOptions) : IGatewayListProvider
+    public class StaticGatewayListProvider : IGatewayListProvider
     {
-        private readonly StaticGatewayListProviderOptions options = optionsAccessor.Value;
-        private readonly TimeSpan maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
+        private readonly StaticGatewayListProviderOptions options;
+        private readonly TimeSpan maxStaleness;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StaticGatewayListProvider"/> class.
+        /// </summary>
+        /// <param name="options">The specific options.</param>
+        /// <param name="gatewayOptions">The general gateway options.</param>
+        public StaticGatewayListProvider(IOptions<StaticGatewayListProviderOptions> options, IOptions<GatewayOptions> gatewayOptions)
+        {
+            this.options = options.Value;
+            this.maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
+        }
 
         /// <inheritdoc />
         public Task InitializeGatewayListProvider() => Task.CompletedTask;

--- a/src/Orleans.Core/Messaging/StaticGatewayListProvider.cs
+++ b/src/Orleans.Core/Messaging/StaticGatewayListProvider.cs
@@ -12,11 +12,11 @@ namespace Orleans.Messaging
     /// <remarks>
     /// Initializes a new instance of the <see cref="StaticGatewayListProvider"/> class.
     /// </remarks>
-    /// <param name="options">The specific options.</param>
+    /// <param name="optionsAccessor">The specific options.</param>
     /// <param name="gatewayOptions">The general gateway options.</param>
-    public class StaticGatewayListProvider(IOptions<StaticGatewayListProviderOptions> options, IOptions<GatewayOptions> gatewayOptions) : IGatewayListProvider
+    public class StaticGatewayListProvider(IOptions<StaticGatewayListProviderOptions> optionsAccessor, IOptions<GatewayOptions> gatewayOptions) : IGatewayListProvider
     {
-        private readonly StaticGatewayListProviderOptions options = options.Value;
+        private readonly StaticGatewayListProviderOptions options = optionsAccessor.Value;
         private readonly TimeSpan maxStaleness = gatewayOptions.Value.GatewayListRefreshPeriod;
 
         /// <inheritdoc />

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -9,39 +9,22 @@ using Orleans.Messaging;
 
 namespace Orleans.Runtime.Messaging
 {
-    internal sealed partial class ClientOutboundConnection : Connection
+    internal sealed partial class ClientOutboundConnection(
+        SiloAddress remoteSiloAddress,
+        ConnectionContext connection,
+        ConnectionDelegate middleware,
+        ClientMessageCenter messageCenter,
+        ConnectionManager connectionManager,
+        ConnectionOptions connectionOptions,
+        ConnectionCommon connectionShared,
+        ConnectionPreambleHelper connectionPreambleHelper,
+        ClusterOptions clusterOptions) : Connection(connection, middleware, connectionShared)
     {
-        private readonly ClientMessageCenter messageCenter;
-        private readonly ConnectionManager connectionManager;
-        private readonly ConnectionOptions connectionOptions;
-        private readonly ClusterOptions clusterOptions;
-        private readonly ConnectionPreambleHelper connectionPreambleHelper;
-
-        public ClientOutboundConnection(
-            SiloAddress remoteSiloAddress,
-            ConnectionContext connection,
-            ConnectionDelegate middleware,
-            ClientMessageCenter messageCenter,
-            ConnectionManager connectionManager,
-            ConnectionOptions connectionOptions,
-            ConnectionCommon connectionShared,
-            ConnectionPreambleHelper connectionPreambleHelper,
-            ClusterOptions clusterOptions)
-            : base(connection, middleware, connectionShared)
-        {
-            this.messageCenter = messageCenter;
-            this.connectionManager = connectionManager;
-            this.connectionOptions = connectionOptions;
-            this.connectionPreambleHelper = connectionPreambleHelper;
-            this.clusterOptions = clusterOptions;
-            this.RemoteSiloAddress = remoteSiloAddress ?? throw new ArgumentNullException(nameof(remoteSiloAddress));
-        }
-
-        public SiloAddress RemoteSiloAddress { get; }
+        public SiloAddress RemoteSiloAddress { get; } = remoteSiloAddress ?? throw new ArgumentNullException(nameof(remoteSiloAddress));
 
         protected override ConnectionDirection ConnectionDirection => ConnectionDirection.ClientToGateway;
 
-        protected override IMessageCenter MessageCenter => this.messageCenter;
+        protected override IMessageCenter MessageCenter => messageCenter;
 
         protected override void RecordMessageReceive(Message msg, int numTotalBytes, int headerBytes)
         {
@@ -55,7 +38,7 @@ namespace Orleans.Runtime.Messaging
 
         protected override void OnReceivedMessage(Message message)
         {
-            this.messageCenter.DispatchLocalMessage(message);
+            messageCenter.DispatchLocalMessage(message);
         }
 
         protected override async Task RunInternal()
@@ -63,15 +46,15 @@ namespace Orleans.Runtime.Messaging
             Exception? error = default;
             try
             {
-                this.messageCenter.OnGatewayConnectionOpen();
+                messageCenter.OnGatewayConnectionOpen();
 
                 var myClusterId = clusterOptions.ClusterId;
                 await connectionPreambleHelper.Write(
                     this.Context,
                     new ConnectionPreamble
                     {
-                        NetworkProtocolVersion = this.connectionOptions.ProtocolVersion,
-                        NodeIdentity = this.messageCenter.ClientId.GrainId,
+                        NetworkProtocolVersion = connectionOptions.ProtocolVersion,
+                        NodeIdentity = messageCenter.ClientId.GrainId,
                         SiloAddress = null,
                         ClusterId = myClusterId
                     });
@@ -96,8 +79,8 @@ namespace Orleans.Runtime.Messaging
             }
             finally
             {
-                this.connectionManager.OnConnectionTerminated(this.RemoteSiloAddress, this, error);
-                this.messageCenter.OnGatewayConnectionClosed();
+                connectionManager.OnConnectionTerminated(this.RemoteSiloAddress, this, error);
+                messageCenter.OnGatewayConnectionClosed();
             }
         }
 
@@ -108,7 +91,7 @@ namespace Orleans.Runtime.Messaging
             {
                 // Recycle the message we've dequeued. Note that this will recycle messages that were queued up to be sent when the gateway connection is declared dead
                 msg.TargetSilo = null;
-                this.messageCenter.SendMessage(msg);
+                messageCenter.SendMessage(msg);
                 return false;
             }
 
@@ -126,7 +109,7 @@ namespace Orleans.Runtime.Messaging
             if (msg.RetryCount < MessagingOptions.DEFAULT_MAX_MESSAGE_SEND_RETRIES)
             {
                 ++msg.RetryCount;
-                this.messageCenter.SendMessage(msg);
+                messageCenter.SendMessage(msg);
             }
             else
             {
@@ -169,7 +152,7 @@ namespace Orleans.Runtime.Messaging
         protected override void OnSendMessageFailure(Message message, string error)
         {
             message.TargetSilo = null;
-            this.messageCenter.SendMessage(message);
+            messageCenter.SendMessage(message);
         }
 
         [LoggerMessage(

--- a/src/Orleans.Core/Networking/ClientOutboundConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnectionFactory.cs
@@ -7,13 +7,18 @@ using Orleans.Messaging;
 
 namespace Orleans.Runtime.Messaging
 {
-    internal sealed class ClientOutboundConnectionFactory : ConnectionFactory
+    internal sealed class ClientOutboundConnectionFactory(
+        IOptions<ConnectionOptions> connectionOptions,
+        IOptions<ClientConnectionOptions> clientConnectionOptions,
+        IOptions<ClusterOptions> clusterOptions,
+        ConnectionCommon connectionShared,
+        ConnectionPreambleHelper connectionPreambleHelper)
+        : ConnectionFactory(connectionShared.ServiceProvider.GetRequiredKeyedService<IConnectionFactory>(ServicesKey),
+            connectionShared.ServiceProvider, connectionOptions)
     {
         internal static readonly object ServicesKey = new object();
-        private readonly ConnectionCommon connectionShared;
-        private readonly ClientConnectionOptions clientConnectionOptions;
-        private readonly ClusterOptions clusterOptions;
-        private readonly ConnectionPreambleHelper connectionPreambleHelper;
+        private readonly ClientConnectionOptions clientConnectionOptions = clientConnectionOptions.Value;
+        private readonly ClusterOptions clusterOptions = clusterOptions.Value;
 #if NET9_0_OR_GREATER
         private readonly Lock initializationLock = new();
 #else
@@ -22,20 +27,6 @@ namespace Orleans.Runtime.Messaging
         private volatile bool isInitialized;
         private ClientMessageCenter messageCenter = null!;
         private ConnectionManager connectionManager = null!;
-
-        public ClientOutboundConnectionFactory(
-            IOptions<ConnectionOptions> connectionOptions,
-            IOptions<ClientConnectionOptions> clientConnectionOptions,
-            IOptions<ClusterOptions> clusterOptions,
-            ConnectionCommon connectionShared,
-            ConnectionPreambleHelper connectionPreambleHelper)
-            : base(connectionShared.ServiceProvider.GetRequiredKeyedService<IConnectionFactory>(ServicesKey), connectionShared.ServiceProvider, connectionOptions)
-        {
-            this.connectionShared = connectionShared;
-            this.clientConnectionOptions = clientConnectionOptions.Value;
-            this.clusterOptions = clusterOptions.Value;
-            this.connectionPreambleHelper = connectionPreambleHelper;
-        }
 
         protected override Connection CreateConnection(SiloAddress address, ConnectionContext context)
         {
@@ -48,8 +39,8 @@ namespace Orleans.Runtime.Messaging
                 this.messageCenter,
                 this.connectionManager,
                 this.ConnectionOptions,
-                this.connectionShared,
-                this.connectionPreambleHelper,
+                connectionShared,
+                connectionPreambleHelper,
                 this.clusterOptions);
         }
 
@@ -67,8 +58,8 @@ namespace Orleans.Runtime.Messaging
                 {
                     if (!isInitialized)
                     {
-                        this.messageCenter = this.connectionShared.ServiceProvider.GetRequiredService<ClientMessageCenter>();
-                        this.connectionManager = this.connectionShared.ServiceProvider.GetRequiredService<ConnectionManager>();
+                        this.messageCenter = connectionShared.ServiceProvider.GetRequiredService<ClientMessageCenter>();
+                        this.connectionManager = connectionShared.ServiceProvider.GetRequiredService<ConnectionManager>();
                         this.isInitialized = true;
                     }
                 }

--- a/src/Orleans.Core/Networking/ClientOutboundConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnectionFactory.cs
@@ -9,16 +9,16 @@ namespace Orleans.Runtime.Messaging
 {
     internal sealed class ClientOutboundConnectionFactory(
         IOptions<ConnectionOptions> connectionOptions,
-        IOptions<ClientConnectionOptions> clientConnectionOptions,
-        IOptions<ClusterOptions> clusterOptions,
+        IOptions<ClientConnectionOptions> clientConnectionOptionsAccessor,
+        IOptions<ClusterOptions> clusterOptionsAccessor,
         ConnectionCommon connectionShared,
         ConnectionPreambleHelper connectionPreambleHelper)
         : ConnectionFactory(connectionShared.ServiceProvider.GetRequiredKeyedService<IConnectionFactory>(ServicesKey),
             connectionShared.ServiceProvider, connectionOptions)
     {
         internal static readonly object ServicesKey = new object();
-        private readonly ClientConnectionOptions clientConnectionOptions = clientConnectionOptions.Value;
-        private readonly ClusterOptions clusterOptions = clusterOptions.Value;
+        private readonly ClientConnectionOptions clientConnectionOptions = clientConnectionOptionsAccessor.Value;
+        private readonly ClusterOptions clusterOptions = clusterOptionsAccessor.Value;
 #if NET9_0_OR_GREATER
         private readonly Lock initializationLock = new();
 #else

--- a/src/Orleans.Core/Networking/ConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ConnectionFactory.cs
@@ -7,7 +7,10 @@ using Orleans.Configuration;
 
 namespace Orleans.Runtime.Messaging
 {
-    internal abstract class ConnectionFactory
+    internal abstract class ConnectionFactory(
+        IConnectionFactory connectionFactory,
+        IServiceProvider serviceProvider,
+        IOptions<ConnectionOptions> connectionOptions)
     {
         private readonly IConnectionFactory connectionFactory;
         private readonly IServiceProvider serviceProvider;
@@ -18,17 +21,7 @@ namespace Orleans.Runtime.Messaging
 #endif
         private ConnectionDelegate? connectionDelegate;
 
-        protected ConnectionFactory(
-            IConnectionFactory connectionFactory,
-            IServiceProvider serviceProvider,
-            IOptions<ConnectionOptions> connectionOptions)
-        {
-            this.connectionFactory = connectionFactory;
-            this.serviceProvider = serviceProvider;
-            this.ConnectionOptions = connectionOptions.Value;
-        }
-
-        protected ConnectionOptions ConnectionOptions { get; }
+        protected ConnectionOptions ConnectionOptions { get; } = connectionOptions.Value;
 
         protected ConnectionDelegate ConnectionDelegate
         {
@@ -41,7 +34,7 @@ namespace Orleans.Runtime.Messaging
                     if (this.connectionDelegate != null) return this.connectionDelegate;
 
                     // Configure the connection builder using the user-defined options.
-                    var connectionBuilder = new ConnectionBuilder(this.serviceProvider);
+                    var connectionBuilder = new ConnectionBuilder(serviceProvider);
                     connectionBuilder.Use(next =>
                     {
                         return context =>
@@ -63,7 +56,7 @@ namespace Orleans.Runtime.Messaging
 
         public virtual async ValueTask<Connection> ConnectAsync(SiloAddress address, CancellationToken cancellationToken)
         {
-            var connectionContext = await this.connectionFactory.ConnectAsync(address.Endpoint, cancellationToken);
+            var connectionContext = await connectionFactory.ConnectAsync(address.Endpoint, cancellationToken);
             var connection = this.CreateConnection(address, connectionContext);
             return connection;
         }

--- a/src/Orleans.Core/Networking/ConnectionFactory.cs
+++ b/src/Orleans.Core/Networking/ConnectionFactory.cs
@@ -12,8 +12,8 @@ namespace Orleans.Runtime.Messaging
         IServiceProvider serviceProvider,
         IOptions<ConnectionOptions> connectionOptions)
     {
-        private readonly IConnectionFactory connectionFactory;
-        private readonly IServiceProvider serviceProvider;
+        private readonly IConnectionFactory connectionFactory = connectionFactory;
+        private readonly IServiceProvider serviceProvider = serviceProvider;
 #if NET9_0_OR_GREATER
         private readonly Lock connectionDelegateLock = new();
 #else

--- a/src/Orleans.Core/Networking/ConnectionLogScope.cs
+++ b/src/Orleans.Core/Networking/ConnectionLogScope.cs
@@ -4,16 +4,9 @@ using System.Collections.Generic;
 
 namespace Orleans.Runtime.Messaging
 {
-    internal class ConnectionLogScope : IReadOnlyList<KeyValuePair<string, object?>>
+    internal class ConnectionLogScope(Connection connection) : IReadOnlyList<KeyValuePair<string, object?>>
     {
-        private readonly Connection _connection;
-
         private string? _cachedToString;
-
-        public ConnectionLogScope(Connection connection)
-        {
-            _connection = connection;
-        }
 
         public KeyValuePair<string, object?> this[int index]
         {
@@ -21,17 +14,17 @@ namespace Orleans.Runtime.Messaging
             {
                 if (index == 0)
                 {
-                    return new KeyValuePair<string, object?>(nameof(Connection.ConnectionId), _connection.ConnectionId);
+                    return new KeyValuePair<string, object?>(nameof(Connection.ConnectionId), connection.ConnectionId);
                 }
 
                 if (index == 1)
                 {
-                    return new KeyValuePair<string, object?>(nameof(Connection.LocalEndPoint), _connection.LocalEndPoint);
+                    return new KeyValuePair<string, object?>(nameof(Connection.LocalEndPoint), connection.LocalEndPoint);
                 }
 
                 if (index == 2)
                 {
-                    return new KeyValuePair<string, object?>(nameof(Connection.RemoteEndPoint), _connection.RemoteEndPoint);
+                    return new KeyValuePair<string, object?>(nameof(Connection.RemoteEndPoint), connection.RemoteEndPoint);
                 }
 
                 throw new ArgumentOutOfRangeException(nameof(index));
@@ -57,7 +50,7 @@ namespace Orleans.Runtime.Messaging
         {
             if (_cachedToString == null)
             {
-                _cachedToString = _connection.ToString();
+                _cachedToString = connection.ToString();
             }
 
             return _cachedToString;

--- a/src/Orleans.Core/Networking/ConnectionManagerLifecycleAdapter.cs
+++ b/src/Orleans.Core/Networking/ConnectionManagerLifecycleAdapter.cs
@@ -3,21 +3,14 @@ using System.Threading.Tasks;
 
 namespace Orleans.Runtime.Messaging
 {
-    internal class ConnectionManagerLifecycleAdapter<TLifecycle>
+    internal class ConnectionManagerLifecycleAdapter<TLifecycle>(ConnectionManager connectionManager)
         : ILifecycleParticipant<TLifecycle>, ILifecycleObserver where TLifecycle : ILifecycleObservable
     {
-        private readonly ConnectionManager connectionManager;
-
-        public ConnectionManagerLifecycleAdapter(ConnectionManager connectionManager)
-        {
-            this.connectionManager = connectionManager;
-        }
-
         public Task OnStart(CancellationToken ct) => Task.CompletedTask;
 
         public async Task OnStop(CancellationToken ct)
         {
-            await Task.Run(() => this.connectionManager.Close(ct), CancellationToken.None);
+            await Task.Run(() => connectionManager.Close(ct), CancellationToken.None);
         }
 
         public void Participate(TLifecycle lifecycle)

--- a/src/Orleans.Core/Networking/ConnectionPreamble.cs
+++ b/src/Orleans.Core/Networking/ConnectionPreamble.cs
@@ -24,21 +24,16 @@ namespace Orleans.Runtime.Messaging
         public string ClusterId { get; init; } = null!;
     }
 
-    internal sealed class ConnectionPreambleHelper
+    internal sealed class ConnectionPreambleHelper(Serializer<ConnectionPreamble> preambleSerializer)
     {
         private const int MaxPreambleLength = 1024;
-        private readonly Serializer<ConnectionPreamble> _preambleSerializer;
-        public ConnectionPreambleHelper(Serializer<ConnectionPreamble> preambleSerializer)
-        {
-            _preambleSerializer = preambleSerializer;
-        }
 
         internal async ValueTask Write(ConnectionContext connection, ConnectionPreamble preamble)
         {
             var output = connection.Transport.Output;
             using var outputWriter = new PrefixingBufferWriter(sizeof(int), 1024, MemoryPool<byte>.Shared);
             outputWriter.Init(output);
-            _preambleSerializer.Serialize(
+            preambleSerializer.Serialize(
                 preamble,
                 outputWriter);
 
@@ -109,7 +104,7 @@ namespace Orleans.Runtime.Messaging
             try
             {
                 // A valid connection preamble payload always deserializes to an instance.
-                var preamble = _preambleSerializer.Deserialize(payloadBuffer)!;
+                var preamble = preambleSerializer.Deserialize(payloadBuffer)!;
                 return preamble;
             }
             finally

--- a/src/Orleans.Core/Networking/Shared/DuplexPipe.cs
+++ b/src/Orleans.Core/Networking/Shared/DuplexPipe.cs
@@ -2,17 +2,11 @@ using System.IO.Pipelines;
 
 namespace Orleans.Networking.Shared
 {
-    internal class DuplexPipe : IDuplexPipe
+    internal class DuplexPipe(PipeReader reader, PipeWriter writer) : IDuplexPipe
     {
-        public DuplexPipe(PipeReader reader, PipeWriter writer)
-        {
-            Input = reader;
-            Output = writer;
-        }
+        public PipeReader Input { get; } = reader;
 
-        public PipeReader Input { get; }
-
-        public PipeWriter Output { get; }
+        public PipeWriter Output { get; } = writer;
 
         public static DuplexPipePair CreateConnectionPair(PipeOptions inputOptions, PipeOptions outputOptions)
         {

--- a/src/Orleans.Core/Networking/Shared/SocketAwaitableEventArgs.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketAwaitableEventArgs.cs
@@ -8,18 +8,10 @@ using System.Threading.Tasks;
 
 namespace Orleans.Networking.Shared
 {
-    internal class SocketAwaitableEventArgs : SocketAsyncEventArgs, ICriticalNotifyCompletion
+    internal class SocketAwaitableEventArgs(PipeScheduler ioScheduler) : SocketAsyncEventArgs, ICriticalNotifyCompletion
     {
         private static readonly Action _callbackCompleted = () => { };
-
-        private readonly PipeScheduler _ioScheduler;
-
         private Action? _callback;
-
-        public SocketAwaitableEventArgs(PipeScheduler ioScheduler)
-        {
-            _ioScheduler = ioScheduler;
-        }
 
         public SocketAwaitableEventArgs GetAwaiter() => this;
         public bool IsCompleted => ReferenceEquals(_callback, _callbackCompleted);
@@ -68,7 +60,7 @@ namespace Orleans.Networking.Shared
 
             if (continuation != null)
             {
-                _ioScheduler.Schedule(state => ((Action)state!)(), continuation);
+                ioScheduler.Schedule(state => ((Action)state!)(), continuation);
             }
         }
     }

--- a/src/Orleans.Core/Networking/Shared/TransportConnection.cs
+++ b/src/Orleans.Core/Networking/Shared/TransportConnection.cs
@@ -13,10 +13,7 @@ namespace Orleans.Networking.Shared
         private IDictionary<object, object?>? _items;
         private string? _connectionId;
 
-        public TransportConnection()
-        {
-            FastReset();
-        }
+        public TransportConnection() => FastReset();
 
         public override EndPoint? LocalEndPoint { get; set; }
         public override EndPoint? RemoteEndPoint { get; set; }

--- a/src/Orleans.Core/Providers/ClientProviderRuntime.cs
+++ b/src/Orleans.Core/Providers/ClientProviderRuntime.cs
@@ -7,39 +7,30 @@ namespace Orleans.Providers
     /// <see cref="IProviderRuntime"/> for clients.
     /// </summary>
     /// <seealso cref="Orleans.Providers.IProviderRuntime" />
-    internal class ClientProviderRuntime : IProviderRuntime
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="ClientProviderRuntime"/> class.
+    /// </remarks>
+    /// <param name="grainFactory">The grain factory.</param>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <param name="clientContext">The client context.</param>
+    internal class ClientProviderRuntime(
+        IInternalGrainFactory grainFactory,
+        IServiceProvider serviceProvider,
+        ClientGrainContext clientContext) : IProviderRuntime
     {
-        private readonly IInternalGrainFactory grainFactory;
-        private readonly ClientGrainContext clientContext;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ClientProviderRuntime"/> class.
-        /// </summary>
-        /// <param name="grainFactory">The grain factory.</param>
-        /// <param name="serviceProvider">The service provider.</param>
-        /// <param name="clientContext">The client context.</param>
-        public ClientProviderRuntime(
-            IInternalGrainFactory grainFactory,
-            IServiceProvider serviceProvider,
-            ClientGrainContext clientContext)
-        {
-            this.grainFactory = grainFactory;
-            this.ServiceProvider = serviceProvider;
-            this.clientContext = clientContext;
-        }
 
         /// <inheritdoc/>
-        public IGrainFactory GrainFactory => this.grainFactory;
+        public IGrainFactory GrainFactory => grainFactory;
 
         /// <inheritdoc/>
-        public IServiceProvider ServiceProvider { get; }
+        public IServiceProvider ServiceProvider { get; } = serviceProvider;
 
         /// <inheritdoc/>
         public (TExtension Extension, TExtensionInterface ExtensionReference) BindExtension<TExtension, TExtensionInterface>(Func<TExtension> newExtensionFunc)
             where TExtension : class, TExtensionInterface
             where TExtensionInterface : class, IGrainExtension
         {
-            return this.clientContext.GetOrSetExtension<TExtension, TExtensionInterface>(newExtensionFunc);
+            return clientContext.GetOrSetExtension<TExtension, TExtensionInterface>(newExtensionFunc);
         }
     }
 }

--- a/src/Orleans.Core/Providers/ProviderStateManager.cs
+++ b/src/Orleans.Core/Providers/ProviderStateManager.cs
@@ -17,10 +17,7 @@ namespace Orleans.Providers
         public ProviderState State { get; private set; }
         private ProviderState presetState;
 
-        public ProviderStateManager()
-        {
-            State = ProviderState.None;
-        }
+        public ProviderStateManager() => State = ProviderState.None;
 
         public bool PresetState(ProviderState state)
         {

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -6,35 +6,23 @@ using Orleans.Serialization.Invocation;
 
 namespace Orleans.Runtime
 {
-    internal sealed partial class CallbackData
+    internal sealed partial class CallbackData(
+        SharedCallbackData shared,
+        IResponseCompletionSource ctx,
+        Message msg,
+        ApplicationRequestInstruments applicationRequestInstruments)
     {
         private const int StateNone = 0;
         private const int StateCompleted = 1;
         private const int StateCancellationRegistrationPending = 2;
         private const int StateCancellationRegistrationPublished = 4;
 
-        private readonly SharedCallbackData shared;
-        private readonly IResponseCompletionSource context;
-        private readonly ApplicationRequestInstruments _applicationRequestInstruments;
         private int _state;
         private StatusResponse? lastKnownStatus;
-        private ValueStopwatch stopwatch;
+        private ValueStopwatch stopwatch = ValueStopwatch.StartNew();
         private CancellationTokenRegistration _cancellationTokenRegistration;
 
-        public CallbackData(
-            SharedCallbackData shared,
-            IResponseCompletionSource ctx,
-            Message msg,
-            ApplicationRequestInstruments applicationRequestInstruments)
-        {
-            this.shared = shared;
-            this.context = ctx;
-            this.Message = msg;
-            _applicationRequestInstruments = applicationRequestInstruments;
-            this.stopwatch = ValueStopwatch.StartNew();
-        }
-
-        public Message Message { get; } // might hold metadata used by response pipeline
+        public Message Message { get; } = msg; // might hold metadata used by response pipeline
 
         public bool IsCompleted => (Volatile.Read(ref _state) & StateCompleted) != 0;
 
@@ -130,10 +118,10 @@ namespace Orleans.Runtime
             stopwatch.Stop();
             SignalCancellation();
             shared.Unregister(Message);
-            _applicationRequestInstruments.OnAppRequestsEnd((long)stopwatch.Elapsed.TotalMilliseconds);
-            _applicationRequestInstruments.OnAppRequestsCanceled(GetTargetGrainType());
+            applicationRequestInstruments.OnAppRequestsEnd((long)stopwatch.Elapsed.TotalMilliseconds);
+            applicationRequestInstruments.OnAppRequestsCanceled(GetTargetGrainType());
             OrleansCallBackDataEvent.Instance.OnCanceled(Message);
-            context.Complete(Response.FromException(new OperationCanceledException(cancellationToken)));
+            ctx.Complete(Response.FromException(new OperationCanceledException(cancellationToken)));
             DisposeCancellationRegistration();
         }
 
@@ -150,10 +138,10 @@ namespace Orleans.Runtime
                 SignalCancellation();
             }
 
-            this.shared.Unregister(this.Message);
+            shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
-            _applicationRequestInstruments.OnAppRequestsTimedOut(GetTargetGrainType());
+            applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            applicationRequestInstruments.OnAppRequestsTimedOut(GetTargetGrainType());
 
             OrleansCallBackDataEvent.Instance.OnTimeout(this.Message);
 
@@ -161,10 +149,10 @@ namespace Orleans.Runtime
 
             var statusMessage = lastKnownStatus is StatusResponse status ? $"Last known status is {status}. " : string.Empty;
             var timeout = GetResponseTimeout();
-            LogTimeout(this.shared.Logger, timeout, msg, statusMessage);
+            LogTimeout(shared.Logger, timeout, msg, statusMessage);
 
             var exception = new TimeoutException($"Response did not arrive on time in {timeout} for message: {msg}. {statusMessage}");
-            context.Complete(Response.FromException(exception));
+            ctx.Complete(Response.FromException(exception));
         }
 
         public void OnTargetSiloFail()
@@ -175,16 +163,16 @@ namespace Orleans.Runtime
             }
 
             this.stopwatch.Stop();
-            this.shared.Unregister(this.Message);
+            shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
 
             OrleansCallBackDataEvent.Instance.OnTargetSiloFail(this.Message);
             var msg = this.Message;
             var statusMessage = lastKnownStatus is StatusResponse status ? $"Last known status is {status}. " : string.Empty;
-            LogTargetSiloFail(this.shared.Logger, msg, statusMessage, Constants.TroubleshootingHelpLink);
+            LogTargetSiloFail(shared.Logger, msg, statusMessage, Constants.TroubleshootingHelpLink);
             var exception = new SiloUnavailableException($"The target silo became unavailable for message: {msg}. {statusMessage}See {Constants.TroubleshootingHelpLink} for troubleshooting help.");
-            this.context.Complete(Response.FromException(exception));
+            ctx.Complete(Response.FromException(exception));
         }
 
         public void OnHostShutdown()
@@ -195,13 +183,13 @@ namespace Orleans.Runtime
             }
 
             this.stopwatch.Stop();
-            this.shared.Unregister(this.Message);
+            shared.Unregister(this.Message);
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
 
             var msg = this.Message;
             var exception = new SiloUnavailableException($"The local Orleans host is shutting down and can no longer process the request: {msg}.");
-            this.context.Complete(Response.FromException(exception));
+            ctx.Complete(Response.FromException(exception));
         }
 
         public void DoCallback(Message response)
@@ -215,10 +203,10 @@ namespace Orleans.Runtime
 
             this.stopwatch.Stop();
             DisposeCancellationRegistration();
-            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+            applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
 
             // do callback outside the CallbackData lock. Just not a good practice to hold a lock for this unrelated operation.
-            ResponseCallback(response, this.context);
+            ResponseCallback(response, ctx);
         }
 
         private bool TryComplete() => (Interlocked.Or(ref _state, StateCompleted) & StateCompleted) == 0;

--- a/src/Orleans.Core/Runtime/ClientGrainContext.cs
+++ b/src/Orleans.Core/Runtime/ClientGrainContext.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Orleans
 {
-    internal sealed class ClientGrainContext : IGrainContext, IGrainExtensionBinder, IGrainContextAccessor
+    internal sealed class ClientGrainContext(OutsideRuntimeClient runtimeClient) : IGrainContext, IGrainExtensionBinder, IGrainContextAccessor
     {
 #if NET9_0_OR_GREATER
         private readonly Lock _lockObj = new();
@@ -14,25 +14,19 @@ namespace Orleans
 #endif
         private readonly ConcurrentDictionary<Type, (object Implementation, IAddressable Reference)> _extensions = new();
         private readonly ConcurrentDictionary<Type, object> _components = new();
-        private readonly OutsideRuntimeClient _runtimeClient;
         private GrainReference? _grainReference;
 
-        public ClientGrainContext(OutsideRuntimeClient runtimeClient)
-        {
-            _runtimeClient = runtimeClient;
-        }
+        public GrainReference GrainReference => _grainReference ??= (GrainReference)runtimeClient.InternalGrainFactory.GetGrain(this.GrainId);
 
-        public GrainReference GrainReference => _grainReference ??= (GrainReference)_runtimeClient.InternalGrainFactory.GetGrain(this.GrainId);
-
-        public GrainId GrainId => _runtimeClient.CurrentActivationAddress.GrainId;
+        public GrainId GrainId => runtimeClient.CurrentActivationAddress.GrainId;
 
         public object? GrainInstance => null;
 
-        public ActivationId ActivationId => _runtimeClient.CurrentActivationAddress.ActivationId;
+        public ActivationId ActivationId => runtimeClient.CurrentActivationAddress.ActivationId;
 
-        public GrainAddress Address => _runtimeClient.CurrentActivationAddress;
+        public GrainAddress Address => runtimeClient.CurrentActivationAddress;
 
-        public IServiceProvider ActivationServices => _runtimeClient.ServiceProvider;
+        public IServiceProvider ActivationServices => runtimeClient.ServiceProvider;
 
         public IGrainLifecycle ObservableLifecycle => throw new NotSupportedException();
 
@@ -104,7 +98,7 @@ namespace Orleans
                 }
 
                 var implementation = newExtensionFunc();
-                var reference = _runtimeClient.InternalGrainFactory.CreateObjectReference<TExtensionInterface>(implementation);
+                var reference = runtimeClient.InternalGrainFactory.CreateObjectReference<TExtensionInterface>(implementation);
                 _extensions[typeof(TExtensionInterface)] = (implementation, reference);
                 result = (implementation, reference);
                 return result;

--- a/src/Orleans.Core/Serialization/OrleansJsonSerializationBinder.cs
+++ b/src/Orleans.Core/Serialization/OrleansJsonSerializationBinder.cs
@@ -10,26 +10,17 @@ namespace Orleans.Serialization
     /// and enforces the configured Orleans type allow-list, preventing arbitrary types from being constructed
     /// during deserialization.
     /// </summary>
-    public class OrleansJsonSerializationBinder : DefaultSerializationBinder
+    /// <remarks>
+    /// This constructor does not enforce the Orleans type allow-list: any resolvable type may be constructed
+    /// during deserialization. It is retained for backwards compatibility. Prefer the constructor which accepts
+    /// a <see cref="TypeConverter"/> so that the type allow-list is enforced.
+    /// </remarks>
+    /// <param name="typeResolver">The type resolver.</param>
+    public class OrleansJsonSerializationBinder(TypeResolver typeResolver) : DefaultSerializationBinder
     {
-        private readonly TypeResolver _typeResolver;
+        private readonly TypeResolver _typeResolver = typeResolver;
         private readonly TypeConverter? _typeConverter;
-        private readonly bool _allowAllTypes;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OrleansJsonSerializationBinder"/> class.
-        /// </summary>
-        /// <param name="typeResolver">The type resolver.</param>
-        /// <remarks>
-        /// This constructor does not enforce the Orleans type allow-list: any resolvable type may be constructed
-        /// during deserialization. It is retained for backwards compatibility. Prefer the constructor which accepts
-        /// a <see cref="TypeConverter"/> so that the type allow-list is enforced.
-        /// </remarks>
-        public OrleansJsonSerializationBinder(TypeResolver typeResolver)
-        {
-            _typeResolver = typeResolver;
-            _allowAllTypes = true;
-        }
+        private readonly bool _allowAllTypes = true;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OrleansJsonSerializationBinder"/> class which enforces the
@@ -42,9 +33,9 @@ namespace Orleans.Serialization
         /// during deserialization, bypassing the type allow-list. This is insecure and is not recommended.
         /// </param>
         public OrleansJsonSerializationBinder(TypeConverter typeConverter, TypeResolver typeResolver, bool allowAllTypes = false)
+            : this(typeResolver)
         {
             _typeConverter = typeConverter;
-            _typeResolver = typeResolver;
             _allowAllTypes = allowAllTypes;
         }
 

--- a/src/Orleans.Core/Serialization/OrleansJsonSerializer.cs
+++ b/src/Orleans.Core/Serialization/OrleansJsonSerializer.cs
@@ -11,7 +11,11 @@ namespace Orleans.Serialization
     /// <summary>
     /// Serializes and deserializes values using Newtonsoft.Json settings configured for Orleans types.
     /// </summary>
-    public class OrleansJsonSerializer
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="OrleansJsonSerializer"/> class.
+    /// </remarks>
+    /// <param name="options">The configured JSON serializer options.</param>
+    public class OrleansJsonSerializer(IOptions<OrleansJsonSerializerOptions> options)
     {
         /// <summary>
         /// The configuration property name for selecting full assembly-qualified type names.
@@ -27,16 +31,7 @@ namespace Orleans.Serialization
         /// The configuration property name for selecting how type names are included in JSON.
         /// </summary>
         public const string TypeNameHandlingProperty = "TypeNameHandling";
-        private readonly JsonSerializerSettings settings;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OrleansJsonSerializer"/> class.
-        /// </summary>
-        /// <param name="options">The configured JSON serializer options.</param>
-        public OrleansJsonSerializer(IOptions<OrleansJsonSerializerOptions> options)
-        {
-            this.settings = options.Value.JsonSerializerSettings;
-        }
+        private readonly JsonSerializerSettings settings = options.Value.JsonSerializerSettings;
 
         /// <summary>
         /// Deserializes an object of the specified expected type from the provided input.

--- a/src/Orleans.Core/Serialization/OrleansJsonSerializerOptions.cs
+++ b/src/Orleans.Core/Serialization/OrleansJsonSerializerOptions.cs
@@ -44,32 +44,19 @@ namespace Orleans.Serialization
         /// <summary>
         /// Initializes a new instance of the <see cref="OrleansJsonSerializerOptions"/> class using the default settings.
         /// </summary>
-        public OrleansJsonSerializerOptions()
-        {
-            JsonSerializerSettings = OrleansJsonSerializerSettings.GetDefaultSerializerSettings();
-        }
+        public OrleansJsonSerializerOptions() => JsonSerializerSettings = OrleansJsonSerializerSettings.GetDefaultSerializerSettings();
     }
 
     /// <summary>
     /// Configures <see cref="OrleansJsonSerializerOptions"/> with the Orleans serialization binder and converters.
     /// </summary>
-    public class ConfigureOrleansJsonSerializerOptions : IPostConfigureOptions<OrleansJsonSerializerOptions>
+    /// <param name="serviceProvider">The service provider used to resolve serializer dependencies.</param>
+    public class ConfigureOrleansJsonSerializerOptions(IServiceProvider serviceProvider) : IPostConfigureOptions<OrleansJsonSerializerOptions>
     {
-        private readonly IServiceProvider _serviceProvider;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigureOrleansJsonSerializerOptions"/> class.
-        /// </summary>
-        /// <param name="serviceProvider">The service provider used to resolve serializer dependencies.</param>
-        public ConfigureOrleansJsonSerializerOptions(IServiceProvider serviceProvider)
-        {
-            _serviceProvider = serviceProvider;
-        }
-
         /// <inheritdoc />
         public void PostConfigure(string? name, OrleansJsonSerializerOptions options)
         {
-            OrleansJsonSerializerSettings.Configure(_serviceProvider, options.JsonSerializerSettings, options.AllowAllTypes);
+            OrleansJsonSerializerSettings.Configure(serviceProvider, options.JsonSerializerSettings, options.AllowAllTypes);
         }
     }
 }

--- a/src/Orleans.Core/Threading/RecursiveInterlockedExchangeLock.cs
+++ b/src/Orleans.Core/Threading/RecursiveInterlockedExchangeLock.cs
@@ -16,10 +16,7 @@ namespace Orleans.Threading
         private int lockState = UNLOCKED;
         private readonly Func<bool> spinCondition;
 
-        public RecursiveInterlockedExchangeLock()
-        {
-            this.spinCondition = this.TryGet;
-        }
+        public RecursiveInterlockedExchangeLock() => this.spinCondition = this.TryGet;
 
         private static int ThreadId => localThreadId != 0 ? localThreadId : localThreadId = Environment.CurrentManagedThreadId;
 

--- a/src/Orleans.Core/Timers/CoarseStopwatch.cs
+++ b/src/Orleans.Core/Timers/CoarseStopwatch.cs
@@ -27,10 +27,7 @@ namespace Orleans.Runtime
         /// <returns>A new stopwatch.</returns>
         public static CoarseStopwatch FromTimestamp(long timestamp) => new(timestamp);
 
-        private CoarseStopwatch(long timestamp)
-        {
-            _value = timestamp;
-        }
+        private CoarseStopwatch(long timestamp) => _value = timestamp;
 
         /// <summary>
         /// The number of ticks per second for this stopwatch.

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -47,7 +47,7 @@ internal sealed partial class ActivationData :
     private readonly WorkItemGroup _workItemGroup;
     private readonly List<(Message Message, CoarseStopwatch QueuedTime)> _waitingRequests = new();
     private readonly Dictionary<Message, CoarseStopwatch> _runningRequests = new();
-    private readonly SingleWaiterAutoResetEvent _workSignal = new() { RunContinuationsAsynchronously = true };
+    private readonly ActivationAutoResetEvent _workSignal;
     private GrainLifecycle? _lifecycle;
     private Queue<object>? _pendingOperations;
     private Message? _blockingRequest;
@@ -101,6 +101,7 @@ internal sealed partial class ActivationData :
         Debug.Assert(_serviceScope != null, "_serviceScope must not be null.");
         _workItemGroup = createWorkItemGroup(this);
         Debug.Assert(_workItemGroup != null, "_workItemGroup must not be null.");
+        _workSignal = new(_workItemGroup);
     }
 
     internal void SetActivationActivity(Activity activity)

--- a/src/Orleans.Runtime/Versions/ActivationAutoResetEvent.cs
+++ b/src/Orleans.Runtime/Versions/ActivationAutoResetEvent.cs
@@ -1,0 +1,204 @@
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+using Orleans.Runtime.Scheduler;
+
+namespace Orleans.Runtime;
+
+/// <summary>
+/// Represents a synchronization event that, when signaled, resets automatically after releasing a single waiter.
+/// This type supports concurrent signalers but only a single waiter.
+/// </summary>
+internal sealed class ActivationAutoResetEvent(WorkItemGroup scheduler) : IValueTaskSource
+{
+    // Signaled indicates that the event has been signaled and not yet reset.
+    private const uint SignaledFlag = 1;
+
+    // Waiting indicates that a waiter is present and waiting for the event to be signaled.
+    private const uint WaitingFlag = 1 << 1;
+
+    // ResetMask is used to clear both status flags.
+    private const uint ResetMask = ~SignaledFlag & ~WaitingFlag;
+
+    private ActivationValueTaskSource _waitSource = new(scheduler);
+    private volatile uint _status;
+
+    ValueTaskSourceStatus IValueTaskSource.GetStatus(short token) => _waitSource.GetStatus(token);
+
+    void IValueTaskSource.OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+        => _waitSource.OnCompleted(continuation, state, token, flags);
+
+    void IValueTaskSource.GetResult(short token)
+    {
+        _waitSource.GetResult(token);
+        _waitSource.Reset();
+        ResetStatus();
+    }
+
+    /// <summary>
+    /// Signal the waiter.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Signal()
+    {
+        if ((_status & SignaledFlag) == SignaledFlag)
+        {
+            return;
+        }
+
+        var status = Interlocked.Or(ref _status, SignaledFlag);
+        if ((status & SignaledFlag) != SignaledFlag && (status & WaitingFlag) == WaitingFlag)
+        {
+            Debug.Assert((_status & (SignaledFlag | WaitingFlag)) == (SignaledFlag | WaitingFlag));
+            _waitSource.SetResult();
+        }
+    }
+
+    /// <summary>
+    /// Wait for the event to be signaled.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask WaitAsync()
+    {
+        var status = Interlocked.Or(ref _status, WaitingFlag);
+        if ((status & WaitingFlag) == WaitingFlag)
+        {
+            ThrowConcurrentWaitersNotSupported();
+        }
+
+        if ((status & SignaledFlag) == SignaledFlag)
+        {
+            ResetStatus();
+            return default;
+        }
+
+        return new(this, _waitSource.Version);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ResetStatus()
+    {
+        var status = Interlocked.And(ref _status, ResetMask);
+        Debug.Assert((status & (WaitingFlag | SignaledFlag)) == (WaitingFlag | SignaledFlag));
+    }
+
+    private static void ThrowConcurrentWaitersNotSupported() => throw new InvalidOperationException("Concurrent waiters are not supported");
+
+    [StructLayout(LayoutKind.Auto)]
+    private struct ActivationValueTaskSource
+    {
+        private static readonly Action<object?> Sentinel = CompletionSentinel;
+
+        private Action<object?>? _continuation;
+        private object? _continuationState;
+        private readonly WorkItemGroup _scheduler;
+        private short _version;
+        private bool _completed;
+
+        public ActivationValueTaskSource(WorkItemGroup scheduler) : this()
+        {
+            _scheduler = scheduler;
+        }
+
+        public readonly short Version => _version;
+
+        public ValueTaskSourceStatus GetStatus(short token)
+        {
+            ValidateToken(token);
+
+            // If completion wins the race but has not yet stored the sentinel, force OnCompleted to schedule the continuation.
+            return Volatile.Read(ref _continuation) is null || !_completed
+                ? ValueTaskSourceStatus.Pending
+                : ValueTaskSourceStatus.Succeeded;
+        }
+
+        [StackTraceHidden]
+        public readonly void GetResult(short token)
+        {
+            if (token != _version || !_completed)
+            {
+                ThrowInvalidOperationException();
+            }
+        }
+
+        public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+        {
+            ArgumentNullException.ThrowIfNull(continuation);
+            ValidateToken(token);
+
+            object? storedContinuation = _continuation;
+            if (storedContinuation is null)
+            {
+                _continuationState = state;
+                storedContinuation = Interlocked.CompareExchange(ref _continuation, continuation, null);
+                if (storedContinuation is null)
+                {
+                    return;
+                }
+            }
+
+            if (!ReferenceEquals(storedContinuation, Sentinel))
+            {
+                ThrowInvalidOperationException();
+            }
+
+            QueueContinuation(continuation, state);
+        }
+
+        public void SetResult()
+        {
+            if (_completed)
+            {
+                ThrowInvalidOperationException();
+            }
+
+            _completed = true;
+
+            var continuation =
+                Volatile.Read(ref _continuation) ??
+                Interlocked.CompareExchange(ref _continuation, Sentinel, null);
+
+            if (continuation is not null)
+            {
+                QueueContinuation(continuation, _continuationState);
+            }
+        }
+
+        public void Reset()
+        {
+            _version++;
+            _continuation = null;
+            _continuationState = null;
+            _completed = false;
+        }
+
+        private readonly void QueueContinuation(Action<object?> continuation, object? state)
+        {
+            _scheduler.QueueAction(continuation, state!);
+        }
+
+        private readonly void ValidateToken(short token)
+        {
+            if (token != _version)
+            {
+                ThrowInvalidOperationException();
+            }
+        }
+
+        private static void CompletionSentinel(object? _)
+        {
+            Debug.Fail("The sentinel delegate should never be invoked.");
+            throw new InvalidOperationException("The sentinel delegate should never be invoked.");
+        }
+
+        [DoesNotReturn, StackTraceHidden]
+        private static void ThrowInvalidOperationException() => throw new InvalidOperationException();
+    }
+}

--- a/test/Orleans.Core.Tests/SchedulerTests/ActivationAutoResetEventTests.cs
+++ b/test/Orleans.Core.Tests/SchedulerTests/ActivationAutoResetEventTests.cs
@@ -1,0 +1,106 @@
+#nullable enable
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Runtime;
+using UnitTests.TesterInternal;
+using Xunit;
+
+namespace UnitTests.SchedulerTests;
+
+[TestCategory("BVT"), TestCategory("Scheduler")]
+public class ActivationAutoResetEventTests
+{
+    [Fact]
+    public async Task SignalBeforeWaitCompletesSynchronously()
+    {
+        using var context = UnitTestSchedulingContext.Create(NullLoggerFactory.Instance);
+        var signal = new ActivationAutoResetEvent(context.WorkItemGroup);
+
+        signal.Signal();
+        var wait = signal.WaitAsync();
+
+        Assert.True(wait.IsCompletedSuccessfully);
+        await wait;
+    }
+
+    [Fact]
+    public async Task WaitBeforeSignalCompletesAfterSignal()
+    {
+        using var context = UnitTestSchedulingContext.Create(NullLoggerFactory.Instance);
+        var signal = new ActivationAutoResetEvent(context.WorkItemGroup);
+
+        var wait = signal.WaitAsync();
+        Assert.False(wait.IsCompleted);
+
+        signal.Signal();
+
+        await wait.AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task SignalCanBeReusedAcrossRepeatedCycles()
+    {
+        using var context = UnitTestSchedulingContext.Create(NullLoggerFactory.Instance);
+        var signal = new ActivationAutoResetEvent(context.WorkItemGroup);
+
+        signal.Signal();
+        await signal.WaitAsync();
+
+        var wait = signal.WaitAsync();
+        Assert.False(wait.IsCompleted);
+
+        signal.Signal();
+        await wait.AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        signal.Signal();
+        await signal.WaitAsync();
+    }
+
+    [Fact]
+    public async Task ConcurrentWaitersAreRejected()
+    {
+        using var context = UnitTestSchedulingContext.Create(NullLoggerFactory.Instance);
+        var signal = new ActivationAutoResetEvent(context.WorkItemGroup);
+
+        var wait = signal.WaitAsync();
+        Assert.False(wait.IsCompleted);
+        Assert.Throws<InvalidOperationException>(() => signal.WaitAsync());
+
+        signal.Signal();
+        await wait.AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task ContinuationRunsOnScheduler()
+    {
+        using var context = UnitTestSchedulingContext.Create(NullLoggerFactory.Instance);
+        var signal = new ActivationAutoResetEvent(context.WorkItemGroup);
+        var observedContext = new TaskCompletionSource<IGrainContext?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var wait = WaitAndCaptureContext(signal, observedContext);
+        signal.Signal();
+
+        Assert.Same(context, await observedContext.Task.WaitAsync(TimeSpan.FromSeconds(5)));
+        await wait.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task WaitAndSignalRaceCompletesRepeatedly()
+    {
+        using var context = UnitTestSchedulingContext.Create(NullLoggerFactory.Instance);
+        var signal = new ActivationAutoResetEvent(context.WorkItemGroup);
+
+        for (var i = 0; i < 1_000; i++)
+        {
+            var wait = signal.WaitAsync();
+            _ = Task.Run(signal.Signal);
+            await wait.AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    private static async Task WaitAndCaptureContext(ActivationAutoResetEvent signal, TaskCompletionSource<IGrainContext?> observedContext)
+    {
+        await signal.WaitAsync();
+        observedContext.SetResult(RuntimeContext.Current);
+    }
+}


### PR DESCRIPTION
## Summary
- Add an activation-specific auto-reset event with a smaller custom value-task source.
- Schedule activation message-loop continuations through the activation `WorkItemGroup` without taking the broad scheduler refactor.
- Add coverage for signal ordering, reuse, concurrent waiter rejection, scheduler continuation affinity, and signal/awaiter races.

## Validation
- `dotnet build src\Orleans.Runtime\Orleans.Runtime.csproj --no-restore --nologo --verbosity minimal -property:UseSharedCompilation=false`
- `dotnet test test\Orleans.Core.Tests\Orleans.Core.Tests.csproj --no-restore --nologo --verbosity minimal --filter FullyQualifiedName~ActivationAutoResetEventTests -property:UseSharedCompilation=false`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10116)