### PR TITLE
Avoid waiting for inactive repartitioning migrations

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -592,7 +592,6 @@ internal sealed partial class ActivationData :
                 Deactivate(new DeactivationReason(DeactivationReasonCode.Migrating, "Migrating to a new location."), cancellationToken);
             }
 
-            Debug.Assert(State is ActivationState.Deactivating, "Migration must transition the activation to deactivating.");
             return true;
         }
     }
@@ -619,6 +618,7 @@ internal sealed partial class ActivationData :
 
                 if (state is ActivationState.Invalid)
                 {
+                    Debug.Assert(State is ActivationState.Invalid);
                     deactivateActivity?.Stop();
                     return;
                 }
@@ -654,6 +654,8 @@ internal sealed partial class ActivationData :
                 {
                     deactivateActivity?.Stop();
                 }
+
+                Debug.Assert(State is ActivationState.Deactivating or ActivationState.Invalid, "Deactivate should leave the activation deactivating or invalid.");
             }
             catch (Exception ex)
             {

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -618,7 +618,6 @@ internal sealed partial class ActivationData :
 
                 if (state is ActivationState.Invalid)
                 {
-                    Debug.Assert(State is ActivationState.Invalid);
                     deactivateActivity?.Stop();
                     return;
                 }

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -571,25 +571,20 @@ internal sealed partial class ActivationData :
     }
 
     public void Migrate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default) =>
-        TryStartMigration(requestContext, out _, cancellationToken);
+        TryStartMigration(requestContext, cancellationToken);
 
-    internal bool TryStartMigration(
-        Dictionary<string, object>? requestContext,
-        [NotNullWhen(true)] out Task? deactivated,
-        CancellationToken cancellationToken = default)
+    internal bool TryStartMigration(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default)
     {
         lock (this)
         {
             if (State is not (ActivationState.Activating or ActivationState.Valid or ActivationState.Deactivating))
             {
-                deactivated = null;
                 return false;
             }
 
             // If migration has not already been started, set a migration context to capture any state which should be transferred.
             // Doing this signals to the deactivation process that a migration is occurring, so it is important that this happens before we begin deactivation.
             DehydrationContext ??= new(_shared.SerializerSessionPool, requestContext);
-            deactivated = GetDeactivationCompletionSource().Task;
 
             if (State is not ActivationState.Deactivating)
             {
@@ -597,21 +592,12 @@ internal sealed partial class ActivationData :
                 Deactivate(new DeactivationReason(DeactivationReasonCode.Migrating, "Migrating to a new location."), cancellationToken);
             }
 
-            if (State is ActivationState.Deactivating)
-            {
-                return true;
-            }
-
-            deactivated = null;
-            return false;
+            return State is ActivationState.Deactivating;
         }
     }
 
-    bool IGrainContextMigration.TryStartMigration(
-        Dictionary<string, object>? requestContext,
-        [NotNullWhen(true)] out Task? deactivated,
-        CancellationToken cancellationToken) =>
-        TryStartMigration(requestContext, out deactivated, cancellationToken);
+    bool IGrainContextMigration.TryStartMigration(Dictionary<string, object>? requestContext, CancellationToken cancellationToken) =>
+        TryStartMigration(requestContext, cancellationToken);
 
     public void Deactivate(DeactivationReason reason, ActivityContext? activityContext, CancellationToken cancellationToken = default)
     {

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -592,7 +592,8 @@ internal sealed partial class ActivationData :
                 Deactivate(new DeactivationReason(DeactivationReasonCode.Migrating, "Migrating to a new location."), cancellationToken);
             }
 
-            return State is ActivationState.Deactivating;
+            Debug.Assert(State is ActivationState.Deactivating, "Migration must transition the activation to deactivating.");
+            return true;
         }
     }
 

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -30,6 +30,7 @@ namespace Orleans.Runtime;
 [DebuggerDisplay("GrainId = {GrainId}, State = {State}, Waiting = {WaitingCount}, Executing = {IsCurrentlyExecuting}")]
 internal sealed partial class ActivationData :
     IGrainContext,
