### PR TITLE
perf(runtime): reduce request monitoring memory footprint

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -180,7 +180,6 @@ internal sealed partial class ActivationData :
     public int WaitingCount => _waitingRequests.Count;
     public bool IsInactive => !IsCurrentlyExecuting && _waitingRequests.Count == 0;
     public bool IsCurrentlyExecuting => _runningRequests.Count > 0;
-    public bool IsIdle { get; set; }
     public IWorkItemScheduler Scheduler => _workItemGroup;
     public Task Deactivated => GetDeactivationCompletionSource().Task;
 

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -180,6 +180,7 @@ internal sealed partial class ActivationData :
     public int WaitingCount => _waitingRequests.Count;
     public bool IsInactive => !IsCurrentlyExecuting && _waitingRequests.Count == 0;
     public bool IsCurrentlyExecuting => _runningRequests.Count > 0;
+    public bool IsIdle { get; set; }
     public IWorkItemScheduler Scheduler => _workItemGroup;
     public Task Deactivated => GetDeactivationCompletionSource().Task;
 

--- a/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
@@ -38,13 +38,7 @@ namespace Orleans.Runtime
 
         public int Count => _activeCount;
 
-        internal void ForEach<TState>(Action<IActivationWorkingSetMember, bool, TState> action, TState state)
-        {
-            foreach (var pair in _members)
-            {
-                action(pair.Key, pair.Value, state);
-            }
-        }
+        internal IEnumerable<KeyValuePair<IActivationWorkingSetMember, bool>> Members => _members;
 
         public void OnActivated(IActivationWorkingSetMember member)
         {
@@ -65,15 +59,21 @@ namespace Orleans.Runtime
 
         public void OnActive(IActivationWorkingSetMember member)
         {
-            _members.AddOrUpdate(
-                member,
-                static (_, state) =>
+            while (true)
+            {
+                if (_members.TryGetValue(member, out var isIdle))
                 {
-                    Interlocked.Increment(ref state._activeCount);
-                    return false;
-                },
-                static (_, _, _) => false,
-                this);
+                    if (_members.TryUpdate(member, false, comparisonValue: isIdle))
+                    {
+                        break;
+                    }
+                }
+                else if (_members.TryAdd(member, false))
+                {
+                    Interlocked.Increment(ref _activeCount);
+                    break;
+                }
+            }
 
             foreach (var observer in _observers)
             {
@@ -151,7 +151,11 @@ namespace Orleans.Runtime
             }
             else
             {
-                _members.TryUpdate(member, false, comparisonValue: isIdle);
+                if (isIdle)
+                {
+                    _members.TryUpdate(member, false, comparisonValue: true);
+                }
+
                 foreach (var observer in _observers)
                 {
                     observer.OnActive(member);

--- a/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
@@ -38,6 +38,14 @@ namespace Orleans.Runtime
 
         public int Count => _activeCount;
 
+        internal void ForEach<TState>(Action<IActivationWorkingSetMember, bool, TState> action, TState state)
+        {
+            foreach (var pair in _members)
+            {
+                action(pair.Key, pair.Value, state);
+            }
+        }
+
         public void OnActivated(IActivationWorkingSetMember member)
         {
             Debug.Assert(member is not ICollectibleGrainContext collectible || collectible.IsValid);

--- a/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
@@ -111,7 +111,7 @@ namespace Orleans.Runtime
                 {
                     try
                     {
-                        VisitMember(pair.Key);
+                        VisitMember(pair.Key, pair.Value);
                     }
                     catch (Exception exception)
                     {
@@ -121,9 +121,9 @@ namespace Orleans.Runtime
             }
         }
 
-        private void VisitMember(IActivationWorkingSetMember member)
+        private void VisitMember(IActivationWorkingSetMember member, bool isIdle)
         {
-            var wouldRemove = member.IsIdle;
+            var wouldRemove = isIdle;
             if (member.IsCandidateForRemoval(wouldRemove))
             {
                 if (wouldRemove)
@@ -132,16 +132,18 @@ namespace Orleans.Runtime
                 }
                 else
                 {
-                    member.IsIdle = true;
-                    foreach (var observer in _observers)
+                    if (_members.TryUpdate(member, true, comparisonValue: isIdle))
                     {
-                        observer.OnIdle(member);
+                        foreach (var observer in _observers)
+                        {
+                            observer.OnIdle(member);
+                        }
                     }
                 }
             }
             else
             {
-                member.IsIdle = false;
+                _members.TryUpdate(member, false, comparisonValue: isIdle);
                 foreach (var observer in _observers)
                 {
                     observer.OnActive(member);
@@ -214,11 +216,6 @@ namespace Orleans.Runtime
     /// </summary>
     public interface IActivationWorkingSetMember
     {
-        /// <summary>
-        /// Gets or sets a value indicating whether this member was idle during the previous working set scan.
-        /// </summary>
-        bool IsIdle { get; set; }
-
         /// <summary>
         /// Returns <see langword="true"/> if the member is eligible for removal, <see langword="false"/> otherwise.
         /// </summary>

--- a/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
@@ -17,12 +17,7 @@ namespace Orleans.Runtime
     /// </summary>
     internal sealed partial class ActivationWorkingSet : IActivationWorkingSet, ILifecycleParticipant<ISiloLifecycle>
     {
-        private class MemberState
-        {
-            public bool IsIdle { get; set; }
-        }
-
-        private readonly ConcurrentDictionary<IActivationWorkingSetMember, MemberState> _members = new();
+        private readonly ConcurrentDictionary<IActivationWorkingSetMember, bool> _members = new();
         private readonly ILogger _logger;
         private readonly IAsyncTimer _scanPeriodTimer;
         private readonly List<IActivationWorkingSetObserver> _observers;
@@ -46,7 +41,7 @@ namespace Orleans.Runtime
         public void OnActivated(IActivationWorkingSetMember member)
         {
             Debug.Assert(member is not ICollectibleGrainContext collectible || collectible.IsValid);
-            if (_members.TryAdd(member, new MemberState()))
+            if (_members.TryAdd(member, false))
             {
                 Interlocked.Increment(ref _activeCount);
                 foreach (var observer in _observers)
@@ -62,14 +57,15 @@ namespace Orleans.Runtime
 
         public void OnActive(IActivationWorkingSetMember member)
         {
-            if (_members.TryGetValue(member, out var state))
-            {
-                state.IsIdle = false;
-            }
-            else if (_members.TryAdd(member, new()))
-            {
-                Interlocked.Increment(ref _activeCount);
-            }
+            _members.AddOrUpdate(
+                member,
+                static (_, state) =>
+                {
+                    Interlocked.Increment(ref state._activeCount);
+                    return false;
+                },
+                static (_, _, _) => false,
+                this);
 
             foreach (var observer in _observers)
             {
@@ -115,7 +111,7 @@ namespace Orleans.Runtime
                 {
                     try
                     {
-                        VisitMember(pair.Key, pair.Value);
+                        VisitMember(pair.Key);
                     }
                     catch (Exception exception)
                     {
@@ -125,9 +121,9 @@ namespace Orleans.Runtime
             }
         }
 
-        private void VisitMember(IActivationWorkingSetMember member, MemberState state)
+        private void VisitMember(IActivationWorkingSetMember member)
         {
-            var wouldRemove = state.IsIdle;
+            var wouldRemove = member.IsIdle;
             if (member.IsCandidateForRemoval(wouldRemove))
             {
                 if (wouldRemove)
@@ -136,7 +132,7 @@ namespace Orleans.Runtime
                 }
                 else
                 {
-                    state.IsIdle = true;
+                    member.IsIdle = true;
                     foreach (var observer in _observers)
                     {
                         observer.OnIdle(member);
@@ -145,7 +141,7 @@ namespace Orleans.Runtime
             }
             else
             {
-                state.IsIdle = false;
+                member.IsIdle = false;
                 foreach (var observer in _observers)
                 {
                     observer.OnActive(member);
@@ -218,6 +214,11 @@ namespace Orleans.Runtime
     /// </summary>
     public interface IActivationWorkingSetMember
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether this member was idle during the previous working set scan.
+        /// </summary>
+        bool IsIdle { get; set; }
+
         /// <summary>
         /// Returns <see langword="true"/> if the member is eligible for removal, <see langword="false"/> otherwise.
         /// </summary>

--- a/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
@@ -17,7 +17,12 @@ namespace Orleans.Runtime
     /// </summary>
     internal sealed partial class ActivationWorkingSet : IActivationWorkingSet, ILifecycleParticipant<ISiloLifecycle>
     {
-        private readonly ConcurrentDictionary<IActivationWorkingSetMember, bool> _members = new();
+        private class MemberState
+        {
+            public bool IsIdle { get; set; }
+        }
+
+        private readonly ConcurrentDictionary<IActivationWorkingSetMember, MemberState> _members = new();
         private readonly ILogger _logger;
         private readonly IAsyncTimer _scanPeriodTimer;
         private readonly List<IActivationWorkingSetObserver> _observers;
@@ -38,12 +43,23 @@ namespace Orleans.Runtime
 
         public int Count => _activeCount;
 
-        internal IEnumerable<KeyValuePair<IActivationWorkingSetMember, bool>> Members => _members;
+        internal IEnumerable<IActivationWorkingSetMember> Members => EnumerateActiveMembers();
+
+        private IEnumerable<IActivationWorkingSetMember> EnumerateActiveMembers()
+        {
+            foreach (var pair in _members)
+            {
+                if (!pair.Value.IsIdle)
+                {
+                    yield return pair.Key;
+                }
+            }
+        }
 
         public void OnActivated(IActivationWorkingSetMember member)
         {
             Debug.Assert(member is not ICollectibleGrainContext collectible || collectible.IsValid);
-            if (_members.TryAdd(member, false))
+            if (_members.TryAdd(member, new MemberState()))
             {
                 Interlocked.Increment(ref _activeCount);
                 foreach (var observer in _observers)
@@ -59,20 +75,13 @@ namespace Orleans.Runtime
 
         public void OnActive(IActivationWorkingSetMember member)
         {
-            while (true)
+            if (_members.TryGetValue(member, out var state))
             {
-                if (_members.TryGetValue(member, out var isIdle))
-                {
-                    if (_members.TryUpdate(member, false, comparisonValue: isIdle))
-                    {
-                        break;
-                    }
-                }
-                else if (_members.TryAdd(member, false))
-                {
-                    Interlocked.Increment(ref _activeCount);
-                    break;
-                }
+                state.IsIdle = false;
+            }
+            else if (_members.TryAdd(member, new()))
+            {
+                Interlocked.Increment(ref _activeCount);
             }
 
             foreach (var observer in _observers)
@@ -129,9 +138,9 @@ namespace Orleans.Runtime
             }
         }
 
-        private void VisitMember(IActivationWorkingSetMember member, bool isIdle)
+        private void VisitMember(IActivationWorkingSetMember member, MemberState state)
         {
-            var wouldRemove = isIdle;
+            var wouldRemove = state.IsIdle;
             if (member.IsCandidateForRemoval(wouldRemove))
             {
                 if (wouldRemove)
@@ -140,22 +149,16 @@ namespace Orleans.Runtime
                 }
                 else
                 {
-                    if (_members.TryUpdate(member, true, comparisonValue: isIdle))
+                    state.IsIdle = true;
+                    foreach (var observer in _observers)
                     {
-                        foreach (var observer in _observers)
-                        {
-                            observer.OnIdle(member);
-                        }
+                        observer.OnIdle(member);
                     }
                 }
             }
             else
             {
-                if (isIdle)
-                {
-                    _members.TryUpdate(member, false, comparisonValue: true);
-                }
-
+                state.IsIdle = false;
                 foreach (var observer in _observers)
                 {
                     observer.OnActive(member);

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -14,58 +12,30 @@ namespace Orleans.Runtime
     /// <summary>
     /// Monitors currently-active requests and sends status notifications to callers for long-running and blocked requests.
     /// </summary>
-    internal sealed class IncomingRequestMonitor : ILifecycleParticipant<ISiloLifecycle>, IActivationWorkingSetObserver
+    internal sealed class IncomingRequestMonitor : ILifecycleParticipant<ISiloLifecycle>
     {
         private static readonly TimeSpan DefaultAnalysisPeriod = TimeSpan.FromSeconds(10);
-        private static readonly TimeSpan InactiveGrainIdleness = TimeSpan.FromMinutes(1);
         private readonly IAsyncTimer _scanPeriodTimer;
+        private readonly ActivationWorkingSet _activationWorkingSet;
         private readonly IServiceProvider _serviceProvider;
         private readonly MessageFactory _messageFactory;
         private readonly IOptionsMonitor<SiloMessagingOptions> _messagingOptions;
-        private readonly ConcurrentDictionary<ActivationData, bool> _recentlyUsedActivations = new ConcurrentDictionary<ActivationData, bool>(ReferenceEqualsComparer<ActivationData>.Default);
         private bool _enabled = true;
         private Task _runTask;
 
         public IncomingRequestMonitor(
+            ActivationWorkingSet activationWorkingSet,
             IAsyncTimerFactory asyncTimerFactory,
             IServiceProvider serviceProvider,
             MessageFactory messageFactory,
             IOptionsMonitor<SiloMessagingOptions> siloMessagingOptions)
         {
             _scanPeriodTimer = asyncTimerFactory.Create(TimeSpan.FromSeconds(1), nameof(IncomingRequestMonitor));
+            _activationWorkingSet = activationWorkingSet;
             _serviceProvider = serviceProvider;
             _messageFactory = messageFactory;
             _messagingOptions = siloMessagingOptions;
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void MarkRecentlyUsed(ActivationData activation)
-        {
-            if (!_enabled)
-            {
-                return;
-            }
-            
-            _recentlyUsedActivations.TryAdd(activation, true);
-        }
-
-        public void OnActive(IActivationWorkingSetMember member)
-        {
-            if (member is ActivationData activation)
-            {
-                MarkRecentlyUsed(activation);
-            }
-        }
-
-        public void OnIdle(IActivationWorkingSetMember member)
-        {
-            if (member is ActivationData activation)
-            {
-                _recentlyUsedActivations.TryRemove(activation, out _);
-            }
-        }
-
-        public void OnEvicted(IActivationWorkingSetMember member) => OnIdle(member);
 
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
         {
@@ -108,7 +78,6 @@ namespace Orleans.Runtime
                         _enabled = false;
                     }
 
-                    _recentlyUsedActivations.Clear();
                     continue;
                 }
 
@@ -118,23 +87,22 @@ namespace Orleans.Runtime
                     _enabled = true;
                 }
 
-                var iteration = 0;
                 var now = DateTime.UtcNow;
-                foreach (var activationEntry in _recentlyUsedActivations)
-                {
-                    var activation = activationEntry.Key;
-                    lock (activation)
+                _activationWorkingSet.ForEach(
+                    static (member, isIdle, state) =>
                     {
-                        activation.AnalyzeWorkload(now, messageCenter, _messageFactory, options);
-                    }
+                        var (self, messageCenter, options, now) = state;
+                        if (isIdle || member is not ActivationData activation)
+                        {
+                            return;
+                        }
 
-                    // Yield execution frequently
-                    if (++iteration % 100 == 0)
-                    {
-                        await Task.Yield();
-                        now = DateTime.UtcNow;
-                    }
-                }
+                        lock (activation)
+                        {
+                            activation.AnalyzeWorkload(now, messageCenter, self._messageFactory, options);
+                        }
+                    },
+                    (this, messageCenter, options, now));
             }
         }
     }

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -88,21 +88,24 @@ namespace Orleans.Runtime
                 }
 
                 var now = DateTime.UtcNow;
-                _activationWorkingSet.ForEach(
-                    static (member, isIdle, state) =>
+                var iteration = 0;
+                foreach (var pair in _activationWorkingSet.Members)
+                {
+                    var member = pair.Key;
+                    if (!pair.Value && member is ActivationData activation)
                     {
-                        var (self, messageCenter, options, now) = state;
-                        if (isIdle || member is not ActivationData activation)
-                        {
-                            return;
-                        }
-
                         lock (activation)
                         {
-                            activation.AnalyzeWorkload(now, messageCenter, self._messageFactory, options);
+                            activation.AnalyzeWorkload(now, messageCenter, _messageFactory, options);
                         }
-                    },
-                    (this, messageCenter, options, now));
+                    }
+
+                    if (++iteration % 100 == 0)
+                    {
+                        await Task.Yield();
+                        now = DateTime.UtcNow;
+                    }
+                }
             }
         }
     }

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -89,10 +89,9 @@ namespace Orleans.Runtime
 
                 var now = DateTime.UtcNow;
                 var iteration = 0;
-                foreach (var pair in _activationWorkingSet.Members)
+                foreach (var member in _activationWorkingSet.Members)
                 {
-                    var member = pair.Key;
-                    if (!pair.Value && member is ActivationData activation)
+                    if (member is ActivationData activation)
                     {
                         lock (activation)
                         {

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -272,7 +272,6 @@ namespace Orleans.Hosting
             services.AddSingleton<IGrainContextAccessor, GrainContextAccessor>();
             services.AddSingleton<IncomingRequestMonitor>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, IncomingRequestMonitor>();
-            services.AddFromExisting<IActivationWorkingSetObserver, IncomingRequestMonitor>();
             services.AddSingleton<ILocalActivationStatusChecker, Runtime.LocalActivationStatusChecker>();
 
             // Scoped to a grain activation


### PR DESCRIPTION
Remove `IncomingRequestMonitor` as a working-set observer and scan the existing activation working set instead of maintaining a second activation dictionary.

This branch includes the activation working-set memory changes because all PRs in this split target `dotnet/orleans:main`.

Validation: `dotnet build src\Orleans.Runtime\Orleans.Runtime.csproj --nologo --verbosity:minimal`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10119)