### PR TITLE
perf(durablejobs): improve journaled shard throughput

### DIFF
--- a/src/Azure/Orleans.DurableJobs.AzureStorage/Hosting/AzureStorageDurableJobsExtensions.cs
+++ b/src/Azure/Orleans.DurableJobs.AzureStorage/Hosting/AzureStorageDurableJobsExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -27,13 +28,56 @@ public static class AzureStorageDurableJobsExtensions
     /// The provided <see cref="ISiloBuilder"/>, for chaining.
     /// </returns>
     public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, Action<AzureBlobJournalStorageOptions> configure)
+        => builder.UseAzureBlobDurableJobs(configure, configureJson: null);
+
+    /// <summary>
+    /// Adds durable jobs storage backed by Azure Blob Storage.
+    /// </summary>
+    /// <param name="builder">
+    /// The builder.
+    /// </param>
+    /// <param name="configure">
+    /// The delegate used to configure the durable jobs storage.
+    /// </param>
+    /// <param name="typeInfoResolver">
+    /// The JSON metadata resolver used for application journal payload types.
+    /// </param>
+    /// <returns>
+    /// The provided <see cref="ISiloBuilder"/>, for chaining.
+    /// </returns>
+    public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, Action<AzureBlobJournalStorageOptions> configure, IJsonTypeInfoResolver typeInfoResolver)
+    {
+        ArgumentNullException.ThrowIfNull(typeInfoResolver);
+        return builder.UseAzureBlobDurableJobs(configure, options => options.AddTypeInfoResolver(typeInfoResolver));
+    }
+
+    /// <summary>
+    /// Adds durable jobs storage backed by Azure Blob Storage.
+    /// </summary>
+    /// <param name="builder">
+    /// The builder.
+    /// </param>
+    /// <param name="configure">
+    /// The delegate used to configure the durable jobs storage.
+    /// </param>
+    /// <param name="configureJson">
+    /// The delegate used to configure JSON journaling for application payload types.
+    /// </param>
+    /// <returns>
+    /// The provided <see cref="ISiloBuilder"/>, for chaining.
+    /// </returns>
+    public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, Action<AzureBlobJournalStorageOptions> configure, Action<JsonJournalOptions>? configureJson)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(configure);
 
         builder.AddDurableJobs();
         builder.AddAzureBlobJournalStorage(configure);
-        builder.UseJsonJournalFormat(options => options.AddTypeInfoResolver(DurableJobsJsonContext.Default));
+        builder.UseJsonJournalFormat(options =>
+        {
+            options.AddTypeInfoResolver(DurableJobsJsonContext.Default);
+            configureJson?.Invoke(options);
+        });
         builder.Services.UseJournaledDurableJobs();
         return builder;
     }
@@ -51,6 +95,45 @@ public static class AzureStorageDurableJobsExtensions
     /// The provided <see cref="IServiceCollection"/>, for chaining.
     /// </returns>
     public static IServiceCollection UseAzureBlobDurableJobs(this IServiceCollection services, Action<AzureBlobJournalStorageOptions> configure)
+        => services.UseAzureBlobDurableJobs(configure, configureJson: null);
+
+    /// <summary>
+    /// Adds durable jobs storage backed by Azure Blob Storage.
+    /// </summary>
+    /// <param name="services">
+    /// The service collection.
+    /// </param>
+    /// <param name="configure">
+    /// The delegate used to configure the durable jobs storage.
+    /// </param>
+    /// <param name="typeInfoResolver">
+    /// The JSON metadata resolver used for application journal payload types.
+    /// </param>
+    /// <returns>
+    /// The provided <see cref="IServiceCollection"/>, for chaining.
+    /// </returns>
+    public static IServiceCollection UseAzureBlobDurableJobs(this IServiceCollection services, Action<AzureBlobJournalStorageOptions> configure, IJsonTypeInfoResolver typeInfoResolver)
+    {
+        ArgumentNullException.ThrowIfNull(typeInfoResolver);
+        return services.UseAzureBlobDurableJobs(configure, options => options.AddTypeInfoResolver(typeInfoResolver));
+    }
+
+    /// <summary>
+    /// Adds durable jobs storage backed by Azure Blob Storage.
+    /// </summary>
+    /// <param name="services">
+    /// The service collection.
+    /// </param>
+    /// <param name="configure">
+    /// The delegate used to configure the durable jobs storage.
+    /// </param>
+    /// <param name="configureJson">
+    /// The delegate used to configure JSON journaling for application payload types.
+    /// </param>
+    /// <returns>
+    /// The provided <see cref="IServiceCollection"/>, for chaining.
+    /// </returns>
+    public static IServiceCollection UseAzureBlobDurableJobs(this IServiceCollection services, Action<AzureBlobJournalStorageOptions> configure, Action<JsonJournalOptions>? configureJson)
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
@@ -59,7 +142,11 @@ public static class AzureStorageDurableJobsExtensions
 
         var builder = new ServiceCollectionSiloBuilder(services);
         builder.AddAzureBlobJournalStorage(configure);
-        builder.UseJsonJournalFormat(options => options.AddTypeInfoResolver(DurableJobsJsonContext.Default));
+        builder.UseJsonJournalFormat(options =>
+        {
+            options.AddTypeInfoResolver(DurableJobsJsonContext.Default);
+            configureJson?.Invoke(options);
+        });
 
         services.UseJournaledDurableJobs();
         return services;

--- a/src/Azure/Orleans.DurableJobs.AzureStorage/Hosting/AzureStorageDurableJobsExtensions.cs
+++ b/src/Azure/Orleans.DurableJobs.AzureStorage/Hosting/AzureStorageDurableJobsExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -28,56 +27,13 @@ public static class AzureStorageDurableJobsExtensions
     /// The provided <see cref="ISiloBuilder"/>, for chaining.
     /// </returns>
     public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, Action<AzureBlobJournalStorageOptions> configure)
-        => builder.UseAzureBlobDurableJobs(configure, configureJson: null);
-
-    /// <summary>
-    /// Adds durable jobs storage backed by Azure Blob Storage.
-    /// </summary>
-    /// <param name="builder">
-    /// The builder.
-    /// </param>
-    /// <param name="configure">
-    /// The delegate used to configure the durable jobs storage.
-    /// </param>
-    /// <param name="typeInfoResolver">
-    /// The JSON metadata resolver used for application journal payload types.
-    /// </param>
-    /// <returns>
-    /// The provided <see cref="ISiloBuilder"/>, for chaining.
-    /// </returns>
-    public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, Action<AzureBlobJournalStorageOptions> configure, IJsonTypeInfoResolver typeInfoResolver)
-    {
-        ArgumentNullException.ThrowIfNull(typeInfoResolver);
-        return builder.UseAzureBlobDurableJobs(configure, options => options.AddTypeInfoResolver(typeInfoResolver));
-    }
-
-    /// <summary>
-    /// Adds durable jobs storage backed by Azure Blob Storage.
-    /// </summary>
-    /// <param name="builder">
-    /// The builder.
-    /// </param>
-    /// <param name="configure">
-    /// The delegate used to configure the durable jobs storage.
-    /// </param>
-    /// <param name="configureJson">
-    /// The delegate used to configure JSON journaling for application payload types.
-    /// </param>
-    /// <returns>
-    /// The provided <see cref="ISiloBuilder"/>, for chaining.
-    /// </returns>
-    public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, Action<AzureBlobJournalStorageOptions> configure, Action<JsonJournalOptions>? configureJson)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(configure);
 
         builder.AddDurableJobs();
         builder.AddAzureBlobJournalStorage(configure);
-        builder.UseJsonJournalFormat(options =>
-        {
-            options.AddTypeInfoResolver(DurableJobsJsonContext.Default);
-            configureJson?.Invoke(options);
-        });
+        builder.Configure<JsonJournalOptions>(options => options.AddTypeInfoResolver(DurableJobsJsonContext.Default));
         builder.Services.UseJournaledDurableJobs();
         return builder;
     }
@@ -95,45 +51,6 @@ public static class AzureStorageDurableJobsExtensions
     /// The provided <see cref="IServiceCollection"/>, for chaining.
     /// </returns>
     public static IServiceCollection UseAzureBlobDurableJobs(this IServiceCollection services, Action<AzureBlobJournalStorageOptions> configure)
-        => services.UseAzureBlobDurableJobs(configure, configureJson: null);
-
-    /// <summary>
-    /// Adds durable jobs storage backed by Azure Blob Storage.
-    /// </summary>
-    /// <param name="services">
-    /// The service collection.
-    /// </param>
-    /// <param name="configure">
-    /// The delegate used to configure the durable jobs storage.
-    /// </param>
-    /// <param name="typeInfoResolver">
-    /// The JSON metadata resolver used for application journal payload types.
-    /// </param>
-    /// <returns>
-    /// The provided <see cref="IServiceCollection"/>, for chaining.
-    /// </returns>
-    public static IServiceCollection UseAzureBlobDurableJobs(this IServiceCollection services, Action<AzureBlobJournalStorageOptions> configure, IJsonTypeInfoResolver typeInfoResolver)
-    {
-        ArgumentNullException.ThrowIfNull(typeInfoResolver);
-        return services.UseAzureBlobDurableJobs(configure, options => options.AddTypeInfoResolver(typeInfoResolver));
-    }
-
-    /// <summary>
-    /// Adds durable jobs storage backed by Azure Blob Storage.
-    /// </summary>
-    /// <param name="services">
-    /// The service collection.
-    /// </param>
-    /// <param name="configure">
-    /// The delegate used to configure the durable jobs storage.
-    /// </param>
-    /// <param name="configureJson">
-    /// The delegate used to configure JSON journaling for application payload types.
-    /// </param>
-    /// <returns>
-    /// The provided <see cref="IServiceCollection"/>, for chaining.
-    /// </returns>
-    public static IServiceCollection UseAzureBlobDurableJobs(this IServiceCollection services, Action<AzureBlobJournalStorageOptions> configure, Action<JsonJournalOptions>? configureJson)
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
@@ -142,11 +59,7 @@ public static class AzureStorageDurableJobsExtensions
 
         var builder = new ServiceCollectionSiloBuilder(services);
         builder.AddAzureBlobJournalStorage(configure);
-        builder.UseJsonJournalFormat(options =>
-        {
-            options.AddTypeInfoResolver(DurableJobsJsonContext.Default);
-            configureJson?.Invoke(options);
-        });
+        builder.Configure<JsonJournalOptions>(options => options.AddTypeInfoResolver(DurableJobsJsonContext.Default));
 
         services.UseJournaledDurableJobs();
         return services;

--- a/src/Orleans.DurableJobs/DurableJobsInstruments.cs
+++ b/src/Orleans.DurableJobs/DurableJobsInstruments.cs
@@ -28,6 +28,7 @@ internal static class DurableJobsInstruments
     private static readonly Counter<long> CancelJobCalls = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-cancel-job-calls");
     private static readonly Counter<long> HandlerExecutionsStarted = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-handler-executions-started");
     private static readonly Counter<long> HandlerExecutions = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-handler-executions");
+    private static readonly Counter<long> StorageBatches = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-storage-batches");
 
     private static readonly Histogram<double> JobScheduleDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-job-schedule-duration", MillisecondsUnit);
     private static readonly Histogram<double> JobDispatchLag = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-job-dispatch-lag", MillisecondsUnit);
@@ -36,6 +37,7 @@ internal static class DurableJobsInstruments
     private static readonly Histogram<double> ScheduleJobCallDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-schedule-job-call-duration", MillisecondsUnit);
     private static readonly Histogram<double> CancelJobCallDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-cancel-job-call-duration", MillisecondsUnit);
     private static readonly Histogram<double> HandlerExecutionDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-handler-execution-duration", MillisecondsUnit);
+    private static readonly Histogram<long> StorageBatchSize = Instruments.Meter.CreateHistogram<long>("orleans-durablejobs-storage-batch-size");
 
     internal static void OnJobScheduled(TimeSpan latency)
     {
@@ -100,6 +102,17 @@ internal static class DurableJobsInstruments
         var status = error ? StatusError : canceled ? StatusCanceled : StatusCompleted;
         ShardsProcessed.Add(1, [new KeyValuePair<string, object?>(StatusTagName, status)]);
         Record(ShardProcessingDuration, latency, status);
+    }
+
+    internal static void OnStorageBatchWritten(long operationCount, bool canceled, bool error)
+    {
+        var status = error ? StatusError : canceled ? StatusCanceled : StatusOk;
+        var tags = new KeyValuePair<string, object?>[] { new(StatusTagName, status) };
+        StorageBatches.Add(1, tags);
+        if (StorageBatchSize.Enabled)
+        {
+            StorageBatchSize.Record(Math.Max(0, operationCount), tags);
+        }
     }
 
     private static void OnScheduleJobCall(TimeSpan latency, string status)

--- a/src/Orleans.DurableJobs/DurableJobsInstruments.cs
+++ b/src/Orleans.DurableJobs/DurableJobsInstruments.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using Orleans.Runtime;
+
+namespace Orleans.DurableJobs;
+
+internal static class DurableJobsInstruments
+{
+    private const string MillisecondsUnit = "ms";
+    private const string StatusTagName = "status";
+    private const string StatusCompleted = "completed";
+    private const string StatusFailed = "failed";
+    private const string StatusRetried = "retried";
+    private const string StatusCanceled = "canceled";
+    private const string StatusError = "error";
+    private const string StatusOk = "ok";
+    private const string StatusNotFound = "not_found";
+
+    private static readonly Counter<long> JobsScheduled = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-scheduled");
+    private static readonly Counter<long> JobAttemptsStarted = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-job-attempts-started");
+    private static readonly Counter<long> JobsCompleted = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-completed");
+    private static readonly Counter<long> JobsFailed = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-failed");
+    private static readonly Counter<long> JobsRetried = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-retried");
+    private static readonly Counter<long> JobsCanceled = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-canceled");
+    private static readonly Counter<long> ShardsProcessed = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-shards-processed");
+    private static readonly Counter<long> ScheduleJobCalls = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-schedule-job-calls");
+    private static readonly Counter<long> CancelJobCalls = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-cancel-job-calls");
+    private static readonly Counter<long> HandlerExecutionsStarted = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-handler-executions-started");
+    private static readonly Counter<long> HandlerExecutions = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-handler-executions");
+
+    private static readonly Histogram<double> JobScheduleDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-job-schedule-duration", MillisecondsUnit);
+    private static readonly Histogram<double> JobDispatchLag = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-job-dispatch-lag", MillisecondsUnit);
+    private static readonly Histogram<double> JobAttemptDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-job-attempt-duration", MillisecondsUnit);
+    private static readonly Histogram<double> ShardProcessingDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-shard-processing-duration", MillisecondsUnit);
+    private static readonly Histogram<double> ScheduleJobCallDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-schedule-job-call-duration", MillisecondsUnit);
+    private static readonly Histogram<double> CancelJobCallDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-cancel-job-call-duration", MillisecondsUnit);
+    private static readonly Histogram<double> HandlerExecutionDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-handler-execution-duration", MillisecondsUnit);
+
+    internal static void OnJobScheduled(TimeSpan latency)
+    {
+        JobsScheduled.Add(1);
+        Record(JobScheduleDuration, latency);
+    }
+
+    internal static void OnJobAttemptStarted(TimeSpan dispatchLag)
+    {
+        JobAttemptsStarted.Add(1);
+        Record(JobDispatchLag, dispatchLag);
+    }
+
+    internal static void OnJobCompleted(TimeSpan latency)
+    {
+        JobsCompleted.Add(1);
+        Record(JobAttemptDuration, latency, StatusCompleted);
+    }
+
+    internal static void OnJobFailed(TimeSpan latency)
+    {
+        JobsFailed.Add(1);
+        Record(JobAttemptDuration, latency, StatusFailed);
+    }
+
+    internal static void OnJobRetried(TimeSpan latency)
+    {
+        JobsRetried.Add(1);
+        Record(JobAttemptDuration, latency, StatusRetried);
+    }
+
+    internal static void OnJobCanceled()
+    {
+        JobsCanceled.Add(1);
+    }
+
+    internal static void OnScheduleJobCallSucceeded(TimeSpan latency) => OnScheduleJobCall(latency, StatusOk);
+
+    internal static void OnScheduleJobCallCanceled(TimeSpan latency) => OnScheduleJobCall(latency, StatusCanceled);
+
+    internal static void OnScheduleJobCallFailed(TimeSpan latency) => OnScheduleJobCall(latency, StatusError);
+
+    internal static void OnCancelJobCall(TimeSpan latency, bool canceledJob) => OnCancelJobCall(latency, canceledJob ? StatusOk : StatusNotFound);
+
+    internal static void OnCancelJobCallCanceled(TimeSpan latency) => OnCancelJobCall(latency, StatusCanceled);
+
+    internal static void OnCancelJobCallFailed(TimeSpan latency) => OnCancelJobCall(latency, StatusError);
+
+    internal static void OnHandlerExecutionStarted()
+    {
+        HandlerExecutionsStarted.Add(1);
+    }
+
+    internal static void OnHandlerExecutionCompleted(TimeSpan latency) => OnHandlerExecution(latency, StatusCompleted);
+
+    internal static void OnHandlerExecutionCanceled(TimeSpan latency) => OnHandlerExecution(latency, StatusCanceled);
+
+    internal static void OnHandlerExecutionFailed(TimeSpan latency) => OnHandlerExecution(latency, StatusFailed);
+
+    internal static void OnShardProcessed(TimeSpan latency, bool canceled, bool error)
+    {
+        var status = error ? StatusError : canceled ? StatusCanceled : StatusCompleted;
+        ShardsProcessed.Add(1, [new KeyValuePair<string, object?>(StatusTagName, status)]);
+        Record(ShardProcessingDuration, latency, status);
+    }
+
+    private static void OnScheduleJobCall(TimeSpan latency, string status)
+    {
+        ScheduleJobCalls.Add(1, [new KeyValuePair<string, object?>(StatusTagName, status)]);
+        Record(ScheduleJobCallDuration, latency, status);
+    }
+
+    private static void OnCancelJobCall(TimeSpan latency, string status)
+    {
+        CancelJobCalls.Add(1, [new KeyValuePair<string, object?>(StatusTagName, status)]);
+        Record(CancelJobCallDuration, latency, status);
+    }
+
+    private static void OnHandlerExecution(TimeSpan latency, string status)
+    {
+        HandlerExecutions.Add(1, [new KeyValuePair<string, object?>(StatusTagName, status)]);
+        Record(HandlerExecutionDuration, latency, status);
+    }
+
+    private static void Record(Histogram<double> histogram, TimeSpan latency)
+    {
+        if (histogram.Enabled)
+        {
+            histogram.Record(Math.Max(0, latency.TotalMilliseconds));
+        }
+    }
+
+    private static void Record(Histogram<double> histogram, TimeSpan latency, string status)
+    {
+        if (histogram.Enabled)
+        {
+            histogram.Record(
+                Math.Max(0, latency.TotalMilliseconds),
+                [new KeyValuePair<string, object?>(StatusTagName, status)]);
+        }
+    }
+}

--- a/src/Orleans.DurableJobs/Hosting/DurableJobsExtensions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsExtensions.cs
@@ -43,7 +43,10 @@ public static class DurableJobsExtensions
         services.AddKeyedTransient<IGrainExtension>(typeof(IDurableJobReceiverExtension), (sp, _) =>
         {
             var grainContextAccessor = sp.GetRequiredService<IGrainContextAccessor>();
-            return new DurableJobReceiverExtension(grainContextAccessor.GrainContext, sp.GetRequiredService<ILogger<DurableJobReceiverExtension>>());
+            return new DurableJobReceiverExtension(
+                grainContextAccessor.GrainContext,
+                sp.GetRequiredService<ILogger<DurableJobReceiverExtension>>(),
+                sp.GetService<TimeProvider>() ?? TimeProvider.System);
         });
     }
 

--- a/src/Orleans.DurableJobs/Hosting/DurableJobsExtensions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.Configuration.Internal;
 using Orleans.Runtime;
 using Orleans.DurableJobs;
@@ -46,7 +47,8 @@ public static class DurableJobsExtensions
             return new DurableJobReceiverExtension(
                 grainContextAccessor.GrainContext,
                 sp.GetRequiredService<ILogger<DurableJobReceiverExtension>>(),
-                sp.GetService<TimeProvider>() ?? TimeProvider.System);
+                sp.GetService<TimeProvider>() ?? TimeProvider.System,
+                sp.GetRequiredService<IOptions<DurableJobsOptions>>());
         });
     }
 

