### PR TITLE
feat(dashboard): add silo lifecycle dependency graph view

### DIFF
--- a/src/Dashboard/Orleans.Dashboard.App/package-lock.json
+++ b/src/Dashboard/Orleans.Dashboard.App/package-lock.json
@@ -15,6 +15,7 @@
         "chart.js": "^4.4.8",
         "eventthing": "^1.0.7",
         "humanize-duration": "^3.32.1",
+        "mermaid": "^11.15.0",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1"
@@ -31,6 +32,19 @@
         "typescript": "~5.7.3",
         "vite": "^8.0.11",
         "vite-plugin-commonjs": "^0.10.4"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -310,6 +324,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -535,6 +561,23 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -584,6 +627,15 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -1029,11 +1081,270 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/humanize-duration": {
       "version": "3.27.4",
@@ -1070,6 +1381,23 @@
       "dev": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1327,6 +1655,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1345,6 +1682,15 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1365,6 +1711,511 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.4",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.4.tgz",
+      "integrity": "sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1389,6 +2240,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1397,6 +2257,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1412,6 +2281,16 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1798,6 +2677,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1813,6 +2698,18 @@
       "integrity": "sha512-hwzSCymnRdFx9YdRkQQ0OYequXiVAV6ZGQA2uzocwB0F4309Ke6pO8dg0P8LHhRQJyVjGteRTAA/zNfEcpXn8A==",
       "funding": {
         "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -1840,6 +2737,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -1847,6 +2754,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -1957,6 +2873,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -1965,6 +2906,17 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -2255,6 +3207,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2292,6 +3250,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2300,6 +3270,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/micromatch": {
@@ -2427,6 +3426,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2438,6 +3443,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -2474,6 +3485,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -2606,6 +3633,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.18",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
@@ -2647,6 +3680,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2670,6 +3715,18 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -2732,6 +3789,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2742,6 +3805,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -2772,6 +3844,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {
@@ -2845,6 +3926,19 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/src/Dashboard/Orleans.Dashboard.App/package.json
+++ b/src/Dashboard/Orleans.Dashboard.App/package.json
@@ -17,6 +17,7 @@
     "chart.js": "^4.4.8",
     "eventthing": "^1.0.7",
     "humanize-duration": "^3.32.1",
+    "mermaid": "^11.15.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1"

--- a/src/Dashboard/Orleans.Dashboard.App/src/index.tsx
+++ b/src/Dashboard/Orleans.Dashboard.App/src/index.tsx
@@ -49,6 +49,7 @@ import SiloCounters from './silos/silo-counters';
 import Reminders from './reminders/reminders';
 import Preferences from './components/preferences';
 import storage from './lib/storage';
+import Lifecycle, { LifecycleStageInfo } from './lifecycle/lifecycle';
 
 interface Settings {
   dashboardGrainsHidden: boolean;
@@ -477,6 +478,33 @@ function renderPage(jsx: JSX.Element, path: string) {
   renderPage(<LogStream xhr={xhr} />, '#/trace');
 });
 
+(routie as any)('/lifecycle', function () {
+  const thisRouteIndex = ++routeIndex;
+  events.clearAll();
+  scroll();
+  renderLoading();
+
+  let stages: LifecycleStageInfo[] | null = null;
+
+  render = function () {
+    if (routeIndex != thisRouteIndex) return;
+    renderPage(
+      <Page title="Lifecycle">
+        <Lifecycle stages={stages} />
+      </Page>,
+      '#/lifecycle'
+    );
+  };
+
+  http.get('LifecycleStages', function (err, data) {
+    if (routeIndex != thisRouteIndex) return;
+    stages = (data as LifecycleStageInfo[]) || [];
+    render();
+  });
+
+  render();
+});
+
 (routie as any)('/preferences', function () {
   const thisRouteIndex = ++routeIndex;
   events.clearAll();
@@ -553,6 +581,11 @@ function getMenu(): MenuItem[] {
       name: 'Silos',
       path: '#/silos',
       icon: 'fa fa-database'
+    },
+    {
+      name: 'Lifecycle',
+      path: '#/lifecycle',
+      icon: 'fa fa-sitemap'
     },
     {
       name: 'Reminders',

--- a/src/Dashboard/Orleans.Dashboard.App/src/lifecycle/lifecycle.tsx
+++ b/src/Dashboard/Orleans.Dashboard.App/src/lifecycle/lifecycle.tsx
@@ -1,0 +1,296 @@
+import React from 'react';
+import mermaid from 'mermaid';
+import Panel from '../components/panel';
+import storage from '../lib/storage';
+
+export interface LifecycleObserverInfo {
+  name: string;
+  observerType?: string;
+  hasOnStart: boolean;
+  hasOnStop: boolean;
+  onStartMethod?: string;
+  onStopMethod?: string;
+}
+
+export interface LifecycleStageInfo {
+  stage: number;
+  stageName: string;
+  isNamedStage: boolean;
+  observers: LifecycleObserverInfo[];
+}
+
+type Direction = 'startup' | 'shutdown';
+
+interface LifecycleProps {
+  stages: LifecycleStageInfo[] | null;
+}
+
+interface LifecycleState {
+  startupSvg: string;
+  shutdownSvg: string;
+  rendering: boolean;
+  errorMessage: string | null;
+  activeTab: Direction;
+}
+
+let initialized = false;
+function ensureMermaidInit() {
+  if (initialized) return;
+  const theme = storage.get('theme') === 'light' ? 'default' : 'dark';
+  mermaid.initialize({
+    startOnLoad: false,
+    theme,
+    securityLevel: 'loose',
+    flowchart: { htmlLabels: true, curve: 'basis' }
+  });
+  initialized = true;
+}
+
+function escape(value: string): string {
+  return (value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function buildStartupGraph(stages: LifecycleStageInfo[]): string {
+  if (!stages.length) return 'flowchart TD\n  empty["No lifecycle data"]';
+
+  const lines: string[] = [
+    'flowchart TD',
+    '  classDef stage fill:#374151,stroke:#9ca3af,color:#f9fafb,text-align:left;',
+    '  classDef named fill:#1f2a44,stroke:#60a5fa,color:#f9fafb,text-align:left;'
+  ];
+
+  stages.forEach((s, idx) => {
+    const id = `s${idx}`;
+    const header = escape(`${s.stageName} (start)`);
+    const body = s.observers
+      .map(o => `&bull; ${escape(o.name)}${o.onStartMethod ? ` &mdash; ${escape(o.onStartMethod)}` : ''}`)
+      .join('<br/>');
+    lines.push(`  ${id}["<b>${header}</b><br/>${body || '<i>(no participants)</i>'}"]`);
+    lines.push(`  class ${id} ${s.isNamedStage ? 'named' : 'stage'};`);
+    if (idx > 0) {
+      lines.push(`  s${idx - 1} --> ${id}`);
+    }
+  });
+
+  return lines.join('\n');
+}
+
+function buildShutdownGraph(stages: LifecycleStageInfo[]): string {
+  if (!stages.length) return 'flowchart TD\n  empty["No lifecycle data"]';
+
+  const reversed = [...stages].reverse();
+  const lines: string[] = [
+    'flowchart TD',
+    '  classDef stage fill:#4b1d1d,stroke:#fca5a5,color:#fef2f2,text-align:left;',
+    '  classDef named fill:#3a0e0e,stroke:#f87171,color:#fef2f2,text-align:left;'
+  ];
+
+  reversed.forEach((s, idx) => {
+    const id = `t${idx}`;
+    const header = escape(`${s.stageName} (stop)`);
+    const body = s.observers
+      .map(o => `&bull; ${escape(o.name)}${o.onStopMethod ? ` &mdash; ${escape(o.onStopMethod)}` : ''}`)
+      .join('<br/>');
+    lines.push(`  ${id}["<b>${header}</b><br/>${body || '<i>(no participants)</i>'}"]`);
+    lines.push(`  class ${id} ${s.isNamedStage ? 'named' : 'stage'};`);
+    if (idx > 0) {
+      lines.push(`  t${idx - 1} --> ${id}`);
+    }
+  });
+
+  return lines.join('\n');
+}
+
+/**
+ * Mermaid emits an SVG with fixed `width`/`height` attributes plus a
+ * `max-width: NNNpx` style that, when the host container is narrower
+ * than the diagram's natural width, leaves the rendered SVG element
+ * at its full natural height while the content scales down — so the
+ * bottom of the diagram gets clipped by the card. Replace those with
+ * an explicit `aspect-ratio` derived from the viewBox so the browser
+ * sizes the SVG element to match the scaled content.
+ */
+function normaliseSvg(svg: string): string {
+  if (typeof DOMParser === 'undefined' || !svg) return svg;
+  try {
+    const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+    const svgEl = doc.documentElement as unknown as SVGSVGElement;
+    if (!svgEl || svgEl.tagName.toLowerCase() !== 'svg') return svg;
+
+    const viewBox = svgEl.getAttribute('viewBox');
+    svgEl.removeAttribute('width');
+    svgEl.removeAttribute('height');
+    svgEl.removeAttribute('style');
+    svgEl.style.display = 'block';
+    svgEl.style.width = '100%';
+    svgEl.style.maxWidth = '100%';
+    svgEl.style.height = 'auto';
+    if (viewBox) {
+      const parts = viewBox.split(/\s+/).map(Number);
+      if (parts.length === 4 && parts[2] > 0 && parts[3] > 0) {
+        svgEl.style.aspectRatio = `${parts[2]} / ${parts[3]}`;
+      }
+    }
+    return svgEl.outerHTML;
+  } catch {
+    return svg;
+  }
+}
+
+export default class Lifecycle extends React.Component<LifecycleProps, LifecycleState> {
+  state: LifecycleState = {
+    startupSvg: '',
+    shutdownSvg: '',
+    rendering: false,
+    errorMessage: null,
+    activeTab: 'startup'
+  };
+
+  componentDidMount() {
+    this.renderDiagrams();
+  }
+
+  componentDidUpdate(prevProps: LifecycleProps) {
+    if (prevProps.stages !== this.props.stages) {
+      this.renderDiagrams();
+    }
+  }
+
+  async renderDiagrams() {
+    if (!this.props.stages || !this.props.stages.length) return;
+    ensureMermaidInit();
+    this.setState({ rendering: true, errorMessage: null });
+    try {
+      const startup = buildStartupGraph(this.props.stages);
+      const shutdown = buildShutdownGraph(this.props.stages);
+      const { svg: startupSvg } = await mermaid.render('lifecycle-startup', startup);
+      const { svg: shutdownSvg } = await mermaid.render('lifecycle-shutdown', shutdown);
+      this.setState({
+        startupSvg: normaliseSvg(startupSvg),
+        shutdownSvg: normaliseSvg(shutdownSvg),
+        rendering: false
+      });
+    } catch (err: any) {
+      this.setState({
+        rendering: false,
+        errorMessage: (err && err.message) || String(err)
+      });
+    }
+  }
+
+  renderTable(direction: Direction) {
+    const stages = this.props.stages || [];
+    const ordered = direction === 'startup' ? stages : [...stages].reverse();
+    return (
+      <table className="table table-sm table-striped">
+        <thead>
+          <tr>
+            <th style={{ width: '20%' }}>Stage</th>
+            <th style={{ width: '25%' }}>Observer</th>
+            <th>{direction === 'startup' ? 'OnStart' : 'OnStop'}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ordered.flatMap(s => {
+            const observers = s.observers.length
+              ? s.observers
+              : ([{ name: '(no participants)', hasOnStart: false, hasOnStop: false }] as LifecycleObserverInfo[]);
+            return observers.map((o, idx) => (
+              <tr key={`${s.stage}-${o.name}-${idx}`}>
+                {idx === 0 ? (
+                  <td rowSpan={observers.length}>
+                    <strong>{s.stageName}</strong>
+                  </td>
+                ) : null}
+                <td>{o.name}</td>
+                <td>
+                  <code style={{ wordBreak: 'break-all' }}>
+                    {direction === 'startup'
+                      ? o.onStartMethod || (o.hasOnStart ? '(unknown)' : '—')
+                      : o.onStopMethod || (o.hasOnStop ? '(unknown)' : '—')}
+                  </code>
+                </td>
+              </tr>
+            ));
+          })}
+        </tbody>
+      </table>
+    );
+  }
+
+  renderTab(direction: Direction) {
+    const { startupSvg, shutdownSvg, rendering, errorMessage } = this.state;
+    const svg = direction === 'startup' ? startupSvg : shutdownSvg;
+    const subTitle = direction === 'startup'
+      ? 'Low → high stage. Tasks within a stage start in parallel; stages execute sequentially.'
+      : 'Reverse order — the highest started stage stops first.';
+    const tableLabel = direction === 'startup' ? 'Startup observers' : 'Shutdown observers';
+    const diagramLabel = direction === 'startup' ? 'Startup stages' : 'Shutdown stages';
+
+    return (
+      <div>
+        <Panel title={diagramLabel} subTitle={subTitle}>
+          <div>
+            {errorMessage ? <pre className="text-danger">{errorMessage}</pre> : null}
+            {rendering && !svg ? <p>Rendering…</p> : null}
+            <div
+              style={{ overflowX: 'auto', width: '100%' }}
+              dangerouslySetInnerHTML={{ __html: svg }}
+            />
+          </div>
+        </Panel>
+
+        <Panel title={tableLabel}>{this.renderTable(direction)}</Panel>
+      </div>
+    );
+  }
+
+  selectTab = (direction: Direction) => () => this.setState({ activeTab: direction });
+
+  render() {
+    if (!this.props.stages) {
+      return (
+        <Panel title="Lifecycle">
+          <p>Loading lifecycle data…</p>
+        </Panel>
+      );
+    }
+
+    if (!this.props.stages.length) {
+      return (
+        <Panel title="Lifecycle">
+          <p>No active silo is available to report its lifecycle.</p>
+        </Panel>
+      );
+    }
+
+    const { activeTab } = this.state;
+    const tabButton = (direction: Direction, label: string) => (
+      <li className="nav-item" role="presentation">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === direction}
+          className={`nav-link${activeTab === direction ? ' active' : ''}`}
+          onClick={this.selectTab(direction)}
+        >
+          {label}
+        </button>
+      </li>
+    );
+
+    return (
+      <div>
+        <ul className="nav nav-tabs mb-3" role="tablist">
+          {tabButton('startup', 'Startup')}
+          {tabButton('shutdown', 'Shutdown')}
+        </ul>
+        {this.renderTab(activeTab)}
+      </div>
+    );
+  }
+}

--- a/src/Dashboard/Orleans.Dashboard.App/src/lifecycle/lifecycle.tsx
+++ b/src/Dashboard/Orleans.Dashboard.App/src/lifecycle/lifecycle.tsx
@@ -106,13 +106,14 @@ function buildShutdownGraph(stages: LifecycleStageInfo[]): string {
 }
 
 /**
- * Mermaid emits an SVG with fixed `width`/`height` attributes plus a
- * `max-width: NNNpx` style that, when the host container is narrower
- * than the diagram's natural width, leaves the rendered SVG element
- * at its full natural height while the content scales down — so the
- * bottom of the diagram gets clipped by the card. Replace those with
- * an explicit `aspect-ratio` derived from the viewBox so the browser
- * sizes the SVG element to match the scaled content.
+ * Mermaid emits an SVG whose `viewBox` is computed before the browser
+ * has laid out the HTML-based labels inside `foreignObject` elements,
+ * so the calculation routinely under-estimates the diagram height — the
+ * bottom row of nodes ends up below the viewBox's lower edge and gets
+ * clipped, while spurious whitespace appears at the top. Strip
+ * Mermaid's fixed width/height/max-width styling so the subsequent
+ * `fixSvgViewBox` pass (which runs after layout) can install its own
+ * intrinsic dimensions derived from the actual rendered bounds.
  */
 function normaliseSvg(svg: string): string {
   if (typeof DOMParser === 'undefined' || !svg) return svg;
@@ -121,24 +122,54 @@ function normaliseSvg(svg: string): string {
     const svgEl = doc.documentElement as unknown as SVGSVGElement;
     if (!svgEl || svgEl.tagName.toLowerCase() !== 'svg') return svg;
 
-    const viewBox = svgEl.getAttribute('viewBox');
     svgEl.removeAttribute('width');
     svgEl.removeAttribute('height');
     svgEl.removeAttribute('style');
     svgEl.style.display = 'block';
-    svgEl.style.width = '100%';
-    svgEl.style.maxWidth = '100%';
-    svgEl.style.height = 'auto';
-    if (viewBox) {
-      const parts = viewBox.split(/\s+/).map(Number);
-      if (parts.length === 4 && parts[2] > 0 && parts[3] > 0) {
-        svgEl.style.aspectRatio = `${parts[2]} / ${parts[3]}`;
-      }
-    }
     return svgEl.outerHTML;
   } catch {
     return svg;
   }
+}
+
+/**
+ * Once the SVG is mounted in the DOM, `getBBox()` returns the union of
+ * the actual rendered bounds of every node — including any HTML labels
+ * that wrapped past Mermaid's internal estimate. Rewrite the viewBox
+ * to that bounding box (with a small padding) and install explicit
+ * `width`/`height` attributes so the SVG renders at natural pixel
+ * size: text stays at 16px and nodes stay at their natural width. The
+ * surrounding wrapper provides scrollbars when the diagram is larger
+ * than the host card.
+ */
+function fixSvgViewBox(container: HTMLElement | null): void {
+  if (!container) return;
+  const svg = container.querySelector('svg') as SVGSVGElement | null;
+  if (!svg) return;
+
+  // getBBox throws on detached/unrendered SVGs; ignore failures.
+  let bbox: { x: number; y: number; width: number; height: number };
+  try {
+    const raw = svg.getBBox();
+    bbox = { x: raw.x, y: raw.y, width: raw.width, height: raw.height };
+  } catch {
+    return;
+  }
+
+  if (bbox.width <= 0 || bbox.height <= 0) return;
+
+  const padding = 16;
+  const x = bbox.x - padding;
+  const y = bbox.y - padding;
+  const w = Math.ceil(bbox.width + padding * 2);
+  const h = Math.ceil(bbox.height + padding * 2);
+
+  svg.setAttribute('viewBox', `${x} ${y} ${w} ${h}`);
+  svg.setAttribute('width', String(w));
+  svg.setAttribute('height', String(h));
+  svg.style.aspectRatio = '';
+  svg.style.maxWidth = '';
+  svg.style.height = '';
 }
 
 export default class Lifecycle extends React.Component<LifecycleProps, LifecycleState> {
@@ -150,13 +181,26 @@ export default class Lifecycle extends React.Component<LifecycleProps, Lifecycle
     activeTab: 'startup'
   };
 
+  private diagramRef = React.createRef<HTMLDivElement>();
+
   componentDidMount() {
     this.renderDiagrams();
   }
 
-  componentDidUpdate(prevProps: LifecycleProps) {
+  componentDidUpdate(prevProps: LifecycleProps, prevState: LifecycleState) {
     if (prevProps.stages !== this.props.stages) {
       this.renderDiagrams();
+    }
+
+    const svgChanged =
+      prevState.startupSvg !== this.state.startupSvg ||
+      prevState.shutdownSvg !== this.state.shutdownSvg ||
+      prevState.activeTab !== this.state.activeTab;
+
+    if (svgChanged) {
+      // Wait one frame so the browser has flushed layout for the freshly
+      // inserted SVG before we measure it with getBBox().
+      requestAnimationFrame(() => fixSvgViewBox(this.diagramRef.current));
     }
   }
 
@@ -238,7 +282,8 @@ export default class Lifecycle extends React.Component<LifecycleProps, Lifecycle
             {errorMessage ? <pre className="text-danger">{errorMessage}</pre> : null}
             {rendering && !svg ? <p>Rendering…</p> : null}
             <div
-              style={{ overflowX: 'auto', width: '100%' }}
+              ref={this.diagramRef}
+              style={{ overflow: 'auto', width: '100%', maxHeight: '80vh' }}
               dangerouslySetInnerHTML={{ __html: svg }}
             />
           </div>

--- a/src/Dashboard/Orleans.Dashboard.App/src/lifecycle/lifecycle.tsx
+++ b/src/Dashboard/Orleans.Dashboard.App/src/lifecycle/lifecycle.tsx
@@ -40,8 +40,8 @@ function ensureMermaidInit() {
   mermaid.initialize({
     startOnLoad: false,
     theme,
-    securityLevel: 'loose',
-    flowchart: { htmlLabels: true, curve: 'basis' }
+    securityLevel: 'strict',
+    flowchart: { htmlLabels: false, curve: 'basis' }
   });
   initialized = true;
 }
@@ -51,7 +51,20 @@ function escape(value: string): string {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    .replace(/[\r\n]+/g, ' ');
+}
+
+function formatStageLabel(stage: LifecycleStageInfo, direction: Direction): string {
+  const title = `${escape(stage.stageName)} (${direction === 'startup' ? 'start' : 'stop'})`;
+  const observerLines = stage.observers.map(observer => {
+    const method = direction === 'startup' ? observer.onStartMethod : observer.onStopMethod;
+    return method
+      ? `- ${escape(observer.name)} - ${escape(method)}`
+      : `- ${escape(observer.name)}`;
+  });
+
+  return [title, ...(observerLines.length ? observerLines : ['(no participants)'])].join('\\n');
 }
 
 function buildStartupGraph(stages: LifecycleStageInfo[]): string {
@@ -65,11 +78,7 @@ function buildStartupGraph(stages: LifecycleStageInfo[]): string {
 
   stages.forEach((s, idx) => {
     const id = `s${idx}`;
-    const header = escape(`${s.stageName} (start)`);
-    const body = s.observers
-      .map(o => `&bull; ${escape(o.name)}${o.onStartMethod ? ` &mdash; ${escape(o.onStartMethod)}` : ''}`)
-      .join('<br/>');
-    lines.push(`  ${id}["<b>${header}</b><br/>${body || '<i>(no participants)</i>'}"]`);
+    lines.push(`  ${id}["${formatStageLabel(s, 'startup')}"]`);
     lines.push(`  class ${id} ${s.isNamedStage ? 'named' : 'stage'};`);
     if (idx > 0) {
       lines.push(`  s${idx - 1} --> ${id}`);
@@ -91,11 +100,7 @@ function buildShutdownGraph(stages: LifecycleStageInfo[]): string {
 
   reversed.forEach((s, idx) => {
     const id = `t${idx}`;
-    const header = escape(`${s.stageName} (stop)`);
-    const body = s.observers
-      .map(o => `&bull; ${escape(o.name)}${o.onStopMethod ? ` &mdash; ${escape(o.onStopMethod)}` : ''}`)
-      .join('<br/>');
-    lines.push(`  ${id}["<b>${header}</b><br/>${body || '<i>(no participants)</i>'}"]`);
+    lines.push(`  ${id}["${formatStageLabel(s, 'shutdown')}"]`);
     lines.push(`  class ${id} ${s.isNamedStage ? 'named' : 'stage'};`);
     if (idx > 0) {
       lines.push(`  t${idx - 1} --> ${id}`);
@@ -106,12 +111,7 @@ function buildShutdownGraph(stages: LifecycleStageInfo[]): string {
 }
 
 /**
- * Mermaid emits an SVG whose `viewBox` is computed before the browser
- * has laid out the HTML-based labels inside `foreignObject` elements,
- * so the calculation routinely under-estimates the diagram height — the
- * bottom row of nodes ends up below the viewBox's lower edge and gets
- * clipped, while spurious whitespace appears at the top. Strip
- * Mermaid's fixed width/height/max-width styling so the subsequent
+ * Strip Mermaid's fixed width/height/max-width styling so the subsequent
  * `fixSvgViewBox` pass (which runs after layout) can install its own
  * intrinsic dimensions derived from the actual rendered bounds.
  */
@@ -134,13 +134,10 @@ function normaliseSvg(svg: string): string {
 
 /**
  * Once the SVG is mounted in the DOM, `getBBox()` returns the union of
- * the actual rendered bounds of every node — including any HTML labels
- * that wrapped past Mermaid's internal estimate. Rewrite the viewBox
- * to that bounding box (with a small padding) and install explicit
- * `width`/`height` attributes so the SVG renders at natural pixel
- * size: text stays at 16px and nodes stay at their natural width. The
- * surrounding wrapper provides scrollbars when the diagram is larger
- * than the host card.
+ * the actual rendered bounds of every node. Rewrite the viewBox to that
+ * bounding box (with a small padding) and install explicit `width`/`height`
+ * attributes so the SVG renders at natural pixel size. The surrounding
+ * wrapper provides scrollbars when the diagram is larger than the host card.
  */
 function fixSvgViewBox(container: HTMLElement | null): void {
   if (!container) return;

--- a/src/Dashboard/Orleans.Dashboard/Core/DashboardClient.cs
+++ b/src/Dashboard/Orleans.Dashboard/Core/DashboardClient.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
 using Orleans.Runtime;
@@ -40,4 +41,23 @@ internal sealed class DashboardClient(IGrainFactory grainFactory) : IDashboardCl
     public async Task<Immutable<string>> GetGrainState(string id, string grainType) => await _dashboardGrain.GetGrainState(id, grainType);
 
     public async Task<Immutable<string[]>> GetGrainTypes(string[] exclusions = null) => await _dashboardGrain.GetGrainTypes(exclusions);
+
+    public async Task<Immutable<LifecycleStageInfo[]>> GetLifecycleStages()
+    {
+        // All silos run an identical lifecycle, so we only need to ask one of them.
+        // Use the management grain to find an active host, then call its dashboard
+        // silo grain proxy.
+        var management = _grainFactory.GetGrain<IManagementGrain>(0);
+        var hosts = await management.GetHosts(onlyActive: true);
+        var siloAddress = hosts
+            .Where(x => x.Value == SiloStatus.Active)
+            .Select(x => x.Key)
+            .FirstOrDefault();
+        if (siloAddress is null)
+        {
+            return new LifecycleStageInfo[0].AsImmutable();
+        }
+
+        return await Silo(siloAddress.ToParsableString()).GetLifecycleStages();
+    }
 }

--- a/src/Dashboard/Orleans.Dashboard/Core/IDashboardClient.cs
+++ b/src/Dashboard/Orleans.Dashboard/Core/IDashboardClient.cs
@@ -33,4 +33,6 @@ internal interface IDashboardClient
     Task<Immutable<string>> GetGrainState(string id, string grainType);
 
     Task<Immutable<string[]>> GetGrainTypes(string[] exclusions = null);
+
+    Task<Immutable<LifecycleStageInfo[]>> GetLifecycleStages();
 }

--- a/src/Dashboard/Orleans.Dashboard/Core/ISiloGrainService.cs
+++ b/src/Dashboard/Orleans.Dashboard/Core/ISiloGrainService.cs
@@ -28,4 +28,7 @@ internal interface ISiloGrainService : IGrainService
 
     [Alias("GetCounters")]
     Task<Immutable<StatCounter[]>> GetCounters();
+
+    [Alias("GetLifecycleStages")]
+    Task<Immutable<LifecycleStageInfo[]>> GetLifecycleStages();
 }

--- a/src/Dashboard/Orleans.Dashboard/Implementation/Grains/SiloGrainProxy.cs
+++ b/src/Dashboard/Orleans.Dashboard/Implementation/Grains/SiloGrainProxy.cs
@@ -37,4 +37,6 @@ internal sealed class SiloGrainProxy : Grain, ISiloGrainProxy
     public Task<Immutable<SiloRuntimeStatistics[]>> GetRuntimeStatistics() => _siloGrainService.GetRuntimeStatistics();
 
     public Task<Immutable<StatCounter[]>> GetCounters() => _siloGrainService.GetCounters();
+
+    public Task<Immutable<LifecycleStageInfo[]>> GetLifecycleStages() => _siloGrainService.GetLifecycleStages();
 }

--- a/src/Dashboard/Orleans.Dashboard/Implementation/LifecycleStageInspector.cs
+++ b/src/Dashboard/Orleans.Dashboard/Implementation/LifecycleStageInspector.cs
@@ -1,0 +1,341 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Dashboard.Model;
+using Orleans.Runtime;
+
+#nullable disable
+namespace Orleans.Dashboard.Implementation;
+
+/// <summary>
+/// Uses reflection to extract the registered lifecycle observers from a
+/// <see cref="ISiloLifecycleSubject"/> so the dashboard can render them as a
+/// dependency graph.
+/// </summary>
+/// <remarks>
+/// The dashboard does not have <c>InternalsVisibleTo</c> access to the
+/// runtime, so we walk the private state of <c>SiloLifecycleSubject</c> and
+/// <c>LifecycleSubject</c> via reflection. The shape of the data
+/// (<c>List&lt;MonitoredObserver&gt;</c> on the silo subject, with public
+/// <c>Name</c>/<c>Stage</c>/<c>StageName</c> properties and a private
+/// <c>observer</c> field) is stable and is the same data structure already
+/// emitted to logs by <c>SiloLifecycleSubject.OnStart</c>.
+/// </remarks>
+internal static class LifecycleStageInspector
+{
+    private static readonly HashSet<int> NamedStageValues = BuildNamedStageValues();
+    private static readonly Func<CancellationToken, Task> NoOpStart = _ => Task.CompletedTask;
+    private static readonly Func<CancellationToken, Task> NoOpStop = _ => Task.CompletedTask;
+
+    public static LifecycleStageInfo[] GetStages(ISiloLifecycleSubject lifecycle)
+    {
+        if (lifecycle is null)
+        {
+            return [];
+        }
+
+        // The silo's lifecycle subject keeps a separate `observers` field
+        // (List<MonitoredObserver>) that carries richer information than the
+        // base `subscribers` field. Prefer that, but fall back to the base list
+        // if reflection fails.
+        var monitored = TryReadField<System.Collections.IEnumerable>(lifecycle, "observers");
+        if (monitored is not null)
+        {
+            return BuildStages(EnumerateMonitored(monitored));
+        }
+
+        var subscribers = TryReadField<System.Collections.IEnumerable>(lifecycle, "subscribers");
+        if (subscribers is not null)
+        {
+            return BuildStages(EnumerateOrdered(subscribers));
+        }
+
+        return [];
+    }
+
+    private static LifecycleStageInfo[] BuildStages(IEnumerable<(int Stage, string StageName, string Name, object InnerObserver)> entries)
+    {
+        return entries
+            .GroupBy(e => e.Stage)
+            .OrderBy(g => g.Key)
+            .Select(group => new LifecycleStageInfo
+            {
+                Stage = group.Key,
+                StageName = group.Select(e => e.StageName).FirstOrDefault(s => !string.IsNullOrEmpty(s)) ?? group.Key.ToString(),
+                IsNamedStage = NamedStageValues.Contains(group.Key),
+                Observers = group.Select(e => BuildObserver(e.Name, e.InnerObserver)).ToArray(),
+            })
+            .ToArray();
+    }
+
+    private static IEnumerable<(int Stage, string StageName, string Name, object InnerObserver)> EnumerateMonitored(System.Collections.IEnumerable monitored)
+    {
+        foreach (var item in monitored)
+        {
+            if (item is null) continue;
+            var type = item.GetType();
+            var stage = (int)(type.GetProperty("Stage")?.GetValue(item) ?? 0);
+            var stageName = type.GetProperty("StageName")?.GetValue(item) as string;
+            var name = type.GetProperty("Name")?.GetValue(item) as string;
+            var inner = type.GetField("observer", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(item);
+            yield return (stage, stageName, name, inner);
+        }
+    }
+
+    private static IEnumerable<(int Stage, string StageName, string Name, object InnerObserver)> EnumerateOrdered(System.Collections.IEnumerable ordered)
+    {
+        foreach (var item in ordered)
+        {
+            if (item is null) continue;
+            var type = item.GetType();
+            var stage = (int)(type.GetProperty("Stage")?.GetValue(item) ?? 0);
+            var inner = type.GetProperty("Observer")?.GetValue(item);
+            yield return (stage, null, null, inner);
+        }
+    }
+
+    private static LifecycleObserverInfo BuildObserver(string name, object inner)
+    {
+        var info = new LifecycleObserverInfo
+        {
+            Name = name ?? "(unnamed)",
+        };
+
+        if (inner is null)
+        {
+            info.ObserverType = "(disposed)";
+            return info;
+        }
+
+        // The base LifecycleSubject wraps every registration in an internal
+        // OrderedObserver. The silo subject wraps that again in MonitoredObserver.
+        // Unwrap one extra layer of MonitoredObserver if reflection returned it.
+        if (inner.GetType().Name == "MonitoredObserver")
+        {
+            inner = inner.GetType().GetField("observer", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(inner) ?? inner;
+        }
+
+        // Try to extract delegate targets/methods. The delegate-based
+        // Subscribe overloads in LifecycleExtensions wrap the delegates in a
+        // private `Observer` (with onStart/onStop fields) or `StartupObserver`
+        // (with an `_onStart` field, OnStop is no-op).
+        var innerType = inner.GetType();
+        Delegate onStart = TryReadDelegateField(inner, innerType, "onStart") ?? TryReadDelegateField(inner, innerType, "_onStart");
+        Delegate onStop = TryReadDelegateField(inner, innerType, "onStop") ?? TryReadDelegateField(inner, innerType, "_onStop");
+
+        if (onStart is null && onStop is null && innerType.GetMethod("OnStart") is not null)
+        {
+            // Concrete ILifecycleObserver implementation.
+            info.ObserverType = FormatType(innerType);
+            info.HasOnStart = true;
+            info.HasOnStop = true;
+            info.OnStartMethod = $"{FormatType(innerType)}.OnStart";
+            info.OnStopMethod = $"{FormatType(innerType)}.OnStop";
+            return info;
+        }
+
+        if (onStart is not null)
+        {
+            info.HasOnStart = !IsNoOp(onStart);
+            info.OnStartMethod = FormatDelegate(onStart);
+        }
+
+        if (onStop is not null)
+        {
+            info.HasOnStop = !IsNoOp(onStop);
+            info.OnStopMethod = FormatDelegate(onStop);
+        }
+
+        info.ObserverType = ResolveOwningType(onStart, onStop) ?? FormatType(innerType);
+
+        return info;
+    }
+
+    private static Delegate TryReadDelegateField(object owner, Type ownerType, string fieldName)
+    {
+        var field = ownerType.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        return field?.GetValue(owner) as Delegate;
+    }
+
+    private static bool IsNoOp(Delegate d)
+    {
+        // We treat compiler-generated `_ => Task.CompletedTask` and the
+        // shared no-op delegates as "no-op" purely so the UI can dim the
+        // edge. Detecting compiler closures is best-effort.
+        if (d is null) return true;
+        if (ReferenceEquals(d, NoOpStart) || ReferenceEquals(d, NoOpStop)) return true;
+        var method = d.Method;
+        if (method.DeclaringType is { } declaring && declaring.Name.Contains("<>c"))
+        {
+            // Lambda. Without analyzing the IL we can't be sure, but it's
+            // almost always a no-op when used in lifecycle wiring.
+            return true;
+        }
+        return false;
+    }
+
+    private static string FormatDelegate(Delegate d)
+    {
+        if (d is null) return null;
+        var method = d.Method;
+        var declaring = method.DeclaringType;
+        if (declaring is null) return CleanMethodName(method.Name);
+
+        // For closures, walk up to the user-visible enclosing type.
+        if (declaring.Name.StartsWith("<>c", StringComparison.Ordinal) && declaring.DeclaringType is not null)
+        {
+            declaring = declaring.DeclaringType;
+        }
+
+        var cleanedMethod = CleanMethodName(method.Name);
+        var targetType = d.Target?.GetType();
+        if (targetType is not null && targetType != declaring && !targetType.Name.StartsWith("<>", StringComparison.Ordinal))
+        {
+            return $"{FormatType(targetType)}.{cleanedMethod}";
+        }
+        return $"{FormatType(declaring)}.{cleanedMethod}";
+    }
+
+    /// <summary>
+    /// Strips compiler-generated prefixes from method names produced by lambdas
+    /// (<c>&lt;Outer&gt;b__N_N</c>) and local functions
+    /// (<c>&lt;Outer&gt;g__Name|N_N</c>). Local functions retain their original
+    /// name; anonymous lambdas are rendered as <c>&lt;lambda in Outer&gt;</c>.
+    /// </summary>
+    private static string CleanMethodName(string methodName)
+    {
+        if (string.IsNullOrEmpty(methodName) || methodName[0] != '<')
+        {
+            return methodName;
+        }
+
+        // Find the matching '>' for the leading '<', accounting for nested
+        // angle brackets in explicit-interface implementations like
+        // `<Orleans.ILifecycleParticipant<Orleans.Runtime.ISiloLifecycle>.Participate>g__Name|N`.
+        var depth = 0;
+        var endOfOuter = -1;
+        for (var i = 0; i < methodName.Length; i++)
+        {
+            var c = methodName[i];
+            if (c == '<') depth++;
+            else if (c == '>')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    endOfOuter = i;
+                    break;
+                }
+            }
+        }
+
+        if (endOfOuter < 0)
+        {
+            return methodName;
+        }
+
+        var outer = methodName.AsSpan(1, endOfOuter - 1).ToString();
+        // Reduce explicit-interface implementations like
+        // `Orleans.ILifecycleParticipant<...>.Participate` down to just
+        // the trailing method name (Participate).
+        var lastDot = LastTopLevelDot(outer);
+        if (lastDot >= 0)
+        {
+            outer = outer[(lastDot + 1)..];
+        }
+
+        var suffix = methodName.AsSpan(endOfOuter + 1);
+        if (suffix.Length >= 3 && suffix[0] == 'g' && suffix[1] == '_' && suffix[2] == '_')
+        {
+            // <Outer>g__LocalName|N_N -> LocalName
+            var rest = suffix[3..];
+            var pipe = rest.IndexOf('|');
+            var localName = pipe >= 0 ? rest[..pipe] : rest;
+            return localName.ToString();
+        }
+
+        if (suffix.Length >= 3 && suffix[0] == 'b' && suffix[1] == '_' && suffix[2] == '_')
+        {
+            // <Outer>b__N_N -> <lambda in Outer>
+            return $"<lambda in {outer}>";
+        }
+
+        return methodName;
+    }
+
+    private static int LastTopLevelDot(string value)
+    {
+        var depth = 0;
+        for (var i = value.Length - 1; i >= 0; i--)
+        {
+            var c = value[i];
+            if (c == '>') depth++;
+            else if (c == '<') depth--;
+            else if (c == '.' && depth == 0)
+            {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static string ResolveOwningType(Delegate onStart, Delegate onStop)
+    {
+        var d = onStart ?? onStop;
+        if (d is null) return null;
+        var target = d.Target?.GetType();
+        if (target is not null && !target.Name.StartsWith("<>", StringComparison.Ordinal))
+        {
+            return FormatType(target);
+        }
+        var declaring = d.Method.DeclaringType;
+        if (declaring is null) return null;
+        if (declaring.Name.StartsWith("<>c", StringComparison.Ordinal) && declaring.DeclaringType is not null)
+        {
+            declaring = declaring.DeclaringType;
+        }
+        return FormatType(declaring);
+    }
+
+    private static string FormatType(Type type)
+    {
+        if (type is null) return null;
+        if (!type.IsGenericType) return type.FullName ?? type.Name;
+        var genericArgs = string.Join(", ", type.GetGenericArguments().Select(FormatType));
+        var name = type.Namespace is null ? type.Name : $"{type.Namespace}.{type.Name}";
+        var tickIndex = name.IndexOf('`');
+        if (tickIndex >= 0) name = name[..tickIndex];
+        return $"{name}<{genericArgs}>";
+    }
+
+    private static T TryReadField<T>(object owner, string fieldName) where T : class
+    {
+        var type = owner.GetType();
+        while (type is not null)
+        {
+            var field = type.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            if (field is not null && field.GetValue(owner) is T value)
+            {
+                return value;
+            }
+            type = type.BaseType;
+        }
+        return null;
+    }
+
+    private static HashSet<int> BuildNamedStageValues()
+    {
+        var values = new HashSet<int>();
+        foreach (var field in typeof(ServiceLifecycleStage).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (field.FieldType == typeof(int))
+            {
+                values.Add((int)field.GetRawConstantValue());
+            }
+        }
+        return values;
+    }
+}

--- a/src/Dashboard/Orleans.Dashboard/Implementation/SiloGrainService.cs
+++ b/src/Dashboard/Orleans.Dashboard/Implementation/SiloGrainService.cs
@@ -9,6 +9,7 @@ using Orleans.Runtime;
 using Orleans.Dashboard.Metrics;
 using Orleans.Dashboard.Model;
 using Orleans.Dashboard.Core;
+using Orleans.Dashboard.Implementation;
 
 #nullable disable
 namespace Orleans.Dashboard.Implementation;
@@ -21,6 +22,7 @@ internal sealed partial class SiloGrainService : GrainService, ISiloGrainService
     private readonly DashboardOptions _options;
     private readonly IGrainProfiler _profiler;
     private readonly IGrainFactory _grainFactory;
+    private readonly ISiloLifecycleSubject _siloLifecycle;
     private readonly ILogger<SiloGrainService> _logger;
     private IDisposable _timer;
     private string _versionOrleans;
@@ -32,11 +34,13 @@ internal sealed partial class SiloGrainService : GrainService, ISiloGrainService
         ILoggerFactory loggerFactory,
         IGrainProfiler profiler,
         IOptions<DashboardOptions> options,
-        IGrainFactory grainFactory) : base(grainId, silo, loggerFactory)
+        IGrainFactory grainFactory,
+        ISiloLifecycleSubject siloLifecycle) : base(grainId, silo, loggerFactory)
     {
         _profiler = profiler;
         _options = options.Value;
         _grainFactory = grainFactory;
+        _siloLifecycle = siloLifecycle;
         _statistics = new Queue<SiloRuntimeStatistics>(_options.HistoryLength + 1);
         _logger = loggerFactory.CreateLogger<SiloGrainService>();
     }
@@ -132,6 +136,11 @@ internal sealed partial class SiloGrainService : GrainService, ISiloGrainService
     public Task<Immutable<StatCounter[]>> GetCounters()
     {
         return Task.FromResult(_counters.Values.OrderBy(x => x.Name).ToArray().AsImmutable());
+    }
+
+    public Task<Immutable<LifecycleStageInfo[]>> GetLifecycleStages()
+    {
+        return Task.FromResult(LifecycleStageInspector.GetStages(_siloLifecycle).AsImmutable());
     }
 
     public Task Enable(bool enabled)

--- a/src/Dashboard/Orleans.Dashboard/Implementation/SiloGrainService.cs
+++ b/src/Dashboard/Orleans.Dashboard/Implementation/SiloGrainService.cs
@@ -9,7 +9,6 @@ using Orleans.Runtime;
 using Orleans.Dashboard.Metrics;
 using Orleans.Dashboard.Model;
 using Orleans.Dashboard.Core;
-using Orleans.Dashboard.Implementation;
 
 #nullable disable
 namespace Orleans.Dashboard.Implementation;

--- a/src/Dashboard/Orleans.Dashboard/Metrics/GrainProfiler.cs
+++ b/src/Dashboard/Orleans.Dashboard/Metrics/GrainProfiler.cs
@@ -30,7 +30,11 @@ internal sealed partial class GrainProfiler(
 
     public bool IsEnabled => options.Value.TraceAlways || _isEnabled;
 
-    public void Participate(ISiloLifecycle lifecycle) => lifecycle.Subscribe<GrainProfiler>(ServiceLifecycleStage.Last, ct => OnStart(), ct => OnStop());
+    public void Participate(ISiloLifecycle lifecycle) => lifecycle.Subscribe<GrainProfiler>(ServiceLifecycleStage.Last, StartProfiler, StopProfiler);
+
+    private Task StartProfiler(CancellationToken ct) => OnStart();
+
+    private Task StopProfiler(CancellationToken ct) => OnStop();
 
     private Task OnStart()
     {

--- a/src/Dashboard/Orleans.Dashboard/Model/LifecycleObserverInfo.cs
+++ b/src/Dashboard/Orleans.Dashboard/Model/LifecycleObserverInfo.cs
@@ -1,0 +1,49 @@
+#nullable disable
+namespace Orleans.Dashboard.Model;
+
+/// <summary>
+/// Describes a single observer/participant registered for a lifecycle stage.
+/// </summary>
+[GenerateSerializer]
+[Immutable]
+[Alias("Orleans.Dashboard.Model.LifecycleObserverInfo")]
+internal sealed class LifecycleObserverInfo
+{
+    /// <summary>
+    /// The observer name supplied when the observer subscribed to the lifecycle.
+    /// </summary>
+    [Id(0)]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// The type of the underlying observer (typically the concrete
+    /// <see cref="ILifecycleObserver"/> implementation, or the type that owns
+    /// the registered delegate when subscribing via delegate-based extensions).
+    /// </summary>
+    [Id(1)]
+    public string ObserverType { get; set; }
+
+    /// <summary>
+    /// True when the observer has a non-default <c>OnStart</c> action.
+    /// </summary>
+    [Id(2)]
+    public bool HasOnStart { get; set; }
+
+    /// <summary>
+    /// True when the observer has a non-default <c>OnStop</c> action.
+    /// </summary>
+    [Id(3)]
+    public bool HasOnStop { get; set; }
+
+    /// <summary>
+    /// The fully-qualified method invoked on start (when known).
+    /// </summary>
+    [Id(4)]
+    public string OnStartMethod { get; set; }
+
+    /// <summary>
+    /// The fully-qualified method invoked on stop (when known).
+    /// </summary>
+    [Id(5)]
+    public string OnStopMethod { get; set; }
+}

--- a/src/Dashboard/Orleans.Dashboard/Model/LifecycleStageInfo.cs
+++ b/src/Dashboard/Orleans.Dashboard/Model/LifecycleStageInfo.cs
@@ -1,0 +1,39 @@
+#nullable disable
+namespace Orleans.Dashboard.Model;
+
+/// <summary>
+/// Describes a single lifecycle stage along with the observers that participate in it.
+/// </summary>
+[GenerateSerializer]
+[Immutable]
+[Alias("Orleans.Dashboard.Model.LifecycleStageInfo")]
+internal sealed class LifecycleStageInfo
+{
+    /// <summary>
+    /// The numeric stage value.
+    /// </summary>
+    [Id(0)]
+    public int Stage { get; set; }
+
+    /// <summary>
+    /// A human-readable stage name. When the stage corresponds to a named
+    /// <see cref="ServiceLifecycleStage"/> field, this contains the field name
+    /// and value (e.g. "RuntimeInitialize (2000)"). Otherwise this is the
+    /// numeric stage value as a string.
+    /// </summary>
+    [Id(1)]
+    public string StageName { get; set; }
+
+    /// <summary>
+    /// Indicates whether the stage corresponds to a named field on
+    /// <see cref="ServiceLifecycleStage"/>.
+    /// </summary>
+    [Id(2)]
+    public bool IsNamedStage { get; set; }
+
+    /// <summary>
+    /// The observers that participate in this stage.
+    /// </summary>
+    [Id(3)]
+    public LifecycleObserverInfo[] Observers { get; set; }
+}

--- a/src/Dashboard/Orleans.Dashboard/ServiceCollectionExtensions.cs
+++ b/src/Dashboard/Orleans.Dashboard/ServiceCollectionExtensions.cs
@@ -272,6 +272,19 @@ public static class ServiceCollectionExtensions
             }
         });
 
+        group.MapGet("/LifecycleStages", async ([FromServices] IDashboardClient client) =>
+        {
+            try
+            {
+                var result = await client.GetLifecycleStages();
+                return Results.Json(result.Value, jsonOptions);
+            }
+            catch (SiloUnavailableException)
+            {
+                return CreateUnavailableResult(true);
+            }
+        });
+
         group.MapGet("/GrainTypes", async (string[] exclude, [FromServices] IDashboardClient client) =>
         {
             try

--- a/src/Orleans.Core/Lifecycle/ServiceLifecycle.cs
+++ b/src/Orleans.Core/Lifecycle/ServiceLifecycle.cs
@@ -42,18 +42,21 @@ internal sealed class ServiceLifecycle<TLifecycleObservable>(ILogger<ServiceLife
             observerName: nameof(Started),
             stage: ServiceLifecycleStage.Active,
             onStart: _started.NotifyCompleted,
-            onStop: _ => Task.CompletedTask);
+            onStop: NoOpStop);
 
         lifecycle.Subscribe(
             observerName: nameof(Stopping),
             stage: ServiceLifecycleStage.Active,
-            onStart: _ => Task.CompletedTask,
+            onStart: NoOpStart,
             onStop: _stopping.NotifyCompleted);
 
         lifecycle.Subscribe(
             observerName: nameof(Stopped),
             stage: ServiceLifecycleStage.RuntimeInitialize - 1,
-            onStart: _ => Task.CompletedTask,
+            onStart: NoOpStart,
             onStop: _stopped.NotifyCompleted);
+
+        static Task NoOpStart(CancellationToken _) => Task.CompletedTask;
+        static Task NoOpStop(CancellationToken _) => Task.CompletedTask;
     }
 }

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -65,49 +65,57 @@ namespace Orleans.Runtime.ReminderService
             observer.Subscribe(
                 nameof(LocalReminderService),
                 ServiceLifecycleStage.BecomeActive,
-                async ct =>
-                {
-                    try
-                    {
-                        await this.QueueTask(() => Initialize(ct));
-                    }
-                    catch (Exception exception)
-                    {
-                        LogErrorActivatingReminderService(exception);
-                        throw;
-                    }
-                },
-                async ct =>
-                {
-                    try
-                    {
-                        await this.QueueTask(Stop).WaitAsync(ct);
-                    }
-                    catch (Exception exception)
-                    {
-                        LogErrorStoppingReminderService(exception);
-                        throw;
-                    }
-                });
+                InitializeReminderService,
+                StopReminderService);
             observer.Subscribe(
                 nameof(LocalReminderService),
                 ServiceLifecycleStage.Active,
-                async ct =>
-                {
-                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                    cts.CancelAfter(this.reminderOptions.InitializationTimeout);
+                StartReminderService,
+                NoOpStop);
 
-                    try
-                    {
-                        await this.QueueTask(Start).WaitAsync(cts.Token);
-                    }
-                    catch (Exception exception)
-                    {
-                        LogErrorStartingReminderService(exception);
-                        throw;
-                    }
-                },
-                ct => Task.CompletedTask);
+            async Task InitializeReminderService(CancellationToken ct)
+            {
+                try
+                {
+                    await this.QueueTask(() => Initialize(ct));
+                }
+                catch (Exception exception)
+                {
+                    LogErrorActivatingReminderService(exception);
+                    throw;
+                }
+            }
+
+            async Task StopReminderService(CancellationToken ct)
+            {
+                try
+                {
+                    await this.QueueTask(Stop).WaitAsync(ct);
+                }
+                catch (Exception exception)
+                {
+                    LogErrorStoppingReminderService(exception);
+                    throw;
+                }
+            }
+
+            async Task StartReminderService(CancellationToken ct)
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                cts.CancelAfter(this.reminderOptions.InitializationTimeout);
+
+                try
+                {
+                    await this.QueueTask(Start).WaitAsync(cts.Token);
+                }
+                catch (Exception exception)
+                {
+                    LogErrorStartingReminderService(exception);
+                    throw;
+                }
+            }
+
+            static Task NoOpStop(CancellationToken _) => Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/Cancellation/GrainCallCancellationManager.cs
+++ b/src/Orleans.Runtime/Cancellation/GrainCallCancellationManager.cs
@@ -295,8 +295,11 @@ internal partial class GrainCallCancellationManager : SystemTarget, IGrainCallCa
         lifecycle.Subscribe(
             nameof(GrainCallCancellationManager),
             ServiceLifecycleStage.RuntimeGrainServices,
-                ct => this.RunOrQueueTask(() => StartAsync(ct)),
-                ct => this.RunOrQueueTask(() => StopAsync(ct)));
+            QueuedStart,
+            QueuedStop);
+
+        Task QueuedStart(CancellationToken ct) => this.RunOrQueueTask(() => StartAsync(ct));
+        Task QueuedStop(CancellationToken ct) => this.RunOrQueueTask(() => StopAsync(ct));
     }
 
     [LoggerMessage(

--- a/src/Orleans.Runtime/Catalog/ActivationMigrationManager.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationMigrationManager.cs
@@ -332,8 +332,11 @@ internal sealed partial class ActivationMigrationManager : SystemTarget, IActiva
         lifecycle.Subscribe(
             nameof(ActivationMigrationManager),
             ServiceLifecycleStage.RuntimeGrainServices,
-                ct => this.RunOrQueueTask(() => StartAsync(ct)),
-                ct => this.RunOrQueueTask(() => StopAsync(ct)));
+            QueuedStart,
+            QueuedStop);
+
+        Task QueuedStart(CancellationToken ct) => this.RunOrQueueTask(() => StartAsync(ct));
+        Task QueuedStop(CancellationToken ct) => this.RunOrQueueTask(() => StopAsync(ct));
     }
 
     private class MigrationWorkItem : IValueTaskSource

--- a/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
@@ -158,20 +158,24 @@ namespace Orleans.Runtime
             lifecycle.Subscribe(
                 nameof(ActivationWorkingSet),
                 ServiceLifecycleStage.BecomeActive,
-                ct =>
+                StartMonitoring,
+                StopMonitoring);
+
+            Task StartMonitoring(CancellationToken ct)
+            {
+                using var _ = new ExecutionContextSuppressor();
+                _runTask = Task.Run(MonitorWorkingSet);
+                return Task.CompletedTask;
+            }
+
+            async Task StopMonitoring(CancellationToken ct)
+            {
+                _scanPeriodTimer.Dispose();
+                if (_runTask is Task task)
                 {
-                    using var _ = new ExecutionContextSuppressor();
-                    _runTask = Task.Run(MonitorWorkingSet);
-                    return Task.CompletedTask;
-                },
-                async ct =>
-                {
-                    _scanPeriodTimer.Dispose();
-                    if (_runTask is Task task)
-                    {
-                        await task.WaitAsync(ct).SuppressThrowing();
-                    }
-                });
+                    await task.WaitAsync(ct).SuppressThrowing();
+                }
+            }
         }
 
         [LoggerMessage(

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -72,19 +72,23 @@ namespace Orleans.Runtime
             lifecycle.Subscribe(
                 nameof(IncomingRequestMonitor),
                 ServiceLifecycleStage.BecomeActive,
-                ct =>
+                StartMonitoring,
+                StopMonitoring);
+
+            Task StartMonitoring(CancellationToken ct)
+            {
+                _runTask = Task.Run(this.Run);
+                return Task.CompletedTask;
+            }
+
+            async Task StopMonitoring(CancellationToken ct)
+            {
+                _scanPeriodTimer.Dispose();
+                if (_runTask is Task task)
                 {
-                    _runTask = Task.Run(this.Run);
-                    return Task.CompletedTask;
-                },
-                async ct =>
-                {
-                    _scanPeriodTimer.Dispose();
-                    if (_runTask is Task task)
-                    {
-                        await task.WaitAsync(ct).SuppressThrowing();
-                    }
-                });
+                    await task.WaitAsync(ct).SuppressThrowing();
+                }
+            }
         }
 
         private async Task Run()

--- a/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/ClientDirectory.cs
@@ -523,26 +523,30 @@ internal sealed partial class ClientDirectory : SystemTarget, ILocalClientDirect
         lifecycle.Subscribe(
             nameof(ClientDirectory),
             ServiceLifecycleStage.RuntimeGrainServices,
-            ct =>
-            {
-                this.RunOrQueueTask(() => _runTask = this.Run()).Ignore();
-                return Task.CompletedTask;
-            },
-            async ct =>
-            {
-                _shutdownCts.Cancel();
-                _refreshTimer?.Dispose();
+            StartPublishingRoutingTable,
+            StopPublishingRoutingTable);
 
-                if (_runTask is Task task)
-                {
-                    await task.WaitAsync(ct).SuppressThrowing();
-                }
+        Task StartPublishingRoutingTable(CancellationToken ct)
+        {
+            this.RunOrQueueTask(() => _runTask = this.Run()).Ignore();
+            return Task.CompletedTask;
+        }
 
-                if (_nextPublishTask is Task publishTask)
-                {
-                    await publishTask.WaitAsync(ct).SuppressThrowing();
-                }
-            });
+        async Task StopPublishingRoutingTable(CancellationToken ct)
+        {
+            _shutdownCts.Cancel();
+            _refreshTimer?.Dispose();
+
+            if (_runTask is Task task)
+            {
+                await task.WaitAsync(ct).SuppressThrowing();
+            }
+
+            if (_nextPublishTask is Task publishTask)
+            {
+                await publishTask.WaitAsync(ct).SuppressThrowing();
+            }
+        }
     }
 
     internal class TestAccessor(ClientDirectory instance)

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -301,7 +301,9 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         observer.Subscribe(nameof(DistributedGrainDirectory), ServiceLifecycleStage.RuntimeInitialize, OnRuntimeInitializeStart, OnRuntimeInitializeStop);
 
         // Transition into 'ShuttingDown'/'Stopping' stage, removing ourselves from directory membership, but allow some time for hand-off before transitioning to 'Dead'.
-        observer.Subscribe(nameof(DistributedGrainDirectory), ServiceLifecycleStage.BecomeActive - 1, _ => Task.CompletedTask, OnShuttingDown);
+        observer.Subscribe(nameof(DistributedGrainDirectory), ServiceLifecycleStage.BecomeActive - 1, NoOpStart, OnShuttingDown);
+
+        static Task NoOpStart(CancellationToken _) => Task.CompletedTask;
 
         Task OnRuntimeInitializeStart(CancellationToken cancellationToken)
         {

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -994,7 +994,10 @@ namespace Orleans.Runtime.GrainDirectory
         }
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
         {
-            lifecycle.Subscribe<LocalGrainDirectory>(ServiceLifecycleStage.RuntimeServices, (ct) => Task.Run(() => Start()), (ct) => Task.Run(() => StopAsync()));
+            lifecycle.Subscribe<LocalGrainDirectory>(ServiceLifecycleStage.RuntimeServices, RunStart, RunStop);
+
+            Task RunStart(CancellationToken ct) => Task.Run(() => Start());
+            Task RunStop(CancellationToken ct) => Task.Run(() => StopAsync());
         }
 
         private readonly struct SiloAddressLogValue(SiloAddress silo)

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -223,13 +223,15 @@ namespace Orleans.Runtime.Metadata
                 nameof(ClusterManifestProvider),
                 ServiceLifecycleStage.RuntimeServices,
                 Initialize,
-                _ => Task.CompletedTask);
+                NoOpStop);
 
             lifecycle.Subscribe(
                 nameof(ClusterManifestProvider),
                 ServiceLifecycleStage.RuntimeGrainServices,
                 StartAsync,
                 StopAsync);
