### PR TITLE
chore: Use IMeterFactory for consistent ring metrics

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/ConsistentRingInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/ConsistentRingInstruments.cs
@@ -4,22 +4,24 @@ using System.Diagnostics.Metrics;
 #nullable disable
 namespace Orleans.Runtime;
 
-internal static class ConsistentRingInstruments
+internal sealed class ConsistentRingInstruments(OrleansInstruments instruments)
 {
-    internal static ObservableGauge<int> RingSize;
-    internal static void RegisterRingSizeObserve(Func<int> observeValue)
+    private ObservableGauge<int> _ringSize;
+    private ObservableGauge<float> _myRangeRingPercentage;
+    private ObservableGauge<float> _averageRingPercentage;
+
+    internal void RegisterRingSizeObserve(Func<int> observeValue)
     {
-        RingSize = Instruments.Meter.CreateObservableGauge(InstrumentNames.CONSISTENTRING_SIZE, observeValue);
+        _ringSize = instruments.Meter.CreateObservableGauge(InstrumentNames.CONSISTENTRING_SIZE, observeValue);
     }
 
-    internal static ObservableGauge<float> MyRangeRingPercentage;
-    internal static void RegisterMyRangeRingPercentageObserve(Func<float> observeValue)
+    internal void RegisterMyRangeRingPercentageObserve(Func<float> observeValue)
     {
-        MyRangeRingPercentage = Instruments.Meter.CreateObservableGauge(InstrumentNames.CONSISTENTRING_LOCAL_SIZE_PERCENTAGE, observeValue);
+        _myRangeRingPercentage = instruments.Meter.CreateObservableGauge(InstrumentNames.CONSISTENTRING_LOCAL_SIZE_PERCENTAGE, observeValue);
     }
-    internal static ObservableGauge<float> AverageRingPercentage;
-    internal static void RegisterAverageRingPercentageObserve(Func<float> observeValue)
+
+    internal void RegisterAverageRingPercentageObserve(Func<float> observeValue)
     {
-        AverageRingPercentage = Instruments.Meter.CreateObservableGauge(InstrumentNames.CONSISTENTRING_AVERAGE_SIZE_PERCENTAGE, observeValue);
+        _averageRingPercentage = instruments.Meter.CreateObservableGauge(InstrumentNames.CONSISTENTRING_AVERAGE_SIZE_PERCENTAGE, observeValue);
     }
 }

--- a/src/Orleans.Runtime/ConsistentRing/VirtualBucketsRingProvider.cs
+++ b/src/Orleans.Runtime/ConsistentRing/VirtualBucketsRingProvider.cs
@@ -27,7 +27,7 @@ namespace Orleans.Runtime.ConsistentRing
         private IRingRange myRange;
         private (IRingRange OldRange, IRingRange NewRange, bool Increased) lastNotification;
 
