### PR TITLE
feat(journaling-azure): add instrumentation and retry tuning

### DIFF
--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics;
 using System.Globalization;
 using Azure;
 using Azure.Storage.Blobs.Models;
@@ -20,6 +21,9 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     // WAL metadata uses this key to record how many WAL bytes are already included in the checkpoint; recovery skips that prefix before replaying the WAL tail.
     internal const string CheckpointOffsetMetadataKey = "checkpoint_offset";
 
+    // WAL metadata uses this provider-owned key to distinguish metadata-only ETag changes from WAL recreation.
+    internal const string WalGenerationMetadataKey = "wal_generation";
+
     // AppendAsync rejects batches above Azure's documented per-block cap before sending an append request.
     internal const long MaxAppendBlockBytes = 100L * 1024 * 1024;
 
@@ -32,11 +36,14 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     // IsCompactionRequested trips at this block count so callers compact before the hard append-blob limit.
     private const int RequestCompactionBlockCount = 49_000;
 
+    private const int MaxMetadataOnlyConflictRetries = 5;
+
     private readonly AzureBlobJournalStorageShared _shared;
     private readonly JournalId _journalId;
     private readonly AppendBlobClient _walClient;
     private int _numBlocks;
     private ETag _walETag;
+    private WalProviderState _walProviderState;
 
     private bool WalExists => _walETag != default;
 
@@ -61,29 +68,55 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         IReadOnlyDictionary<string, string>? metadata = null,
         CancellationToken cancellationToken = default)
     {
+        var startTimestamp = Stopwatch.GetTimestamp();
+        var succeeded = false;
         var callerMetadata = CopyAndValidateCallerMetadata(metadata);
         try
         {
-            var response = await CreateWalAsync(
+            var created = await CreateWalAsync(
                 checkpointName: null,
                 new AppendBlobRequestConditions { IfNoneMatch = ETag.All },
                 cancellationToken,
                 callerMetadata).ConfigureAwait(false);
-            SetWal(response.Value.ETag, blockCount: 0);
+            SetWal(created.Response.Value.ETag, created.ProviderState);
+            succeeded = true;
             return true;
         }
         catch (RequestFailedException exception) when (exception.Status is 409 or 412)
         {
+            succeeded = true;
             return false;
+        }
+        finally
+        {
+            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+                AzureBlobJournalStorageInstruments.OperationCreate,
+                Stopwatch.GetElapsedTime(startTimestamp),
+                bytes: 0,
+                succeeded);
         }
     }
 
     public async ValueTask<IJournalMetadata?> GetMetadataAsync(CancellationToken cancellationToken = default)
     {
-        var properties = await GetPropertiesCoreAsync(_walClient, conditions: null, cancellationToken).ConfigureAwait(false);
-        return properties is null || properties.BlobType != BlobType.Append
-            ? null
-            : CreateJournalMetadata(properties.ETag, properties.Metadata);
+        var startTimestamp = Stopwatch.GetTimestamp();
+        var succeeded = false;
+        try
+        {
+            var properties = await GetPropertiesCoreAsync(_walClient, conditions: null, cancellationToken).ConfigureAwait(false);
+            succeeded = true;
+            return properties is null || properties.BlobType != BlobType.Append
+                ? null
+                : CreateJournalMetadata(properties.ETag, properties.Metadata);
+        }
+        finally
+        {
+            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+                AzureBlobJournalStorageInstruments.OperationGetMetadata,
+                Stopwatch.GetElapsedTime(startTimestamp),
+                bytes: 0,
+                succeeded);
+        }
     }
 
     public async ValueTask<IJournalMetadata?> UpdateMetadataAsync(
@@ -92,316 +125,460 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         string? expectedETag = null,
         CancellationToken cancellationToken = default)
     {
+        var startTimestamp = Stopwatch.GetTimestamp();
+        var succeeded = false;
         var setValues = CopyAndValidateCallerMetadata(set);
         var removeValues = CopyRemove(remove, setValues);
-        for (var attempt = 0; attempt < 3; attempt++)
+        try
         {
-            BlobProperties? properties;
-            try
+            for (var attempt = 0; attempt < 3; attempt++)
             {
-                properties = await GetPropertiesCoreAsync(
-                    _walClient,
-                    expectedETag is null ? null : new BlobRequestConditions { IfMatch = ToAzureETag(expectedETag) },
-                    cancellationToken).ConfigureAwait(false);
-            }
-            catch (RequestFailedException exception) when (exception.Status is 412)
-            {
-                return null;
-            }
-
-            if (properties is null || properties.BlobType != BlobType.Append)
-            {
-                return null;
-            }
-
-            var metadata = CopyMetadata(properties.Metadata);
-            if (!ApplyCallerMetadataUpdate(metadata, setValues, removeValues))
-            {
-                return CreateJournalMetadata(properties.ETag, metadata);
-            }
-
-            var conditions = new BlobRequestConditions
-            {
-                IfMatch = expectedETag is null ? properties.ETag : ToAzureETag(expectedETag),
-            };
-
-            try
-            {
-                var response = await _walClient.SetMetadataAsync(metadata, conditions, cancellationToken).ConfigureAwait(false);
-                return CreateJournalMetadata(response.Value.ETag, metadata);
-            }
-            catch (RequestFailedException exception) when (exception.Status is 412)
-            {
-                if (expectedETag is not null)
+                BlobProperties? properties;
+                try
                 {
+                    properties = await GetPropertiesCoreAsync(
+                        _walClient,
+                        expectedETag is null ? null : new BlobRequestConditions { IfMatch = ToAzureETag(expectedETag) },
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch (RequestFailedException exception) when (exception.Status is 412)
+                {
+                    succeeded = true;
                     return null;
                 }
-            }
-        }
 
-        return null;
+                if (properties is null || properties.BlobType != BlobType.Append)
+                {
+                    succeeded = true;
+                    return null;
+                }
+
+                var walState = CreateWalState(properties);
+                var metadata = CopyMetadata(properties.Metadata);
+                if (!ApplyCallerMetadataUpdate(metadata, setValues, removeValues))
+                {
+                    SetWal(walState.ETag, walState.ProviderState);
+                    succeeded = true;
+                    return CreateJournalMetadata(properties.ETag, metadata);
+                }
+
+                var conditions = new BlobRequestConditions
+                {
+                    IfMatch = expectedETag is null ? properties.ETag : ToAzureETag(expectedETag),
+                };
+
+                try
+                {
+                    var response = await _walClient.SetMetadataAsync(metadata, conditions, cancellationToken).ConfigureAwait(false);
+                    SetWal(response.Value.ETag, walState.ProviderState);
+                    succeeded = true;
+                    return CreateJournalMetadata(response.Value.ETag, metadata);
+                }
+                catch (RequestFailedException exception) when (exception.Status is 412)
+                {
+                    if (expectedETag is not null)
+                    {
+                        succeeded = true;
+                        return null;
+                    }
+                }
+            }
+
+            succeeded = true;
+            return null;
+        }
+        finally
+        {
+            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+                AzureBlobJournalStorageInstruments.OperationUpdateMetadata,
+                Stopwatch.GetElapsedTime(startTimestamp),
+                bytes: 0,
+                succeeded);
+        }
     }
 
     public async ValueTask AppendAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
         // Appends are written as one Azure append block, so validate blob limits before touching storage.
         ThrowIfBatchTooLarge(value.Length);
+        var startTimestamp = Stopwatch.GetTimestamp();
+        var succeeded = false;
 
