### PR TITLE
perf(grain): move runtime access to grain context

### DIFF
--- a/playground/ActivationRepartitioning/ActivationRepartitioning.Frontend/Program.cs
+++ b/playground/ActivationRepartitioning/ActivationRepartitioning.Frontend/Program.cs
@@ -97,7 +97,7 @@ public class LoaderGrain : Grain, ILoaderGrain
     {
         ++_resetCount;
         _numForests = 0;
-        await ServiceProvider.GetRequiredService<ClusterDiagnosticsService>().ResetAsync();
+        await ServiceProvider!.GetRequiredService<ClusterDiagnosticsService>().ResetAsync();
         await GrainFactory.GetGrain<IManagementGrain>(0).ResetGrainCallFrequencies();
     }
 

--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -14,6 +14,8 @@ namespace Orleans;
 /// </summary>
 public abstract partial class Grain : IGrainBase, IAddressable
 {
+    private IGrainRuntime? _grainRuntime;
+
     // Do not use this directly because we currently don't provide a way to inject it;
     // any interaction with it will result in non unit-testable code. Any behavior that can be accessed
     // from within client code (including subclasses of this class), should be exposed through IGrainRuntime.
@@ -23,7 +25,7 @@ public abstract partial class Grain : IGrainBase, IAddressable
 
     public GrainReference GrainReference { get { return GrainContext.GrainReference; } }
 
-    internal IGrainRuntime Runtime { get; }
+    internal IGrainRuntime Runtime => _grainRuntime ??= GetGrainRuntime()!;
 
     /// <summary>
     /// Gets an object which can be used to access other grains. Null if this grain is not associated with a Runtime, such as when created directly for unit testing.
@@ -54,9 +56,7 @@ public abstract partial class Grain : IGrainBase, IAddressable
     protected Grain(IGrainContext grainContext, IGrainRuntime? grainRuntime = null)
     {
         GrainContext = grainContext;
-
-        // ! The runtime ensures that this is not null and Unit testing frameworks must make sure that this is not null.
-        Runtime = grainRuntime ?? grainContext?.ActivationServices.GetService<IGrainRuntime>()!;
+        _grainRuntime = grainRuntime;
     }
 
     /// <summary>
@@ -162,6 +162,22 @@ public abstract partial class Grain : IGrainBase, IAddressable
     /// <param name="reason">The reason for deactivation. Informational only.</param>
     /// <param name="cancellationToken">A cancellation token which signals when deactivation should complete promptly.</param>
     public virtual Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private IGrainRuntime? GetGrainRuntime()
+    {
+        var grainContext = GrainContext;
+        if (grainContext is null)
+        {
+            return null;
+        }
+
+        if (grainContext.GetComponent(typeof(IGrainRuntime)) is IGrainRuntime grainRuntime)
+        {
+            return grainRuntime;
+        }
+
+        return grainContext.ActivationServices.GetService<IGrainRuntime>();
+    }
 
     internal void EnsureRuntime()
     {

--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -49,7 +49,7 @@ public abstract partial class Grain : IGrainBase, IAddressable
     /// <summary>
     /// Gets the IServiceProvider managed by the runtime. Null if this grain is not associated with a Runtime, such as when created directly for unit testing.
     /// </summary>
-    protected internal IServiceProvider ServiceProvider => GrainContext?.ActivationServices ?? RuntimeOrDefault?.ServiceProvider!;
+    protected internal IServiceProvider? ServiceProvider => GrainContext?.ActivationServices ?? RuntimeOrDefault?.ServiceProvider;
 
     internal GrainId GrainId => GrainContext.GrainId;
 

--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -29,18 +29,21 @@ public abstract partial class Grain : IGrainBase, IAddressable
     /// </summary>
     public GrainReference GrainReference { get { return GrainContext.GrainReference; } }
 
-    internal IGrainRuntime Runtime { get; }
+    internal IGrainRuntime Runtime => GrainContext?.GrainRuntime
+        ?? throw new InvalidOperationException("Grain was created outside of the Orleans creation process and no runtime was specified.");
 
     /// <summary>
-    /// Gets an object which can be used to access other grains. Null if this grain is not associated with a Runtime, such as when created directly for unit testing.
+    /// Gets an object which can be used to access other grains.
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The grain was created outside of the Orleans activation process and no runtime was provided.
+    /// </exception>
     protected IGrainFactory GrainFactory => Runtime.GrainFactory;
 
     /// <summary>
     /// Gets the IServiceProvider managed by the runtime. Null if this grain is not associated with a Runtime, such as when created directly for unit testing.
     /// </summary>
-    // ! The runtime ensures that this is not null and Unit testing frameworks must make sure that this is not null.
-    protected internal IServiceProvider ServiceProvider => GrainContext?.ActivationServices ?? Runtime?.ServiceProvider!;
+    protected internal IServiceProvider ServiceProvider => GrainContext?.ActivationServices ?? GrainContext?.GrainRuntime?.ServiceProvider!;
 
     internal GrainId GrainId => GrainContext.GrainId;
 
@@ -57,12 +60,17 @@ public abstract partial class Grain : IGrainBase, IAddressable
     /// This constructor is particularly useful for unit testing where test code can create a Grain and replace
     /// the IGrainIdentity and IGrainRuntime with test doubles (mocks/stubs).
     /// </summary>
+    /// <remarks>
+    /// When <paramref name="grainRuntime"/> is provided, it is registered as an <see cref="IGrainRuntime"/>
+    /// component on <paramref name="grainContext"/>.
+    /// </remarks>
     protected Grain(IGrainContext grainContext, IGrainRuntime? grainRuntime = null)
     {
         GrainContext = grainContext;
-
-        // ! The runtime ensures that this is not null and Unit testing frameworks must make sure that this is not null.
-        Runtime = grainRuntime ?? grainContext?.ActivationServices.GetService<IGrainRuntime>()!;
+        if (grainRuntime is not null)
+        {
+            grainContext!.GrainRuntime = grainRuntime;
+        }
     }
 
     /// <summary>
@@ -74,7 +82,7 @@ public abstract partial class Grain : IGrainBase, IAddressable
     /// A unique identifier for the current silo.
     /// There is no semantic content to this string, but it may be useful for logging.
     /// </summary>
-    public string RuntimeIdentity => Runtime?.SiloIdentity ?? string.Empty;
+    public string RuntimeIdentity => GrainContext?.GrainRuntime?.SiloIdentity ?? string.Empty;
 
     /// <summary>
     /// Registers a timer to send periodic callbacks to this grain.
@@ -169,13 +177,7 @@ public abstract partial class Grain : IGrainBase, IAddressable
     /// <param name="cancellationToken">A cancellation token which signals when deactivation should complete promptly.</param>
     public virtual Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken) => Task.CompletedTask;
 
-    internal void EnsureRuntime()
-    {
-        if (Runtime == null)
-        {
-            throw new InvalidOperationException("Grain was created outside of the Orleans creation process and no runtime was specified.");
-        }
-    }
+    internal void EnsureRuntime() => _ = Runtime;
 }
 
 /// <summary>