--- a/src/Orleans.DurableJobs/Hosting/DurableJobsExtensions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsExtensions.cs
@@ -64,7 +64,7 @@ public static class DurableJobsExtensions
     {
         builder.AddDurableJobs();
         builder.AddJournalStorage();
-        builder.UseJsonJournalFormat(options => options.AddTypeInfoResolver(DurableJobsJsonContext.Default));
+        builder.Configure<JsonJournalOptions>(options => options.AddTypeInfoResolver(DurableJobsJsonContext.Default));
 
         builder.ConfigureServices(services => services.UseVolatileJournaledDurableJobs());
         return builder;
@@ -82,7 +82,7 @@ public static class DurableJobsExtensions
     {
         var builder = new ServiceCollectionSiloBuilder(services);
         builder.AddJournalStorage();
-        builder.UseJsonJournalFormat(options => options.AddTypeInfoResolver(DurableJobsJsonContext.Default));
+        builder.Configure<JsonJournalOptions>(options => options.AddTypeInfoResolver(DurableJobsJsonContext.Default));
         return services.UseVolatileJournaledDurableJobs();
     }
 

--- a/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
@@ -88,6 +88,19 @@ public sealed class DurableJobsOptions
     public Func<IJobRunContext, Exception, DateTimeOffset?> ShouldRetry { get; set; } = DefaultShouldRetry;
 
     /// <summary>
+    /// Gets or sets the maximum amount of time the shard operation processor will wait for
+    /// additional mutations to join an in-flight batch after the first one arrives.
+    /// </summary>
+    /// <remarks>
+    /// When set to a positive value, the operation processor delays for up to this duration after
+    /// dequeuing the first mutation, giving subsequent mutations a chance to be coalesced into
+    /// the same journal write. This trades a bounded latency increase for the first request in
+    /// each batch against larger batch sizes under bursty/moderate load. Defaults to
+    /// <see cref="TimeSpan.Zero"/> (no linger, behavior unchanged).
+    /// </remarks>
+    public TimeSpan ShardBatchLingerDelay { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
     /// Gets or sets the maximum number of times a shard can be adopted from a dead owner before
     /// being marked as poisoned. A shard that repeatedly causes silos to crash will exceed this
     /// threshold as it bounces between owners. When the next adoption would cause the adopted count
@@ -211,6 +224,10 @@ public sealed partial class DurableJobsOptionsValidator : IConfigurationValidato
         if (options.MaxAdoptedCount < 0)
         {
             throw new OrleansConfigurationException("DurableJobsOptions.MaxAdoptedCount must be greater than or equal to zero.");
+        }
+        if (options.ShardBatchLingerDelay < TimeSpan.Zero)
+        {
+            throw new OrleansConfigurationException("DurableJobsOptions.ShardBatchLingerDelay must be non-negative.");
         }
         if (options.ShardClaimInitialBudget < 0)
         {

--- a/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
@@ -30,6 +30,20 @@ public sealed class DurableJobsOptions
     public TimeSpan ShardActivationBufferPeriod { get; set; } = TimeSpan.FromMinutes(5);
 
     /// <summary>
+    /// Gets or sets the number of writable shards to use for each shard time bucket.
+    /// Increasing this value distributes jobs with the same due-time bucket across multiple shard journals.
+    /// Default: 1.
+    /// </summary>
+    public int ShardStripeCount { get; set; } = 1;
+
+    /// <summary>
+    /// Gets or sets the delay before polling an asynchronous durable job handler again.
+    /// The job continues holding its concurrency slot while it is polled.
+    /// Default: 1 second.
+    /// </summary>
+    public TimeSpan JobStatusPollInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
     /// Gets or sets the maximum number of jobs that can be executed concurrently on a single silo.
     /// Default: 10,000 × processor count.
     /// </summary>
@@ -165,6 +179,18 @@ public sealed partial class DurableJobsOptionsValidator : IConfigurationValidato
         if (options.ShardDuration <= TimeSpan.Zero)
         {
             throw new OrleansConfigurationException("DurableJobsOptions.ShardDuration must be greater than zero.");
+        }
+        if (options.ShardStripeCount <= 0)
+        {
+            throw new OrleansConfigurationException("DurableJobsOptions.ShardStripeCount must be greater than zero.");
+        }
+        if (options.ShardStripeCount > 1024)
+        {
+            throw new OrleansConfigurationException("DurableJobsOptions.ShardStripeCount must be less than or equal to 1024.");
+        }
+        if (options.JobStatusPollInterval <= TimeSpan.Zero)
+        {
+            throw new OrleansConfigurationException("DurableJobsOptions.JobStatusPollInterval must be greater than zero.");
         }
         if (options.ShouldRetry is null)
         {

--- a/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsOptions.cs
@@ -197,9 +197,9 @@ public sealed partial class DurableJobsOptionsValidator : IConfigurationValidato
         {
             throw new OrleansConfigurationException("DurableJobsOptions.ShardStripeCount must be greater than zero.");
         }
-        if (options.ShardStripeCount > 1024)
+        if (options.ShardStripeCount > 32 * 1024)
         {
-            throw new OrleansConfigurationException("DurableJobsOptions.ShardStripeCount must be less than or equal to 1024.");
+            throw new OrleansConfigurationException("DurableJobsOptions.ShardStripeCount must be less than or equal to 32768.");
         }
         if (options.JobStatusPollInterval <= TimeSpan.Zero)
         {

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,19 +63,14 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         var key = GetExecutionKey(context);
         JobAttemptState state;
         ref var stateRef = ref CollectionsMarshal.GetValueRefOrAddDefault(_jobAttempts, key, out var exists);
-        if (Unsafe.IsNullRef(ref stateRef))
+        if (!exists)
         {
-            Debug.Assert(!exists);
             Debug.Assert(stateRef is null);
-            state = stateRef = new JobAttemptState(StartJob(context, cancellationToken));
-        }
-        else
-        {
-            Debug.Assert(exists);
-            Debug.Assert(stateRef is not null);
-            state = stateRef;
+            stateRef = new JobAttemptState(StartJob(context, cancellationToken));
         }
 
+        Debug.Assert(stateRef is not null);
+        state = stateRef;
         return GetJobStatus(key, context, state);
     }
 

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -15,7 +16,7 @@ internal interface IDurableJobReceiverExtension : IGrainExtension
 {
     /// <summary>
     /// Handles a durable job by either starting execution or checking the status of an already running job.
-    /// If the job identified by <see cref="IJobRunContext.RunId"/> has not been started, it will be executed.
+    /// If the job attempt identified by <see cref="IJobRunContext.Job"/> and <see cref="IJobRunContext.DequeueCount"/> has not been started, it will be executed.
     /// If it is already running, the current status is returned.
     /// </summary>
     /// <param name="context">The context containing information about the durable job.</param>
@@ -31,7 +32,12 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     private readonly IGrainContext _grain;
     private readonly ILogger<DurableJobReceiverExtension> _logger;
     private readonly TimeProvider _timeProvider;
-    private readonly ConcurrentDictionary<string, Task> _runningJobs = new();
+    private readonly ConcurrentDictionary<(string JobId, int DequeueCount), JobAttemptState> _jobAttempts = new();
+    private readonly ConcurrentQueue<CompletedJobAttempt> _completedJobAttempts = new();
+    private int _completedJobAttemptCount;
+
+    private const int MaxCompletedJobAttempts = 65_536;
+    private static readonly TimeSpan CompletedJobAttemptRetention = TimeSpan.FromMinutes(1);
 
     public DurableJobReceiverExtension(IGrainContext grain, ILogger<DurableJobReceiverExtension> logger, TimeProvider timeProvider)
     {
@@ -43,15 +49,17 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     /// <inheritdoc />
     public Task<DurableJobRunResult> HandleDurableJobAsync(IJobRunContext context, CancellationToken cancellationToken)
     {
-        if (_runningJobs.TryGetValue(context.RunId, out var runningTask))
-        {
-            return GetJobStatus(context, runningTask);
-        }
+        PruneCompletedJobAttempts();
 
-        return StartJobAsync(context, cancellationToken);
+        var key = GetExecutionKey(context);
+        var state = _jobAttempts.GetOrAdd(
+            key,
+            static (_, state) => new JobAttemptState(state.Extension.StartJob(state.Context, state.CancellationToken)),
+            (Extension: this, Context: context, CancellationToken: cancellationToken));
+        return GetJobStatus(key, context, state);
     }
 
-    private Task<DurableJobRunResult> StartJobAsync(IJobRunContext context, CancellationToken cancellationToken)
+    private Task<DurableJobRunResult> StartJob(IJobRunContext context, CancellationToken cancellationToken)
     {
         if (_grain.GrainInstance is not IDurableJobHandler handler)
         {
@@ -59,13 +67,10 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
             throw new InvalidOperationException($"Grain {_grain.GrainId} does not implement IDurableJobHandler");
         }
 
-        var task = ExecuteHandlerAsync(handler, context, cancellationToken);
-        _runningJobs[context.RunId] = task;
-
-        return GetJobStatus(context, task);
+        return ExecuteHandlerAsync(handler, context, cancellationToken);
     }
 
-    private async Task ExecuteHandlerAsync(IDurableJobHandler handler, IJobRunContext context, CancellationToken cancellationToken)
+    private async Task<DurableJobRunResult> ExecuteHandlerAsync(IDurableJobHandler handler, IJobRunContext context, CancellationToken cancellationToken)
     {
         var startTimestamp = _timeProvider.GetTimestamp();
         DurableJobsInstruments.OnHandlerExecutionStarted();
@@ -73,43 +78,101 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         {
             await handler.ExecuteJobAsync(context, cancellationToken);
             DurableJobsInstruments.OnHandlerExecutionCompleted(_timeProvider.GetElapsedTime(startTimestamp));
+            return DurableJobRunResult.Completed;
         }
         catch (OperationCanceledException)
         {
             DurableJobsInstruments.OnHandlerExecutionCanceled(_timeProvider.GetElapsedTime(startTimestamp));
             throw;
         }
-        catch
+        catch (Exception exception)
         {
             DurableJobsInstruments.OnHandlerExecutionFailed(_timeProvider.GetElapsedTime(startTimestamp));
-            throw;
+            LogErrorExecutingDurableJob(exception, context.Job.Id, _grain.GrainId);
+            return DurableJobRunResult.Failed(exception);
         }
     }
 
-    private Task<DurableJobRunResult> GetJobStatus(IJobRunContext context, Task task)
+    private Task<DurableJobRunResult> GetJobStatus((string JobId, int DequeueCount) key, IJobRunContext context, JobAttemptState state)
     {
         // Cancellation is cooperative: only terminal task state is authoritative for job outcome.
-        if (!task.IsCompleted)
+        if (!state.Task.IsCompleted)
         {
             return Task.FromResult(DurableJobRunResult.PollAfter(TimeSpan.FromSeconds(1)));
         }
 
-        _runningJobs.TryRemove(context.RunId, out _);
+        RecordCompletedJobAttempt(key, state);
 
-        if (task.IsCompletedSuccessfully)
+        if (state.Task.IsCompletedSuccessfully)
         {
-            return Task.FromResult(DurableJobRunResult.Completed);
+            return state.Task;
         }
 
-        if (task.IsFaulted)
+        if (state.Task.IsFaulted)
         {
-            var ex = task.Exception!.InnerException ?? task.Exception;
+            var ex = state.Task.Exception!.InnerException ?? state.Task.Exception;
             LogErrorExecutingDurableJob(ex, context.Job.Id, _grain.GrainId);
             return Task.FromResult(DurableJobRunResult.Failed(ex));
         }
 
         return Task.FromCanceled<DurableJobRunResult>(new CancellationToken(canceled: true));
     }
+
+    private void RecordCompletedJobAttempt((string JobId, int DequeueCount) key, JobAttemptState state)
+    {
+        if (Interlocked.CompareExchange(ref state.CompletionRecorded, 1, 0) == 0)
+        {
+            var completedTimestamp = _timeProvider.GetTimestamp();
+            Volatile.Write(ref state.CompletedTimestamp, completedTimestamp);
+            _completedJobAttempts.Enqueue(new CompletedJobAttempt(key, completedTimestamp));
+            Interlocked.Increment(ref _completedJobAttemptCount);
+        }
+
+        PruneCompletedJobAttempts();
+    }
+
+    private void PruneCompletedJobAttempts()
+    {
+        var now = _timeProvider.GetTimestamp();
+        while (_completedJobAttempts.TryPeek(out var completedAttempt))
+        {
+            var expired = _timeProvider.GetElapsedTime(completedAttempt.CompletedTimestamp, now) >= CompletedJobAttemptRetention;
+            var overLimit = Volatile.Read(ref _completedJobAttemptCount) > MaxCompletedJobAttempts;
+            if (!expired && !overLimit)
+            {
+                return;
+            }
+
+            if (!_completedJobAttempts.TryDequeue(out completedAttempt))
+            {
+                return;
+            }
+
+            if (_jobAttempts.TryGetValue(completedAttempt.Key, out var state)
+                && state.Task.IsCompleted
+                && Volatile.Read(ref state.CompletedTimestamp) == completedAttempt.CompletedTimestamp)
+            {
+                ((ICollection<KeyValuePair<(string JobId, int DequeueCount), JobAttemptState>>)_jobAttempts).Remove(
+                    new KeyValuePair<(string JobId, int DequeueCount), JobAttemptState>(completedAttempt.Key, state));
+            }
+
+            Interlocked.Decrement(ref _completedJobAttemptCount);
+        }
+    }
+
+    private static (string JobId, int DequeueCount) GetExecutionKey(IJobRunContext context)
+        => (context.Job.Id, context.DequeueCount);
+
+    private sealed class JobAttemptState(Task<DurableJobRunResult> task)
+    {
+        public Task<DurableJobRunResult> Task { get; } = task;
+
+        public int CompletionRecorded;
+
+        public long CompletedTimestamp;
+    }
+
+    private readonly record struct CompletedJobAttempt((string JobId, int DequeueCount) Key, long CompletedTimestamp);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Error executing durable job {JobId} on grain {GrainId}")]
     private partial void LogErrorExecutingDurableJob(Exception exception, string jobId, GrainId grainId);

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -30,12 +30,14 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
 {
     private readonly IGrainContext _grain;
     private readonly ILogger<DurableJobReceiverExtension> _logger;
+    private readonly TimeProvider _timeProvider;
     private readonly ConcurrentDictionary<string, Task> _runningJobs = new();
 
-    public DurableJobReceiverExtension(IGrainContext grain, ILogger<DurableJobReceiverExtension> logger)
+    public DurableJobReceiverExtension(IGrainContext grain, ILogger<DurableJobReceiverExtension> logger, TimeProvider timeProvider)
     {
         _grain = grain;
         _logger = logger;
+        _timeProvider = timeProvider;
     }
 
     /// <inheritdoc />
@@ -57,10 +59,31 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
             throw new InvalidOperationException($"Grain {_grain.GrainId} does not implement IDurableJobHandler");
         }
 
-        var task = handler.ExecuteJobAsync(context, cancellationToken);
+        var task = ExecuteHandlerAsync(handler, context, cancellationToken);
         _runningJobs[context.RunId] = task;
 
         return GetJobStatus(context, task);
+    }
+
+    private async Task ExecuteHandlerAsync(IDurableJobHandler handler, IJobRunContext context, CancellationToken cancellationToken)
+    {
+        var startTimestamp = _timeProvider.GetTimestamp();
+        DurableJobsInstruments.OnHandlerExecutionStarted();
+        try
+        {
+            await handler.ExecuteJobAsync(context, cancellationToken);
+            DurableJobsInstruments.OnHandlerExecutionCompleted(_timeProvider.GetElapsedTime(startTimestamp));
+        }
+        catch (OperationCanceledException)
+        {
+            DurableJobsInstruments.OnHandlerExecutionCanceled(_timeProvider.GetElapsedTime(startTimestamp));
+            throw;
+        }
+        catch
+        {
+            DurableJobsInstruments.OnHandlerExecutionFailed(_timeProvider.GetElapsedTime(startTimestamp));
+            throw;
+        }
     }
 
     private Task<DurableJobRunResult> GetJobStatus(IJobRunContext context, Task task)
@@ -94,4 +117,3 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     [LoggerMessage(Level = LogLevel.Error, Message = "Grain {GrainId} does not implement IDurableJobHandler")]
     private partial void LogGrainDoesNotImplementHandler(GrainId grainId);
 }
-

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -4,7 +4,9 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orleans.Concurrency;
+using Orleans.Hosting;
 using Orleans.Runtime;
 
 namespace Orleans.DurableJobs;
@@ -32,6 +34,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     private readonly IGrainContext _grain;
     private readonly ILogger<DurableJobReceiverExtension> _logger;
     private readonly TimeProvider _timeProvider;
+    private readonly DurableJobsOptions _options;
     private readonly ConcurrentDictionary<(string JobId, int DequeueCount), JobAttemptState> _jobAttempts = new();
     private readonly ConcurrentQueue<CompletedJobAttempt> _completedJobAttempts = new();
     private int _completedJobAttemptCount;
@@ -39,11 +42,16 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     private const int MaxCompletedJobAttempts = 65_536;
     private static readonly TimeSpan CompletedJobAttemptRetention = TimeSpan.FromMinutes(1);
 
-    public DurableJobReceiverExtension(IGrainContext grain, ILogger<DurableJobReceiverExtension> logger, TimeProvider timeProvider)
+    public DurableJobReceiverExtension(
+        IGrainContext grain,
+        ILogger<DurableJobReceiverExtension> logger,
+        TimeProvider timeProvider,
+        IOptions<DurableJobsOptions> options)
     {
         _grain = grain;
         _logger = logger;
         _timeProvider = timeProvider;
+        _options = options.Value;
     }
 
     /// <inheritdoc />
@@ -98,7 +106,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         // Cancellation is cooperative: only terminal task state is authoritative for job outcome.
         if (!state.Task.IsCompleted)
         {
-            return Task.FromResult(DurableJobRunResult.PollAfter(TimeSpan.FromSeconds(1)));
+            return Task.FromResult(DurableJobRunResult.PollAfter(_options.JobStatusPollInterval));
         }
 
         RecordCompletedJobAttempt(key, state);

--- a/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
+++ b/src/Orleans.DurableJobs/IDurableJobReceiverExtension.cs
@@ -1,6 +1,8 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -25,7 +27,7 @@ internal interface IDurableJobReceiverExtension : IGrainExtension
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous operation and contains the job execution result.</returns>
     [AlwaysInterleave]
-    Task<DurableJobRunResult> HandleDurableJobAsync(IJobRunContext context, CancellationToken cancellationToken);
+    ValueTask<DurableJobRunResult> HandleDurableJobAsync(IJobRunContext context, CancellationToken cancellationToken);
 }
 
 /// <inheritdoc />
@@ -35,8 +37,8 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     private readonly ILogger<DurableJobReceiverExtension> _logger;
     private readonly TimeProvider _timeProvider;
     private readonly DurableJobsOptions _options;
-    private readonly ConcurrentDictionary<(string JobId, int DequeueCount), JobAttemptState> _jobAttempts = new();
-    private readonly ConcurrentQueue<CompletedJobAttempt> _completedJobAttempts = new();
+    private readonly Dictionary<(string JobId, int DequeueCount), JobAttemptState> _jobAttempts = [];
+    private readonly Queue<CompletedJobAttempt> _completedJobAttempts = new();
     private int _completedJobAttemptCount;
 
     private const int MaxCompletedJobAttempts = 65_536;
@@ -55,15 +57,26 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     }
 
     /// <inheritdoc />
-    public Task<DurableJobRunResult> HandleDurableJobAsync(IJobRunContext context, CancellationToken cancellationToken)
+    public ValueTask<DurableJobRunResult> HandleDurableJobAsync(IJobRunContext context, CancellationToken cancellationToken)
     {
         PruneCompletedJobAttempts();
 
         var key = GetExecutionKey(context);
-        var state = _jobAttempts.GetOrAdd(
-            key,
-            static (_, state) => new JobAttemptState(state.Extension.StartJob(state.Context, state.CancellationToken)),
-            (Extension: this, Context: context, CancellationToken: cancellationToken));
+        JobAttemptState state;
+        ref var stateRef = ref CollectionsMarshal.GetValueRefOrAddDefault(_jobAttempts, key, out var exists);
+        if (Unsafe.IsNullRef(ref stateRef))
+        {
+            Debug.Assert(!exists);
+            Debug.Assert(stateRef is null);
+            state = stateRef = new JobAttemptState(StartJob(context, cancellationToken));
+        }
+        else
+        {
+            Debug.Assert(exists);
+            Debug.Assert(stateRef is not null);
+            state = stateRef;
+        }
+
         return GetJobStatus(key, context, state);
     }
 
@@ -90,6 +103,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         }
         catch (OperationCanceledException)
         {
+            // Cancellation can be retried.
             DurableJobsInstruments.OnHandlerExecutionCanceled(_timeProvider.GetElapsedTime(startTimestamp));
             throw;
         }
@@ -101,39 +115,40 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         }
     }
 
-    private Task<DurableJobRunResult> GetJobStatus((string JobId, int DequeueCount) key, IJobRunContext context, JobAttemptState state)
+    private ValueTask<DurableJobRunResult> GetJobStatus((string JobId, int DequeueCount) key, IJobRunContext context, JobAttemptState state)
     {
         // Cancellation is cooperative: only terminal task state is authoritative for job outcome.
         if (!state.Task.IsCompleted)
         {
-            return Task.FromResult(DurableJobRunResult.PollAfter(_options.JobStatusPollInterval));
+            return new(DurableJobRunResult.PollAfter(_options.JobStatusPollInterval));
         }
 
         RecordCompletedJobAttempt(key, state);
 
         if (state.Task.IsCompletedSuccessfully)
         {
-            return state.Task;
+            return new(state.Task);
         }
 
         if (state.Task.IsFaulted)
         {
             var ex = state.Task.Exception!.InnerException ?? state.Task.Exception;
             LogErrorExecutingDurableJob(ex, context.Job.Id, _grain.GrainId);
-            return Task.FromResult(DurableJobRunResult.Failed(ex));
+            return new(DurableJobRunResult.Failed(ex));
         }
 
-        return Task.FromCanceled<DurableJobRunResult>(new CancellationToken(canceled: true));
+        return ValueTask.FromCanceled<DurableJobRunResult>(new CancellationToken(canceled: true));
     }
 
     private void RecordCompletedJobAttempt((string JobId, int DequeueCount) key, JobAttemptState state)
     {
-        if (Interlocked.CompareExchange(ref state.CompletionRecorded, 1, 0) == 0)
+        if (!state.CompletionRecorded)
         {
+            state.CompletionRecorded = true;
             var completedTimestamp = _timeProvider.GetTimestamp();
-            Volatile.Write(ref state.CompletedTimestamp, completedTimestamp);
+            state.CompletedTimestamp = completedTimestamp;
             _completedJobAttempts.Enqueue(new CompletedJobAttempt(key, completedTimestamp));
-            Interlocked.Increment(ref _completedJobAttemptCount);
+            _completedJobAttemptCount++;
         }
 
         PruneCompletedJobAttempts();
@@ -145,7 +160,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
         while (_completedJobAttempts.TryPeek(out var completedAttempt))
         {
             var expired = _timeProvider.GetElapsedTime(completedAttempt.CompletedTimestamp, now) >= CompletedJobAttemptRetention;
-            var overLimit = Volatile.Read(ref _completedJobAttemptCount) > MaxCompletedJobAttempts;
+            var overLimit = _completedJobAttemptCount > MaxCompletedJobAttempts;
             if (!expired && !overLimit)
             {
                 return;
@@ -158,13 +173,13 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
 
             if (_jobAttempts.TryGetValue(completedAttempt.Key, out var state)
                 && state.Task.IsCompleted
-                && Volatile.Read(ref state.CompletedTimestamp) == completedAttempt.CompletedTimestamp)
+                && state.CompletedTimestamp == completedAttempt.CompletedTimestamp)
             {
                 ((ICollection<KeyValuePair<(string JobId, int DequeueCount), JobAttemptState>>)_jobAttempts).Remove(
                     new KeyValuePair<(string JobId, int DequeueCount), JobAttemptState>(completedAttempt.Key, state));
             }
 
-            Interlocked.Decrement(ref _completedJobAttemptCount);
+            _completedJobAttemptCount--;
         }
     }
 
@@ -175,7 +190,7 @@ internal sealed partial class DurableJobReceiverExtension : IDurableJobReceiverE
     {
         public Task<DurableJobRunResult> Task { get; } = task;
 
-        public int CompletionRecorded;
+        public bool CompletionRecorded;
 
         public long CompletedTimestamp;
     }

--- a/src/Orleans.DurableJobs/InMemoryJobQueue.cs
+++ b/src/Orleans.DurableJobs/InMemoryJobQueue.cs
@@ -205,8 +205,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
     {
         while (true)
         {
-            JobBucket? bucketToProcess = null;
-            DateTimeOffset bucketKey = default;
+            List<(DurableJob Job, int DequeueCount)>? jobsToYield = null;
             Task? queueChanged = null;
             TimeSpan? delay = null;
 
@@ -229,9 +228,16 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                     var now = _timeProvider.GetUtcNow();
                     if (nextBucket.DueTime <= now)
                     {
-                        // Dequeue the entire bucket to process outside the lock
-                        bucketToProcess = _queue.Dequeue();
-                        bucketKey = bucketToProcess.DueTime;
+                        // Dequeue the bucket and remove it from _buckets atomically so a concurrent
+                        // Enqueue for the same DueTime cannot reuse this bucket. Without this,
+                        // GetJobBucket would find the bucket still in _buckets and add to it,
+                        // but the bucket is no longer in _queue, so the new job would be stranded.
+                        var bucketToProcess = _queue.Dequeue();
+                        _buckets.Remove(bucketToProcess.DueTime);
+
+                        // Snapshot the jobs under the lock so concurrent Cancel/Retry mutations
+                        // do not race the enumeration.
+                        jobsToYield = new List<(DurableJob Job, int DequeueCount)>(bucketToProcess.Jobs);
                     }
                     else
                     {
@@ -245,10 +251,10 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                 }
             }
 
-            if (bucketToProcess is not null)
+            if (jobsToYield is not null)
             {
                 // Process all jobs in the bucket outside the lock for better concurrency
-                foreach (var (job, dequeueCount) in bucketToProcess.Jobs.ToList())
+                foreach (var (job, dequeueCount) in jobsToYield)
                 {
                     // Verify job hasn't been cancelled while we were processing
                     bool shouldYield;
@@ -262,12 +268,6 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                     {
                         yield return new JobRunContext(job, Guid.NewGuid().ToString(), dequeueCount + 1);
                     }
-                }
-
-                // Clean up the bucket from dictionary after processing all jobs
-                lock (_syncLock)
-                {
-                    _buckets.Remove(bucketKey);
                 }
             }
             else

--- a/src/Orleans.DurableJobs/InMemoryJobQueue.cs
+++ b/src/Orleans.DurableJobs/InMemoryJobQueue.cs
@@ -16,6 +16,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
     private readonly PriorityQueue<JobBucket, DateTimeOffset> _queue = new();
     private readonly Dictionary<string, JobBucket> _jobsIdToBucket = new();
     private readonly Dictionary<DateTimeOffset, JobBucket> _buckets = new();
+    private TaskCompletionSource _queueChanged = CreateQueueChangedSource();
     private bool _isComplete;
 #if NET9_0_OR_GREATER
     private readonly Lock _syncLock = new();
@@ -56,6 +57,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
             var bucket = GetJobBucket(job.DueTime);
             bucket.AddJob(job, dequeueCount);
             _jobsIdToBucket[job.Id] = bucket;
+            SignalQueueChanged();
         }
     }
 
@@ -68,6 +70,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
         lock (_syncLock)
         {
             _isComplete = true;
+            SignalQueueChanged();
         }
     }
 
@@ -89,6 +92,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                 bucket.RemoveJob(jobId);
                 _jobsIdToBucket.Remove(jobId);
                 // Note: The bucket remains in the priority queue until processed
+                SignalQueueChanged();
                 return true;
             }
 
@@ -148,6 +152,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
             var newBucket = GetJobBucket(newDueTime);
             newBucket.AddJob(newJob, dequeueCount);
             _jobsIdToBucket[jobId] = newBucket;
+            SignalQueueChanged();
             return true;
         }
     }
@@ -184,6 +189,7 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
             _jobsIdToBucket.Clear();
             _buckets.Clear();
             _isComplete = false;
+            SignalQueueChanged();
         }
     }
 
@@ -193,34 +199,49 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>
     /// An async enumerator that returns <see cref="IJobRunContext"/> instances for jobs that are due.
