### PR TITLE
Refactor InsideRuntimeClient response handling

### DIFF
--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -395,7 +395,15 @@ namespace Orleans.Runtime
         public void ReceiveResponse(Message message)
         {
             OrleansInsideRuntimeClientEvent.Instance.ReceiveResponse(message);
-            if (message.Result is Message.ResponseTypes.Rejection)
+
+            var result = message.Result;
+            if (result != Message.ResponseTypes.Rejection && result != Message.ResponseTypes.Status)
+            {
+                ProcessResponseCallback(message);
+                return;
+            }
+
+            if (result is Message.ResponseTypes.Rejection)
             {
                 if (!message.TargetSilo.Matches(this.MySilo))
                 {
@@ -429,46 +437,18 @@ namespace Orleans.Runtime
                         LogErrorUnsupportedRejectionType(this.logger, rejection.RejectionType);
                         break;
                 }
+
+                ProcessResponseCallback(message);
             }
-            else if (message.Result == Message.ResponseTypes.Status)
+            else
             {
-                var status = (StatusResponse)message.BodyObject;
-                callbacks.TryGetValue((message.TargetGrain, message.Id), out var callback);
-                var request = callback?.Message;
-                if (request is not null)
-                {
-                    callback.OnStatusUpdate(status);
-                    if (status.Diagnostics != null && status.Diagnostics.Count > 0)
-                    {
-                        LogInformationReceivedStatusUpdate(this.logger, request, status.Diagnostics);
-                    }
-                }
-                else
-                {
-                    if (messagingOptions.CancelUnknownRequestOnStatusUpdate)
-                    {
-                        // Cancel the call since the caller has abandoned it.
-                        // Note that the target and sender arguments are swapped because this is a response to the original request.
-                        _cancellationManager.SignalCancellation(
-                            message.SendingSilo,
-                            targetGrainId: message.SendingGrain,
-                            sendingGrainId: message.TargetGrain,
-                            messageId: message.Id);
-                    }
-
-                    if (status.Diagnostics != null && status.Diagnostics.Count > 0 && logger.IsEnabled(LogLevel.Debug))
-                    {
-                        var diagnosticsString = string.Join("\n", status.Diagnostics);
-                        LogDebugReceivedStatusUpdateUnknownRequest(this.logger, message, diagnosticsString);
-                    }
-                }
-
-                return;
+                ProcessStatusResponse(message);
             }
+        }
 
-            CallbackData callbackData;
-            bool found = callbacks.TryRemove((message.TargetGrain, message.Id), out callbackData);
-            if (found)
+        private void ProcessResponseCallback(Message message)
+        {
+            if (callbacks.TryRemove((message.TargetGrain, message.Id), out var callbackData))
             {
                 // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
                 // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
@@ -477,6 +457,45 @@ namespace Orleans.Runtime
             else
             {
                 LogDebugNoCallbackForResponse(this.logger, message);
+            }
+        }
+
+        private void ProcessStatusResponse(Message message)
+        {
+            var status = (StatusResponse)message.BodyObject;
+            callbacks.TryGetValue((message.TargetGrain, message.Id), out var callback);
+            var request = callback?.Message;
+            if (request is not null)
+            {
+                callback.OnStatusUpdate(status);
+                if (status.Diagnostics is { Count: > 0 })
+                {
+                    LogInformationReceivedStatusUpdate(this.logger, request, status.Diagnostics);
+                }
+
+                return;
+            }
+
+            HandleUnknownStatusUpdate(message, status);
+        }
+
+        private void HandleUnknownStatusUpdate(Message message, StatusResponse status)
+        {
+            if (messagingOptions.CancelUnknownRequestOnStatusUpdate)
+            {
+                // Cancel the call since the caller has abandoned it.
+                // Note that the target and sender arguments are swapped because this is a response to the original request.
+                _cancellationManager.SignalCancellation(
+                    message.SendingSilo,
+                    targetGrainId: message.SendingGrain,
+                    sendingGrainId: message.TargetGrain,
+                    messageId: message.Id);
+            }
+
+            if (status.Diagnostics is { Count: > 0 } && logger.IsEnabled(LogLevel.Debug))
+            {
+                var diagnosticsString = string.Join("\n", status.Diagnostics);
+                LogDebugReceivedStatusUpdateUnknownRequest(this.logger, message, diagnosticsString);
             }
         }
 


### PR DESCRIPTION
## Reason
PR #10065's runtime response handling refactor should be reviewed independently from serialization changes.

## Solution
Fast-path normal InsideRuntimeClient responses before rejection/status handling and move callback/status update handling into helper methods. The existing early returns for gatewayed rejections, cache-invalidation rejections, and status responses are preserved. I did not include OutsideRuntimeClient changes because PR #10065 does not contain any.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10128)