### PR TITLE
Stabilize activation rebalancer control test

### DIFF
--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
@@ -69,8 +69,8 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
             await Task.Delay(100);
         }
 
-        report = await rebalancer.GetRebalancingReport(true);
-        Assert.False(report.SuspensionDuration.HasValue);
+        Assert.Equal(RebalancerStatus.Executing, report.Status);
+        Assert.Null(report.SuspensionDuration);
         Assert.Equal(host, report.Host);
 
         await rebalancer.SuspendRebalancing(); // Suspend indefinitely


### PR DESCRIPTION
## Reason

PR #10126 hit a failure in `ControlRebalancerTests.Rebalancer_Should_Be_Controllable_And_Report_To_Listeners`, but the failed test is unrelated to the grain-directory changes in that PR. The test had a timing race after a timed suspension expired.

## Solution

The test now asserts the report that already observed the rebalancer return to `Executing`, instead of forcing a second report. That extra report could race with the next normal rebalancing session and observe a valid new suspension, causing a false failure.

This keeps the assertion focused on the behavior under test: the timed suspension expires and returns an executing report with no suspension duration.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10131)