### PR TITLE
perf(runtime): remove activation response state lock

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1531,17 +1531,15 @@ internal sealed partial class ActivationData :
 
     private void ReceiveResponse(Message message)
     {
-        lock (this)
+        var state = State;
+        if (state == ActivationState.Invalid)
         {
-            if (State == ActivationState.Invalid)
-            {
-                _shared.InternalRuntime.MessagingTrace.OnDispatcherReceiveInvalidActivation(message, State);
-                // Note that we always process responses, even if the activation is invalid.
-            }
-            else
-            {
-                MessagingProcessingInstruments.OnDispatcherMessageProcessedOk(message);
-            }
+            _shared.InternalRuntime.MessagingTrace.OnDispatcherReceiveInvalidActivation(message, state);
+            // Note that we always process responses, even if the activation is invalid.
+        }
+        else
+        {
+            MessagingProcessingInstruments.OnDispatcherMessageProcessedOk(message);
         }
 
         _shared.InternalRuntime.RuntimeClient.ReceiveResponse(message);


### PR DESCRIPTION
This removes the remaining lock in ActivationData.ReceiveResponse by reading the activation state directly before recording dispatcher diagnostics. Responses continue to be delivered even when the activation is invalid.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10141)