-        internal VirtualBucketsRingProvider(SiloAddress siloAddress, ILoggerFactory loggerFactory, int numVirtualBuckets, ISiloStatusOracle siloStatusOracle)
+        internal VirtualBucketsRingProvider(SiloAddress siloAddress, ILoggerFactory loggerFactory, int numVirtualBuckets, ISiloStatusOracle siloStatusOracle, ConsistentRingInstruments consistentRingInstruments)
         {
             numBucketsPerSilo = numVirtualBuckets;
             _siloStatusOracle = siloStatusOracle;
@@ -43,9 +43,9 @@ namespace Orleans.Runtime.ConsistentRing
 
             LogDebugStarting(logger, nameof(VirtualBucketsRingProvider), new(siloAddress));
 
-            ConsistentRingInstruments.RegisterRingSizeObserve(() => GetRingSize());
-            ConsistentRingInstruments.RegisterMyRangeRingPercentageObserve(() => (float)((IRingRangeInternal)myRange).RangePercentage());
-            ConsistentRingInstruments.RegisterAverageRingPercentageObserve(() =>
+            consistentRingInstruments.RegisterRingSizeObserve(() => GetRingSize());
+            consistentRingInstruments.RegisterMyRangeRingPercentageObserve(() => (float)((IRingRangeInternal)myRange).RangePercentage());
+            consistentRingInstruments.RegisterAverageRingPercentageObserve(() =>
             {
                 int size = GetRingSize();
                 return size == 0 ? 0 : ((float)100.0 / size);

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -67,6 +67,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<TimeProvider>(TimeProvider.System);
             services.TryAddSingleton<OrleansInstruments>();
             services.TryAddSingleton<SchedulerInstruments>();
+            services.TryAddSingleton<ConsistentRingInstruments>();
 
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));
@@ -286,9 +287,10 @@ namespace Orleans.Hosting
                     var siloDetails = sp.GetRequiredService<ILocalSiloDetails>();
                     var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
                     var siloStatusOracle = sp.GetRequiredService<ISiloStatusOracle>();
+                    var consistentRingInstruments = sp.GetRequiredService<ConsistentRingInstruments>();
                     if (consistentRingOptions.UseVirtualBucketsConsistentRing)
                     {
-                        return new VirtualBucketsRingProvider(siloDetails.SiloAddress, loggerFactory, consistentRingOptions.NumVirtualBucketsConsistentRing, siloStatusOracle);
+                        return new VirtualBucketsRingProvider(siloDetails.SiloAddress, loggerFactory, consistentRingOptions.NumVirtualBucketsConsistentRing, siloStatusOracle, consistentRingInstruments);
                     }
 
                     return new ConsistentRingProvider(siloDetails.SiloAddress, loggerFactory, siloStatusOracle);

--- a/test/Orleans.Runtime.Internal.Tests/LivenessTests/ConsistentRingProviderTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/LivenessTests/ConsistentRingProviderTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Net;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.Configuration;
 using Orleans.Runtime.ConsistentRing;
@@ -35,7 +36,7 @@ namespace UnitTests.LivenessTests
         public void ConsistentRingProvider_Test2()
         {
             SiloAddress silo1 = SiloAddressUtils.NewLocalSiloAddress(0);
-            VirtualBucketsRingProvider ring = new VirtualBucketsRingProvider(silo1, NullLoggerFactory.Instance, 30, new FakeSiloStatusOracle());
+            VirtualBucketsRingProvider ring = new VirtualBucketsRingProvider(silo1, NullLoggerFactory.Instance, 30, new FakeSiloStatusOracle(), CreateConsistentRingInstruments());
             _output.WriteLine("\n\n*** Silo1 range: {0}.\n*** The whole ring with 1 silo is:\n{1}\n\n", ring.GetMyRange(), ring.ToString());
 
             for (int i = 1; i <= 10; i++)
@@ -54,7 +55,7 @@ namespace UnitTests.LivenessTests
 
             Random random = new Random();
             SiloAddress silo1 = SiloAddressUtils.NewLocalSiloAddress(random.Next(100000));
-            VirtualBucketsRingProvider ring = new VirtualBucketsRingProvider(silo1, NullLoggerFactory.Instance, 50, new FakeSiloStatusOracle());
+            VirtualBucketsRingProvider ring = new VirtualBucketsRingProvider(silo1, NullLoggerFactory.Instance, 50, new FakeSiloStatusOracle(), CreateConsistentRingInstruments());
 
             for (int i = 1; i <= NUM_SILOS - 1; i++)
             {
@@ -115,6 +116,15 @@ namespace UnitTests.LivenessTests
             }
             //queueHistogram.Sort((t1, t2) => t1.Item2.CompareTo(t2.Item2));
             return queueHistogram;
+        }
+
+        private static ConsistentRingInstruments CreateConsistentRingInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<ConsistentRingInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<ConsistentRingInstruments>();
         }
 
         internal sealed class FakeSiloStatusOracle : ISiloStatusOracle

--- a/test/Orleans.Runtime.Tests/Diagnostics/ConsistentRingInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/ConsistentRingInstrumentsTests.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class ConsistentRingInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void ConsistentRingInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new ConsistentRingInstruments(new OrleansInstruments(meterFactory));
+        using var ringSizeCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.CONSISTENTRING_SIZE);
+        using var localRangeCollector = new MetricCollector<float>(meterFactory, "Microsoft.Orleans", InstrumentNames.CONSISTENTRING_LOCAL_SIZE_PERCENTAGE);
+        using var averageRangeCollector = new MetricCollector<float>(meterFactory, "Microsoft.Orleans", InstrumentNames.CONSISTENTRING_AVERAGE_SIZE_PERCENTAGE);
+
+        instruments.RegisterRingSizeObserve(() => 3);
+        instruments.RegisterMyRangeRingPercentageObserve(() => 25.0f);
+        instruments.RegisterAverageRingPercentageObserve(() => 33.3f);
+
+        ringSizeCollector.RecordObservableInstruments();
+        localRangeCollector.RecordObservableInstruments();
+        averageRangeCollector.RecordObservableInstruments();
+
+        Assert.Equal(3, Assert.Single(ringSizeCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(25.0f, Assert.Single(localRangeCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(33.3f, Assert.Single(averageRangeCollector.GetMeasurementSnapshot()).Value);
+    }
+}


### PR DESCRIPTION
Related to #9608.

Converts ConsistentRingInstruments from static global Meter usage to a singleton, OrleansInstruments-backed implementation. VirtualBucketsRingProvider now registers ring-size and range-percentage observable gauges through the shared consistent-ring instruments instance supplied by the silo service provider.

Adds a focused MetricCollector test to verify consistent-ring metrics are emitted through IMeterFactory.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10144)