-        // Ensure local state has the current WAL ETag and manifest before making a conditional append.
-        if (!WalExists)
-        {
-            await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        ThrowIfCompactionRequired();
-
-        using var stream = new ReadOnlySequenceStream(value);
         try
         {
-            // Use the last observed WAL ETag so appends fail if the WAL changed since this instance recovered it.
-            var result = await _walClient.AppendBlockAsync(
-                stream,
-                new AppendBlobAppendBlockOptions
+            for (var attempt = 0; ; attempt++)
+            {
+                // Ensure local state has the current WAL ETag and manifest before making a conditional append.
+                if (!WalExists)
                 {
-                    Conditions = new AppendBlobRequestConditions
+                    await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                ThrowIfCompactionRequired();
+
+                var expectedETag = _walETag;
+                var expectedProviderState = _walProviderState;
+                using var stream = new ReadOnlySequenceStream(value);
+                try
+                {
+                    // Use the last observed WAL ETag so appends fail if the WAL changed since this instance recovered it.
+                    var result = await _walClient.AppendBlockAsync(
+                        stream,
+                        new AppendBlobAppendBlockOptions
+                        {
+                            Conditions = new AppendBlobRequestConditions
+                            {
+                                IfMatch = expectedETag,
+                            }
+                        },
+                        cancellationToken).ConfigureAwait(false);
+
+                    LogAppend(_shared.Logger, stream.Length, _walClient.BlobContainerName, _walClient.Name);
+
+                    // Cache Azure's post-append state so the next mutation is guarded by the new ETag and block count.
+                    SetWal(
+                        result.Value.ETag,
+                        expectedProviderState with
+                        {
+                            ContentLength = expectedProviderState.ContentLength + value.Length,
+                            CommittedBlockCount = result.Value.BlobCommittedBlockCount
+                        });
+                    succeeded = true;
+                    return;
+                }
+                catch (RequestFailedException exception) when (IsBlobSealed(exception))
+                {
+                    throw CreateInconsistentWalStateException(
+                        "Azure Blob journal WAL is sealed; recovery is required before appending.",
+                        expectedETag,
+                        exception);
+                }
+                catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
+                {
+                    var refreshed = attempt < MaxMetadataOnlyConflictRetries
+                        ? await TryRefreshWalStateAfterMetadataOnlyConflictAsync(expectedProviderState, cancellationToken).ConfigureAwait(false)
+                        : null;
+                    if (refreshed is not null)
                     {
-                        IfMatch = _walETag,
+                        continue;
                     }
-                },
-                cancellationToken).ConfigureAwait(false);
 
-            LogAppend(_shared.Logger, stream.Length, _walClient.BlobContainerName, _walClient.Name);
-
-            // Cache Azure's post-append state so the next mutation is guarded by the new ETag and block count.
-            SetWal(result.Value.ETag, result.Value.BlobCommittedBlockCount);
+                    throw CreateInconsistentWalStateException(
+                        "Azure Blob journal WAL changed while appending; recovery is required.",
+                        expectedETag,
+                        exception);
+                }
+            }
         }
-        catch (RequestFailedException exception) when (IsBlobSealed(exception))
+        finally
         {
-            throw CreateInconsistentWalStateException(
-                "Azure Blob journal WAL is sealed; recovery is required before appending.",
-                _walETag,
-                exception);
-        }
-        catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
-        {
-            throw CreateInconsistentWalStateException(
-                "Azure Blob journal WAL changed while appending; recovery is required.",
-                _walETag,
-                exception);
+            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+                AzureBlobJournalStorageInstruments.OperationAppend,
+                Stopwatch.GetElapsedTime(startTimestamp),
+                value.Length,
+                succeeded);
         }
     }
 
     public async ValueTask DeleteAsync(CancellationToken cancellationToken)
     {
-        var conditions = WalExists ? new BlobRequestConditions { IfMatch = _walETag } : null;
-        WalState? walState;
+        var startTimestamp = Stopwatch.GetTimestamp();
+        var succeeded = false;
         try
         {
-            // Load the WAL manifest only when deletion needs to know which checkpoint may become unreachable.
-            walState = await TryLoadWalStateAsync(conditions, cancellationToken).ConfigureAwait(false);
-        }
-        catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
-        {
-            throw CreateInconsistentWalStateException(
-                "Azure Blob journal WAL changed while deleting the journal; recovery is required.",
-                _walETag,
-                exception);
-        }
-
-        if (walState is null)
-        {
-            if (conditions is not null)
+            WalState? walState;
+            var expectedETag = _walETag;
+            var expectedProviderState = _walProviderState;
+            var conditions = WalExists ? new BlobRequestConditions { IfMatch = expectedETag } : null;
+            try
             {
-                throw CreateInconsistentWalStateException(
-                    "Azure Blob journal WAL changed while deleting the journal; recovery is required.",
-                    _walETag);
+                // Load the WAL manifest only when deletion needs to know which checkpoint may become unreachable.
+                walState = await TryLoadWalStateAsync(conditions, cancellationToken).ConfigureAwait(false);
+            }
+            catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
+            {
+                walState = conditions is not null
+                    ? await TryRefreshWalStateAfterMetadataOnlyConflictAsync(expectedProviderState, cancellationToken).ConfigureAwait(false)
+                    : null;
+                if (walState is null)
+                {
+                    throw CreateInconsistentWalStateException(
+                        "Azure Blob journal WAL changed while deleting the journal; recovery is required.",
+                        expectedETag,
+                        exception);
+                }
             }
 
-            return;
-        }
+            if (walState is null)
+            {
+                if (conditions is not null)
+                {
+                    throw CreateInconsistentWalStateException(
+                        "Azure Blob journal WAL changed while deleting the journal; recovery is required.",
+                        _walETag);
+                }
 
-        // Remember the checkpoint before clearing local WAL state so obsolete checkpoint cleanup can still run.
-        var checkpointName = walState.Value.Manifest.Checkpoint?.Name;
-        try
-        {
-            // Delete the WAL under its ETag before checkpoint cleanup so a racing WAL update cannot lose its checkpoint.
-            await _walClient.DeleteIfExistsAsync(
-                DeleteSnapshotsOption.None,
-                new BlobRequestConditions { IfMatch = walState.Value.ETag },
-                cancellationToken).ConfigureAwait(false);
-            SetWal(eTag: default, blockCount: 0);
-        }
-        catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
-        {
-            throw CreateInconsistentWalStateException(
-                "Azure Blob journal WAL changed while deleting the journal; recovery is required.",
-                walState.Value.ETag,
-                exception);
-        }
+                succeeded = true;
+                return;
+            }
 
-        if (checkpointName is not null)
+            // Remember the checkpoint before clearing local WAL state so obsolete checkpoint cleanup can still run.
+            var checkpointName = walState.Value.Manifest.Checkpoint?.Name;
+            for (var attempt = 0; ; attempt++)
+            {
+                var deleteWalState = walState.Value;
+                try
+                {
+                    // Delete the WAL under its ETag before checkpoint cleanup so a racing WAL update cannot lose its checkpoint.
+                    await _walClient.DeleteIfExistsAsync(
+                        DeleteSnapshotsOption.None,
+                        new BlobRequestConditions { IfMatch = deleteWalState.ETag },
+                        cancellationToken).ConfigureAwait(false);
+                    SetWal(eTag: default, providerState: default);
+                    break;
+                }
+                catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
+                {
+                    var refreshed = attempt < MaxMetadataOnlyConflictRetries
+                        ? await TryRefreshWalStateAfterMetadataOnlyConflictAsync(deleteWalState.ProviderState, cancellationToken).ConfigureAwait(false)
+                        : null;
+                    if (refreshed is { } refreshedState)
+                    {
+                        walState = refreshedState;
+                        checkpointName = refreshedState.Manifest.Checkpoint?.Name;
+                        continue;
+                    }
+
+                    throw CreateInconsistentWalStateException(
+                        "Azure Blob journal WAL changed while deleting the journal; recovery is required.",
+                        deleteWalState.ETag,
+                        exception);
+                }
+            }
+
+            if (checkpointName is not null)
+            {
+                // Checkpoint cleanup happens after WAL deletion because without the WAL manifest it is unreachable.
+                await DeleteCheckpointIfExistsAsync(checkpointName, cancellationToken).ConfigureAwait(false);
+            }
+
+            succeeded = true;
+        }
+        finally
         {
-            // Checkpoint cleanup happens after WAL deletion because without the WAL manifest it is unreachable.
-            await DeleteCheckpointIfExistsAsync(checkpointName, cancellationToken).ConfigureAwait(false);
+            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+                AzureBlobJournalStorageInstruments.OperationDelete,
+                Stopwatch.GetElapsedTime(startTimestamp),
+                bytes: 0,
+                succeeded);
         }
     }
 
     public async ValueTask ReadAsync(IJournalStorageConsumer consumer, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(consumer);
+        var startTimestamp = Stopwatch.GetTimestamp();
+        var succeeded = false;
+        var bytes = 0L;
 
-        Response<BlobDownloadStreamingResult> walResult;
         try
         {
-            // Download the WAL first because its metadata is the manifest for any checkpoint that must be replayed.
-            walResult = await _walClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-        catch (RequestFailedException exception) when (exception.Status is 404)
-        {
-            // A missing WAL is an empty journal; clear cached state before reporting completion.
-            SetWal(eTag: default, blockCount: 0);
-            consumer.Complete(metadata: null);
-            return;
-        }
-
-        var walDetails = walResult.Value.Details;
-        var manifest = CreateWalManifest(walDetails.Metadata);
-
-        // Recovery refreshes the cached ETag and block count from the WAL manifest.
-        SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount);
-
-        await using var walStream = walResult.Value.Content;
-        var expectedFormat = manifest.Metadata.Format;
-        if (manifest.Checkpoint is { } checkpoint)
-        {
-            var checkpointClient = GetCheckpointClient(checkpoint.Name);
-            var checkpointResult = await checkpointClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            await using var checkpointStream = checkpointResult.Value.Content;
-
-            // Replay the immutable checkpoint first because it represents the compacted prefix before WAL entries.
-            var checkpointMetadata = ValidateCheckpointMetadata(checkpoint, checkpointResult.Value.Details, expectedFormat);
-            var totalCheckpointBytes = await consumer.ReadAsync(
-                checkpointStream,
-                checkpointMetadata,
-                complete: false,
-                cancellationToken).ConfigureAwait(false);
-            LogRead(_shared.Logger, totalCheckpointBytes, checkpointClient.BlobContainerName, checkpointClient.Name);
-            expectedFormat = checkpointMetadata.Format;
-        }
-
-        if (manifest.Checkpoint is { WalOffset: > 0 } checkpointOffset)
-        {
-            if (checkpointOffset.WalOffset > walDetails.ContentLength)
+            Response<BlobDownloadStreamingResult> walResult;
+            try
             {
-                throw new InvalidOperationException(
-                    $"Azure Blob journal checkpoint offset {checkpointOffset.WalOffset:N0} exceeds WAL length {walDetails.ContentLength:N0}.");
+                // Download the WAL first because its metadata is the manifest for any checkpoint that must be replayed.
+                walResult = await _walClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (RequestFailedException exception) when (exception.Status is 404)
+            {
+                // A missing WAL is an empty journal; clear cached state before reporting completion.
+                SetWal(eTag: default, providerState: default);
+                consumer.Complete(metadata: null);
+                succeeded = true;
+                return;
             }
 
-            // The checkpoint already contains WAL bytes through this offset, so replay only the WAL tail.
-            await AzureBlobJournalStorageStreamHelpers.SkipStreamAsync(walStream, checkpointOffset.WalOffset, cancellationToken).ConfigureAwait(false);
+            var walDetails = walResult.Value.Details;
+            var manifest = CreateWalManifest(walDetails.Metadata);
+
+            // Recovery refreshes the cached ETag and block count from the WAL manifest.
+            SetWal(walDetails.ETag, CreateWalProviderState(manifest, walDetails.ContentLength, walDetails.BlobCommittedBlockCount));
+
+            await using var walStream = walResult.Value.Content;
+            var expectedFormat = manifest.Metadata.Format;
+            if (manifest.Checkpoint is { } checkpoint)
+            {
+                var checkpointClient = GetCheckpointClient(checkpoint.Name);
+                var checkpointResult = await checkpointClient.DownloadStreamingAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                await using var checkpointStream = checkpointResult.Value.Content;
+
+                // Replay the immutable checkpoint first because it represents the compacted prefix before WAL entries.
+                var checkpointMetadata = ValidateCheckpointMetadata(checkpoint, checkpointResult.Value.Details, expectedFormat);
+                var totalCheckpointBytes = await consumer.ReadAsync(
+                    checkpointStream,
+                    checkpointMetadata,
+                    complete: false,
+                    cancellationToken).ConfigureAwait(false);
+                LogRead(_shared.Logger, totalCheckpointBytes, checkpointClient.BlobContainerName, checkpointClient.Name);
+                bytes += totalCheckpointBytes;
+                expectedFormat = checkpointMetadata.Format;
+            }
+
+            if (manifest.Checkpoint is { WalOffset: > 0 } checkpointOffset)
+            {
+                if (checkpointOffset.WalOffset > walDetails.ContentLength)
+                {
+                    throw new InvalidOperationException(
+                        $"Azure Blob journal checkpoint offset {checkpointOffset.WalOffset:N0} exceeds WAL length {walDetails.ContentLength:N0}.");
+                }
+
+                // The checkpoint already contains WAL bytes through this offset, so replay only the WAL tail.
+                await AzureBlobJournalStorageStreamHelpers.SkipStreamAsync(walStream, checkpointOffset.WalOffset, cancellationToken).ConfigureAwait(false);
+            }
+
+            // Prefer WAL format metadata, falling back to the checkpoint when compaction recreated an empty WAL.
+            var walMetadata = manifest.Metadata.Format is { Length: > 0 }
+                ? manifest.Metadata
+                : expectedFormat is { Length: > 0 }
+                    ? new JournalMetadata(expectedFormat)
+                    : JournalMetadata.Empty;
+            var totalWalBytes = await consumer.ReadAsync(
+                walStream,
+                walMetadata,
+                complete: false,
+                cancellationToken).ConfigureAwait(false);
+            LogRead(_shared.Logger, totalWalBytes, _walClient.BlobContainerName, _walClient.Name);
+            bytes += totalWalBytes;
+
+            // Complete only after checkpoint and WAL tail have streamed as one logical journal.
+            consumer.Complete(walMetadata);
+            succeeded = true;
         }
-
-        // Prefer WAL format metadata, falling back to the checkpoint when compaction recreated an empty WAL.
-        var walMetadata = manifest.Metadata.Format is { Length: > 0 }
-            ? manifest.Metadata
-            : expectedFormat is { Length: > 0 }
-                ? new JournalMetadata(expectedFormat)
-                : JournalMetadata.Empty;
-        var totalWalBytes = await consumer.ReadAsync(
-            walStream,
-            walMetadata,
-            complete: false,
-            cancellationToken).ConfigureAwait(false);
-        LogRead(_shared.Logger, totalWalBytes, _walClient.BlobContainerName, _walClient.Name);
-
-        // Complete only after checkpoint and WAL tail have streamed as one logical journal.
-        consumer.Complete(walMetadata);
+        finally
+        {
+            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+                AzureBlobJournalStorageInstruments.OperationRead,
+                Stopwatch.GetElapsedTime(startTimestamp),
+                bytes,
+                succeeded);
+        }
     }
 
     public async ValueTask ReplaceAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
     {
-        // Compaction publishes through WAL metadata, so first recover or create the WAL whose ETag will be checked.
-        await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
-
-        var expectedWalETag = _walETag;
-        WalState? walState;
+        var startTimestamp = Stopwatch.GetTimestamp();
+        var succeeded = false;
         try
         {
-            // Read the WAL manifest so compaction preserves caller-owned metadata while replacing provider-owned checkpoint metadata.
-            walState = await TryLoadWalStateAsync(new BlobRequestConditions { IfMatch = expectedWalETag }, cancellationToken).ConfigureAwait(false);
-            if (walState is null)
-            {
-                throw CreateInconsistentWalStateException(
-                    "Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.",
-                    expectedWalETag);
-            }
-        }
-        catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
-        {
-            throw CreateInconsistentWalStateException(
-                "Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.",
-                expectedWalETag,
-                exception);
-        }
+            // Compaction publishes through WAL metadata, so first recover or create the WAL whose ETag will be checked.
+            await EnsureWalAsync(cancellationToken).ConfigureAwait(false);
 
-        expectedWalETag = walState.Value.ETag;
-        var previousCheckpointName = _shared.Options.DeleteOldCheckpoints ? walState.Value.Manifest.Checkpoint?.Name : null;
-        var callerMetadata = walState.Value.Manifest.Metadata.Properties;
-
-        using var checkpointStream = new ReadOnlySequenceStream(value);
-        while (true)
-        {
-            // The checkpoint blob is immutable and content-addressed by a random snapshot id for safe retry on collision.
-            var checkpointName = GetCheckpointName(Guid.NewGuid().ToString("N"));
-            var checkpointClient = GetCheckpointClient(checkpointName);
+            var expectedWalETag = _walETag;
+            var expectedProviderState = _walProviderState;
+            WalState? walState;
             try
             {
-                // Upload the checkpoint before publishing it from WAL metadata so upload failures leave recovery unchanged.
-                checkpointStream.Position = 0;
-                await checkpointClient.UploadAsync(
-                    checkpointStream,
-                    new BlobUploadOptions
-                    {
-                        Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All },
-                        HttpHeaders = CreateHttpHeaders(_shared.MimeType),
-                        Metadata = CreateCheckpointBlobMetadata(),
-                    },
-                    cancellationToken).ConfigureAwait(false);
-            }
-            catch (RequestFailedException exception) when (IsBlobAlreadyExists(exception))
-            {
-                // Snapshot ids are random, so this should be vanishingly rare. Retry with a new id.
-                continue;
-            }
-
-            try
-            {
-                // Recreate the WAL under its ETag to publish the checkpoint only if the existing WAL is unchanged.
-                var result = await CreateWalAsync(
-                    checkpointName,
-                    new AppendBlobRequestConditions { IfMatch = expectedWalETag },
-                    cancellationToken,
-                    callerMetadata).ConfigureAwait(false);
-                SetWal(result.Value.ETag, blockCount: 0);
+                // Read the WAL manifest so compaction preserves caller-owned metadata while replacing provider-owned checkpoint metadata.
+                walState = await TryLoadWalStateAsync(new BlobRequestConditions { IfMatch = expectedWalETag }, cancellationToken).ConfigureAwait(false);
+                if (walState is null)
+                {
+                    throw CreateInconsistentWalStateException(
+                        "Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.",
+                        expectedWalETag);
+                }
             }
             catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
             {
-                throw CreateInconsistentWalStateException(
-                    "Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.",
-                    expectedWalETag,
-                    exception);
+                walState = await TryRefreshWalStateAfterMetadataOnlyConflictAsync(expectedProviderState, cancellationToken).ConfigureAwait(false);
+                if (walState is null)
+                {
+                    throw CreateInconsistentWalStateException(
+                        "Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.",
+                        expectedWalETag,
+                        exception);
+                }
             }
 
-            if (previousCheckpointName is not null && !string.Equals(previousCheckpointName, checkpointName, StringComparison.Ordinal))
+            var previousCheckpointName = _shared.Options.DeleteOldCheckpoints ? walState.Value.Manifest.Checkpoint?.Name : null;
+
+            using var checkpointStream = new ReadOnlySequenceStream(value);
+            while (true)
             {
-                // Keep the previous checkpoint until the new WAL is published so its manifest never points at a missing blob.
-                await DeleteCheckpointIfExistsAsync(previousCheckpointName, cancellationToken).ConfigureAwait(false);
+                // The checkpoint blob is immutable and content-addressed by a random snapshot id for safe retry on collision.
+                var checkpointName = GetCheckpointName(Guid.NewGuid().ToString("N"));
+                var checkpointClient = GetCheckpointClient(checkpointName);
+                try
+                {
+                    // Upload the checkpoint before publishing it from WAL metadata so upload failures leave recovery unchanged.
+                    checkpointStream.Position = 0;
+                    await checkpointClient.UploadAsync(
+                        checkpointStream,
+                        new BlobUploadOptions
+                        {
+                            Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All },
+                            HttpHeaders = CreateHttpHeaders(_shared.MimeType),
+                            Metadata = CreateCheckpointBlobMetadata(),
+                        },
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch (RequestFailedException exception) when (IsBlobAlreadyExists(exception))
+                {
+                    // Snapshot ids are random, so this should be vanishingly rare. Retry with a new id.
+                    continue;
+                }
+
+                for (var attempt = 0; ; attempt++)
+                {
+                    var publishWalState = walState.Value;
+                    try
+                    {
+                        // Recreate the WAL under its ETag to publish the checkpoint only if the existing WAL is unchanged.
+                        var created = await CreateWalAsync(
+                            checkpointName,
+                            new AppendBlobRequestConditions { IfMatch = publishWalState.ETag },
+                            cancellationToken,
+                            publishWalState.Manifest.Metadata.Properties).ConfigureAwait(false);
+                        SetWal(created.Response.Value.ETag, created.ProviderState);
+                        break;
+                    }
+                    catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
+                    {
+                        var refreshed = attempt < MaxMetadataOnlyConflictRetries
+                            ? await TryRefreshWalStateAfterMetadataOnlyConflictAsync(publishWalState.ProviderState, cancellationToken).ConfigureAwait(false)
+                            : null;
+                        if (refreshed is { } refreshedState)
+                        {
+                            walState = refreshedState;
+                            continue;
+                        }
+
+                        throw CreateInconsistentWalStateException(
+                            "Azure Blob journal WAL changed while publishing a checkpoint; recovery is required.",
+                            publishWalState.ETag,
+                            exception);
+                    }
+                }
+
+                if (previousCheckpointName is not null && !string.Equals(previousCheckpointName, checkpointName, StringComparison.Ordinal))
+                {
+                    // Keep the previous checkpoint until the new WAL is published so its manifest never points at a missing blob.
+                    await DeleteCheckpointIfExistsAsync(previousCheckpointName, cancellationToken).ConfigureAwait(false);
+                }
+
+                LogReplace(_shared.Logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
+
+                // At this point the new checkpoint is reachable from WAL metadata and old state has been detached.
+                succeeded = true;
+                return;
             }
-
-            LogReplace(_shared.Logger, checkpointClient.BlobContainerName, checkpointClient.Name, checkpointStream.Length);
-
-            // At this point the new checkpoint is reachable from WAL metadata and old state has been detached.
-            return;
+        }
+        finally
+        {
+            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+                AzureBlobJournalStorageInstruments.OperationReplace,
+                Stopwatch.GetElapsedTime(startTimestamp),
+                value.Length,
+                succeeded);
         }
     }
 
