### PR TITLE
feat: add connection middleware abstractions and framing helpers

### DIFF
--- a/src/Orleans.Connections.Security/Hosting/HostingExtensions.cs
+++ b/src/Orleans.Connections.Security/Hosting/HostingExtensions.cs
@@ -19,11 +19,7 @@ namespace Orleans
             }
 
             var loggerFactory = builder.ApplicationServices.GetService(typeof(ILoggerFactory)) as ILoggerFactory ?? NullLoggerFactory.Instance;
-            builder.Use(next =>
-            {
-                var middleware = new TlsServerConnectionMiddleware(next, options, loggerFactory);
-                return middleware.OnConnectionAsync;
-            });
+            builder.UseMiddleware(new TlsServerConnectionMiddleware(options, loggerFactory));
         }
 
         public static void UseClientTls(
@@ -36,11 +32,7 @@ namespace Orleans
             }
 
             var loggerFactory = builder.ApplicationServices.GetService(typeof(ILoggerFactory)) as ILoggerFactory ?? NullLoggerFactory.Instance;
-            builder.Use(next =>
-            {
-                var middleware = new TlsClientConnectionMiddleware(next, options, loggerFactory);
-                return middleware.OnConnectionAsync;
-            });
+            builder.UseMiddleware(new TlsClientConnectionMiddleware(options, loggerFactory));
         }
 
         internal static void ThrowNoPrivateKey(X509Certificate2 certificate, string parameterName)

