### PR TITLE
docs: require conventional commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - Push feature branches to your personal fork, which is configured as `origin`.
 - Create PRs using `dotnet/orleans` as the base repository and `origin`/personal fork branches as the head.
 - Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages from now on.
-- When creating PRs, keep the PR description simple. Describe the reason the PR was opened, meaning the problem it addresses, and the solution implemented in the PR. In the solution section, explain why this is the right solution and include the rationale. Include notes for remaining follow-up work if relevant, and call out areas reviewers should focus on. Do not include a section describing what commands to run to test the PR.
+- When creating PRs, keep the PR description simple: explain the problem it addresses and the solution it implements, including the rationale where helpful. Do not include a section describing what commands to run to test the PR.
 
 Example:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Do not push feature branches directly to `dotnet/orleans` or the `upstream` remote.
 - Push feature branches to your personal fork, which is configured as `origin`.
 - Create PRs using `dotnet/orleans` as the base repository and `origin`/personal fork branches as the head.
+- Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages from now on.
 - When creating PRs, keep the PR description simple. Describe the reason the PR was opened, meaning the problem it addresses, and the solution implemented in the PR. In the solution section, explain why this is the right solution and include the rationale. Include notes for remaining follow-up work if relevant, and call out areas reviewers should focus on. Do not include a section describing what commands to run to test the PR.
 
 Example:


### PR DESCRIPTION
## Reason
This PR documents the repository workflow update to use Conventional Commits for commit messages going forward.

## Solution
Adds a concise AGENTS.md guideline linking to Conventional Commits v1.0.0 so future commit guidance is explicit and easy to find.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10133)