@@ -439,22 +616,25 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             try
             {
                 // A newly-created WAL has no checkpoint pointer; existing WALs are handled by the conflict path.
-                var response = await CreateWalAsync(
+                var created = await CreateWalAsync(
                     checkpointName: null,
                     new AppendBlobRequestConditions { IfNoneMatch = ETag.All },
                     cancellationToken).ConfigureAwait(false);
-                SetWal(response.Value.ETag, blockCount: 0);
+                SetWal(created.Response.Value.ETag, created.ProviderState);
                 return;
             }
             catch (RequestFailedException exception) when (IsBlobAlreadyExists(exception))
             {
                 // Another instance created the WAL first; load only the properties needed before appending.
-                await TryLoadWalStateAsync(conditions: null, cancellationToken).ConfigureAwait(false);
+                await TryLoadWalStateAsync(conditions: null, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
         }
     }
 
-    private async ValueTask<WalState?> TryLoadWalStateAsync(BlobRequestConditions? conditions, CancellationToken cancellationToken)
+    private async ValueTask<WalState?> TryLoadWalStateAsync(
+        BlobRequestConditions? conditions,
+        CancellationToken cancellationToken,
+        bool updateCache = true)
     {
         Response<BlobProperties> walProperties;
         try
@@ -465,23 +645,51 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         catch (RequestFailedException exception) when (exception.Status is 404)
         {
             // Missing WAL means there is no durable state to delete or mutate.
-            SetWal(eTag: default, blockCount: 0);
+            if (updateCache)
+            {
+                SetWal(eTag: default, providerState: default);
+            }
+
             return null;
         }
 
         var walDetails = walProperties.Value;
-        var manifest = CreateWalManifest(walDetails.Metadata);
+        var walState = CreateWalState(walDetails);
 
         // Cache the mutation precondition and compaction signal without replaying journal bytes.
-        SetWal(walDetails.ETag, walDetails.BlobCommittedBlockCount);
-        return new WalState(walDetails.ETag, manifest);
+        if (updateCache)
+        {
+            SetWal(walState.ETag, walState.ProviderState);
+        }
+
+        return walState;
     }
 
-    private void SetWal(ETag eTag, int blockCount)
+    private async ValueTask<WalState?> TryRefreshWalStateAfterMetadataOnlyConflictAsync(
+        WalProviderState expectedProviderState,
+        CancellationToken cancellationToken)
+    {
+        if (expectedProviderState.Generation is null)
+        {
+            return null;
+        }
+
+        var walState = await TryLoadWalStateAsync(conditions: null, cancellationToken: cancellationToken, updateCache: false).ConfigureAwait(false);
+        if (walState is null || walState.Value.ProviderState != expectedProviderState)
+        {
+            return null;
+        }
+
+        SetWal(walState.Value.ETag, walState.Value.ProviderState);
+        return walState;
+    }
+
+    private void SetWal(ETag eTag, WalProviderState providerState)
     {
         // Keep the cached WAL mutation precondition and compaction counter in sync.
         _walETag = eTag;
-        _numBlocks = blockCount;
+        _walProviderState = providerState;
+        _numBlocks = providerState.CommittedBlockCount;
     }
 
     private AppendBlobClient GetWalClient()
@@ -491,21 +699,24 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         return client ?? throw new InvalidOperationException("The configured Azure Blob journal WAL client provider returned null.");
     }
 
