### PR TITLE
chore: Use IMeterFactory for gateway metrics

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/GatewayInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/GatewayInstruments.cs
@@ -2,9 +2,24 @@ using System.Diagnostics.Metrics;
 
 namespace Orleans.Runtime;
 
-internal static class GatewayInstruments
+internal sealed class GatewayInstruments(OrleansInstruments instruments)
 {
-    internal static readonly Counter<int> GatewaySent = Instruments.Meter.CreateCounter<int>(InstrumentNames.GATEWAY_SENT);
-    internal static readonly Counter<int> GatewayReceived = Instruments.Meter.CreateCounter<int>(InstrumentNames.GATEWAY_RECEIVED);
-    internal static readonly Counter<int> GatewayLoadShedding = Instruments.Meter.CreateCounter<int>(InstrumentNames.GATEWAY_LOAD_SHEDDING);
+    private readonly Counter<int> _gatewaySent = instruments.Meter.CreateCounter<int>(InstrumentNames.GATEWAY_SENT);
+    private readonly Counter<int> _gatewayReceived = instruments.Meter.CreateCounter<int>(InstrumentNames.GATEWAY_RECEIVED);
+    private readonly Counter<int> _gatewayLoadShedding = instruments.Meter.CreateCounter<int>(InstrumentNames.GATEWAY_LOAD_SHEDDING);
+
+    internal void OnGatewaySent()
+    {
+        _gatewaySent.Add(1);
+    }
+
+    internal void OnGatewayReceived()
+    {
+        _gatewayReceived.Add(1);
+    }
+
+    internal void OnGatewayLoadShedding()
+    {
+        _gatewayLoadShedding.Add(1);
+    }
 }

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -41,7 +41,8 @@ namespace Orleans.Runtime.Messaging
             ILocalSiloDetails siloDetails,
             ILoggerFactory loggerFactory,
             IOptions<SiloMessagingOptions> options,
-            IAsyncTimerFactory timerFactory)
+            IAsyncTimerFactory timerFactory,
+            OrleansInstruments orleansInstruments)
         {
             this.messageCenter = messageCenter;
             this.messagingOptions = options.Value;
@@ -50,9 +51,12 @@ namespace Orleans.Runtime.Messaging
             this.clientDropTimeout = messagingOptions.ClientDropTimeout;
             clientsReplyRoutingCache = new ClientsReplyRoutingCache(messagingOptions.ResponseTimeout);
             this.gatewayAddress = siloDetails.GatewayAddress;
+            this.GatewayInstruments = new(orleansInstruments);
             this.gatewayMaintenanceTimer = timerFactory.Create(messagingOptions.ClientDropTimeout, nameof(PerformGatewayMaintenance));
             this.gatewayMaintenanceTask = Task.Run(PerformGatewayMaintenance);
         }
+
+        internal GatewayInstruments GatewayInstruments { get; }
 
         public static GrainAddress GetClientActivationAddress(GrainId clientId, SiloAddress siloAddress)
         {
@@ -449,7 +453,7 @@ namespace Orleans.Runtime.Messaging
                 try
                 {
                     connection.Send(message);
-                    GatewayInstruments.GatewaySent.Add(1);
+                    _gateway.GatewayInstruments.OnGatewaySent();
                     return true;
                 }
                 catch (Exception exception)

--- a/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
@@ -62,7 +62,8 @@ namespace Orleans.Runtime.Messaging
                 this.ConnectionOptions,
                 this.messageCenter,
                 this.connectionShared,
-                this.connectionPreambleHelper);
+                this.connectionPreambleHelper,
+                this.gateway.GatewayInstruments);
         }
 
         protected override void ConfigureConnectionBuilder(IConnectionBuilder connectionBuilder)

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -15,6 +15,7 @@ namespace Orleans.Runtime.Messaging
         private readonly ConnectionPreambleHelper connectionPreambleHelper;
         private readonly ConnectionOptions connectionOptions;
         private readonly Gateway gateway;
+        private readonly GatewayInstruments gatewayInstruments;
         private readonly OverloadDetector overloadDetector;
         private readonly SiloAddress myAddress;
         private readonly string myClusterId;
@@ -28,11 +29,13 @@ namespace Orleans.Runtime.Messaging
             ConnectionOptions connectionOptions,
             MessageCenter messageCenter,
             ConnectionCommon connectionShared,
-            ConnectionPreambleHelper connectionPreambleHelper)
+            ConnectionPreambleHelper connectionPreambleHelper,
+            GatewayInstruments gatewayInstruments)
             : base(connection, middleware, connectionShared)
         {
             this.connectionOptions = connectionOptions;
             this.gateway = gateway;
+            this.gatewayInstruments = gatewayInstruments;
             this.overloadDetector = overloadDetector;
             this.messageCenter = messageCenter;
             this.connectionPreambleHelper = connectionPreambleHelper;
@@ -47,13 +50,13 @@ namespace Orleans.Runtime.Messaging
         protected override void RecordMessageReceive(Message msg, int numTotalBytes, int headerBytes)
         {
             MessagingInstruments.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection);
-            GatewayInstruments.GatewayReceived.Add(1);
+            this.gatewayInstruments.OnGatewayReceived();
         }
 
         protected override void RecordMessageSend(Message msg, int numTotalBytes, int headerBytes)
         {
             MessagingInstruments.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection);
-            GatewayInstruments.GatewaySent.Add(1);
+            this.gatewayInstruments.OnGatewaySent();
         }
 
         protected override void OnReceivedMessage(Message msg)
@@ -72,7 +75,7 @@ namespace Orleans.Runtime.Messaging
                 Message rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.GatewayTooBusy, "Shedding load");
                 this.messageCenter.TryDeliverToProxy(rejection, targetCache: null);
                 LogRejectingRequestDueToOverloading(this.Log, msg);
-                GatewayInstruments.GatewayLoadShedding.Add(1);
+                this.gatewayInstruments.OnGatewayLoadShedding();
                 return;
             }
 

--- a/test/Orleans.Runtime.Tests/Diagnostics/GatewayInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/GatewayInstrumentsTests.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class GatewayInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void GatewayInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new GatewayInstruments(new OrleansInstruments(meterFactory));
+        using var sentCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.GATEWAY_SENT);
+        using var receivedCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.GATEWAY_RECEIVED);
+        using var loadSheddingCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.GATEWAY_LOAD_SHEDDING);
+
+        instruments.OnGatewaySent();
+        instruments.OnGatewayReceived();
+        instruments.OnGatewayLoadShedding();
+
+        Assert.Equal(1, Assert.Single(sentCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(receivedCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(loadSheddingCollector.GetMeasurementSnapshot()).Value);
+    }
+}


### PR DESCRIPTION
Related to #9608.

Converts GatewayInstruments from static global Meter usage to an instance-based implementation backed by OrleansInstruments. Gateway now owns the gateway instruments instance and GatewayInboundConnection records gateway send/receive/load-shedding metrics through that DI-created Orleans meter.

Adds a focused MetricCollector test to verify gateway metrics are emitted through IMeterFactory.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10142)