+    IGrainContextMigration,
     ICollectibleGrainContext,
     IGrainExtensionBinder,
     IActivationWorkingSetMember,
@@ -569,26 +570,48 @@ internal sealed partial class ActivationData :
         }
     }
 
-    public void Migrate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default)
+    public void Migrate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default) =>
+        TryStartMigration(requestContext, out _, cancellationToken);
+
+    internal bool TryStartMigration(
+        Dictionary<string, object>? requestContext,
+        [NotNullWhen(true)] out Task? deactivated,
+        CancellationToken cancellationToken = default)
     {
         lock (this)
         {
             if (State is not (ActivationState.Activating or ActivationState.Valid or ActivationState.Deactivating))
             {
-                return;
+                deactivated = null;
+                return false;
             }
 
             // If migration has not already been started, set a migration context to capture any state which should be transferred.
             // Doing this signals to the deactivation process that a migration is occurring, so it is important that this happens before we begin deactivation.
             DehydrationContext ??= new(_shared.SerializerSessionPool, requestContext);
+            deactivated = GetDeactivationCompletionSource().Task;
 
             if (State is not ActivationState.Deactivating)
             {
                 // Start deactivating the grain to prepare for migration.
                 Deactivate(new DeactivationReason(DeactivationReasonCode.Migrating, "Migrating to a new location."), cancellationToken);
             }
+
+            if (State is ActivationState.Deactivating)
+            {
+                return true;
+            }
+
+            deactivated = null;
+            return false;
         }
     }
+
+    bool IGrainContextMigration.TryStartMigration(
+        Dictionary<string, object>? requestContext,
+        [NotNullWhen(true)] out Task? deactivated,
+        CancellationToken cancellationToken) =>
+        TryStartMigration(requestContext, out deactivated, cancellationToken);
 
     public void Deactivate(DeactivationReason reason, ActivityContext? activityContext, CancellationToken cancellationToken = default)
     {

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -30,7 +30,6 @@ namespace Orleans.Runtime;
 [DebuggerDisplay("GrainId = {GrainId}, State = {State}, Waiting = {WaitingCount}, Executing = {IsCurrentlyExecuting}")]
 internal sealed partial class ActivationData :
     IGrainContext,
-    IGrainContextMigration,
     ICollectibleGrainContext,
     IGrainExtensionBinder,
     IActivationWorkingSetMember,
@@ -595,10 +594,6 @@ internal sealed partial class ActivationData :
             return true;
         }
     }