-    private async ValueTask<Response<BlobContentInfo>> CreateWalAsync(
+    private async ValueTask<CreatedWal> CreateWalAsync(
         string? checkpointName,
         AppendBlobRequestConditions conditions,
         CancellationToken cancellationToken,
         IReadOnlyDictionary<string, string>? callerMetadata = null)
     {
+        var metadata = CreateWalMetadata(checkpointName, checkpointOffset: 0, callerMetadata);
         // Creating an append blob is also how compaction publishes a fresh WAL manifest.
-        return await _walClient.CreateAsync(
+        var response = await _walClient.CreateAsync(
             new AppendBlobCreateOptions
             {
                 Conditions = conditions,
                 HttpHeaders = CreateHttpHeaders(_shared.MimeType),
-                Metadata = CreateWalMetadata(checkpointName, checkpointOffset: 0, callerMetadata),
+                Metadata = metadata,
             },
             cancellationToken).ConfigureAwait(false);
+        var manifest = CreateWalManifest(metadata);
+        return new CreatedWal(response, manifest, CreateWalProviderState(manifest, contentLength: 0, committedBlockCount: 0));
     }
 
     private static BlobHttpHeaders? CreateHttpHeaders(string? contentType)
@@ -568,6 +779,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     {
         // WAL metadata is the recovery manifest: common format plus optional checkpoint pointer and WAL offset.
         var metadata = CreateMetadataDictionary();
+        metadata[WalGenerationMetadataKey] = Guid.NewGuid().ToString("N");
         if (callerMetadata is not null)
         {
             foreach (var (key, value) in callerMetadata)
@@ -597,9 +809,14 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     {
         // Decode the WAL manifest, accepting non-compacted WALs that have no checkpoint pointer.
         var fileMetadata = CreateJournalMetadata(eTag: default, metadata);
+        var generation = metadata is not null
+            && metadata.TryGetValue(WalGenerationMetadataKey, out var storedGeneration)
+            && storedGeneration is { Length: > 0 }
+                ? storedGeneration
+                : null;
         if (metadata is null || !metadata.TryGetValue(CheckpointMetadataKey, out var checkpointName) || checkpointName is not { Length: > 0 })
         {
-            return new WalManifest(fileMetadata, Checkpoint: null);
+            return new WalManifest(fileMetadata, Checkpoint: null, generation);
         }
 
         var checkpointOffset = 0L;
@@ -611,8 +828,26 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 $"Azure Blob journal checkpoint offset metadata is invalid: '{checkpointOffsetValue}'.");
         }
 
-        return new WalManifest(fileMetadata, new CheckpointReference(checkpointName, checkpointOffset));
+        return new WalManifest(fileMetadata, new CheckpointReference(checkpointName, checkpointOffset), generation);
     }
+
+    private static WalState CreateWalState(BlobProperties properties)
+    {
+        var manifest = CreateWalManifest(properties.Metadata);
+        return new WalState(
+            properties.ETag,
+            manifest,
+            CreateWalProviderState(manifest, properties.ContentLength, properties.BlobCommittedBlockCount));
+    }
+
+    private static WalProviderState CreateWalProviderState(WalManifest manifest, long contentLength, int committedBlockCount)
+        => new(
+            manifest.Metadata.Format,
+            manifest.Checkpoint?.Name,
+            manifest.Checkpoint?.WalOffset ?? 0,
+            manifest.Generation,
+            contentLength,
+            committedBlockCount);
 
     private static IJournalMetadata ValidateCheckpointMetadata(CheckpointReference checkpoint, BlobDownloadDetails checkpointDetails, string? expectedFormat)
     {
@@ -773,6 +1008,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         => string.Equals(key, FormatMetadataKey, StringComparison.OrdinalIgnoreCase)
             || string.Equals(key, CheckpointMetadataKey, StringComparison.OrdinalIgnoreCase)
             || string.Equals(key, CheckpointOffsetMetadataKey, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(key, WalGenerationMetadataKey, StringComparison.OrdinalIgnoreCase)
             || key.StartsWith("$", StringComparison.Ordinal);
 
     private static ETag ToAzureETag(string eTag)
@@ -826,9 +1062,19 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         Message = "Failed to delete obsolete Azure Blob journal checkpoint \"{ContainerName}/{BlobName}\"")]
     private static partial void LogCheckpointCleanupFailure(ILogger logger, string containerName, string blobName, Exception exception);
 
-    private sealed record WalManifest(IJournalMetadata Metadata, CheckpointReference? Checkpoint);
+    private sealed record WalManifest(IJournalMetadata Metadata, CheckpointReference? Checkpoint, string? Generation);
 
-    private readonly record struct WalState(ETag ETag, WalManifest Manifest);
+    private readonly record struct WalProviderState(
+        string? Format,
+        string? CheckpointName,
+        long CheckpointOffset,
+        string? Generation,
+        long ContentLength,
+        int CommittedBlockCount);
+
+    private readonly record struct WalState(ETag ETag, WalManifest Manifest, WalProviderState ProviderState);
+
+    private readonly record struct CreatedWal(Response<BlobContentInfo> Response, WalManifest Manifest, WalProviderState ProviderState);
 
     private readonly record struct CheckpointReference(string Name, long WalOffset);
 

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -36,8 +36,6 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
     // IsCompactionRequested trips at this block count so callers compact before the hard append-blob limit.
     private const int RequestCompactionBlockCount = 49_000;
 
-    private const int MaxMetadataOnlyConflictRetries = 5;
-
     private readonly AzureBlobJournalStorageShared _shared;
     private readonly JournalId _journalId;
     private readonly AppendBlobClient _walClient;
@@ -255,8 +253,8 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 }
                 catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
                 {
-                    var refreshed = attempt < MaxMetadataOnlyConflictRetries
-                        ? await TryRefreshWalStateAfterMetadataOnlyConflictAsync(expectedProviderState, cancellationToken).ConfigureAwait(false)
+                    var refreshed = attempt < _shared.Options.MaxMetadataOnlyConflictRetries
+                        ? await RetryAfterMetadataOnlyConflictAsync(attempt, expectedProviderState, cancellationToken).ConfigureAwait(false)
                         : null;
                     if (refreshed is not null)
                     {
@@ -339,8 +337,8 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                 }
                 catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
                 {
-                    var refreshed = attempt < MaxMetadataOnlyConflictRetries
-                        ? await TryRefreshWalStateAfterMetadataOnlyConflictAsync(deleteWalState.ProviderState, cancellationToken).ConfigureAwait(false)
+                    var refreshed = attempt < _shared.Options.MaxMetadataOnlyConflictRetries
+                        ? await RetryAfterMetadataOnlyConflictAsync(attempt, deleteWalState.ProviderState, cancellationToken).ConfigureAwait(false)
                         : null;
                     if (refreshed is { } refreshedState)
                     {
@@ -543,8 +541,8 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
                     }
                     catch (RequestFailedException exception) when (IsWalMutationConflict(exception))
                     {
-                        var refreshed = attempt < MaxMetadataOnlyConflictRetries
-                            ? await TryRefreshWalStateAfterMetadataOnlyConflictAsync(publishWalState.ProviderState, cancellationToken).ConfigureAwait(false)
+                        var refreshed = attempt < _shared.Options.MaxMetadataOnlyConflictRetries
+                            ? await RetryAfterMetadataOnlyConflictAsync(attempt, publishWalState.ProviderState, cancellationToken).ConfigureAwait(false)
                             : null;
                         if (refreshed is { } refreshedState)
                         {
@@ -663,6 +661,29 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
 
         return walState;
+    }
+
+    private async ValueTask<WalState?> RetryAfterMetadataOnlyConflictAsync(
+        int attempt,
+        WalProviderState expectedProviderState,
+        CancellationToken cancellationToken)
+    {
+        var initial = _shared.Options.MetadataOnlyConflictInitialBackoff;
+        if (initial > TimeSpan.Zero)
+        {
+            var max = _shared.Options.MetadataOnlyConflictMaxBackoff;
+            if (max < initial)
+            {
+                max = initial;
+            }
+
+            var multiplier = 1L << Math.Min(attempt, 16);
+            var scaledTicks = initial.Ticks * multiplier;
+            var cappedTicks = Math.Min(scaledTicks, max.Ticks);
+            await Task.Delay(TimeSpan.FromTicks(cappedTicks), cancellationToken).ConfigureAwait(false);
+        }
+
+        return await TryRefreshWalStateAfterMetadataOnlyConflictAsync(expectedProviderState, cancellationToken).ConfigureAwait(false);
     }
 
     private async ValueTask<WalState?> TryRefreshWalStateAfterMetadataOnlyConflictAsync(
@@ -1017,6 +1038,11 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         return new ETag(eTag);
     }
 
+    /// <summary>
+    /// Returns true when an Azure response indicates an append blob was sealed (HTTP 409 / BlobIsSealed).
+    /// A sealed WAL is permanently closed for new appends; the journaling layer must recover before
+    /// any further writes can proceed.
+    /// </summary>
     private static bool IsBlobSealed(RequestFailedException exception)
         => exception.Status == 409
             && (string.Equals(exception.ErrorCode, "BlobIsSealed", StringComparison.Ordinal)
@@ -1027,6 +1053,17 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             && (string.Equals(exception.ErrorCode, "BlobAlreadyExists", StringComparison.Ordinal)
                 || exception.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase));
 
+    /// <summary>
+    /// Returns true when an Azure response indicates the WAL has been mutated since our cached ETag
+    /// was captured: HTTP 404 (WAL deleted/recreated), HTTP 412 (precondition failed / IfMatch
+    /// rejected), or HTTP 409 with <c>ConditionNotMet</c> (matched-write conflict). When this
+    /// returns true, callers should attempt
+    /// <see cref="RetryAfterMetadataOnlyConflictAsync"/> to refresh the cached ETag in place when
+    /// the change was metadata-only, and otherwise propagate
+    /// <see cref="Orleans.Storage.InconsistentStateException"/> to trigger journaling-layer recovery.
+    /// Transient transport failures (HTTP 5xx, network errors, timeouts) are handled by the Azure
+    /// SDK's built-in retry policy and never reach this classifier.
+    /// </summary>
     private static bool IsWalMutationConflict(RequestFailedException exception)
     {
         // These failures mean our cached WAL view is stale or gone, so the caller must recover before retrying.
@@ -1093,6 +1130,22 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
 
             Logger = logger;
             Options = options.Value;
+            ArgumentNullException.ThrowIfNull(Options);
+            if (Options.MaxMetadataOnlyConflictRetries < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options), $"{nameof(AzureBlobJournalStorageOptions.MaxMetadataOnlyConflictRetries)} must be non-negative.");
+            }
+
+            if (Options.MetadataOnlyConflictInitialBackoff < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options), $"{nameof(AzureBlobJournalStorageOptions.MetadataOnlyConflictInitialBackoff)} must be non-negative.");
+            }
+
+            if (Options.MetadataOnlyConflictMaxBackoff < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options), $"{nameof(AzureBlobJournalStorageOptions.MetadataOnlyConflictMaxBackoff)} must be non-negative.");
+            }
+
             MimeType = mimeType;
             JournalFormatKey = journalFormatKey;
             BlobClientProvider = blobClientProvider;

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageInstruments.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageInstruments.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics.Metrics;
+using Orleans.Runtime;
+
+namespace Orleans.Journaling;
+
+internal static class AzureBlobJournalStorageInstruments
+{
+    private const string MillisecondsUnit = "ms";
+    private const string BytesUnit = "bytes";
+    private const string OperationTagName = "operation";
+    private const string StatusTagName = "status";
+    private const string StatusOk = "ok";
+    private const string StatusError = "error";
+
+    internal const string OperationCreate = "create";
+    internal const string OperationGetMetadata = "get_metadata";
+    internal const string OperationUpdateMetadata = "update_metadata";
+    internal const string OperationAppend = "append";
+    internal const string OperationDelete = "delete";
+    internal const string OperationRead = "read";
+    internal const string OperationReplace = "replace";
+
+    private static readonly Counter<long> Operations = Instruments.Meter.CreateCounter<long>("orleans-journaling-azure-blob-operations");
+    private static readonly Counter<long> OperationBytes = Instruments.Meter.CreateCounter<long>("orleans-journaling-azure-blob-operation-bytes", BytesUnit);
+    private static readonly Histogram<double> OperationDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-azure-blob-operation-duration", MillisecondsUnit);
+
+    internal static void OnOperationCompleted(string operation, TimeSpan latency, long bytes, bool succeeded)
+    {
+        var tags = CreateTags(operation, succeeded);
+        if (Operations.Enabled)
+        {
+            Operations.Add(1, tags);
+        }
+
+        if (OperationDuration.Enabled)
+        {
+            OperationDuration.Record(Math.Max(0, latency.TotalMilliseconds), tags);
+        }
+
+        if (succeeded && bytes > 0 && OperationBytes.Enabled)
+        {
+            OperationBytes.Add(bytes, [new KeyValuePair<string, object?>(OperationTagName, operation)]);
+        }
+    }
+
+    private static KeyValuePair<string, object?>[] CreateTags(string operation, bool succeeded) =>
+        [
+            new(OperationTagName, operation),
+            new(StatusTagName, succeeded ? StatusOk : StatusError)
+        ];
+}

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
@@ -48,6 +48,33 @@ public sealed class AzureBlobJournalStorageOptions
     public bool DeleteOldCheckpoints { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets the maximum number of times a journaling Append, Replace, or Delete operation
+    /// will refresh its cached WAL ETag and retry in place after observing a metadata-only ETag
+    /// conflict (for example, a concurrent caller-owned metadata update or generation bump).
+    /// When the cap is exceeded the storage layer falls back to throwing
+    /// <see cref="Orleans.Storage.InconsistentStateException"/> and the journaling layer recovers
+    /// before retrying. Defaults to 5.
+    /// </summary>
+    public int MaxMetadataOnlyConflictRetries { get; set; } = DEFAULT_MAX_METADATA_ONLY_CONFLICT_RETRIES;
+    public const int DEFAULT_MAX_METADATA_ONLY_CONFLICT_RETRIES = 5;
+
+    /// <summary>
+    /// Gets or sets the initial delay applied before re-trying after a metadata-only ETag conflict.
+    /// Subsequent attempts double the delay (capped at <see cref="MetadataOnlyConflictMaxBackoff"/>).
+    /// Set to <see cref="TimeSpan.Zero"/> to retry immediately without backoff. Defaults to 10 ms.
+    /// </summary>
+    public TimeSpan MetadataOnlyConflictInitialBackoff { get; set; } = DEFAULT_METADATA_ONLY_CONFLICT_INITIAL_BACKOFF;
+    public static readonly TimeSpan DEFAULT_METADATA_ONLY_CONFLICT_INITIAL_BACKOFF = TimeSpan.FromMilliseconds(10);
+
+    /// <summary>
+    /// Gets or sets the upper bound on the per-attempt backoff used by metadata-only conflict
+    /// retries. The exponential schedule starts at <see cref="MetadataOnlyConflictInitialBackoff"/>
+    /// and never exceeds this value. Defaults to 200 ms.
+    /// </summary>
+    public TimeSpan MetadataOnlyConflictMaxBackoff { get; set; } = DEFAULT_METADATA_ONLY_CONFLICT_MAX_BACKOFF;
+    public static readonly TimeSpan DEFAULT_METADATA_ONLY_CONFLICT_MAX_BACKOFF = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
     /// The optional delegate used to create a <see cref="BlobServiceClient"/> instance.
     /// </summary>
     internal Func<CancellationToken, Task<BlobServiceClient>>? CreateClient { get; private set; }

--- a/src/Orleans.Journaling/JournaledStateManager.cs
+++ b/src/Orleans.Journaling/JournaledStateManager.cs
@@ -190,6 +190,12 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                         workItem = dequeuedWorkItem;
                     }
 
