### PR TITLE
fix(lifecycle): stabilize late registration scheduling

### DIFF
--- a/src/Orleans.Core/Lifecycle/ServiceLifecycleNotificationStage.cs
+++ b/src/Orleans.Core/Lifecycle/ServiceLifecycleNotificationStage.cs
@@ -78,7 +78,7 @@ internal sealed partial class ServiceLifecycleNotificationStage(ILogger logger, 
         }
 
         LogStageAlreadyCompleted(logger, name);
-        _ = ExecuteLateCallback(participant);
+        _ = Task.Run(() => ExecuteLateCallback(participant));
 
         return participant;
 

--- a/src/Orleans.Core/Lifecycle/ServiceLifecycleNotificationStage.cs
+++ b/src/Orleans.Core/Lifecycle/ServiceLifecycleNotificationStage.cs
@@ -70,17 +70,15 @@ internal sealed partial class ServiceLifecycleNotificationStage(ILogger logger, 
 
         lock (_lock)
         {
-            if (_isNotifyingOrHasCompleted)
+            if (!_isNotifyingOrHasCompleted)
             {
-                LogStageAlreadyCompleted(logger, name);
-
-                _ = Task.Run(() => ExecuteLateCallback(participant));
-
+                _participants.Add(participant);
                 return participant;
             }
-
-            _participants.Add(participant);
         }
+
+        LogStageAlreadyCompleted(logger, name);
+        _ = ExecuteLateCallback(participant);
 
         return participant;
 

--- a/test/Orleans.Core.Tests/ServiceLifecycleTests.cs
+++ b/test/Orleans.Core.Tests/ServiceLifecycleTests.cs
@@ -232,7 +232,7 @@ public class ServiceLifecycleTests
         // Registering after stage completes should run immediately
         var (task, _) = RegisterCallback(_lifecycle.Stopping);
 
-        await task.WaitAsync(TimeSpan.FromSeconds(1));
+        await task.WaitAsync(Timeout);
     }
 
     [Fact]
@@ -364,4 +364,3 @@ public class ServiceLifecycleTests
         }
     }
 }
-


### PR DESCRIPTION
Late service lifecycle registrations are expected to execute shortly after a stage completes, but the test asserted that the queued callback completed within one second. Under CI thread-pool pressure, that deadline can be too aggressive even when the late registration path is working correctly.

This keeps late callbacks queued with `Task.Run`, but schedules that work after leaving the stage lock. The test now waits on the existing callback signal using the suite-level timeout instead of a hard-coded one-second timeout, making the assertion less sensitive to transient CI scheduling delays.