### PR TITLE
fix(redis)!: fix multiplexer ownership

### DIFF
--- a/src/Redis/Orleans.Clustering.Redis/Hosting/RedisClusteringProviderBuilder.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Hosting/RedisClusteringProviderBuilder.cs
@@ -31,7 +31,7 @@ internal sealed class RedisClusteringProviderBuilder : IProviderBuilder<ISiloBui
                 {
                     // Get a connection multiplexer instance by name.
                     var multiplexer = services.GetRequiredKeyedService<IConnectionMultiplexer>(serviceKey);
-                    options.CreateMultiplexer = _ => Task.FromResult(multiplexer);
+                    options.CreateMultiplexer = _ => Task.FromResult((Multiplexer: multiplexer, IsShared: true));
                     options.ConfigurationOptions = new ConfigurationOptions();
                 }
                 else
@@ -64,7 +64,7 @@ internal sealed class RedisClusteringProviderBuilder : IProviderBuilder<ISiloBui
                 {
                     // Get a connection multiplexer instance by name.
                     var multiplexer = services.GetRequiredKeyedService<IConnectionMultiplexer>(serviceKey);
-                    options.CreateMultiplexer = _ => Task.FromResult(multiplexer);
+                    options.CreateMultiplexer = _ => Task.FromResult((Multiplexer: multiplexer, IsShared: true));
                     options.ConfigurationOptions = new ConfigurationOptions();
                 }
                 else

--- a/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Providers/RedisClusteringOptions.cs
@@ -21,9 +21,12 @@ namespace Orleans.Clustering.Redis
         public ConfigurationOptions ConfigurationOptions { get; set; }
 
         /// <summary>
-        /// The delegate used to create a Redis connection multiplexer.
+        /// The delegate used to create a Redis connection multiplexer and indicate whether it is shared.
         /// </summary>
-        public Func<RedisClusteringOptions, Task<IConnectionMultiplexer>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
+        /// <remarks>
+        /// When <c>IsShared</c> is <see langword="true"/>, the provider will not dispose the returned multiplexer.
+        /// </remarks>
+        public Func<RedisClusteringOptions, Task<(IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
 
         /// <summary>
         /// The delegate used to create redis key for RedisMembershipTable.
@@ -39,9 +42,9 @@ namespace Orleans.Clustering.Redis
         /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
-        public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisClusteringOptions options)
+        public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisClusteringOptions options)
         {
-            return await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions);
+            return (await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions), false);
         }
 
         /// <summary>

--- a/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
@@ -21,6 +21,7 @@ namespace Orleans.Clustering.Redis
         private readonly RedisKey _clusterKey;
         private IConnectionMultiplexer _muxer = null!;
         private IDatabase _db = null!;
