### PR TITLE
Make deactivation placement test deterministic

### DIFF
--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
@@ -10,6 +10,7 @@ using Orleans.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Orleans.Runtime.Placement;
 
 namespace UnitTests.ActivationsLifeCycleTests
 {
@@ -236,6 +237,8 @@ namespace UnitTests.ActivationsLifeCycleTests
 
         private async Task<ICollectionTestGrain> PickGrainInNonPrimary()
         {
+            var targetSilo = this.testCluster.SecondarySilos.First().SiloAddress;
+
             for (int i = 0; i < 500; i++)
             {
                 if (i % 30 == 29) await Task.Delay(1000); // give some extra time to stabilize if it can't find a suitable grain
@@ -250,7 +253,18 @@ namespace UnitTests.ActivationsLifeCycleTests
                 {
                     continue;
                 }
-                string siloHostingActivation = await grain.GetRuntimeInstanceId();
+
+                string siloHostingActivation;
+                try
+                {
+                    RequestContext.Set(IPlacementDirector.PlacementHintKey, targetSilo);
+                    siloHostingActivation = await grain.GetRuntimeInstanceId();
+                }
+                finally
+                {
+                    RequestContext.Remove(IPlacementDirector.PlacementHintKey);
+                }
+
                 if (this.testCluster.Primary.SiloAddress.ToString().Equals(siloHostingActivation))
                 {
                     continue;


### PR DESCRIPTION
## Problem
PR #10119 hit a CI failure in DeactivateOnIdle_NonExistentActivation_1 because the test relied on default placement eventually choosing a non-primary silo. Under resource-optimized placement, calls entering through the primary gateway can prefer the primary silo, making the test nondeterministic.

## Solution
Force the activation probe call to use a placement hint for the secondary silo while keeping the existing requirement that the grain directory owner is also non-primary. This preserves the forwarding/cache-invalidation scenario under test without depending on default placement randomness.

Reviewers should focus on whether the placement hint preserves the intended scenario.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10132)