### PR TITLE
Avoid per-activation scheduler logger fields

### DIFF
--- a/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
+++ b/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Metadata;
@@ -11,8 +10,6 @@ internal partial class ActivationDataActivatorProvider(
     GrainClassMap grainClassMap,
     IServiceProvider serviceProvider,
     GrainTypeSharedContextResolver sharedComponentsResolver,
-    ILogger<WorkItemGroup> workItemGroupLogger,
-    ILogger<ActivationTaskScheduler> activationTaskSchedulerLogger,
     IOptions<SchedulingOptions> schedulingOptions,
     IOptions<StatelessWorkerOptions> statelessWorkerOptions) : IGrainContextActivatorProvider
 {
@@ -35,8 +32,6 @@ internal partial class ActivationDataActivatorProvider(
             instanceActivator,
             serviceProvider,
             sharedContext,
-            workItemGroupLogger,
-            activationTaskSchedulerLogger,
             schedulingOptions);
 
         if (sharedContext.PlacementStrategy is StatelessWorkerPlacement)
@@ -54,8 +49,6 @@ internal partial class ActivationDataActivatorProvider(
 
     private partial class ActivationDataActivator : IGrainContextActivator
     {
-        private readonly ILogger<WorkItemGroup> _workItemGroupLogger;
-        private readonly ILogger<ActivationTaskScheduler> _activationTaskSchedulerLogger;
         private readonly IOptions<SchedulingOptions> _schedulingOptions;
         private readonly IGrainActivator _grainActivator;
         private readonly IServiceProvider _serviceProvider;
@@ -67,22 +60,16 @@ internal partial class ActivationDataActivatorProvider(
             IGrainActivator grainActivator,
             IServiceProvider serviceProvider,
             GrainTypeSharedContext sharedComponents,
-            ILogger<WorkItemGroup> workItemGroupLogger,
-            ILogger<ActivationTaskScheduler> activationTaskSchedulerLogger,
             IOptions<SchedulingOptions> schedulingOptions)
         {
-            _workItemGroupLogger = workItemGroupLogger;
-            _activationTaskSchedulerLogger = activationTaskSchedulerLogger;
             _schedulingOptions = schedulingOptions;
             _grainActivator = grainActivator;
             _serviceProvider = serviceProvider;
             _sharedComponents = sharedComponents;
             _createWorkItemGroup = context => new WorkItemGroup(
                 context,
-                _workItemGroupLogger,
-                _activationTaskSchedulerLogger,
                 _schedulingOptions);
-             _startActivation = state => ((ActivationData)state!).Start(_grainActivator);
+            _startActivation = state => ((ActivationData)state!).Start(_grainActivator);
         }
 
         public IGrainContext CreateContext(GrainAddress activationAddress)

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -9,6 +9,7 @@ using Orleans.GrainDirectory;
 using Orleans.GrainReferences;
 using Orleans.Metadata;
 using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Scheduler;
 using Orleans.Runtime.Placement;
 using Orleans.Serialization.Session;
 using Orleans.Serialization.TypeSystem;
@@ -45,6 +46,7 @@ public sealed class GrainTypeSharedContext
         SerializerSessionPool = serializerSessionPool;
         GrainTypeName = RuntimeTypeNameFormatter.Format(grainClass);
         Logger = loggerFactory.CreateLogger("Orleans.Grain");
+        SchedulerLogger = loggerFactory.CreateLogger<WorkItemGroup>();
         MessagingOptions = messagingOptions.Value;
         GrainReferenceActivator = grainReferenceActivator;
         _serviceProvider = serviceProvider;
@@ -160,6 +162,8 @@ public sealed class GrainTypeSharedContext
     /// Gets the logger.
     /// </summary>
     public ILogger Logger { get; }
+
+    internal ILogger SchedulerLogger { get; }
 
     /// <summary>
     /// Gets the serializer session pool.

--- a/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
+++ b/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
@@ -17,8 +17,6 @@ internal sealed class SystemTargetShared(
     ITimerRegistry timerRegistry,
     ActivationDirectory activations)
 {
-    private readonly ILogger<WorkItemGroup> _workItemGroupLogger = loggerFactory.CreateLogger<WorkItemGroup>();
-    private readonly ILogger<ActivationTaskScheduler> _activationTaskSchedulerLogger = loggerFactory.CreateLogger<ActivationTaskScheduler>();
     public SiloAddress SiloAddress => localSiloDetails.SiloAddress;
 
     public ILoggerFactory LoggerFactory => loggerFactory;
@@ -33,8 +31,6 @@ internal sealed class SystemTargetShared(
         ArgumentNullException.ThrowIfNull(systemTarget);
         return new WorkItemGroup(
             systemTarget,
-            _workItemGroupLogger,
-            _activationTaskSchedulerLogger,
             schedulingOptions);
     }
 }

--- a/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
+++ b/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
@@ -20,6 +20,7 @@ internal sealed class SystemTargetShared(
     public SiloAddress SiloAddress => localSiloDetails.SiloAddress;
 
     public ILoggerFactory LoggerFactory => loggerFactory;
+    internal ILogger SchedulerLogger { get; } = loggerFactory.CreateLogger<WorkItemGroup>();
     public GrainReferenceActivator GrainReferenceActivator => grainReferenceActivator;
     public ITimerRegistry TimerRegistry => timerRegistry;
 

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -28,6 +28,8 @@ namespace Orleans.Runtime
         internal ActivationId ActivationId { get; set; }
         private readonly ILogger _logger;
 
+        internal ILogger SchedulerLogger => _shared.SchedulerLogger;
+
         internal InsideRuntimeClient RuntimeClient => _shared.RuntimeClient;
 
         /// <inheritdoc/>

--- a/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
+++ b/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs
@@ -14,24 +14,30 @@ namespace Orleans.Runtime.Scheduler
     [DebuggerDisplay("ActivationTaskScheduler RunQueue={workerGroup.ExternalWorkItemCount} GrainContext={workerGroup.GrainContext}")]
     internal sealed partial class ActivationTaskScheduler : TaskScheduler
     {
+#if DEBUG
         private readonly ILogger logger;
 
         private static long idCounter;
         private readonly long myId;
+#endif
         private readonly WorkItemGroup workerGroup;
 #if EXTRA_STATS
         private readonly CounterStatistic turnsExecutedStatistic;
 #endif
 
-        internal ActivationTaskScheduler(WorkItemGroup workGroup, ILogger<ActivationTaskScheduler> logger)
+        internal ActivationTaskScheduler(WorkItemGroup workGroup)
         {
-            this.logger = logger;
+#if DEBUG
+            logger = workGroup.Logger;
             myId = Interlocked.Increment(ref idCounter);
+#endif
             workerGroup = workGroup;
 #if EXTRA_STATS
             turnsExecutedStatistic = CounterStatistic.FindOrCreate(name + ".TasksExecuted");
 #endif
+#if DEBUG
             LogCreatedTaskScheduler(this, workerGroup.GrainContext);
+#endif
         }
 
         /// <summary>Gets an enumerable of the tasks currently scheduled on this scheduler.</summary>
@@ -108,8 +114,16 @@ namespace Orleans.Runtime.Scheduler
             return done;
         }
 
-        public override string ToString() => $"{GetType().Name}-{myId}:Queued={workerGroup.ExternalWorkItemCount}";
+        public override string ToString()
+        {
+#if DEBUG
+            return $"{GetType().Name}-{myId}:Queued={workerGroup.ExternalWorkItemCount}";
+#else
+            return $"{GetType().Name}:Queued={workerGroup.ExternalWorkItemCount}";
+#endif
+        }
 
+#if DEBUG
         [LoggerMessage(
             Level = LogLevel.Debug,
             Message = "Created {TaskScheduler} with GrainContext={GrainContext}"
@@ -152,5 +166,6 @@ namespace Orleans.Runtime.Scheduler
             Message = "{TaskScheduler} Completed TryExecuteTaskInline Task Id={TaskId} Thread={Thread} Execute=Done Ok={Ok}"
         )]
         private partial void LogTraceTryExecuteTaskInlineCompleted(long taskScheduler, int taskId, int thread, bool ok);
+#endif
     }
 }

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -43,7 +43,12 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
 
     public IGrainContext GrainContext { get; set; }
 
-    internal ILogger Logger => GrainContext.ActivationServices.GetRequiredService<ILogger<WorkItemGroup>>();
+    internal ILogger Logger => GrainContext switch
+    {
+        ActivationData activation => activation.Shared.SchedulerLogger,
+        SystemTarget systemTarget => systemTarget.SchedulerLogger,
+        _ => GrainContext.ActivationServices.GetRequiredService<ILogger<WorkItemGroup>>()
+    };
 
     internal int ExternalWorkItemCount
     {

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
@@ -22,7 +23,6 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
         Running = 2
     }
 
-    private readonly ILogger _log;
 #if NET9_0_OR_GREATER
     private readonly Lock _lockObj = new();
 #else
@@ -43,6 +43,8 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
 
     public IGrainContext GrainContext { get; set; }
 
+    internal ILogger Logger => GrainContext.ActivationServices.GetRequiredService<ILogger<WorkItemGroup>>();
+
     internal int ExternalWorkItemCount
     {
         get { lock (_lockObj) { return _workItems.Count; } }
@@ -50,16 +52,13 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
 
     public WorkItemGroup(
         IGrainContext grainContext,
-        ILogger<WorkItemGroup> logger,
-        ILogger<ActivationTaskScheduler> activationTaskSchedulerLogger,
         IOptions<SchedulingOptions> schedulingOptions)
     {
         ArgumentNullException.ThrowIfNull(grainContext);
         GrainContext = grainContext;
         _schedulingOptions = schedulingOptions.Value;
         _state = WorkGroupStatus.Waiting;
-        _log = logger;
-        TaskScheduler = new ActivationTaskScheduler(this, activationTaskSchedulerLogger);
+        TaskScheduler = new ActivationTaskScheduler(this);
     }
 
     /// <summary>
@@ -70,9 +69,10 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
     public void EnqueueTask(Task task)
     {
 #if DEBUG
-        if (_log.IsEnabled(LogLevel.Trace))
+        var logger = Logger;
+        if (logger.IsEnabled(LogLevel.Trace))
         {
-            LogTraceEnqueueWorkItem(_log, task, GrainContext, System.Threading.Tasks.TaskScheduler.Current);
+            LogTraceEnqueueWorkItem(logger, task, GrainContext, System.Threading.Tasks.TaskScheduler.Current);
         }
 #endif
 
@@ -101,9 +101,10 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
 
             _state = WorkGroupStatus.Runnable;
 #if DEBUG
-            if (_log.IsEnabled(LogLevel.Trace))
+            var runQueueLogger = Logger;
+            if (runQueueLogger.IsEnabled(LogLevel.Trace))
             {
-                LogTraceAddToRunQueue(_log, task, thisSequenceNumber, GrainContext);
+                LogTraceAddToRunQueue(runQueueLogger, task, thisSequenceNumber, GrainContext);
             }
 #endif
             ScheduleExecution(this);
@@ -113,7 +114,7 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void LogTooManyTasksInQueue(int count, int maxPendingItemsLimit)
     {
-        LogWarningTooManyPendingItems(_log, count, GrainContext?.ToString() ?? "Unknown", maxPendingItemsLimit);
+        LogWarningTooManyPendingItems(Logger, count, GrainContext?.ToString() ?? "Unknown", maxPendingItemsLimit);
     }
 
     /// <summary>
@@ -215,9 +216,10 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void LogTaskStart(Task task)
     {
-        if (_log.IsEnabled(LogLevel.Trace))
+        var logger = Logger;
+        if (logger.IsEnabled(LogLevel.Trace))
         {
-            LogTraceAboutToExecuteTask(_log, task, GrainContext);
+            LogTraceAboutToExecuteTask(logger, task, GrainContext);
         }
     }
 #endif
@@ -225,7 +227,7 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void LogTaskLoopError(Exception ex)
     {
-        LogErrorTaskLoop(_log, ex, Environment.CurrentManagedThreadId);
+        LogErrorTaskLoop(Logger, ex, Environment.CurrentManagedThreadId);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -238,7 +240,7 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
 
         var taskDuration = TimeSpan.FromMilliseconds(taskDurationMs);
         LogWarningLongRunningTurn(
-            _log,
+            Logger,
             task.AsyncState ?? task,
             GrainContext?.ToString() ?? "Unknown",
             taskDuration.ToString("g"),

--- a/test/Orleans.Core.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
+++ b/test/Orleans.Core.Tests/SchedulerTests/OrleansTaskSchedulerBasicTests.cs
@@ -17,11 +17,13 @@ namespace UnitTests.SchedulerTests
         public static UnitTestSchedulingContext Create(ILoggerFactory loggerFactory)
         {
             var result = new UnitTestSchedulingContext();
-            result.WorkItemGroup = SchedulingHelper.CreateWorkItemGroupForTesting(result, loggerFactory);
+            result.WorkItemGroup = SchedulingHelper.CreateWorkItemGroupForTesting(result, loggerFactory, out result._activationServices);
             return result;
         }
 
         private UnitTestSchedulingContext() { }
+
+        private IServiceProvider _activationServices;
 
         public WorkItemGroup WorkItemGroup { get; private set; }
 
@@ -35,7 +37,7 @@ namespace UnitTests.SchedulerTests
 
         public GrainAddress Address => throw new NotImplementedException();
 
-        public IServiceProvider ActivationServices => throw new NotImplementedException();
+        public IServiceProvider ActivationServices => _activationServices;
 
         public IDictionary<object, object> Items => throw new NotImplementedException();
 
@@ -52,7 +54,11 @@ namespace UnitTests.SchedulerTests
         public void Activate(Dictionary<string, object> requestContext, CancellationToken cancellationToken) => throw new NotImplementedException();
         public void Deactivate(DeactivationReason deactivationReason, CancellationToken cancellationToken) { }
         public Task Deactivated => Task.CompletedTask;
-        public void Dispose() => (Scheduler as IDisposable)?.Dispose();
+        public void Dispose()
+        {
+            (Scheduler as IDisposable)?.Dispose();
+            (_activationServices as IDisposable)?.Dispose();
+        }
         public object GetComponent(Type componentType) => throw new NotImplementedException();
         public object GetTarget() => throw new NotImplementedException();
         public void ReceiveMessage(object message) => throw new NotImplementedException();

--- a/test/Orleans.Core.Tests/SchedulingHelper.cs
+++ b/test/Orleans.Core.Tests/SchedulingHelper.cs
@@ -11,7 +11,8 @@ namespace UnitTests.TesterInternal
     {
         internal static WorkItemGroup CreateWorkItemGroupForTesting(
             IGrainContext context,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            out IServiceProvider activationServices)
         {
             ArgumentNullException.ThrowIfNull(context);
             ArgumentNullException.ThrowIfNull(loggerFactory);
@@ -27,13 +28,10 @@ namespace UnitTests.TesterInternal
                 options.StoppedActivationWarningInterval = TimeSpan.FromMilliseconds(200);
             });
 
-            var s = services.BuildServiceProvider();
-            var result = new WorkItemGroup(
+            activationServices = services.BuildServiceProvider();
+            return new WorkItemGroup(
                 context,
-                s.GetRequiredService<ILogger<WorkItemGroup>>(),
-                s.GetRequiredService<ILogger<ActivationTaskScheduler>>(),
-                s.GetRequiredService<IOptions<SchedulingOptions>>());
-            return result;
+                activationServices.GetRequiredService<IOptions<SchedulingOptions>>());
         }
     }
 }


### PR DESCRIPTION
Reduce per-activation scheduler overhead by removing logger fields from `WorkItemGroup` and making `ActivationTaskScheduler` logging state debug-only.

This intentionally avoids the broader scheduler queue and synchronization-context refactors from the aggregate branch.

Validation: `dotnet build src\Orleans.Runtime\Orleans.Runtime.csproj --nologo --verbosity:minimal`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10118)