--- a/src/Orleans.Connections.Security/Security/TlsClientConnectionMiddleware.cs
+++ b/src/Orleans.Connections.Security/Security/TlsClientConnectionMiddleware.cs
@@ -8,25 +8,23 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.Extensions.Logging;
+using Orleans.Runtime.Messaging;
 
 namespace Orleans.Connections.Security
 {
-    internal partial class TlsClientConnectionMiddleware
+    internal partial class TlsClientConnectionMiddleware : IConnectionMiddleware
     {
-        private readonly ConnectionDelegate _next;
         private readonly TlsOptions _options;
         private readonly ILogger? _logger;
         private readonly X509Certificate2? _certificate;
         private readonly Func<object, string, X509CertificateCollection, X509Certificate?, string[], X509Certificate2?>? _certificateSelector;
 
-        public TlsClientConnectionMiddleware(ConnectionDelegate next, TlsOptions options, ILoggerFactory? loggerFactory)
+        public TlsClientConnectionMiddleware(TlsOptions options, ILoggerFactory? loggerFactory)
         {
             if (options == null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
-
-            _next = next;
 
             // capture the certificate now so it can't be switched after validation
             _certificate = ValidateCertificate(options.LocalCertificate, options.ClientCertificateMode);
@@ -37,12 +35,12 @@ namespace Orleans.Connections.Security
             _logger = loggerFactory?.CreateLogger<TlsClientConnectionMiddleware>();
         }
 
-        public Task OnConnectionAsync(ConnectionContext context)
+        public Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next)
         {
-            return InnerOnConnectionAsync(context);
+            return InnerOnConnectionAsync(context, next);
         }
 
-        private async Task InnerOnConnectionAsync(ConnectionContext context)
+        private async Task InnerOnConnectionAsync(ConnectionContext context, ConnectionDelegate next)
         {
             var feature = new TlsConnectionFeature();
             context.Features.Set<ITlsConnectionFeature>(feature);
@@ -195,7 +193,7 @@ namespace Orleans.Connections.Security
                 await using (sslStream)
                 await using (tlsDuplexPipe)
                 {
-                    await _next(context);
+                    await next(context);
                     // Dispose the inner stream (tlsDuplexPipe) before disposing the SslStream
                     // as the duplex pipe can hit an ODE as it still may be writing.
                 }

--- a/src/Orleans.Connections.Security/Security/TlsServerConnectionMiddleware.cs
+++ b/src/Orleans.Connections.Security/Security/TlsServerConnectionMiddleware.cs
@@ -7,25 +7,23 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.Extensions.Logging;
+using Orleans.Runtime.Messaging;
 
 namespace Orleans.Connections.Security
 {
-    internal partial class TlsServerConnectionMiddleware
+    internal partial class TlsServerConnectionMiddleware : IConnectionMiddleware
     {
-        private readonly ConnectionDelegate _next;
         private readonly TlsOptions _options;
         private readonly ILogger? _logger;
         private readonly X509Certificate2? _certificate;
         private readonly Func<ConnectionContext, string?, X509Certificate2>? _certificateSelector;
 
-        public TlsServerConnectionMiddleware(ConnectionDelegate next, TlsOptions options, ILoggerFactory? loggerFactory)
+        public TlsServerConnectionMiddleware(TlsOptions options, ILoggerFactory? loggerFactory)
         {
             if (options == null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
-
-            _next = next;
 
             // capture the certificate now so it can't be switched after validation
             _certificate = options.LocalCertificate;
@@ -50,12 +48,12 @@ namespace Orleans.Connections.Security
             _logger = loggerFactory?.CreateLogger<TlsServerConnectionMiddleware>();
         }
 
-        public Task OnConnectionAsync(ConnectionContext context)
+        public Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next)
         {
-            return InnerOnConnectionAsync(context);
+            return InnerOnConnectionAsync(context, next);
         }
 
-        private async Task InnerOnConnectionAsync(ConnectionContext context)
+        private async Task InnerOnConnectionAsync(ConnectionContext context, ConnectionDelegate next)
         {
             bool certificateRequired;
             var feature = new TlsConnectionFeature();
@@ -222,7 +220,7 @@ namespace Orleans.Connections.Security
                 await using (sslStream)
                 await using (tlsDuplexPipe)
                 {
-                    await _next(context);
+                    await next(context);
                     // Dispose the inner stream (TlsDuplexPipe) before disposing the SslStream
                     // as the duplex pipe can hit an ODE as it still may be writing.
                 }

--- a/src/Orleans.Core/Networking/ConnectionFrameHelper.cs
+++ b/src/Orleans.Core/Networking/ConnectionFrameHelper.cs
@@ -69,18 +69,31 @@ namespace Orleans.Runtime.Messaging
             if (frameLength > maxFrameLength)
                 throw new InvalidOperationException($"Frame length {frameLength} exceeds maximum allowed length of {maxFrameLength}.");
 
-            var totalNeeded = 4 + frameLength;
-            while (buffer.Length < totalNeeded)
+            input.AdvanceTo(buffer.GetPosition(4));
+
+            var frameBytes = new byte[frameLength];
+            var bytesRead = 0;
+            while (bytesRead < frameLength)
             {
-                input.AdvanceTo(buffer.Start, buffer.End);
                 readResult = await input.ReadAsync(cancellationToken);
                 buffer = readResult.Buffer;
-                CheckCompletionWithData(ref readResult, totalNeeded);
-            }
 
-            var frameSlice = buffer.Slice(4, frameLength);
-            var frameBytes = new byte[frameLength];
-            frameSlice.CopyTo(frameBytes);
+                if (readResult.IsCanceled)
+                {
+                    input.AdvanceTo(buffer.Start, buffer.End);
+                    throw new InvalidOperationException("Connection terminated during frame exchange.");
+                }
+
+                var bytesToCopy = (int)Math.Min(buffer.Length, frameLength - bytesRead);
+                buffer.Slice(0, bytesToCopy).CopyTo(frameBytes.AsSpan(bytesRead, bytesToCopy));
+                bytesRead += bytesToCopy;
+                input.AdvanceTo(buffer.GetPosition(bytesToCopy));
+
+                if (readResult.IsCompleted && bytesRead < frameLength)
+                {
+                    throw new InvalidOperationException("Connection terminated during frame exchange.");
+                }
+            }
 
             byte frameType = frameBytes[0];
             byte[] payload;
@@ -93,8 +106,6 @@ namespace Orleans.Runtime.Messaging
             {
                 payload = Array.Empty<byte>();
             }
-
-            input.AdvanceTo(buffer.GetPosition(totalNeeded));
 
             return (frameType, payload);
         }
@@ -156,17 +167,17 @@ namespace Orleans.Runtime.Messaging
         /// </summary>
         public static string ReadLengthPrefixedString(byte[] data, ref int offset)
         {
-            if (offset + 4 > data.Length)
+            if ((uint)offset > (uint)data.Length || data.Length - offset < sizeof(int))
                 throw new InvalidOperationException("Not enough data to read string length.");
 
-            var length = BinaryPrimitives.ReadInt32LittleEndian(data.AsSpan(offset, 4));
-            offset += 4;
+            var length = BinaryPrimitives.ReadInt32LittleEndian(data.AsSpan(offset, sizeof(int)));
+            offset += sizeof(int);
 
             if (length < 0)
                 throw new InvalidOperationException($"Invalid string length: {length}.");
             if (length == 0)
                 return string.Empty;
-            if (offset + length > data.Length)
+            if (length > data.Length - offset)
                 throw new InvalidOperationException($"Not enough data to read string of length {length}. Available: {data.Length - offset}.");
 
             var result = Encoding.UTF8.GetString(data, offset, length);

--- a/src/Orleans.Core/Networking/ConnectionFrameHelper.cs
+++ b/src/Orleans.Core/Networking/ConnectionFrameHelper.cs
@@ -20,6 +20,11 @@ namespace Orleans.Runtime.Messaging
     /// (like TLS) and register via <c>SiloConnectionOptions</c> or <c>ClientConnectionOptions</c>.
     /// Use these helpers for structured frame I/O within your middleware.
     /// </para>
+    /// <para>
+    /// This helper is optional. Middleware authors who need custom protocols can read/write
+    /// directly from <c>context.Transport.Input</c> (PipeReader) and <c>context.Transport.Output</c>
+    /// (PipeWriter) without using this class.
+    /// </para>
     /// </summary>
     public static class ConnectionFrameHelper
     {
@@ -45,14 +50,14 @@ namespace Orleans.Runtime.Messaging
 
             var readResult = await input.ReadAsync(cancellationToken);
             var buffer = readResult.Buffer;
-            CheckCompletion(ref readResult);
+            CheckCompletionWithData(ref readResult, 4);
 
             while (buffer.Length < 4)
             {
                 input.AdvanceTo(buffer.Start, buffer.End);
                 readResult = await input.ReadAsync(cancellationToken);
                 buffer = readResult.Buffer;
-                CheckCompletion(ref readResult);
+                CheckCompletionWithData(ref readResult, 4);
             }
 
             var lengthBytes = new byte[4];
@@ -70,7 +75,7 @@ namespace Orleans.Runtime.Messaging
                 input.AdvanceTo(buffer.Start, buffer.End);
                 readResult = await input.ReadAsync(cancellationToken);
                 buffer = readResult.Buffer;
-                CheckCompletion(ref readResult);
+                CheckCompletionWithData(ref readResult, totalNeeded);
             }
 
             var frameSlice = buffer.Slice(4, frameLength);
@@ -112,16 +117,15 @@ namespace Orleans.Runtime.Messaging
 
         /// <summary>
         /// Writes a frame using zero-copy framing via <see cref="PrefixingBufferWriter"/>.
-        /// The <paramref name="writeBody"/> delegate writes payload directly into the transport pipe buffer.
+        /// The <paramref name="writePayload"/> delegate writes payload directly into the transport pipe buffer.
         /// </summary>
         public static async ValueTask WriteFrameAsync(
             ConnectionContext connection,
             byte frameType,
-            Action<IBufferWriter<byte>> writeBody,
-            MemoryPool<byte> memoryPool,
+            Action<IBufferWriter<byte>> writePayload,
             CancellationToken cancellationToken)
         {
-            WriteFrameWithPrefixingWriter(connection.Transport.Output, frameType, writeBody, memoryPool);
+            WriteFrameWithPrefixingWriter(connection.Transport.Output, frameType, writePayload, MemoryPool<byte>.Shared);
 
             var flushResult = await connection.Transport.Output.FlushAsync(cancellationToken);
             if (flushResult.IsCanceled)
@@ -213,9 +217,11 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
-        private static void CheckCompletion(ref ReadResult result)
+        private static void CheckCompletionWithData(ref ReadResult result, long required)
         {
-            if (result.IsCanceled || result.IsCompleted)
+            if (result.IsCanceled)
+                throw new InvalidOperationException("Connection terminated during frame exchange.");
+            if (result.IsCompleted && result.Buffer.Length < required)
                 throw new InvalidOperationException("Connection terminated during frame exchange.");
         }
     }

--- a/src/Orleans.Core/Networking/ConnectionFrameHelper.cs
+++ b/src/Orleans.Core/Networking/ConnectionFrameHelper.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.IO.Pipelines;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+
+namespace Orleans.Runtime.Messaging
+{
+    /// <summary>
+    /// Provides framing utilities for connection middleware authors.
+    /// <para>
+    /// Wire format per frame: [4-byte LE length] [1-byte frame type] [payload].
+    /// The length field equals 1 + payload.Length.
+    /// </para>
+    /// <para>
+    /// Connection middlewares should follow the <see cref="ConnectionDelegate"/> pipeline pattern
+    /// (like TLS) and register via <c>SiloConnectionOptions</c> or <c>ClientConnectionOptions</c>.
+    /// Use these helpers for structured frame I/O within your middleware.
+    /// </para>
+    /// </summary>
+    public static class ConnectionFrameHelper
+    {
+        /// <summary>
+        /// Default maximum frame length (1 MB).
+        /// </summary>
+        public const int DefaultMaxFrameLength = 1024 * 1024;
+
+        /// <summary>
+        /// Prefix size: 4 bytes (LE length) + 1 byte (frame type) = 5 bytes.
+        /// </summary>
+        public const int FramePrefixSize = 5;
+
+        /// <summary>
+        /// Reads a single frame from the connection.
+        /// </summary>
+        public static async ValueTask<(byte FrameType, byte[] Payload)> ReadFrameAsync(
+            ConnectionContext connection,
+            CancellationToken cancellationToken,
+            int maxFrameLength = DefaultMaxFrameLength)
+        {
+            var input = connection.Transport.Input;
+
+            var readResult = await input.ReadAsync(cancellationToken);
+            var buffer = readResult.Buffer;
+            CheckCompletion(ref readResult);
+
+            while (buffer.Length < 4)
+            {
+                input.AdvanceTo(buffer.Start, buffer.End);
+                readResult = await input.ReadAsync(cancellationToken);
+                buffer = readResult.Buffer;
+                CheckCompletion(ref readResult);
+            }
+
+            var lengthBytes = new byte[4];
+            buffer.Slice(0, 4).CopyTo(lengthBytes);
+            var frameLength = BinaryPrimitives.ReadInt32LittleEndian(lengthBytes);
+
+            if (frameLength < 1)
+                throw new InvalidOperationException($"Invalid frame length: {frameLength}. Minimum is 1 (frame type byte).");
+            if (frameLength > maxFrameLength)
+                throw new InvalidOperationException($"Frame length {frameLength} exceeds maximum allowed length of {maxFrameLength}.");
+
+            var totalNeeded = 4 + frameLength;
+            while (buffer.Length < totalNeeded)
+            {
+                input.AdvanceTo(buffer.Start, buffer.End);
+                readResult = await input.ReadAsync(cancellationToken);
+                buffer = readResult.Buffer;
+                CheckCompletion(ref readResult);
+            }
+
+            var frameSlice = buffer.Slice(4, frameLength);
+            var frameBytes = new byte[frameLength];
+            frameSlice.CopyTo(frameBytes);
+
+            byte frameType = frameBytes[0];
+            byte[] payload;
+            if (frameLength > 1)
+            {
+                payload = new byte[frameLength - 1];
+                Array.Copy(frameBytes, 1, payload, 0, payload.Length);
+            }
+            else
+            {
+                payload = Array.Empty<byte>();
+            }
+
+            input.AdvanceTo(buffer.GetPosition(totalNeeded));
+
+            return (frameType, payload);
+        }
+
+        /// <summary>
+        /// Writes a frame with the given type and raw payload bytes.
+        /// </summary>
+        public static async ValueTask WriteFrameAsync(
+            ConnectionContext connection,
+            byte frameType,
+            byte[] payload,
+            CancellationToken cancellationToken)
+        {
+            WriteFrameToOutput(connection.Transport.Output, frameType, payload);
+
+            var flushResult = await connection.Transport.Output.FlushAsync(cancellationToken);
+            if (flushResult.IsCanceled)
+                throw new OperationCanceledException("Flush canceled while writing frame.");
+        }
+
+        /// <summary>
+        /// Writes a frame using zero-copy framing via <see cref="PrefixingBufferWriter"/>.
+        /// The <paramref name="writeBody"/> delegate writes payload directly into the transport pipe buffer.
+        /// </summary>
+        public static async ValueTask WriteFrameAsync(
+            ConnectionContext connection,
+            byte frameType,
+            Action<IBufferWriter<byte>> writeBody,
+            MemoryPool<byte> memoryPool,
+            CancellationToken cancellationToken)
+        {
+            WriteFrameWithPrefixingWriter(connection.Transport.Output, frameType, writeBody, memoryPool);
+
+            var flushResult = await connection.Transport.Output.FlushAsync(cancellationToken);
+            if (flushResult.IsCanceled)
+                throw new OperationCanceledException("Flush canceled while writing frame.");
+        }
+
+        /// <summary>
+        /// Writes a length-prefixed UTF-8 string (4-byte LE length + bytes) into a buffer.
+        /// </summary>
+        public static void WriteLengthPrefixedString(IBufferWriter<byte> writer, string value)
+        {
+            var bytes = Encoding.UTF8.GetBytes(value ?? string.Empty);
+
+            var lengthSpan = writer.GetSpan(4);
+            BinaryPrimitives.WriteInt32LittleEndian(lengthSpan, bytes.Length);
+            writer.Advance(4);
+
+            if (bytes.Length > 0)
+            {
+                var dataSpan = writer.GetSpan(bytes.Length);
+                bytes.CopyTo(dataSpan);
+                writer.Advance(bytes.Length);
+            }
+        }
+
+        /// <summary>
+        /// Reads a length-prefixed UTF-8 string from a payload byte array.
+        /// </summary>
+        public static string ReadLengthPrefixedString(byte[] data, ref int offset)
+        {
+            if (offset + 4 > data.Length)
+                throw new InvalidOperationException("Not enough data to read string length.");
+
+            var length = BinaryPrimitives.ReadInt32LittleEndian(data.AsSpan(offset, 4));
+            offset += 4;
+
+            if (length < 0)
+                throw new InvalidOperationException($"Invalid string length: {length}.");
+            if (length == 0)
+                return string.Empty;
+            if (offset + length > data.Length)
+                throw new InvalidOperationException($"Not enough data to read string of length {length}. Available: {data.Length - offset}.");
+
+            var result = Encoding.UTF8.GetString(data, offset, length);
+            offset += length;
+            return result;
+        }
+
+        private static void WriteFrameToOutput(PipeWriter output, byte frameType, byte[] payload)
+        {
+            var payloadLength = payload?.Length ?? 0;
+            var frameLength = 1 + payloadLength;
+
+            Span<byte> prefix = stackalloc byte[FramePrefixSize];
+            BinaryPrimitives.WriteInt32LittleEndian(prefix, frameLength);
+            prefix[4] = frameType;
+            output.Write(prefix);
+
+            if (payloadLength > 0)
+            {
+                output.Write(payload);
+            }
+        }
+
+        private static void WriteFrameWithPrefixingWriter(
+            PipeWriter output,
+            byte frameType,
+            Action<IBufferWriter<byte>> writeBody,
+            MemoryPool<byte> memoryPool)
+        {
+            using var prefixWriter = new PrefixingBufferWriter(FramePrefixSize, 256, memoryPool);
+            prefixWriter.Init(output);
+
+            try
+            {
+                writeBody?.Invoke(prefixWriter);
+
+                var payloadLength = prefixWriter.CommittedBytes;
+                var frameLength = 1 + payloadLength;
+                Span<byte> prefix = stackalloc byte[FramePrefixSize];
+                BinaryPrimitives.WriteInt32LittleEndian(prefix, frameLength);
+                prefix[4] = frameType;
+
+                prefixWriter.Complete(prefix);
+            }
+            finally
+            {
+                prefixWriter.Reset();
+            }
+        }
+
+        private static void CheckCompletion(ref ReadResult result)
+        {
+            if (result.IsCanceled || result.IsCompleted)
+                throw new InvalidOperationException("Connection terminated during frame exchange.");
+        }
+    }
+}

--- a/src/Orleans.Core/Networking/ConnectionFrameHelper.cs
+++ b/src/Orleans.Core/Networking/ConnectionFrameHelper.cs
@@ -120,10 +120,7 @@ namespace Orleans.Runtime.Messaging
             CancellationToken cancellationToken)
         {
             WriteFrameToOutput(connection.Transport.Output, frameType, payload);
-
-            var flushResult = await connection.Transport.Output.FlushAsync(cancellationToken);
-            if (flushResult.IsCanceled)
-                throw new OperationCanceledException("Flush canceled while writing frame.");
+            await FlushFrameAsync(connection.Transport.Output, cancellationToken);
         }
 
         /// <summary>
@@ -137,10 +134,16 @@ namespace Orleans.Runtime.Messaging
             CancellationToken cancellationToken)
         {
             WriteFrameWithPrefixingWriter(connection.Transport.Output, frameType, writePayload, MemoryPool<byte>.Shared);
+            await FlushFrameAsync(connection.Transport.Output, cancellationToken);
+        }
 
-            var flushResult = await connection.Transport.Output.FlushAsync(cancellationToken);
+        private static async ValueTask FlushFrameAsync(PipeWriter output, CancellationToken cancellationToken)
+        {
+            var flushResult = await output.FlushAsync(cancellationToken);
             if (flushResult.IsCanceled)
                 throw new OperationCanceledException("Flush canceled while writing frame.");
+            if (flushResult.IsCompleted)
+                throw new InvalidOperationException("Connection terminated while writing frame.");
         }
 
         /// <summary>

--- a/src/Orleans.Core/Networking/ConnectionMiddlewareExtensions.cs
+++ b/src/Orleans.Core/Networking/ConnectionMiddlewareExtensions.cs
@@ -1,0 +1,47 @@
+using System;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime.Messaging;
+
+namespace Orleans
+{
+    /// <summary>
+    /// Extension methods for registering <see cref="IConnectionMiddleware"/> in the connection pipeline.
+    /// </summary>
+    public static class ConnectionMiddlewareExtensions
+    {
+        /// <summary>
+        /// Adds an <see cref="IConnectionMiddleware"/> to the connection pipeline.
+        /// The middleware is resolved from DI.
+        /// </summary>
+        /// <typeparam name="T">The middleware type implementing <see cref="IConnectionMiddleware"/>.</typeparam>
+        public static IConnectionBuilder UseMiddleware<T>(this IConnectionBuilder builder) where T : IConnectionMiddleware
+        {
+            builder.Use(next =>
+            {
+                var middleware = ActivatorUtilities.CreateInstance<T>(builder.ApplicationServices, next);
+                return context => middleware.OnConnectionAsync(context, next);
+            });
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConnectionMiddleware"/> instance to the connection pipeline.
+        /// </summary>
+        public static IConnectionBuilder UseMiddleware(this IConnectionBuilder builder, IConnectionMiddleware middleware)
+        {
+            if (middleware is null)
+            {
+                throw new ArgumentNullException(nameof(middleware));
+            }
+
+            builder.Use(next =>
+            {
+                return context => middleware.OnConnectionAsync(context, next);
+            });
+
+            return builder;
+        }
+    }
+}

--- a/src/Orleans.Core/Networking/ConnectionMiddlewareExtensions.cs
+++ b/src/Orleans.Core/Networking/ConnectionMiddlewareExtensions.cs
@@ -12,14 +12,14 @@ namespace Orleans
     {
         /// <summary>
         /// Adds an <see cref="IConnectionMiddleware"/> to the connection pipeline.
-        /// The middleware is resolved from DI.
+        /// The middleware is resolved from DI when registered, or activated using DI otherwise.
         /// </summary>
         /// <typeparam name="T">The middleware type implementing <see cref="IConnectionMiddleware"/>.</typeparam>
         public static IConnectionBuilder UseMiddleware<T>(this IConnectionBuilder builder) where T : IConnectionMiddleware
         {
             builder.Use(next =>
             {
-                var middleware = ActivatorUtilities.CreateInstance<T>(builder.ApplicationServices);
+                var middleware = ActivatorUtilities.GetServiceOrCreateInstance<T>(builder.ApplicationServices);
                 return context => middleware.OnConnectionAsync(context, next);
             });
 

--- a/src/Orleans.Core/Networking/ConnectionMiddlewareExtensions.cs
+++ b/src/Orleans.Core/Networking/ConnectionMiddlewareExtensions.cs
@@ -19,7 +19,7 @@ namespace Orleans
         {
             builder.Use(next =>
             {
-                var middleware = ActivatorUtilities.CreateInstance<T>(builder.ApplicationServices, next);
+                var middleware = ActivatorUtilities.CreateInstance<T>(builder.ApplicationServices);
                 return context => middleware.OnConnectionAsync(context, next);
             });
 

--- a/src/Orleans.Core/Networking/ConnectionMiddlewareExtensions.cs
+++ b/src/Orleans.Core/Networking/ConnectionMiddlewareExtensions.cs
@@ -12,14 +12,14 @@ namespace Orleans
     {
         /// <summary>
         /// Adds an <see cref="IConnectionMiddleware"/> to the connection pipeline.
-        /// The middleware is resolved from DI when registered, or activated using DI otherwise.
+        /// The middleware must be registered as a singleton service and must be safe for concurrent use.
         /// </summary>
         /// <typeparam name="T">The middleware type implementing <see cref="IConnectionMiddleware"/>.</typeparam>
         public static IConnectionBuilder UseMiddleware<T>(this IConnectionBuilder builder) where T : IConnectionMiddleware
         {
             builder.Use(next =>
             {
-                var middleware = ActivatorUtilities.GetServiceOrCreateInstance<T>(builder.ApplicationServices);
+                var middleware = builder.ApplicationServices.GetRequiredService<T>();
                 return context => middleware.OnConnectionAsync(context, next);
             });
 
@@ -29,6 +29,10 @@ namespace Orleans
         /// <summary>
         /// Adds an <see cref="IConnectionMiddleware"/> instance to the connection pipeline.
         /// </summary>
+        /// <remarks>
+        /// The instance is shared by all connections and must be safe for concurrent use.
+        /// The caller owns the instance and is responsible for disposing it.
+        /// </remarks>
         public static IConnectionBuilder UseMiddleware(this IConnectionBuilder builder, IConnectionMiddleware middleware)
         {
             if (middleware is null)

--- a/src/Orleans.Core/Networking/IConnectionMiddleware.cs
+++ b/src/Orleans.Core/Networking/IConnectionMiddleware.cs
@@ -10,6 +10,11 @@ namespace Orleans.Runtime.Messaging
     /// <see cref="ConnectionDelegate"/> to continue the pipeline.
     /// </para>
     /// <para>
+    /// Middleware instances can be invoked concurrently for multiple connections.
+    /// Per-connection state should be stored in local variables or on the
+    /// <see cref="ConnectionContext"/>.
+    /// </para>
+    /// <para>
     /// Register via <c>builder.UseMiddleware()</c> or manually with
     /// <c>builder.Use(next =&gt; ctx =&gt; middleware.OnConnectionAsync(ctx, next))</c>.
     /// </para>

--- a/src/Orleans.Core/Networking/IConnectionMiddleware.cs
+++ b/src/Orleans.Core/Networking/IConnectionMiddleware.cs
@@ -6,9 +6,8 @@ namespace Orleans.Runtime.Messaging
     /// <summary>
     /// Interface for connection middleware.
     /// <para>
-    /// Implementers only need to provide <see cref="OnConnectionAsync"/>; the pipeline
-    /// automatically invokes the next delegate after this middleware completes (unless
-    /// the middleware calls next itself or throws).
+    /// Implementers provide <see cref="OnConnectionAsync"/> and invoke the supplied
+    /// <see cref="ConnectionDelegate"/> to continue the pipeline.
     /// </para>
     /// <para>
     /// Register via <c>builder.UseMiddleware()</c> or manually with

--- a/src/Orleans.Core/Networking/IConnectionMiddleware.cs
+++ b/src/Orleans.Core/Networking/IConnectionMiddleware.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+
+namespace Orleans.Runtime.Messaging
+{
+    /// <summary>
+    /// Interface for connection middleware.
+    /// <para>
+    /// Implementers only need to provide <see cref="OnConnectionAsync"/>; the pipeline
+    /// automatically invokes the next delegate after this middleware completes (unless
+    /// the middleware calls next itself or throws).
+    /// </para>
+    /// <para>
+    /// Register via <c>builder.UseMiddleware()</c> or manually with
+    /// <c>builder.Use(next =&gt; ctx =&gt; middleware.OnConnectionAsync(ctx, next))</c>.
+    /// </para>
+    /// </summary>
+    public interface IConnectionMiddleware
+    {
+        /// <summary>
+        /// Called when a connection is established. Implementations should call
+        /// <paramref name="next"/> to continue the pipeline after performing their work.
+        /// </summary>
+        /// <param name="context">The connection context.</param>
+        /// <param name="next">The next delegate in the connection pipeline.</param>
+        Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next);
+    }
+}

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -87,6 +87,14 @@ namespace Orleans
         public void Populate(System.IServiceProvider services, System.Type grainClass, Runtime.GrainType grainType, System.Collections.Generic.Dictionary<string, string> properties) { }
     }
 
+    public static partial class ConnectionMiddlewareExtensions
+    {
+        public static Microsoft.AspNetCore.Connections.IConnectionBuilder UseMiddleware(this Microsoft.AspNetCore.Connections.IConnectionBuilder builder, Runtime.Messaging.IConnectionMiddleware middleware) { throw null; }
+
+        public static Microsoft.AspNetCore.Connections.IConnectionBuilder UseMiddleware<T>(this Microsoft.AspNetCore.Connections.IConnectionBuilder builder)
+            where T : Runtime.Messaging.IConnectionMiddleware { throw null; }
+    }
+
     public delegate void ConnectionToClusterLostHandler(object? sender, System.EventArgs e);
     public delegate TInstance Factory<out TInstance>();
     public delegate TInstance Factory<in TParam1, out TInstance>(TParam1 param1);
@@ -1620,6 +1628,26 @@ namespace Orleans.Runtime.Messaging
         public ConnectionFailedException(string message, System.Exception innerException) { }
 
         public ConnectionFailedException(string message) { }
+    }
+
+    public static partial class ConnectionFrameHelper
+    {
+        public const int DefaultMaxFrameLength = 1048576;
+        public const int FramePrefixSize = 5;
+        public static System.Threading.Tasks.ValueTask<(byte FrameType, byte[] Payload)> ReadFrameAsync(Microsoft.AspNetCore.Connections.ConnectionContext connection, System.Threading.CancellationToken cancellationToken, int maxFrameLength = 1048576) { throw null; }
+
+        public static string ReadLengthPrefixedString(byte[] data, ref int offset) { throw null; }
+
+        public static System.Threading.Tasks.ValueTask WriteFrameAsync(Microsoft.AspNetCore.Connections.ConnectionContext connection, byte frameType, System.Action<System.Buffers.IBufferWriter<byte>> writePayload, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static System.Threading.Tasks.ValueTask WriteFrameAsync(Microsoft.AspNetCore.Connections.ConnectionContext connection, byte frameType, byte[] payload, System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        public static void WriteLengthPrefixedString(System.Buffers.IBufferWriter<byte> writer, string value) { }
+    }
+
+    public partial interface IConnectionMiddleware
+    {
+        System.Threading.Tasks.Task OnConnectionAsync(Microsoft.AspNetCore.Connections.ConnectionContext context, Microsoft.AspNetCore.Connections.ConnectionDelegate next);
     }
 
     [GenerateSerializer]

--- a/test/Orleans.Core.Tests/Networking/ConnectionFrameHelperTests.cs
+++ b/test/Orleans.Core.Tests/Networking/ConnectionFrameHelperTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
 using System.IO.Pipelines;
 using System.Text;
 using System.Threading;
@@ -131,6 +132,28 @@ namespace Orleans.Core.Tests.Networking
         }
 
         [Fact]
+        public async Task ReadFrame_ConsumesDataUnderBackpressure()
+        {
+            var pipe = new Pipe(new PipeOptions(
+                pauseWriterThreshold: 64,
+                resumeWriterThreshold: 32,
+                minimumSegmentSize: 16,
+                useSynchronizationContext: false));
+            var context = new TestConnectionContext(pipe);
+            var expectedPayload = new byte[256];
+            Array.Fill(expectedPayload, (byte)0x2A);
+
+            var writeTask = WriteFrameInChunksAsync(pipe.Writer, 0x04, expectedPayload, 16);
+            var readTask = ConnectionFrameHelper.ReadFrameAsync(context, CancellationToken.None).AsTask();
+
+            await Task.WhenAll(writeTask, readTask).WaitAsync(TimeSpan.FromSeconds(10));
+
+            var (frameType, payload) = await readTask;
+            Assert.Equal(0x04, frameType);
+            Assert.Equal(expectedPayload, payload);
+        }
+
+        [Fact]
         public void WriteLengthPrefixedString_ReadLengthPrefixedString_RoundTrips()
         {
             var buffer = new ArrayBufferWriter<byte>();
@@ -187,6 +210,44 @@ namespace Orleans.Core.Tests.Networking
 
             Assert.Throws<InvalidOperationException>(() =>
                 ConnectionFrameHelper.ReadLengthPrefixedString(data, ref offset));
+        }
+
+        [Fact]
+        public void ReadLengthPrefixedString_OversizedLength_Throws()
+        {
+            var data = new byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32LittleEndian(data, int.MaxValue);
+            int offset = 0;
+
+            Assert.Throws<InvalidOperationException>(() =>
+                ConnectionFrameHelper.ReadLengthPrefixedString(data, ref offset));
+        }
+
+        [Fact]
+        public void ReadLengthPrefixedString_NegativeOffset_Throws()
+        {
+            var data = Array.Empty<byte>();
+            int offset = -1;
+
+            Assert.Throws<InvalidOperationException>(() =>
+                ConnectionFrameHelper.ReadLengthPrefixedString(data, ref offset));
+        }
+
+        private static async Task WriteFrameInChunksAsync(PipeWriter writer, byte frameType, byte[] payload, int chunkSize)
+        {
+            var frame = new byte[ConnectionFrameHelper.FramePrefixSize + payload.Length];
+            BinaryPrimitives.WriteInt32LittleEndian(frame, payload.Length + 1);
+            frame[4] = frameType;
+            payload.CopyTo(frame, ConnectionFrameHelper.FramePrefixSize);
+
+            for (var offset = 0; offset < frame.Length; offset += chunkSize)
+            {
+                var length = Math.Min(chunkSize, frame.Length - offset);
+                writer.Write(frame.AsSpan(offset, length));
+                await writer.FlushAsync();
+            }
+
+            await writer.CompleteAsync();
         }
 
         /// <summary>

--- a/test/Orleans.Core.Tests/Networking/ConnectionFrameHelperTests.cs
+++ b/test/Orleans.Core.Tests/Networking/ConnectionFrameHelperTests.cs
@@ -204,7 +204,7 @@ namespace Orleans.Core.Tests.Networking
             public override string ConnectionId { get; set; } = Guid.NewGuid().ToString();
             public override IDuplexPipe Transport { get => _transport; set => throw new NotSupportedException(); }
             public override IFeatureCollection Features { get; } = new FeatureCollection();
-            public override IDictionary<object, object> Items { get; set; } = new Dictionary<object, object>();
+            public override IDictionary<object, object?> Items { get; set; } = new Dictionary<object, object?>();
 
             private sealed class DuplexPipe : IDuplexPipe
             {
@@ -218,17 +218,6 @@ namespace Orleans.Core.Tests.Networking
                 public PipeWriter Output { get; }
             }
 
-            private sealed class FeatureCollection : IFeatureCollection
-            {
-                public object this[Type key] { get => null; set { } }
-                public bool IsReadOnly => false;
-                public int Revision => 0;
-                public TFeature Get<TFeature>() => default;
-                public void Set<TFeature>(TFeature instance) { }
-                public IEnumerator<KeyValuePair<Type, object>> GetEnumerator()
-                    => Enumerable.Empty<KeyValuePair<Type, object>>().GetEnumerator();
-                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
-            }
         }
     }
 }

--- a/test/Orleans.Core.Tests/Networking/ConnectionFrameHelperTests.cs
+++ b/test/Orleans.Core.Tests/Networking/ConnectionFrameHelperTests.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Features;
+using Orleans.Runtime.Messaging;
+using Xunit;
+
+namespace Orleans.Core.Tests.Networking
+{
+    [Trait("Category", "BVT")]
+    public class ConnectionFrameHelperTests
+    {
+        [Fact]
+        public async Task WriteAndReadFrame_RoundTrips()
+        {
+            var pipe = new Pipe();
+            var context = new TestConnectionContext(pipe);
+
+            byte expectedFrameType = 0x01;
+            byte[] expectedPayload = Encoding.UTF8.GetBytes("hello world");
+
+            await ConnectionFrameHelper.WriteFrameAsync(context, expectedFrameType, expectedPayload, CancellationToken.None);
+            await pipe.Writer.CompleteAsync();
+
+            var (frameType, payload) = await ConnectionFrameHelper.ReadFrameAsync(context, CancellationToken.None);
+
+            Assert.Equal(expectedFrameType, frameType);
+            Assert.Equal(expectedPayload, payload);
+        }
+
+        [Fact]
+        public async Task WriteAndReadFrame_EmptyPayload()
+        {
+            var pipe = new Pipe();
+            var context = new TestConnectionContext(pipe);
+
+            byte expectedFrameType = 0x05;
+            byte[] expectedPayload = Array.Empty<byte>();
+
+            await ConnectionFrameHelper.WriteFrameAsync(context, expectedFrameType, expectedPayload, CancellationToken.None);
+            await pipe.Writer.CompleteAsync();
+
+            var (frameType, payload) = await ConnectionFrameHelper.ReadFrameAsync(context, CancellationToken.None);
+
+            Assert.Equal(expectedFrameType, frameType);
+            Assert.Empty(payload);
+        }
+
+        [Fact]
+        public async Task WriteAndReadFrame_ZeroCopyPath_RoundTrips()
+        {
+            var pipe = new Pipe();
+            var context = new TestConnectionContext(pipe);
+
+            byte expectedFrameType = 0x02;
+            var expectedText = "zero-copy test";
+
+            await ConnectionFrameHelper.WriteFrameAsync(
+                context,
+                expectedFrameType,
+                writer => { writer.Write(Encoding.UTF8.GetBytes(expectedText)); },
+                CancellationToken.None);
+
+            await pipe.Writer.CompleteAsync();
+
+            var (frameType, payload) = await ConnectionFrameHelper.ReadFrameAsync(context, CancellationToken.None);
+
+            Assert.Equal(expectedFrameType, frameType);
+            Assert.Equal(expectedText, Encoding.UTF8.GetString(payload));
+        }
+
+        [Fact]
+        public async Task ReadFrame_RejectsFrameExceedingMaxLength()
+        {
+            var pipe = new Pipe();
+            var context = new TestConnectionContext(pipe);
+
+            var output = pipe.Writer;
+            var lengthBytes = new byte[4];
+            System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(lengthBytes, 2_000_000);
+            output.Write(lengthBytes);
+            await output.FlushAsync();
+            await output.CompleteAsync();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await ConnectionFrameHelper.ReadFrameAsync(context, CancellationToken.None, maxFrameLength: 1024));
+        }
+
+        [Fact]
+        public async Task ReadFrame_RejectsInvalidFrameLength()
+        {
+            var pipe = new Pipe();
+            var context = new TestConnectionContext(pipe);
+
+            var output = pipe.Writer;
+            var lengthBytes = new byte[4];
+            System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(lengthBytes, 0);
+            output.Write(lengthBytes);
+            await output.FlushAsync();
+            await output.CompleteAsync();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await ConnectionFrameHelper.ReadFrameAsync(context, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task WriteAndReadMultipleFrames()
+        {
+            var pipe = new Pipe();
+            var context = new TestConnectionContext(pipe);
+
+            await ConnectionFrameHelper.WriteFrameAsync(context, 0x01, Encoding.UTF8.GetBytes("first"), CancellationToken.None);
+            await ConnectionFrameHelper.WriteFrameAsync(context, 0x02, Encoding.UTF8.GetBytes("second"), CancellationToken.None);
+            await ConnectionFrameHelper.WriteFrameAsync(context, 0x03, Encoding.UTF8.GetBytes("third"), CancellationToken.None);
+            await pipe.Writer.CompleteAsync();
+
+            var (type1, payload1) = await ConnectionFrameHelper.ReadFrameAsync(context, CancellationToken.None);
+            var (type2, payload2) = await ConnectionFrameHelper.ReadFrameAsync(context, CancellationToken.None);
+            var (type3, payload3) = await ConnectionFrameHelper.ReadFrameAsync(context, CancellationToken.None);
+
+            Assert.Equal(0x01, type1);
+            Assert.Equal("first", Encoding.UTF8.GetString(payload1));
+            Assert.Equal(0x02, type2);
+            Assert.Equal("second", Encoding.UTF8.GetString(payload2));
+            Assert.Equal(0x03, type3);
+            Assert.Equal("third", Encoding.UTF8.GetString(payload3));
+        }
+
+        [Fact]
+        public void WriteLengthPrefixedString_ReadLengthPrefixedString_RoundTrips()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            var expected = "hello, orleans!";
+
+            ConnectionFrameHelper.WriteLengthPrefixedString(buffer, expected);
+
+            var data = buffer.WrittenSpan.ToArray();
+            int offset = 0;
+            var result = ConnectionFrameHelper.ReadLengthPrefixedString(data, ref offset);
+
+            Assert.Equal(expected, result);
+            Assert.Equal(data.Length, offset);
+        }
+
+        [Fact]
+        public void WriteLengthPrefixedString_EmptyString()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+
+            ConnectionFrameHelper.WriteLengthPrefixedString(buffer, "");
+
+            var data = buffer.WrittenSpan.ToArray();
+            int offset = 0;
+            var result = ConnectionFrameHelper.ReadLengthPrefixedString(data, ref offset);
+
+            Assert.Equal("", result);
+            Assert.Equal(4, offset);
+        }
+
+        [Fact]
+        public void WriteLengthPrefixedString_MultipleStrings()
+        {
+            var buffer = new ArrayBufferWriter<byte>();
+            var strings = new[] { "alpha", "beta", "gamma" };
+
+            foreach (var s in strings)
+                ConnectionFrameHelper.WriteLengthPrefixedString(buffer, s);
+
+            var data = buffer.WrittenSpan.ToArray();
+            int offset = 0;
+            foreach (var expected in strings)
+            {
+                var result = ConnectionFrameHelper.ReadLengthPrefixedString(data, ref offset);
+                Assert.Equal(expected, result);
+            }
+        }
+
+        [Fact]
+        public void ReadLengthPrefixedString_InsufficientData_Throws()
+        {
+            var data = new byte[] { 0x01, 0x02 };
+            int offset = 0;
+
+            Assert.Throws<InvalidOperationException>(() =>
+                ConnectionFrameHelper.ReadLengthPrefixedString(data, ref offset));
+        }
+
+        /// <summary>
+        /// Minimal ConnectionContext backed by a Pipe for testing.
+        /// </summary>
+        private sealed class TestConnectionContext : ConnectionContext
+        {
+            private readonly IDuplexPipe _transport;
+
+            public TestConnectionContext(Pipe pipe)
+            {
+                _transport = new DuplexPipe(pipe.Reader, pipe.Writer);
+            }
+
+            public override string ConnectionId { get; set; } = Guid.NewGuid().ToString();
+            public override IDuplexPipe Transport { get => _transport; set => throw new NotSupportedException(); }
+            public override IFeatureCollection Features { get; } = new FeatureCollection();
+            public override IDictionary<object, object> Items { get; set; } = new Dictionary<object, object>();
+
+            private sealed class DuplexPipe : IDuplexPipe
+            {
+                public DuplexPipe(PipeReader input, PipeWriter output)
+                {
+                    Input = input;
+                    Output = output;
+                }
+
+                public PipeReader Input { get; }
+                public PipeWriter Output { get; }
+            }
+
+            private sealed class FeatureCollection : IFeatureCollection
+            {
+                public object this[Type key] { get => null; set { } }
+                public bool IsReadOnly => false;
+                public int Revision => 0;
+                public TFeature Get<TFeature>() => default;
+                public void Set<TFeature>(TFeature instance) { }
+                public IEnumerator<KeyValuePair<Type, object>> GetEnumerator()
+                    => Enumerable.Empty<KeyValuePair<Type, object>>().GetEnumerator();
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/Networking/ConnectionFrameHelperTests.cs
+++ b/test/Orleans.Core.Tests/Networking/ConnectionFrameHelperTests.cs
@@ -75,6 +75,28 @@ namespace Orleans.Core.Tests.Networking
         }
 
         [Fact]
+        public async Task WriteFrame_CompletedReader_Throws()
+        {
+            var pipe = new Pipe();
+            var context = new TestConnectionContext(pipe);
+            await pipe.Reader.CompleteAsync();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await ConnectionFrameHelper.WriteFrameAsync(context, 0x01, Array.Empty<byte>(), CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task WriteFrame_ZeroCopyPath_CompletedReader_Throws()
+        {
+            var pipe = new Pipe();
+            var context = new TestConnectionContext(pipe);
+            await pipe.Reader.CompleteAsync();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await ConnectionFrameHelper.WriteFrameAsync(context, 0x01, _ => { }, CancellationToken.None));
+        }
+
+        [Fact]
         public async Task ReadFrame_RejectsFrameExceedingMaxLength()
         {
             var pipe = new Pipe();

--- a/test/Orleans.Core.Tests/Networking/ConnectionMiddlewareTests.cs
+++ b/test/Orleans.Core.Tests/Networking/ConnectionMiddlewareTests.cs
@@ -172,7 +172,7 @@ namespace Orleans.Core.Tests.Networking
             public override string ConnectionId { get; set; } = Guid.NewGuid().ToString();
             public override IDuplexPipe Transport { get => _transport; set => throw new NotSupportedException(); }
             public override IFeatureCollection Features { get; } = new FeatureCollection();
-            public override IDictionary<object, object> Items { get; set; } = new Dictionary<object, object>();
+            public override IDictionary<object, object?> Items { get; set; } = new Dictionary<object, object?>();
 
             private sealed class DuplexPipe : IDuplexPipe
             {
@@ -186,17 +186,6 @@ namespace Orleans.Core.Tests.Networking
                 public PipeWriter Output { get; }
             }
 
-            private sealed class FeatureCollection : IFeatureCollection
-            {
-                public object this[Type key] { get => null; set { } }
-                public bool IsReadOnly => false;
-                public int Revision => 0;
-                public TFeature Get<TFeature>() => default;
-                public void Set<TFeature>(TFeature instance) { }
-                public IEnumerator<KeyValuePair<Type, object>> GetEnumerator()
-                    => Enumerable.Empty<KeyValuePair<Type, object>>().GetEnumerator();
-                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
-            }
         }
     }
 }

--- a/test/Orleans.Core.Tests/Networking/ConnectionMiddlewareTests.cs
+++ b/test/Orleans.Core.Tests/Networking/ConnectionMiddlewareTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime.Messaging;
+using Xunit;
+
+namespace Orleans.Core.Tests.Networking
+{
+    [Trait("Category", "BVT")]
+    public class ConnectionMiddlewareTests
+    {
+        [Fact]
+        public async Task UseMiddleware_InvokesMiddlewareAndNext()
+        {
+            var callOrder = new List<string>();
+
+            var services = new ServiceCollection().BuildServiceProvider();
+            var builder = new TestConnectionBuilder(services);
+
+            builder.UseMiddleware(new TrackingMiddleware("first", callOrder));
+            builder.UseMiddleware(new TrackingMiddleware("second", callOrder));
+
+            var pipeline = builder.Build();
+            var context = CreateContext();
+
+            await pipeline(context);
+
+            Assert.Equal(new[] { "first", "second" }, callOrder);
+        }
+
+        [Fact]
+        public async Task UseMiddleware_MiddlewareThatDoesNotCallNext_TerminatesPipeline()
+        {
+            var callOrder = new List<string>();
+
+            var services = new ServiceCollection().BuildServiceProvider();
+            var builder = new TestConnectionBuilder(services);
+
+            builder.UseMiddleware(new TerminatingMiddleware("blocker", callOrder));
+            builder.UseMiddleware(new TrackingMiddleware("should-not-run", callOrder));
+
+            var pipeline = builder.Build();
+            var context = CreateContext();
+
+            await pipeline(context);
+
+            Assert.Equal(new[] { "blocker" }, callOrder);
+        }
+
+        [Fact]
+        public async Task UseMiddleware_Generic_ResolvesFromDI()
+        {
+            var callOrder = new List<string>();
+
+            var services = new ServiceCollection()
+                .AddSingleton(callOrder)
+                .BuildServiceProvider();
+
+            var builder = new TestConnectionBuilder(services);
+            builder.UseMiddleware<DiMiddleware>();
+
+            var pipeline = builder.Build();
+            var context = CreateContext();
+
+            await pipeline(context);
+
+            Assert.Equal(new[] { "di-middleware" }, callOrder);
+        }
+
+        private static ConnectionContext CreateContext()
+        {
+            var pipe = new Pipe();
+            return new TestConnectionContext(pipe);
+        }
+
+        private sealed class TrackingMiddleware : IConnectionMiddleware
+        {
+            private readonly string _name;
+            private readonly List<string> _callOrder;
+
+            public TrackingMiddleware(string name, List<string> callOrder)
+            {
+                _name = name;
+                _callOrder = callOrder;
+            }
+
+            public async Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next)
+            {
+                _callOrder.Add(_name);
+                await next(context);
+            }
+        }
+
+        private sealed class TerminatingMiddleware : IConnectionMiddleware
+        {
+            private readonly string _name;
+            private readonly List<string> _callOrder;
+
+            public TerminatingMiddleware(string name, List<string> callOrder)
+            {
+                _name = name;
+                _callOrder = callOrder;
+            }
+
+            public Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next)
+            {
+                _callOrder.Add(_name);
+                // Intentionally NOT calling next
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class DiMiddleware : IConnectionMiddleware
+        {
+            private readonly List<string> _callOrder;
+
+            public DiMiddleware(List<string> callOrder)
+            {
+                _callOrder = callOrder;
+            }
+
+            public async Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next)
+            {
+                _callOrder.Add("di-middleware");
+                await next(context);
+            }
+        }
+
+        private sealed class TestConnectionBuilder : IConnectionBuilder
+        {
+            private readonly List<Func<ConnectionDelegate, ConnectionDelegate>> _middlewares = new();
+
+            public TestConnectionBuilder(IServiceProvider services)
+            {
+                ApplicationServices = services;
+            }
+
+            public IServiceProvider ApplicationServices { get; }
+
+            public IConnectionBuilder Use(Func<ConnectionDelegate, ConnectionDelegate> middleware)
+            {
+                _middlewares.Add(middleware);
+                return this;
+            }
+
+            public ConnectionDelegate Build()
+            {
+                ConnectionDelegate app = _ => Task.CompletedTask;
+
+                for (var i = _middlewares.Count - 1; i >= 0; i--)
+                {
+                    app = _middlewares[i](app);
+                }
+
+                return app;
+            }
+        }
+
+        private sealed class TestConnectionContext : ConnectionContext
+        {
+            private readonly IDuplexPipe _transport;
+
+            public TestConnectionContext(Pipe pipe)
+            {
+                _transport = new DuplexPipe(pipe.Reader, pipe.Writer);
+            }
+
+            public override string ConnectionId { get; set; } = Guid.NewGuid().ToString();
+            public override IDuplexPipe Transport { get => _transport; set => throw new NotSupportedException(); }
+            public override IFeatureCollection Features { get; } = new FeatureCollection();
+            public override IDictionary<object, object> Items { get; set; } = new Dictionary<object, object>();
+
+            private sealed class DuplexPipe : IDuplexPipe
+            {
+                public DuplexPipe(PipeReader input, PipeWriter output)
+                {
+                    Input = input;
+                    Output = output;
+                }
+
+                public PipeReader Input { get; }
+                public PipeWriter Output { get; }
+            }
+
+            private sealed class FeatureCollection : IFeatureCollection
+            {
+                public object this[Type key] { get => null; set { } }
+                public bool IsReadOnly => false;
+                public int Revision => 0;
+                public TFeature Get<TFeature>() => default;
+                public void Set<TFeature>(TFeature instance) { }
+                public IEnumerator<KeyValuePair<Type, object>> GetEnumerator()
+                    => Enumerable.Empty<KeyValuePair<Type, object>>().GetEnumerator();
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+            }
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/Networking/ConnectionMiddlewareTests.cs
+++ b/test/Orleans.Core.Tests/Networking/ConnectionMiddlewareTests.cs
@@ -55,9 +55,11 @@ namespace Orleans.Core.Tests.Networking
         public async Task UseMiddleware_Generic_ResolvesFromDI()
         {
             var callOrder = new List<string>();
+            var middleware = new InjectedMiddleware(callOrder);
 
             var services = new ServiceCollection()
                 .AddSingleton(callOrder)
+                .AddSingleton(middleware)
                 .BuildServiceProvider();
 
             var builder = new TestConnectionBuilder(services);
@@ -69,6 +71,7 @@ namespace Orleans.Core.Tests.Networking
             await pipeline(context);
 
             Assert.Equal(new[] { "injected-middleware" }, callOrder);
+            Assert.Equal(1, middleware.InvocationCount);
         }
 
         private static ConnectionContext CreateContext()
@@ -123,8 +126,11 @@ namespace Orleans.Core.Tests.Networking
                 _callOrder = callOrder;
             }
 
+            public int InvocationCount { get; private set; }
+
             public async Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next)
             {
+                InvocationCount++;
                 _callOrder.Add("injected-middleware");
                 await next(context);
             }

--- a/test/Orleans.Core.Tests/Networking/ConnectionMiddlewareTests.cs
+++ b/test/Orleans.Core.Tests/Networking/ConnectionMiddlewareTests.cs
@@ -61,14 +61,14 @@ namespace Orleans.Core.Tests.Networking
                 .BuildServiceProvider();
 
             var builder = new TestConnectionBuilder(services);
-            builder.UseMiddleware<DiMiddleware>();
+            builder.UseMiddleware<InjectedMiddleware>();
 
             var pipeline = builder.Build();
             var context = CreateContext();
 
             await pipeline(context);
 
-            Assert.Equal(new[] { "di-middleware" }, callOrder);
+            Assert.Equal(new[] { "injected-middleware" }, callOrder);
         }
 
         private static ConnectionContext CreateContext()
@@ -114,18 +114,18 @@ namespace Orleans.Core.Tests.Networking
             }
         }
 
-        private sealed class DiMiddleware : IConnectionMiddleware
+        private sealed class InjectedMiddleware : IConnectionMiddleware
         {
             private readonly List<string> _callOrder;
 
-            public DiMiddleware(List<string> callOrder)
+            public InjectedMiddleware(List<string> callOrder)
             {
                 _callOrder = callOrder;
             }
 
             public async Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next)
             {
-                _callOrder.Add("di-middleware");
+                _callOrder.Add("injected-middleware");
                 await next(context);
             }
         }

--- a/test/Orleans.Core.Tests/Networking/ConnectionMiddlewareTests.cs
+++ b/test/Orleans.Core.Tests/Networking/ConnectionMiddlewareTests.cs
@@ -74,6 +74,16 @@ namespace Orleans.Core.Tests.Networking
             Assert.Equal(1, middleware.InvocationCount);
         }
 
+        [Fact]
+        public void UseMiddleware_Generic_RequiresRegistration()
+        {
+            var services = new ServiceCollection().BuildServiceProvider();
+            var builder = new TestConnectionBuilder(services);
+            builder.UseMiddleware<InjectedMiddleware>();
+
+            Assert.Throws<InvalidOperationException>(() => builder.Build());
+        }
+
         private static ConnectionContext CreateContext()
         {
             var pipe = new Pipe();


### PR DESCRIPTION
This PR enables users to plug custom middleware (such as authentication) into Orleans silo-to-silo or client-to-silo connections.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10136)