+        private bool _muxerIsShared;
 
         public RedisMembershipTable(IOptions<RedisClusteringOptions> redisOptions, IOptions<ClusterOptions> clusterOptions)
         {
@@ -39,7 +40,7 @@ namespace Orleans.Clustering.Redis
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
         {
-            _muxer = await _redisOptions.CreateMultiplexer(_redisOptions);
+            (_muxer, _muxerIsShared) = await _redisOptions.CreateMultiplexer(_redisOptions);
             _db = _muxer.GetDatabase();
 
             if (tryInitTableVersion)
@@ -215,7 +216,14 @@ namespace Orleans.Clustering.Redis
 
         public void Dispose()
         {
-            _muxer?.Dispose();
+            if (!_muxerIsShared)
+            {
+                _muxer?.Dispose();
+            }
+
+            _muxer = null!;
+            _db = null!;
+            _muxerIsShared = false;
         }
 
         private enum UpsertResult

--- a/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
+++ b/src/Redis/Orleans.Clustering.Redis/Storage/RedisMembershipTable.cs
@@ -11,7 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Orleans.Clustering.Redis
 {
-    internal class RedisMembershipTable : IMembershipTable, IDisposable
+    internal class RedisMembershipTable : IMembershipTable, IDisposable, IAsyncDisposable
     {
         private const string TableVersionKey = "Version";
         private static readonly TableVersion DefaultTableVersion = new TableVersion(0, "0");
@@ -216,14 +216,40 @@ namespace Orleans.Clustering.Redis
 
         public void Dispose()
         {
-            if (!_muxerIsShared)
+            var muxer = _muxer;
+            if (muxer is null)
             {
-                _muxer?.Dispose();
+                return;
             }
 
+            var muxerIsShared = _muxerIsShared;
             _muxer = null!;
             _db = null!;
             _muxerIsShared = false;
+
+            if (!muxerIsShared)
+            {
+                muxer.Dispose();
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            var muxer = _muxer;
+            if (muxer is null)
+            {
+                return;
+            }
+
+            var muxerIsShared = _muxerIsShared;
+            _muxer = null!;
+            _db = null!;
+            _muxerIsShared = false;
+
+            if (!muxerIsShared)
+            {
+                await muxer.DisposeAsync().ConfigureAwait(false);
+            }
         }
 
         private enum UpsertResult

--- a/src/Redis/Orleans.GrainDirectory.Redis/Hosting/RedisGrainDirectoryProviderBuilder.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Hosting/RedisGrainDirectoryProviderBuilder.cs
@@ -28,7 +28,7 @@ internal sealed class RedisGrainDirectoryProviderBuilder : IProviderBuilder<ISil
                 {
                     // Get a connection multiplexer instance by name.
                     var multiplexer = services.GetRequiredKeyedService<IConnectionMultiplexer>(serviceKey);
-                    options.CreateMultiplexer = _ => Task.FromResult(multiplexer);
+                    options.CreateMultiplexer = _ => Task.FromResult((Multiplexer: multiplexer, IsShared: true));
                     options.ConfigurationOptions = new ConfigurationOptions();
                 }
                 else

--- a/src/Redis/Orleans.GrainDirectory.Redis/Options/RedisGrainDirectoryOptions.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/Options/RedisGrainDirectoryOptions.cs
@@ -19,9 +19,12 @@ namespace Orleans.Configuration
         public ConfigurationOptions ConfigurationOptions { get; set; }
 
         /// <summary>
-        /// The delegate used to create a Redis connection multiplexer.
+        /// The delegate used to create a Redis connection multiplexer and indicate whether it is shared.
         /// </summary>
-        public Func<RedisGrainDirectoryOptions, Task<IConnectionMultiplexer>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
+        /// <remarks>
+        /// When <c>IsShared</c> is <see langword="true"/>, the provider will not dispose the returned multiplexer.
+        /// </remarks>
+        public Func<RedisGrainDirectoryOptions, Task<(IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
 
         /// <summary>
         /// Entry expiry, null by default. A value should be set ONLY for ephemeral environments (like in tests).
@@ -32,7 +35,8 @@ namespace Orleans.Configuration
         /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
-        public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisGrainDirectoryOptions options) => await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions);
+        public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisGrainDirectoryOptions options)
+            => (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions), IsShared: false);
     }
 
     internal class RedactRedisConfigurationOptions : RedactAttribute

--- a/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
@@ -198,6 +198,10 @@ namespace Orleans.GrainDirectory.Redis
             }
 
             var redisIsShared = _redisIsShared;
+            redis.ConnectionRestored -= LogConnectionRestored;
+            redis.ConnectionFailed -= LogConnectionFailed;
+            redis.ErrorMessage -= LogErrorMessage;
+            redis.InternalError -= LogInternalError;
             _disposed = true;
             _redis = null!;
             _database = null!;

--- a/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
@@ -25,6 +25,7 @@ namespace Orleans.GrainDirectory.Redis
         // Both are initialized in the Initialize method.
         private IConnectionMultiplexer _redis = null!;
         private IDatabase _database = null!;
+        private bool _redisIsShared;
 
         private bool _disposed;
 
@@ -177,7 +178,7 @@ namespace Orleans.GrainDirectory.Redis
 
         public async Task Initialize(CancellationToken ct = default)
         {
-            _redis = await _directoryOptions.CreateMultiplexer(_directoryOptions);
+            (_redis, _redisIsShared) = await _directoryOptions.CreateMultiplexer(_directoryOptions);
 
             // Configure logging
             _redis.ConnectionRestored += LogConnectionRestored;
@@ -190,14 +191,28 @@ namespace Orleans.GrainDirectory.Redis
 
         private async Task Uninitialize(CancellationToken arg)
         {
-            if (_redis != null && _redis.IsConnected)
+            if (_redis != null)
             {
                 _disposed = true;
 
-                await _redis.CloseAsync();
-                _redis.Dispose();
-                _redis = null!;
-                _database = null!;
+                try
+                {
+                    _redis.ConnectionRestored -= LogConnectionRestored;
+                    _redis.ConnectionFailed -= LogConnectionFailed;
+                    _redis.ErrorMessage -= LogErrorMessage;
+                    _redis.InternalError -= LogInternalError;
+
+                    if (!_redisIsShared)
+                    {
+                        await _redis.DisposeAsync();
+                    }
+                }
+                finally
+                {
+                    _redis = null!;
+                    _database = null!;
+                    _redisIsShared = false;
+                }
             }
         }
 

--- a/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
@@ -222,6 +222,10 @@ namespace Orleans.GrainDirectory.Redis
             }
 
             var redisIsShared = _redisIsShared;