-    /// The enumerator checks for due jobs every second and terminates when the queue is marked complete and empty.
+    /// The enumerator wakes when the queue changes or the next job becomes due, and terminates when the queue is marked complete and empty.
     /// </returns>
     public async IAsyncEnumerator<IJobRunContext> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {
-        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1), _timeProvider);
         while (true)
         {
             JobBucket? bucketToProcess = null;
             DateTimeOffset bucketKey = default;
+            Task? queueChanged = null;
+            TimeSpan? delay = null;
 
             lock (_syncLock)
             {
+                RemoveEmptyBuckets();
+
                 if (Count == 0)
                 {
                     if (_isComplete)
                     {
                         yield break; // Exit if the queue is frozen and empty
                     }
+
+                    queueChanged = _queueChanged.Task;
                 }
                 else if (_queue.Count > 0)
                 {
                     var nextBucket = _queue.Peek();
-                    if (nextBucket.DueTime < _timeProvider.GetUtcNow())
+                    var now = _timeProvider.GetUtcNow();
+                    if (nextBucket.DueTime <= now)
                     {
                         // Dequeue the entire bucket to process outside the lock
                         bucketToProcess = _queue.Dequeue();
                         bucketKey = bucketToProcess.DueTime;
                     }
+                    else
+                    {
+                        queueChanged = _queueChanged.Task;
+                        delay = nextBucket.DueTime - now;
+                    }
+                }
+                else
+                {
+                    queueChanged = _queueChanged.Task;
                 }
             }
 
@@ -251,25 +272,61 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
             }
             else
             {
-                await timer.WaitForNextTickAsync(cancellationToken);
+                await WaitForQueueChangeOrDelayAsync(queueChanged!, delay, cancellationToken);
             }
         }
     }
 
     private JobBucket GetJobBucket(DateTimeOffset dueTime)
     {
-        // Truncate to second precision and add 1 second to normalize bucket key
-        // This ensures all jobs within the same second (e.g., 12:00:00.000-12:00:00.999) share the same bucket (12:00:01)
-        var key = new DateTimeOffset(dueTime.Year, dueTime.Month, dueTime.Day, dueTime.Hour, dueTime.Minute, dueTime.Second, dueTime.Offset);
-        key = key.AddSeconds(1);
-        if (!_buckets.TryGetValue(key, out var bucket))
+        if (!_buckets.TryGetValue(dueTime, out var bucket))
         {
-            bucket = new JobBucket(key);
-            _buckets[key] = bucket;
-            _queue.Enqueue(bucket, key);
+            bucket = new JobBucket(dueTime);
+            _buckets[dueTime] = bucket;
+            _queue.Enqueue(bucket, dueTime);
         }
+
         return bucket;
-    }   
+    }
+
+    private void RemoveEmptyBuckets()
+    {
+        while (_queue.Count > 0 && _queue.Peek().Count == 0)
+        {
+            var bucket = _queue.Dequeue();
+            _buckets.Remove(bucket.DueTime);
+        }
+    }
+
+    private void SignalQueueChanged()
+    {
+        var previous = _queueChanged;
+        _queueChanged = CreateQueueChangedSource();
+        previous.TrySetResult();
+    }
+
+    private async Task WaitForQueueChangeOrDelayAsync(Task queueChanged, TimeSpan? delay, CancellationToken cancellationToken)
+    {
+        if (delay is null)
+        {
+            await queueChanged.WaitAsync(cancellationToken);
+            return;
+        }
+
+        if (delay <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var queueChangedTask = queueChanged.WaitAsync(waitCancellation.Token);
+        var delayTask = Task.Delay(delay.Value, _timeProvider, waitCancellation.Token);
+        var completedTask = await Task.WhenAny(queueChangedTask, delayTask);
+        waitCancellation.Cancel();
+        await completedTask;
+    }
+
+    private static TaskCompletionSource CreateQueueChangedSource() => new(TaskCreationOptions.RunContinuationsAsynchronously);
 }
 
 internal sealed class JobBucket

--- a/src/Orleans.DurableJobs/JournaledJobShard.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShard.cs
@@ -14,6 +14,8 @@ internal sealed class JournaledJobShard : IJobShard
     private readonly JournaledJobShardState _state;
     private readonly IJournaledStateManager _stateManager;
     private readonly JournaledJobShardManager _shardManager;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _batchLingerDelay;
     private readonly SemaphoreSlim _operationLock = new(1, 1);
     private readonly object _pendingOperationsLock = new();
     private readonly Queue<PendingOperation> _pendingOperations = new();
@@ -33,6 +35,11 @@ internal sealed class JournaledJobShard : IJobShard
     /// <param name="state">The journaled shard state.</param>
     /// <param name="stateManager">The manager used to persist journaled state.</param>
     /// <param name="shardManager">The shard manager that owns this shard.</param>
+    /// <param name="timeProvider">The time provider used for batch linger delays. Defaults to <see cref="TimeProvider.System"/>.</param>
+    /// <param name="batchLingerDelay">
+    /// Optional duration the operation processor waits for additional mutations to join the batch
+    /// after the first one arrives. Use <see cref="TimeSpan.Zero"/> (the default) to disable linger.
+    /// </param>
     public JournaledJobShard(
         JobShardId shardId,
         DateTimeOffset startTime,
@@ -41,11 +48,17 @@ internal sealed class JournaledJobShard : IJobShard
         bool isClosed,
         JournaledJobShardState state,
         IJournaledStateManager stateManager,
-        JournaledJobShardManager shardManager)
+        JournaledJobShardManager shardManager,
+        TimeProvider? timeProvider = null,
+        TimeSpan batchLingerDelay = default)
     {
         ArgumentNullException.ThrowIfNull(state);
         ArgumentNullException.ThrowIfNull(stateManager);
         ArgumentNullException.ThrowIfNull(shardManager);
+        if (batchLingerDelay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(batchLingerDelay), batchLingerDelay, "Batch linger delay must be non-negative.");
+        }
 
         Id = shardId.Value;
         StartTime = startTime;
@@ -54,6 +67,8 @@ internal sealed class JournaledJobShard : IJobShard
         _state = state;
         _stateManager = stateManager;
         _shardManager = shardManager;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _batchLingerDelay = batchLingerDelay;
 
         if (isClosed)
         {
@@ -236,6 +251,10 @@ internal sealed class JournaledJobShard : IJobShard
                 {
                     batch.Add(mutation);
                     DequeueConsecutiveMutations(batch);
+                    if (_batchLingerDelay > TimeSpan.Zero)
+                    {
+                        await LingerForMoreMutationsAsync(batch).ConfigureAwait(false);
+                    }
                     await ProcessMutationBatchAsync(batch).ConfigureAwait(false);
                     batch.Clear();
                 }
@@ -253,6 +272,20 @@ internal sealed class JournaledJobShard : IJobShard
             CancelOperations(batch);
             CancelQueuedOperations();
         }
+    }
+
+    private async Task LingerForMoreMutationsAsync(List<PendingMutationOperation> batch)
+    {
+        try
+        {
+            await Task.Delay(_batchLingerDelay, _timeProvider, _shutdownCancellation.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (_shutdownCancellation.IsCancellationRequested)
+        {
+            return;
+        }
+
+        DequeueConsecutiveMutations(batch);
     }
 
     private bool TryDequeueOperation(out PendingOperation? operation)

--- a/src/Orleans.DurableJobs/JournaledJobShard.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShard.cs
@@ -15,6 +15,11 @@ internal sealed class JournaledJobShard : IJobShard
     private readonly IJournaledStateManager _stateManager;
     private readonly JournaledJobShardManager _shardManager;
     private readonly SemaphoreSlim _operationLock = new(1, 1);
+    private readonly object _pendingOperationsLock = new();
+    private readonly Queue<PendingOperation> _pendingOperations = new();
+    private readonly SemaphoreSlim _pendingOperationSignal = new(0);
+    private readonly CancellationTokenSource _shutdownCancellation = new();
+    private readonly Task _operationProcessor;
     private int _disposed;
 
     /// <summary>
@@ -54,6 +59,8 @@ internal sealed class JournaledJobShard : IJobShard
         {
             _state.MarkAsComplete();
         }
+
+        _operationProcessor = Task.Run(ProcessOperationsAsync);
     }
 
     /// <inheritdoc/>
@@ -87,22 +94,15 @@ internal sealed class JournaledJobShard : IJobShard
     {
         ThrowIfDisposed();
 
-        await _operationLock.WaitAsync(cancellationToken);
+        var operation = new MarkAsCompleteOperation(cancellationToken);
         try
         {
-            if (_state.IsAddingCompleted)
-            {
-                return;
-            }
-
-            if (await _shardManager.TryMarkShardClosedAsync(Id, cancellationToken))
-            {
-                _state.MarkAsComplete();
-            }
+            EnqueueOperation(operation);
+            await operation.Task.ConfigureAwait(false);
         }
         finally
         {
-            _operationLock.Release();
+            operation.Dispose();
         }
     }
 
@@ -112,21 +112,15 @@ internal sealed class JournaledJobShard : IJobShard
         ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
         ThrowIfDisposed();
 
-        await _operationLock.WaitAsync(cancellationToken);
+        var operation = new RemoveJobOperation(jobId, cancellationToken);
         try
         {
-            if (!await _shardManager.IsShardOwnedByLocalSiloAsync(Id, cancellationToken))
-            {
-                return false;
-            }
-
-            var removed = _state.RemoveJob(jobId);
-            await _stateManager.WriteStateAsync(cancellationToken);
-            return removed;
+            EnqueueOperation(operation);
+            return await operation.Task.ConfigureAwait(false);
         }
         finally
         {
-            _operationLock.Release();
+            operation.Dispose();
         }
     }
 
@@ -136,20 +130,15 @@ internal sealed class JournaledJobShard : IJobShard
         ArgumentNullException.ThrowIfNull(jobContext);
         ThrowIfDisposed();
 
-        await _operationLock.WaitAsync(cancellationToken);
+        var operation = new RetryJobLaterOperation(jobContext, newDueTime, cancellationToken);
         try
         {
-            if (!await _shardManager.IsShardOwnedByLocalSiloAsync(Id, cancellationToken))
-            {
-                return;
-            }
-
-            _state.RetryJobLater(jobContext, newDueTime);
-            await _stateManager.WriteStateAsync(cancellationToken);
+            EnqueueOperation(operation);
+            await operation.Task.ConfigureAwait(false);
         }
         finally
         {
-            _operationLock.Release();
+            operation.Dispose();
         }
     }
 
@@ -158,31 +147,15 @@ internal sealed class JournaledJobShard : IJobShard
     {
         ThrowIfDisposed();
 
-        await _operationLock.WaitAsync(cancellationToken);
+        var operation = new ScheduleJobOperation(request, cancellationToken);
         try
         {
-            if (_state.IsAddingCompleted)
-            {
-                return null;
-            }
-
-            if (!await _shardManager.IsShardOwnedByLocalSiloAsync(Id, cancellationToken))
-            {
-                return null;
-            }
-
-            var job = _state.TryScheduleJob(request);
-            if (job is null)
-            {
-                return null;
-            }
-
-            await _stateManager.WriteStateAsync(cancellationToken);
-            return job;
+            EnqueueOperation(operation);
+            return await operation.Task.ConfigureAwait(false);
         }
         finally
         {
-            _operationLock.Release();
+            operation.Dispose();
         }
     }
 
@@ -195,14 +168,15 @@ internal sealed class JournaledJobShard : IJobShard
     {
         ThrowIfDisposed();
 
-        await _operationLock.WaitAsync(cancellationToken);
+        var operation = new DeleteStateOperation(cancellationToken);
         try
         {
-            await _stateManager.DeleteStateAsync(cancellationToken);
+            EnqueueOperation(operation);
+            await operation.Task.ConfigureAwait(false);
         }
         finally
         {
-            _operationLock.Release();
+            operation.Dispose();
         }
     }
 
@@ -216,14 +190,458 @@ internal sealed class JournaledJobShard : IJobShard
 
         try
         {
+            _shutdownCancellation.Cancel();
+            _pendingOperationSignal.Release();
+            await _operationProcessor.ConfigureAwait(false);
             await _stateManager.DisposeAsync();
         }
         finally
         {
+            _shutdownCancellation.Dispose();
+            _pendingOperationSignal.Dispose();
             _operationLock.Dispose();
             GC.SuppressFinalize(this);
         }
     }
 
     private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposed != 0, this);
+
+    private void EnqueueOperation(PendingOperation operation)
+    {
+        operation.CancellationToken.ThrowIfCancellationRequested();
+
+        lock (_pendingOperationsLock)
+        {
+            ThrowIfDisposed();
+            _pendingOperations.Enqueue(operation);
+            _pendingOperationSignal.Release();
+        }
+    }
+
+    private async Task ProcessOperationsAsync()
+    {
+        var batch = new List<PendingMutationOperation>();
+        try
+        {
+            while (true)
+            {
+                await _pendingOperationSignal.WaitAsync(_shutdownCancellation.Token).ConfigureAwait(false);
+
+                if (!TryDequeueOperation(out var operation) || operation is null)
+                {
+                    continue;
+                }
+
+                if (operation is PendingMutationOperation mutation)
+                {
+                    batch.Add(mutation);
+                    DequeueConsecutiveMutations(batch);
+                    await ProcessMutationBatchAsync(batch).ConfigureAwait(false);
+                    batch.Clear();
+                }
+                else
+                {
+                    await ProcessBarrierOperationAsync(operation).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (_shutdownCancellation.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            CancelOperations(batch);
+            CancelQueuedOperations();
+        }
+    }
+
+    private bool TryDequeueOperation(out PendingOperation? operation)
+    {
+        lock (_pendingOperationsLock)
+        {
+            return _pendingOperations.TryDequeue(out operation);
+        }
+    }
+
+    private void DequeueConsecutiveMutations(List<PendingMutationOperation> batch)
+    {
+        lock (_pendingOperationsLock)
+        {
+            while (_pendingOperations.TryPeek(out var operation) && operation is PendingMutationOperation mutation)
+            {
+                _pendingOperations.Dequeue();
+                batch.Add(mutation);
+            }
+        }
+    }
+
+    private void CancelQueuedOperations()
+    {
+        lock (_pendingOperationsLock)
+        {
+            while (_pendingOperations.TryDequeue(out var operation))
+            {
+                operation.TryCancel(_shutdownCancellation.Token);
+            }
+        }
+    }
+
+    private void CancelOperations(List<PendingMutationOperation> operations)
+    {
+        foreach (var operation in operations)
+        {
+            operation.TryCancel(_shutdownCancellation.Token);
+        }
+
+        operations.Clear();
+    }
+
+    private async Task ProcessMutationBatchAsync(List<PendingMutationOperation> operations)
+    {
+        var lockTaken = false;
+        var startedOperations = new List<PendingMutationOperation>(operations.Count);
+        var appliedOperations = new List<PendingMutationOperation>(operations.Count);
+
+        try
+        {
+            await _operationLock.WaitAsync(_shutdownCancellation.Token).ConfigureAwait(false);
+            lockTaken = true;
+
+            foreach (var operation in operations)
+            {
+                if (!operation.TryStart())
+                {
+                    continue;
+                }
+
+                if (operation.TryCompleteWithoutOwnership(this))
+                {
+                    continue;
+                }
+
+                startedOperations.Add(operation);
+            }
+
+            if (startedOperations.Count == 0)
+            {
+                return;
+            }
+
+            if (!await _shardManager.IsShardOwnedByLocalSiloAsync(Id, _shutdownCancellation.Token).ConfigureAwait(false))
+            {
+                foreach (var operation in startedOperations)
+                {
+                    operation.CompleteNotOwned();
+                }
+
+                return;
+            }
+
+            foreach (var operation in startedOperations)
+            {
+                try
+                {
+                    if (operation.Apply(this))
+                    {
+                        appliedOperations.Add(operation);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    operation.TrySetException(exception);
+                }
+            }
+
+            if (appliedOperations.Count == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                await _stateManager.WriteStateAsync(_shutdownCancellation.Token).ConfigureAwait(false);
+                DurableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: false, error: false);
+                foreach (var operation in appliedOperations)
+                {
+                    operation.CompleteAfterWrite();
+                }
+            }
+            catch (OperationCanceledException exception) when (_shutdownCancellation.IsCancellationRequested)
+            {
+                DurableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: true, error: false);
+                foreach (var operation in appliedOperations)
+                {
+                    operation.TrySetCanceled(exception.CancellationToken);
+                }
+            }
+            catch (Exception exception)
+            {
+                DurableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: false, error: true);
+                foreach (var operation in appliedOperations)
+                {
+                    operation.TrySetException(exception);
+                }
+            }
+        }
+        catch (OperationCanceledException exception) when (_shutdownCancellation.IsCancellationRequested)
+        {
+            CompleteIncompleteOperations(operations, exception);
+        }
+        catch (Exception exception)
+        {
+            CompleteIncompleteOperations(operations, exception);
+        }
+        finally
+        {
+            if (lockTaken)
+            {
+                _operationLock.Release();
+            }
+        }
+    }
+
+    private async Task ProcessBarrierOperationAsync(PendingOperation operation)
+    {
+        if (!operation.TryStart())
+        {
+            return;
+        }
+
+        var lockTaken = false;
+        try
+        {
+            await _operationLock.WaitAsync(_shutdownCancellation.Token).ConfigureAwait(false);
+            lockTaken = true;
+
+            switch (operation)
+            {
+                case MarkAsCompleteOperation markAsComplete:
+                    if (!_state.IsAddingCompleted && await _shardManager.TryMarkShardClosedAsync(Id, _shutdownCancellation.Token).ConfigureAwait(false))
+                    {
+                        _state.MarkAsComplete();
+                    }
+
+                    markAsComplete.Complete();
+                    break;
+                case DeleteStateOperation deleteState:
+                    await _stateManager.DeleteStateAsync(_shutdownCancellation.Token).ConfigureAwait(false);
+                    deleteState.Complete();
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unsupported DurableJobs shard operation '{operation.GetType().Name}'.");
+            }
+        }
+        catch (OperationCanceledException exception) when (_shutdownCancellation.IsCancellationRequested)
+        {
+            operation.TrySetCanceled(exception.CancellationToken);
+        }
+        catch (Exception exception)
+        {
+            operation.TrySetException(exception);
+        }
+        finally
+        {
+            if (lockTaken)
+            {
+                _operationLock.Release();
+            }
+        }
+    }
+
+    private void CompleteIncompleteOperations(List<PendingMutationOperation> operations, Exception exception)
+    {
+        foreach (var operation in operations)
+        {
+            if (exception is OperationCanceledException cancellation && _shutdownCancellation.IsCancellationRequested)
+            {
+                operation.TrySetCanceled(cancellation.CancellationToken);
+            }
+            else
+            {
+                operation.TrySetException(exception);
+            }
+        }
+    }
+
+    private abstract class PendingOperation : IDisposable
+    {
+        private readonly CancellationTokenRegistration _cancellationRegistration;
+        private int _started;
+
+        protected PendingOperation(CancellationToken cancellationToken)
+        {
+            CancellationToken = cancellationToken;
+            if (cancellationToken.CanBeCanceled)
+            {
+                _cancellationRegistration = cancellationToken.Register(static state => ((PendingOperation)state!).TryCancel(), this);
+            }
+        }
+
+        public CancellationToken CancellationToken { get; }
+
+        public abstract Task Completion { get; }
+
+        public bool TryStart()
+        {
+            if (CancellationToken.IsCancellationRequested)
+            {
+                TryCancel();
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _started, 1, 0) != 0)
+            {
+                return false;
+            }
+
+            return !Completion.IsCompleted;
+        }
+
+        public void TryCancel() => TryCancel(CancellationToken);
+
+        public void TryCancel(CancellationToken cancellationToken)
+        {
+            if (Volatile.Read(ref _started) == 0)
+            {
+                TrySetCanceled(cancellationToken);
+            }
+        }
+
+        public abstract void TrySetCanceled(CancellationToken cancellationToken);
+
+        public abstract void TrySetException(Exception exception);
+
+        public void Dispose() => _cancellationRegistration.Dispose();
+    }
+
+    private abstract class PendingOperation<TResult> : PendingOperation
+    {
+        private readonly TaskCompletionSource<TResult> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected PendingOperation(CancellationToken cancellationToken) : base(cancellationToken)
+        {
+        }
+
+        public Task<TResult> Task => _completion.Task;
+
+        public override Task Completion => _completion.Task;
+
+        public override void TrySetCanceled(CancellationToken cancellationToken) => _completion.TrySetCanceled(cancellationToken);
+
+        public override void TrySetException(Exception exception) => _completion.TrySetException(exception);
+
+        protected void TrySetResult(TResult result) => _completion.TrySetResult(result);
+    }
+
+    private abstract class PendingMutationOperation : PendingOperation
+    {
+        protected PendingMutationOperation(CancellationToken cancellationToken) : base(cancellationToken)
+        {
+        }
+
+        public virtual bool TryCompleteWithoutOwnership(JournaledJobShard shard) => false;
+
+        public abstract void CompleteNotOwned();
+
+        public abstract bool Apply(JournaledJobShard shard);
+
+        public abstract void CompleteAfterWrite();
+    }
+
+    private abstract class PendingMutationOperation<TResult> : PendingMutationOperation
+    {
+        private readonly TaskCompletionSource<TResult> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private TResult _result = default!;
+
+        protected PendingMutationOperation(CancellationToken cancellationToken) : base(cancellationToken)
+        {
+        }
+
+        public Task<TResult> Task => _completion.Task;
+
+        public override Task Completion => _completion.Task;
+
+        protected abstract TResult NotOwnedResult { get; }
+
+        protected abstract bool Apply(JournaledJobShard shard, out TResult result);
+
+        public override void TrySetCanceled(CancellationToken cancellationToken) => _completion.TrySetCanceled(cancellationToken);
+
+        public override void TrySetException(Exception exception) => _completion.TrySetException(exception);
+
+        public override void CompleteNotOwned() => _completion.TrySetResult(NotOwnedResult);
+
+        public override bool Apply(JournaledJobShard shard)
+        {
+            var writeRequired = Apply(shard, out _result);
+            if (!writeRequired)
+            {
+                _completion.TrySetResult(_result);
+            }
+
+            return writeRequired;
+        }
+
+        public override void CompleteAfterWrite() => _completion.TrySetResult(_result);
+
+        protected void TrySetResult(TResult result) => _completion.TrySetResult(result);
+    }
+
+    private sealed class ScheduleJobOperation(ScheduleJobRequest request, CancellationToken cancellationToken)
+        : PendingMutationOperation<DurableJob?>(cancellationToken)
+    {
+        protected override DurableJob? NotOwnedResult => null;
+
+        public override bool TryCompleteWithoutOwnership(JournaledJobShard shard)
+        {
+            if (!shard._state.IsAddingCompleted)
+            {
+                return false;
+            }
+
+            TrySetResult(null);
+            return true;
+        }
+
+        protected override bool Apply(JournaledJobShard shard, out DurableJob? result)
+        {
+            result = shard._state.TryScheduleJob(request);
+            return result is not null;
+        }
+    }
+
+    private sealed class RemoveJobOperation(string jobId, CancellationToken cancellationToken)
+        : PendingMutationOperation<bool>(cancellationToken)
+    {
+        protected override bool NotOwnedResult => false;
+
+        protected override bool Apply(JournaledJobShard shard, out bool result)
+        {
+            result = shard._state.RemoveJob(jobId);
+            return true;
+        }
+    }
+
+    private sealed class RetryJobLaterOperation(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken)
+        : PendingMutationOperation<bool>(cancellationToken)
+    {
+        protected override bool NotOwnedResult => true;
+
+        protected override bool Apply(JournaledJobShard shard, out bool result)
+        {
+            shard._state.RetryJobLater(jobContext, newDueTime);
+            result = true;
+            return true;
+        }
+    }
+
+    private sealed class MarkAsCompleteOperation(CancellationToken cancellationToken) : PendingOperation<bool>(cancellationToken)
+    {
+        public void Complete() => TrySetResult(true);
+    }
+
+    private sealed class DeleteStateOperation(CancellationToken cancellationToken) : PendingOperation<bool>(cancellationToken)
+    {
+        public void Complete() => TrySetResult(true);
+    }
 }

--- a/src/Orleans.DurableJobs/JournaledJobShard.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShard.cs
@@ -16,7 +16,6 @@ internal sealed class JournaledJobShard : IJobShard
     private readonly JournaledJobShardManager _shardManager;
     private readonly TimeProvider _timeProvider;
     private readonly TimeSpan _batchLingerDelay;
