### PR TITLE
Fix grain lifecycle diagnostic listener name

### DIFF
--- a/src/Orleans.Runtime/Diagnostics/GrainLifecycleEvents.cs
+++ b/src/Orleans.Runtime/Diagnostics/GrainLifecycleEvents.cs
@@ -15,7 +15,7 @@ public static class GrainLifecycleEvents
     /// <summary>
     /// The name of the diagnostic listener for grain activation events.
     /// </summary>
-    public const string ListenerName = "Orleans.GrainsLifecycle";
+    public const string ListenerName = "Orleans.GrainLifecycle";
 
     private static readonly DiagnosticListener Listener = new(ListenerName);
 


### PR DESCRIPTION
## Reason
`GrainLifecycleEvents.ListenerName` used `Orleans.GrainsLifecycle`, which includes an extra `s` in `Grains`.

## Solution
Update the listener name to `Orleans.GrainLifecycle` so it matches the singular grain lifecycle naming used by the diagnostic API.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10121)