### PR TITLE
chore: Use IMeterFactory for watchdog metrics

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/WatchdogInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/WatchdogInstruments.cs
@@ -2,7 +2,7 @@ using System.Diagnostics.Metrics;
 
 namespace Orleans.Runtime;
 
-internal class WatchdogInstruments(OrleansInstruments instruments)
+internal sealed class WatchdogInstruments(OrleansInstruments instruments)
 {
     private readonly Counter<int> _healthChecks = instruments.Meter.CreateCounter<int>(InstrumentNames.WATCHDOG_NUM_HEALTH_CHECKS);
     private readonly Counter<int> _failedHealthChecks = instruments.Meter.CreateCounter<int>(InstrumentNames.WATCHDOG_NUM_FAILED_HEALTH_CHECKS);

--- a/src/Orleans.Core/Diagnostics/Metrics/WatchdogInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/WatchdogInstruments.cs
@@ -2,8 +2,18 @@ using System.Diagnostics.Metrics;
 
 namespace Orleans.Runtime;
 
-internal static class WatchdogInstruments
+internal class WatchdogInstruments(OrleansInstruments instruments)
 {
-    internal static Counter<int> HealthChecks = Instruments.Meter.CreateCounter<int>(InstrumentNames.WATCHDOG_NUM_HEALTH_CHECKS);
-    internal static Counter<int> FailedHealthChecks = Instruments.Meter.CreateCounter<int>(InstrumentNames.WATCHDOG_NUM_FAILED_HEALTH_CHECKS);
+    private readonly Counter<int> _healthChecks = instruments.Meter.CreateCounter<int>(InstrumentNames.WATCHDOG_NUM_HEALTH_CHECKS);
+    private readonly Counter<int> _failedHealthChecks = instruments.Meter.CreateCounter<int>(InstrumentNames.WATCHDOG_NUM_FAILED_HEALTH_CHECKS);
+
+    internal void OnHealthCheck()
+    {
+        _healthChecks.Add(1);
+    }
+
+    internal void OnFailedHealthCheck()
+    {
+        _failedHealthChecks.Add(1);
+    }
 }

--- a/src/Orleans.Runtime/Silo/Watchdog.cs
+++ b/src/Orleans.Runtime/Silo/Watchdog.cs
@@ -13,13 +13,18 @@ namespace Orleans.Runtime
     /// <summary>
     /// Monitors runtime and component health periodically, reporting complaints.
     /// </summary>
-    internal partial class Watchdog(IOptions<ClusterMembershipOptions> clusterMembershipOptions, IEnumerable<IHealthCheckParticipant> participants, ILogger<Watchdog> logger) : IDisposable
+    internal partial class Watchdog(
+        IOptions<ClusterMembershipOptions> clusterMembershipOptions,
+        IEnumerable<IHealthCheckParticipant> participants,
+        ILogger<Watchdog> logger,
+        OrleansInstruments orleansInstruments) : IDisposable
     {
         private static readonly TimeSpan PlatformWatchdogHeartbeatPeriod = TimeSpan.FromMilliseconds(1000);
         private readonly CancellationTokenSource _cancellation = new();
         private readonly TimeSpan _componentHealthCheckPeriod = clusterMembershipOptions.Value.LocalHealthDegradationMonitoringPeriod;
         private readonly List<IHealthCheckParticipant> _participants = participants.ToList();
         private readonly ILogger _logger = logger;
+        private readonly WatchdogInstruments _watchdogInstruments = new(orleansInstruments);
         private ValueStopwatch _platformWatchdogStopwatch;
         private ValueStopwatch _componentWatchdogStopwatch;
 
@@ -130,7 +135,7 @@ namespace Orleans.Runtime
 
         private void CheckComponentHealth()
         {
-            WatchdogInstruments.HealthChecks.Add(1);
+            _watchdogInstruments.OnHealthCheck();
             var numFailedChecks = 0;
             StringBuilder? complaints = null;
 
@@ -161,7 +166,7 @@ namespace Orleans.Runtime
 
             if (complaints != null)
             {
-                WatchdogInstruments.FailedHealthChecks.Add(1);
+                _watchdogInstruments.OnFailedHealthCheck();
                 LogWarningHealthCheckFailure(_logger, numFailedChecks, _participants.Count, complaints);
             }
 

--- a/test/Orleans.Runtime.Tests/Diagnostics/WatchdogInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/WatchdogInstrumentsTests.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class WatchdogInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void WatchdogInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new WatchdogInstruments(new OrleansInstruments(meterFactory));
+        using var healthCheckCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.WATCHDOG_NUM_HEALTH_CHECKS);
+        using var failedHealthCheckCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.WATCHDOG_NUM_FAILED_HEALTH_CHECKS);
+
+        instruments.OnHealthCheck();
+        instruments.OnFailedHealthCheck();
+
+        Assert.Equal(1, Assert.Single(healthCheckCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(failedHealthCheckCollector.GetMeasurementSnapshot()).Value);
+    }
+}


### PR DESCRIPTION
Related to #9608.

Converts WatchdogInstruments from static global Meter usage to an instance-based implementation backed by OrleansInstruments. Watchdog now owns the watchdog instruments instance and records health check metrics through the DI-created Orleans meter.

Adds a focused MetricCollector test to verify watchdog metrics are emitted through IMeterFactory.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10138)