-    private readonly SemaphoreSlim _operationLock = new(1, 1);
     private readonly object _pendingOperationsLock = new();
     private readonly Queue<PendingOperation> _pendingOperations = new();
     private readonly SemaphoreSlim _pendingOperationSignal = new(0);
@@ -214,7 +213,6 @@ internal sealed class JournaledJobShard : IJobShard
         {
             _shutdownCancellation.Dispose();
             _pendingOperationSignal.Dispose();
-            _operationLock.Dispose();
             GC.SuppressFinalize(this);
         }
     }
@@ -254,6 +252,7 @@ internal sealed class JournaledJobShard : IJobShard
                     if (_batchLingerDelay > TimeSpan.Zero)
                     {
                         await LingerForMoreMutationsAsync(batch).ConfigureAwait(false);
+                        DequeueConsecutiveMutations(batch);
                     }
                     await ProcessMutationBatchAsync(batch).ConfigureAwait(false);
                     batch.Clear();
@@ -284,8 +283,6 @@ internal sealed class JournaledJobShard : IJobShard
         {
             return;
         }
-
-        DequeueConsecutiveMutations(batch);
     }
 
     private bool TryDequeueOperation(out PendingOperation? operation)
@@ -331,15 +328,11 @@ internal sealed class JournaledJobShard : IJobShard
 
     private async Task ProcessMutationBatchAsync(List<PendingMutationOperation> operations)
     {
-        var lockTaken = false;
         var startedOperations = new List<PendingMutationOperation>(operations.Count);
         var appliedOperations = new List<PendingMutationOperation>(operations.Count);
 
         try
         {
-            await _operationLock.WaitAsync(_shutdownCancellation.Token).ConfigureAwait(false);
-            lockTaken = true;
-
             foreach (var operation in operations)
             {
                 if (!operation.TryStart())
@@ -424,13 +417,6 @@ internal sealed class JournaledJobShard : IJobShard
         {
             CompleteIncompleteOperations(operations, exception);
         }
-        finally
-        {
-            if (lockTaken)
-            {
-                _operationLock.Release();
-            }
-        }
     }
 
     private async Task ProcessBarrierOperationAsync(PendingOperation operation)
@@ -440,12 +426,8 @@ internal sealed class JournaledJobShard : IJobShard
             return;
         }
 
-        var lockTaken = false;
         try
         {
-            await _operationLock.WaitAsync(_shutdownCancellation.Token).ConfigureAwait(false);
-            lockTaken = true;
-
             switch (operation)
             {
                 case MarkAsCompleteOperation markAsComplete:
@@ -471,13 +453,6 @@ internal sealed class JournaledJobShard : IJobShard
         catch (Exception exception)
         {
             operation.TrySetException(exception);
-        }
-        finally
-        {
-            if (lockTaken)
-            {
-                _operationLock.Release();
-            }
         }
     }
 

--- a/src/Orleans.DurableJobs/JournaledJobShardManager.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShardManager.cs
@@ -34,6 +34,11 @@ internal sealed class JournaledJobShardManager : JobShardManager
     private readonly JournaledStateManagerOptions _journaledStateManagerOptions;
     private readonly TimeProvider _timeProvider;
     private readonly ConcurrentDictionary<string, JournaledJobShard> _jobShardCache = new();
+    // Sticky positive cache for IsShardOwnedByLocalSiloAsync. Entries are added once a shard is
+    // confirmed to be owned by this silo, and removed only when ownership is released locally
+    // (via UnregisterShardAsync). Mis-cache from split-brain is bounded by storage-layer ETag
+    // conflicts triggering InconsistentStateException → the journaling layer's recovery path.
+    private readonly ConcurrentDictionary<string, bool> _ownedShards = new(StringComparer.Ordinal);
 
     public JournaledJobShardManager(
         ILocalSiloDetails localSiloDetails,
@@ -205,6 +210,7 @@ internal sealed class JournaledJobShardManager : JobShardManager
         finally
         {
             _jobShardCache.TryRemove(shard.Id, out _);
+            _ownedShards.TryRemove(shard.Id, out _);
             await journaledShard.DisposeAsync();
         }
     }
@@ -234,8 +240,19 @@ internal sealed class JournaledJobShardManager : JobShardManager
 
     internal override async ValueTask<bool> IsShardOwnedByLocalSiloAsync(string shardId, CancellationToken cancellationToken)
     {
+        if (_ownedShards.ContainsKey(shardId))
+        {
+            return true;
+        }
+
         var descriptor = await GetDescriptorAsync(shardId, cancellationToken);
-        return descriptor is { Poisoned: false, Owner: { } owner } && owner.Equals(SiloAddress);
+        var isOwned = descriptor is { Poisoned: false, Owner: { } owner } && owner.Equals(SiloAddress);
+        if (isOwned)
+        {
+            _ownedShards[shardId] = true;
+        }
+
+        return isOwned;
     }
 
     internal async ValueTask<bool> TryMarkShardClosedAsync(string shardId, CancellationToken cancellationToken)
@@ -362,6 +379,13 @@ internal sealed class JournaledJobShardManager : JobShardManager
         {
             await manager.DisposeAsync().ConfigureAwait(false);
             throw;
+        }
+
+        // Pre-populate the ownership cache when the descriptor confirms this silo owns the shard,
+        // so the first batch flush does not pay an Azure metadata round trip.
+        if (descriptor is { Poisoned: false, Owner: { } owner } && owner.Equals(SiloAddress))
+        {
+            _ownedShards[descriptor.ShardId.Value] = true;
         }
 
         return new JournaledJobShard(

--- a/src/Orleans.DurableJobs/JournaledJobShardManager.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShardManager.cs
@@ -372,7 +372,9 @@ internal sealed class JournaledJobShardManager : JobShardManager
             descriptor.Closed,
             state,
             manager,
-            this);
+            this,
+            _timeProvider,
+            _options.ShardBatchLingerDelay);
     }
 
     private IDurableValueCommandCodec<DurableJobShardJournalRecord> CreateOperationCodec()

--- a/src/Orleans.DurableJobs/JournaledJobShardState.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShardState.cs
@@ -141,6 +141,11 @@ internal sealed class JournaledJobShardState : IJournaledState, IDurableValueCom
 
         switch (record.Kind)
         {
+            case DurableJobShardJournalRecordKind.None:
+                throw new InvalidOperationException(
+                    "DurableJobs shard journal record has an uninitialized Kind (None). This usually " +
+                    "indicates a malformed or default-constructed journal payload — for example, a JSON " +
+                    "record whose 'kind' property was missing.");
             case DurableJobShardJournalRecordKind.Schedule:
                 ApplySchedule(GetRequired(record.Schedule, nameof(record.Schedule)).Job);
                 break;
@@ -226,10 +231,19 @@ internal sealed class JournaledJobShardState : IJournaledState, IDurableValueCom
 [Alias("Orleans.DurableJobs.DurableJobShardJournalRecordKind")]
 internal enum DurableJobShardJournalRecordKind : byte
 {
-    Schedule = 0,
-    Remove = 1,
-    Retry = 2,
-    Snapshot = 3
+    /// <summary>
+    /// Reserved sentinel. A record whose <see cref="DurableJobShardJournalRecord.Kind"/>
+    /// is <see cref="None"/> is invalid — it indicates a default-constructed instance or a
+    /// malformed journal payload (for example, a JSON record where <c>kind</c> was omitted
+    /// because the serializer drops default-valued properties). Apply paths must reject it.
+    /// Keep this at value 0 so that the default surfaces as an explicit failure rather than
+    /// silently aliasing to another kind.
+    /// </summary>
+    None = 0,
+    Schedule = 1,
+    Remove = 2,
+    Retry = 3,
+    Snapshot = 4,
 }
 
 [GenerateSerializer]

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.Log.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.Log.cs
@@ -110,15 +110,15 @@ internal partial class LocalDurableJobManager
 
     [LoggerMessage(
         Level = LogLevel.Debug,
-        Message = "Writable shard {ShardId} for key {ShardKey} was disposed while scheduling. Removing stale entry and retrying."
+        Message = "Writable shard {ShardId} for key {ShardStartTime}/{ShardStripe} was disposed while scheduling. Removing stale entry and retrying."
     )]
-    private static partial void LogWritableShardDisposedDuringScheduling(ILogger logger, Exception exception, string shardId, DateTimeOffset shardKey);
+    private static partial void LogWritableShardDisposedDuringScheduling(ILogger logger, Exception exception, string shardId, DateTimeOffset shardStartTime, int shardStripe);
 
     [LoggerMessage(
         Level = LogLevel.Debug,
-        Message = "Expired writable shard {ShardId} for key {ShardKey} was already disposed while completing. Removing stale entry."
+        Message = "Expired writable shard {ShardId} for key {ShardStartTime}/{ShardStripe} was already disposed while completing. Removing stale entry."
     )]
-    private static partial void LogExpiredWritableShardAlreadyDisposed(ILogger logger, Exception exception, string shardId, DateTimeOffset shardKey);
+    private static partial void LogExpiredWritableShardAlreadyDisposed(ILogger logger, Exception exception, string shardId, DateTimeOffset shardStartTime, int shardStripe);
 
     [LoggerMessage(
         Level = LogLevel.Information,
@@ -140,9 +140,9 @@ internal partial class LocalDurableJobManager
 
     [LoggerMessage(
         Level = LogLevel.Information,
-        Message = "Creating new shard for key {ShardKey}"
+        Message = "Creating new shard for key {ShardStartTime}/{ShardStripe}"
     )]
-    private static partial void LogCreatingNewShard(ILogger logger, DateTimeOffset shardKey);
+    private static partial void LogCreatingNewShard(ILogger logger, DateTimeOffset shardStartTime, int shardStripe);
 
     [LoggerMessage(
         Level = LogLevel.Information,

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.Log.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.Log.cs
@@ -109,6 +109,18 @@ internal partial class LocalDurableJobManager
     private static partial void LogErrorInPeriodicCheck(ILogger logger, Exception exception);
 
     [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Writable shard {ShardId} for key {ShardKey} was disposed while scheduling. Removing stale entry and retrying."
+    )]
+    private static partial void LogWritableShardDisposedDuringScheduling(ILogger logger, Exception exception, string shardId, DateTimeOffset shardKey);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Expired writable shard {ShardId} for key {ShardKey} was already disposed while completing. Removing stale entry."
+    )]
+    private static partial void LogExpiredWritableShardAlreadyDisposed(ILogger logger, Exception exception, string shardId, DateTimeOffset shardKey);
+
+    [LoggerMessage(
         Level = LogLevel.Information,
         Message = "Unregistered shard {ShardId}"
     )]

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -70,51 +70,68 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
     /// <inheritdoc/>
     public async Task<DurableJob> ScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
     {
-        LogSchedulingJob(_logger, request.JobName, request.Target, request.DueTime);
-
-        var shardKey = GetShardKey(request.DueTime);
-
-        while (true)
+        var startTimestamp = _timeProvider.GetTimestamp();
+        try
         {
-            // Fast path: shard already exists
-            if (_writeableShards.TryGetValue(shardKey, out var existingShard))
-            {
-                var job = await existingShard.TryScheduleJobAsync(request, cancellationToken);
-                if (job is not null)
-                {
-                    LogJobScheduled(_logger, request.JobName, job.Id, existingShard.Id, request.Target);
-                    return job;
-                }
+            LogSchedulingJob(_logger, request.JobName, request.Target, request.DueTime);
 
-                // Shard is full or no longer writable, remove from writable shards and try again
-                _writeableShards.TryRemove(shardKey, out _);
-                continue;
-            }
+            var shardKey = GetShardKey(request.DueTime);
 
-            // Slow path: need to create shard
-            await _shardCreationLock.WaitAsync(cancellationToken);
-            try
+            while (true)
             {
-                // Double-check after acquiring lock
-                if (_writeableShards.TryGetValue(shardKey, out existingShard))
+                // Fast path: shard already exists
+                if (_writeableShards.TryGetValue(shardKey, out var existingShard))
                 {
+                    var job = await existingShard.TryScheduleJobAsync(request, cancellationToken);
+                    if (job is not null)
+                    {
+                        var elapsed = _timeProvider.GetElapsedTime(startTimestamp);
+                        LogJobScheduled(_logger, request.JobName, job.Id, existingShard.Id, request.Target);
+                        DurableJobsInstruments.OnJobScheduled(elapsed);
+                        DurableJobsInstruments.OnScheduleJobCallSucceeded(elapsed);
+                        return job;
+                    }
+
+                    // Shard is full or no longer writable, remove from writable shards and try again
+                    _writeableShards.TryRemove(shardKey, out _);
                     continue;
                 }
 
-                // Create new shard
-                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
-                var endTime = shardKey.Add(_options.ShardDuration);
-                var newShard = await _shardManager.CreateShardAsync(shardKey, endTime, EmptyMetadata, linkedCts.Token);
+                // Slow path: need to create shard
+                await _shardCreationLock.WaitAsync(cancellationToken);
+                try
+                {
+                    // Double-check after acquiring lock
+                    if (_writeableShards.TryGetValue(shardKey, out existingShard))
+                    {
+                        continue;
+                    }
 
-                LogCreatingNewShard(_logger, shardKey);
-                _writeableShards[shardKey] = newShard;
-                _shardCache.TryAdd(newShard.Id, newShard);
-                TryActivateShard(newShard);
+                    // Create new shard
+                    using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
+                    var endTime = shardKey.Add(_options.ShardDuration);
+                    var newShard = await _shardManager.CreateShardAsync(shardKey, endTime, EmptyMetadata, linkedCts.Token);
+
+                    LogCreatingNewShard(_logger, shardKey);
+                    _writeableShards[shardKey] = newShard;
+                    _shardCache.TryAdd(newShard.Id, newShard);
+                    TryActivateShard(newShard);
+                }
+                finally
+                {
+                    _shardCreationLock.Release();
+                }
             }
-            finally
-            {
-                _shardCreationLock.Release();
-            }
+        }
+        catch (OperationCanceledException)
+        {
+            DurableJobsInstruments.OnScheduleJobCallCanceled(_timeProvider.GetElapsedTime(startTimestamp));
+            throw;
+        }
+        catch
+        {
+            DurableJobsInstruments.OnScheduleJobCallFailed(_timeProvider.GetElapsedTime(startTimestamp));
+            throw;
         }
     }
 
@@ -180,37 +197,60 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
     /// <inheritdoc/>
     public async Task<bool> TryCancelDurableJobAsync(DurableJob job, CancellationToken cancellationToken)
     {
-        LogCancellingJob(_logger, job.Id, job.Name, job.ShardId);
-
-        if (_shardCache.TryGetValue(job.ShardId, out var shard))
+        var startTimestamp = _timeProvider.GetTimestamp();
+        try
         {
-            if (!await _shardManager.IsShardOwnedByLocalSiloAsync(job.ShardId, cancellationToken))
+            LogCancellingJob(_logger, job.Id, job.Name, job.ShardId);
+
+            if (_shardCache.TryGetValue(job.ShardId, out var shard))
+            {
+                if (!await _shardManager.IsShardOwnedByLocalSiloAsync(job.ShardId, cancellationToken))
+                {
+                    LogJobCancellationFailed(_logger, job.Id, job.Name, job.ShardId);
+                    DurableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), canceledJob: false);
+                    return false;
+                }
+
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
+                var wasRemoved = await shard.RemoveJobAsync(job.Id, linkedCts.Token);
+                LogJobCancelled(_logger, job.Id, job.Name, job.ShardId);
+                if (wasRemoved)
+                {
+                    DurableJobsInstruments.OnJobCanceled();
+                }
+
+                DurableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), wasRemoved);
+                return wasRemoved;
+            }
+
+            var owner = await _shardManager.GetShardOwnerAsync(job.ShardId, cancellationToken);
+            if (owner is null || owner.Equals(Silo))
             {
                 LogJobCancellationFailed(_logger, job.Id, job.Name, job.ShardId);
+                DurableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), canceledJob: false);
                 return false;
             }
 
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
-            var wasRemoved = await shard.RemoveJobAsync(job.Id, linkedCts.Token);
-            LogJobCancelled(_logger, job.Id, job.Name, job.ShardId);
-            return wasRemoved;
-        }
+            var remote = _grainFactory.GetSystemTarget<ILocalDurableJobManagerSystemTarget>(JobManagerGrainType, owner);
+            var routed = await remote.TryCancelDurableJobAsync(job, cancellationToken);
+            if (!routed)
+            {
+                LogJobCancellationFailed(_logger, job.Id, job.Name, job.ShardId);
+            }
 
-        var owner = await _shardManager.GetShardOwnerAsync(job.ShardId, cancellationToken);
-        if (owner is null || owner.Equals(Silo))
+            DurableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), routed);
+            return routed;
+        }
+        catch (OperationCanceledException)
         {
-            LogJobCancellationFailed(_logger, job.Id, job.Name, job.ShardId);
-            return false;
+            DurableJobsInstruments.OnCancelJobCallCanceled(_timeProvider.GetElapsedTime(startTimestamp));
+            throw;
         }
-
-        var remote = _grainFactory.GetSystemTarget<ILocalDurableJobManagerSystemTarget>(JobManagerGrainType, owner);
-        var routed = await remote.TryCancelDurableJobAsync(job, cancellationToken);
-        if (!routed)
+        catch
         {
-            LogJobCancellationFailed(_logger, job.Id, job.Name, job.ShardId);
+            DurableJobsInstruments.OnCancelJobCallFailed(_timeProvider.GetElapsedTime(startTimestamp));
+            throw;
         }
-
-        return routed;
     }
 
     private async Task ProcessMembershipUpdates()

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -45,6 +45,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
     // Slow-start state
     private long _startTimestamp;
     private int _totalClaimedShards;
+    private int _stripeCounter;
 
     public LocalDurableJobManager(
         JobShardManager shardManager,
@@ -574,7 +575,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
     }
 
     private WritableShardKey GetWritableShardKey(ScheduleJobRequest request)
-        => new(GetShardStartTime(request.DueTime), GetShardStripe(request));
+        => new(GetShardStartTime(request.DueTime), GetShardStripe());
 
     private DateTimeOffset GetShardStartTime(DateTimeOffset scheduledTime)
     {
@@ -584,64 +585,18 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         return new DateTimeOffset(bucketTicks, TimeSpan.Zero);
     }
 
-    private int GetShardStripe(ScheduleJobRequest request)
+    private int GetShardStripe()
     {
         if (_options.ShardStripeCount <= 1)
         {
             return 0;
         }
 
-        var hash = AddStableHash(2_166_136_261u, request.Target.GetUniformHashCode());
-        hash = AddStableHash(hash, request.JobName);
-
-        if (request.Metadata is { Count: > 0 } metadata)
-        {
-            foreach (var entry in metadata.OrderBy(static entry => entry.Key, StringComparer.Ordinal))
-            {
-                hash = AddStableHash(hash, entry.Key);
-                hash = AddStableHash(hash, entry.Value);
-            }
-        }
-
-        return (int)(hash % (uint)_options.ShardStripeCount);
-    }
-
-    private static uint AddStableHash(uint hash, uint value)
-    {
-        unchecked
-        {
-            hash ^= value & 0xFF;
-            hash *= 16_777_619u;
-            hash ^= (value >> 8) & 0xFF;
-            hash *= 16_777_619u;
-            hash ^= (value >> 16) & 0xFF;
-            hash *= 16_777_619u;
-            hash ^= (value >> 24) & 0xFF;
-            hash *= 16_777_619u;
-            return hash;
-        }
-    }
-
-    private static uint AddStableHash(uint hash, string? value)
-    {
-        unchecked
-        {
-            if (value is null)
-            {
-                return AddStableHash(hash, 0);
-            }
-
-            foreach (var character in value)
-            {
-                var code = (uint)character;
-                hash ^= code & 0xFFu;
-                hash *= 16_777_619u;
-                hash ^= code >> 8;
-                hash *= 16_777_619u;
-            }
-
-            return hash;
-        }
+        // Round-robin assignment. Stripe selection is a write-side fan-out knob only:
+        // the persisted job location is the shard id, not (StartTime, Stripe), so consistency
+        // across calls/silos is not required and round-robin distributes evenly under any input skew.
+        var next = (uint)Interlocked.Increment(ref _stripeCounter);
+        return (int)(next % (uint)_options.ShardStripeCount);
     }
 
     private readonly record struct WritableShardKey(DateTimeOffset StartTime, int Stripe);

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -34,7 +35,8 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
 
     // Shard tracking state
     private readonly ConcurrentDictionary<string, IJobShard> _shardCache = new();
-    private readonly ConcurrentDictionary<DateTimeOffset, IJobShard> _writeableShards = new();
+    private readonly ConcurrentDictionary<WritableShardKey, IJobShard> _writeableShards = new();
+    private readonly ConcurrentDictionary<string, WritableShardKey> _writeableShardKeys = new();
     private readonly ConcurrentDictionary<string, Task> _runningShards = new();
     private readonly SemaphoreSlim _shardCreationLock = new(1, 1);
     private readonly SemaphoreSlim _shardCheckSignal = new(0);
@@ -44,6 +46,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
     private int _totalClaimedShards;
 
     private static readonly IDictionary<string, string> EmptyMetadata = new Dictionary<string, string>();
