### PR TITLE
Optimize response completion source

### DIFF
--- a/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
+++ b/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
@@ -11,6 +11,8 @@ namespace Orleans.Serialization.Invocation
     /// </summary>
     public sealed class ResponseCompletionSource : IResponseCompletionSource, IValueTaskSource<Response>, IValueTaskSource
     {
+        // This source is pooled and GetResult returns it to the pool. Continuations must not run inline from SetResult/SetException,
+        // or they can reset/reuse this instance before completion unwinds.
         private ManualResetValueTaskSourceCore<Response> _core = new() { RunContinuationsAsynchronously = true };
 
         /// <summary>
@@ -114,6 +116,8 @@ namespace Orleans.Serialization.Invocation
     /// <typeparam name="TResult">The underlying result type.</typeparam>
     public sealed class ResponseCompletionSource<TResult> : IResponseCompletionSource, IValueTaskSource<TResult>, IValueTaskSource
     {
+        // This source is pooled and GetResult returns it to the pool. Continuations must not run inline from SetResult/SetException,
+        // or they can reset/reuse this instance before completion unwinds.
         private ManualResetValueTaskSourceCore<TResult> _core = new() { RunContinuationsAsynchronously = true };
 
         /// <summary>
@@ -156,31 +160,36 @@ namespace Orleans.Serialization.Invocation
         public void SetResult(TResult result) => _core.SetResult(result);
 
         /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Complete(Response value)
         {
-            if (value is Response<TResult> typed)
-            {
-                Complete(typed);
-            }
-            else if (value.Exception is { } exception)
+            // Fast path: check exception first since it's a simple null check
+            if (value.Exception is { } exception)
             {
                 SetException(exception);
+                return;
+            }
+
+            // Check for typed response (common for void returns)
+            if (value is Response<TResult> typed)
+            {
+                SetResult(typed.TypedResult);
+                return;
+            }
+
+            // Handle untyped successful response
+            var result = value.Result;
+            if (result is null)
+            {
+                SetResult(default);
+            }
+            else if (result is TResult typedResult)
+            {
+                SetResult(typedResult);
             }
             else
             {
-                var result = value.Result;
-                if (result is null)
-                {
-                    SetResult(default);
-                }
-                else if (result is TResult typedResult)
-                {
-                    SetResult(typedResult);
-                }
-                else
-                {
-                    SetInvalidCastException(result);
-                }
+                SetInvalidCastException(result);
             }
         }
 

--- a/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
+++ b/src/Orleans.Serialization/Invocation/ResponseCompletionSource.cs
@@ -163,7 +163,7 @@ namespace Orleans.Serialization.Invocation
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Complete(Response value)
         {
-            // Fast path: check exception first since it's a simple null check
+            // Check exception first since it's a simple null check
             if (value.Exception is { } exception)
             {
                 SetException(exception);

--- a/test/Orleans.Serialization.UnitTests/ResponseCompletionSourceTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ResponseCompletionSourceTests.cs
@@ -1,0 +1,90 @@
+#nullable enable
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Serialization.Invocation;
+using Xunit;
+
+#pragma warning disable xUnit1031 // These tests manually complete ValueTaskSource awaiters and must call GetResult.
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+public class ResponseCompletionSourceTests
+{
+    [Fact]
+    public async Task TypedCompletionRunsContinuationsAsynchronously()
+    {
+        var source = ResponseCompletionSourcePool.Get<int>();
+        var awaiter = source.AsValueTask().GetAwaiter();
+        var continuation = RegisterContinuation(awaiter);
+
+        using var response = Response.FromResult(42);
+        continuation.CompletionThreadId = Thread.CurrentThread.ManagedThreadId;
+        source.Complete(response);
+
+        Assert.NotEqual(continuation.CompletionThreadId, Volatile.Read(ref continuation.ContinuationThreadId));
+
+        await WaitForContinuation(continuation.Task);
+        Assert.Equal(42, awaiter.GetResult());
+    }
+
+    [Fact]
+    public async Task UntypedCompletionRunsContinuationsAsynchronously()
+    {
+        var source = ResponseCompletionSourcePool.Get();
+        var awaiter = source.AsValueTask().GetAwaiter();
+        var continuation = RegisterContinuation(awaiter);
+        var response = Response.FromResult(42);
+        Response? result = null;
+
+        try
+        {
+            continuation.CompletionThreadId = Thread.CurrentThread.ManagedThreadId;
+            source.Complete(response);
+
+            Assert.NotEqual(continuation.CompletionThreadId, Volatile.Read(ref continuation.ContinuationThreadId));
+
+            await WaitForContinuation(continuation.Task);
+            result = awaiter.GetResult();
+            Assert.Same(response, result);
+            Assert.Equal(42, result.GetResult<int>());
+        }
+        finally
+        {
+            (result ?? response).Dispose();
+        }
+    }
+
+    private static ContinuationProbe RegisterContinuation<T>(ValueTaskAwaiter<T> awaiter)
+    {
+        var continuation = new ContinuationProbe();
+
+        awaiter.OnCompleted(() =>
+        {
+            Volatile.Write(ref continuation.ContinuationThreadId, Thread.CurrentThread.ManagedThreadId);
+            continuation.SetResult();
+        });
+
+        return continuation;
+    }
+
+    private static async Task WaitForContinuation(Task continuation)
+    {
+        var completed = await Task.WhenAny(continuation, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(continuation, completed);
+        await continuation;
+    }
+
+    private sealed class ContinuationProbe
+    {
+        private readonly TaskCompletionSource<bool> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int CompletionThreadId = -1;
+        public int ContinuationThreadId = -1;
+        public Task Task => _completion.Task;
+
+        public void SetResult() => _completion.SetResult(true);
+    }
+}


### PR DESCRIPTION
## Reason
PR #10065 mixed ResponseCompletionSource changes with runtime client changes. This separates the serialization-side change for focused review.

## Solution
Optimize ResponseCompletionSource<TResult>.Complete for exception, typed, and untyped response paths, and add regression coverage showing pooled response completion sources do not run continuations inline. Keeping this isolated lets reviewers evaluate the completion behavior independently.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10127)