+                    var processingTimestamp = _shared.TimeProvider.GetTimestamp();
+                    var queueOperation = GetStorageQueueOperation(workItem);
+                    var queueDuration = queueOperation is null
+                        ? default
+                        : _shared.TimeProvider.GetElapsedTime(workItem.EnqueuedTimestamp, processingTimestamp);
+                    var recordQueueDuration = workItem is DeleteStateWorkItem;
                     try
                     {
                         // Note that the implementation of each command is inlined to avoid allocating unnecessary async states.
@@ -302,6 +308,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
 
                                     if (hasCommittedBuffer)
                                     {
+                                        recordQueueDuration = true;
                                         var writeSequence = committedBuffer.AsReadOnlySequence();
 #if DEBUG
                                         // Defensive: copy the sequence into a pooled buffer so we can poison it
@@ -321,7 +328,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                                         {
                                             if (isSnapshot && hasBufferToConsume)
                                             {
-                                                await _storage.AppendAsync(bufferToConsume.AsReadOnlySequence(), _shutdownCancellation.Token).ConfigureAwait(true);
+                                                await AppendStorageAsync(bufferToConsume.AsReadOnlySequence(), _shutdownCancellation.Token).ConfigureAwait(true);
                                                 lock (_lock)
                                                 {
                                                     _journalWriter.Consume(bufferToConsume);
@@ -337,11 +344,11 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
 
                                             if (isSnapshot)
                                             {
-                                                await _storage.ReplaceAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
+                                                await ReplaceStorageAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
                                             }
                                             else
                                             {
-                                                await _storage.AppendAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
+                                                await AppendStorageAsync(writeSequence, _shutdownCancellation.Token).ConfigureAwait(true);
                                             }
 
                                             writeCompleted = true;
@@ -395,7 +402,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                             case DeleteStateWorkItem:
                                 {
                                     // Clear storage.
-                                    await _storage.DeleteAsync(_shutdownCancellation.Token).ConfigureAwait(true);
+                                    await DeleteStorageAsync(_shutdownCancellation.Token).ConfigureAwait(true);
 
                                     lock (_lock)
                                     {
@@ -448,10 +455,20 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                                 }
                         }
 
+                        if (recordQueueDuration && queueOperation is not null)
+                        {
+                            JournalingInstruments.OnStorageOperationQueued(queueOperation, queueDuration, succeeded: true);
+                        }
+
                         workItem.SetResult();
                     }
                     catch (Exception exception)
                     {
+                        if (recordQueueDuration && queueOperation is not null)
+                        {
+                            JournalingInstruments.OnStorageOperationQueued(queueOperation, queueDuration, succeeded: false);
+                        }
+
                         workItem.SetException(exception);
                         if (IsRecoverySignal(exception))
                         {
@@ -575,17 +592,37 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
             _workSignal.Signal();
         }
 
-        await task;
+        var startTimestamp = _shared.TimeProvider.GetTimestamp();
+        try
+        {
+            await task;
+            JournalingInstruments.OnStateDeleteRequest(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: true);
+        }
+        catch
+        {
+            JournalingInstruments.OnStateDeleteRequest(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: false);
+            throw;
+        }
     }
 
     private async Task RecoverAsync(CancellationToken cancellationToken)
     {
+        var startTimestamp = _shared.TimeProvider.GetTimestamp();
         lock (_lock)
         {
             ResetForRecovery();
         }
 
-        await _storage.ReadAsync(this, cancellationToken).ConfigureAwait(true);
+        try
+        {
+            await ReadStorageAsync(this, cancellationToken).ConfigureAwait(true);
+            JournalingInstruments.OnRecovery(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: true);
+        }
+        catch
+        {
+            JournalingInstruments.OnRecovery(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: false);
+            throw;
+        }
 
         lock (_lock)
         {
@@ -718,9 +755,12 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
 
         Task pendingWrite;
         bool didEnqueue;
+        string operation;
         lock (_lock)
         {
-            pendingWrite = _migrationSnapshotRequired || _storage.IsCompactionRequested
+            var isSnapshot = _migrationSnapshotRequired || _storage.IsCompactionRequested;
+            operation = isSnapshot ? JournalingInstruments.OperationSnapshot : JournalingInstruments.OperationAppend;
+            pendingWrite = isSnapshot
                 ? EnqueueOrGetPendingWorkItem<WriteSnapshotWorkItem>(out didEnqueue)
                 : EnqueueOrGetPendingWorkItem<AppendJournalWorkItem>(out didEnqueue);
         }
@@ -730,7 +770,77 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
             _workSignal.Signal();
         }
 
-        await pendingWrite.WaitAsync(cancellationToken);
+        var startTimestamp = _shared.TimeProvider.GetTimestamp();
+        try
+        {
+            await pendingWrite.WaitAsync(cancellationToken);
+            JournalingInstruments.OnStateWriteRequest(operation, _shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: true);
+        }
+        catch
+        {
+            JournalingInstruments.OnStateWriteRequest(operation, _shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: false);
+            throw;
+        }
+    }
+
+    private async ValueTask ReadStorageAsync(IJournalStorageConsumer consumer, CancellationToken cancellationToken)
+    {
+        var startTimestamp = _shared.TimeProvider.GetTimestamp();
+        try
+        {
+            await _storage.ReadAsync(consumer, cancellationToken).ConfigureAwait(true);
+            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationRead, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: true);
+        }
+        catch
+        {
+            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationRead, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: false);
+            throw;
+        }
+    }
+
+    private async ValueTask AppendStorageAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
+    {
+        var startTimestamp = _shared.TimeProvider.GetTimestamp();
+        try
+        {
+            await _storage.AppendAsync(value, cancellationToken).ConfigureAwait(true);
+            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationAppend, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: true);
+        }
+        catch
+        {
+            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationAppend, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: false);
+            throw;
+        }
+    }
+
+    private async ValueTask ReplaceStorageAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
+    {
+        var startTimestamp = _shared.TimeProvider.GetTimestamp();
+        try
+        {
+            await _storage.ReplaceAsync(value, cancellationToken).ConfigureAwait(true);
+            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationReplace, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: true);
+        }
+        catch
+        {
+            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationReplace, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: false);
+            throw;
+        }
+    }
+
+    private async ValueTask DeleteStorageAsync(CancellationToken cancellationToken)
+    {
+        var startTimestamp = _shared.TimeProvider.GetTimestamp();
+        try
+        {
+            await _storage.DeleteAsync(cancellationToken).ConfigureAwait(true);
+            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationDelete, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: true);
+        }
+        catch
+        {
+            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationDelete, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: false);
+            throw;
+        }
     }
 
     private Task EnqueueOrGetPendingWorkItem<TWorkItem>(out bool didEnqueue)