+    private const string ShardStripeMetadataKey = "stripe";
 
     public LocalDurableJobManager(
         JobShardManager shardManager,
@@ -75,7 +78,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         {
             LogSchedulingJob(_logger, request.JobName, request.Target, request.DueTime);
 
-            var shardKey = GetShardKey(request.DueTime);
+            var shardKey = GetWritableShardKey(request);
 
             while (true)
             {
@@ -89,7 +92,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
                     }
                     catch (ObjectDisposedException ex) when (TryRemoveWritableShard(shardKey, existingShard) || !IsWritableShard(shardKey, existingShard))
                     {
-                        LogWritableShardDisposedDuringScheduling(_logger, ex, existingShard.Id, shardKey);
+                        LogWritableShardDisposedDuringScheduling(_logger, ex, existingShard.Id, shardKey.StartTime, shardKey.Stripe);
                         continue;
                     }
 
@@ -119,11 +122,12 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
 
                     // Create new shard
                     using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
-                    var endTime = shardKey.Add(_options.ShardDuration);
-                    var newShard = await _shardManager.CreateShardAsync(shardKey, endTime, EmptyMetadata, linkedCts.Token);
+                    var endTime = shardKey.StartTime.Add(_options.ShardDuration);
+                    var newShard = await _shardManager.CreateShardAsync(shardKey.StartTime, endTime, CreateShardMetadata(shardKey), linkedCts.Token);
 
-                    LogCreatingNewShard(_logger, shardKey);
+                    LogCreatingNewShard(_logger, shardKey.StartTime, shardKey.Stripe);
                     _writeableShards[shardKey] = newShard;
+                    _writeableShardKeys[newShard.Id] = shardKey;
                     _shardCache.TryAdd(newShard.Id, newShard);
                     TryActivateShard(newShard);
                 }
@@ -343,16 +347,17 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         var now = _timeProvider.GetUtcNow();
         foreach (var key in _writeableShards.Keys.ToArray())
         {
-            var shardEndTime = key.Add(_options.ShardDuration);
+            var shardEndTime = key.StartTime.Add(_options.ShardDuration);
             if (shardEndTime < now && _writeableShards.TryRemove(key, out var expiredShard))
             {
+                _writeableShardKeys.TryRemove(expiredShard.Id, out _);
                 try
                 {
                     await expiredShard.MarkAsCompleteAsync(cancellationToken);
                 }
                 catch (ObjectDisposedException ex)
                 {
-                    LogExpiredWritableShardAlreadyDisposed(_logger, ex, expiredShard.Id, key);
+                    LogExpiredWritableShardAlreadyDisposed(_logger, ex, expiredShard.Id, key.StartTime, key.Stripe);
                 }
             }
         }
@@ -495,7 +500,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         finally
         {
             // Clean up tracking and dispose the shard
-            TryRemoveWritableShard(shard.StartTime, shard);
+            TryRemoveWritableShard(shard);
             _shardCache.TryRemove(shard.Id, out _);
             _runningShards.TryRemove(shard.Id, out _);
 
@@ -516,28 +521,51 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         return _timeProvider.GetUtcNow() >= activationTime;
     }
 
-    private bool IsWritableShard(DateTimeOffset shardKey, IJobShard shard)
+    private bool IsWritableShard(WritableShardKey shardKey, IJobShard shard)
         => _writeableShards.TryGetValue(shardKey, out var existingShard) && ReferenceEquals(existingShard, shard);
 
-    private bool TryRemoveWritableShard(DateTimeOffset shardKey, IJobShard shard)
+    private bool TryRemoveWritableShard(WritableShardKey shardKey, IJobShard shard)
     {
-        var entry = new KeyValuePair<DateTimeOffset, IJobShard>(shardKey, shard);
-        return ((ICollection<KeyValuePair<DateTimeOffset, IJobShard>>)_writeableShards).Remove(entry);
+        var entry = new KeyValuePair<WritableShardKey, IJobShard>(shardKey, shard);
+        var removed = ((ICollection<KeyValuePair<WritableShardKey, IJobShard>>)_writeableShards).Remove(entry);
+        if (removed)
+        {
+            var keyEntry = new KeyValuePair<string, WritableShardKey>(shard.Id, shardKey);
+            ((ICollection<KeyValuePair<string, WritableShardKey>>)_writeableShardKeys).Remove(keyEntry);
+        }
+
+        return removed;
+    }
+
+    private bool TryRemoveWritableShard(IJobShard shard)
+    {
+        if (_writeableShardKeys.TryGetValue(shard.Id, out var shardKey))
+        {
+            return TryRemoveWritableShard(shardKey, shard);
+        }
+
+        return false;
     }
 
     internal sealed class TestAccessor(LocalDurableJobManager manager)
     {
         public Task ProcessShardCheckCycleAsync(CancellationToken cancellationToken) => manager.ProcessShardCheckCycleAsync(cancellationToken);
 
-        public void AddWritableShard(DateTimeOffset shardKey, IJobShard shard)
+        public void AddWritableShard(DateTimeOffset shardKey, IJobShard shard, int stripe = 0)
         {
-            manager._writeableShards[shardKey] = shard;
+            var key = new WritableShardKey(shardKey, stripe);
+            manager._writeableShards[key] = shard;
+            manager._writeableShardKeys[shard.Id] = key;
             manager._shardCache.TryAdd(shard.Id, shard);
         }
 
-        public bool HasWritableShard(DateTimeOffset shardKey) => manager._writeableShards.ContainsKey(shardKey);
+        public bool HasWritableShard(DateTimeOffset shardKey, int stripe = 0) => manager._writeableShards.ContainsKey(new WritableShardKey(shardKey, stripe));
 
-        public bool TryGetWritableShard(DateTimeOffset shardKey, out IJobShard? shard) => manager._writeableShards.TryGetValue(shardKey, out shard);
+        public bool TryGetWritableShard(DateTimeOffset shardKey, out IJobShard? shard, int stripe = 0) => manager._writeableShards.TryGetValue(new WritableShardKey(shardKey, stripe), out shard);
+
+        public int GetWritableShardStripe(ScheduleJobRequest request) => manager.GetWritableShardKey(request).Stripe;
+
+        public int WritableShardCount => manager._writeableShards.Count;
 
         public void TryActivateShard(IJobShard shard) => manager.TryActivateShard(shard);
 
@@ -546,11 +574,89 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         public bool HasCachedShard(string shardId) => manager._shardCache.ContainsKey(shardId);
     }
 
-    private DateTimeOffset GetShardKey(DateTimeOffset scheduledTime)
+    private WritableShardKey GetWritableShardKey(ScheduleJobRequest request)
+        => new(GetShardStartTime(request.DueTime), GetShardStripe(request));
+
+    private DateTimeOffset GetShardStartTime(DateTimeOffset scheduledTime)
     {
         var shardDurationTicks = _options.ShardDuration.Ticks;
         var epochTicks = scheduledTime.UtcTicks;
         var bucketTicks = (epochTicks / shardDurationTicks) * shardDurationTicks;
         return new DateTimeOffset(bucketTicks, TimeSpan.Zero);
     }
+
+    private int GetShardStripe(ScheduleJobRequest request)
+    {
+        if (_options.ShardStripeCount <= 1)
+        {
+            return 0;
+        }
+
+        var hash = AddStableHash(2_166_136_261u, request.Target.GetUniformHashCode());
+        hash = AddStableHash(hash, request.JobName);
+
+        if (request.Metadata is { Count: > 0 } metadata)
+        {
+            foreach (var entry in metadata.OrderBy(static entry => entry.Key, StringComparer.Ordinal))
+            {
+                hash = AddStableHash(hash, entry.Key);
+                hash = AddStableHash(hash, entry.Value);
+            }
+        }
+
+        return (int)(hash % (uint)_options.ShardStripeCount);
+    }
+
+    private IDictionary<string, string> CreateShardMetadata(WritableShardKey shardKey)
+    {
+        if (_options.ShardStripeCount <= 1)
+        {
+            return EmptyMetadata;
+        }
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ShardStripeMetadataKey] = shardKey.Stripe.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static uint AddStableHash(uint hash, uint value)
+    {
+        unchecked
+        {
+            hash ^= value & 0xFF;
+            hash *= 16_777_619u;
+            hash ^= (value >> 8) & 0xFF;
+            hash *= 16_777_619u;
+            hash ^= (value >> 16) & 0xFF;
+            hash *= 16_777_619u;
+            hash ^= (value >> 24) & 0xFF;
+            hash *= 16_777_619u;
+            return hash;
+        }
+    }
+
+    private static uint AddStableHash(uint hash, string? value)
+    {
+        unchecked
+        {
+            if (value is null)
+            {
+                return AddStableHash(hash, 0);
+            }
+
+            foreach (var character in value)
+            {
+                var code = (uint)character;
+                hash ^= code & 0xFFu;
+                hash *= 16_777_619u;
+                hash ^= code >> 8;
+                hash *= 16_777_619u;
+            }
+
+            return hash;
+        }
+    }
+
+    private readonly record struct WritableShardKey(DateTimeOffset StartTime, int Stripe);
 }

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -13,6 +13,7 @@ using Orleans.Internal;
 using Orleans.Runtime;
 using Orleans.Runtime.Internal;
 using Orleans.Runtime.Messaging;
+using Orleans.Runtime.Scheduler;
 
 namespace Orleans.DurableJobs;
 
@@ -476,7 +477,8 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         if (_runningShards.TryAdd(shard.Id, Task.CompletedTask))
         {
             LogStartingShard(_logger, shard.Id, shard.StartTime, shard.EndTime);
-            _runningShards[shard.Id] = RunShardWithCleanupAsync(shard);
+            using var _ = new ExecutionContextSuppressor();
+            _runningShards[shard.Id] = this.RunOrQueueTask(() => RunShardWithCleanupAsync(shard));
         }
     }
 

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -82,7 +82,17 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
                 // Fast path: shard already exists
                 if (_writeableShards.TryGetValue(shardKey, out var existingShard))
                 {
-                    var job = await existingShard.TryScheduleJobAsync(request, cancellationToken);
+                    DurableJob? job;
+                    try
+                    {
+                        job = await existingShard.TryScheduleJobAsync(request, cancellationToken);
+                    }
+                    catch (ObjectDisposedException ex) when (TryRemoveWritableShard(shardKey, existingShard) || !IsWritableShard(shardKey, existingShard))
+                    {
+                        LogWritableShardDisposedDuringScheduling(_logger, ex, existingShard.Id, shardKey);
+                        continue;
+                    }
+
                     if (job is not null)
                     {
                         var elapsed = _timeProvider.GetElapsedTime(startTimestamp);
@@ -93,7 +103,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
                     }
 
                     // Shard is full or no longer writable, remove from writable shards and try again
-                    _writeableShards.TryRemove(shardKey, out _);
+                    TryRemoveWritableShard(shardKey, existingShard);
                     continue;
                 }
 
@@ -336,7 +346,14 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
             var shardEndTime = key.Add(_options.ShardDuration);
             if (shardEndTime < now && _writeableShards.TryRemove(key, out var expiredShard))
             {
-                await expiredShard.MarkAsCompleteAsync(cancellationToken);
+                try
+                {
+                    await expiredShard.MarkAsCompleteAsync(cancellationToken);
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    LogExpiredWritableShardAlreadyDisposed(_logger, ex, expiredShard.Id, key);
+                }
             }
         }
 
@@ -478,6 +495,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         finally
         {
             // Clean up tracking and dispose the shard
+            TryRemoveWritableShard(shard.StartTime, shard);
             _shardCache.TryRemove(shard.Id, out _);
             _runningShards.TryRemove(shard.Id, out _);
 
@@ -498,6 +516,15 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         return _timeProvider.GetUtcNow() >= activationTime;
     }
 
+    private bool IsWritableShard(DateTimeOffset shardKey, IJobShard shard)
+        => _writeableShards.TryGetValue(shardKey, out var existingShard) && ReferenceEquals(existingShard, shard);
+
+    private bool TryRemoveWritableShard(DateTimeOffset shardKey, IJobShard shard)
+    {
+        var entry = new KeyValuePair<DateTimeOffset, IJobShard>(shardKey, shard);
+        return ((ICollection<KeyValuePair<DateTimeOffset, IJobShard>>)_writeableShards).Remove(entry);
+    }
+
     internal sealed class TestAccessor(LocalDurableJobManager manager)
     {
         public Task ProcessShardCheckCycleAsync(CancellationToken cancellationToken) => manager.ProcessShardCheckCycleAsync(cancellationToken);
@@ -509,6 +536,8 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         }
 
         public bool HasWritableShard(DateTimeOffset shardKey) => manager._writeableShards.ContainsKey(shardKey);
+
+        public bool TryGetWritableShard(DateTimeOffset shardKey, out IJobShard? shard) => manager._writeableShards.TryGetValue(shardKey, out shard);
 
         public void TryActivateShard(IJobShard shard) => manager.TryActivateShard(shard);
 

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -46,9 +46,6 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
     private long _startTimestamp;
     private int _totalClaimedShards;
 
-    private static readonly IDictionary<string, string> EmptyMetadata = new Dictionary<string, string>();
-    private const string ShardStripeMetadataKey = "stripe";
-
     public LocalDurableJobManager(
         JobShardManager shardManager,
         ShardExecutor shardExecutor,
@@ -124,7 +121,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
                     // Create new shard
                     using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
                     var endTime = shardKey.StartTime.Add(_options.ShardDuration);
-                    var newShard = await _shardManager.CreateShardAsync(shardKey.StartTime, endTime, CreateShardMetadata(shardKey), linkedCts.Token);
+                    var newShard = await _shardManager.CreateShardAsync(shardKey.StartTime, endTime, new Dictionary<string, string>(), linkedCts.Token);
 
                     LogCreatingNewShard(_logger, shardKey.StartTime, shardKey.Stripe);
                     _writeableShards[shardKey] = newShard;
@@ -607,19 +604,6 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         }
 
         return (int)(hash % (uint)_options.ShardStripeCount);
-    }
-
-    private IDictionary<string, string> CreateShardMetadata(WritableShardKey shardKey)
-    {
-        if (_options.ShardStripeCount <= 1)
-        {
-            return EmptyMetadata;
-        }
-
-        return new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [ShardStripeMetadataKey] = shardKey.Stripe.ToString(CultureInfo.InvariantCulture)
-        };
     }
 
     private static uint AddStableHash(uint hash, uint value)

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -46,6 +46,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
     private long _startTimestamp;
     private int _totalClaimedShards;
     private int _stripeCounter;
+    private const string ShardStripeMetadataKey = "stripe";
 
     public LocalDurableJobManager(
         JobShardManager shardManager,
@@ -122,7 +123,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
                     // Create new shard
                     using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
                     var endTime = shardKey.StartTime.Add(_options.ShardDuration);
-                    var newShard = await _shardManager.CreateShardAsync(shardKey.StartTime, endTime, new Dictionary<string, string>(), linkedCts.Token);
+                    var newShard = await _shardManager.CreateShardAsync(shardKey.StartTime, endTime, CreateShardMetadata(shardKey), linkedCts.Token);
 
                     LogCreatingNewShard(_logger, shardKey.StartTime, shardKey.Stripe);
                     _writeableShards[shardKey] = newShard;
@@ -576,6 +577,17 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
 
     private WritableShardKey GetWritableShardKey(ScheduleJobRequest request)
         => new(GetShardStartTime(request.DueTime), GetShardStripe());
+
+    private IDictionary<string, string> CreateShardMetadata(WritableShardKey shardKey)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (_options.ShardStripeCount > 1)
+        {
+            result[ShardStripeMetadataKey] = shardKey.Stripe.ToString(CultureInfo.InvariantCulture);
+        }
+
+        return result;
+    }
 
     private DateTimeOffset GetShardStartTime(DateTimeOffset scheduledTime)
     {

--- a/src/Orleans.DurableJobs/ShardExecutor.cs
+++ b/src/Orleans.DurableJobs/ShardExecutor.cs
@@ -62,11 +62,7 @@ internal sealed partial class ShardExecutor
     {
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding | ConfigureAwaitOptions.ContinueOnCapturedContext);
 
-        if (Volatile.Read(ref _currentCapacity) < _options.MaxConcurrentJobsPerSilo
-            && Interlocked.CompareExchange(ref _slowStartRampUpStarted, 1, 0) == 0)
-        {
-            _ = Task.Run(SlowStartRampUpAsync);
-        }
+        EnsureSlowStartRampUpStarted();
 
         var tasks = new ConcurrentDictionary<string, Task>();
         var processingStarted = false;
@@ -91,21 +87,12 @@ internal sealed partial class ShardExecutor
             // Process all jobs in the shard
             await foreach (var jobContext in shard.ConsumeDurableJobsAsync().WithCancellation(cancellationToken))
             {
-                // Check for overload and pause batch processing if needed
-                if (_overloadDetector.IsOverloaded)
-                {
-                    LogOverloadDetected(_logger, shard.Id);
-                    while (_overloadDetector.IsOverloaded)
-                    {
-                        await Task.Delay(_options.OverloadBackoffDelay, _timeProvider, cancellationToken);
-                    }
-                    LogOverloadCleared(_logger, shard.Id);
-                }
+                await WaitForOverloadToClearAsync(shard.Id, cancellationToken);
 
                 // Wait for concurrency slot
                 await _jobConcurrencyLimiter.WaitAsync(cancellationToken);
-                // Start processing the job. RunJobAsync will release the semaphore when done and remove itself from the tasks dictionary
-                tasks[jobContext.Job.Id] = RunJobAsync(jobContext, shard, tasks, cancellationToken);
+                // Start processing the job. ExecuteJobAsync will release the semaphore when done and remove itself from the tasks dictionary
+                tasks[jobContext.Job.Id] = ExecuteJobAsync(jobContext, shard, tasks, cancellationToken);
             }
 
             LogCompletedProcessingShard(_logger, shard.Id);
@@ -140,6 +127,30 @@ internal sealed partial class ShardExecutor
                     DurableJobsInstruments.OnShardProcessed(_timeProvider.GetElapsedTime(processingStartTimestamp), canceled, error);
                 }
             }
+        }
+    }
+
+    private void EnsureSlowStartRampUpStarted()
+    {
+        if (Volatile.Read(ref _currentCapacity) < _options.MaxConcurrentJobsPerSilo
+            && Interlocked.CompareExchange(ref _slowStartRampUpStarted, 1, 0) == 0)
+        {
+            _ = Task.Run(SlowStartRampUpAsync);
+        }
+    }
+
+    private async Task WaitForOverloadToClearAsync(string shardId, CancellationToken cancellationToken)
+    {
+        // Check for overload and pause batch processing if needed
+        if (_overloadDetector.IsOverloaded)
+        {
+            LogOverloadDetected(_logger, shardId);
+            while (_overloadDetector.IsOverloaded)
+            {
+                await Task.Delay(_options.OverloadBackoffDelay, _timeProvider, cancellationToken);
+            }
+
+            LogOverloadCleared(_logger, shardId);
         }
     }
 
@@ -196,10 +207,10 @@ internal sealed partial class ShardExecutor
         LogSlowStartComplete(_logger, Volatile.Read(ref _currentCapacity));
     }
 
-    private async Task RunJobAsync(
+    private async Task ExecuteJobAsync(
         IJobRunContext jobContext,
         IJobShard shard,
-        ConcurrentDictionary<string, Task> runningTasks,
+        ConcurrentDictionary<string, Task>? runningTasks,
         CancellationToken cancellationToken)
     {
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext | ConfigureAwaitOptions.ForceYielding);
@@ -269,7 +280,7 @@ internal sealed partial class ShardExecutor
         {
             // Cleanup must happen even when retry persistence throws, otherwise slots leak and shard processing can stall.
             _jobConcurrencyLimiter.Release();
-            runningTasks.TryRemove(jobContext.Job.Id, out _);
+            runningTasks?.TryRemove(jobContext.Job.Id, out _);
         }
     }
 }

--- a/src/Orleans.DurableJobs/ShardExecutor.cs
+++ b/src/Orleans.DurableJobs/ShardExecutor.cs
@@ -69,6 +69,10 @@ internal sealed partial class ShardExecutor
         }
 
         var tasks = new ConcurrentDictionary<string, Task>();
+        var processingStarted = false;
+        var processingStartTimestamp = 0L;
+        var canceled = false;
+        var error = false;
         try
         {
             var now = _timeProvider.GetUtcNow();
@@ -81,6 +85,8 @@ internal sealed partial class ShardExecutor
             }
 
             LogBeginProcessingShard(_logger, shard.Id);
+            processingStarted = true;
+            processingStartTimestamp = _timeProvider.GetTimestamp();
 
             // Process all jobs in the shard
             await foreach (var jobContext in shard.ConsumeDurableJobsAsync().WithCancellation(cancellationToken))
@@ -106,13 +112,34 @@ internal sealed partial class ShardExecutor
         }
         catch (OperationCanceledException)
         {
+            canceled = true;
             LogShardCancelled(_logger, shard.Id);
+            throw;
+        }
+        catch
+        {
+            error = true;
             throw;
         }
         finally
         {
             // Wait for all jobs to complete
-            await Task.WhenAll(tasks.Values);
+            try
+            {
+                await Task.WhenAll(tasks.Values);
+            }
+            catch
+            {
+                error = true;
+                throw;
+            }
+            finally
+            {
+                if (processingStarted)
+                {
+                    DurableJobsInstruments.OnShardProcessed(_timeProvider.GetElapsedTime(processingStartTimestamp), canceled, error);
+                }
+            }
         }
     }
 
@@ -178,6 +205,8 @@ internal sealed partial class ShardExecutor
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext | ConfigureAwaitOptions.ForceYielding);
 
         Exception? failureException = null;
+        var attemptStartTimestamp = _timeProvider.GetTimestamp();
+        DurableJobsInstruments.OnJobAttemptStarted(_timeProvider.GetUtcNow() - jobContext.Job.DueTime);
 
         try
         {
@@ -204,6 +233,7 @@ internal sealed partial class ShardExecutor
                 {
                     await shard.RemoveJobAsync(jobContext.Job.Id, cancellationToken);
                     LogJobExecutedSuccessfully(_logger, jobContext.Job.Id, jobContext.Job.Name);
+                    DurableJobsInstruments.OnJobCompleted(_timeProvider.GetElapsedTime(attemptStartTimestamp));
                 }
                 else if (result.IsFailed)
                 {
@@ -226,10 +256,12 @@ internal sealed partial class ShardExecutor
                 {
                     LogRetryingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, retryTime.Value, jobContext.DequeueCount);
                     await shard.RetryJobLaterAsync(jobContext, retryTime.Value, cancellationToken);
+                    DurableJobsInstruments.OnJobRetried(_timeProvider.GetElapsedTime(attemptStartTimestamp));
                 }
                 else
                 {
                     LogJobFailedNoRetry(_logger, jobContext.Job.Id, jobContext.Job.Name, jobContext.DequeueCount);
+                    DurableJobsInstruments.OnJobFailed(_timeProvider.GetElapsedTime(attemptStartTimestamp));
                 }
             }
         }

--- a/src/Orleans.DurableJobs/ShardExecutor.cs
+++ b/src/Orleans.DurableJobs/ShardExecutor.cs
@@ -91,6 +91,7 @@ internal sealed partial class ShardExecutor
 
                 // Wait for concurrency slot
                 await _jobConcurrencyLimiter.WaitAsync(cancellationToken);
+
                 // Start processing the job. ExecuteJobAsync will release the semaphore when done and remove itself from the tasks dictionary
                 tasks[jobContext.Job.Id] = ExecuteJobAsync(jobContext, shard, tasks, cancellationToken);
             }

--- a/src/Orleans.Journaling/Formats/Json/JsonCommandCodecServices.cs
+++ b/src/Orleans.Journaling/Formats/Json/JsonCommandCodecServices.cs
@@ -1,9 +1,11 @@
+using Microsoft.Extensions.Options;
+
 namespace Orleans.Journaling.Json;
 
-internal sealed class JsonDurableDictionaryCommandCodecService<TKey, TValue>(JsonJournalOptions options)
+internal sealed class JsonDurableDictionaryCommandCodecService<TKey, TValue>(IOptions<JsonJournalOptions> options)
     : IDurableDictionaryCommandCodec<TKey, TValue> where TKey : notnull
 {
-    private readonly JsonDurableDictionaryCommandCodec<TKey, TValue> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).SerializerOptions);
+    private readonly JsonDurableDictionaryCommandCodec<TKey, TValue> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).Value.SerializerOptions);
 
     public void WriteSet(TKey key, TValue value, JournalStreamWriter writer) => _inner.WriteSet(key, value, writer);
 
@@ -17,10 +19,10 @@ internal sealed class JsonDurableDictionaryCommandCodecService<TKey, TValue>(Jso
 
 }
 
-internal sealed class JsonDurableListCommandCodecService<T>(JsonJournalOptions options)
+internal sealed class JsonDurableListCommandCodecService<T>(IOptions<JsonJournalOptions> options)
     : IDurableListCommandCodec<T>
 {
-    private readonly JsonDurableListCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).SerializerOptions);
+    private readonly JsonDurableListCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).Value.SerializerOptions);
 
     public void WriteAdd(T item, JournalStreamWriter writer) => _inner.WriteAdd(item, writer);
 
@@ -38,10 +40,10 @@ internal sealed class JsonDurableListCommandCodecService<T>(JsonJournalOptions o
 
 }
 
-internal sealed class JsonDurableQueueCommandCodecService<T>(JsonJournalOptions options)
+internal sealed class JsonDurableQueueCommandCodecService<T>(IOptions<JsonJournalOptions> options)
     : IDurableQueueCommandCodec<T>
 {
-    private readonly JsonDurableQueueCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).SerializerOptions);
+    private readonly JsonDurableQueueCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).Value.SerializerOptions);
 
     public void WriteEnqueue(T item, JournalStreamWriter writer) => _inner.WriteEnqueue(item, writer);
 
@@ -55,10 +57,10 @@ internal sealed class JsonDurableQueueCommandCodecService<T>(JsonJournalOptions 
 
 }
 
-internal sealed class JsonDurableSetCommandCodecService<T>(JsonJournalOptions options)
+internal sealed class JsonDurableSetCommandCodecService<T>(IOptions<JsonJournalOptions> options)
     : IDurableSetCommandCodec<T>
 {
-    private readonly JsonDurableSetCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).SerializerOptions);
+    private readonly JsonDurableSetCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).Value.SerializerOptions);
 
     public void WriteAdd(T item, JournalStreamWriter writer) => _inner.WriteAdd(item, writer);
 
@@ -72,10 +74,10 @@ internal sealed class JsonDurableSetCommandCodecService<T>(JsonJournalOptions op
 
 }
 
-internal sealed class JsonDurableValueCommandCodecService<T>(JsonJournalOptions options)
+internal sealed class JsonDurableValueCommandCodecService<T>(IOptions<JsonJournalOptions> options)
     : IDurableValueCommandCodec<T>
 {
-    private readonly JsonDurableValueCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).SerializerOptions);
+    private readonly JsonDurableValueCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).Value.SerializerOptions);
 
     public void WriteSet(T value, JournalStreamWriter writer) => _inner.WriteSet(value, writer);
 
@@ -83,10 +85,10 @@ internal sealed class JsonDurableValueCommandCodecService<T>(JsonJournalOptions 
 
 }
 
-internal sealed class JsonPersistentStateCommandCodecService<T>(JsonJournalOptions options)
+internal sealed class JsonPersistentStateCommandCodecService<T>(IOptions<JsonJournalOptions> options)
     : IPersistentStateCommandCodec<T>
 {
-    private readonly JsonPersistentStateCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).SerializerOptions);
+    private readonly JsonPersistentStateCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).Value.SerializerOptions);
 
     public void WriteSet(T state, ulong version, JournalStreamWriter writer) => _inner.WriteSet(state, version, writer);
 