--- a/src/Orleans.Core.Abstractions/Core/Grain.cs
+++ b/src/Orleans.Core.Abstractions/Core/Grain.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,6 +15,8 @@ namespace Orleans;
 /// </summary>
 public abstract partial class Grain : IGrainBase, IAddressable
 {
+    private static readonly ConditionalWeakTable<Grain, IGrainRuntime> StandaloneRuntimes = new();
+
     // Do not use this directly because we currently don't provide a way to inject it;
     // any interaction with it will result in non unit-testable code. Any behavior that can be accessed
     // from within client code (including subclasses of this class), should be exposed through IGrainRuntime.
@@ -29,7 +32,10 @@ public abstract partial class Grain : IGrainBase, IAddressable
     /// </summary>
     public GrainReference GrainReference { get { return GrainContext.GrainReference; } }
 
-    internal IGrainRuntime Runtime => GrainContext?.GrainRuntime
+    private IGrainRuntime? RuntimeOrDefault => GrainContext?.GrainRuntime
+        ?? (StandaloneRuntimes.TryGetValue(this, out var runtime) ? runtime : null);
+
+    internal IGrainRuntime Runtime => RuntimeOrDefault
         ?? throw new InvalidOperationException("Grain was created outside of the Orleans creation process and no runtime was specified.");
 
     /// <summary>
@@ -43,7 +49,7 @@ public abstract partial class Grain : IGrainBase, IAddressable
     /// <summary>
     /// Gets the IServiceProvider managed by the runtime. Null if this grain is not associated with a Runtime, such as when created directly for unit testing.
     /// </summary>
-    protected internal IServiceProvider ServiceProvider => GrainContext?.ActivationServices ?? GrainContext?.GrainRuntime?.ServiceProvider!;
+    protected internal IServiceProvider ServiceProvider => GrainContext?.ActivationServices ?? RuntimeOrDefault?.ServiceProvider!;
 
     internal GrainId GrainId => GrainContext.GrainId;
 
@@ -61,15 +67,22 @@ public abstract partial class Grain : IGrainBase, IAddressable
     /// the IGrainIdentity and IGrainRuntime with test doubles (mocks/stubs).
     /// </summary>
     /// <remarks>
-    /// When <paramref name="grainRuntime"/> is provided, it is registered as an <see cref="IGrainRuntime"/>
-    /// component on <paramref name="grainContext"/>.
+    /// When <paramref name="grainRuntime"/> is provided, it is associated with this grain and registered as an
+    /// <see cref="IGrainRuntime"/> component when <paramref name="grainContext"/> is available.
     /// </remarks>
     protected Grain(IGrainContext grainContext, IGrainRuntime? grainRuntime = null)
     {
         GrainContext = grainContext;
         if (grainRuntime is not null)
         {
-            grainContext!.GrainRuntime = grainRuntime;
+            if (grainContext is null)
+            {
+                StandaloneRuntimes.Add(this, grainRuntime);
+            }
+            else
+            {
+                grainContext.GrainRuntime = grainRuntime;
+            }
         }
     }
 
@@ -82,7 +95,7 @@ public abstract partial class Grain : IGrainBase, IAddressable
     /// A unique identifier for the current silo.
     /// There is no semantic content to this string, but it may be useful for logging.
     /// </summary>
-    public string RuntimeIdentity => GrainContext?.GrainRuntime?.SiloIdentity ?? string.Empty;
+    public string RuntimeIdentity => RuntimeOrDefault?.SiloIdentity ?? string.Empty;
 
     /// <summary>
     /// Registers a timer to send periodic callbacks to this grain.

--- a/src/Orleans.Core.Abstractions/Core/IGrainContext.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainContext.cs
@@ -43,11 +43,11 @@ namespace Orleans.Runtime
         IServiceProvider ActivationServices { get; }
 
         /// <summary>
-        /// Gets the grain runtime, if available.
+        /// Gets or sets the grain runtime associated with this context.
         /// </summary>
         /// <remarks>
-        /// Runtime contexts provide this value directly. Custom contexts can override it by registering an
-        /// <see cref="IGrainRuntime"/> component or service.
+        /// Runtime contexts provide the activation runtime directly. Custom contexts resolve an
+        /// <see cref="IGrainRuntime"/> component before resolving an activation service.
         /// </remarks>
         IGrainRuntime? GrainRuntime
         {

--- a/src/Orleans.Core.Abstractions/Core/IGrainContext.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainContext.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Serialization.Invocation;
 
 namespace Orleans.Runtime
@@ -40,6 +41,20 @@ namespace Orleans.Runtime
         /// Gets the <see cref="IServiceProvider" /> that provides access to the grain activation's service container.
         /// </summary>
         IServiceProvider ActivationServices { get; }
+
+        /// <summary>
+        /// Gets the grain runtime, if available.
+        /// </summary>
+        /// <remarks>
+        /// Runtime contexts provide this value directly. Custom contexts can override it by registering an
+        /// <see cref="IGrainRuntime"/> component or service.
+        /// </remarks>
+        IGrainRuntime? GrainRuntime
+        {
+            get => GetComponent(typeof(IGrainRuntime)) as IGrainRuntime
+                ?? ActivationServices?.GetService<IGrainRuntime>();
+            set => SetComponent(value);
+        }
 
         /// <summary>
         /// Gets the observable <see cref="Grain"/> lifecycle, which can be used to add lifecycle hooks.

--- a/src/Orleans.Core/Runtime/InvokableObjectManager.cs
+++ b/src/Orleans.Core/Runtime/InvokableObjectManager.cs
@@ -117,6 +117,18 @@ namespace Orleans
 
             IServiceProvider IGrainContext.ActivationServices => throw new NotSupportedException();
 
+            IGrainRuntime? IGrainContext.GrainRuntime
+            {
+                get => null;
+                set
+                {
+                    if (value is not null)
+                    {
+                        throw new ArgumentException("Local observer contexts do not have a grain runtime.", nameof(value));
+                    }
+                }
+            }
+
             IGrainLifecycle IGrainContext.ObservableLifecycle => throw new NotImplementedException();
 
             public IWorkItemScheduler Scheduler => throw new NotImplementedException();

--- a/src/Orleans.EventSourcing/LogConsistency/LogConsistentGrain.cs
+++ b/src/Orleans.EventSourcing/LogConsistency/LogConsistentGrain.cs
@@ -56,11 +56,12 @@ namespace Orleans.EventSourcing
         private Task OnSetupState(CancellationToken ct)
         {
             if (ct.IsCancellationRequested) return Task.CompletedTask;
-            IGrainContextAccessor grainContextAccessor = this.ServiceProvider.GetRequiredService<IGrainContextAccessor>();
-            Factory<IGrainContext, ILogConsistencyProtocolServices> protocolServicesFactory = this.ServiceProvider.GetRequiredService<Factory<IGrainContext, ILogConsistencyProtocolServices>>();
+            var serviceProvider = ServiceProvider!;
+            IGrainContextAccessor grainContextAccessor = serviceProvider.GetRequiredService<IGrainContextAccessor>();
+            Factory<IGrainContext, ILogConsistencyProtocolServices> protocolServicesFactory = serviceProvider.GetRequiredService<Factory<IGrainContext, ILogConsistencyProtocolServices>>();
             IGrainContext grainContext = grainContextAccessor.GrainContext!;
             ILogViewAdaptorFactory consistencyProvider = SetupLogConsistencyProvider(grainContext);
-            IGrainStorage? grainStorage = consistencyProvider.UsesStorageProvider ? GrainStorageHelpers.GetGrainStorage((grainContext?.GrainInstance!.GetType())!, this.ServiceProvider) : null;
+            IGrainStorage? grainStorage = consistencyProvider.UsesStorageProvider ? GrainStorageHelpers.GetGrainStorage((grainContext?.GrainInstance!.GetType())!, serviceProvider) : null;
             InstallLogViewAdaptor(grainContext!, protocolServicesFactory, consistencyProvider, grainStorage);
             return Task.CompletedTask;
         }
@@ -92,10 +93,11 @@ namespace Orleans.EventSourcing
         private ILogViewAdaptorFactory SetupLogConsistencyProvider(IGrainContext activationContext)
         {
             var attr = this.GetType().GetCustomAttributes<LogConsistencyProviderAttribute>(true).FirstOrDefault();
+            var serviceProvider = ServiceProvider!;
 
             ILogViewAdaptorFactory? defaultFactory = attr != null
-                ? this.ServiceProvider.GetKeyedService<ILogViewAdaptorFactory>(attr.ProviderName)
-                : this.ServiceProvider.GetService<ILogViewAdaptorFactory>();
+                ? serviceProvider.GetKeyedService<ILogViewAdaptorFactory>(attr.ProviderName)
+                : serviceProvider.GetService<ILogViewAdaptorFactory>();
             if (attr != null && defaultFactory == null)
             {
                 var errMsg = $"Cannot find consistency provider with Name={attr.ProviderName} for grain type {this.GetType().FullName}";

--- a/src/Orleans.Journaling/DurableGrain.cs
+++ b/src/Orleans.Journaling/DurableGrain.cs
@@ -12,7 +12,7 @@ public abstract class DurableGrain : Grain, IGrainBase
     /// </summary>
     protected DurableGrain()
     {
-        StateManager = ServiceProvider.GetRequiredService<IJournaledStateManager>();
+        StateManager = ServiceProvider!.GetRequiredService<IJournaledStateManager>();
         if (StateManager is ILifecycleParticipant<IGrainLifecycle> participant)
         {
             participant.Participate(((IGrainBase)this).GrainContext.ObservableLifecycle);
@@ -31,7 +31,7 @@ public abstract class DurableGrain : Grain, IGrainBase
     /// <param name="name">The name used to register the state.</param>
     /// <returns>The existing or newly created state.</returns>
     protected TState GetOrCreateState<TState>(string name) where TState : class, IJournaledState
-        => GetOrCreateState(name, static sp => sp.GetRequiredService<TState>(), ServiceProvider);
+        => GetOrCreateState(name, static sp => sp.GetRequiredService<TState>(), ServiceProvider!);
 
     /// <summary>
     /// Gets the registered state with the specified name or creates it using the supplied factory and argument.

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -399,6 +399,11 @@ internal sealed partial class ActivationData :
 
     public void SetComponent(Type componentType, object? instance)
     {
+        if (instance is not null && !componentType.IsInstanceOfType(instance))
+        {
+            throw new ArgumentException($"Component instance of type '{instance.GetType()}' is not assignable to component type '{componentType}'.", nameof(instance));
+        }
+
         if (componentType.IsAssignableFrom(GrainInstance?.GetType()))
         {
             throw new ArgumentException("Cannot override a component which is implemented by this grain");

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -412,7 +412,16 @@ internal sealed partial class ActivationData :
         {
             if (componentType == typeof(IGrainRuntime))
             {
-                _extras ??= new();
+                if (_extras is null)
+                {
+                    if (instance is null)
+                    {
+                        return;
+                    }
+
+                    _extras = new();
+                }
+
                 Volatile.Write(ref _extras.GrainRuntime, (IGrainRuntime?)instance);
                 return;
             }

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -146,7 +146,7 @@ internal sealed partial class ActivationData :
     {
         get
         {
-            var extras = _extras;
+            var extras = Volatile.Read(ref _extras);
             return extras is null ? _shared.Runtime : Volatile.Read(ref extras.GrainRuntime) ?? _shared.Runtime;
         }
     }
@@ -412,17 +412,20 @@ internal sealed partial class ActivationData :
         {
             if (componentType == typeof(IGrainRuntime))
             {
-                if (_extras is null)
+                var extras = Volatile.Read(ref _extras);
+                if (extras is null)
                 {
                     if (instance is null)
                     {
                         return;
                     }
 
-                    _extras = new();
+                    extras = new() { GrainRuntime = (IGrainRuntime)instance };
+                    Volatile.Write(ref _extras, extras);
+                    return;
                 }
 
-                Volatile.Write(ref _extras.GrainRuntime, (IGrainRuntime?)instance);
+                Volatile.Write(ref extras.GrainRuntime, (IGrainRuntime?)instance);
                 return;
             }
 

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -142,7 +142,20 @@ internal sealed partial class ActivationData :
     }
 
     public ActivationTaskScheduler ActivationTaskScheduler => _workItemGroup.TaskScheduler;
-    public IGrainRuntime GrainRuntime => _shared.Runtime;
+    public IGrainRuntime GrainRuntime
+    {
+        get
+        {
+            var extras = _extras;
+            return extras is null ? _shared.Runtime : Volatile.Read(ref extras.GrainRuntime) ?? _shared.Runtime;
+        }
+    }
+
+    IGrainRuntime? IGrainContext.GrainRuntime
+    {
+        get => GrainRuntime;
+        set => SetComponent(value);
+    }
     public object? GrainInstance { get; private set; }
     public GrainAddress Address { get; private set; }
     public GrainReference GrainReference => _selfReference ??= _shared.GrainReferenceActivator.CreateReference(GrainId, default);
@@ -357,6 +370,10 @@ internal sealed partial class ActivationData :
         {
             result = this;
         }
+        else if (componentType == typeof(IGrainRuntime))
+        {
+            result = GrainRuntime;
+        }
         else if (_extras is { } components && components.TryGetValue(componentType, out var resultObj))
         {
             result = resultObj;
@@ -393,6 +410,13 @@ internal sealed partial class ActivationData :
 
         lock (this)
         {
+            if (componentType == typeof(IGrainRuntime))
+            {
+                _extras ??= new();
+                Volatile.Write(ref _extras.GrainRuntime, (IGrainRuntime?)instance);
+                return;
+            }
+
             if (instance == null)
             {
                 _extras?.Remove(componentType);
@@ -2373,6 +2397,8 @@ internal sealed partial class ActivationData :
         private const int IsStuckDeactivatingFlag = 1 << 1;
         private const int IsDisposingFlag = 1 << 2;
         private byte _flags;
+
+        public IGrainRuntime? GrainRuntime;
 
         public HashSet<IGrainTimer>? Timers { get => GetValueOrDefault<HashSet<IGrainTimer>>(nameof(Timers)); set => SetOrRemoveValue(nameof(Timers), value); }
 

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -109,6 +109,11 @@ public sealed class GrainTypeSharedContext
             return (TComponent)Logger;
         }
 
+        if (typeof(TComponent) == typeof(IGrainRuntime) && Runtime is TComponent runtime)
+        {
+            return runtime;
+        }
+
         if (_components is null) return default;
         _components.TryGetValue(typeof(TComponent), out var resultObj);
         return (TComponent?)resultObj;
@@ -129,6 +134,11 @@ public sealed class GrainTypeSharedContext
         if (componentType == typeof(ILogger))
         {
             return Logger;
+        }
+
+        if (componentType == typeof(IGrainRuntime))
+        {
+            return Runtime;
         }
 
         if (_components is null) return default;

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -21,8 +21,10 @@ namespace Orleans.Runtime;
 /// </summary>
 public sealed class GrainTypeSharedContext
 {
+    private readonly IGrainRuntime _defaultRuntime;
     private readonly IServiceProvider _serviceProvider;
     private readonly Dictionary<Type, object> _components = [];
+    private IGrainRuntime? _runtimeOverride;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GrainTypeSharedContext"/> class.
@@ -72,7 +74,7 @@ public sealed class GrainTypeSharedContext
         var grainDirectoryResolver = serviceProvider.GetRequiredService<GrainDirectoryResolver>();
         GrainDirectory = PlacementStrategy.IsUsingGrainDirectory ? grainDirectoryResolver.Resolve(grainType) : null;
         SchedulingOptions = schedulingOptions.Value;
-        Runtime = grainRuntime;
+        _defaultRuntime = grainRuntime;
         MigrationManager = _serviceProvider.GetService<IActivationMigrationManager>();
         CatalogInstruments = serviceProvider.GetRequiredService<CatalogInstruments>();
         GrainInstruments = serviceProvider.GetRequiredService<GrainInstruments>();
@@ -134,6 +136,11 @@ public sealed class GrainTypeSharedContext
             return (TComponent)Logger;
         }
 
+        if (typeof(TComponent) == typeof(IGrainRuntime) && Runtime is TComponent runtime)
+        {
+            return runtime;
+        }
+
         if (_components is null) return default;
         _components.TryGetValue(typeof(TComponent), out var resultObj);
         return (TComponent?)resultObj;
@@ -156,6 +163,11 @@ public sealed class GrainTypeSharedContext
             return Logger;
         }
 
+        if (componentType == typeof(IGrainRuntime))
+        {
+            return Runtime;
+        }
+
         if (_components is null) return default;
         _components.TryGetValue(componentType, out var resultObj);
         return resultObj;
@@ -167,6 +179,12 @@ public sealed class GrainTypeSharedContext
     /// <typeparam name="TComponent">The type which can be used as a key to <see cref="GetComponent{TComponent}"/>.</typeparam>
     public void SetComponent<TComponent>(TComponent? instance)
     {
+        if (typeof(TComponent) == typeof(IGrainRuntime))
+        {
+            Volatile.Write(ref _runtimeOverride, instance as IGrainRuntime);
+            return;
+        }
+
         if (instance == null)
         {
             _components.Remove(typeof(TComponent));
@@ -231,7 +249,7 @@ public sealed class GrainTypeSharedContext
     /// <summary>
     /// Gets the grain runtime.
     /// </summary>
-    public IGrainRuntime Runtime { get; }
+    public IGrainRuntime Runtime => Volatile.Read(ref _runtimeOverride) ?? _defaultRuntime;
 
     /// <summary>
     /// Gets the local activation migration manager.

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -21,10 +21,8 @@ namespace Orleans.Runtime;
 /// </summary>
 public sealed class GrainTypeSharedContext
 {
-    private readonly IGrainRuntime _defaultRuntime;
     private readonly IServiceProvider _serviceProvider;
     private readonly Dictionary<Type, object> _components = [];
-    private IGrainRuntime? _runtimeOverride;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GrainTypeSharedContext"/> class.
@@ -74,7 +72,7 @@ public sealed class GrainTypeSharedContext
         var grainDirectoryResolver = serviceProvider.GetRequiredService<GrainDirectoryResolver>();
         GrainDirectory = PlacementStrategy.IsUsingGrainDirectory ? grainDirectoryResolver.Resolve(grainType) : null;
         SchedulingOptions = schedulingOptions.Value;
-        _defaultRuntime = grainRuntime;
+        Runtime = grainRuntime;
         MigrationManager = _serviceProvider.GetService<IActivationMigrationManager>();
         CatalogInstruments = serviceProvider.GetRequiredService<CatalogInstruments>();
         GrainInstruments = serviceProvider.GetRequiredService<GrainInstruments>();
@@ -136,11 +134,6 @@ public sealed class GrainTypeSharedContext
             return (TComponent)Logger;
         }
 
-        if (typeof(TComponent) == typeof(IGrainRuntime) && Runtime is TComponent runtime)
-        {
-            return runtime;
-        }
-
         if (_components is null) return default;
         _components.TryGetValue(typeof(TComponent), out var resultObj);
         return (TComponent?)resultObj;
@@ -163,11 +156,6 @@ public sealed class GrainTypeSharedContext
             return Logger;
         }
 
-        if (componentType == typeof(IGrainRuntime))
-        {
-            return Runtime;
-        }
-
         if (_components is null) return default;
         _components.TryGetValue(componentType, out var resultObj);
         return resultObj;
@@ -179,12 +167,6 @@ public sealed class GrainTypeSharedContext
     /// <typeparam name="TComponent">The type which can be used as a key to <see cref="GetComponent{TComponent}"/>.</typeparam>
     public void SetComponent<TComponent>(TComponent? instance)
     {
-        if (typeof(TComponent) == typeof(IGrainRuntime))
-        {
-            Volatile.Write(ref _runtimeOverride, instance as IGrainRuntime);
-            return;
-        }
-
         if (instance == null)
         {
             _components.Remove(typeof(TComponent));
@@ -249,7 +231,7 @@ public sealed class GrainTypeSharedContext
     /// <summary>
     /// Gets the grain runtime.
     /// </summary>
-    public IGrainRuntime Runtime => Volatile.Read(ref _runtimeOverride) ?? _defaultRuntime;
+    public IGrainRuntime Runtime { get; }
 
     /// <summary>
     /// Gets the local activation migration manager.

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -82,7 +82,13 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
     IGrainRuntime? IGrainContext.GrainRuntime
     {
         get => GrainRuntime;
-        set => _shared.Shared.SetComponent(value);
+        set
+        {
+            if (!ReferenceEquals(value, GrainRuntime))
+            {
+                throw new ArgumentException("The runtime for a stateless worker context is provided by its shared grain type context.", nameof(value));
+            }
+        }
     }
 
     public IServiceProvider ActivationServices => throw new NotImplementedException();

--- a/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
+++ b/src/Orleans.Runtime/Catalog/StatelessWorkerGrainContext.cs
@@ -77,6 +77,14 @@ internal partial class StatelessWorkerGrainContext : IGrainContext, IAsyncDispos
 
     public GrainAddress Address { get; }
 
+    public IGrainRuntime GrainRuntime => _shared.Shared.Runtime;
+
+    IGrainRuntime? IGrainContext.GrainRuntime
+    {
+        get => GrainRuntime;
+        set => _shared.Shared.SetComponent(value);
+    }
+
     public IServiceProvider ActivationServices => throw new NotImplementedException();
 
     public IGrainLifecycle ObservableLifecycle => throw new NotImplementedException();

--- a/src/Orleans.TestingHost/TestStorageProviders/StorageFaultGrain.cs
+++ b/src/Orleans.TestingHost/TestStorageProviders/StorageFaultGrain.cs
@@ -23,7 +23,7 @@ namespace Orleans.TestingHost
         public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             await base.OnActivateAsync(cancellationToken);
-            logger = this.ServiceProvider.GetService<ILoggerFactory>()!.CreateLogger($"{typeof(StorageFaultGrain).FullName}-{IdentityString}-{RuntimeIdentity}");
+            logger = ServiceProvider!.GetService<ILoggerFactory>()!.CreateLogger($"{typeof(StorageFaultGrain).FullName}-{IdentityString}-{RuntimeIdentity}");
             readFaults = new();
             writeFaults = new();
             clearfaults = new();

--- a/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
+++ b/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
@@ -1071,7 +1071,7 @@ namespace Orleans
 
         public string RuntimeIdentity { get { throw null; } }
 
-        protected internal System.IServiceProvider ServiceProvider { get { throw null; } }
+        protected internal System.IServiceProvider? ServiceProvider { get { throw null; } }
 
         protected void DeactivateOnIdle() { }
 

--- a/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
+++ b/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
@@ -2574,6 +2574,8 @@ namespace Orleans.Runtime
 
         GrainReference GrainReference { get; }
 
+        IGrainRuntime? GrainRuntime { get; set; }
+
         IGrainLifecycle ObservableLifecycle { get; }
 
         IWorkItemScheduler Scheduler { get; }

--- a/test/Grains/TestGrains/MessageSerializationGrain.cs
+++ b/test/Grains/TestGrains/MessageSerializationGrain.cs
@@ -59,8 +59,9 @@ namespace UnitTests.Grains
             IMessageSerializationGrain otherGrain;
             var id = this.GetPrimaryKeyLong();
             var currentSiloIdentity = await this.GetSiloIdentity();
-            var silos = ServiceProvider.GetRequiredService<IClusterMembershipService>().CurrentSnapshot.Members.Where(kv => kv.Value.Status == SiloStatus.Active).Select(kv => kv.Key).ToHashSet();
-            silos.Remove(ServiceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress);
+            var serviceProvider = ServiceProvider!;
+            var silos = serviceProvider.GetRequiredService<IClusterMembershipService>().CurrentSnapshot.Members.Where(kv => kv.Value.Status == SiloStatus.Active).Select(kv => kv.Key).ToHashSet();
+            silos.Remove(serviceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress);
             while (true)
             {
                 RequestContext.Set(IPlacementDirector.PlacementHintKey, silos.First());

--- a/test/Grains/TestGrains/ProgrammaticSubscribe/SubscribeGrain.cs
+++ b/test/Grains/TestGrains/ProgrammaticSubscribe/SubscribeGrain.cs
@@ -14,7 +14,7 @@ namespace UnitTests.Grains.ProgrammaticSubscribe
     {
         public Task<bool> CanGetSubscriptionManager(string providerName)
         {
-            return Task.FromResult(this.ServiceProvider.GetKeyedService<IStreamProvider>(providerName)!.TryGetStreamSubscriptionManager(out _)); // The test configures the named provider before invoking this grain.
+            return Task.FromResult(ServiceProvider!.GetKeyedService<IStreamProvider>(providerName)!.TryGetStreamSubscriptionManager(out _)); // The test configures the named provider before invoking this grain.
         }
     }
 

--- a/test/Grains/TestGrains/SimpleDIGrain.cs
+++ b/test/Grains/TestGrains/SimpleDIGrain.cs
@@ -65,9 +65,10 @@ namespace UnitTests.Grains
 
         public Task AssertCanResolveSameServiceInstances()
         {
-            if (!ReferenceEquals(this.ServiceProvider.GetRequiredService<IInjectedService>(), this.injectedService)) throw new Exception("singleton not equal");
-            if (!ReferenceEquals(this.ServiceProvider.GetRequiredService<IInjectedScopedService>(), this.injectedScopedService)) throw new Exception("scoped not equal");
-            if (!ReferenceEquals(this.ServiceProvider.GetRequiredService<IGrainContextAccessor>().GrainContext, this.originalGrainContext)) throw new Exception("scoped grain activation context not equal");
+            var serviceProvider = ServiceProvider!;
+            if (!ReferenceEquals(serviceProvider.GetRequiredService<IInjectedService>(), this.injectedService)) throw new Exception("singleton not equal");
+            if (!ReferenceEquals(serviceProvider.GetRequiredService<IInjectedScopedService>(), this.injectedScopedService)) throw new Exception("scoped not equal");
+            if (!ReferenceEquals(serviceProvider.GetRequiredService<IGrainContextAccessor>().GrainContext, this.originalGrainContext)) throw new Exception("scoped grain activation context not equal");
 
             return Task.CompletedTask;
         }

--- a/test/Grains/TestInternalGrains/CollectionTestGrain.cs
+++ b/test/Grains/TestInternalGrains/CollectionTestGrain.cs
@@ -29,7 +29,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>()
+            logger = ServiceProvider!.GetRequiredService<ILoggerFactory>()
                 .CreateLogger(string.Format("CollectionTestGrain {0} {1} on {2}.", GrainId, _grainContext.ActivationId, RuntimeIdentity));
             logger.LogInformation("OnActivateAsync.");
             activated = DateTime.UtcNow;
@@ -127,7 +127,7 @@ namespace UnitTests.Grains
 
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>()
+            logger = ServiceProvider!.GetRequiredService<ILoggerFactory>()
                 .CreateLogger($"CollectionTestGrain {GrainId} {_grainContext.ActivationId} on {RuntimeIdentity}.");
             logger.LogInformation("OnActivateAsync.");
             counter = 0;

--- a/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
+++ b/test/Grains/TestInternalGrains/PersistenceTestGrains.cs
@@ -67,7 +67,7 @@ namespace UnitTests.Grains
 
         public Task<string> CheckProviderType()
         {
-            IGrainStorage grainStorage = GrainStorageHelpers.GetGrainStorage(GetType(), this.ServiceProvider);
+            IGrainStorage grainStorage = GrainStorageHelpers.GetGrainStorage(GetType(), ServiceProvider!);
             Assert.NotNull(grainStorage);
             return Task.FromResult(grainStorage.GetType().FullName!);
         }

--- a/test/Grains/TestInternalGrains/PlacementTestGrain.cs
+++ b/test/Grains/TestInternalGrains/PlacementTestGrain.cs
@@ -252,7 +252,7 @@ namespace UnitTests.Grains
     {
         public Task<PlacementStrategy> GetDefaultPlacement()
         {
-            var defaultStrategy = this.ServiceProvider.GetRequiredService<PlacementStrategy>();
+            var defaultStrategy = ServiceProvider!.GetRequiredService<PlacementStrategy>();
             return Task.FromResult(defaultStrategy);
         }
     }

--- a/test/Grains/TestInternalGrains/SerializerPresenceTestGrain.cs
+++ b/test/Grains/TestInternalGrains/SerializerPresenceTestGrain.cs
@@ -8,7 +8,7 @@ namespace UnitTests.Grains
     {
         public Task<bool> SerializerExistsForType(Type t)
         {
-            return Task.FromResult(this.ServiceProvider.GetRequiredService<Serializer>().CanSerialize(t));
+            return Task.FromResult(ServiceProvider!.GetRequiredService<Serializer>().CanSerialize(t));
         }
 
         public Task TakeSerializedData(object data)

--- a/test/Grains/TestInternalGrains/StreamingGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingGrain.cs
@@ -467,7 +467,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             var activationId = _grainContext.ActivationId;
-            _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ProducerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
+            _logger = ServiceProvider!.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ProducerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
             _logger.LogInformation("OnActivateAsync");
             _producers = new List<IProducerObserver>();
             _cleanedUpFlag = new InterlockedFlag();
@@ -584,7 +584,7 @@ namespace UnitTests.Grains
         {
             await base.OnActivateAsync(cancellationToken);
             var activationId = _grainContext.ActivationId;
-            _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.PersistentStreaming_ProducerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
+            _logger = ServiceProvider!.GetRequiredService<ILoggerFactory>().CreateLogger("Test.PersistentStreaming_ProducerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
             _logger.LogInformation("OnActivateAsync");
             if (State.Producers == null)
             {
@@ -658,7 +658,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             var activationId = _grainContext.ActivationId;
-            _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
+            _logger = ServiceProvider!.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
             _logger.LogInformation("OnActivateAsync");
             _observers = new List<IConsumerObserver>();
             return Task.CompletedTask;
@@ -722,7 +722,7 @@ namespace UnitTests.Grains
         {
             await base.OnActivateAsync(cancellationToken);
             var activationId = _grainContext.ActivationId;
-            _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.PersistentStreaming_ConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
+            _logger = ServiceProvider!.GetRequiredService<ILoggerFactory>().CreateLogger("Test.PersistentStreaming_ConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
             _logger.LogInformation("OnActivateAsync");
 
             if (State.Consumers == null)
@@ -770,7 +770,7 @@ namespace UnitTests.Grains
         public override async Task OnActivateAsync(CancellationToken cancellationToken)
         {
             var activationId = RuntimeContext.Current!.ActivationId;
-            _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_Reentrant_ProducerConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
+            _logger = ServiceProvider!.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_Reentrant_ProducerConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
             _logger.LogInformation("OnActivateAsync");
             await base.OnActivateAsync(cancellationToken);
         }
@@ -786,7 +786,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             var activationId = RuntimeContext.Current!.ActivationId;
-            _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ProducerConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
+            _logger = ServiceProvider!.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ProducerConsumerGrain " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
             _logger.LogInformation("OnActivateAsync");
             return Task.CompletedTask;
         }
@@ -897,7 +897,7 @@ namespace UnitTests.Grains
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
             var activationId = RuntimeContext.Current!.ActivationId;
-            _logger = this.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ImplicitConsumerGrain1 " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
+            _logger = ServiceProvider!.GetRequiredService<ILoggerFactory>().CreateLogger("Test.Streaming_ImplicitConsumerGrain1 " + RuntimeIdentity + "/" + IdentityString + "/" + activationId);
             _logger.LogInformation("{Type}.OnActivateAsync", GetType().FullName);
             _observers = new Dictionary<string, IConsumerObserver>();
             return Task.CompletedTask;

--- a/test/Grains/TestInternalGrains/TestGrain.cs
+++ b/test/Grains/TestInternalGrains/TestGrain.cs
@@ -204,7 +204,7 @@ namespace UnitTests.Grains
             return Task.FromResult(_id);
         }
 
-        public Task<SiloAddress> GetSiloAddress() => Task.FromResult(ServiceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress);
+        public Task<SiloAddress> GetSiloAddress() => Task.FromResult(ServiceProvider!.GetRequiredService<ILocalSiloDetails>().SiloAddress);
     }
 
     internal class OneWayGrain : Grain, IOneWayGrain, ISimpleGrainObserver
@@ -219,8 +219,8 @@ namespace UnitTests.Grains
 
         public OneWayGrain(GrainLocator grainLocator) => this.grainLocator = grainLocator;
 
-        private ILocalGrainDirectory LocalGrainDirectory => this.ServiceProvider.GetRequiredService<ILocalGrainDirectory>();
-        private ILocalSiloDetails LocalSiloDetails => this.ServiceProvider.GetRequiredService<ILocalSiloDetails>();
+        private ILocalGrainDirectory LocalGrainDirectory => ServiceProvider!.GetRequiredService<ILocalGrainDirectory>();
+        private ILocalSiloDetails LocalSiloDetails => ServiceProvider!.GetRequiredService<ILocalSiloDetails>();
 
         public Task Notify()
         {
@@ -264,7 +264,7 @@ namespace UnitTests.Grains
 
             async Task<IOneWayGrain> GetGrainOnOtherSilo()
             {
-                var silos = ServiceProvider.GetRequiredService<IClusterMembershipService>().CurrentSnapshot.Members.Where(kv => kv.Value.Status == SiloStatus.Active).Select(kv => kv.Key).ToHashSet();
+                var silos = ServiceProvider!.GetRequiredService<IClusterMembershipService>().CurrentSnapshot.Members.Where(kv => kv.Value.Status == SiloStatus.Active).Select(kv => kv.Key).ToHashSet();
                 var thisSilo = await this.GetSiloAddress();
                 silos.Remove(thisSilo);
                 while (true)

--- a/test/Orleans.Core.Tests/Runtime/GrainRuntimeResolutionTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/GrainRuntimeResolutionTests.cs
@@ -238,6 +238,16 @@ public class GrainRuntimeResolutionTests
     }
 
     [Fact, TestCategory("BVT")]
+    public void ActivationContext_InvalidRuntimeOverride_ThrowsArgumentException()
+    {
+        var activation = CreateActivationData(CreateSharedContext(Substitute.For<IGrainRuntime>()));
+
+        var exception = Assert.Throws<ArgumentException>(() => activation.SetComponent(typeof(IGrainRuntime), new object()));
+
+        Assert.Equal("instance", exception.ParamName);
+    }
+
+    [Fact, TestCategory("BVT")]
     public void StatelessWorkerContext_RuntimeOverride_DoesNotMutateSharedContext()
     {
         var defaultRuntime = Substitute.For<IGrainRuntime>();

--- a/test/Orleans.Core.Tests/Runtime/GrainRuntimeResolutionTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/GrainRuntimeResolutionTests.cs
@@ -1,0 +1,246 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Runtime.Placement;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.Runtime;
+
+[TestSuite("BVT")]
+[TestProvider("None")]
+[TestArea("Runtime")]
+public class GrainRuntimeResolutionTests
+{
+    [Fact, TestCategory("BVT")]
+    public void Constructor_DoesNotResolveRuntime()
+    {
+        var grainContext = new TestGrainContext();
+
+        _ = new TestGrain(grainContext);
+
+        Assert.Equal(0, grainContext.GetComponentCallCount);
+        Assert.Equal(0, grainContext.ActivationServicesAccessCount);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void Runtime_ContextComponent_ReturnsRuntime()
+    {
+        var grainRuntime = Substitute.For<IGrainRuntime>();
+        var grainContext = new TestGrainContext();
+        grainContext.SetComponent(grainRuntime);
+        var grain = new TestGrain(grainContext);
+
+        var first = grain.Runtime;
+        var second = grain.Runtime;
+
+        Assert.Same(grainRuntime, first);
+        Assert.Same(first, second);
+        Assert.Equal(2, grainContext.GetComponentCallCount);
+        Assert.Equal(0, grainContext.ActivationServicesAccessCount);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task Runtime_ConcurrentAccess_UsesContextRuntime()
+    {
+        var grainRuntime = Substitute.For<IGrainRuntime>();
+        var grainContext = new TestGrainContext();
+        grainContext.SetComponent(grainRuntime);
+        var grain = new TestGrain(grainContext);
+
+        var results = await Task.WhenAll(Enumerable.Range(0, 32).Select(_ => Task.Run(() => grain.Runtime)));
+
+        Assert.All(results, result => Assert.Same(grainRuntime, result));
+        Assert.Equal(results.Length, grainContext.GetComponentCallCount);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void Runtime_ExplicitRuntime_RegistersContextComponent()
+    {
+        var grainContext = new TestGrainContext();
+        var grainRuntime = Substitute.For<IGrainRuntime>();
+        var grain = new TestGrain(grainContext, grainRuntime);
+
+        Assert.Same(grainRuntime, ((IGrainContext)grainContext).GrainRuntime);
+        Assert.Same(grainRuntime, grain.Runtime);
+        Assert.Equal(1, grainContext.SetComponentCallCount);
+        Assert.Equal(0, grainContext.ActivationServicesAccessCount);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void Runtime_ExplicitRuntime_WorksWithMockContext()
+    {
+        var grainContext = Substitute.For<IGrainContext>();
+        var grainRuntime = Substitute.For<IGrainRuntime>();
+        var grain = new TestGrain(grainContext, grainRuntime);
+
+        Assert.Same(grainRuntime, grainContext.GrainRuntime);
+        Assert.Same(grainRuntime, grain.Runtime);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void Runtime_ContextComponent_TakesPrecedenceOverActivationServices()
+    {
+        var componentRuntime = Substitute.For<IGrainRuntime>();
+        var serviceRuntime = Substitute.For<IGrainRuntime>();
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(serviceRuntime)
+            .BuildServiceProvider();
+        var grainContext = new TestGrainContext(serviceProvider);
+        grainContext.SetComponent(componentRuntime);
+        var grain = new TestGrain(grainContext);
+
+        Assert.Same(componentRuntime, grain.Runtime);
+        Assert.Equal(0, grainContext.ActivationServicesAccessCount);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void Runtime_ContextComponentUnavailable_UsesActivationServices()
+    {
+        var grainRuntime = Substitute.For<IGrainRuntime>();
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(grainRuntime)
+            .BuildServiceProvider();
+        var grainContext = new TestGrainContext(serviceProvider);
+        var grain = new TestGrain(grainContext);
+
+        Assert.Same(grainRuntime, grain.Runtime);
+        Assert.Equal(1, grainContext.GetComponentCallCount);
+        Assert.Equal(1, grainContext.ActivationServicesAccessCount);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void Runtime_Unavailable_ThrowsDeterministicException()
+    {
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var grain = new TestGrain(new TestGrainContext(serviceProvider));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => grain.Runtime);
+
+        Assert.Equal("Grain was created outside of the Orleans creation process and no runtime was specified.", exception.Message);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void Runtime_NullActivationServices_ThrowsDeterministicException()
+    {
+        var grain = new TestGrain(new TestGrainContext());
+
+        var exception = Assert.Throws<InvalidOperationException>(() => grain.Runtime);
+
+        Assert.Equal("Grain was created outside of the Orleans creation process and no runtime was specified.", exception.Message);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void DirectConstruction_WithoutRuntime_PreservesOptionalRuntimeBehavior()
+    {
+        var grain = new TestGrain(null!);
+
+        Assert.Null(grain.ServiceProvider);
+        Assert.Empty(grain.RuntimeIdentity);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task Runtime_RemainsAvailableAcrossLifecycleCallbacks()
+    {
+        var grainRuntime = Substitute.For<IGrainRuntime>();
+        var grainContext = new TestGrainContext();
+        grainContext.SetComponent(grainRuntime);
+        var grain = new LifecycleGrain(grainContext);
+
+        await grain.OnActivateAsync(CancellationToken.None);
+        await grain.OnDeactivateAsync(new(DeactivationReasonCode.ApplicationRequested, "test"), CancellationToken.None);
+
+        Assert.Same(grainRuntime, grain.ActivationRuntime);
+        Assert.Same(grainRuntime, grain.DeactivationRuntime);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void Grain_DoesNotRetainRuntimeField()
+    {
+        var runtimeFields = typeof(Grain)
+            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Where(field => field.FieldType == typeof(IGrainRuntime));
+
+        Assert.Empty(runtimeFields);
+    }
+
+    private sealed class TestGrain(IGrainContext grainContext, IGrainRuntime? grainRuntime = null)
+        : Grain(grainContext, grainRuntime);
+
+    private sealed class LifecycleGrain(IGrainContext grainContext) : Grain(grainContext)
+    {
+        public IGrainRuntime? ActivationRuntime { get; private set; }
+
+        public IGrainRuntime? DeactivationRuntime { get; private set; }
+
+        public override Task OnActivateAsync(CancellationToken cancellationToken)
+        {
+            ActivationRuntime = Runtime;
+            return Task.CompletedTask;
+        }
+
+        public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+        {
+            DeactivationRuntime = Runtime;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestGrainContext(IServiceProvider? activationServices = null) : IGrainContext
+    {
+        private readonly Dictionary<Type, object> _components = [];
+
+        public int ActivationServicesAccessCount;
+        public int GetComponentCallCount;
+        public int SetComponentCallCount;
+
+        public GrainReference GrainReference => throw new NotImplementedException();
+        public GrainId GrainId => default;
+        public object? GrainInstance => null;
+        public ActivationId ActivationId => default;
+        public GrainAddress Address => throw new NotImplementedException();
+        public IServiceProvider ActivationServices
+        {
+            get
+            {
+                Interlocked.Increment(ref ActivationServicesAccessCount);
+                return activationServices!;
+            }
+        }
+
+        public IGrainLifecycle ObservableLifecycle => throw new NotImplementedException();
+        public IWorkItemScheduler Scheduler => throw new NotImplementedException();
+        public Task Deactivated => Task.CompletedTask;
+        public PlacementStrategy PlacementStrategy => throw new NotImplementedException();
+
+        public object? GetComponent(Type componentType)
+        {
+            Interlocked.Increment(ref GetComponentCallCount);
+            return _components.TryGetValue(componentType, out var component) ? component : null;
+        }
+
+        public object? GetTarget() => null;
+
+        public void SetComponent<TComponent>(TComponent? value) where TComponent : class
+        {
+            Interlocked.Increment(ref SetComponentCallCount);
+            if (value is null)
+            {
+                _components.Remove(typeof(TComponent));
+            }
+            else
+            {
+                _components[typeof(TComponent)] = value;
+            }
+        }
+
+        public void ReceiveMessage(object message) => throw new NotImplementedException();
+        public void Activate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public void Deactivate(DeactivationReason deactivationReason, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public void Rehydrate(IRehydrationContext context) => throw new NotImplementedException();
+        public void Migrate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public bool Equals(IGrainContext? other) => ReferenceEquals(this, other);
+    }
+}

--- a/test/Orleans.Core.Tests/Runtime/GrainRuntimeResolutionTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/GrainRuntimeResolutionTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Orleans;
@@ -142,6 +143,21 @@ public class GrainRuntimeResolutionTests
     }
 
     [Fact, TestCategory("BVT")]
+    public void DirectConstruction_WithExplicitRuntime_PreservesRuntimeBehavior()
+    {
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var grainRuntime = Substitute.For<IGrainRuntime>();
+        grainRuntime.ServiceProvider.Returns(serviceProvider);
+        grainRuntime.SiloIdentity.Returns("test-silo");
+
+        var grain = new TestGrain(null!, grainRuntime);
+
+        Assert.Same(grainRuntime, grain.Runtime);
+        Assert.Same(serviceProvider, grain.ServiceProvider);
+        Assert.Equal("test-silo", grain.RuntimeIdentity);
+    }
+
+    [Fact, TestCategory("BVT")]
     public async Task Runtime_RemainsAvailableAcrossLifecycleCallbacks()
     {
         var grainRuntime = Substitute.For<IGrainRuntime>();
@@ -164,6 +180,102 @@ public class GrainRuntimeResolutionTests
             .Where(field => field.FieldType == typeof(IGrainRuntime));
 
         Assert.Empty(runtimeFields);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void ActivationContext_RuntimeOverride_IsPerActivation()
+    {
+        var defaultRuntime = Substitute.For<IGrainRuntime>();
+        var overrideRuntime = Substitute.For<IGrainRuntime>();
+        var shared = CreateSharedContext(defaultRuntime);
+        var first = CreateActivationData(shared);
+        var second = CreateActivationData(shared);
+
+        ((IGrainContext)first).GrainRuntime = overrideRuntime;
+
+        Assert.Same(overrideRuntime, first.GrainRuntime);
+        Assert.Same(defaultRuntime, second.GrainRuntime);
+        Assert.Same(defaultRuntime, shared.Runtime);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task ActivationContext_RuntimeOverride_IsSafelyPublished()
+    {
+        var defaultRuntime = Substitute.For<IGrainRuntime>();
+        var overrideRuntime = Substitute.For<IGrainRuntime>();
+        var activation = CreateActivationData(CreateSharedContext(defaultRuntime));
+        var context = (IGrainContext)activation;
+
+        var writer = Task.Run(() =>
+        {
+            for (var i = 0; i < 100_000; i++)
+            {
+                context.GrainRuntime = (i & 1) == 0 ? overrideRuntime : null;
+            }
+        }, TestContext.Current.CancellationToken);
+        var reader = Task.Run(() =>
+        {
+            for (var i = 0; i < 100_000; i++)
+            {
+                var runtime = context.GrainRuntime;
+                Assert.True(ReferenceEquals(runtime, defaultRuntime) || ReferenceEquals(runtime, overrideRuntime));
+            }
+        }, TestContext.Current.CancellationToken);
+
+        await Task.WhenAll(writer, reader);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void ActivationContext_ClearingAbsentRuntimeOverride_DoesNotCreateExtras()
+    {
+        var activation = CreateActivationData(CreateSharedContext(Substitute.For<IGrainRuntime>()));
+
+        ((IGrainContext)activation).GrainRuntime = null;
+
+        Assert.Null(typeof(ActivationData)
+            .GetField("_extras", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(activation));
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void StatelessWorkerContext_RuntimeOverride_DoesNotMutateSharedContext()
+    {
+        var defaultRuntime = Substitute.For<IGrainRuntime>();
+        var overrideRuntime = Substitute.For<IGrainRuntime>();
+        var shared = CreateSharedContext(defaultRuntime);
+        var statelessShared = (StatelessWorkerGrainTypeSharedContext)RuntimeHelpers.GetUninitializedObject(typeof(StatelessWorkerGrainTypeSharedContext));
+        typeof(StatelessWorkerGrainTypeSharedContext)
+            .GetField("<Shared>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(statelessShared, shared);
+        var context = (StatelessWorkerGrainContext)RuntimeHelpers.GetUninitializedObject(typeof(StatelessWorkerGrainContext));
+        typeof(StatelessWorkerGrainContext)
+            .GetField("_shared", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(context, statelessShared);
+
+        ((IGrainContext)context).GrainRuntime = defaultRuntime;
+        var exception = Assert.Throws<ArgumentException>(() => ((IGrainContext)context).GrainRuntime = overrideRuntime);
+
+        Assert.Equal("value", exception.ParamName);
+        Assert.Same(defaultRuntime, context.GrainRuntime);
+        Assert.Same(defaultRuntime, shared.Runtime);
+    }
+
+    private static GrainTypeSharedContext CreateSharedContext(IGrainRuntime runtime)
+    {
+        var shared = (GrainTypeSharedContext)RuntimeHelpers.GetUninitializedObject(typeof(GrainTypeSharedContext));
+        typeof(GrainTypeSharedContext)
+            .GetField("<Runtime>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(shared, runtime);
+        return shared;
+    }
+
+    private static ActivationData CreateActivationData(GrainTypeSharedContext shared)
+    {
+        var activation = (ActivationData)RuntimeHelpers.GetUninitializedObject(typeof(ActivationData));
+        typeof(ActivationData)
+            .GetField("_shared", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(activation, shared);
+        return activation;
     }
 
     private sealed class TestGrain(IGrainContext grainContext, IGrainRuntime? grainRuntime = null)

--- a/test/Orleans.Core.Tests/Runtime/GrainRuntimeResolutionTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/GrainRuntimeResolutionTests.cs
@@ -260,6 +260,17 @@ public class GrainRuntimeResolutionTests
         Assert.Same(defaultRuntime, shared.Runtime);
     }
 
+    [Fact, TestCategory("BVT")]
+    public void LocalObserverContext_DoesNotAccessUnsupportedActivationServices()
+    {
+        var context = (IGrainContext)RuntimeHelpers.GetUninitializedObject(typeof(InvokableObjectManager.LocalObjectData));
+
+        Assert.Null(context.GrainRuntime);
+        var exception = Assert.Throws<ArgumentException>(() => context.GrainRuntime = Substitute.For<IGrainRuntime>());
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
     private static GrainTypeSharedContext CreateSharedContext(IGrainRuntime runtime)
     {
         var shared = (GrainTypeSharedContext)RuntimeHelpers.GetUninitializedObject(typeof(GrainTypeSharedContext));

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/CustomToleranceTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/CustomToleranceTests.cs
@@ -185,13 +185,13 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
         public Task<SiloAddress> GetAddress() => Task.FromResult(GrainContext.Address.SiloAddress!);
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            ServiceProvider.GetRequiredService<ILogger<E>>().LogInformation("Activating {GrainId} on silo {SiloAddress}", this.GrainId, this.Runtime.SiloAddress);
+            ServiceProvider!.GetRequiredService<ILogger<E>>().LogInformation("Activating {GrainId} on silo {SiloAddress}", this.GrainId, this.Runtime.SiloAddress);
             return base.OnActivateAsync(cancellationToken);
         }
 
         public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
-            ServiceProvider.GetRequiredService<ILogger<E>>().LogInformation("Deactivating {GrainId} on silo {SiloAddress}. Reason: {Reason}", this.GrainId, this.Runtime.SiloAddress, reason);
+            ServiceProvider!.GetRequiredService<ILogger<E>>().LogInformation("Deactivating {GrainId} on silo {SiloAddress}. Reason: {Reason}", this.GrainId, this.Runtime.SiloAddress, reason);
             return base.OnDeactivateAsync(reason, cancellationToken);
         }
     }
@@ -204,13 +204,13 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
 
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            ServiceProvider.GetRequiredService<ILogger<F>>().LogInformation("Activating {GrainId} on silo {SiloAddress}", this.GrainId, this.Runtime.SiloAddress);
+            ServiceProvider!.GetRequiredService<ILogger<F>>().LogInformation("Activating {GrainId} on silo {SiloAddress}", this.GrainId, this.Runtime.SiloAddress);
             return base.OnActivateAsync(cancellationToken);
         }
 
         public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
-            ServiceProvider.GetRequiredService<ILogger<F>>().LogInformation("Deactivating {GrainId} on silo {SiloAddress}. Reason: {Reason}", this.GrainId, this.Runtime.SiloAddress, reason);
+            ServiceProvider!.GetRequiredService<ILogger<F>>().LogInformation("Deactivating {GrainId} on silo {SiloAddress}. Reason: {Reason}", this.GrainId, this.Runtime.SiloAddress, reason);
             return base.OnDeactivateAsync(reason, cancellationToken);
         }
     }
@@ -227,13 +227,13 @@ public class CustomToleranceTests(CustomToleranceTests.Fixture fixture, ITestOut
 
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            ServiceProvider.GetRequiredService<ILogger<X>>().LogInformation("Activating {GrainId} on silo {SiloAddress}", this.GrainId, this.Runtime.SiloAddress);
+            ServiceProvider!.GetRequiredService<ILogger<X>>().LogInformation("Activating {GrainId} on silo {SiloAddress}", this.GrainId, this.Runtime.SiloAddress);
             return base.OnActivateAsync(cancellationToken);
         }
 
         public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
-            ServiceProvider.GetRequiredService<ILogger<X>>().LogInformation("Deactivating {GrainId} on silo {SiloAddress}. Reason: {Reason}", this.GrainId, this.Runtime.SiloAddress, reason);
+            ServiceProvider!.GetRequiredService<ILogger<X>>().LogInformation("Deactivating {GrainId} on silo {SiloAddress}. Reason: {Reason}", this.GrainId, this.Runtime.SiloAddress, reason);
             return base.OnDeactivateAsync(reason, cancellationToken);
         }
     }

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/Grains/BlockingCallGrains.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/Grains/BlockingCallGrains.cs
@@ -48,7 +48,7 @@ namespace Orleans.TestingHost.Tests.Grains
             => GetState(key).Entered.WaitAsync(timeout, cancellationToken);
 
         public Task<string> GetSiloIdentity() =>
-            Task.FromResult(this.ServiceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress.ToString());
+            Task.FromResult(ServiceProvider!.GetRequiredService<ILocalSiloDetails>().SiloAddress.ToString());
 
         public Task BlockUntilReleased()
         {
@@ -87,7 +87,7 @@ namespace Orleans.TestingHost.Tests.Grains
     public class LauncherGrain : Grain, ILauncherGrain
     {
         public Task<string> GetSiloIdentity() =>
-            Task.FromResult(this.ServiceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress.ToString());
+            Task.FromResult(ServiceProvider!.GetRequiredService<ILocalSiloDetails>().SiloAddress.ToString());
 
         public Task StartBlockingCall(ILocalWorkerGrain worker, IRemoteBlockerGrain remote)
         {


### PR DESCRIPTION
## Reason

Each `Grain` instance retained an `IGrainRuntime` reference even though its activation context already owns access to the configured runtime. Keeping runtime access on the grain duplicated state across every activation.

## Solution

Add `IGrainContext.GrainRuntime` and make `Grain` delegate runtime access to its context. Runtime contexts expose the configured shared runtime directly, while the default interface implementation supports custom contexts through an `IGrainRuntime` component or activation-service registration.

The protected `Grain(IGrainContext, IGrainRuntime?)` constructor now installs the supplied test runtime through `IGrainContext.GrainRuntime`. `ActivationData` and `GrainTypeSharedContext` use dedicated, safely published override fields so normal runtime access performs field reads rather than component dictionary or DI lookups. Stateless-worker contexts delegate to the same shared runtime.

Required runtime access retains the deterministic `InvalidOperationException` when no runtime is available. Optional direct-construction behavior remains compatible: `ServiceProvider` can be null and `RuntimeIdentity` returns an empty string.

## Measured tradeoff

BenchmarkDotNet on .NET 10 measured the eager grain shape at 32 bytes and the context-owned shape at 24 bytes. Retained managed memory scaled from approximately 40 to 32 bytes per array-held grain, confirming an 8-byte grain-object reduction: about 8 MB per million live grain objects, 24 MB at three million, and 48 MB at six million.

Activations whose `ActivationDataExtra` is allocated also carry an 8-byte optional runtime-override slot, and each grain type has one additional shared override slot. Consequently, the full object-graph saving is approximately `8 × (grains without extras) - 8 × grain types`; stateless-worker activations always have extras, so their total retained-memory saving is effectively zero.

Construction improved from 19.24 ns to 10.90 ns when runtime was never accessed and from 18.85 ns to 9.80 ns including first access. Cached ordinary access measured 0.97 ns versus 1.48 ns; the stateless/extras path measured 0.97 ns versus 1.87 ns. All paths remain allocation-free after construction.

## OrleansTestKit migration

Current OrleansTestKit versions reflect the removed `Grain.Runtime` backing field. TestKit must instead set `context.GrainRuntime` (or register an `IGrainRuntime` component/service) before grain creation and remove the backing-field reflection. The new context API includes a setter specifically for this test override seam.

Focused coverage exercises component and DI fallback precedence, standard mock contexts, explicit runtime injection, concurrent access, unavailable-runtime diagnostics, direct construction, lifecycle callbacks, field removal, and the existing stateless-worker runtime path.