+            redis.ConnectionRestored -= LogConnectionRestored;
+            redis.ConnectionFailed -= LogConnectionFailed;
+            redis.ErrorMessage -= LogErrorMessage;
+            redis.InternalError -= LogInternalError;
             _disposed = true;
             _redis = null!;
             _database = null!;

--- a/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
+++ b/src/Redis/Orleans.GrainDirectory.Redis/RedisGrainDirectory.cs
@@ -14,7 +14,7 @@ using StackExchange.Redis;
 
 namespace Orleans.GrainDirectory.Redis
 {
-    public partial class RedisGrainDirectory : IGrainDirectory, ILifecycleParticipant<ISiloLifecycle>
+    public partial class RedisGrainDirectory : IGrainDirectory, ILifecycleParticipant<ISiloLifecycle>, IDisposable, IAsyncDisposable
     {
         private readonly RedisGrainDirectoryOptions _directoryOptions;
         private readonly ClusterOptions _clusterOptions;
@@ -173,7 +173,7 @@ namespace Orleans.GrainDirectory.Redis
 
         public void Participate(ISiloLifecycle lifecycle)
         {
-            lifecycle.Subscribe(nameof(RedisGrainDirectory), ServiceLifecycleStage.RuntimeInitialize, Initialize, Uninitialize);
+            lifecycle.Subscribe(nameof(RedisGrainDirectory), ServiceLifecycleStage.RuntimeInitialize, Initialize);
         }
 
         public async Task Initialize(CancellationToken ct = default)
@@ -189,30 +189,43 @@ namespace Orleans.GrainDirectory.Redis
             _database = _redis.GetDatabase();
         }
 
-        private async Task Uninitialize(CancellationToken arg)
+        public void Dispose()
         {
-            if (_redis != null)
+            var redis = _redis;
+            if (redis is null)
             {
-                _disposed = true;
+                return;
+            }
 
-                try
-                {
-                    _redis.ConnectionRestored -= LogConnectionRestored;
-                    _redis.ConnectionFailed -= LogConnectionFailed;
-                    _redis.ErrorMessage -= LogErrorMessage;
-                    _redis.InternalError -= LogInternalError;
+            var redisIsShared = _redisIsShared;
+            _disposed = true;
+            _redis = null!;
+            _database = null!;
+            _redisIsShared = false;
 
-                    if (!_redisIsShared)
-                    {
-                        await _redis.DisposeAsync();
-                    }
-                }
-                finally
-                {
-                    _redis = null!;
-                    _database = null!;
-                    _redisIsShared = false;
-                }
+            if (!redisIsShared)
+            {
+                redis.Dispose();
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            var redis = _redis;
+            if (redis is null)
+            {
+                return;
+            }
+
+            var redisIsShared = _redisIsShared;
+            _disposed = true;
+            _redis = null!;
+            _database = null!;
+            _redisIsShared = false;
+
+            if (!redisIsShared)
+            {
+                await redis.DisposeAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/Redis/Orleans.Persistence.Redis/Hosting/RedisGrainStorageProviderBuilder.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Hosting/RedisGrainStorageProviderBuilder.cs
@@ -29,7 +29,7 @@ internal sealed class RedisGrainStorageProviderBuilder : IProviderBuilder<ISiloB
                 {
                     // Get a connection multiplexer instance by name.
                     var multiplexer = services.GetRequiredKeyedService<IConnectionMultiplexer>(serviceKey);
-                    options.CreateMultiplexer = _ => Task.FromResult(multiplexer);
+                    options.CreateMultiplexer = _ => Task.FromResult((Multiplexer: multiplexer, IsShared: true));
                     options.ConfigurationOptions = new ConfigurationOptions();
                 }
                 else

--- a/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Providers/RedisStorageOptions.cs
@@ -34,9 +34,12 @@ namespace Orleans.Persistence
         public ConfigurationOptions? ConfigurationOptions { get; set; }
 
         /// <summary>
-        /// The delegate used to create a Redis connection multiplexer.
+        /// The delegate used to create a Redis connection multiplexer and indicate whether it is shared.
         /// </summary>
-        public Func<RedisStorageOptions, Task<IConnectionMultiplexer>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
+        /// <remarks>
+        /// When <c>IsShared</c> is <see langword="true"/>, the provider will not dispose the returned multiplexer.
+        /// </remarks>
+        public Func<RedisStorageOptions, Task<(IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
 
         /// <summary>
         /// Entry expiry, null by default. A value should be set only for ephemeral environments, such as testing environments.
@@ -52,7 +55,8 @@ namespace Orleans.Persistence
         /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
-        public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisStorageOptions options) => await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!);
+        public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisStorageOptions options)
+            => (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions!), IsShared: false);
     }
 
     /// <summary>