@@ -748,6 +858,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         }
 
         var newWorkItem = new TWorkItem();
+        newWorkItem.EnqueuedTimestamp = _shared.TimeProvider.GetTimestamp();
         _workQueue.Enqueue(newWorkItem);
         didEnqueue = true;
         return newWorkItem.Task;
@@ -812,6 +923,8 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
 
     private abstract class WorkItem : TaskCompletionSource
     {
+        public long EnqueuedTimestamp { get; set; }
+
         protected WorkItem() : base(TaskCreationOptions.RunContinuationsAsynchronously)
         {
         }
@@ -821,6 +934,15 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         }
 
     }
+
+    private static string? GetStorageQueueOperation(WorkItem workItem) =>
+        workItem switch
+        {
+            AppendJournalWorkItem => JournalingInstruments.OperationAppend,
+            WriteSnapshotWorkItem => JournalingInstruments.OperationSnapshot,
+            DeleteStateWorkItem => JournalingInstruments.OperationDelete,
+            _ => null
+        };
 
     private sealed class InitializeWorkItem : WorkItem;
 

--- a/src/Orleans.Journaling/JournalingInstruments.cs
+++ b/src/Orleans.Journaling/JournalingInstruments.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using Orleans.Runtime;
+
+namespace Orleans.Journaling;
+
+internal static class JournalingInstruments
+{
+    private const string MillisecondsUnit = "ms";
+    private const string BytesUnit = "bytes";
+    private const string OperationTagName = "operation";
+    private const string StatusTagName = "status";
+    private const string StatusOk = "ok";
+    private const string StatusError = "error";
+
+    internal const string OperationAppend = "append";
+    internal const string OperationSnapshot = "snapshot";
+    internal const string OperationReplace = "replace";
+    internal const string OperationRead = "read";
+    internal const string OperationDelete = "delete";
+    internal const string OperationRecovery = "recovery";
+
+    private static readonly Counter<long> StateWriteRequests = Instruments.Meter.CreateCounter<long>("orleans-journaling-state-write-requests");
+    private static readonly Counter<long> StateDeleteRequests = Instruments.Meter.CreateCounter<long>("orleans-journaling-state-delete-requests");
+    private static readonly Counter<long> Recoveries = Instruments.Meter.CreateCounter<long>("orleans-journaling-recoveries");
+    private static readonly Counter<long> StorageOperations = Instruments.Meter.CreateCounter<long>("orleans-journaling-storage-operations");
+    private static readonly Counter<long> StorageBytes = Instruments.Meter.CreateCounter<long>("orleans-journaling-storage-bytes", BytesUnit);
+
+    private static readonly Histogram<double> StateWriteDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-state-write-duration", MillisecondsUnit);
+    private static readonly Histogram<double> StateDeleteDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-state-delete-duration", MillisecondsUnit);
+    private static readonly Histogram<double> RecoveryDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-recovery-duration", MillisecondsUnit);
+    private static readonly Histogram<double> StorageOperationDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-storage-operation-duration", MillisecondsUnit);
+    private static readonly Histogram<long> StorageOperationBytes = Instruments.Meter.CreateHistogram<long>("orleans-journaling-storage-operation-bytes", BytesUnit);
+    private static readonly Histogram<double> StorageOperationQueueDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-storage-operation-queue-duration", MillisecondsUnit);
+
+    internal static void OnStateWriteRequest(string operation, TimeSpan latency, bool succeeded)
+    {
+        Add(StateWriteRequests, operation, succeeded);
+        Record(StateWriteDuration, operation, latency, succeeded);
+    }
+
+    internal static void OnStateDeleteRequest(TimeSpan latency, bool succeeded)
+    {
+        Add(StateDeleteRequests, OperationDelete, succeeded);
+        Record(StateDeleteDuration, OperationDelete, latency, succeeded);
+    }
+
+    internal static void OnRecovery(TimeSpan latency, bool succeeded)
+    {
+        Add(Recoveries, OperationRecovery, succeeded);
+        Record(RecoveryDuration, OperationRecovery, latency, succeeded);
+    }
+
+    internal static void OnStorageOperation(string operation, TimeSpan latency, long bytes, bool succeeded)
+    {
+        Add(StorageOperations, operation, succeeded);
+        Record(StorageOperationDuration, operation, latency, succeeded);
+        if (succeeded && bytes > 0)
+        {
+            StorageBytes.Add(bytes, [new KeyValuePair<string, object?>(OperationTagName, operation)]);
+            Record(StorageOperationBytes, operation, bytes, succeeded: true);
+        }
+    }
+
+    internal static void OnStorageOperationQueued(string operation, TimeSpan latency, bool succeeded)
+    {
+        Record(StorageOperationQueueDuration, operation, latency, succeeded);
+    }
+
+    private static void Add(Counter<long> counter, string operation, bool succeeded)
+    {
+        if (counter.Enabled)
+        {
+            counter.Add(1, CreateTags(operation, succeeded));
+        }
+    }
+
+    private static void Record(Histogram<double> histogram, string operation, TimeSpan latency, bool succeeded)
+    {
+        if (histogram.Enabled)
+        {
+            histogram.Record(Math.Max(0, latency.TotalMilliseconds), CreateTags(operation, succeeded));
+        }
+    }
+
+    private static void Record(Histogram<long> histogram, string operation, long value, bool succeeded)
+    {
+        if (histogram.Enabled)
+        {
+            histogram.Record(value, CreateTags(operation, succeeded));
+        }
+    }
+
+    private static KeyValuePair<string, object?>[] CreateTags(string operation, bool succeeded) =>
+        [
+            new(OperationTagName, operation),
+            new(StatusTagName, succeeded ? StatusOk : StatusError)
+        ];
+}