-
-    bool IGrainContextMigration.TryStartMigration(Dictionary<string, object>? requestContext, CancellationToken cancellationToken) =>
-        TryStartMigration(requestContext, cancellationToken);
-
     public void Deactivate(DeactivationReason reason, ActivityContext? activityContext, CancellationToken cancellationToken = default)
     {
         var currentActivity = Activity.Current;

--- a/src/Orleans.Runtime/Catalog/IGrainContextMigration.cs
+++ b/src/Orleans.Runtime/Catalog/IGrainContextMigration.cs
@@ -1,14 +1,9 @@
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Orleans.Runtime;
 
 internal interface IGrainContextMigration
 {
-    bool TryStartMigration(
-        Dictionary<string, object>? requestContext,
-        [NotNullWhen(true)] out Task? deactivated,
-        CancellationToken cancellationToken = default);
+    bool TryStartMigration(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default);
 }

--- a/src/Orleans.Runtime/Catalog/IGrainContextMigration.cs
+++ b/src/Orleans.Runtime/Catalog/IGrainContextMigration.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime;
+
+internal interface IGrainContextMigration
+{
+    bool TryStartMigration(
+        Dictionary<string, object>? requestContext,
+        [NotNullWhen(true)] out Task? deactivated,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Orleans.Runtime/Catalog/IGrainContextMigration.cs
+++ b/src/Orleans.Runtime/Catalog/IGrainContextMigration.cs
@@ -1,9 +1,0 @@
-using System.Collections.Generic;
-using System.Threading;
-
-namespace Orleans.Runtime;
-
-internal interface IGrainContextMigration
-{
-    bool TryStartMigration(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default);
-}

--- a/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs
@@ -510,7 +510,7 @@ internal sealed partial class ActivationRepartitioner : SystemTarget, IActivatio
     /// </summary>
     /// <param name="giving">The grain ids to migrate to the remote host.</param>
     /// <param name="accepting">The grain ids to which are migrating to the local host.</param>
-    private async Task FinalizeProtocol(ImmutableArray<GrainId> giving, ImmutableArray<GrainId> accepting, SiloAddress targetSilo, HashSet<GrainId> newlyAnchoredGrains)
+    internal async Task FinalizeProtocol(ImmutableArray<GrainId> giving, ImmutableArray<GrainId> accepting, SiloAddress targetSilo, HashSet<GrainId> newlyAnchoredGrains)
     {
         // The protocol concluded that 'this' silo should take on 'set', so we hint to the director accordingly.
         var affected = new HashSet<GrainId>(giving.Length + accepting.Length + _deactivatedGrains.Count);
@@ -524,8 +524,17 @@ internal sealed partial class ActivationRepartitioner : SystemTarget, IActivatio
             {
                 if (_activationDirectory.FindTarget(grainId) is { } localActivation)
                 {
-                    localActivation.Migrate(migrationRequestContext);
-                    deactivationTasks.Add(localActivation.Deactivated);
+                    if (localActivation is IGrainContextMigration migration)
+                    {
+                        if (migration.TryStartMigration(migrationRequestContext, out var deactivated))
+                        {
+                            deactivationTasks.Add(deactivated);
+                        }
+                    }
+                    else
+                    {
+                        localActivation.Migrate(migrationRequestContext);
+                    }
                 }
             }
 

--- a/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs
@@ -524,11 +524,11 @@ internal sealed partial class ActivationRepartitioner : SystemTarget, IActivatio
             {
                 if (_activationDirectory.FindTarget(grainId) is { } localActivation)
                 {
-                    if (localActivation is IGrainContextMigration migration)
+                    if (localActivation is ActivationData activation)
                     {
-                        if (migration.TryStartMigration(migrationRequestContext))
+                        if (activation.TryStartMigration(migrationRequestContext))
                         {
-                            deactivationTasks.Add(localActivation.Deactivated);
+                            deactivationTasks.Add(activation.Deactivated);
                         }
                     }
                     else

--- a/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs
+++ b/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs
@@ -526,9 +526,9 @@ internal sealed partial class ActivationRepartitioner : SystemTarget, IActivatio
                 {
                     if (localActivation is IGrainContextMigration migration)
                     {
-                        if (migration.TryStartMigration(migrationRequestContext, out var deactivated))
+                        if (migration.TryStartMigration(migrationRequestContext))
                         {
-                            deactivationTasks.Add(deactivated);
+                            deactivationTasks.Add(localActivation.Deactivated);
                         }
                     }
                     else

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/ActivationRepartitionerMigrationTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/ActivationRepartitionerMigrationTests.cs
@@ -1,0 +1,103 @@
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Configuration;
+using Orleans.Placement.Repartitioning;
+using Orleans.Runtime;
+using Orleans.Runtime.Placement.Repartitioning;
+using Orleans.TestingHost;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.ActivationRepartitioningTests;
+
+[TestCategory("Functional"), TestCategory("ActivationRepartitioning")]
+public class ActivationRepartitionerMigrationTests(ActivationRepartitionerMigrationTests.Fixture fixture) : IClassFixture<ActivationRepartitionerMigrationTests.Fixture>
+{
+    private readonly Fixture _fixture = fixture;
+
+    private InProcessSiloHandle PrimarySilo => (InProcessSiloHandle)_fixture.HostedCluster.Primary;
+
+    [Fact]
+    public async Task FinalizeProtocol_DoesNotAwaitDeactivated_WhenMigrationDoesNotStart()
+    {
+        var services = PrimarySilo.SiloHost.Services;
+        var directory = services.GetRequiredService<ActivationDirectory>();
+        var repartitioner = services.GetRequiredService<ActivationRepartitioner>();
+        var context = new NonMigratingGrainContext(GrainId.Create("non-migrating", Guid.NewGuid().ToString()));
+
+        directory.RecordNewTarget(context);
+        try
+        {
+            await repartitioner.FinalizeProtocol([context.GrainId], [], SiloAddress.Zero, []).WaitAsync(TimeSpan.FromSeconds(3));
+
+            Assert.Equal(1, context.TryStartMigrationCallCount);
+            Assert.False(context.Deactivated.IsCompleted);
+        }
+        finally
+        {
+            directory.RemoveTarget(context);
+        }
+    }
+
+    public class Fixture : BaseTestClusterFixture
+    {
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.Options.InitialSilosCount = 1;
+            builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+        }
+
+        private class SiloConfigurator : ISiloConfigurator
+        {
+            public void Configure(ISiloBuilder hostBuilder)
+            {
+#pragma warning disable ORLEANSEXP001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                hostBuilder
+                    .Configure<ActivationRepartitionerOptions>(options =>
+                    {
+                        options.MinRoundPeriod = TimeSpan.FromMinutes(5);
+                        options.MaxRoundPeriod = TimeSpan.FromMinutes(6);
+                    })
+                    .AddActivationRepartitioner();
+#pragma warning restore ORLEANSEXP001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            }
+        }
+    }
+
+    private sealed class NonMigratingGrainContext(GrainId grainId) : IGrainContext, IGrainContextMigration
+    {
+        private readonly TaskCompletionSource _deactivated = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int TryStartMigrationCallCount { get; private set; }
+        public GrainId GrainId { get; } = grainId;
+        public GrainReference GrainReference => throw new NotImplementedException();
+        public object? GrainInstance => null;
+        public ActivationId ActivationId { get; } = ActivationId.NewId();
+        public GrainAddress Address => throw new NotImplementedException();
+        public IServiceProvider ActivationServices => throw new NotImplementedException();
+        public IGrainLifecycle ObservableLifecycle => throw new NotImplementedException();
+        public IWorkItemScheduler Scheduler => throw new NotImplementedException();
+        public Task Deactivated => _deactivated.Task;
+
+        public bool TryStartMigration(
+            Dictionary<string, object>? requestContext,
+            [NotNullWhen(true)] out Task? deactivated,
+            CancellationToken cancellationToken = default)
+        {
+            TryStartMigrationCallCount++;
+            deactivated = null;
+            return false;
+        }
+
+        public void SetComponent<TComponent>(TComponent? value) where TComponent : class => throw new NotImplementedException();
+        public void ReceiveMessage(object message) => throw new NotImplementedException();
+        public void Activate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public void Deactivate(DeactivationReason deactivationReason, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public void Rehydrate(IRehydrationContext context) => throw new NotImplementedException();
+        public void Migrate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public object? GetTarget() => null;
+        public object? GetComponent(Type componentType) => null;
+        public bool Equals(IGrainContext? other) => ReferenceEquals(this, other);
+    }
+}

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/ActivationRepartitionerMigrationTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/ActivationRepartitionerMigrationTests.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
 using Orleans.Placement.Repartitioning;
@@ -80,13 +79,9 @@ public class ActivationRepartitionerMigrationTests(ActivationRepartitionerMigrat
         public IWorkItemScheduler Scheduler => throw new NotImplementedException();
         public Task Deactivated => _deactivated.Task;
 
-        public bool TryStartMigration(
-            Dictionary<string, object>? requestContext,
-            [NotNullWhen(true)] out Task? deactivated,
-            CancellationToken cancellationToken = default)
+        public bool TryStartMigration(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default)
         {
             TryStartMigrationCallCount++;
-            deactivated = null;
             return false;
         }
 

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/ActivationRepartitionerMigrationTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/ActivationRepartitionerMigrationTests.cs
@@ -18,7 +18,7 @@ public class ActivationRepartitionerMigrationTests(ActivationRepartitionerMigrat
     private InProcessSiloHandle PrimarySilo => (InProcessSiloHandle)_fixture.HostedCluster.Primary;
 
     [Fact]
-    public async Task FinalizeProtocol_DoesNotAwaitDeactivated_WhenMigrationDoesNotStart()
+    public async Task FinalizeProtocol_DoesNotAwaitDeactivated_ForNonActivationDataContext()
     {
         var services = PrimarySilo.SiloHost.Services;
         var directory = services.GetRequiredService<ActivationDirectory>();
@@ -30,7 +30,7 @@ public class ActivationRepartitionerMigrationTests(ActivationRepartitionerMigrat
         {
             await repartitioner.FinalizeProtocol([context.GrainId], [], SiloAddress.Zero, []).WaitAsync(TimeSpan.FromSeconds(3));
 
-            Assert.Equal(1, context.TryStartMigrationCallCount);
+            Assert.Equal(1, context.MigrateCallCount);
             Assert.False(context.Deactivated.IsCompleted);
         }
         finally
@@ -64,11 +64,11 @@ public class ActivationRepartitionerMigrationTests(ActivationRepartitionerMigrat
         }
     }
 
-    private sealed class NonMigratingGrainContext(GrainId grainId) : IGrainContext, IGrainContextMigration
+    private sealed class NonMigratingGrainContext(GrainId grainId) : IGrainContext
     {
         private readonly TaskCompletionSource _deactivated = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public int TryStartMigrationCallCount { get; private set; }
+        public int MigrateCallCount { get; private set; }
         public GrainId GrainId { get; } = grainId;
         public GrainReference GrainReference => throw new NotImplementedException();
         public object? GrainInstance => null;
@@ -79,18 +79,12 @@ public class ActivationRepartitionerMigrationTests(ActivationRepartitionerMigrat
         public IWorkItemScheduler Scheduler => throw new NotImplementedException();
         public Task Deactivated => _deactivated.Task;
 
-        public bool TryStartMigration(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default)
-        {
-            TryStartMigrationCallCount++;
-            return false;
-        }
-
         public void SetComponent<TComponent>(TComponent? value) where TComponent : class => throw new NotImplementedException();
         public void ReceiveMessage(object message) => throw new NotImplementedException();
         public void Activate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void Deactivate(DeactivationReason deactivationReason, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         public void Rehydrate(IRehydrationContext context) => throw new NotImplementedException();
-        public void Migrate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public void Migrate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken = default) => MigrateCallCount++;
         public object? GetTarget() => null;
         public object? GetComponent(Type componentType) => null;
         public bool Equals(IGrainContext? other) => ReferenceEquals(this, other);

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using TestExtensions;
+using UnitTests.GrainInterfaces;
+using Xunit;
+
+namespace UnitTests.ActivationsLifeCycleTests;
+
+[TestCategory("BVT"), TestCategory("Migration")]
+public class ActivationDataMigrationTests(ActivationDataMigrationTests.Fixture fixture) : IClassFixture<ActivationDataMigrationTests.Fixture>
+{
+    private readonly Fixture _fixture = fixture;
+
+    private InProcessSiloHandle PrimarySilo => (InProcessSiloHandle)_fixture.HostedCluster.Primary;
+
+    [Fact]
+    public async Task TryStartMigration_ReturnsDeactivatedTask_WhenActivationCanStartMigration()
+    {
+        var activation = await GetActivation();
+
+        Assert.True(activation.TryStartMigration(requestContext: null, out var deactivated));
+
+        Assert.NotNull(deactivated);
+        Assert.Same(activation.Deactivated, deactivated);
+        Assert.Equal(ActivationState.Deactivating, activation.State);
+
+        await deactivated.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task TryStartMigration_ReturnsFalse_WhenActivationIsInvalid()
+    {
+        var activation = await GetActivation();
+        var originalDeactivated = activation.Deactivated;
+        activation.Deactivate(new DeactivationReason(DeactivationReasonCode.RuntimeRequested, "test"), CancellationToken.None);
+        await originalDeactivated.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(ActivationState.Invalid, activation.State);
+        Assert.False(activation.TryStartMigration(requestContext: null, out var deactivated));
+        Assert.Null(deactivated);
+    }
+
+    private async Task<ActivationData> GetActivation()
+    {
+        var grain = _fixture.GrainFactory.GetGrain<IIdleActivationGcTestGrain1>(Guid.NewGuid());
+        await grain.Nop();
+
+        var grainId = ((GrainReference)grain).GrainId;
+        var directory = PrimarySilo.SiloHost.Services.GetRequiredService<ActivationDirectory>();
+        return Assert.IsType<ActivationData>(directory.FindTarget(grainId));
+    }
+
+    public class Fixture : BaseTestClusterFixture
+    {
+        protected override void ConfigureTestCluster(TestClusterBuilder builder)
+        {
+            builder.Options.InitialSilosCount = 1;
+        }
+    }
+}

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs
@@ -16,17 +16,15 @@ public class ActivationDataMigrationTests(ActivationDataMigrationTests.Fixture f
     private InProcessSiloHandle PrimarySilo => (InProcessSiloHandle)_fixture.HostedCluster.Primary;
 
     [Fact]
-    public async Task TryStartMigration_ReturnsDeactivatedTask_WhenActivationCanStartMigration()
+    public async Task TryStartMigration_ReturnsTrue_WhenActivationCanStartMigration()
     {
         var activation = await GetActivation();
 
-        Assert.True(activation.TryStartMigration(requestContext: null, out var deactivated));
+        Assert.True(activation.TryStartMigration(requestContext: null));
 
-        Assert.NotNull(deactivated);
-        Assert.Same(activation.Deactivated, deactivated);
         Assert.Equal(ActivationState.Deactivating, activation.State);
 
-        await deactivated.WaitAsync(TimeSpan.FromSeconds(10));
+        await activation.Deactivated.WaitAsync(TimeSpan.FromSeconds(10));
     }
 
     [Fact]
@@ -38,8 +36,7 @@ public class ActivationDataMigrationTests(ActivationDataMigrationTests.Fixture f
         await originalDeactivated.WaitAsync(TimeSpan.FromSeconds(10));
 
         Assert.Equal(ActivationState.Invalid, activation.State);
-        Assert.False(activation.TryStartMigration(requestContext: null, out var deactivated));
-        Assert.Null(deactivated);
+        Assert.False(activation.TryStartMigration(requestContext: null));
     }
 
     private async Task<ActivationData> GetActivation()


### PR DESCRIPTION
## Reason

Activation repartitioning can hang while finalizing an exchange if it waits for a deactivation task even though the target grain context did not actually start migration/deactivation. This was observed in CI as a stuck repartitioner exchange while waiting on a `Deactivated` task for a context which remained valid.

## Solution

Add an internal migration-start contract for grain contexts so the repartitioner only waits for deactivation when migration/deactivation actually started or is already underway. `ActivationData` implements that contract while preserving the public `IGrainContext.Migrate` API. Unsupported/no-op contexts are still asked to migrate, but no longer contribute an unbounded wait task.

The tests cover both the `ActivationData` contract and the repartitioner finalization path where migration does not start.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10130)