### PR TITLE
chore: Use IMeterFactory for networking metrics

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/NetworkingInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/NetworkingInstruments.cs
@@ -5,18 +5,18 @@ using Orleans.Messaging;
 #nullable disable
 namespace Orleans.Runtime;
 
-internal static class NetworkingInstruments
+internal class NetworkingInstruments(OrleansInstruments instruments)
 {
-    internal static Counter<int> ClosedSocketsCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.NETWORKING_SOCKETS_CLOSED);
-    internal static Counter<int> OpenedSocketsCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.NETWORKING_SOCKETS_OPENED);
+    private readonly Counter<int> _closedSocketsCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.NETWORKING_SOCKETS_CLOSED);
+    private readonly Counter<int> _openedSocketsCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.NETWORKING_SOCKETS_OPENED);
 
-    internal static void OnOpenedSocket(ConnectionDirection direction)
+    internal void OnOpenedSocket(ConnectionDirection direction)
     {
-        OpenedSocketsCounter.Add(1, new KeyValuePair<string, object>("Direction", direction.ToString()));
+        _openedSocketsCounter.Add(1, new KeyValuePair<string, object>("Direction", direction.ToString()));
     }
 
-    internal static void OnClosedSocket(ConnectionDirection direction)
+    internal void OnClosedSocket(ConnectionDirection direction)
     {
-        ClosedSocketsCounter.Add(1, new KeyValuePair<string, object>("Direction", direction.ToString()));
+        _closedSocketsCounter.Add(1, new KeyValuePair<string, object>("Direction", direction.ToString()));
     }
 }

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -103,7 +103,7 @@ namespace Orleans.Runtime.Messaging
             var connection = context.Features.Get<Connection>();
             context.ConnectionClosed.Register(OnConnectionClosedDelegate, connection);
 
-            NetworkingInstruments.OnOpenedSocket(connection.ConnectionDirection);
+            connection.shared.NetworkingInstruments.OnOpenedSocket(connection.ConnectionDirection);
             return connection.RunInternal();
         }
 
@@ -163,7 +163,7 @@ namespace Orleans.Runtime.Messaging
         /// </summary>
         private async Task CloseAsync()
         {
-            NetworkingInstruments.OnClosedSocket(this.ConnectionDirection);
+            this.shared.NetworkingInstruments.OnClosedSocket(this.ConnectionDirection);
 
             // Signal the outgoing message processor to exit gracefully.
             this.outgoingMessageWriter.TryComplete();

--- a/src/Orleans.Core/Networking/ConnectionShared.cs
+++ b/src/Orleans.Core/Networking/ConnectionShared.cs
@@ -8,11 +8,13 @@ namespace Orleans.Runtime.Messaging
         IServiceProvider serviceProvider,
         MessageFactory messageFactory,
         MessagingTrace messagingTrace,
+        OrleansInstruments orleansInstruments,
         ILogger<Connection> logger,
         IMessageStatisticsSink messageStatisticsSink)
     {
         public MessageFactory MessageFactory { get; } = messageFactory;
         public IServiceProvider ServiceProvider { get; } = serviceProvider;
+        public NetworkingInstruments NetworkingInstruments { get; } = new(orleansInstruments);
         public ILogger<Connection> Logger { get; } = logger;
         public IMessageStatisticsSink MessageStatisticsSink { get; } = messageStatisticsSink;
         public MessagingTrace MessagingTrace { get; } = messagingTrace;

--- a/test/Orleans.Runtime.Tests/Diagnostics/NetworkingInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/NetworkingInstrumentsTests.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Messaging;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class NetworkingInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void NetworkingInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new NetworkingInstruments(new OrleansInstruments(meterFactory));
+        using var openedCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.NETWORKING_SOCKETS_OPENED);
+        using var closedCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.NETWORKING_SOCKETS_CLOSED);
+
+        instruments.OnOpenedSocket(ConnectionDirection.SiloToSilo);
+        instruments.OnClosedSocket(ConnectionDirection.SiloToSilo);
+
+        Assert.Equal(1, Assert.Single(openedCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(closedCollector.GetMeasurementSnapshot()).Value);
+    }
+}


### PR DESCRIPTION
Related to #9608.

Converts NetworkingInstruments from static global Meter usage to an instance-based implementation backed by OrleansInstruments. ConnectionCommon now owns the networking instruments instance so Connection records socket open/close metrics through the DI-created Orleans meter.

Adds a focused MetricCollector test to verify networking metrics are emitted through IMeterFactory.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10137)