### PR TITLE
Restore local grain directory lookup fast path

### DIFF
--- a/src/Orleans.Core/GrainDirectory/IGrainLocator.cs
+++ b/src/Orleans.Core/GrainDirectory/IGrainLocator.cs
@@ -55,7 +55,8 @@ namespace Orleans.GrainDirectory
         void InvalidateCache(GrainAddress address);
 
         /// <summary>
-        /// Attempts to find the grain address for the provided grain id in the local lookup cache.
+        /// Attempts to find the grain address for the provided grain id without performing asynchronous work.
+        /// Implementations may consult local caches or authoritative local directory partitions.
         /// </summary>
         /// <param name="grainId">The grain id to find.</param>
         /// <param name="address">The resulting grain address, if found, or <see langword="null"/> if not found.</param>

--- a/src/Orleans.Runtime/GrainDirectory/DhtGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DhtGrainLocator.cs
@@ -79,17 +79,7 @@ namespace Orleans.Runtime.GrainDirectory
         public void UpdateCache(GrainId grainId, SiloAddress siloAddress) => _localGrainDirectory.AddOrUpdateCacheEntry(grainId, siloAddress);
         public void InvalidateCache(GrainId grainId) => _localGrainDirectory.InvalidateCacheEntry(grainId);
         public void InvalidateCache(GrainAddress address) => _localGrainDirectory.InvalidateCacheEntry(address);
