### PR TITLE
chore: Use IMeterFactory for scheduler metrics

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/SchedulerInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/SchedulerInstruments.cs
@@ -2,7 +2,12 @@ using System.Diagnostics.Metrics;
 
 namespace Orleans.Runtime;
 
-internal class SchedulerInstruments
+internal sealed class SchedulerInstruments(OrleansInstruments instruments)
 {
-    internal static readonly Counter<int> LongRunningTurnsCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.SCHEDULER_NUM_LONG_RUNNING_TURNS);
+    private readonly Counter<int> _longRunningTurns = instruments.Meter.CreateCounter<int>(InstrumentNames.SCHEDULER_NUM_LONG_RUNNING_TURNS);
+
+    internal void OnLongRunningTurn()
+    {
+        _longRunningTurns.Add(1);
+    }
 }

--- a/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
+++ b/src/Orleans.Runtime/Activation/ActivationDataActivatorProvider.cs
@@ -11,6 +11,7 @@ internal partial class ActivationDataActivatorProvider(
     IServiceProvider serviceProvider,
     GrainTypeSharedContextResolver sharedComponentsResolver,
     IOptions<SchedulingOptions> schedulingOptions,
+    SchedulerInstruments schedulerInstruments,
     IOptions<StatelessWorkerOptions> statelessWorkerOptions) : IGrainContextActivatorProvider
 {
     public bool TryGet(GrainType grainType, [NotNullWhen(true)] out IGrainContextActivator? activator)
@@ -32,7 +33,8 @@ internal partial class ActivationDataActivatorProvider(
             instanceActivator,
             serviceProvider,
             sharedContext,
-            schedulingOptions);
+            schedulingOptions,
+            schedulerInstruments);
 
         if (sharedContext.PlacementStrategy is StatelessWorkerPlacement)
         {
@@ -60,7 +62,8 @@ internal partial class ActivationDataActivatorProvider(
             IGrainActivator grainActivator,
             IServiceProvider serviceProvider,
             GrainTypeSharedContext sharedComponents,
-            IOptions<SchedulingOptions> schedulingOptions)
+            IOptions<SchedulingOptions> schedulingOptions,
+            SchedulerInstruments schedulerInstruments)
         {
             _schedulingOptions = schedulingOptions;
             _grainActivator = grainActivator;
@@ -68,7 +71,8 @@ internal partial class ActivationDataActivatorProvider(
             _sharedComponents = sharedComponents;
             _createWorkItemGroup = context => new WorkItemGroup(
                 context,
-                _schedulingOptions);
+                _schedulingOptions,
+                schedulerInstruments);
             _startActivation = state => ((ActivationData)state!).Start(_grainActivator);
         }
 

--- a/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
+++ b/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
@@ -15,7 +15,8 @@ internal sealed class SystemTargetShared(
     IOptions<SchedulingOptions> schedulingOptions,
     GrainReferenceActivator grainReferenceActivator,
     ITimerRegistry timerRegistry,
-    ActivationDirectory activations)
+    ActivationDirectory activations,
+    SchedulerInstruments schedulerInstruments)
 {
     public SiloAddress SiloAddress => localSiloDetails.SiloAddress;
 
@@ -32,6 +33,7 @@ internal sealed class SystemTargetShared(
         ArgumentNullException.ThrowIfNull(systemTarget);
         return new WorkItemGroup(
             systemTarget,
-            schedulingOptions);
+            schedulingOptions,
+            schedulerInstruments);
     }
 }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -66,6 +66,7 @@ namespace Orleans.Hosting
             services.AddMetrics();
             services.TryAddSingleton<TimeProvider>(TimeProvider.System);
             services.TryAddSingleton<OrleansInstruments>();
+            services.TryAddSingleton<SchedulerInstruments>();
 
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));

--- a/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
+++ b/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs
@@ -30,6 +30,7 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
 #endif
     private readonly Queue<Task> _workItems = new();
     private readonly SchedulingOptions _schedulingOptions;
+    private readonly SchedulerInstruments _schedulerInstruments;
 
     private long _totalItemsEnqueued;
     private long _totalItemsProcessed;
@@ -57,11 +58,13 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
 
     public WorkItemGroup(
         IGrainContext grainContext,
-        IOptions<SchedulingOptions> schedulingOptions)
+        IOptions<SchedulingOptions> schedulingOptions,
+        SchedulerInstruments schedulerInstruments)
     {
         ArgumentNullException.ThrowIfNull(grainContext);
         GrainContext = grainContext;
         _schedulingOptions = schedulingOptions.Value;
+        _schedulerInstruments = schedulerInstruments;
         _state = WorkGroupStatus.Waiting;
         TaskScheduler = new ActivationTaskScheduler(this);
     }
@@ -182,7 +185,7 @@ internal sealed partial class WorkItemGroup : IThreadPoolWorkItem, IWorkItemSche
                     taskStart = taskEnd;
                     if (taskDurationMs > turnWarningDurationMs)
                     {
-                        SchedulerInstruments.LongRunningTurnsCounter.Add(1);
+                        _schedulerInstruments.OnLongRunningTurn();
                         LogLongRunningTurn(task, taskDurationMs);
                     }
 

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -156,7 +156,8 @@ namespace UnitTests.Directory
                 schedulingOptions: Options.Create(new SchedulingOptions()),
                 grainReferenceActivator: null,
                 timerRegistry: null,