--- a/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
@@ -11,6 +11,10 @@ namespace Orleans.Journaling
     public sealed partial class AzureBlobJournalStorageOptions
     {
         public const string DEFAULT_CONTAINER_NAME = "state";
+        public const int DEFAULT_MAX_METADATA_ONLY_CONFLICT_RETRIES = 5;
+        public static readonly System.TimeSpan DEFAULT_METADATA_ONLY_CONFLICT_INITIAL_BACKOFF;
+        public static readonly System.TimeSpan DEFAULT_METADATA_ONLY_CONFLICT_MAX_BACKOFF;
+
         public Azure.Storage.Blobs.BlobServiceClient? BlobServiceClient { get { throw null; } set { } }
 
         public System.Func<System.IServiceProvider, AzureBlobJournalStorageOptions, IBlobContainerFactory> BuildContainerFactory { get { throw null; } set { } }
@@ -22,6 +26,12 @@ namespace Orleans.Journaling
         public bool DeleteOldCheckpoints { get { throw null; } set { } }
 
         public System.Func<JournalId, string> GetBlobName { get { throw null; } set { } }
+
+        public int MaxMetadataOnlyConflictRetries { get { throw null; } set { } }
+
+        public System.TimeSpan MetadataOnlyConflictInitialBackoff { get { throw null; } set { } }
+
+        public System.TimeSpan MetadataOnlyConflictMaxBackoff { get { throw null; } set { } }
 
         public void ConfigureBlobServiceClient(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<Azure.Storage.Blobs.BlobServiceClient>> createClientCallback) { }
 

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -75,6 +75,22 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
+    public async Task AppendAsync_WhenWalRecreatedWithSameShape_RequiresRecovery()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        appendBlobs.Add("blob/wal", [9], WalMetadata(generation: "recreated"), isSealed: false);
+
+        var exception = await Assert.ThrowsAsync<InconsistentStateException>(
+            () => storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None).AsTask());
+
+        Assert.Contains("recovery", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal([9], appendBlobs.GetContent("blob/wal"));
+    }
+
+    [Fact]
     public async Task AppendAsync_AfterSameInstanceMetadataUpdate_UsesUpdatedETag()
     {
         var appendBlobs = new FakeAppendBlobStore();
@@ -634,12 +650,17 @@ public sealed class AzureBlobJournalStorageTests
             JournalId.FromGrainId(GrainId.Create("test-grain", "0")));
     }
 