+
+            static Task NoOpStop(CancellationToken _) => Task.CompletedTask;
         }
 
         public async ValueTask DisposeAsync()

--- a/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloStatusListenerManager.cs
@@ -148,8 +148,8 @@ internal sealed partial class SiloStatusListenerManager : ILifecycleParticipant<
     {
         Task? task = null;
 
-        lifecycle.Subscribe(nameof(SiloStatusListenerManager), ServiceLifecycleStage.AfterRuntimeGrainServices, OnStart, _ => Task.CompletedTask);
-        lifecycle.Subscribe(nameof(SiloStatusListenerManager), ServiceLifecycleStage.RuntimeInitialize, _ => Task.CompletedTask, OnStop);
+        lifecycle.Subscribe(nameof(SiloStatusListenerManager), ServiceLifecycleStage.AfterRuntimeGrainServices, OnStart, NoOpStop);
+        lifecycle.Subscribe(nameof(SiloStatusListenerManager), ServiceLifecycleStage.RuntimeInitialize, NoOpStart, OnStop);
 
         Task OnStart(CancellationToken ct)
         {
@@ -165,6 +165,9 @@ internal sealed partial class SiloStatusListenerManager : ILifecycleParticipant<
                 await task.WaitAsync(ct).SuppressThrowing();
             }
         }