-        public bool TryLookupInCache(GrainId grainId, out GrainAddress address)
-        {
-            DirectoryInstruments.LookupsLocalIssued.Add(1);
-            if (!_localGrainDirectory.TryCachedLookup(grainId, out address))
-            {
-                return false;
-            }
-
-            DirectoryInstruments.LookupsLocalSuccesses.Add(1);
-            return true;
-        }
+        public bool TryLookupInCache(GrainId grainId, out GrainAddress address) => _localGrainDirectory.TryLocalLookup(grainId, out address);
 
         private class BatchedDeregistrationWorker
         {

--- a/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ILocalGrainDirectory.cs
@@ -73,6 +73,14 @@ namespace Orleans.Runtime.GrainDirectory
         AddressAndTag GetLocalDirectoryData(GrainId grain);
 
         /// <summary>
+        /// Attempts to find the grain address in this silo's local cache or authoritative local directory partition.
+        /// </summary>
+        /// <param name="grainId">The grain id to find.</param>
+        /// <param name="address">The resulting grain address, if found, or <see langword="null"/> if not found.</param>
+        /// <returns>A value indicating whether a valid entry was found.</returns>
+        bool TryLocalLookup(GrainId grainId, [NotNullWhen(true)] out GrainAddress? address);
+
+        /// <summary>
         /// For testing and troubleshooting purposes only.
         /// Returns the directory information held in a local directory cache for the provided grain ID.
         /// The result will be null if no information is held.

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -790,6 +790,36 @@ namespace Orleans.Runtime.GrainDirectory
 
         public AddressAndTag GetLocalDirectoryData(GrainId grain) => DirectoryPartition.LookUpActivation(grain);
 
+        public bool TryLocalLookup(GrainId grainId, [NotNullWhen(true)] out GrainAddress? address)
+        {
+            DirectoryInstruments.LookupsLocalIssued.Add(1);
+            if (TryCachedLookup(grainId, out address))
+            {
+                DirectoryInstruments.LookupsLocalSuccesses.Add(1);
+                return true;
+            }
+
+            var owner = CalculateGrainDirectoryPartition(grainId, this.directoryMembership);
+            if (!MyAddress.Equals(owner))
+            {
+                address = null;
+                return false;
+            }
+
+            DirectoryInstruments.LookupsLocalDirectoryIssued.Add(1);
+            var localResult = DirectoryPartition.LookUpActivation(grainId);
+            if (localResult.Address is null)
+            {
+                address = null;
+                return false;
+            }
+
+            address = localResult.Address;
+            DirectoryInstruments.LookupsLocalDirectorySuccesses.Add(1);
+            DirectoryInstruments.LookupsLocalSuccesses.Add(1);
+            return true;
+        }
+
         public GrainAddress? GetLocalCacheData(GrainId grain)
         {
             if (!DirectoryCache.LookUp(grain, out var cache))

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -243,6 +243,69 @@ namespace UnitTests.Directory
         }
 
         [Fact]
+        public async Task LocalGrainDirectoryTryLocalLookupFindsLocalPartitionEntryOnCacheMiss()
+        {
+            var localSilo = GenerateSiloAddress();
+            var membershipService = new MockClusterMembershipService(new()
+            {
+                [localSilo] = (SiloStatus.Active, "local")
+            });
+            var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+            localSiloDetails.SiloAddress.Returns(localSilo);
+            localSiloDetails.GatewayAddress.Returns(localSilo);
+            localSiloDetails.DnsHostName.Returns("localhost");
+            localSiloDetails.Name.Returns("TestSilo");
+            localSiloDetails.ClusterId.Returns("TestCluster");
+            var siloStatusOracle = Substitute.For<ISiloStatusOracle>();
+            var grainFactory = Substitute.For<IInternalGrainFactory>();
+            var services = new ServiceCollection().BuildServiceProvider();
+            Factory<LocalGrainDirectoryPartition> partitionFactory = () => new LocalGrainDirectoryPartition(
+                membershipService.Target,
+                Options.Create(new GrainDirectoryOptions()),
+                this.loggerFactory);
+            var systemTargetShared = new SystemTargetShared(
+                runtimeClient: null!,
+                localSiloDetails: localSiloDetails,
+                loggerFactory: this.loggerFactory,
+                schedulingOptions: Options.Create(new SchedulingOptions()),
+                grainReferenceActivator: null,
+                timerRegistry: null,
+                activations: new ActivationDirectory());
+            var localGrainDirectory = new LocalGrainDirectory(
+                serviceProvider: services,
+                siloDetails: localSiloDetails,
+                siloStatusOracle: siloStatusOracle,
+                clusterMembershipService: membershipService.Target,
+                grainFactory: grainFactory,
+                grainDirectoryPartitionFactory: partitionFactory,
+                developmentClusterMembershipOptions: Options.Create(new DevelopmentClusterMembershipOptions()),
+                grainDirectoryOptions: Options.Create(new GrainDirectoryOptions()),
+                loggerFactory: this.loggerFactory,
+                systemTargetShared: systemTargetShared)
+            {
+                Running = true
+            };
+
+            var address = GenerateGrainAddress(localSilo, membershipService.CurrentVersion);
+
+            try
+            {
+                var registered = await localGrainDirectory.RegisterAsync(address, hopCount: 0);
+                Assert.Equal(address, registered.Address);
+
+                localGrainDirectory.InvalidateCacheEntry(address.GrainId);
+                Assert.False(localGrainDirectory.TryCachedLookup(address.GrainId, out _));
+
+                Assert.True(localGrainDirectory.TryLocalLookup(address.GrainId, out var result));
+                Assert.Equal(address, result);
+            }
+            finally
+            {
+                await localGrainDirectory.StopAsync();
+            }
+        }
+
+        [Fact]
         public async Task RegisterWhenOtherEntryExists()
         {
             var expectedSilo = GenerateSiloAddress();

--- a/test/Orleans.Core.Tests/Directory/MockLocalGrainDirectory.cs
+++ b/test/Orleans.Core.Tests/Directory/MockLocalGrainDirectory.cs
@@ -117,6 +117,7 @@ namespace UnitTests.Directory
 
         public void InvalidateCacheEntry(GrainId grainId) => throw new NotImplementedException();
         public bool TryCachedLookup(GrainId grainId, out GrainAddress address) => throw new NotImplementedException();
+        public bool TryLocalLookup(GrainId grainId, out GrainAddress address) => throw new NotImplementedException();
         #endregion
     }
 }


### PR DESCRIPTION
## Reason

The grain directory metrics PR should stay focused on metric wiring and cleanup. The local lookup fast path restoration is a related but separate runtime behavior change, so it is split into this follow-up PR.

This PR is stacked on #10124. Until #10124 merges, GitHub may show the lower-stack metrics commits in the diff; the incremental change is the `Restore local directory lookup fast path` commit.

## Solution

Restore a DHT fast path for cache-miss-heavy local-owner cases. The DHT locator now delegates its synchronous lookup path to the local grain directory, which checks the cache first and then, when this silo owns the grain's directory partition, reads the authoritative local partition before queueing placement work.

This keeps custom/pluggable grain directory behavior cache-only while allowing the built-in DHT directory to avoid unnecessary placement worker queuing for local partition hits.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10126)