@@ -96,10 +98,10 @@ internal sealed class JsonPersistentStateCommandCodecService<T>(JsonJournalOptio
 
 }
 
-internal sealed class JsonDurableTaskCompletionSourceCommandCodecService<T>(JsonJournalOptions options)
+internal sealed class JsonDurableTaskCompletionSourceCommandCodecService<T>(IOptions<JsonJournalOptions> options)
     : IDurableTaskCompletionSourceCommandCodec<T>
 {
-    private readonly JsonDurableTaskCompletionSourceCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).SerializerOptions);
+    private readonly JsonDurableTaskCompletionSourceCommandCodec<T> _inner = new((options ?? throw new ArgumentNullException(nameof(options))).Value.SerializerOptions);
 
     public void WritePending(JournalStreamWriter writer) => _inner.WritePending(writer);
 

--- a/src/Orleans.Journaling/Formats/Json/JsonJournalExtensions.cs
+++ b/src/Orleans.Journaling/Formats/Json/JsonJournalExtensions.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Orleans.Journaling.Json;
 
@@ -79,14 +80,11 @@ public static class JsonJournalExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        var options = new JsonJournalOptions();
-        configure?.Invoke(options);
-
-        // Capture the serializer options directly — avoid registering a bare
-        // JsonSerializerOptions singleton that could collide with other components.
-        var jsonOptions = options.SerializerOptions;
-
-        builder.Services.AddJsonJournalFormat(jsonOptions, tryAdd: false);
+        builder.Services.AddJsonJournalFormat(tryAdd: false);
+        if (configure is not null)
+        {
+            builder.Configure(configure);
+        }
 
         return builder;
     }
@@ -113,16 +111,15 @@ public static class JsonJournalExtensions
         return builder.UseJsonJournalFormat(options => options.AddTypeInfoResolver(typeInfoResolver));
     }
 