+
+        static Task NoOpStart(CancellationToken _) => Task.CompletedTask;
+        static Task NoOpStop(CancellationToken _) => Task.CompletedTask;
     }
 
     [LoggerMessage(

--- a/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
+++ b/src/Orleans.Runtime/Networking/GatewayConnectionListener.cs
@@ -78,7 +78,9 @@ namespace Orleans.Runtime.Messaging
             if (this.Endpoint is null) return;
 
             lifecycle.Subscribe(nameof(GatewayConnectionListener), ServiceLifecycleStage.RuntimeInitialize - 1, this);
-            lifecycle.Subscribe(nameof(GatewayConnectionListener), ServiceLifecycleStage.Active, _ => Task.Run(Start));
+            lifecycle.Subscribe(nameof(GatewayConnectionListener), ServiceLifecycleStage.Active, RunStart);
+
+            Task RunStart(CancellationToken ct) => Task.Run(Start);
         }
 
         Task ILifecycleObserver.OnStart(CancellationToken ct) => Task.Run(BindAsync);

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -253,11 +253,13 @@ namespace Orleans.Runtime
                 nameof(DeploymentLoadPublisher),
                 ServiceLifecycleStage.RuntimeGrainServices,
                 StartAsync,
-                ct =>
+                DisposePublishTimer);
+
+            Task DisposePublishTimer(CancellationToken ct)
             {
                 _publishTimer.Dispose();
                 return Task.CompletedTask;
-            });
+            }
         }
 
         [LoggerMessage(

--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -102,8 +102,10 @@ namespace Orleans.Runtime.Placement
             lifecycle.Subscribe(
                 nameof(PlacementService),
                 ServiceLifecycleStage.RuntimeInitialize + 1,
-                static _ => Task.CompletedTask,
+                NoOpStart,
                 StopAsync);
+
+            static Task NoOpStart(CancellationToken _) => Task.CompletedTask;
         }
 
         private async Task StopAsync(CancellationToken cancellationToken)

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -465,11 +465,23 @@ namespace Orleans.Runtime
 
         private void Participate(ISiloLifecycle lifecycle)
         {
-            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeInitialize, (ct) => Task.Run(() => OnRuntimeInitializeStart(ct)), (ct) => Task.Run(() => OnRuntimeInitializeStop(ct)));
-            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeServices, (ct) => Task.Run(() => OnRuntimeServicesStart(ct)), (ct) => Task.Run(() => OnRuntimeServicesStop(ct)));
-            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeGrainServices, (ct) => Task.Run(() => OnRuntimeGrainServicesStart(ct)));
-            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.BecomeActive, (ct) => Task.Run(() => OnBecomeActiveStart(ct)), (ct) => Task.Run(() => OnBecomeActiveStop(ct)));
-            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.Active, (ct) => Task.Run(() => OnActiveStart(ct)), (ct) => Task.Run(() => OnActiveStop(ct)));
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeInitialize, RunOnRuntimeInitializeStart, RunOnRuntimeInitializeStop);
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeServices, RunOnRuntimeServicesStart, RunOnRuntimeServicesStop);
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeGrainServices, RunOnRuntimeGrainServicesStart);
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.BecomeActive, RunOnBecomeActiveStart, RunOnBecomeActiveStop);
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.Active, RunOnActiveStart, RunOnActiveStop);
+
+            // Stage callbacks are dispatched onto the thread pool so that any blocking
+            // work in the silo start/stop paths does not stall the lifecycle scheduler.
+            Task RunOnRuntimeInitializeStart(CancellationToken ct) => Task.Run(() => OnRuntimeInitializeStart(ct));
+            Task RunOnRuntimeInitializeStop(CancellationToken ct) => Task.Run(() => OnRuntimeInitializeStop(ct));
+            Task RunOnRuntimeServicesStart(CancellationToken ct) => Task.Run(() => OnRuntimeServicesStart(ct));
+            Task RunOnRuntimeServicesStop(CancellationToken ct) => Task.Run(() => OnRuntimeServicesStop(ct));
+            Task RunOnRuntimeGrainServicesStart(CancellationToken ct) => Task.Run(() => OnRuntimeGrainServicesStart(ct));
+            Task RunOnBecomeActiveStart(CancellationToken ct) => Task.Run(() => OnBecomeActiveStart(ct));
+            Task RunOnBecomeActiveStop(CancellationToken ct) => Task.Run(() => OnBecomeActiveStop(ct));
+            Task RunOnActiveStart(CancellationToken ct) => Task.Run(() => OnActiveStart(ct));
+            Task RunOnActiveStop(CancellationToken ct) => Task.Run(() => OnActiveStop(ct));
         }
 
         public async ValueTask DisposeAsync()

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/LifecycleStageInspectorTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/LifecycleStageInspectorTests.cs
@@ -1,0 +1,127 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans;
+using Orleans.Dashboard.Implementation;
+using Orleans.Runtime;
+using Xunit;
+
+namespace UnitTests;
+
+public class LifecycleStageInspectorTests
+{
+    [Fact]
+    public void GetStages_GroupsObserversByStage_AndPreservesOrder()
+    {
+        var lifecycle = new SiloLifecycleSubject(NullLogger<SiloLifecycleSubject>.Instance);
+
+        lifecycle.Subscribe("A", ServiceLifecycleStage.RuntimeInitialize, Start, Stop);
+        lifecycle.Subscribe("B", ServiceLifecycleStage.RuntimeServices, Start, Stop);
+        lifecycle.Subscribe("C", ServiceLifecycleStage.RuntimeServices, Start, Stop);
+        lifecycle.Subscribe("D", 4242, Start, Stop); // numeric-only stage
+
+        var stages = LifecycleStageInspector.GetStages(lifecycle);
+
+        // 3 distinct stages, ordered ascending
+        Assert.Equal(3, stages.Length);
+        Assert.Equal(ServiceLifecycleStage.RuntimeInitialize, stages[0].Stage);
+        Assert.Equal(ServiceLifecycleStage.RuntimeServices, stages[1].Stage);
+        Assert.Equal(4242, stages[2].Stage);
+
+        // Named stages flagged as such; numeric-only stages are not.
+        Assert.True(stages[0].IsNamedStage);
+        Assert.True(stages[1].IsNamedStage);
+        Assert.False(stages[2].IsNamedStage);
+
+        // Observers grouped per stage with their registration names.
+        Assert.Single(stages[0].Observers);
+        Assert.Equal("A", stages[0].Observers[0].Name);
+        Assert.Equal(2, stages[1].Observers.Length);
+        Assert.Equal(["B", "C"], stages[1].Observers.Select(o => o.Name).ToArray());
+        Assert.Single(stages[2].Observers);
+        Assert.Equal("D", stages[2].Observers[0].Name);
+
+        // Delegate-based subscribers expose method names for OnStart/OnStop.
+        var aObserver = stages[0].Observers[0];
+        Assert.True(aObserver.HasOnStart);
+        Assert.True(aObserver.HasOnStop);
+        Assert.Contains("Start", aObserver.OnStartMethod, System.StringComparison.Ordinal);
+        Assert.Contains("Stop", aObserver.OnStopMethod, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetStages_StartupOnlyObserver_IsRecognisedAsStartOnly()
+    {
+        var lifecycle = new SiloLifecycleSubject(NullLogger<SiloLifecycleSubject>.Instance);
+
+        // Subscribe overload without onStop creates a StartupObserver.
+        lifecycle.Subscribe("StartOnly", ServiceLifecycleStage.ApplicationServices, Start);
+
+        var stages = LifecycleStageInspector.GetStages(lifecycle);
+        var observer = Assert.Single(Assert.Single(stages).Observers);
+
+        Assert.True(observer.HasOnStart);
+        Assert.False(observer.HasOnStop);
+        Assert.NotNull(observer.OnStartMethod);
+        Assert.Null(observer.OnStopMethod);
+    }
+
+    [Fact]
+    public void GetStages_HandlesNullLifecycle()
+    {
+        var stages = LifecycleStageInspector.GetStages(null);
+        Assert.Empty(stages);
+    }
+
+    [Fact]
+    public void GetStages_PrettyPrintsStaticLocalFunctionNames_EvenInExplicitInterfaceImplementations()
+    {
+        // A type that subscribes via Orleans.ILifecycleParticipant<ISiloLifecycle>.Participate
+        // (explicit interface). This exercises the nested-generic outer-name path
+        // in LifecycleStageInspector.CleanMethodName.
+        var subject = new SiloLifecycleSubject(NullLogger<SiloLifecycleSubject>.Instance);
+        var participant = new ExplicitInterfaceParticipant();
+        ((ILifecycleParticipant<ISiloLifecycle>)participant).Participate(subject);
+
+        var stages = LifecycleStageInspector.GetStages(subject);
+        var observer = Assert.Single(Assert.Single(stages).Observers);
+
+        Assert.Equal("MyStaticLocalStart", observer.OnStartMethod?.Split('.')[^1]);
+        Assert.Equal("MyStaticLocalStop", observer.OnStopMethod?.Split('.')[^1]);
+        Assert.DoesNotContain("g__", observer.OnStartMethod ?? string.Empty, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("g__", observer.OnStopMethod ?? string.Empty, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetStages_LabelsAnonymousLambdas_AsLambdaInOuterMethod()
+    {
+        var subject = new SiloLifecycleSubject(NullLogger<SiloLifecycleSubject>.Instance);
+        subject.Subscribe("WithLambda", ServiceLifecycleStage.ApplicationServices, _ => Task.CompletedTask, _ => Task.CompletedTask);
+
+        var stages = LifecycleStageInspector.GetStages(subject);
+        var observer = Assert.Single(Assert.Single(stages).Observers);
+
+        // Anonymous lambdas inside this test method should be reported as
+        // `<lambda in GetStages_LabelsAnonymousLambdas_AsLambdaInOuterMethod>` rather than
+        // exposing the compiler-generated b__N_N suffix.
+        Assert.Contains("<lambda in", observer.OnStartMethod ?? string.Empty, System.StringComparison.Ordinal);
+        Assert.Contains("<lambda in", observer.OnStopMethod ?? string.Empty, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("b__", observer.OnStartMethod ?? string.Empty, System.StringComparison.Ordinal);
+    }
+
+    private static Task Start(CancellationToken ct) => Task.CompletedTask;
+
+    private static Task Stop(CancellationToken ct) => Task.CompletedTask;
+
+    private sealed class ExplicitInterfaceParticipant : ILifecycleParticipant<ISiloLifecycle>
+    {
+        void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle observer)
+        {
+            observer.Subscribe(nameof(ExplicitInterfaceParticipant), ServiceLifecycleStage.RuntimeServices, MyStaticLocalStart, MyStaticLocalStop);
+
+            static Task MyStaticLocalStart(CancellationToken _) => Task.CompletedTask;
+            static Task MyStaticLocalStop(CancellationToken _) => Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Add a **Lifecycle** view to the Orleans Dashboard that renders the silo startup and shutdown stages as a Mermaid dependency graph.

## Problem

Orleans silos compose their startup/shutdown from many ILifecycleParticipant<ISiloLifecycle> registrations across the runtime, providers, and storage backends. Today there's no way for an operator to look at a running silo and answer "what runs at stage X?" or "where does the silo currently sit in its boot sequence?" — that information is only visible at debug-log level via `SiloLifecycleSubject`.

In addition, a large share of those registrations were made via anonymous lambdas (`ct => Task.Run(...)`), so even when introspected they surface as compiler-generated `<Participate>b__N_N` names that are useless for diagnostics.

## Solution

Two changes, in two commits:

1. `feat(dashboard): add silo lifecycle dependency graph view`
   - New `LifecycleStageInspector` reflects over `SiloLifecycleSubject.observers` to recover each observer's name, stage, and OnStart/OnStop target method (drilling through the private `LifecycleExtensions.Observer` / `StartupObserver` delegate wrappers). Compiler-generated suffixes from static local functions (`g__Name|N`) and anonymous lambdas (`b__N_N`) are stripped so the output reads as `Type.MethodName` rather than a mangled symbol.
   - New `ISiloGrainService.GetLifecycleStages()` exposes the data; `DashboardClient` asks any active silo via `IManagementGrain.GetHosts(onlyActive: true)` since all silos share the same lifecycle.
   - New `/LifecycleStages` route in `MapOrleansDashboard`.
   - New React/TypeScript `Lifecycle` page renders a Mermaid `flowchart TD` for Startup and (in a separate tab) Shutdown, plus per-stage observer tables. Adds `mermaid` as a dependency and a sidebar menu entry.
   - Refactors every anonymous lambda passed to `ISiloLifecycle.Subscribe` across the runtime and dashboard into named local functions (or `NoOpStart`/`NoOpStop` helpers) so the view shows meaningful method names. Touches `Silo`, `PlacementService`, `LocalGrainDirectory`, `DistributedGrainDirectory`, `ClusterManifestProvider`, `ActivationMigrationManager`, `GrainCallCancellationManager`, `ActivationWorkingSet`, `ClientDirectory`, `IncomingRequestMonitor`, `LocalReminderService`, `GatewayConnectionListener`, `SiloStatusListenerManager`, `DeploymentLoadPublisher`, `ServiceLifecycle`, and `GrainProfiler`.
   - Adds `LifecycleStageInspectorTests` covering grouping/ordering, named-vs-numeric stage detection, start-only observers, the null-lifecycle guard, the explicit-interface static-local-function case, and the anonymous-lambda fallback formatting.

2. `fix(dashboard): recompute lifecycle SVG viewBox from rendered bounds`
   - Mermaid computes its SVG `viewBox` before the browser lays out the HTML labels inside `foreignObject` elements, so the bottom row of stages ends up clipped and a strip of whitespace appears above the diagram. After insertion we `requestAnimationFrame` → `getBBox()` → rewrite `viewBox` and install intrinsic `width`/`height` attributes so the SVG renders at natural pixel size. The host card scrolls when the diagram exceeds the panel.

## Rationale

Lifecycle wiring is a key part of the silo's contract with hosted components, but most users only encounter it when something fails mid-startup. Surfacing it as a first-class dashboard view — together with the named-function refactor that makes the output legible — gives operators a fast, accurate map of what runs when, and gives contributors a way to spot ordering mistakes without resorting to trace logs.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10145)