-                activations: new ActivationDirectory());
+                activations: new ActivationDirectory(),
+                schedulerInstruments: CreateSchedulerInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -207,7 +208,8 @@ namespace UnitTests.Directory
                 schedulingOptions: Options.Create(new SchedulingOptions()),
                 grainReferenceActivator: null,
                 timerRegistry: null,
-                activations: new ActivationDirectory());
+                activations: new ActivationDirectory(),
+                schedulerInstruments: CreateSchedulerInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -270,7 +272,8 @@ namespace UnitTests.Directory
                 schedulingOptions: Options.Create(new SchedulingOptions()),
                 grainReferenceActivator: null,
                 timerRegistry: null,
-                activations: new ActivationDirectory());
+                activations: new ActivationDirectory(),
+                schedulerInstruments: CreateSchedulerInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -813,6 +816,15 @@ namespace UnitTests.Directory
             }
 
             return silos[^1];
+        }
+
+        private static SchedulerInstruments CreateSchedulerInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<SchedulerInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<SchedulerInstruments>();
         }
 
         private int generation = 0;

--- a/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
@@ -80,7 +80,8 @@ namespace NonSilo.Tests.Directory
                 schedulingOptions: Options.Create(new SchedulingOptions()),
                 grainReferenceActivator: null,
                 timerRegistry: null,
-                activations: new ActivationDirectory());
+                activations: new ActivationDirectory(),
+                schedulerInstruments: CreateSchedulerInstruments());
 
             _directory = new ClientDirectory(
                 grainFactory: _grainFactory,
@@ -95,6 +96,15 @@ namespace NonSilo.Tests.Directory
 
             // Disable automatic publishing to simplify testing.
             _testAccessor.SchedulePublishUpdate = () => { };
+        }
+
+        private static SchedulerInstruments CreateSchedulerInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<SchedulerInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<SchedulerInstruments>();
         }
 
         /// <summary>

--- a/test/Orleans.Core.Tests/SchedulingHelper.cs
+++ b/test/Orleans.Core.Tests/SchedulingHelper.cs
@@ -19,7 +19,10 @@ namespace UnitTests.TesterInternal
             var services = new ServiceCollection();
             services.AddOptions();
             services.AddLogging();
+            services.AddMetrics();
             services.AddSingleton(loggerFactory);
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<SchedulerInstruments>();
             services.Configure<SchedulingOptions>(options =>
             {
                 options.DelayWarningThreshold = TimeSpan.FromMilliseconds(100);
@@ -31,7 +34,8 @@ namespace UnitTests.TesterInternal
             activationServices = services.BuildServiceProvider();
             return new WorkItemGroup(
                 context,
-                activationServices.GetRequiredService<IOptions<SchedulingOptions>>());
+                activationServices.GetRequiredService<IOptions<SchedulingOptions>>(),
+                activationServices.GetRequiredService<SchedulerInstruments>());
         }
     }
 }

--- a/test/Orleans.Runtime.Tests/Diagnostics/SchedulerInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/SchedulerInstrumentsTests.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class SchedulerInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void SchedulerInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new SchedulerInstruments(new OrleansInstruments(meterFactory));
+        using var collector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.SCHEDULER_NUM_LONG_RUNNING_TURNS);
+
+        instruments.OnLongRunningTurn();
+
+        Assert.Equal(1, Assert.Single(collector.GetMeasurementSnapshot()).Value);
+    }
+}

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -165,8 +166,9 @@ namespace UnitTests.StreamingTests
                 NullLoggerFactory.Instance,
                 Options.Create(new SchedulingOptions()),
                 grainReferenceActivator: null!,
-                timerRegistry,
-                activations: new ActivationDirectory());
+                timerRegistry: timerRegistry,
+                activations: new ActivationDirectory(),
+                schedulerInstruments: CreateSchedulerInstruments());
 
             receiver ??= Substitute.For<IQueueAdapterReceiver>();
             receiver.Initialize(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
@@ -192,6 +194,15 @@ namespace UnitTests.StreamingTests
         }
 
         private static Task InitializeAgent(PersistentStreamPullingAgent agent) => agent.RunOrQueueTask(() => agent.Initialize());
+
+        private static SchedulerInstruments CreateSchedulerInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<SchedulerInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<SchedulerInstruments>();
+        }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task RegisterStream_KeepsCacheEntryWhenSubscriberHandshakeFails()


### PR DESCRIPTION
Related to #9608.

Converts SchedulerInstruments from static global Meter usage to a singleton, OrleansInstruments-backed implementation. WorkItemGroup now records long-running turn metrics through the shared scheduler instruments instance supplied by the silo service provider.

Adds a focused MetricCollector test to verify scheduler metrics are emitted through IMeterFactory.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10143)