--- a/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
@@ -34,6 +34,7 @@ namespace Orleans.Persistence
         private readonly Func<string, GrainId, RedisKey> _getKeyFunc;
         private IConnectionMultiplexer _connection;
         private IDatabase _db;
+        private bool _connectionIsShared;
 
         /// <summary>
         /// Creates a new instance of the <see cref="RedisGrainStorage"/> type.
@@ -72,7 +73,7 @@ namespace Orleans.Persistence
             {
                 LogDebugInitializing(_name, _serviceId, _options.DeleteStateOnClear);
 
-                _connection = await _options.CreateMultiplexer(_options).ConfigureAwait(false);
+                (_connection, _connectionIsShared) = await _options.CreateMultiplexer(_options).ConfigureAwait(false);
                 _db = _connection.GetDatabase();
 
                 var elapsed = Stopwatch.GetElapsedTime(startTime);
@@ -256,8 +257,20 @@ namespace Orleans.Persistence
         {
             if (_connection is null) return;
 
-            await _connection.CloseAsync().ConfigureAwait(false);
-            _connection.Dispose();
+            try
+            {
+                 if (!_connectionIsShared)
+                {
+                    await _connection.CloseAsync().ConfigureAwait(false);
+                    _connection.Dispose();
+                }
+            }
+            finally
+            {
+                _connection = null;
+                _db = null;
+                _connectionIsShared = false;
+            }
         }
 
         private T CreateInstance<T>() => _activatorProvider.GetActivator<T>().Create();

--- a/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
+++ b/src/Redis/Orleans.Persistence.Redis/Storage/RedisGrainStorage.cs
@@ -21,7 +21,7 @@ namespace Orleans.Persistence
     /// <summary>
     /// Redis-based grain storage provider
     /// </summary>
-    public partial class RedisGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLifecycle>
+    public partial class RedisGrainStorage : IGrainStorage, ILifecycleParticipant<ISiloLifecycle>, IDisposable, IAsyncDisposable
     {
         private readonly string _serviceId;
         private readonly RedisValue _ttl;
@@ -62,7 +62,7 @@ namespace Orleans.Persistence
         public void Participate(ISiloLifecycle lifecycle)
         {
             var name = OptionFormattingUtilities.Name<RedisGrainStorage>(_name);
-            lifecycle.Subscribe(name, _options.InitStage, Init, Close);
+            lifecycle.Subscribe(name, _options.InitStage, Init);
         }
 
         private async Task Init(CancellationToken cancellationToken)
@@ -253,23 +253,41 @@ namespace Orleans.Persistence
             }
         }
 