-    internal static IServiceCollection AddJsonJournalFormat(this IServiceCollection services, JsonSerializerOptions jsonOptions, bool tryAdd)
+    internal static IServiceCollection AddJsonJournalFormat(this IServiceCollection services, bool tryAdd)
     {
         ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(jsonOptions);
 
         var key = JournalFormatServices.ValidateJournalFormatKey(JournalFormatKey);
-        var options = new JsonJournalOptions { SerializerOptions = jsonOptions };
+        services.AddOptions<JsonJournalOptions>();
         if (tryAdd)
         {
-            services.TryAddSingleton(options);
+            services.TryAddSingleton<JsonJournalOptions>(static sp => sp.GetRequiredService<IOptions<JsonJournalOptions>>().Value);
             services.TryAddSingleton<JsonLinesJournalFormat>();
             services.TryAddKeyedSingleton<IJournalFormat>(key, static (sp, _) => sp.GetRequiredService<JsonLinesJournalFormat>());
             services.TryAddSingleton<IJournalFormat>(static sp => sp.GetRequiredService<JsonLinesJournalFormat>());
@@ -137,7 +134,7 @@ public static class JsonJournalExtensions
         }
         else
         {
-            services.Replace(ServiceDescriptor.Singleton(options));
+            services.Replace(ServiceDescriptor.Singleton<JsonJournalOptions>(static sp => sp.GetRequiredService<IOptions<JsonJournalOptions>>().Value));
             services.AddSingleton<JsonLinesJournalFormat>();
             services.AddKeyedSingleton<IJournalFormat>(key, static (sp, _) => sp.GetRequiredService<JsonLinesJournalFormat>());
             services.AddSingleton<IJournalFormat>(static sp => sp.GetRequiredService<JsonLinesJournalFormat>());

--- a/src/Orleans.Journaling/Formats/Json/JsonJournalExtensions.cs
+++ b/src/Orleans.Journaling/Formats/Json/JsonJournalExtensions.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 
 namespace Orleans.Journaling.Json;
 
@@ -119,7 +118,6 @@ public static class JsonJournalExtensions
         services.AddOptions<JsonJournalOptions>();
         if (tryAdd)
         {
-            services.TryAddSingleton<JsonJournalOptions>(static sp => sp.GetRequiredService<IOptions<JsonJournalOptions>>().Value);
             services.TryAddSingleton<JsonLinesJournalFormat>();
             services.TryAddKeyedSingleton<IJournalFormat>(key, static (sp, _) => sp.GetRequiredService<JsonLinesJournalFormat>());
             services.TryAddSingleton<IJournalFormat>(static sp => sp.GetRequiredService<JsonLinesJournalFormat>());
@@ -134,7 +132,6 @@ public static class JsonJournalExtensions
         }
         else
         {
-            services.Replace(ServiceDescriptor.Singleton<JsonJournalOptions>(static sp => sp.GetRequiredService<IOptions<JsonJournalOptions>>().Value));
             services.AddSingleton<JsonLinesJournalFormat>();
             services.AddKeyedSingleton<IJournalFormat>(key, static (sp, _) => sp.GetRequiredService<JsonLinesJournalFormat>());
             services.AddSingleton<IJournalFormat>(static sp => sp.GetRequiredService<JsonLinesJournalFormat>());

--- a/src/Orleans.Journaling/Formats/Json/JsonTypeInfoHelpers.cs
+++ b/src/Orleans.Journaling/Formats/Json/JsonTypeInfoHelpers.cs
@@ -34,8 +34,8 @@ internal static class JsonTypeInfoHelpers
         return new(
             $"JSON journaling requires System.Text.Json metadata for journaled payload type '{valueType.FullName}'. "
             + "Add the type to a source-generated JsonSerializerContext using [JsonSerializable(typeof(...))] and register the context "
-            + $"with UseJsonJournalFormat(MyJournalJsonContext.Default), {nameof(JsonJournalOptions)}.{nameof(JsonJournalOptions.AddTypeInfoResolver)}, "
-            + $"or {nameof(JsonJournalOptions)}.{nameof(JsonJournalOptions.SerializerOptions)}.{nameof(JsonSerializerOptions.TypeInfoResolver)}.",
+            + $"with UseJsonJournalFormat(MyJournalJsonContext.Default) or Configure<{nameof(JsonJournalOptions)}>(options => "
+            + $"options.{nameof(JsonJournalOptions.AddTypeInfoResolver)}(MyJournalJsonContext.Default)).",
             innerException);
     }
 }

--- a/src/Orleans.Journaling/HostingExtensions.cs
+++ b/src/Orleans.Journaling/HostingExtensions.cs
@@ -14,7 +14,7 @@ public static class HostingExtensions
         builder.Services.TryAddSingleton<IJournaledStateManagerFactory, JournaledStateManagerFactory>();
 
         // Register JSON as the default format family and keep Orleans binary available for existing data.
-        builder.Services.AddJsonJournalFormat(new JsonJournalOptions().SerializerOptions, tryAdd: true);
+        builder.Services.AddJsonJournalFormat(tryAdd: true);
         TryAddOrleansBinaryJournalingFormat(builder.Services);
 
         builder.Services.TryAddKeyedScoped(typeof(IDurableDictionary<,>), KeyedService.AnyKey, typeof(DurableDictionary<,>));

--- a/src/Orleans.Journaling/README.md
+++ b/src/Orleans.Journaling/README.md
@@ -39,12 +39,12 @@ var builder = Host.CreateApplicationBuilder(args)
 await builder.Build().RunAsync();
 ```
 
-If you need to customize `JsonSerializerOptions`, add the generated context through `JsonJournalOptions`:
+If you need to customize `JsonSerializerOptions`, configure `JsonJournalOptions` through the options pipeline:
 
 ```csharp
 siloBuilder
     .AddAzureBlobJournalStorage()
-    .UseJsonJournalFormat(options =>
+    .Configure<JsonJournalOptions>(options =>
     {
         options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
         options.AddTypeInfoResolver(JournalJsonContext.Default);
@@ -90,9 +90,9 @@ public sealed class ShoppingCartGrain(
 }
 ```
 
-All durable state types use the configured JSON codec automatically. `JsonJournalOptions` exposes the `JsonSerializerOptions` instance used for entry payloads. Journaling command names and record shape are fixed by the storage format, so serializer naming policies only affect user payload values.
+All durable state types use the configured JSON codec automatically. Configure `JsonJournalOptions` to control the `JsonSerializerOptions` instance used for entry payloads. Journaling command names and record shape are fixed by the storage format, so serializer naming policies only affect user payload values.
 
-For trimming and Native AOT, configure `SerializerOptions.TypeInfoResolver`, `SerializerOptions.TypeInfoResolverChain`, or `JsonJournalOptions.AddTypeInfoResolver(...)` with source-generated metadata for every journaled key, value, and state type. The `UseJsonJournalFormat(JournalJsonContext.Default)` overload is the recommended low-friction path. If metadata is unavailable, the JSON durable entry codecs fail with a configuration error instead of falling back to reflection-based serialization.
+For trimming and Native AOT, use `Configure<JsonJournalOptions>(...)` to configure `SerializerOptions.TypeInfoResolver`, `SerializerOptions.TypeInfoResolverChain`, or `JsonJournalOptions.AddTypeInfoResolver(...)` with source-generated metadata for every journaled key, value, and state type. The `UseJsonJournalFormat(JournalJsonContext.Default)` overload is the recommended low-friction path when you also want to enable the JSON format explicitly. If metadata is unavailable, the JSON durable entry codecs fail with a configuration error instead of falling back to reflection-based serialization.
 
 ## Storage format
 

--- a/src/api/Azure/Orleans.DurableJobs.AzureStorage/Orleans.DurableJobs.AzureStorage.cs
+++ b/src/api/Azure/Orleans.DurableJobs.AzureStorage/Orleans.DurableJobs.AzureStorage.cs
@@ -12,6 +12,14 @@ namespace Orleans.Hosting
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection UseAzureBlobDurableJobs(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Journaling.AzureBlobJournalStorageOptions> configure) { throw null; }
 
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection UseAzureBlobDurableJobs(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Journaling.AzureBlobJournalStorageOptions> configure, System.Action<Journaling.Json.JsonJournalOptions>? configureJson) { throw null; }
+
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection UseAzureBlobDurableJobs(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Journaling.AzureBlobJournalStorageOptions> configure, System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver typeInfoResolver) { throw null; }
+
         public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, System.Action<Journaling.AzureBlobJournalStorageOptions> configure) { throw null; }
+
+        public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, System.Action<Journaling.AzureBlobJournalStorageOptions> configure, System.Action<Journaling.Json.JsonJournalOptions>? configureJson) { throw null; }
+
+        public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, System.Action<Journaling.AzureBlobJournalStorageOptions> configure, System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver typeInfoResolver) { throw null; }
     }
 }

--- a/src/api/Azure/Orleans.DurableJobs.AzureStorage/Orleans.DurableJobs.AzureStorage.cs
+++ b/src/api/Azure/Orleans.DurableJobs.AzureStorage/Orleans.DurableJobs.AzureStorage.cs
@@ -12,14 +12,6 @@ namespace Orleans.Hosting
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection UseAzureBlobDurableJobs(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Journaling.AzureBlobJournalStorageOptions> configure) { throw null; }
 
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection UseAzureBlobDurableJobs(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Journaling.AzureBlobJournalStorageOptions> configure, System.Action<Journaling.Json.JsonJournalOptions>? configureJson) { throw null; }
-
-        public static Microsoft.Extensions.DependencyInjection.IServiceCollection UseAzureBlobDurableJobs(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Action<Journaling.AzureBlobJournalStorageOptions> configure, System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver typeInfoResolver) { throw null; }
-
         public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, System.Action<Journaling.AzureBlobJournalStorageOptions> configure) { throw null; }
-
-        public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, System.Action<Journaling.AzureBlobJournalStorageOptions> configure, System.Action<Journaling.Json.JsonJournalOptions>? configureJson) { throw null; }
-
-        public static ISiloBuilder UseAzureBlobDurableJobs(this ISiloBuilder builder, System.Action<Journaling.AzureBlobJournalStorageOptions> configure, System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver typeInfoResolver) { throw null; }
     }
 }

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -179,6 +179,8 @@ namespace Orleans.Hosting
     {
         public bool ConcurrencySlowStartEnabled { get { throw null; } set { } }
 
+        public System.TimeSpan JobStatusPollInterval { get { throw null; } set { } }
+
         public int MaxAdoptedCount { get { throw null; } set { } }
 
         public int MaxConcurrentJobsPerSilo { get { throw null; } set { } }
@@ -194,6 +196,8 @@ namespace Orleans.Hosting
         public System.TimeSpan ShardClaimRampUpDuration { get { throw null; } set { } }
 
         public System.TimeSpan ShardDuration { get { throw null; } set { } }
+
+        public int ShardStripeCount { get { throw null; } set { } }
 
         public System.Func<DurableJobs.IJobRunContext, System.Exception, System.DateTimeOffset?> ShouldRetry { get { throw null; } set { } }
 

--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.DurableJobs;
+using Orleans.Journaling.Json;
+using Orleans.Hosting;
+using Xunit;
+
+namespace Tester.AzureUtils.DurableJobs;
+
+#pragma warning disable ORLEANSEXP005
+
+public class AzureStorageDurableJobsConfigurationTests
+{
+    [Fact]
+    public void UseAzureBlobDurableJobs_ComposesDurableJobsAndApplicationJsonMetadata()
+    {
+        var builder = new TestSiloBuilder();
+
+        builder.UseAzureBlobDurableJobs(
+            options =>
+            {
+                options.ConfigureBlobServiceClient("UseDevelopmentStorage=true");
+                options.ContainerName = "durable-jobs-test";
+            },
+            AzureStorageDurableJobsConfigurationTestJsonContext.Default);
+
+        using var serviceProvider = builder.Services.BuildServiceProvider();
+        var options = serviceProvider.GetRequiredService<JsonJournalOptions>();
+
+        Assert.NotNull(options.SerializerOptions.GetTypeInfo(typeof(DurableJob)));
+        Assert.NotNull(options.SerializerOptions.GetTypeInfo(typeof(TestPayload)));
+    }
+
+    public sealed record TestPayload(string Value);
+
+    private sealed class TestSiloBuilder : ISiloBuilder
+    {
+        public IServiceCollection Services { get; } = new ServiceCollection();
+
+        public IConfiguration Configuration { get; } = new ConfigurationBuilder().Build();
+    }
+}
+
+#pragma warning restore ORLEANSEXP005
+
+[JsonSerializable(typeof(AzureStorageDurableJobsConfigurationTests.TestPayload))]
+internal sealed partial class AzureStorageDurableJobsConfigurationTestJsonContext : JsonSerializerContext;

--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.DurableJobs;
@@ -13,26 +12,22 @@ namespace Tester.AzureUtils.DurableJobs;
 public class AzureStorageDurableJobsConfigurationTests
 {
     [Fact]
-    public void UseAzureBlobDurableJobs_ComposesDurableJobsAndApplicationJsonMetadata()
+    public void UseAzureBlobDurableJobs_ConfiguresDurableJobsJsonMetadata()
     {
         var builder = new TestSiloBuilder();
 
-        builder.UseAzureBlobDurableJobs(
-            options =>
-            {
-                options.ConfigureBlobServiceClient("UseDevelopmentStorage=true");
-                options.ContainerName = "durable-jobs-test";
-            },
-            AzureStorageDurableJobsConfigurationTestJsonContext.Default);
+        builder.UseAzureBlobDurableJobs(options =>
+        {
+            options.ConfigureBlobServiceClient("UseDevelopmentStorage=true");
+            options.ContainerName = "durable-jobs-test";
+        });
 
         using var serviceProvider = builder.Services.BuildServiceProvider();
         var options = serviceProvider.GetRequiredService<JsonJournalOptions>();
 
-        Assert.NotNull(options.SerializerOptions.GetTypeInfo(typeof(DurableJob)));
-        Assert.NotNull(options.SerializerOptions.GetTypeInfo(typeof(TestPayload)));
+        var durableJobsJsonContextType = typeof(DurableJob).Assembly.GetType("Orleans.DurableJobs.DurableJobsJsonContext", throwOnError: true);
+        Assert.Contains(options.SerializerOptions.TypeInfoResolverChain, resolver => durableJobsJsonContextType.IsInstanceOfType(resolver));
     }
-
-    public sealed record TestPayload(string Value);
 
     private sealed class TestSiloBuilder : ISiloBuilder
     {
@@ -43,6 +38,3 @@ public class AzureStorageDurableJobsConfigurationTests
 }
 
 #pragma warning restore ORLEANSEXP005
-
-[JsonSerializable(typeof(AzureStorageDurableJobsConfigurationTests.TestPayload))]
-internal sealed partial class AzureStorageDurableJobsConfigurationTestJsonContext : JsonSerializerContext;

--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Orleans.DurableJobs;
 using Orleans.Journaling.Json;
 using Orleans.Hosting;
@@ -22,8 +23,9 @@ public class AzureStorageDurableJobsConfigurationTests
             options.ContainerName = "durable-jobs-test";
         });
 
+        Assert.DoesNotContain(builder.Services, service => service.ServiceType == typeof(JsonJournalOptions));
         using var serviceProvider = builder.Services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<JsonJournalOptions>();
+        var options = serviceProvider.GetRequiredService<IOptions<JsonJournalOptions>>().Value;
 
         var durableJobsJsonContextType = typeof(DurableJob).Assembly.GetType("Orleans.DurableJobs.DurableJobsJsonContext", throwOnError: true);
         Assert.Contains(options.SerializerOptions.TypeInfoResolverChain, resolver => durableJobsJsonContextType.IsInstanceOfType(resolver));

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -21,7 +21,7 @@ public class DurableJobReceiverExtensionTests
         var extension = CreateExtension(handler);
         var context = CreateJobContext("run-1");
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => extension.HandleDurableJobAsync(context, CancellationToken.None));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => extension.HandleDurableJobAsync(context, CancellationToken.None).AsTask());
     }
 
     [Fact]

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -46,6 +46,41 @@ public class DurableJobReceiverExtensionTests
     }
 
     [Fact]
+    public async Task HandleDurableJobAsync_WhenSameJobAttemptHasDifferentRunIds_DeduplicatesExecution()
+    {
+        var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = Substitute.For<IDurableJobHandler>();
+        handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(executionTask.Task);
+
+        var extension = CreateExtension(handler);
+        var firstNotification = CreateJobContext("run-1", jobId: "job-1", dequeueCount: 1);
+        var secondNotification = CreateJobContext("run-2", jobId: "job-1", dequeueCount: 1);
+
+        var first = await extension.HandleDurableJobAsync(firstNotification, CancellationToken.None);
+        var second = await extension.HandleDurableJobAsync(secondNotification, CancellationToken.None);
+
+        Assert.True(first.IsPending);
+        Assert.True(second.IsPending);
+        await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+
+        executionTask.SetResult(true);
+
+        var completed = await WaitForTerminalResult(extension, firstNotification);
+        Assert.Equal(DurableJobRunStatus.Completed, completed.Status);
+        await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+
+        var duplicateAfterCompletion = await extension.HandleDurableJobAsync(secondNotification, CancellationToken.None);
+        Assert.Equal(DurableJobRunStatus.Completed, duplicateAfterCompletion.Status);
+        await handler.Received(1).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+
+        var nextAttempt = CreateJobContext("run-3", jobId: "job-1", dequeueCount: 2);
+        var retryResult = await extension.HandleDurableJobAsync(nextAttempt, CancellationToken.None);
+        Assert.Equal(DurableJobRunStatus.Completed, retryResult.Status);
+        await handler.Received(2).ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public void DurableJobRunResult_Failed_ThrowsForNullException()
     {
         Assert.Throws<ArgumentNullException>(() => DurableJobRunResult.Failed(null!));
@@ -59,15 +94,15 @@ public class DurableJobReceiverExtensionTests
         return new DurableJobReceiverExtension(grainContext, NullLogger<DurableJobReceiverExtension>.Instance, TimeProvider.System);
     }
 
-    private static IJobRunContext CreateJobContext(string runId)
+    private static IJobRunContext CreateJobContext(string runId, string jobId = "job-1", int dequeueCount = 1)
     {
         var context = Substitute.For<IJobRunContext>();
         context.RunId.Returns(runId);
-        context.DequeueCount.Returns(1);
+        context.DequeueCount.Returns(dequeueCount);
         context.Job.Returns(new DurableJob
         {
-            Id = "job-1",
-            Name = "job-1",
+            Id = jobId,
+            Name = jobId,
             DueTime = DateTimeOffset.UtcNow,
             TargetGrainId = GrainId.Create("test", "grain-1"),
             ShardId = "shard-1"
@@ -75,5 +110,20 @@ public class DurableJobReceiverExtensionTests
 
         return context;
     }
-}
 
+    private static async Task<DurableJobRunResult> WaitForTerminalResult(DurableJobReceiverExtension extension, IJobRunContext context)
+    {
+        for (var i = 0; i < 10; i++)
+        {
+            var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+            if (!result.IsPending)
+            {
+                return result;
+            }
+
+            await Task.Yield();
+        }
+
+        throw new TimeoutException("Durable job receiver did not observe terminal job status.");
+    }
+}

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -56,7 +56,7 @@ public class DurableJobReceiverExtensionTests
         var grainContext = Substitute.For<IGrainContext>();
         grainContext.GrainInstance.Returns(handler);
         grainContext.GrainId.Returns(GrainId.Create("test", "grain-1"));
-        return new DurableJobReceiverExtension(grainContext, NullLogger<DurableJobReceiverExtension>.Instance);
+        return new DurableJobReceiverExtension(grainContext, NullLogger<DurableJobReceiverExtension>.Instance, TimeProvider.System);
     }
 
     private static IJobRunContext CreateJobContext(string runId)

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Orleans.DurableJobs;
+using Orleans.Hosting;
 using Orleans.Runtime;
 using Xunit;
 
@@ -46,6 +48,26 @@ public class DurableJobReceiverExtensionTests
     }
 
     [Fact]
+    public async Task HandleDurableJobAsync_WhenExecutionIsPending_UsesConfiguredPollInterval()
+    {
+        var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = Substitute.For<IDurableJobHandler>();
+        handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(executionTask.Task);
+        var pollInterval = TimeSpan.FromMilliseconds(25);
+
+        var extension = CreateExtension(handler, pollInterval);
+        var context = CreateJobContext("run-1");
+
+        var result = await extension.HandleDurableJobAsync(context, CancellationToken.None);
+
+        Assert.True(result.IsPending);
+        Assert.Equal(pollInterval, result.PollAfterDelay);
+
+        executionTask.SetResult(true);
+    }
+
+    [Fact]
     public async Task HandleDurableJobAsync_WhenSameJobAttemptHasDifferentRunIds_DeduplicatesExecution()
     {
         var executionTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -86,12 +108,16 @@ public class DurableJobReceiverExtensionTests
         Assert.Throws<ArgumentNullException>(() => DurableJobRunResult.Failed(null!));
     }
 
-    private static DurableJobReceiverExtension CreateExtension(IDurableJobHandler handler)
+    private static DurableJobReceiverExtension CreateExtension(IDurableJobHandler handler, TimeSpan? jobStatusPollInterval = null)
     {
         var grainContext = Substitute.For<IGrainContext>();
         grainContext.GrainInstance.Returns(handler);
         grainContext.GrainId.Returns(GrainId.Create("test", "grain-1"));
-        return new DurableJobReceiverExtension(grainContext, NullLogger<DurableJobReceiverExtension>.Instance, TimeProvider.System);
+        return new DurableJobReceiverExtension(
+            grainContext,
+            NullLogger<DurableJobReceiverExtension>.Instance,
+            TimeProvider.System,
+            Options.Create(new DurableJobsOptions { JobStatusPollInterval = jobStatusPollInterval ?? TimeSpan.FromSeconds(1) }));
     }
 
     private static IJobRunContext CreateJobContext(string runId, string jobId = "job-1", int dequeueCount = 1)

--- a/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
@@ -130,6 +130,23 @@ public class InMemoryJobQueueTests
     }
 
     [Fact]
+    public async Task GetAsyncEnumerator_WhenDueJobIsEnqueued_WakesWithoutAdvancingTime()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var queue = new InMemoryJobQueue(timeProvider);
+
+        await using var enumerator = queue.GetAsyncEnumerator(CancellationToken.None);
+        var moveNextTask = enumerator.MoveNextAsync().AsTask();
+        await Task.Yield();
+
+        var job = CreateJob("job1", timeProvider.GetUtcNow());
+        queue.Enqueue(job, 0);
+
+        Assert.True(await moveNextTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal(job.Id, enumerator.Current.Job.Id);
+    }
+
+    [Fact]
     public async Task GetAsyncEnumerator_CompletesWhenQueueIsMarkedComplete()
     {
         var queue = new InMemoryJobQueue();

--- a/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
@@ -346,6 +346,70 @@ public class InMemoryJobQueueTests
         });
     }
 
+    [Fact]
+    public async Task Enqueue_WithSameDueTimeAsDrainingBucket_DoesNotStrandJob()
+    {
+        // Regression: Enqueueing a job with the same DueTime as a bucket currently being
+        // drained by the enumerator previously reused the dequeued bucket via _buckets,
+        // but that bucket was no longer in the priority queue, so the new job was stranded.
+        var queue = new InMemoryJobQueue();
+        var sharedDueTime = DateTimeOffset.UtcNow.AddMilliseconds(-100);
+        var job1 = CreateJob("job1", sharedDueTime);
+        var job2 = CreateJob("job2", sharedDueTime);
+
+        queue.Enqueue(job1, 0);
+
+        await using var enumerator = queue.GetAsyncEnumerator(CancellationToken.None);
+
+        // Drain the first job. After this returns, the enumerator is between yields with
+        // the bucket already dequeued from _queue.
+        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal("job1", enumerator.Current.Job.Name);
+        queue.CancelJob(enumerator.Current.Job.Id);
+
+        // Enqueue a second job at the same DueTime. With the bug, this would target the
+        // already-dequeued bucket and never become visible to the enumerator.
+        queue.Enqueue(job2, 0);
+        queue.MarkAsComplete();
+
+        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal("job2", enumerator.Current.Job.Name);
+        queue.CancelJob(enumerator.Current.Job.Id);
+
+        Assert.False(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public async Task Enqueue_AfterBucketProcessingCompletes_CreatesNewBucket()
+    {
+        // After a bucket is fully drained and removed, a subsequent Enqueue at the same
+        // DueTime must create a fresh bucket and re-enter the priority queue so the new
+        // job is processed.
+        var queue = new InMemoryJobQueue();
+        var sharedDueTime = DateTimeOffset.UtcNow.AddMilliseconds(-100);
+        var job1 = CreateJob("job1", sharedDueTime);
+
+        queue.Enqueue(job1, 0);
+
+        await using var enumerator = queue.GetAsyncEnumerator(CancellationToken.None);
+
+        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal("job1", enumerator.Current.Job.Name);
+        queue.CancelJob(enumerator.Current.Job.Id);
+
+        // job1 has been yielded and removed; a new job at the same DueTime must be visible
+        // to the next MoveNextAsync.
+        var job2 = CreateJob("job2", sharedDueTime);
+        queue.Enqueue(job2, 0);
+        queue.MarkAsComplete();
+
+        Assert.True(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Equal("job2", enumerator.Current.Job.Name);
+        queue.CancelJob(enumerator.Current.Job.Id);
+
+        Assert.False(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+    }
+
     private static DurableJob CreateJob(string id, DateTimeOffset dueTime)
     {
         return new DurableJob

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -45,6 +45,30 @@ public class LocalDurableJobManagerTests
     }
 
     [Fact]
+    public async Task ProcessShardCheckCycleAsync_MarksAllExpiredWritableShardStripesComplete()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        options.ShardStripeCount = 2;
+        var shardManager = new TestJobShardManager();
+        var manager = CreateManager(shardManager, timeProvider, options);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+        var shardKey = timeProvider.GetUtcNow().Subtract(options.ShardDuration * 2);
+        var firstShard = CreateSubstituteShard("expired-shard-0", shardKey, shardKey.Add(options.ShardDuration));
+        var secondShard = CreateSubstituteShard("expired-shard-1", shardKey, shardKey.Add(options.ShardDuration));
+
+        accessor.AddWritableShard(shardKey, firstShard, stripe: 0);
+        accessor.AddWritableShard(shardKey, secondShard, stripe: 1);
+
+        await accessor.ProcessShardCheckCycleAsync(CancellationToken.None);
+
+        Assert.False(accessor.HasWritableShard(shardKey, stripe: 0));
+        Assert.False(accessor.HasWritableShard(shardKey, stripe: 1));
+        await firstShard.Received(1).MarkAsCompleteAsync(Arg.Any<CancellationToken>());
+        await secondShard.Received(1).MarkAsCompleteAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ProcessShardCheckCycleAsync_LeavesNonExpiredWritableShardOpen()
     {
         var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
@@ -262,6 +286,70 @@ public class LocalDurableJobManagerTests
         Assert.Equal(1, shard.MarkAsCompleteCallCount);
         Assert.True(shard.IsAddingCompleted);
         Assert.False(accessor.HasWritableShard(shardKey));
+    }
+
+    [Fact]
+    public async Task ScheduleJobAsync_WhenShardStripingEnabled_DistributesJobsAcrossWritableShards()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        options.ShardStripeCount = 4;
+        var shardManager = new TestJobShardManager();
+        var manager = CreateManager(shardManager, timeProvider, options);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+        var dueTime = timeProvider.GetUtcNow().AddMinutes(5);
+        var shardKey = new DateTimeOffset(
+            (dueTime.UtcTicks / options.ShardDuration.Ticks) * options.ShardDuration.Ticks,
+            TimeSpan.Zero);
+        var targetsByStripe = new Dictionary<int, GrainId>();
+        for (var i = 0; i < 10_000 && targetsByStripe.Count < options.ShardStripeCount; i++)
+        {
+            var target = GrainId.Create("test", $"target-{i}");
+            var request = new ScheduleJobRequest
+            {
+                Target = target,
+                JobName = "striped-job",
+                DueTime = dueTime
+            };
+            targetsByStripe.TryAdd(accessor.GetWritableShardStripe(request), target);
+        }
+
+        Assert.Equal(options.ShardStripeCount, targetsByStripe.Count);
+
+        shardManager.CreateShard = (minDueTime, maxDueTime, metadata, _) =>
+        {
+            Assert.Equal(shardKey, minDueTime);
+            Assert.Equal(shardKey.Add(options.ShardDuration), maxDueTime);
+            Assert.True(metadata.TryGetValue("stripe", out var stripe));
+            return Task.FromResult<IJobShard>(new SchedulingShard($"stripe-shard-{stripe}", minDueTime, maxDueTime));
+        };
+
+        var initialJobs = await Task.WhenAll(targetsByStripe
+            .OrderBy(static entry => entry.Key)
+            .Select(entry => manager.ScheduleJobAsync(new()
+            {
+                Target = entry.Value,
+                JobName = "striped-job",
+                DueTime = dueTime
+            }, CancellationToken.None)));
+
+        Assert.Equal(options.ShardStripeCount, shardManager.CreateShardCallCount);
+        Assert.Equal(options.ShardStripeCount, accessor.WritableShardCount);
+        Assert.Equal(options.ShardStripeCount, initialJobs.Select(static job => job.ShardId).Distinct().Count());
+
+        var secondRoundJobs = await Task.WhenAll(targetsByStripe
+            .OrderBy(static entry => entry.Key)
+            .Select(entry => manager.ScheduleJobAsync(new()
+            {
+                Target = entry.Value,
+                JobName = "striped-job",
+                DueTime = dueTime
+            }, CancellationToken.None)));
+
+        Assert.Equal(options.ShardStripeCount, shardManager.CreateShardCallCount);
+        Assert.Equal(
+            initialJobs.Select(static job => job.ShardId).OrderBy(static id => id).ToArray(),
+            secondRoundJobs.Select(static job => job.ShardId).OrderBy(static id => id).ToArray());
     }
 
     [Fact]
@@ -586,7 +674,11 @@ public class LocalDurableJobManagerTests
         var grainContext = Substitute.For<IGrainContext>();
         grainContext.GrainInstance.Returns(handler);
         grainContext.GrainId.Returns(GrainId.Create("test", "target"));
-        var extension = new DurableJobReceiverExtension(grainContext, NullLogger<DurableJobReceiverExtension>.Instance, timeProvider);
+        var extension = new DurableJobReceiverExtension(
+            grainContext,
+            NullLogger<DurableJobReceiverExtension>.Instance,
+            timeProvider,
+            Options.Create(new DurableJobsOptions()));
         var grainFactory = Substitute.For<IInternalGrainFactory>();
         grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
         return (grainFactory, handledJob, () => Volatile.Read(ref handleCount));

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -652,7 +652,7 @@ public class LocalDurableJobManagerTests
             .Returns(callInfo =>
             {
                 handledJob.TrySetResult(callInfo.ArgAt<IJobRunContext>(0));
-                return Task.FromResult(DurableJobRunResult.Completed);
+                return DurableJobRunResult.Completed;
             });
         grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
         return (grainFactory, handledJob);

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -217,6 +217,155 @@ public class LocalDurableJobManagerTests
         Assert.Null(await storageProvider.CreateStorage(JobShardId.Parse(job.ShardId).ToJournalId()).GetMetadataAsync());
     }
 
+    [Fact]
+    public async Task ScheduleJobAsync_WhenJobIsDueNow_DispatchesWithoutAdvancingTime()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        options.ShardDuration = TimeSpan.FromSeconds(1);
+        var storageProvider = new VolatileJournalStorageProvider();
+        await using var services = CreateJournaledServices(storageProvider, timeProvider);
+        var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5010), 0);
+        var localSiloDetails = new TestLocalSiloDetails(siloAddress);
+        var membership = new TestClusterMembershipService();
+        membership.SetSiloStatus(siloAddress, SiloStatus.Active);
+        var optionsWrapper = Options.Create(options);
+        var journaledShardManager = new JournaledJobShardManager(
+            localSiloDetails,
+            services.GetRequiredService<IJournaledStateManagerFactory>(),
+            services.GetRequiredService<IJournalStorageProvider>(),
+            services.GetRequiredService<IJournalStorageCatalog>(),
+            membership,
+            services,
+            optionsWrapper,
+            services.GetRequiredService<IOptions<JournaledStateManagerOptions>>());
+        var (grainFactory, handledJob, getHandleCount) = CreateCountingGrainFactory(timeProvider);
+        var overloadDetector = Substitute.For<IOverloadDetector>();
+        overloadDetector.IsOverloaded.Returns(false);
+        var shardExecutor = new ShardExecutor(
+            grainFactory,
+            optionsWrapper,
+            overloadDetector,
+            NullLogger<ShardExecutor>.Instance,
+            timeProvider);
+        var manager = new LocalDurableJobManager(
+            journaledShardManager,
+            shardExecutor,
+            grainFactory,
+            membership,
+            overloadDetector,
+            timeProvider,
+            optionsWrapper,
+            CreateSystemTargetShared(localSiloDetails),
+            NullLogger<LocalDurableJobManager>.Instance);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+
+        var job = await manager.ScheduleJobAsync(new()
+        {
+            Target = GrainId.Create("test", "target"),
+            JobName = "due-now-job",
+            DueTime = timeProvider.GetUtcNow()
+        }, CancellationToken.None);
+
+        Assert.True(accessor.TryGetRunningShardTask(job.ShardId, out var runTask));
+        var jobContext = await handledJob.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(job.Id, jobContext.Job.Id);
+        Assert.Equal(1, getHandleCount());
+
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+        await accessor.ProcessShardCheckCycleAsync(CancellationToken.None);
+        await AdvanceUntilCompletedAsync(timeProvider, runTask!, TimeSpan.FromSeconds(1));
+        await runTask!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, getHandleCount());
+    }
+
+    [Fact]
+    public async Task ScheduleJobAsync_WhenJobIsDueNow_WaitsForShardConsumer()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        var shardManager = new TestJobShardManager();
+        var (grainFactory, handledJob, _) = CreateCountingGrainFactory(timeProvider);
+        var manager = CreateManager(shardManager, timeProvider, options, grainFactory);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+        var shardKey = timeProvider.GetUtcNow();
+        var shard = new ControlledConsumingShard("controlled-shard", shardKey, shardKey.Add(options.ShardDuration));
+
+        accessor.AddWritableShard(shardKey, shard);
+        accessor.TryActivateShard(shard);
+        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var job = await manager.ScheduleJobAsync(new()
+        {
+            Target = GrainId.Create("test", "target"),
+            JobName = "due-now-job",
+            DueTime = shardKey
+        }, CancellationToken.None);
+
+        var unexpectedDispatch = await Task.WhenAny(handledJob.Task, Task.Delay(TimeSpan.FromMilliseconds(100)));
+        Assert.NotSame(handledJob.Task, unexpectedDispatch);
+
+        shard.AllowConsume.SetResult();
+
+        var jobContext = await handledJob.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(job.Id, jobContext.Job.Id);
+    }
+
+    [Fact]
+    public async Task ScheduleJobAsync_WhenJobIsDueInFuture_DoesNotDispatchImmediately()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        options.ShardDuration = TimeSpan.FromSeconds(1);
+        var storageProvider = new VolatileJournalStorageProvider();
+        await using var services = CreateJournaledServices(storageProvider, timeProvider);
+        var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5010), 0);
+        var localSiloDetails = new TestLocalSiloDetails(siloAddress);
+        var membership = new TestClusterMembershipService();
+        membership.SetSiloStatus(siloAddress, SiloStatus.Active);
+        var optionsWrapper = Options.Create(options);
+        var journaledShardManager = new JournaledJobShardManager(
+            localSiloDetails,
+            services.GetRequiredService<IJournaledStateManagerFactory>(),
+            services.GetRequiredService<IJournalStorageProvider>(),
+            services.GetRequiredService<IJournalStorageCatalog>(),
+            membership,
+            services,
+            optionsWrapper,
+            services.GetRequiredService<IOptions<JournaledStateManagerOptions>>());
+        var (grainFactory, handledJob, getHandleCount) = CreateCountingGrainFactory(timeProvider);
+        var overloadDetector = Substitute.For<IOverloadDetector>();
+        overloadDetector.IsOverloaded.Returns(false);
+        var shardExecutor = new ShardExecutor(
+            grainFactory,
+            optionsWrapper,
+            overloadDetector,
+            NullLogger<ShardExecutor>.Instance,
+            timeProvider);
+        var manager = new LocalDurableJobManager(
+            journaledShardManager,
+            shardExecutor,
+            grainFactory,
+            membership,
+            overloadDetector,
+            timeProvider,
+            optionsWrapper,
+            CreateSystemTargetShared(localSiloDetails),
+            NullLogger<LocalDurableJobManager>.Instance);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+
+        var job = await manager.ScheduleJobAsync(new()
+        {
+            Target = GrainId.Create("test", "target"),
+            JobName = "future-job",
+            DueTime = timeProvider.GetUtcNow().AddSeconds(5)
+        }, CancellationToken.None);
+
+        Assert.False(handledJob.Task.IsCompleted);
+        Assert.Equal(0, getHandleCount());
+        Assert.False(accessor.TryGetRunningShardTask(job.ShardId, out _));
+    }
+
     private static DurableJobsOptions CreateOptions() => new()
     {
         ShardDuration = TimeSpan.FromMinutes(1),
@@ -229,11 +378,12 @@ public class LocalDurableJobManagerTests
     private static LocalDurableJobManager CreateManager(
         JobShardManager shardManager,
         FakeTimeProvider timeProvider,
-        DurableJobsOptions options)
+        DurableJobsOptions options,
+        IInternalGrainFactory? grainFactory = null)
     {
         var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5000), 0);
         var localSiloDetails = new TestLocalSiloDetails(siloAddress);
-        var grainFactory = Substitute.For<IInternalGrainFactory>();
+        grainFactory ??= Substitute.For<IInternalGrainFactory>();
         var overloadDetector = Substitute.For<IOverloadDetector>();
         overloadDetector.IsOverloaded.Returns(false);
         var optionsWrapper = Options.Create(options);
@@ -312,6 +462,28 @@ public class LocalDurableJobManagerTests
         return (grainFactory, handledJob);
     }
 
+    private static (IInternalGrainFactory GrainFactory, TaskCompletionSource<IJobRunContext> HandledJob, Func<int> GetHandleCount) CreateCountingGrainFactory(TimeProvider timeProvider)
+    {
+        var handledJob = new TaskCompletionSource<IJobRunContext>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handleCount = 0;
+        var handler = Substitute.For<IDurableJobHandler>();
+        handler.ExecuteJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                Interlocked.Increment(ref handleCount);
+                handledJob.TrySetResult(callInfo.ArgAt<IJobRunContext>(0));
+                return Task.CompletedTask;
+            });
+
+        var grainContext = Substitute.For<IGrainContext>();
+        grainContext.GrainInstance.Returns(handler);
+        grainContext.GrainId.Returns(GrainId.Create("test", "target"));
+        var extension = new DurableJobReceiverExtension(grainContext, NullLogger<DurableJobReceiverExtension>.Instance, timeProvider);
+        var grainFactory = Substitute.For<IInternalGrainFactory>();
+        grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
+        return (grainFactory, handledJob, () => Volatile.Read(ref handleCount));
+    }
+
     private static async Task AdvanceUntilCompletedAsync(FakeTimeProvider timeProvider, Task task, TimeSpan advanceBy)
     {
         for (var i = 0; i < 10 && !task.IsCompleted; i++)
@@ -367,6 +539,61 @@ public class LocalDurableJobManagerTests
             ConsumeStarted.TrySetResult();
             await _completed.Task.WaitAsync(cancellationToken);
             yield break;
+        }
+    }
+
+    private sealed class ControlledConsumingShard(string id, DateTimeOffset start, DateTimeOffset end) : IJobShard
+    {
+        private readonly TaskCompletionSource<DurableJob> _scheduledJob = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ConsumeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowConsume { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string Id { get; } = id;
+
+        public DateTimeOffset StartTime { get; } = start;
+
+        public DateTimeOffset EndTime { get; } = end;
+
+        public IDictionary<string, string>? Metadata => null;
+
+        public bool IsAddingCompleted => false;
+
+        public IAsyncEnumerable<IJobRunContext> ConsumeDurableJobsAsync() => ConsumeAsync();
+
+        public ValueTask<int> GetJobCountAsync() => ValueTask.FromResult(_scheduledJob.Task.IsCompleted ? 1 : 0);
+
+        public Task MarkAsCompleteAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(true);
+
+        public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
+        {
+            var job = new DurableJob
+            {
+                Id = Guid.NewGuid().ToString(),
+                Name = request.JobName,
+                DueTime = request.DueTime,
+                TargetGrainId = request.Target,
+                ShardId = Id,
+                Metadata = request.Metadata
+            };
+
+            _scheduledJob.SetResult(job);
+            return Task.FromResult<DurableJob?>(job);
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        private async IAsyncEnumerable<IJobRunContext> ConsumeAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            ConsumeStarted.TrySetResult();
+            var job = await _scheduledJob.Task.WaitAsync(cancellationToken);
+            await AllowConsume.Task.WaitAsync(cancellationToken);
+            yield return new JobRunContext(job, Guid.NewGuid().ToString(), retryCount: 1);
         }
     }
 

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -120,6 +120,114 @@ public class LocalDurableJobManagerTests
     }
 
     [Fact]
+    public async Task CompletedWritableShardCleanup_RemovesWritableShard()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        var shardManager = new TestJobShardManager();
+        var manager = CreateManager(shardManager, timeProvider, options);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+        var shardKey = timeProvider.GetUtcNow();
+        var shard = new CompletingShard("completed-writable-shard", shardKey, shardKey.Add(options.ShardDuration));
+
+        accessor.AddWritableShard(shardKey, shard);
+        accessor.TryActivateShard(shard);
+
+        Assert.True(accessor.TryGetRunningShardTask(shard.Id, out var runTask));
+
+        await shard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await shard.MarkAsCompleteAsync(CancellationToken.None);
+        await runTask!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(accessor.HasWritableShard(shardKey));
+        Assert.False(accessor.HasCachedShard(shard.Id));
+        Assert.False(accessor.TryGetRunningShardTask(shard.Id, out _));
+        Assert.Same(shard, Assert.Single(shardManager.UnregisteredShards));
+        Assert.Equal(1, shard.DisposeCallCount);
+    }
+
+    [Fact]
+    public async Task CompletedWritableShardCleanup_DoesNotRemoveReplacementWritableShard()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        var shardManager = new TestJobShardManager();
+        var manager = CreateManager(shardManager, timeProvider, options);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+        var shardKey = timeProvider.GetUtcNow();
+        var completedShard = new CompletingShard("completed-writable-shard", shardKey, shardKey.Add(options.ShardDuration));
+        var replacementShard = CreateSubstituteShard("replacement-writable-shard", shardKey, shardKey.Add(options.ShardDuration));
+
+        accessor.AddWritableShard(shardKey, completedShard);
+        accessor.TryActivateShard(completedShard);
+
+        Assert.True(accessor.TryGetRunningShardTask(completedShard.Id, out var runTask));
+
+        await completedShard.ConsumeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        accessor.AddWritableShard(shardKey, replacementShard);
+        await completedShard.MarkAsCompleteAsync(CancellationToken.None);
+        await runTask!.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(accessor.TryGetWritableShard(shardKey, out var currentShard));
+        Assert.Same(replacementShard, currentShard);
+    }
+
+    [Fact]
+    public async Task ProcessShardCheckCycleAsync_WhenExpiredWritableShardIsDisposed_RemovesWritableShard()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        var shardManager = new TestJobShardManager();
+        var manager = CreateManager(shardManager, timeProvider, options);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+        var shardKey = timeProvider.GetUtcNow().Subtract(options.ShardDuration * 2);
+        var shard = new DisposedSchedulingShard("disposed-expired-shard", shardKey, shardKey.Add(options.ShardDuration));
+
+        accessor.AddWritableShard(shardKey, shard);
+
+        await accessor.ProcessShardCheckCycleAsync(CancellationToken.None);
+
+        Assert.False(accessor.HasWritableShard(shardKey));
+    }
+
+    [Fact]
+    public async Task ScheduleJobAsync_WhenWritableShardIsDisposed_RemovesStaleShardAndRetries()
+    {
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = CreateOptions();
+        var shardManager = new TestJobShardManager();
+        var manager = CreateManager(shardManager, timeProvider, options);
+        var accessor = new LocalDurableJobManager.TestAccessor(manager);
+        var dueTime = timeProvider.GetUtcNow().AddMinutes(5);
+        var shardKey = new DateTimeOffset(
+            (dueTime.UtcTicks / options.ShardDuration.Ticks) * options.ShardDuration.Ticks,
+            TimeSpan.Zero);
+        var staleShard = new DisposedSchedulingShard("disposed-writable-shard", shardKey, shardKey.Add(options.ShardDuration));
+        var replacementShard = new SchedulingShard("replacement-writable-shard", shardKey, shardKey.Add(options.ShardDuration));
+        shardManager.CreateShard = (minDueTime, maxDueTime, _, _) =>
+        {
+            Assert.Equal(shardKey, minDueTime);
+            Assert.Equal(shardKey.Add(options.ShardDuration), maxDueTime);
+            return Task.FromResult<IJobShard>(replacementShard);
+        };
+
+        accessor.AddWritableShard(shardKey, staleShard);
+
+        var job = await manager.ScheduleJobAsync(new()
+        {
+            Target = GrainId.Create("test", "target"),
+            JobName = "retried-job",
+            DueTime = dueTime
+        }, CancellationToken.None);
+
+        Assert.Equal("retried-job", job.Name);
+        Assert.Equal(replacementShard.Id, job.ShardId);
+        Assert.Equal(1, shardManager.CreateShardCallCount);
+        Assert.True(accessor.TryGetWritableShard(shardKey, out var currentShard));
+        Assert.Same(replacementShard, currentShard);
+    }
+
+    [Fact]
     public async Task ScheduleJobAsync_WhenExpiryWaitsBehindScheduling_CompletesShardAfterJobIsAccepted()
     {
         var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
@@ -597,6 +705,83 @@ public class LocalDurableJobManagerTests
         }
     }
 
+    private sealed class DisposedSchedulingShard(string id, DateTimeOffset start, DateTimeOffset end) : IJobShard
+    {
+        public string Id { get; } = id;
+
+        public DateTimeOffset StartTime { get; } = start;
+
+        public DateTimeOffset EndTime { get; } = end;
+
+        public IDictionary<string, string>? Metadata => null;
+
+        public bool IsAddingCompleted => true;
+
+        public IAsyncEnumerable<IJobRunContext> ConsumeDurableJobsAsync() => ConsumeAsync();
+
+        public ValueTask<int> GetJobCountAsync() => ValueTask.FromResult(0);
+
+        public Task MarkAsCompleteAsync(CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
+
+        public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
+
+        public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
+
+        public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken) => throw new ObjectDisposedException(GetType().FullName);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        private static async IAsyncEnumerable<IJobRunContext> ConsumeAsync()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    private sealed class SchedulingShard(string id, DateTimeOffset start, DateTimeOffset end) : IJobShard
+    {
+        public string Id { get; } = id;
+
+        public DateTimeOffset StartTime { get; } = start;
+
+        public DateTimeOffset EndTime { get; } = end;
+
+        public IDictionary<string, string>? Metadata => null;
+
+        public bool IsAddingCompleted => false;
+
+        public IAsyncEnumerable<IJobRunContext> ConsumeDurableJobsAsync() => ConsumeAsync();
+
+        public ValueTask<int> GetJobCountAsync() => ValueTask.FromResult(0);
+
+        public Task MarkAsCompleteAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task<bool> RemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.FromResult(false);
+
+        public Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task<DurableJob?> TryScheduleJobAsync(ScheduleJobRequest request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<DurableJob?>(new()
+            {
+                Id = Guid.NewGuid().ToString(),
+                Name = request.JobName,
+                DueTime = request.DueTime,
+                TargetGrainId = request.Target,
+                ShardId = Id,
+                Metadata = request.Metadata
+            });
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        private static async IAsyncEnumerable<IJobRunContext> ConsumeAsync()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
     private sealed class GateableSchedulingShard(string id, DateTimeOffset start, DateTimeOffset end) : IJobShard
     {
         private readonly SemaphoreSlim _lock = new(1, 1);
@@ -687,6 +872,10 @@ public class LocalDurableJobManagerTests
 
         public List<IJobShard> UnregisteredShards { get; } = [];
 
+        public Func<DateTimeOffset, DateTimeOffset, IDictionary<string, string>, CancellationToken, Task<IJobShard>>? CreateShard { get; set; }
+
+        public int CreateShardCallCount { get; private set; }
+
         public DateTimeOffset LastMaxDueTime { get; private set; }
 
         public override Task<List<IJobShard>> AssignJobShardsAsync(DateTimeOffset maxDueTime, int maxNewClaims, CancellationToken cancellationToken)
@@ -696,7 +885,12 @@ public class LocalDurableJobManagerTests
         }
 
         public override Task<IJobShard> CreateShardAsync(DateTimeOffset minDueTime, DateTimeOffset maxDueTime, IDictionary<string, string> metadata, CancellationToken cancellationToken)
-            => throw new NotSupportedException();
+        {
+            CreateShardCallCount++;
+            return CreateShard is null
+                ? throw new NotSupportedException()
+                : CreateShard(minDueTime, maxDueTime, metadata, cancellationToken);
+        }
 
         public override Task UnregisterShardAsync(IJobShard shard, CancellationToken cancellationToken)
         {

--- a/test/Orleans.Core.Tests/DurableJobs/ShardClaimBudgetTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardClaimBudgetTests.cs
@@ -193,6 +193,34 @@ public class ShardClaimBudgetTests
     }
 
     [Fact]
+    public void ValidateConfiguration_NonPositiveShardStripeCount_Throws()
+    {
+        var options = Options.Create(new DurableJobsOptions
+        {
+            ShardStripeCount = 0
+        });
+        var validator = new DurableJobsOptionsValidator(
+            NullLogger<DurableJobsOptionsValidator>.Instance,
+            options);
+
+        Assert.Throws<OrleansConfigurationException>(validator.ValidateConfiguration);
+    }
+
+    [Fact]
+    public void ValidateConfiguration_NonPositiveJobStatusPollInterval_Throws()
+    {
+        var options = Options.Create(new DurableJobsOptions
+        {
+            JobStatusPollInterval = TimeSpan.Zero
+        });
+        var validator = new DurableJobsOptionsValidator(
+            NullLogger<DurableJobsOptionsValidator>.Instance,
+            options);
+
+        Assert.Throws<OrleansConfigurationException>(validator.ValidateConfiguration);
+    }
+
+    [Fact]
     public void ValidateConfiguration_ValidShardClaimOptions_DoesNotThrow()
     {
         var options = Options.Create(new DurableJobsOptions

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -310,11 +310,11 @@ public class ShardExecutorTests
                 if (currentCall == 1)
                 {
                     firstCall.SetResult();
-                    return Task.FromResult(DurableJobRunResult.PollAfter(TimeSpan.FromSeconds(5)));
+                    return DurableJobRunResult.PollAfter(TimeSpan.FromSeconds(5));
                 }
 
                 secondCall.SetResult();
-                return Task.FromResult(DurableJobRunResult.Completed);
+                return DurableJobRunResult.Completed;
             });
         grainFactory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
         var executor = new ShardExecutor(grainFactory, options, overloadDetector, NullLogger<ShardExecutor>.Instance, timeProvider);
@@ -729,7 +729,7 @@ public class ShardExecutorTests
                 {
                     completedJobs.Add(context.Job.Id);
                 }
-                return Task.FromResult(DurableJobRunResult.Completed);
+                return DurableJobRunResult.Completed;
             });
         
         factory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
@@ -741,11 +741,11 @@ public class ShardExecutorTests
     {
         var extension = Substitute.For<IDurableJobReceiverExtension>();
         extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
-            .Returns(async callInfo =>
+            .Returns((Func<NSubstitute.Core.CallInfo, ValueTask<DurableJobRunResult>>)(async callInfo =>
             {
                 await executionAction();
                 return DurableJobRunResult.Completed;
-            });
+            }));
         
         factory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
     }
@@ -773,7 +773,7 @@ public class ShardExecutorTests
                         failedJobs.Add(context.Job.Id);
                     }
                     var exception = new InvalidOperationException("Simulated job failure");
-                    return Task.FromResult(DurableJobRunResult.Failed(exception));
+                    return DurableJobRunResult.Failed(exception);
                 }
                 
                 // Other jobs succeed
@@ -781,7 +781,7 @@ public class ShardExecutorTests
                 {
                     completedJobs.Add(context.Job.Id);
                 }
-                return Task.FromResult(DurableJobRunResult.Completed);
+                return DurableJobRunResult.Completed;
             });
         
         factory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
@@ -795,7 +795,7 @@ public class ShardExecutorTests
 
         var extension = Substitute.For<IDurableJobReceiverExtension>();
         extension.HandleDurableJobAsync(Arg.Any<IJobRunContext>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromCanceled<DurableJobRunResult>(new CancellationToken(canceled: true)));
+            .Returns(ValueTask.FromCanceled<DurableJobRunResult>(new CancellationToken(canceled: true)));
 
         factory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
 
@@ -816,9 +816,9 @@ public class ShardExecutorTests
                 var currentCall = Interlocked.Increment(ref callBox.Value);
                 if (currentCall < 4)
                 {
-                    return Task.FromResult(DurableJobRunResult.PollAfter(TimeSpan.FromMilliseconds(10)));
+                    return DurableJobRunResult.PollAfter(TimeSpan.FromMilliseconds(10));
                 }
-                return Task.FromResult(DurableJobRunResult.Completed);
+                return DurableJobRunResult.Completed;
             });
         
         factory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
@@ -840,10 +840,10 @@ public class ShardExecutorTests
                 var currentCall = Interlocked.Increment(ref callBox.Value);
                 if (currentCall < 4)
                 {
-                    return Task.FromResult(DurableJobRunResult.PollAfter(TimeSpan.FromMilliseconds(10)));
+                    return DurableJobRunResult.PollAfter(TimeSpan.FromMilliseconds(10));
                 }
                 var exception = new InvalidOperationException("Job failed after polling");
-                return Task.FromResult(DurableJobRunResult.Failed(exception));
+                return DurableJobRunResult.Failed(exception);
             });
         
         factory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);
@@ -875,9 +875,9 @@ public class ShardExecutorTests
                 
                 if (currentCall < 4)
                 {
-                    return Task.FromResult(DurableJobRunResult.PollAfter(TimeSpan.FromMilliseconds(pollDelayMs)));
+                    return DurableJobRunResult.PollAfter(TimeSpan.FromMilliseconds(pollDelayMs));
                 }
-                return Task.FromResult(DurableJobRunResult.Completed);
+                return DurableJobRunResult.Completed;
             });
         
         factory.GetGrain<IDurableJobReceiverExtension>(Arg.Any<GrainId>()).Returns(extension);

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardManagerTests.cs
@@ -1,4 +1,7 @@
+using System.Buffers;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Diagnostics.Metrics;
 using System.Net;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -131,7 +134,7 @@ public class JournaledJobShardManagerTests
         Assert.NotNull(scheduled);
 
         await shard.MarkAsCompleteAsync(CancellationToken.None);
-        await shard.DisposeAsync();
+        await manager.UnregisterShardAsync(shard, CancellationToken.None);
 
         var reopenedManager = CreateManager(services, membership, silo);
         var reopened = await reopenedManager.AssignJobShardsAsync(DateTimeOffset.UtcNow.AddHours(1), int.MaxValue, CancellationToken.None);
@@ -155,6 +158,121 @@ public class JournaledJobShardManagerTests
 
         Assert.Equal(0, await shard.GetJobCountAsync());
         await reopenedManager.UnregisterShardAsync(shard, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ConcurrentSchedules_ArePersistedInStorageBatches()
+    {
+        const int JobCount = 32;
+        var storageProvider = new CountingJournalStorageProvider(delayAppends: true);
+        using var services = CreateServices(storageProvider);
+        var membership = new TestClusterMembershipService();
+        var silo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5016), 0);
+        membership.SetSiloStatus(silo, SiloStatus.Active);
+        var manager = CreateManager(services, membership, silo);
+        var start = DateTimeOffset.UtcNow.AddMinutes(-1);
+        var end = start.AddHours(1);
+        var shard = await manager.CreateShardAsync(
+            start,
+            end,
+            new Dictionary<string, string> { ["Purpose"] = "ConcurrentBatching" },
+            CancellationToken.None);
+        var observedBatchSizes = new ConcurrentBag<long>();
+        using var listener = CreateStorageBatchSizeListener(observedBatchSizes);
+
+        var scheduleTasks = Enumerable.Range(0, JobCount)
+            .Select(index => shard.TryScheduleJobAsync(new()
+            {
+                Target = GrainId.Create("type", $"target-{index}"),
+                JobName = $"batched-job-{index}",
+                DueTime = start.AddSeconds(1),
+                Metadata = null
+            }, CancellationToken.None))
+            .ToArray();
+
+        await storageProvider.AppendStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        storageProvider.AllowAppends();
+        var scheduledJobs = await Task.WhenAll(scheduleTasks).WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.All(scheduledJobs, job => Assert.NotNull(job));
+        Assert.True(
+            storageProvider.AppendCount < JobCount,
+            $"Expected fewer storage appends than scheduled jobs, but saw {storageProvider.AppendCount} appends for {JobCount} jobs.");
+        Assert.Contains(observedBatchSizes, size => size > 1);
+
+        await manager.UnregisterShardAsync(shard, CancellationToken.None);
+
+        var reopenedManager = CreateManager(services, membership, silo);
+        var reopened = await reopenedManager.AssignJobShardsAsync(end, int.MaxValue, CancellationToken.None);
+        var reopenedShard = Assert.Single(reopened);
+        var consumed = new List<IJobRunContext>();
+        await foreach (var jobContext in reopenedShard.ConsumeDurableJobsAsync().WithCancellation(CancellationToken.None))
+        {
+            consumed.Add(jobContext);
+            await reopenedShard.RemoveJobAsync(jobContext.Job.Id, CancellationToken.None);
+        }
+
+        Assert.Equal(JobCount, consumed.Count);
+        Assert.Subset(
+            consumed.Select(context => context.Job.Id).ToHashSet(StringComparer.Ordinal),
+            scheduledJobs.Select(job => job!.Id).ToHashSet(StringComparer.Ordinal));
+
+        await reopenedManager.UnregisterShardAsync(reopenedShard, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ConcurrentSchedules_WhenOneRequestIsInvalid_PersistsOtherRequests()
+    {
+        const int JobCount = 8;
+        const int InvalidIndex = 3;
+        var storageProvider = new CountingJournalStorageProvider(delayAppends: true);
+        using var services = CreateServices(storageProvider);
+        var membership = new TestClusterMembershipService();
+        var silo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 5017), 0);
+        membership.SetSiloStatus(silo, SiloStatus.Active);
+        var manager = CreateManager(services, membership, silo);
+        var start = DateTimeOffset.UtcNow.AddMinutes(-1);
+        var end = start.AddHours(1);
+        var shard = await manager.CreateShardAsync(
+            start,
+            end,
+            new Dictionary<string, string> { ["Purpose"] = "ConcurrentBatchingInvalidItem" },
+            CancellationToken.None);
+
+        var scheduleTasks = Enumerable.Range(0, JobCount)
+            .Select(index => shard.TryScheduleJobAsync(new()
+            {
+                Target = GrainId.Create("type", $"target-{index}"),
+                JobName = $"batched-job-{index}",
+                DueTime = index == InvalidIndex ? end.AddSeconds(1) : start.AddSeconds(1),
+                Metadata = null
+            }, CancellationToken.None))
+            .ToArray();
+
+        await storageProvider.AppendStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        storageProvider.AllowAppends();
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => scheduleTasks[InvalidIndex].WaitAsync(TimeSpan.FromSeconds(5)));
+        var scheduledJobs = await Task.WhenAll(scheduleTasks.Where((_, index) => index != InvalidIndex)).WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.All(scheduledJobs, job => Assert.NotNull(job));
+        Assert.True(
+            storageProvider.AppendCount < JobCount,
+            $"Expected fewer storage appends than scheduled jobs, but saw {storageProvider.AppendCount} appends for {JobCount - 1} valid jobs.");
+
+        await manager.UnregisterShardAsync(shard, CancellationToken.None);
+
+        var reopenedManager = CreateManager(services, membership, silo);
+        var reopened = await reopenedManager.AssignJobShardsAsync(end, int.MaxValue, CancellationToken.None);
+        var reopenedShard = Assert.Single(reopened);
+        var consumed = new List<IJobRunContext>();
+        await foreach (var jobContext in reopenedShard.ConsumeDurableJobsAsync().WithCancellation(CancellationToken.None))
+        {
+            consumed.Add(jobContext);
+            await reopenedShard.RemoveJobAsync(jobContext.Job.Id, CancellationToken.None);
+        }
+
+        Assert.Equal(JobCount - 1, consumed.Count);
+        await reopenedManager.UnregisterShardAsync(reopenedShard, CancellationToken.None);
     }
 
     [Fact]
@@ -386,7 +504,7 @@ public class JournaledJobShardManagerTests
         }
     }
 
-    private static ServiceProvider CreateServices(VolatileJournalStorageProvider storageProvider)
+    private static ServiceProvider CreateServices(IJournalStorageProvider storageProvider)
     {
         var builder = new TestSiloBuilder();
         builder.AddJournalStorage();
@@ -394,8 +512,95 @@ public class JournaledJobShardManagerTests
         builder.Services.AddLogging();
         builder.Services.AddSingleton(TimeProvider.System);
         builder.Services.AddSingleton<IJournalStorageProvider>(storageProvider);
-        builder.Services.AddSingleton<IJournalStorageCatalog>(storageProvider);
+        builder.Services.AddSingleton((IJournalStorageCatalog)storageProvider);
         return builder.Services.BuildServiceProvider();
+    }
+
+    private static MeterListener CreateStorageBatchSizeListener(ConcurrentBag<long> observedBatchSizes)
+    {
+        var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == "Microsoft.Orleans" && instrument.Name == "orleans-durablejobs-storage-batch-size")
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, measurement, _, _) => observedBatchSizes.Add(measurement));
+        listener.Start();
+        return listener;
+    }
+
+    private sealed class CountingJournalStorageProvider : IJournalStorageProvider, IJournalStorageCatalog
+    {
+        private readonly VolatileJournalStorageProvider _inner = new();
+        private readonly bool _delayAppends;
+        private readonly TaskCompletionSource _appendStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _allowAppends = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _appendCount;
+
+        public CountingJournalStorageProvider(bool delayAppends)
+        {
+            _delayAppends = delayAppends;
+            if (!delayAppends)
+            {
+                _allowAppends.SetResult();
+            }
+        }
+
+        public Task AppendStarted => _appendStarted.Task;
+
+        public int AppendCount => Volatile.Read(ref _appendCount);
+
+        public void AllowAppends() => _allowAppends.TrySetResult();
+
+        public IJournalStorage CreateStorage(JournalId journalId) => new CountingJournalStorage(this, _inner.CreateStorage(journalId));
+
+        public IAsyncEnumerable<JournalId> ListAsync(JournalId prefix = default, CancellationToken cancellationToken = default)
+            => _inner.ListAsync(prefix, cancellationToken);
+
+        private async ValueTask OnAppendAsync(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _appendCount);
+            _appendStarted.TrySetResult();
+            if (_delayAppends)
+            {
+                await _allowAppends.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private sealed class CountingJournalStorage(CountingJournalStorageProvider owner, IJournalStorage inner) : IJournalStorage
+        {
+            public bool IsCompactionRequested => inner.IsCompactionRequested;
+
+            public ValueTask<bool> CreateIfNotExistsAsync(IReadOnlyDictionary<string, string> metadata = null, CancellationToken cancellationToken = default)
+                => inner.CreateIfNotExistsAsync(metadata, cancellationToken);
+
+            public ValueTask<IJournalMetadata> GetMetadataAsync(CancellationToken cancellationToken = default)
+                => inner.GetMetadataAsync(cancellationToken);
+
+            public ValueTask<IJournalMetadata> UpdateMetadataAsync(
+                IReadOnlyDictionary<string, string> set = null,
+                IEnumerable<string> remove = null,
+                string expectedETag = null,
+                CancellationToken cancellationToken = default)
+                => inner.UpdateMetadataAsync(set, remove, expectedETag, cancellationToken);
+
+            public ValueTask ReadAsync(IJournalStorageConsumer consumer, CancellationToken cancellationToken)
+                => inner.ReadAsync(consumer, cancellationToken);
+
+            public async ValueTask AppendAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
+            {
+                await owner.OnAppendAsync(cancellationToken).ConfigureAwait(false);
+                await inner.AppendAsync(value, cancellationToken).ConfigureAwait(false);
+            }
+
+            public ValueTask ReplaceAsync(ReadOnlySequence<byte> value, CancellationToken cancellationToken)
+                => inner.ReplaceAsync(value, cancellationToken);
+
+            public ValueTask DeleteAsync(CancellationToken cancellationToken)
+                => inner.DeleteAsync(cancellationToken);
+        }
     }
 
     private static JournaledJobShardManager CreateManager(

--- a/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardStateTests.cs
+++ b/test/Orleans.DurableJobs.Tests/DurableJobs/JournaledJobShardStateTests.cs
@@ -120,6 +120,22 @@ public class JournaledJobShardStateTests
         Assert.Equal(shardId, JobShardId.FromJournalId(storageId));
     }
 
+    [Fact]
+    public void Apply_DefaultKind_Throws()
+    {
+        var shardId = new JobShardId("shard-default-kind");
+        var start = DateTimeOffset.UtcNow;
+        var state = new JournaledJobShardState(shardId, start, start.AddHours(1));
+
+        // A default-constructed record has Kind == DurableJobShardJournalRecordKind.None.
+        // This simulates an uninitialized record or a JSON payload where 'kind' was omitted
+        // because the serializer is configured to skip default-valued properties.
+        var record = new DurableJobShardJournalRecord();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => state.Apply(record));
+        Assert.Contains("uninitialized Kind", exception.Message, StringComparison.Ordinal);
+    }
+
     private static DurableJob CreateJob(JobShardId shardId, string id, string name, DateTimeOffset dueTime) => new()
     {
         Id = id,

--- a/test/Orleans.Journaling.Json.Tests/CodecRecoveryTests.cs
+++ b/test/Orleans.Journaling.Json.Tests/CodecRecoveryTests.cs
@@ -364,7 +364,7 @@ public class CodecRecoveryTests : JournalingTestBase
         var services = new ServiceCollection();
         services.AddSerializer();
         services.AddLogging();
-        services.AddSingleton(new JsonJournalOptions { SerializerOptions = jsonOptions });
+        services.Configure<JsonJournalOptions>(options => options.SerializerOptions = jsonOptions);
         services.AddKeyedSingleton<IJournalFormat>(JsonJournalExtensions.JournalFormatKey, new JsonLinesJournalFormat());
         services.AddKeyedSingleton(
             typeof(IDurableDictionaryCommandCodec<,>),
@@ -389,7 +389,7 @@ public class CodecRecoveryTests : JournalingTestBase
             typeof(OrleansBinaryDurableDictionaryCommandCodec<,>));
 
         var jsonOptions = CreateJsonOptions();
-        services.AddSingleton(new JsonJournalOptions { SerializerOptions = jsonOptions });
+        services.Configure<JsonJournalOptions>(options => options.SerializerOptions = jsonOptions);
         services.AddKeyedSingleton<IJournalFormat>(JsonJournalExtensions.JournalFormatKey, new JsonLinesJournalFormat());
         services.AddKeyedSingleton(
             typeof(IDurableDictionaryCommandCodec<,>),

--- a/test/Orleans.Journaling.Json.Tests/JsonCodecTests.cs
+++ b/test/Orleans.Journaling.Json.Tests/JsonCodecTests.cs
@@ -65,6 +65,22 @@ public class JsonCodecTests
     }
 
     [Fact]
+    public void ConfigureJsonJournalOptions_AfterAddJournalStorage_RegistersPayloadMetadata()
+    {
+        var builder = new TestSiloBuilder();
+        builder.AddJournalStorage();
+        builder.Configure<JsonJournalOptions>(options => options.AddTypeInfoResolver(JsonCodecTestJsonContext.Default));
+        using var serviceProvider = builder.Services.BuildServiceProvider();
+        var codec = serviceProvider.GetRequiredKeyedService<IDurableValueCommandCodec<JsonCodecTestValue>>(JsonJournalExtensions.JournalFormatKey);
+
+        var input = CodecTestHelpers.WriteEntry(writer => codec.WriteSet(new("test", 1), writer));
+        var consumer = new ValueConsumer<JsonCodecTestValue>();
+        codec.Apply(CodecTestHelpers.ReadBuffer(input), consumer);
+
+        Assert.Equal(new("test", 1), consumer.Value);
+    }
+
+    [Fact]
     public void JsonDictionaryCodec_Snapshot_RoundTrips()
     {
         var codec = new JsonDurableDictionaryCommandCodec<string, int>(Options);

--- a/test/Orleans.Journaling.Json.Tests/JsonCodecTests.cs
+++ b/test/Orleans.Journaling.Json.Tests/JsonCodecTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Orleans.Journaling.Json;
 using Orleans.Journaling.Tests;
 using Orleans.Serialization.Buffers;
@@ -70,7 +71,9 @@ public class JsonCodecTests
         var builder = new TestSiloBuilder();
         builder.AddJournalStorage();
         builder.Configure<JsonJournalOptions>(options => options.AddTypeInfoResolver(JsonCodecTestJsonContext.Default));
+        Assert.DoesNotContain(builder.Services, service => service.ServiceType == typeof(JsonJournalOptions));
         using var serviceProvider = builder.Services.BuildServiceProvider();
+        Assert.Contains(JsonCodecTestJsonContext.Default, serviceProvider.GetRequiredService<IOptions<JsonJournalOptions>>().Value.SerializerOptions.TypeInfoResolverChain);
         var codec = serviceProvider.GetRequiredKeyedService<IDurableValueCommandCodec<JsonCodecTestValue>>(JsonJournalExtensions.JournalFormatKey);
 
         var input = CodecTestHelpers.WriteEntry(writer => codec.WriteSet(new("test", 1), writer));

--- a/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
@@ -218,7 +218,7 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
             typeof(OrleansBinaryDurableDictionaryCommandCodec<,>));
 
         var jsonOptions = new System.Text.Json.JsonSerializerOptions { TypeInfoResolver = JournalingTestsJsonContext.Default };
-        services.AddSingleton(new JsonJournalOptions { SerializerOptions = jsonOptions });
+        services.Configure<JsonJournalOptions>(options => options.SerializerOptions = jsonOptions);
         services.AddKeyedSingleton<IJournalFormat>(JsonJournalExtensions.JournalFormatKey, new JsonLinesJournalFormat());
         services.AddKeyedSingleton(
             typeof(IDurableDictionaryCommandCodec<,>),


### PR DESCRIPTION
Depends on #10148.

Adds DurableJobs throughput and correctness improvements on top of the journaled storage foundation: due-now execution, shard striping controls, batched shard journal writes, ownership lookup caching, scheduler marshalling, receiver ValueTask status handling, and journal record validation.

This branch is stacked on #10148, so the PR diff is cumulative until the foundation lands and this branch is rebased.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10150)