-    private static Dictionary<string, string> WalMetadata(string? format = null)
+    private static Dictionary<string, string> WalMetadata(string? format = null, string? generation = null)
     {
         var result = new Dictionary<string, string>();
         if (format is not null)
         {
             result[AzureBlobJournalStorage.FormatMetadataKey] = format;
+        }
+
+        if (generation is not null)
+        {
+            result[AzureBlobJournalStorage.WalGenerationMetadataKey] = generation;
         }
 
         return result;

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -58,6 +58,77 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
+    public async Task AppendAsync_WhenWalETagChangesOnlyForMetadata_ReloadsWalAndAppends()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs);
+        var catalogStorage = CreateStorage(appendBlobs);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        Assert.NotNull(await catalogStorage.UpdateMetadataAsync(
+            set: new Dictionary<string, string> { ["catalog"] = "closed" },
+            cancellationToken: CancellationToken.None));
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+
+        Assert.Equal([1, 2], appendBlobs.GetContent("blob/wal"));
+    }
+
+    [Fact]
+    public async Task AppendAsync_AfterSameInstanceMetadataUpdate_UsesUpdatedETag()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        Assert.NotNull(await storage.UpdateMetadataAsync(
+            set: new Dictionary<string, string> { ["catalog"] = "closed" },
+            cancellationToken: CancellationToken.None));
+        await storage.AppendAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+
+        Assert.Equal(new ETag("\"metadata-1\""), appendBlobs.AppendCalls.Last().IfMatch);
+        Assert.Equal([1, 2], appendBlobs.GetContent("blob/wal"));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenWalETagChangesOnlyForMetadata_ReloadsWalAndDeletes()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs);
+        var catalogStorage = CreateStorage(appendBlobs);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        Assert.NotNull(await catalogStorage.UpdateMetadataAsync(
+            set: new Dictionary<string, string> { ["catalog"] = "closed" },
+            cancellationToken: CancellationToken.None));
+
+        await storage.DeleteAsync(CancellationToken.None);
+
+        Assert.False(appendBlobs.Exists("blob/wal"));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenWalETagChangesOnlyForMetadata_ReloadsWalAndPublishesCheckpoint()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(appendBlobs, checkpoints);
+        var catalogStorage = CreateStorage(appendBlobs, checkpoints);
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        Assert.NotNull(await catalogStorage.UpdateMetadataAsync(
+            set: new Dictionary<string, string> { ["catalog"] = "closed" },
+            cancellationToken: CancellationToken.None));
+
+        await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+
+        Assert.Equal("closed", appendBlobs.CreateCalls.Last().Metadata["catalog"]);
+        var consumer = new CapturingJournalStorageConsumer();
+        await CreateStorage(appendBlobs, checkpoints).ReadAsync(consumer, CancellationToken.None);
+        Assert.Equal([2], consumer.Bytes.ToArray());
+    }
+
+    [Fact]
     public async Task AppendAsync_WhenMimeTypeConfigured_SetsBlobContentType()
     {
         var appendBlobs = new FakeAppendBlobStore();

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -1,4 +1,6 @@
 using System.Buffers;
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using Orleans.Serialization.Buffers;
@@ -257,6 +259,63 @@ public class StateManagerTests : JournalingTestBase
         var replacement = Assert.Single(storage.Replaces);
         Assert.Single(storage.Appends);
         AssertContainsRuntimeAndApplicationEntries(ReadBinaryEntries(replacement));
+    }
+
+    [Fact]
+    public async Task StateManager_StorageOperationBytesMetric_RecordsWritePayloadSizes()
+    {
+        var observedBytes = new ConcurrentBag<MetricMeasurement<long>>();
+        using var listener = CreateMetricListener("orleans-journaling-storage-operation-bytes", observedBytes);
+        var storage = new CapturingStorage { IsCompactionRequested = true };
+        var sut = CreateTestSystem(storage: storage);
+        var value = new DurableValue<int>("value", sut.Manager, CreateValueCodec<int>());
+
+        await sut.Lifecycle.OnStart();
+        value.Value = 42;
+        await sut.Manager.WriteStateAsync(CancellationToken.None);
+
+        var append = Assert.Single(storage.Appends);
+        var replacement = Assert.Single(storage.Replaces);
+        Assert.Contains(observedBytes, measurement => measurement.Operation == "append" && measurement.Status == "ok" && measurement.Value == append.Length);
+        Assert.Contains(observedBytes, measurement => measurement.Operation == "replace" && measurement.Status == "ok" && measurement.Value == replacement.Length);
+    }
+
+    [Fact]
+    public void JournalingInstruments_StorageOperationBytesMetric_SkipsZeroByteAndFailedOperations()
+    {
+        var observedBytes = new ConcurrentBag<MetricMeasurement<long>>();
+        using var listener = CreateMetricListener("orleans-journaling-storage-operation-bytes", observedBytes);
+        var operation = $"test-{Guid.NewGuid():N}";
+
+        JournalingInstruments.OnStorageOperation(operation, TimeSpan.Zero, bytes: 0, succeeded: true);
+        JournalingInstruments.OnStorageOperation(operation, TimeSpan.Zero, bytes: 1, succeeded: false);
+
+        Assert.DoesNotContain(observedBytes, measurement => measurement.Operation == operation);
+    }
+
+    [Fact]
+    public async Task StateManager_StorageOperationQueueDurationMetric_RecordsWaitBehindPreviousAppend()
+    {
+        var observedDurations = new ConcurrentBag<MetricMeasurement<double>>();
+        using var listener = CreateMetricListener("orleans-journaling-storage-operation-queue-duration", observedDurations);
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var storage = new BlockingAppendStorage();
+        var sut = CreateTestSystem(storage: storage, provider: timeProvider);
+        var state = new AlwaysWritingState();
+        sut.Manager.RegisterState("state", state);
+
+        await sut.Lifecycle.OnStart();
+        var firstWrite = sut.Manager.WriteStateAsync(CancellationToken.None).AsTask();
+        await storage.FirstAppendStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var secondWrite = sut.Manager.WriteStateAsync(CancellationToken.None).AsTask();
+        timeProvider.Advance(TimeSpan.FromMilliseconds(250));
+        storage.AllowFirstAppend.SetResult();
+
+        await Task.WhenAll(firstWrite, secondWrite).WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(2, storage.Appends.Count);
+        Assert.Contains(observedDurations, measurement => measurement.Operation == "append" && measurement.Status == "ok" && measurement.Value >= 250);
     }
 
     [Fact]
@@ -1370,6 +1429,74 @@ public class StateManagerTests : JournalingTestBase
             BeganEntryIds.Add(streamId.Value);
             base.WritePreservedEntry(streamId, entry);
         }
+    }
+
+    private readonly record struct MetricMeasurement<T>(T Value, string? Operation, string? Status);
+
+    private static MeterListener CreateMetricListener<T>(string instrumentName, ConcurrentBag<MetricMeasurement<T>> measurements)
+        where T : struct
+    {
+        var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == "Microsoft.Orleans" && instrument.Name == instrumentName)
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+
+        listener.SetMeasurementEventCallback<T>((_, measurement, tags, _) =>
+            measurements.Add(new(measurement, GetTag(tags, "operation"), GetTag(tags, "status"))));
+        listener.Start();
+        return listener;
+    }
+
+    private static string? GetTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string name)
+    {
+        foreach (var tag in tags)
+        {
+            if (tag.Key == name)
+            {
+                return tag.Value?.ToString();
+            }
+        }
+
+        return null;
+    }
+
+    private sealed class BlockingAppendStorage : IJournalStorage
+    {
+        private int _appendCount;
+
+        public TaskCompletionSource FirstAppendStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowFirstAppend { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public List<byte[]> Appends { get; } = [];
+
+        public bool IsCompactionRequested => false;
+
+        public ValueTask ReadAsync(IJournalStorageConsumer consumer, CancellationToken cancellationToken)
+        {
+            consumer.Complete(metadata: null);
+            return default;
+        }
+
+        public ValueTask ReplaceAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken) => default;
+
+        public async ValueTask AppendAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Interlocked.Increment(ref _appendCount) == 1)
+            {
+                FirstAppendStarted.SetResult();
+                await AllowFirstAppend.Task.WaitAsync(cancellationToken);
+            }
+
+            Appends.Add(value.ToArray());
+        }
+
+        public ValueTask DeleteAsync(CancellationToken cancellationToken) => default;
     }
 
     private sealed class CapturingStorage : IJournalStorage


### PR DESCRIPTION
Depends on #10148.

Adds Azure Blob journaling instrumentation and tunes metadata-only WAL conflict retry handling. This branch is stacked on the DurableJobs journaled storage foundation, so the PR diff is cumulative until #10148 lands and this branch is rebased.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10149)