-        private async Task Close(CancellationToken cancellationToken)
+        public void Dispose()
         {
-            if (_connection is null) return;
-
-            try
+            var connection = _connection;
+            if (connection is null)
             {
-                 if (!_connectionIsShared)
-                {
-                    await _connection.CloseAsync().ConfigureAwait(false);
-                    _connection.Dispose();
-                }
+                return;
             }
-            finally
+
+            var connectionIsShared = _connectionIsShared;
+            _connection = null;
+            _db = null;
+            _connectionIsShared = false;
+
+            if (!connectionIsShared)
             {
-                _connection = null;
-                _db = null;
-                _connectionIsShared = false;
+                connection.Dispose();
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            var connection = _connection;
+            if (connection is null)
+            {
+                return;
+            }
+
+            var connectionIsShared = _connectionIsShared;
+            _connection = null;
+            _db = null;
+            _connectionIsShared = false;
+
+            if (!connectionIsShared)
+            {
+                await connection.DisposeAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/Redis/Orleans.Reminders.Redis/Hosting/RedisRemindersProviderBuilder.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Hosting/RedisRemindersProviderBuilder.cs
@@ -27,7 +27,7 @@ internal sealed class RedisRemindersProviderBuilder : IProviderBuilder<ISiloBuil
                 {
                     // Get a connection multiplexer instance by name.
                     var multiplexer = services.GetRequiredKeyedService<IConnectionMultiplexer>(serviceKey);
-                    options.CreateMultiplexer = _ => Task.FromResult(multiplexer);
+                    options.CreateMultiplexer = _ => Task.FromResult((Multiplexer: multiplexer, IsShared: true));
                     options.ConfigurationOptions = new ConfigurationOptions();
                 }
                 else

--- a/src/Redis/Orleans.Reminders.Redis/Providers/RedisReminderTableOptions.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Providers/RedisReminderTableOptions.cs
@@ -20,9 +20,12 @@ namespace Orleans.Configuration
         public ConfigurationOptions ConfigurationOptions { get; set; }
 
         /// <summary>
-        /// The delegate used to create a Redis connection multiplexer.
+        /// The delegate used to create a Redis connection multiplexer and indicate whether it is shared.
         /// </summary>
-        public Func<RedisReminderTableOptions, Task<IConnectionMultiplexer>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
+        /// <remarks>
+        /// When <c>IsShared</c> is <see langword="true"/>, the provider will not dispose the returned multiplexer.
+        /// </remarks>
+        public Func<RedisReminderTableOptions, Task<(IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get; set; } = DefaultCreateMultiplexer;
 
         /// <summary>
         /// Entry expiry, null by default. A value should be set ONLY for ephemeral environments (like in tests).
@@ -33,7 +36,8 @@ namespace Orleans.Configuration
         /// <summary>
         /// The default multiplexer creation delegate.
         /// </summary>
-        public static async Task<IConnectionMultiplexer> DefaultCreateMultiplexer(RedisReminderTableOptions options) => await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions);
+        public static async Task<(IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisReminderTableOptions options)
+            => (Multiplexer: await ConnectionMultiplexer.ConnectAsync(options.ConfigurationOptions), IsShared: false);
     }
 
     internal class RedactRedisConfigurationOptions : RedactAttribute

--- a/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
@@ -17,7 +17,7 @@ using static System.FormattableString;
 #nullable disable
 namespace Orleans.Reminders.Redis
 {
-    internal partial class RedisReminderTable : IReminderTable
+    internal partial class RedisReminderTable : IReminderTable, IDisposable
     {
         private readonly RedisKey _hashSetKey;
         private readonly RedisReminderTableOptions _redisOptions;
@@ -25,6 +25,7 @@ namespace Orleans.Reminders.Redis
         private readonly ILogger _logger;
         private IConnectionMultiplexer _muxer;
         private IDatabase _db;
+        private bool _muxerIsShared;
 
         public RedisReminderTable(
             ILogger<RedisReminderTable> logger,
@@ -42,7 +43,7 @@ namespace Orleans.Reminders.Redis
         {
             try
             {
-                _muxer = await _redisOptions.CreateMultiplexer(_redisOptions);
+                (_muxer, _muxerIsShared) = await _redisOptions.CreateMultiplexer(_redisOptions);
                 _db = _muxer.GetDatabase();
 
                 if (_redisOptions.EntryExpiry is { } expiry)
@@ -177,6 +178,18 @@ namespace Orleans.Reminders.Redis
             {
                 throw new RedisRemindersException(Invariant($"{exception.GetType()}: {exception.Message}"));
             }
+        }
+
+        public void Dispose()
+        {
+            if (!_muxerIsShared)
+            {
+                _muxer?.Dispose();
+            }
+
+            _muxer = null;
+            _db = null;
+            _muxerIsShared = false;
         }
 
         private static ReminderEntry ConvertToEntry(string reminderValue)

--- a/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
+++ b/src/Redis/Orleans.Reminders.Redis/Storage/RedisReminderTable.cs
@@ -17,7 +17,7 @@ using static System.FormattableString;
 #nullable disable
 namespace Orleans.Reminders.Redis
 {
-    internal partial class RedisReminderTable : IReminderTable, IDisposable
+    internal partial class RedisReminderTable : IReminderTable, IDisposable, IAsyncDisposable
     {
         private readonly RedisKey _hashSetKey;
         private readonly RedisReminderTableOptions _redisOptions;
@@ -182,14 +182,40 @@ namespace Orleans.Reminders.Redis
 
         public void Dispose()
         {
-            if (!_muxerIsShared)
+            var muxer = _muxer;
+            if (muxer is null)
             {
-                _muxer?.Dispose();
+                return;
             }
 
+            var muxerIsShared = _muxerIsShared;
             _muxer = null;
             _db = null;
             _muxerIsShared = false;
+
+            if (!muxerIsShared)
+            {
+                muxer.Dispose();
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            var muxer = _muxer;
+            if (muxer is null)
+            {
+                return;
+            }
+
+            var muxerIsShared = _muxerIsShared;
+            _muxer = null;
+            _db = null;
+            _muxerIsShared = false;
+
+            if (!muxerIsShared)
+            {
+                await muxer.DisposeAsync().ConfigureAwait(false);
+            }
         }
 
         private static ReminderEntry ConvertToEntry(string reminderValue)

--- a/src/api/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.cs
+++ b/src/api/Redis/Orleans.Clustering.Redis/Orleans.Clustering.Redis.cs
@@ -41,13 +41,13 @@ namespace Orleans.Clustering.Redis
     {
         public StackExchange.Redis.ConfigurationOptions ConfigurationOptions { get { throw null; } set { } }
 
-        public System.Func<RedisClusteringOptions, System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer>> CreateMultiplexer { get { throw null; } set { } }
+        public System.Func<RedisClusteringOptions, System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get { throw null; } set { } }
 
         public System.Func<Configuration.ClusterOptions, StackExchange.Redis.RedisKey> CreateRedisKey { get { throw null; } set { } }
 
         public System.TimeSpan? EntryExpiry { get { throw null; } set { } }
 
-        public static System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer> DefaultCreateMultiplexer(RedisClusteringOptions options) { throw null; }
+        public static System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisClusteringOptions options) { throw null; }
 
         public static StackExchange.Redis.RedisKey DefaultCreateRedisKey(Configuration.ClusterOptions clusterOptions) { throw null; }
     }

--- a/src/api/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.cs
+++ b/src/api/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.cs
@@ -12,11 +12,11 @@ namespace Orleans.Configuration
     {
         public StackExchange.Redis.ConfigurationOptions ConfigurationOptions { get { throw null; } set { } }
 
-        public System.Func<RedisGrainDirectoryOptions, System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer>> CreateMultiplexer { get { throw null; } set { } }
+        public System.Func<RedisGrainDirectoryOptions, System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get { throw null; } set { } }
 
         public System.TimeSpan? EntryExpiry { get { throw null; } set { } }
 
-        public static System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer> DefaultCreateMultiplexer(RedisGrainDirectoryOptions options) { throw null; }
+        public static System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisGrainDirectoryOptions options) { throw null; }
     }
 
     public partial class RedisGrainDirectoryOptionsValidator : IConfigurationValidator

--- a/src/api/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.cs
+++ b/src/api/Redis/Orleans.GrainDirectory.Redis/Orleans.GrainDirectory.Redis.cs
@@ -29,9 +29,13 @@ namespace Orleans.Configuration
 
 namespace Orleans.GrainDirectory.Redis
 {
-    public partial class RedisGrainDirectory : IGrainDirectory, ILifecycleParticipant<Runtime.ISiloLifecycle>
+    public partial class RedisGrainDirectory : IGrainDirectory, ILifecycleParticipant<Runtime.ISiloLifecycle>, System.IDisposable, System.IAsyncDisposable
     {
         public RedisGrainDirectory(Configuration.RedisGrainDirectoryOptions directoryOptions, Microsoft.Extensions.Options.IOptions<Configuration.ClusterOptions> clusterOptions, Microsoft.Extensions.Logging.ILogger<RedisGrainDirectory> logger) { }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
 
         public System.Threading.Tasks.Task Initialize(System.Threading.CancellationToken ct = default) { throw null; }
 

--- a/src/api/Redis/Orleans.Persistence.Redis/Orleans.Persistence.Redis.cs
+++ b/src/api/Redis/Orleans.Persistence.Redis/Orleans.Persistence.Redis.cs
@@ -59,7 +59,7 @@ namespace Orleans.Persistence
     {
         public StackExchange.Redis.ConfigurationOptions? ConfigurationOptions { get { throw null; } set { } }
 
-        public System.Func<RedisStorageOptions, System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer>> CreateMultiplexer { get { throw null; } set { } }
+        public System.Func<RedisStorageOptions, System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get { throw null; } set { } }
 
         public bool DeleteStateOnClear { get { throw null; } set { } }
 
@@ -71,7 +71,7 @@ namespace Orleans.Persistence
 
         public int InitStage { get { throw null; } set { } }
 
-        public static System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer> DefaultCreateMultiplexer(RedisStorageOptions options) { throw null; }
+        public static System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisStorageOptions options) { throw null; }
     }
 
     public static partial class RedisStorageOptionsExtensions

--- a/src/api/Redis/Orleans.Persistence.Redis/Orleans.Persistence.Redis.cs
+++ b/src/api/Redis/Orleans.Persistence.Redis/Orleans.Persistence.Redis.cs
@@ -37,11 +37,15 @@ namespace Orleans.Hosting
 
 namespace Orleans.Persistence
 {
-    public partial class RedisGrainStorage : Storage.IGrainStorage, ILifecycleParticipant<Runtime.ISiloLifecycle>
+    public partial class RedisGrainStorage : Storage.IGrainStorage, ILifecycleParticipant<Runtime.ISiloLifecycle>, System.IDisposable, System.IAsyncDisposable
     {
         public RedisGrainStorage(string name, RedisStorageOptions options, Storage.IGrainStorageSerializer grainStorageSerializer, Microsoft.Extensions.Options.IOptions<Configuration.ClusterOptions> clusterOptions, Serialization.Serializers.IActivatorProvider activatorProvider, Microsoft.Extensions.Logging.ILogger<RedisGrainStorage> logger) { }
 
         public System.Threading.Tasks.Task ClearStateAsync<T>(string grainType, Runtime.GrainId grainId, IGrainState<T> grainState) { throw null; }
+
+        public void Dispose() { }
+
+        public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
 
         public void Participate(Runtime.ISiloLifecycle lifecycle) { }
 

--- a/src/api/Redis/Orleans.Reminders.Redis/Orleans.Reminders.Redis.cs
+++ b/src/api/Redis/Orleans.Reminders.Redis/Orleans.Reminders.Redis.cs
@@ -12,11 +12,11 @@ namespace Orleans.Configuration
     {
         public StackExchange.Redis.ConfigurationOptions ConfigurationOptions { get { throw null; } set { } }
 
-        public System.Func<RedisReminderTableOptions, System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer>> CreateMultiplexer { get { throw null; } set { } }
+        public System.Func<RedisReminderTableOptions, System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)>> CreateMultiplexer { get { throw null; } set { } }
 
         public System.TimeSpan? EntryExpiry { get { throw null; } set { } }
 
-        public static System.Threading.Tasks.Task<StackExchange.Redis.IConnectionMultiplexer> DefaultCreateMultiplexer(RedisReminderTableOptions options) { throw null; }
+        public static System.Threading.Tasks.Task<(StackExchange.Redis.IConnectionMultiplexer Multiplexer, bool IsShared)> DefaultCreateMultiplexer(RedisReminderTableOptions options) { throw null; }
     }
 
     public partial class RedisReminderTableOptionsValidator : IConfigurationValidator


### PR DESCRIPTION
Fixes Redis provider ownership handling for shared `IConnectionMultiplexer` instances.

Redis providers can be configured with a `ServiceKey` to use a DI-provided multiplexer. Those instances are shared and owned by DI, so providers should not close or dispose them.

This updates the non-streaming Redis providers to report whether created multiplexers are shared, marks `ServiceKey`-resolved multiplexers as shared, and implements standard `Dispose`/`DisposeAsync` cleanup so owned multiplexers are disposed naturally when the container is disposed while shared multiplexers are left alone.
