### PR TITLE
chore(playground): add DurableJobs journaling playground

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Aspire.Azure.Data.Tables" Version="13.0.0" />
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="13.0.0" />
     <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="13.0.0" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.1" />
     <PackageVersion Include="Aspire.Hosting.Orleans" Version="13.1.1" />
@@ -121,6 +123,8 @@
   </ItemGroup>
   <!-- Updates for later TFMs -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageVersion Update="Aspire.Azure.Data.Tables" Version="13.2.4" />
+    <PackageVersion Update="Aspire.Azure.Storage.Blobs" Version="13.2.4" />
     <PackageVersion Update="Aspire.Azure.Storage.Queues" Version="13.2.4" />
     <PackageVersion Update="Aspire.Hosting.AppHost" Version="13.2.4" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.2.4" />

--- a/Orleans.slnx
+++ b/Orleans.slnx
@@ -16,6 +16,13 @@
     <Project Path="playground/ChaoticCluster/ChaoticCluster.ServiceDefaults/ChaoticCluster.ServiceDefaults.csproj" />
     <Project Path="playground/ChaoticCluster/ChaoticCluster.Silo/ChaoticCluster.Silo.csproj" />
   </Folder>
+  <Folder Name="/playground/DurableJobsJournaling/">
+    <Project Path="playground/DurableJobsJournaling/DurableJobsJournaling.Abstractions/DurableJobsJournaling.Abstractions.csproj" />
+    <Project Path="playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/DurableJobsJournaling.AppHost.csproj" />
+    <Project Path="playground/DurableJobsJournaling/DurableJobsJournaling.ServiceDefaults/DurableJobsJournaling.ServiceDefaults.csproj" />
+    <Project Path="playground/DurableJobsJournaling/DurableJobsJournaling.Silo/DurableJobsJournaling.Silo.csproj" />
+    <Project Path="playground/DurableJobsJournaling/DurableJobsJournaling.Web/DurableJobsJournaling.Web.csproj" />
+  </Folder>
   <Folder Name="/playground/Dashboard/">
     <Project Path="playground/DashboardCohosted/DashboardCohosted.csproj" />
     <Project Path="playground/DashboardSeparateHost/DashboardSeparateHost.csproj" />

--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/DurableJobsJournaling.AppHost.csproj"
+  }
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Abstractions/Contracts.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Abstractions/Contracts.cs
@@ -1,0 +1,238 @@
+using Orleans.Concurrency;
+
+namespace DurableJobsJournaling.Abstractions;
+
+public interface IWorkflowCoordinatorGrain : IGrainWithGuidKey
+{
+    Task StartAsync(WorkflowStartRequest request);
+
+    [AlwaysInterleave]
+    Task<WorkflowResult> AwaitCompletionAsync();
+
+    [AlwaysInterleave]
+    Task<WorkflowSnapshot> GetSnapshotAsync();
+
+    Task CancelAsync();
+}
+
+public interface IChaosGrain : IGrainWithStringKey
+{
+    Task<ChaosResult> TryKillSiloAsync();
+
+    [AlwaysInterleave]
+    Task<ChaosResult> GetLastResultAsync();
+}
+
+[GenerateSerializer]
+public enum WorkflowStage
+{
+    Accept = 0,
+    ReserveInventory = 1,
+    ChargePayment = 2,
+    PackShipment = 3,
+    Audit = 4,
+    Complete = 5
+}
+
+[GenerateSerializer]
+public enum WorkflowStatus
+{
+    NotStarted = 0,
+    Running = 1,
+    Completed = 2,
+    Failed = 3,
+    Canceled = 4
+}
+
+[GenerateSerializer]
+public enum ChildTaskRole
+{
+    Inventory = 0,
+    Payment = 1,
+    Shipping = 2,
+    Audit = 3
+}
+
+[GenerateSerializer]
+public enum DueTimeMode
+{
+    Immediate = 0,
+    Delayed = 1,
+    Alternating = 2
+}
+
+[GenerateSerializer, Immutable]
+public sealed record LoadSettings(
+    [property: Id(0)] int TargetConcurrency,
+    [property: Id(1)] double TargetStartsPerSecond,
+    [property: Id(3)] int StageDelayMilliseconds,
+    [property: Id(4)] int StageJitterMilliseconds,
+    [property: Id(5)] double FailureRate,
+    [property: Id(6)] DueTimeMode DueTimeMode,
+    [property: Id(7)] int StageDueDelayMilliseconds)
+{
+    public static LoadSettings Default { get; } = new(
+        TargetConcurrency: 16,
+        TargetStartsPerSecond: 8,
+        StageDelayMilliseconds: 0,
+        StageJitterMilliseconds: 0,
+        FailureRate: 0,
+        DueTimeMode: DueTimeMode.Immediate,
+        StageDueDelayMilliseconds: 0);
+
+    public LoadSettings Normalize() => this with
+    {
+        TargetConcurrency = Math.Clamp(TargetConcurrency, 0, 10_000),
+        TargetStartsPerSecond = double.IsFinite(TargetStartsPerSecond) ? Math.Clamp(TargetStartsPerSecond, 0, 100_000) : 0,
+        StageDelayMilliseconds = 0,
+        StageJitterMilliseconds = 0,
+        FailureRate = 0,
+        DueTimeMode = DueTimeMode.Immediate,
+        StageDueDelayMilliseconds = 0
+    };
+}
+
+[GenerateSerializer, Immutable]
+public sealed record WorkflowStartRequest(
+    [property: Id(0)] Guid WorkflowId,
+    [property: Id(1)] DateTimeOffset CreatedAt,
+    [property: Id(2)] LoadSettings Settings);
+
+[GenerateSerializer, Immutable]
+public sealed record ChildTaskResult(
+    [property: Id(0)] Guid WorkflowId,
+    [property: Id(1)] WorkflowStage Stage,
+    [property: Id(2)] ChildTaskRole Role,
+    [property: Id(3)] int Sequence,
+    [property: Id(4)] int Attempt,
+    [property: Id(5)] DateTimeOffset StartedAt,
+    [property: Id(6)] DateTimeOffset CompletedAt,
+    [property: Id(7)] double LatencyMilliseconds,
+    [property: Id(8)] string WorkerKey);
+
+[GenerateSerializer, Immutable]
+public sealed record WorkflowState(
+    [property: Id(0)] Guid WorkflowId,
+    [property: Id(1)] WorkflowStatus Status,
+    [property: Id(2)] WorkflowStage ActiveStage,
+    [property: Id(3)] DateTimeOffset CreatedAt,
+    [property: Id(4)] DateTimeOffset UpdatedAt,
+    [property: Id(5)] DateTimeOffset? CompletedAt,
+    [property: Id(6)] int RetryCount,
+    [property: Id(7)] int FailureCount,
+    [property: Id(8)] string? Error,
+    [property: Id(9)] LoadSettings Settings);
+
+[GenerateSerializer, Immutable]
+public sealed record WorkflowStageRecord(
+    [property: Id(0)] WorkflowStage Stage,
+    [property: Id(1)] int Attempt,
+    [property: Id(2)] string DurableJobId,
+    [property: Id(3)] DateTimeOffset ScheduledAt,
+    [property: Id(4)] DateTimeOffset HandlerStartedAt,
+    [property: Id(5)] DateTimeOffset CompletedAt,
+    [property: Id(6)] double ScheduleToStartMilliseconds,
+    [property: Id(7)] double ExecutionMilliseconds,
+    [property: Id(8)] double RescheduleGapMilliseconds,
+    [property: Id(9)] int ChildCount,
+    [property: Id(10)] bool Succeeded,
+    [property: Id(11)] string? Error,
+    [property: Id(12)] DateTimeOffset PreviousStageCompletedAt = default,
+    [property: Id(13)] DateTimeOffset StateWriteStartedAt = default,
+    [property: Id(14)] DateTimeOffset StateWriteCompletedAt = default,
+    [property: Id(15)] DateTimeOffset ScheduleRequestedAt = default,
+    [property: Id(16)] DateTimeOffset ScheduleCompletedAt = default);
+
+[GenerateSerializer, Immutable]
+public sealed record WorkflowResult(
+    [property: Id(0)] Guid WorkflowId,
+    [property: Id(1)] WorkflowStatus Status,
+    [property: Id(2)] DateTimeOffset CreatedAt,
+    [property: Id(3)] DateTimeOffset CompletedAt,
+    [property: Id(4)] double TotalLatencyMilliseconds,
+    [property: Id(5)] WorkflowStageRecord[] Stages,
+    [property: Id(6)] ChildTaskResult[] ChildResults,
+    [property: Id(7)] int RetryCount,
+    [property: Id(8)] int FailureCount,
+    [property: Id(9)] string? Error);
+
+[GenerateSerializer, Immutable]
+public sealed record WorkflowSnapshot(
+    [property: Id(0)] WorkflowState? State,
+    [property: Id(1)] WorkflowStageRecord[] Stages,
+    [property: Id(2)] ChildTaskResult[] ChildResults,
+    [property: Id(3)] bool IsCompletionSet);
+
+[GenerateSerializer, Immutable]
+public sealed record LoadDriverState(
+    [property: Id(0)] bool Enabled,
+    [property: Id(1)] LoadSettings Settings,
+    [property: Id(2)] int InFlight,
+    [property: Id(3)] long Started,
+    [property: Id(4)] long Completed,
+    [property: Id(5)] long Failed,
+    [property: Id(6)] DateTimeOffset? StartedAt);
+
+[GenerateSerializer, Immutable]
+public sealed record RateSnapshot(
+    [property: Id(0)] double StartsPerSecond,
+    [property: Id(1)] double CompletionsPerSecond,
+    [property: Id(2)] double FailuresPerSecond,
+    [property: Id(3)] double RetriesPerSecond);
+
+[GenerateSerializer, Immutable]
+public sealed record LatencySummary(
+    [property: Id(0)] long Count,
+    [property: Id(1)] double AverageMilliseconds,
+    [property: Id(2)] double P50Milliseconds,
+    [property: Id(3)] double P95Milliseconds,
+    [property: Id(4)] double P99Milliseconds,
+    [property: Id(5)] double MaxMilliseconds);
+
+[GenerateSerializer, Immutable]
+public sealed record WorkflowStageMetric(
+    [property: Id(0)] WorkflowStage Stage,
+    [property: Id(1)] long Completed,
+    [property: Id(2)] long Failed,
+    [property: Id(3)] double AverageLatencyMilliseconds,
+    [property: Id(4)] LatencySummary HandoffLatency,
+    [property: Id(5)] LatencySummary StateWriteLatency,
+    [property: Id(6)] LatencySummary ScheduleCallLatency,
+    [property: Id(7)] LatencySummary DueWaitLatency,
+    [property: Id(8)] LatencySummary QueueLatency,
+    [property: Id(9)] LatencySummary ExecutionLatency,
+    [property: Id(10)] LatencySummary StageTotalLatency,
+    [property: Id(11)] LatencySummary WorkflowElapsedLatency,
+    [property: Id(12)] LatencySummary UnaccountedLatency);
+
+[GenerateSerializer, Immutable]
+public sealed record RecentWorkflowSummary(
+    [property: Id(0)] Guid WorkflowId,
+    [property: Id(1)] WorkflowStatus Status,
+    [property: Id(2)] DateTimeOffset CompletedAt,
+    [property: Id(3)] double TotalLatencyMilliseconds,
+    [property: Id(4)] int RetryCount,
+    [property: Id(5)] int FailureCount,
+    [property: Id(6)] string? Error);
+
+[GenerateSerializer, Immutable]
+public sealed record MetricSnapshot(
+    [property: Id(0)] DateTimeOffset Timestamp,
+    [property: Id(1)] LoadDriverState Load,
+    [property: Id(2)] RateSnapshot Rates,
+    [property: Id(3)] LatencySummary EndToEndLatency,
+    [property: Id(4)] LatencySummary ScheduleToStartLatency,
+    [property: Id(5)] LatencySummary StageExecutionLatency,
+    [property: Id(6)] LatencySummary RescheduleGapLatency,
+    [property: Id(7)] WorkflowStageMetric[] Stages,
+    [property: Id(8)] RecentWorkflowSummary[] Recent,
+    [property: Id(9)] ChaosResult? LastChaos);
+
+[GenerateSerializer, Immutable]
+public sealed record ChaosResult(
+    [property: Id(0)] bool Requested,
+    [property: Id(1)] bool Succeeded,
+    [property: Id(2)] string Message,
+    [property: Id(3)] string? SiloAddress,
+    [property: Id(4)] DateTimeOffset Timestamp,
+    [property: Id(5)] string[] ActiveSilos);

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Abstractions/DurableJobsJournaling.Abstractions.csproj
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Abstractions/DurableJobsJournaling.Abstractions.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Orleans.Sdk\Orleans.Sdk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/DurableJobsJournaling.AppHost.csproj
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/DurableJobsJournaling.AppHost.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.2.4" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>809ee43f-2f9d-47ca-a162-ee03f0856c17</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" />
+    <PackageReference Include="Aspire.Hosting.Orleans" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DurableJobsJournaling.Silo\DurableJobsJournaling.Silo.csproj" />
+    <ProjectReference Include="..\DurableJobsJournaling.Web\DurableJobsJournaling.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/OpenTelemetryCollector/OpenTelemetryCollectorResource.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/OpenTelemetryCollector/OpenTelemetryCollectorResource.cs
@@ -1,0 +1,9 @@
+using Aspire.Hosting.ApplicationModel;
+
+namespace DurableJobsJournaling.AppHost.OpenTelemetryCollector;
+
+public sealed class OpenTelemetryCollectorResource(string name) : ContainerResource(name)
+{
+    internal const string OtlpGrpcEndpointName = "grpc";
+    internal const string OtlpHttpEndpointName = "http";
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/OpenTelemetryCollector/OpenTelemetryCollectorResourceBuilderExtensions.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/OpenTelemetryCollector/OpenTelemetryCollectorResourceBuilderExtensions.cs
@@ -1,0 +1,72 @@
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace DurableJobsJournaling.AppHost.OpenTelemetryCollector;
+
+public static class OpenTelemetryCollectorResourceBuilderExtensions
+{
+    private const string OtelExporterOtlpEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT";
+    private const string AspireDashboardOtlpUrlVariableName = "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL";
+    private const string DotNetDashboardOtlpUrlVariableName = "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL";
+    private const string DashboardOtlpApiKeyVariableName = "AppHost:OtlpApiKey";
+    private const string DashboardOtlpUrlDefaultValue = "http://localhost:18889";
+    private const string OTelCollectorImageName = "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib";
+    private const string OTelCollectorImageTag = "0.123.0";
+
+    public static IResourceBuilder<OpenTelemetryCollectorResource> AddOpenTelemetryCollector(
+        this IDistributedApplicationBuilder builder,
+        string name,
+        string configFileLocation)
+    {
+        var url = builder.Configuration[AspireDashboardOtlpUrlVariableName]
+            ?? builder.Configuration[DotNetDashboardOtlpUrlVariableName]
+            ?? DashboardOtlpUrlDefaultValue;
+        var isHttpsEnabled = url.StartsWith("https", StringComparison.OrdinalIgnoreCase);
+        var dashboardOtlpEndpoint = new HostUrl(url);
+
+        var collectorResource = new OpenTelemetryCollectorResource(name);
+        var resourceBuilder = builder.AddResource(collectorResource)
+            .WithImage(OTelCollectorImageName, OTelCollectorImageTag)
+            .WithEndpoint(targetPort: 4317, name: OpenTelemetryCollectorResource.OtlpGrpcEndpointName, scheme: "http")
+            .WithEndpoint(targetPort: 4318, name: OpenTelemetryCollectorResource.OtlpHttpEndpointName, scheme: "http")
+            .WithUrlForEndpoint(OpenTelemetryCollectorResource.OtlpGrpcEndpointName, url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly)
+            .WithUrlForEndpoint(OpenTelemetryCollectorResource.OtlpHttpEndpointName, url => url.DisplayLocation = UrlDisplayLocation.DetailsOnly)
+            .WithBindMount(configFileLocation, "/etc/otelcol-contrib/config.yaml", isReadOnly: true)
+            .WithEnvironment("ASPIRE_ENDPOINT", $"{dashboardOtlpEndpoint}")
+            .WithEnvironment("ASPIRE_API_KEY", builder.Configuration[DashboardOtlpApiKeyVariableName] ?? string.Empty)
+            .WithEnvironment("ASPIRE_INSECURE", isHttpsEnabled ? "false" : "true")
+            .WithArgs("--config=/etc/otelcol-contrib/config.yaml");
+
+        builder.Eventing.Subscribe<BeforeStartEvent>((@event, _) =>
+        {
+            var logger = @event.Services.GetRequiredService<ILogger<OpenTelemetryCollectorResource>>();
+            var endpoint = collectorResource.GetEndpoint(OpenTelemetryCollectorResource.OtlpGrpcEndpointName);
+
+            if (!endpoint.Exists)
+            {
+                logger.LogWarning("No {EndpointName} endpoint for the OpenTelemetry Collector.", OpenTelemetryCollectorResource.OtlpGrpcEndpointName);
+                return Task.CompletedTask;
+            }
+
+            var appModel = @event.Services.GetRequiredService<DistributedApplicationModel>();
+            foreach (var resource in appModel.Resources)
+            {
+                resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+                {
+                    if (context.EnvironmentVariables.ContainsKey(OtelExporterOtlpEndpoint))
+                    {
+                        logger.LogDebug("Forwarding telemetry for {ResourceName} to the OpenTelemetry Collector.", resource.Name);
+                        context.EnvironmentVariables[OtelExporterOtlpEndpoint] = endpoint;
+                    }
+                }));
+            }
+
+            return Task.CompletedTask;
+        });
+
+        return resourceBuilder;
+    }
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/Program.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/Program.cs
@@ -1,0 +1,103 @@
+using Aspire.Hosting;
+using Aspire.Hosting.Azure;
+using Azure.Provisioning;
+using Azure.Provisioning.Storage;
+using DurableJobsJournaling.AppHost.OpenTelemetryCollector;
+using Microsoft.Extensions.Configuration;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var prometheus = builder.AddContainer("prometheus", "prom/prometheus", "v3.2.1")
+    .WithBindMount(Path.Combine("monitoring", "prometheus"), "/etc/prometheus", isReadOnly: true)
+    .WithArgs("--web.enable-otlp-receiver", "--config.file=/etc/prometheus/prometheus.yml")
+    .WithHttpEndpoint(targetPort: 9090, name: "http")
+    .WithUrlForEndpoint("http", url => url.DisplayText = "Prometheus");
+
+var grafana = builder.AddContainer("grafana", "grafana/grafana", "12.3.0")
+    .WithBindMount(Path.Combine("monitoring", "grafana", "config", "grafana.ini"), "/etc/grafana/grafana.ini", isReadOnly: true)
+    .WithBindMount(Path.Combine("monitoring", "grafana", "config", "provisioning"), "/etc/grafana/provisioning", isReadOnly: true)
+    .WithBindMount(Path.Combine("monitoring", "grafana", "dashboards"), "/var/lib/grafana/dashboards", isReadOnly: true)
+    .WithEnvironment("PROMETHEUS_ENDPOINT", prometheus.GetEndpoint("http"))
+    .WithHttpEndpoint(targetPort: 3000, name: "http")
+    .WithUrlForEndpoint("http", url => url.DisplayText = "Grafana")
+    .WaitFor(prometheus);
+
+var otelCollector = builder.AddOpenTelemetryCollector("otelcollector", Path.Combine("monitoring", "otelcollector", "config.yaml"))
+    .WithEnvironment("PROMETHEUS_ENDPOINT", $"{prometheus.GetEndpoint("http")}/api/v1/otlp")
+    .WaitFor(prometheus);
+
+const string OtelMetricExportIntervalMilliseconds = "5000";
+
+var storageProvider = builder.Configuration.GetValue("Playground:Storage:Provider", "Azurite");
+var useAzurite = storageProvider.Equals("Azurite", StringComparison.OrdinalIgnoreCase);
+var useAzure = storageProvider.Equals("Azure", StringComparison.OrdinalIgnoreCase);
+
+var storage = builder.AddAzureStorage("storage");
+if (useAzurite)
+{
+    storage.RunAsEmulator();
+}
+else if (useAzure)
+{
+    storage.ConfigureInfrastructure(infrastructure =>
+    {
+        var storageAccount = infrastructure.GetProvisionableResources().OfType<StorageAccount>().Single();
+        storageAccount.Kind = StorageKind.BlockBlobStorage;
+        storageAccount.Sku = new StorageSku { Name = StorageSkuName.PremiumLrs };
+        storageAccount.AccessTier.ClearValue();
+        RemoveUnsupportedPremiumBlobStorageOutputs(infrastructure);
+    });
+}
+else
+{
+    throw new InvalidOperationException($"Unknown Playground:Storage:Provider value '{storageProvider}'. Use 'Azurite' or 'Azure'.");
+}
+
+var blobs = storage.AddBlobs("blobs");
+var tableStorage = useAzurite ? storage : builder.AddAzureStorage("clusteringstorage");
+if (useAzure && builder.ExecutionContext.IsPublishMode)
+{
+    storage.ClearDefaultRoleAssignments();
+    tableStorage.ClearDefaultRoleAssignments();
+}
+
+var tables = tableStorage.AddTables("tables");
+
+var orleans = builder.AddOrleans("cluster")
+    .WithClustering(tables);
+
+var storagePrefix = $"run-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}";
+var silo = builder.AddProject<Projects.DurableJobsJournaling_Silo>("silo")
+    .WithReference(orleans)
+    .WithReference(blobs)
+    .WithReference(tables)
+    .WaitFor(blobs)
+    .WaitFor(tables)
+    .WaitFor(otelCollector)
+    .WithReplicas(1)
+    .WithEnvironment("Playground__Storage__Container", "durablejobs-journaling-playground")
+    .WithEnvironment("Playground__Storage__Prefix", storagePrefix)
+    .WithEnvironment("OTEL_METRIC_EXPORT_INTERVAL", OtelMetricExportIntervalMilliseconds);
+
+builder.AddProject<Projects.DurableJobsJournaling_Web>("web")
+    .WithReference(orleans.AsClient())
+    .WithReference(tables)
+    .WithEnvironment("GRAFANA_URL", grafana.GetEndpoint("http"))
+    .WithEnvironment("OTEL_METRIC_EXPORT_INTERVAL", OtelMetricExportIntervalMilliseconds)
+    .WaitFor(silo)
+    .WaitFor(tables)
+    .WaitFor(otelCollector)
+    .WithReplicas(1);
+
+builder.Build().Run();
+
+static void RemoveUnsupportedPremiumBlobStorageOutputs(AzureResourceInfrastructure infrastructure)
+{
+    foreach (var output in infrastructure.GetProvisionableResources()
+        .OfType<ProvisioningOutput>()
+        .Where(output => output.BicepIdentifier is "queueEndpoint" or "tableEndpoint")
+        .ToArray())
+    {
+        infrastructure.Remove(output);
+    }
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/Properties/launchSettings.json
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/Properties/launchSettings.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17321;http://localhost:15321",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "Playground__Storage__Provider": "Azurite",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21321",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22321"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15321",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "Playground__Storage__Provider": "Azurite",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19321",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20321"
+      }
+    },
+    "https-azure": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17321;http://localhost:15321",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "Playground__Storage__Provider": "Azure",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21321",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22321"
+      }
+    },
+    "http-azure": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15321",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "Playground__Storage__Provider": "Azure",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19321",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20321"
+      }
+    }
+  }
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/config/grafana.ini
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/config/grafana.ini
@@ -1,0 +1,9 @@
+[auth.anonymous]
+enabled = true
+org_name = Main Org.
+org_role = Admin
+hide_version = true
+
+[dashboards]
+default_home_dashboard_path = /var/lib/grafana/dashboards/orleans-overview.json
+min_refresh_interval = 1s

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/config/provisioning/dashboards/dashboards.yml
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/config/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: Orleans
+    orgId: 1
+    folder: Orleans
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/config/provisioning/datasources/prometheus.yml
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/config/provisioning/datasources/prometheus.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: ${PROMETHEUS_ENDPOINT}
+    isDefault: true
+    editable: true
+    jsonData:
+      timeInterval: 5s

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/dashboards/aspnetcore-endpoint.json
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/dashboards/aspnetcore-endpoint.json
@@ -1,0 +1,929 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "ASP.NET Core endpoint metrics from OpenTelemetry",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": " ASP.NET Core",
+      "tooltip": "",
+      "type": "link",
+      "url": "/d/KdDACDp4z/asp-net-core-metrics"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-green",
+            "mode": "continuous-GrYlRd",
+            "seriesBy": "max"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "index": 0,
+                  "text": "0 ms"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "p50"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p75",
+          "range": true,
+          "refId": "p75"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "p90"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.98, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p98",
+          "range": true,
+          "refId": "p98"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "p99"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.999, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p99.9",
+          "range": true,
+          "refId": "p99.9"
+        }
+      ],
+      "title": "Requests Duration - $method $route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic",
+            "seriesBy": "max"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "index": 0,
+                  "text": "0%"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "All"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4XX"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5XX"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\", http_response_status_code=~\"4..|5..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval]))",
+          "legendFormat": "All",
+          "range": true,
+          "refId": "All"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\", http_response_status_code=~\"4..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "4XX",
+          "range": true,
+          "refId": "4XX"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\", http_response_status_code=~\"5..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "5XX",
+          "range": true,
+          "refId": "5XX"
+        }
+      ],
+      "title": "Errors Rate - $method $route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-YlRd"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Route"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "",
+                    "url": "/d/NagEsjE4z/asp-net-core-endpoint-details?var-route=${__data.fields.Route}&var-method=${__data.fields.Method}&${__url_time_range}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "hideTimeOverride": false,
+      "id": 44,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (error_type) (\r\n  ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\", error_type!=\"\"}[$__range]))\r\n)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{route}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Unhandled Exceptions",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "method": false
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 2,
+              "error_type": 1
+            },
+            "renameByName": {
+              "Value": "Requests",
+              "error_type": "Exception",
+              "http_request_method": "Method",
+              "http_route": "Route"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_response_status_code) (\r\n    ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__range]))\r\n  )",
+          "legendFormat": "Status {{http_response_status_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests HTTP Status Code",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 13
+      },
+      "id": 48,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (url_scheme) (\r\n    ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__range]))\r\n  )",
+          "legendFormat": "{{scheme}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests Secured",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 13
+      },
+      "id": 50,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (method_route) (\r\n    label_replace(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__range])), \"method_route\", \"http/$1\", \"network_protocol_version\", \"(.*)\")\r\n  )",
+          "legendFormat": "{{protocol}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests HTTP Protocol",
+      "type": "stat"
+    }
+  ],
+  "refresh": "10s",
+  "revision": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "dotnet",
+    "prometheus",
+    "aspnetcore"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "pluginId": "prometheus",
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(http_server_active_requests,job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_active_requests,job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(http_server_active_requests{job=~\"$job\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_active_requests{job=~\"$job\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(http_server_request_duration_seconds_count,http_route)",
+        "description": "Route",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Route",
+        "multi": false,
+        "name": "route",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_request_duration_seconds_count,http_route)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(http_server_request_duration_seconds_count{http_route=~\"$route\"},http_request_method)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Method",
+        "multi": false,
+        "name": "method",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_request_duration_seconds_count{http_route=~\"$route\"},http_request_method)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "ASP.NET Core Endpoint",
+  "uid": "aspnetcore-endpoint",
+  "version": 2,
+  "weekStart": "",
+  "gnetId": 19925
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/dashboards/aspnetcore.json
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/dashboards/aspnetcore.json
@@ -1,0 +1,1333 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "ASP.NET Core metrics from OpenTelemetry",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 19924,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-green",
+            "mode": "continuous-GrYlRd",
+            "seriesBy": "max"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "index": 1,
+                  "text": "0 ms"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "p50"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p75",
+          "range": true,
+          "refId": "p75"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "p90"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.98, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p98",
+          "range": true,
+          "refId": "p98"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "p99"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.999, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p99.9",
+          "range": true,
+          "refId": "p99.9"
+        }
+      ],
+      "title": "Requests Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic",
+            "seriesBy": "max"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "index": 1,
+                  "text": "0%"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "All"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4XX"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5XX"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 47,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_response_status_code=~\"4..|5..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "All",
+          "range": true,
+          "refId": "All"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_response_status_code=~\"4..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "4XX",
+          "range": true,
+          "refId": "4XX"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_response_status_code=~\"5..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "5XX",
+          "range": true,
+          "refId": "5XX"
+        }
+      ],
+      "title": "Errors Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 9
+      },
+      "id": 49,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(kestrel_active_connections{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "active connections",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Current Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 9
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(http_server_active_requests{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "active requests",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Current Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 9
+      },
+      "id": 58,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__range])))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-red",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 9
+      },
+      "id": 59,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", error_type!=\"\"}[$__range])))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Unhandled Exceptions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 13
+      },
+      "id": 60,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (url_scheme) (\r\n    ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__range]))\r\n  )",
+          "legendFormat": "{{scheme}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests Secured",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 13
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (method_route) (\r\n    label_replace(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__range])), \"method_route\", \"http/$1\", \"network_protocol_version\", \"(.*)\")\r\n  )",
+          "legendFormat": "{{protocol}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests HTTP Protocol",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-BlPu"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Endpoint"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": false,
+                    "title": "${__data.fields.http_request_method} ${__data.fields.http_route}",
+                    "url": "/d/NagEsjE4z/asp-net-core-endpoint-details?${job:queryparam}&${instance:queryparam}&var-route=${__data.fields.http_route}&var-method=${__data.fields.http_request_method}&${__url_time_range}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_route"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_request_method"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "hideTimeOverride": false,
+      "id": 51,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "  topk(10,\r\n  sum by (http_route, http_request_method, method_route) (\r\n    label_join(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route!=\"\"}[$__range])), \"method_route\", \" \", \"http_request_method\", \"http_route\")\r\n  ))",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{route}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Requested Endpoints",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "method": false,
+              "route": false
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 4,
+              "method": 2,
+              "method_route": 3,
+              "route": 1
+            },
+            "renameByName": {
+              "Value": "Requests",
+              "method": "",
+              "method_route": "Endpoint",
+              "route": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-YlRd"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Endpoint"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": false,
+                    "title": "${__data.fields.http_request_method} ${__data.fields.http_route}",
+                    "url": "/d/NagEsjE4z/asp-net-core-endpoint-details?${job:queryparam}&${instance:queryparam}&var-route=${__data.fields.http_route}&var-method=${__data.fields.http_request_method}&${__url_time_range}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_route"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_request_method"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "hideTimeOverride": false,
+      "id": 54,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "  topk(10,\r\n  sum by (http_route, http_request_method, method_route) (\r\n    label_join(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route!=\"\", error_type!=\"\"}[$__range])), \"method_route\", \" \", \"http_request_method\", \"http_route\")\r\n  ))",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{route}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Unhandled Exception Endpoints",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "method": false
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 4,
+              "method": 2,
+              "method_route": 3,
+              "route": 1
+            },
+            "renameByName": {
+              "Value": "Requests",
+              "method": "",
+              "method_route": "Endpoint",
+              "route": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "10s",
+  "revision": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "dotnet",
+    "prometheus",
+    "aspnetcore"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "pluginId": "prometheus",
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(http_server_active_requests,job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_active_requests,job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(http_server_active_requests{job=~\"$job\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_active_requests{job=~\"$job\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "ASP.NET Core",
+  "uid": "aspnetcore-overview",
+  "version": 2,
+  "weekStart": ""
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/dashboards/dotnet-runtime-metrics.json
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/dashboards/dotnet-runtime-metrics.json
@@ -1,0 +1,2022 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Provisioned .NET runtime metrics dashboard based on Grafana dashboard 23179, enhanced with contention, ThreadPool queueing, exception, allocation, and process health panels.",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 136,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "These include both handled and unhandled exceptions!",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Exceptions"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 55,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "  topk(10,\r\n  sum by (error_type, job) (\r\n    ceil(increase({__name__=~\"dotnet_exceptions_total|process_runtime_dotnet_exceptions_count_total\", job=~\"$job\", instance=~\"$instance\"}[$__range]))\r\n  ))",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "{{error_type}}",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Thrown Exceptions",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "The total number of .NET assemblies loaded into the process.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "Assemblies"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 192,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "avg by (job) ({__name__=~\"dotnet_assembly_count|process_runtime_dotnet_assemblies_count\", job=~\"$job\"})",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Assemblies by Job",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Exceptions and Assemblies",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 110,
+      "panels": [],
+      "repeat": "job",
+      "repeatDirection": "h",
+      "title": ".NET GC and Memory [$job]",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total amount of seconds the GC was paused in each process.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 2
+      },
+      "id": 84,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "right",
+          "showLegend": false
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (irate(dotnet_gc_pause_time_seconds_total{job=~\"$job\",instance=~\"$instance\"}[$__range])) or sum by (job) (irate(process_runtime_dotnet_gc_duration_nanoseconds_total{job=~\"$job\",instance=~\"$instance\"}[$__range]) / 1e9)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET GC Pause Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of GC collection attempts per generation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "collections"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 2
+      },
+      "id": 83,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "right",
+          "showLegend": false
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job, gc_heap_generation) (ceil(irate({__name__=~\"dotnet_gc_collections_total|process_runtime_dotnet_gc_collections_count_total\", job=~\"$job\", instance=~\"$instance\"}[$__range])))",
+          "instant": false,
+          "legendFormat": "{{job}} - {{gc_heap_generation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET GC Collection Attempts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The amount of physical memory in-use inside each .NET process.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 82,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "right",
+          "showLegend": false
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) ({__name__=~\"dotnet_gc_last_collection_memory_committed_size_bytes|process_runtime_dotnet_gc_committed_memory_size_bytes\", job=~\"$job\",instance=~\"$instance\"})",
+          "instant": false,
+          "legendFormat": "{{job}} - {{gc_heap_generation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET GC Memory Committed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Memory fragmentation in the managed heap, per-GC generation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "right",
+          "showLegend": false
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job, gc_heap_generation) ({__name__=~\"dotnet_gc_last_collection_heap_fragmentation_size_bytes|process_runtime_dotnet_gc_heap_fragmentation_size_bytes\", job=~\"$job\",instance=~\"$instance\"})",
+          "instant": false,
+          "legendFormat": "{{job}} - {{gc_heap_generation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET GC Heap Fragmentation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "The size of each of the managed heaps, following their last GC collection attempt.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 81,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "right",
+          "showLegend": false
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job, gc_heap_generation) ({__name__=~\"dotnet_gc_last_collection_heap_size_bytes|process_runtime_dotnet_gc_heap_size_bytes\", job=~\"$job\",instance=~\"$instance\"})",
+          "instant": false,
+          "legendFormat": "{{job}} - {{gc_heap_generation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET GC Last Collection Heap Size",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 5,
+      "panels": [],
+      "repeat": "job",
+      "repeatDirection": "h",
+      "title": "CPU and ThreadPool [$job]",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of work items completed by the .NET managed ThreadPool on this [$job]",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "items"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (floor(irate({__name__=~\"dotnet_thread_pool_work_item_count_total|process_runtime_dotnet_thread_pool_completed_items_count_total\", job=~\"$job\",instance=~\"$instance\"}[$__range])))",
+          "instant": false,
+          "legendFormat": "{{job}} completed items",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET ThreadPool Workload",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of .NET ThreadPool threads and timers on [$job]",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "threads"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(job) ({__name__=~\"dotnet_thread_pool_thread_count_total|process_runtime_dotnet_thread_pool_threads_count\", job=~\"$job\",instance=~\"$instance\"})",
+          "instant": false,
+          "legendFormat": "{{job}} threads",
+          "range": true,
+          "refId": "threads"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(job) ({__name__=~\"dotnet_timer_count|process_runtime_dotnet_timer_count\", job=~\"$job\",instance=~\"$instance\"})",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "{{job}} timers",
+          "range": true,
+          "refId": "timers"
+        }
+      ],
+      "title": ".NET ThreadPool Threads and Timers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "⚠️ Requires .NET 9+ built-in metrics (not available in OpenTelemetry.Instrumentation.Runtime package for .NET 6/7/8).\n\nThe amount of CPU time used by instances of [$job]",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "series",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "sdkbin-production/nuget-service [user]"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job, cpu_mode) (irate(dotnet_process_cpu_time_seconds_total{job=~\"$job\"}[$__range]))",
+          "instant": false,
+          "legendFormat": "{{job}} [{{cpu_mode}}]",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Seconds by Job",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "⚠️ Requires .NET 9+ built-in metrics (not available in OpenTelemetry.Instrumentation.Runtime package for .NET 6/7/8).\n\nAll logical CPUs available to this process - these are shared with other processes running on the same machine.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Logical CPUs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 6,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by(job, instance) (dotnet_process_cpu_count{job=~\"$job\", instance=~\"$instance\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{instance}}/{{job}} CPU",
+          "range": false,
+          "refId": "CPUs"
+        }
+      ],
+      "title": "Available CPUs",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Time": 0,
+              "Value": 3,
+              "instance": 2,
+              "job": 1
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 248,
+      "panels": [],
+      "repeat": "job",
+      "repeatDirection": "h",
+      "title": ".NET JIT [$job]",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total amount of time spent by the .NET Just-in-Time (JIT) compiler.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "id": 304,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(job) (irate(dotnet_jit_compilation_time_seconds_total{job=~\"$job\",instance=~\"$instance\"}[$__range])) or sum by(job) (irate(process_runtime_dotnet_jit_compilation_time_nanoseconds_total{job=~\"$job\",instance=~\"$instance\"}[$__range]) / 1e9)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET JIT Compilation Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Determined by the total number of methods compiled by the .NET Just-in-Time (JIT) compiler.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "compilations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "id": 305,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (ceil(irate({__name__=~\"dotnet_jit_compiled_methods_total|process_runtime_dotnet_jit_methods_compiled_count_total\", job=~\"$job\"}[$__range])))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET JIT Compilations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total amount of .NET IL bytes emitted by the JIT.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "id": 306,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) ({__name__=~\"dotnet_jit_compiled_il_size_bytes_total|process_runtime_dotnet_jit_il_compiled_size_bytes_total\", job=~\"$job\", instance=~\"$instance\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET JIT Compiled IL Bytes",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "id": 400,
+      "panels": [],
+      "title": "Runtime pressure: exceptions, contention, and ThreadPool queueing [$job]",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 61
+      },
+      "id": 401,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (job) (rate({__name__=~\"dotnet_exceptions_total|process_runtime_dotnet_exceptions_count_total\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET Exception rate",
+      "type": "timeseries",
+      "description": "Exceptions thrown per second. A rising rate can explain throughput loss even if failures are not surfaced at the workload layer."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 61
+      },
+      "id": 402,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (job) (rate({__name__=~\"dotnet_monitor_lock_contentions_total|process_runtime_dotnet_monitor_lock_contention_count_total\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET Lock contention rate",
+      "type": "timeseries",
+      "description": "Managed monitor lock contentions per second. Sustained contention here points to blocked critical sections rather than storage or network latency."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      },
+      "id": 403,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (job, instance) ({__name__=~\"dotnet_thread_pool_queue_length|process_runtime_dotnet_thread_pool_queue_length\", job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "{{job}} {{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET ThreadPool queue length",
+      "type": "timeseries",
+      "description": "Queued ThreadPool work items by process. Non-zero sustained queue length indicates worker starvation or blocking work."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 69
+      },
+      "id": 404,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (job) (rate({__name__=~\"dotnet_thread_pool_work_item_count_total|process_runtime_dotnet_thread_pool_completed_items_count_total\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET ThreadPool completed work-item rate",
+      "type": "timeseries",
+      "description": "Completed ThreadPool work items per second, useful for correlating runtime throughput with workload throughput."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 77
+      },
+      "id": 405,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (job, instance) ({__name__=~\"dotnet_thread_pool_thread_count|dotnet_thread_pool_thread_count_total|process_runtime_dotnet_thread_pool_threads_count\", job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "{{job}} {{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET ThreadPool thread count",
+      "type": "timeseries",
+      "description": "ThreadPool worker thread count by process."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 77
+      },
+      "id": 406,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (job, instance) ({__name__=~\"dotnet_timer_count|process_runtime_dotnet_timer_count\", job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "{{job}} {{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET Timer count",
+      "type": "timeseries",
+      "description": "Active timers by process. Unexpected growth can indicate leaked scheduled work."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 85
+      },
+      "id": 410,
+      "panels": [],
+      "title": "Runtime memory and GC pressure [$job]",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 86
+      },
+      "id": 411,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (job) (rate({__name__=~\"dotnet_gc_heap_total_allocated_bytes_total|process_runtime_dotnet_gc_allocations_size_total|process_runtime_dotnet_gc_allocations_size_bytes_total\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{job}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET GC allocation rate",
+      "type": "timeseries",
+      "description": "Allocated bytes per second across selected instances."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 86
+      },
+      "id": 412,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (job, gc_heap_generation) (rate({__name__=~\"dotnet_gc_collections_total|process_runtime_dotnet_gc_collections_count_total\", job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{job}} gen {{gc_heap_generation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET GC collection rate by generation",
+      "type": "timeseries",
+      "description": "GC collection rate by generation."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 94
+      },
+      "id": 413,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (job, instance) ({__name__=~\"dotnet_gc_last_collection_memory_committed_size_bytes|process_runtime_dotnet_gc_committed_memory_size_bytes\", job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "{{job}} {{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET GC committed memory",
+      "type": "timeseries",
+      "description": "GC committed memory by process."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 94
+      },
+      "id": 414,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (job, instance) ({__name__=~\"dotnet_assembly_count|process_runtime_dotnet_assemblies_count\", job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "{{job}} {{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": ".NET Assembly count",
+      "type": "timeseries",
+      "description": "Loaded assembly count by process. Unexpected growth can indicate dynamic load/unload issues."
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 41,
+  "tags": [
+    "aspire",
+    "dotnet",
+    "runtime",
+    "diagnostics",
+    "orleans",
+    "durablejobs",
+    "journaling",
+    "playground"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "pluginId": "prometheus",
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(target_info, job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(target_info, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(target_info{job=~\"$job\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(target_info{job=~\"$job\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timeRangeUpdatedDuringEditOrView": false,
+  "timepicker": {},
+  "timezone": "browser",
+  "title": ".NET Runtime Metrics",
+  "uid": "dotnet-runtime-metrics",
+  "version": 1,
+  "weekStart": "",
+  "gnetId": 23179
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/dashboards/orleans-overview.json
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/grafana/dashboards/orleans-overview.json
@@ -1,0 +1,3535 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Subsystem-oriented Orleans runtime, directory, activation, storage, Azure Blob journaling, DurableJobs, and workload metrics with live quantiles and Prometheus bucket heatmaps.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": ".NET runtime metrics",
+      "tooltip": "Open the linked .NET runtime dashboard with the current time range and variables.",
+      "type": "link",
+      "url": "/d/dotnet-runtime-metrics?${__url.params}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "ASP.NET Core",
+      "tooltip": "Open the ASP.NET Core dashboard with the current time range and variables.",
+      "type": "link",
+      "url": "/d/aspnetcore-overview?${__url.params}"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "ASP.NET Core Endpoint",
+      "tooltip": "Open the ASP.NET Core per-endpoint dashboard with the current time range and variables.",
+      "type": "link",
+      "url": "/d/aspnetcore-endpoint?${__url.params}"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1000,
+      "panels": [],
+      "title": "Executive overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of scraped Orleans silo instances in the current selection. Counts only instances that emit silo-specific metrics so non-silo services (for example, the web frontend) are excluded.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1001,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "count(count by (instance) (orleans_catalog_activations{job=~\"$job\", instance=~\"$instance\"}))",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active silos",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current live Orleans grain activations across selected silos.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 1002,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(orleans_grains{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Live grain activations",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Incoming grain calls recorded by the playground filter, grouped by grain type rather than grain id.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 1003,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(playground_grain_requests_total{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Error ratio for incoming grain calls recorded by the playground filter.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 1004,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(playground_grain_requests_total{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\", status=\"error\"}[$__rate_interval])) / clamp_min(sum(rate(playground_grain_requests_total{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\"}[$__rate_interval])), 1e-9)",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request error %",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "P99 incoming grain call latency from the playground grain-type histogram.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 1005,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(playground_grain_request_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\"}[$__rate_interval])))",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request p99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "P99 end-to-end workflow latency for the playground workload.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 1006,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(playground_workflow_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workflow p99 latency",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 1100,
+      "panels": [],
+      "title": "Silo / host overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Incoming grain calls per silo, tagged by success/error status and grain type.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 1101,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (instance, status) (rate(playground_grain_requests_total{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}} {{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Per-silo request rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "P95 incoming grain call latency per silo.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 1102,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, instance) (rate(playground_grain_request_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Per-silo p95 latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Live grain activations split by silo and Orleans grain type label.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 1103,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (instance, type) (orleans_grains{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "{{instance}} {{type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Per-silo live grain activations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Directory registration throughput per silo.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 1104,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (instance) (rate(orleans_directory_registrations_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Per-silo directory registration rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 1200,
+      "panels": [],
+      "title": "Grain requests",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Top live grain activation counts using Orleans runtime grain type labels.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 1201,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "topk(10, sum by (type) (orleans_grains{job=~\"$job\", instance=~\"$instance\"}))",
+          "legendFormat": "{{type}}",
+          "range": true,
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Top live grain types",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Incoming grain call throughput by GrainId.Type.ToString() and status.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 1202,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (grain_type, status) (rate(playground_grain_requests_total{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\"}[$__rate_interval]))",
+          "legendFormat": "{{grain_type}} {{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Per-grain-type error ratio. The grain_type label is the grain type only, not the grain id/key.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 1203,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (grain_type) (rate(playground_grain_requests_total{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\", status=\"error\"}[$__rate_interval])) / clamp_min(sum by (grain_type) (rate(playground_grain_requests_total{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\"}[$__rate_interval])), 1e-9)",
+          "legendFormat": "{{grain_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request error rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Per-grain-type latency quantiles from the playground incoming call filter.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 1204,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, grain_type) (rate(playground_grain_request_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{grain_type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, grain_type) (rate(playground_grain_request_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{grain_type}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, grain_type) (rate(playground_grain_request_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{grain_type}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Request latency quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Heatmap for selected grain-type request latency buckets. This is tagged by grain type only, never grain id/key.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 1205,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ops"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(playground_grain_request_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", grain_type=~\"$grain_type\", le!=\"+Inf\"}[$__rate_interval]))",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A",
+          "format": "heatmap"
+        }
+      ],
+      "title": "Request latency heatmap",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 102,
+      "panels": [],
+      "title": "Orleans messaging and app requests",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_gateway_received_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "gateway received",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_gateway_sent_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "gateway sent",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_messaging_processing_dispatcher_received_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "dispatcher received",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_messaging_processing_dispatcher_processed_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "dispatcher processed",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Orleans request/response rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_app_requests_timedout_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "request timeouts",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_app_requests_canceled_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "request cancellations",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_messaging_sent_failed_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "send failures",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_messaging_rejected_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "rejected",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_messaging_expired_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "expired",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Orleans error rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 44
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (duration) (rate(orleans_app_requests_latency_bucket_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{duration}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Global Orleans app request latency quantiles",
+      "type": "timeseries",
+      "description": "Global Orleans app request latency quantiles. This runtime metric is not split by grain type."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 44
+      },
+      "id": 35,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ops"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (label_replace(rate(orleans_app_requests_latency_bucket_total{job=~\"$job\", instance=~\"$instance\", duration!=\"9223372036854775807ms\"}[$__rate_interval]), \"le\", \"$1\", \"duration\", \"([0-9]+)ms\"))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Global grain request latency heatmap",
+      "type": "heatmap",
+      "description": "Global Orleans app request latency heatmap. Use the Grain requests row for per-grain-type latency."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 103,
+      "panels": [],
+      "title": "Catalog / Grain activation",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(orleans_catalog_activations{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "activations",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(orleans_catalog_activation_working_set{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "activation working set",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(orleans_grains{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "grains",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(orleans_system_targets{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "system targets",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Catalog and activation gauges",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_catalog_activation_created_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "created",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_catalog_activation_failed_to_activate_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "failed to activate",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_catalog_activation_destroyed_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "destroyed",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(orleans_catalog_activation_duration_milliseconds_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "completed {{status}}",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Grain activation throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 61
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, status, directory) (rate(orleans_catalog_activation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{status}} {{directory}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, status, directory) (rate(orleans_catalog_activation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{status}} {{directory}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, status, directory) (rate(orleans_catalog_activation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{status}} {{directory}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Grain activation latency quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 61
+      },
+      "id": 22,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ops"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(orleans_catalog_activation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", le!=\"+Inf\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Grain activation latency heatmap",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 69
+      },
+      "id": 104,
+      "panels": [],
+      "title": "Grain directory",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 70
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (instance) (orleans_directory_cache_size{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "cache {{instance}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (instance) (orleans_directory_partition_size{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "partition {{instance}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Grain directory cache and partition size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 70
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_directory_lookups_full_issued_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "full lookups",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_directory_lookups_local_directory_issued_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "local directory lookups",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_directory_lookups_cache_issued_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "cache lookups",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_directory_validations_cache_sent_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "cache validations sent",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Grain directory operation rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 78
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (locator, status) (rate(orleans_directory_registrations_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{locator}} {{status}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_directory_registrations_single_act_issued_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "DHT issued",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_directory_registrations_single_act_local_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "DHT local",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_directory_registrations_single_act_remote_sent_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "DHT remote sent",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_directory_registrations_single_act_remote_received_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "DHT remote received",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Directory registration throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 78
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, locator, status) (rate(orleans_directory_registration_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{locator}} {{status}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, locator, status) (rate(orleans_directory_registration_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{locator}} {{status}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, locator, status) (rate(orleans_directory_registration_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{locator}} {{status}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Directory registration latency quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      },
+      "id": 25,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ops"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(orleans_directory_registration_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", le!=\"+Inf\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Directory registration latency heatmap",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 94
+      },
+      "id": 105,
+      "panels": [],
+      "title": "Storage / Journaling / Azure Blob",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 95
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, operation, status) (rate(orleans_journaling_storage_operation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{operation}} {{status}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, operation, status) (rate(orleans_journaling_storage_operation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{operation}} {{status}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, operation, status) (rate(orleans_journaling_storage_operation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{operation}} {{status}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Journaling storage latency quantiles by operation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 95
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (operation) (rate(orleans_journaling_storage_operations_total{job=~\"$job\", instance=~\"$instance\", status=\"error\"}[$__rate_interval])) or on(operation) (0 * sum by (operation) (rate(orleans_journaling_storage_operations_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "{{operation}} errors",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_journaling_storage_operations_total{job=~\"$job\", instance=~\"$instance\", status=\"error\"}[$__rate_interval])) or vector(0)",
+          "legendFormat": "total errors",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Journaling storage error rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 103
+      },
+      "id": 26,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ops"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(orleans_journaling_storage_operation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", operation=~\"append|replace\", le!=\"+Inf\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Journaling storage write latency heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 103
+      },
+      "id": 27,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ops"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(orleans_journaling_storage_operation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", operation=\"read\", le!=\"+Inf\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Journaling storage read latency heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 111
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (operation, status) (rate(orleans_journaling_state_write_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "state write {{operation}} {{status}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (operation, status) (rate(orleans_journaling_state_delete_requests_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "state delete {{operation}} {{status}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (operation, status) (rate(orleans_journaling_storage_operations_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "storage {{operation}} {{status}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (operation, status) (rate(orleans_journaling_recoveries_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "recovery {{operation}} {{status}}",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Journaling throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 111
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, operation, status) (rate(orleans_journaling_state_write_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "write {{operation}} {{status}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, operation, status) (rate(orleans_journaling_storage_operation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "storage {{operation}} {{status}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, operation, status) (rate(orleans_journaling_recovery_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "recovery {{operation}} {{status}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Logical journaling latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 119
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (operation, status) (rate(orleans_journaling_azure_blob_operations_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "{{operation}} {{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Azure Blob journal throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 119
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, operation, status) (rate(orleans_journaling_azure_blob_operation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{operation}} {{status}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, operation, status) (rate(orleans_journaling_azure_blob_operation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{operation}} {{status}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, operation, status) (rate(orleans_journaling_azure_blob_operation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{operation}} {{status}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Azure Blob journal latency quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 127
+      },
+      "id": 30,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ops"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(orleans_journaling_azure_blob_operation_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", le!=\"+Inf\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Azure Blob journal operation latency heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Logical append payload size produced by Orleans.Journaling before the storage provider writes it. Use this to tune append batch size.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 135
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, status) (rate(orleans_journaling_storage_operation_bytes_bucket{job=~\"$job\", instance=~\"$instance\", operation=\"append\"}[$__rate_interval])))",
+          "legendFormat": "p50 append {{status}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, status) (rate(orleans_journaling_storage_operation_bytes_bucket{job=~\"$job\", instance=~\"$instance\", operation=\"append\"}[$__rate_interval])))",
+          "legendFormat": "p95 append {{status}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, status) (rate(orleans_journaling_storage_operation_bytes_bucket{job=~\"$job\", instance=~\"$instance\", operation=\"append\"}[$__rate_interval])))",
+          "legendFormat": "p99 append {{status}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(orleans_journaling_storage_operation_bytes_sum{job=~\"$job\", instance=~\"$instance\", operation=\"append\"}[$__rate_interval])) / sum by (status) (rate(orleans_journaling_storage_operation_bytes_count{job=~\"$job\", instance=~\"$instance\", operation=\"append\"}[$__rate_interval]))",
+          "legendFormat": "avg append {{status}}",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Journaling append batch bytes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Time a logical storage work item spent waiting in the JournaledStateManager serialized work queue before processing began. Provider-internal waits and retries remain part of storage operation latency.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 135
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, operation, status) (rate(orleans_journaling_storage_operation_queue_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", operation=~\"append|snapshot|delete\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{operation}} {{status}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, operation, status) (rate(orleans_journaling_storage_operation_queue_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", operation=~\"append|snapshot|delete\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{operation}} {{status}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, operation, status) (rate(orleans_journaling_storage_operation_queue_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", operation=~\"append|snapshot|delete\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{operation}} {{status}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Journaling storage queue delay quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Distribution of JournaledStateManager work-queue wait time for logical storage writes/deletes.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 143
+      },
+      "id": 40,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ops"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(orleans_journaling_storage_operation_queue_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", operation=~\"append|snapshot|delete\", le!=\"+Inf\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Journaling storage queue delay heatmap",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 151
+      },
+      "id": 106,
+      "panels": [],
+      "title": "DurableJobs backend",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 152
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_durablejobs_jobs_scheduled_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "scheduled",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_durablejobs_job_attempts_started_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "attempts started",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_durablejobs_jobs_completed_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "completed",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_durablejobs_jobs_failed_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "failed",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_durablejobs_jobs_retried_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "retried",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(orleans_durablejobs_jobs_canceled_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "canceled",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "DurableJobs backend throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 152
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(orleans_durablejobs_schedule_job_calls_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "schedule {{status}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(orleans_durablejobs_handler_executions_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "handler {{status}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(orleans_durablejobs_shards_processed_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "shard {{status}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "DurableJobs caller and shard throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 160
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(orleans_durablejobs_schedule_job_call_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 ScheduleJobAsync",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(orleans_durablejobs_schedule_job_call_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 ScheduleJobAsync",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(orleans_durablejobs_schedule_job_call_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 ScheduleJobAsync",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(orleans_durablejobs_handler_execution_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 ExecuteJobAsync",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(orleans_durablejobs_handler_execution_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 ExecuteJobAsync",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(orleans_durablejobs_handler_execution_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 ExecuteJobAsync",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(orleans_durablejobs_job_attempt_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 attempt",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(orleans_durablejobs_job_attempt_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 attempt",
+          "range": true,
+          "refId": "H"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(orleans_durablejobs_job_attempt_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 attempt",
+          "range": true,
+          "refId": "I"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(orleans_durablejobs_job_dispatch_lag_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 dispatch lag",
+          "range": true,
+          "refId": "J"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(orleans_durablejobs_job_dispatch_lag_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 dispatch lag",
+          "range": true,
+          "refId": "K"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(orleans_durablejobs_job_dispatch_lag_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 dispatch lag",
+          "range": true,
+          "refId": "L"
+        }
+      ],
+      "title": "DurableJobs latency quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 160
+      },
+      "id": 32,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ops"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(orleans_durablejobs_job_attempt_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", le!=\"+Inf\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DurableJobs job attempt latency heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 168
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, status) (rate(orleans_durablejobs_storage_batch_size_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 {{status}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, status) (rate(orleans_durablejobs_storage_batch_size_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 {{status}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, status) (rate(orleans_durablejobs_storage_batch_size_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 {{status}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(orleans_durablejobs_storage_batch_size_sum{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) / clamp_min(sum by (status) (rate(orleans_durablejobs_storage_batch_size_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])), 1e-9)",
+          "legendFormat": "avg {{status}}",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "DurableJobs storage batch size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 168
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (status) (rate(orleans_durablejobs_storage_batches_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "batches {{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DurableJobs storage batch writes",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 176
+      },
+      "id": 107,
+      "panels": [],
+      "title": "Playground workload",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 177
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(playground_workflow_started_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "workflow starts",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(playground_workflow_completed_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "workflow completions",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(playground_workflow_failed_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "workflow failures",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(playground_workflow_retries_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "workflow retries",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Playground workflow throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 177
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(playground_workflow_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 workflow",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(playground_workflow_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 workflow",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(playground_workflow_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 workflow",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(playground_stage_schedule_to_start_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 schedule-to-start",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(playground_stage_schedule_to_start_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 schedule-to-start",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(playground_stage_schedule_to_start_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 schedule-to-start",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(playground_stage_execution_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 stage execution",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(playground_stage_execution_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 stage execution",
+          "range": true,
+          "refId": "H"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(playground_stage_execution_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 stage execution",
+          "range": true,
+          "refId": "I"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(playground_stage_reschedule_gap_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p50 reschedule gap",
+          "range": true,
+          "refId": "J"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(playground_stage_reschedule_gap_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p95 reschedule gap",
+          "range": true,
+          "refId": "K"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(playground_stage_reschedule_gap_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))",
+          "legendFormat": "p99 reschedule gap",
+          "range": true,
+          "refId": "L"
+        }
+      ],
+      "title": "Playground workflow latency quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 185
+      },
+      "id": 33,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ops"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(playground_workflow_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", le!=\"+Inf\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workflow duration heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 185
+      },
+      "id": 34,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "ops"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "ms"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(playground_stage_execution_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\", le!=\"+Inf\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Stage execution latency heatmap",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 193
+      },
+      "id": 108,
+      "panels": [],
+      "title": "Metric discovery",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 194
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "topk(40, count by (__name__) ({__name__=~\"orleans_.+_total\", job=~\"$job\", instance=~\"$instance\"}))",
+          "legendFormat": "{{__name__}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Observed Orleans counter series",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 202
+      },
+      "id": 19,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "count by (__name__) ({__name__=~\"orleans_.*|playground_.*\", job=~\"$job\", instance=~\"$instance\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Discovered Orleans and playground metric series",
+      "type": "table"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 41,
+  "tags": [
+    "orleans",
+    "aspire",
+    "durablejobs",
+    "journaling",
+    "runtime",
+    "playground"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "pluginId": "prometheus",
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(target_info, job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(target_info, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(target_info{job=~\"$job\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(target_info{job=~\"$job\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(playground_grain_requests_total{job=~\"$job\", instance=~\"$instance\"}, grain_type)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Grain type",
+        "multi": true,
+        "name": "grain_type",
+        "options": [],
+        "query": {
+          "query": "label_values(playground_grain_requests_total{job=~\"$job\", instance=~\"$instance\"}, grain_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Orleans DurableJobs Journaling Overview",
+  "uid": "orleans-durablejobs-journaling",
+  "version": 2,
+  "weekStart": ""
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/otelcollector/config.yaml
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/otelcollector/config.yaml
@@ -1,0 +1,40 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  otlp/aspire:
+    endpoint: ${env:ASPIRE_ENDPOINT}
+    headers:
+      x-otlp-api-key: ${env:ASPIRE_API_KEY}
+    tls:
+      insecure: ${env:ASPIRE_INSECURE}
+      insecure_skip_verify: true
+  otlphttp/prometheus:
+    endpoint: ${env:PROMETHEUS_ENDPOINT}
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/aspire]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/aspire]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters:
+        - otlp/aspire
+        - otlphttp/prometheus

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/prometheus/prometheus.yml
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.AppHost/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+storage:
+  tsdb:
+    out_of_order_time_window: 30m
+
+otlp:
+  translation_strategy: UnderscoreEscapingWithSuffixes
+  keep_identifying_resource_attributes: true
+  promote_resource_attributes:
+    - service.instance.id
+    - service.name
+    - service.namespace
+    - service.version
+    - deployment.environment.name

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.ServiceDefaults/DurableJobsJournaling.ServiceDefaults.csproj
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.ServiceDefaults/DurableJobsJournaling.ServiceDefaults.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+  </ItemGroup>
+
+</Project>

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.ServiceDefaults/Extensions.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.ServiceDefaults/Extensions.cs
@@ -1,0 +1,162 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting;
+
+public static class Extensions
+{
+    private const string HealthEndpointPath = "/health";
+    private const string AlivenessEndpointPath = "/alive";
+    private const string PlaygroundMeterName = "Orleans.Playground.DurableJobsJournaling";
+    private static readonly double[] LatencyHistogramBoundaries =
+    [
+        0, 1, 2, 5, 10, 25, 50, 100, 250, 500,
+        1_000, 2_000, 5_000, 10_000, 15_000, 20_000, 30_000, 60_000
+    ];
+
+    private static readonly double[] BatchSizeHistogramBoundaries =
+    [
+        1, 2, 4, 8, 16, 32, 64, 128,
+        256, 512, 1_024, 2_048, 4_096, 8_192, 16_384
+    ];
+
+    private static readonly double[] StorageOperationByteHistogramBoundaries =
+    [
+        256, 512, 1_024, 2_048, 4_096, 8_192, 16_384, 32_768,
+        65_536, 131_072, 262_144, 524_288, 1_048_576, 2_097_152,
+        4_194_304, 8_388_608, 16_777_216, 33_554_432, 67_108_864, 104_857_600
+    ];
+
+    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+    {
+        builder.ConfigureOpenTelemetry();
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            http.AddStandardResilienceHandler();
+            http.AddServiceDiscovery();
+        });
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation()
+                    .AddMeter("Microsoft.Orleans")
+                    .AddMeter(PlaygroundMeterName)
+                    .AddView("playground.grain.request.duration", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.workflow.duration", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.stage.schedule_to_start", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.stage.handoff", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.stage.state_write", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.stage.schedule_call", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.stage.due_wait", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.stage.queue_delay", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.stage.execution", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.stage.total", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.stage.workflow_elapsed", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.stage.unaccounted", CreateLatencyHistogramConfiguration())
+                    .AddView("playground.stage.reschedule_gap", CreateLatencyHistogramConfiguration())
+                    .AddView("orleans-durablejobs-job-dispatch-lag", CreateLatencyHistogramConfiguration())
+                    .AddView("orleans-durablejobs-job-attempt-duration", CreateLatencyHistogramConfiguration())
+                    .AddView("orleans-durablejobs-handler-execution-duration", CreateLatencyHistogramConfiguration())
+                    .AddView("orleans-durablejobs-schedule-job-call-duration", CreateLatencyHistogramConfiguration())
+                    .AddView("orleans-journaling-state-write-duration", CreateLatencyHistogramConfiguration())
+                    .AddView("orleans-journaling-storage-operation-duration", CreateLatencyHistogramConfiguration())
+                    .AddView("orleans-journaling-storage-operation-queue-duration", CreateLatencyHistogramConfiguration())
+                    .AddView("orleans-journaling-storage-operation-bytes", CreateStorageOperationByteHistogramConfiguration())
+                    .AddView("orleans-journaling-azure-blob-operation-duration", CreateLatencyHistogramConfiguration())
+                    .AddView("orleans-durablejobs-storage-batch-size", CreateBatchSizeHistogramConfiguration());
+            })
+            .WithTracing(tracing =>
+            {
+                if (builder.Environment.IsDevelopment())
+                {
+                    tracing.SetSampler(new AlwaysOnSampler());
+                }
+
+                tracing
+                    .AddSource(builder.Environment.ApplicationName)
+                    .AddSource("Microsoft.Orleans.Application")
+                    .AddSource("Microsoft.Orleans.Lifecycle")
+                    .AddSource("Microsoft.Orleans.Runtime")
+                    .AddSource("Microsoft.Orleans.Storage")
+                    .AddSource("Microsoft.Orleans.DurableJobs")
+                    .AddSource("Azure.*")
+                    .AddAspNetCoreInstrumentation(options =>
+                    {
+                        options.Filter = context =>
+                            !context.Request.Path.StartsWithSegments(HealthEndpointPath)
+                            && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath);
+                    })
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static IHostApplicationBuilder AddOpenTelemetryExporters(this IHostApplicationBuilder builder)
+    {
+        if (!string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]))
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        return builder;
+    }
+
+    private static ExplicitBucketHistogramConfiguration CreateLatencyHistogramConfiguration()
+        => new() { Boundaries = LatencyHistogramBoundaries };
+
+    private static ExplicitBucketHistogramConfiguration CreateBatchSizeHistogramConfiguration()
+        => new() { Boundaries = BatchSizeHistogramBoundaries };
+
+    private static ExplicitBucketHistogramConfiguration CreateStorageOperationByteHistogramConfiguration()
+        => new() { Boundaries = StorageOperationByteHistogramBoundaries };
+
+    public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddHealthChecks()
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        if (app.Environment.IsDevelopment())
+        {
+            app.MapHealthChecks(HealthEndpointPath);
+            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
+            {
+                Predicate = healthCheck => healthCheck.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/ChaosGrain.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/ChaosGrain.cs
@@ -1,0 +1,46 @@
+using DurableJobsJournaling.Abstractions;
+
+namespace DurableJobsJournaling.Silo;
+
+public sealed class ChaosGrain(
+    IClusterMembershipService clusterMembership,
+    ILocalSiloDetails localSiloDetails)
+    : Grain, IChaosGrain
+{
+    private ChaosResult? _lastResult;
+
+    public async Task<ChaosResult> TryKillSiloAsync()
+    {
+        var activeSilos = clusterMembership.CurrentSnapshot.Members
+            .Where(static item => item.Value.Status == SiloStatus.Active)
+            .Select(static item => item.Key)
+            .OrderBy(static silo => silo.ToString(), StringComparer.Ordinal)
+            .ToArray();
+
+        var target = activeSilos.FirstOrDefault(silo => !silo.Equals(localSiloDetails.SiloAddress)) ?? activeSilos.FirstOrDefault();
+        if (target is null)
+        {
+            return _lastResult = new ChaosResult(
+                Requested: true,
+                Succeeded: false,
+                Message: "No active silo was available to mark dead.",
+                SiloAddress: null,
+                DateTimeOffset.UtcNow,
+                activeSilos.Select(static silo => silo.ToString()).ToArray());
+        }
+
+        var succeeded = await clusterMembership.TryKill(target);
+        return _lastResult = new ChaosResult(
+            Requested: true,
+            Succeeded: succeeded,
+            Message: succeeded
+                ? $"Marked silo {target} dead through the cluster membership service."
+                : $"The cluster membership service did not mark silo {target} dead.",
+            SiloAddress: target.ToString(),
+            DateTimeOffset.UtcNow,
+            activeSilos.Select(static silo => silo.ToString()).ToArray());
+    }
+
+    public Task<ChaosResult> GetLastResultAsync()
+        => Task.FromResult(_lastResult ?? new ChaosResult(false, false, "No chaos action has been requested.", null, DateTimeOffset.UtcNow, []));
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/DurableJobsJournaling.Silo.csproj
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/DurableJobsJournaling.Silo.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+    <NoWarn>$(NoWarn);ORLEANSEXP005</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Azure.Data.Tables" />
+    <PackageReference Include="Aspire.Azure.Storage.Blobs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DurableJobsJournaling.Abstractions\DurableJobsJournaling.Abstractions.csproj" />
+    <ProjectReference Include="..\DurableJobsJournaling.ServiceDefaults\DurableJobsJournaling.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\..\src\Orleans.Server\Orleans.Server.csproj" />
+    <ProjectReference Include="..\..\..\src\Orleans.Sdk\Orleans.Sdk.csproj" />
+    <ProjectReference Include="..\..\..\src\Orleans.DurableJobs\Orleans.DurableJobs.csproj" />
+    <ProjectReference Include="..\..\..\src\Orleans.Journaling\Orleans.Journaling.csproj" />
+    <ProjectReference Include="..\..\..\src\Azure\Orleans.DurableJobs.AzureStorage\Orleans.DurableJobs.AzureStorage.csproj" />
+    <ProjectReference Include="..\..\..\src\Azure\Orleans.Journaling.AzureStorage\Orleans.Journaling.AzureStorage.csproj" />
+    <ProjectReference Include="..\..\..\src\Azure\Orleans.Clustering.AzureStorage\Orleans.Clustering.AzureStorage.csproj" />
+    <ProjectReference Include="..\..\..\src\Dashboard\Orleans.Dashboard\Orleans.Dashboard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/DurableJobsJournalingJsonContext.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/DurableJobsJournalingJsonContext.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+using DurableJobsJournaling.Abstractions;
+
+namespace DurableJobsJournaling.Silo;
+
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(ulong))]
+[JsonSerializable(typeof(DateTime))]
+[JsonSerializable(typeof(DateTimeOffset))]
+[JsonSerializable(typeof(LoadSettings))]
+[JsonSerializable(typeof(WorkflowStartRequest))]
+[JsonSerializable(typeof(WorkflowState))]
+[JsonSerializable(typeof(WorkflowStageRecord))]
+[JsonSerializable(typeof(ChildTaskResult))]
+[JsonSerializable(typeof(WorkflowResult))]
+internal sealed partial class DurableJobsJournalingJsonContext : JsonSerializerContext;

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/GrainRequestMetricsFilter.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/GrainRequestMetricsFilter.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace DurableJobsJournaling.Silo;
+
+public sealed class GrainRequestMetricsFilter : IIncomingGrainCallFilter
+{
+    private static readonly Meter Meter = new("Orleans.Playground.DurableJobsJournaling");
+    private static readonly Counter<long> Requests = Meter.CreateCounter<long>("playground.grain.requests");
+    private static readonly Histogram<double> Duration = Meter.CreateHistogram<double>("playground.grain.request.duration", unit: "ms");
+
+    public async Task Invoke(IIncomingGrainCallContext context)
+    {
+        var startedAt = Stopwatch.GetTimestamp();
+        var grainType = context.TargetId.Type.ToString() ?? "unknown";
+
+        try
+        {
+            await context.Invoke();
+            Record(grainType, "success", startedAt);
+        }
+        catch
+        {
+            Record(grainType, "error", startedAt);
+            throw;
+        }
+    }
+
+    private static void Record(string grainType, string status, long startedAt)
+    {
+        var elapsedMilliseconds = Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds;
+        var tags = new TagList
+        {
+            { "grain_type", grainType },
+            { "status", status }
+        };
+
+        Requests.Add(1, tags);
+        Duration.Record(elapsedMilliseconds, tags);
+    }
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Program.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Program.cs
@@ -1,0 +1,61 @@
+using Azure.Storage.Blobs;
+using DurableJobsJournaling.Abstractions;
+using DurableJobsJournaling.Silo;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Configuration;
+using Orleans.Dashboard;
+using Orleans.Hosting;
+using Orleans.Journaling;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+builder.AddAzureBlobServiceClient("blobs");
+builder.AddKeyedAzureTableServiceClient("tables");
+
+var storageContainer = builder.Configuration.GetValue("Playground:Storage:Container", "durablejobs-journaling-playground");
+var storagePrefix = builder.Configuration.GetValue("Playground:Storage:Prefix", $"run-{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss}");
+
+builder.UseOrleans(siloBuilder =>
+{
+    siloBuilder
+        .AddActivityPropagation()
+        .AddIncomingGrainCallFilter<GrainRequestMetricsFilter>()
+        .AddAzureBlobJournalStorage()
+        .UseAzureBlobDurableJobs(
+            options =>
+            {
+                options.ContainerName = storageContainer;
+                options.GetBlobName = journalId => $"{storagePrefix}/{journalId.Value}";
+            },
+            DurableJobsJournalingJsonContext.Default)
+        .Configure<DurableJobsOptions>(options =>
+        {
+            options.ShardDuration = TimeSpan.FromMinutes(5);
+            options.ShardActivationBufferPeriod = TimeSpan.FromSeconds(30);
+            options.ShardStripeCount = 1;
+            options.JobStatusPollInterval = TimeSpan.FromMilliseconds(100);
+            options.MaxConcurrentJobsPerSilo = 512;
+            options.ConcurrencySlowStartEnabled = true;
+            options.SlowStartInitialConcurrency = 16;
+            options.SlowStartInterval = TimeSpan.FromSeconds(5);
+            builder.Configuration.GetSection("Playground:DurableJobs").Bind(options);
+            options.ShouldRetry = (context, _) => context.DequeueCount < 3
+                ? DateTimeOffset.UtcNow.AddMilliseconds(250 * Math.Pow(2, context.DequeueCount))
+                : null;
+        })
+        .AddDashboard();
+});
+
+builder.Services.AddOptions<AzureBlobJournalStorageOptions>()
+    .Configure<BlobServiceClient>((options, blobServiceClient) =>
+    {
+        options.BlobServiceClient = blobServiceClient;
+    });
+
+var app = builder.Build();
+app.MapDefaultEndpoints();
+app.MapOrleansDashboard();
+
+await app.RunAsync();

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Program.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Program.cs
@@ -14,10 +14,12 @@ var storagePrefix = builder.Configuration.GetValue("Playground:Storage:Prefix", 
 
 builder.UseOrleans(siloBuilder =>
 {
+#pragma warning disable ORLEANSEXP003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     siloBuilder
         .AddDashboard()
         .AddActivityPropagation()
         .AddIncomingGrainCallFilter<GrainRequestMetricsFilter>()
+        .AddDistributedGrainDirectory()
         .AddAzureBlobJournalStorage()
         .UseAzureBlobDurableJobs(
             options =>
@@ -28,20 +30,19 @@ builder.UseOrleans(siloBuilder =>
             DurableJobsJournalingJsonContext.Default)
         .Configure<DurableJobsOptions>(options =>
         {
-            options.ShardDuration = TimeSpan.FromMinutes(5);
+            options.ShardDuration = TimeSpan.FromMinutes(2);
             options.ShardActivationBufferPeriod = TimeSpan.FromSeconds(30);
             options.ShardStripeCount = 2;
             options.JobStatusPollInterval = TimeSpan.FromMilliseconds(100);
-            options.MaxConcurrentJobsPerSilo = 512;
+            options.MaxConcurrentJobsPerSilo = 8196;
             options.ConcurrencySlowStartEnabled = true;
-            options.SlowStartInitialConcurrency = 16;
-            options.SlowStartInterval = TimeSpan.FromSeconds(5);
+            options.SlowStartInterval = TimeSpan.FromSeconds(2);
             builder.Configuration.GetSection("Playground:DurableJobs").Bind(options);
             options.ShouldRetry = (context, _) => context.DequeueCount < 3
                 ? DateTimeOffset.UtcNow.AddMilliseconds(250 * Math.Pow(2, context.DequeueCount))
                 : null;
-        })
-        .AddDashboard();
+        });
+#pragma warning restore ORLEANSEXP003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 });
 
 builder.Services.AddOptions<AzureBlobJournalStorageOptions>()

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Program.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Program.cs
@@ -1,11 +1,6 @@
 using Azure.Storage.Blobs;
-using DurableJobsJournaling.Abstractions;
 using DurableJobsJournaling.Silo;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Orleans.Configuration;
 using Orleans.Dashboard;
-using Orleans.Hosting;
 using Orleans.Journaling;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -20,6 +15,7 @@ var storagePrefix = builder.Configuration.GetValue("Playground:Storage:Prefix", 
 builder.UseOrleans(siloBuilder =>
 {
     siloBuilder
+        .AddDashboard()
         .AddActivityPropagation()
         .AddIncomingGrainCallFilter<GrainRequestMetricsFilter>()
         .AddAzureBlobJournalStorage()
@@ -34,7 +30,7 @@ builder.UseOrleans(siloBuilder =>
         {
             options.ShardDuration = TimeSpan.FromMinutes(5);
             options.ShardActivationBufferPeriod = TimeSpan.FromSeconds(30);
-            options.ShardStripeCount = 1;
+            options.ShardStripeCount = 2;
             options.JobStatusPollInterval = TimeSpan.FromMilliseconds(100);
             options.MaxConcurrentJobsPerSilo = 512;
             options.ConcurrencySlowStartEnabled = true;

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Program.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Program.cs
@@ -2,6 +2,7 @@ using Azure.Storage.Blobs;
 using DurableJobsJournaling.Silo;
 using Orleans.Dashboard;
 using Orleans.Journaling;
+using Orleans.Journaling.Json;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,14 +21,13 @@ builder.UseOrleans(siloBuilder =>
         .AddActivityPropagation()
         .AddIncomingGrainCallFilter<GrainRequestMetricsFilter>()
         .AddDistributedGrainDirectory()
-        .AddAzureBlobJournalStorage()
         .UseAzureBlobDurableJobs(
             options =>
             {
                 options.ContainerName = storageContainer;
                 options.GetBlobName = journalId => $"{storagePrefix}/{journalId.Value}";
-            },
-            DurableJobsJournalingJsonContext.Default)
+            })
+        .Configure<JsonJournalOptions>(options => options.AddTypeInfoResolver(DurableJobsJournalingJsonContext.Default))
         .Configure<DurableJobsOptions>(options =>
         {
             options.ShardDuration = TimeSpan.FromMinutes(2);

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Properties/launchSettings.json
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "DurableJobsJournaling.Silo": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:52747;http://localhost:52748"
+    }
+  }
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/WorkflowGrains.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/WorkflowGrains.cs
@@ -79,6 +79,7 @@ public sealed class WorkflowCoordinatorGrain(ILocalDurableJobManager jobManager)
 
     public async Task ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken)
     {
+        await Task.Delay(10);
         var currentState = _state ?? CreateDefaultState(DateTimeOffset.UtcNow);
         if (currentState.Status is WorkflowStatus.Completed or WorkflowStatus.Failed or WorkflowStatus.Canceled)
         {

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/WorkflowGrains.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/WorkflowGrains.cs
@@ -1,0 +1,275 @@
+using System.Diagnostics;
+using DurableJobsJournaling.Abstractions;
+using Orleans.DurableJobs;
+
+namespace DurableJobsJournaling.Silo;
+
+[CollectionAgeLimit(Minutes = 1.01)]
+public sealed class WorkflowCoordinatorGrain(ILocalDurableJobManager jobManager)
+    : Grain, IWorkflowCoordinatorGrain, IDurableJobHandler
+{
+    private const string WorkflowJobName = "workflow";
+
+    private WorkflowState? _state;
+    private List<WorkflowStageRecord> stages = [];
+    TaskCompletionSource<WorkflowResult> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private Stopwatch? _workflowStopwatch;
+
+    public async Task StartAsync(WorkflowStartRequest request)
+    {
+        if (_state is { Status: WorkflowStatus.Running })
+        {
+            return;
+        }
+
+        stages.Clear();
+        _workflowStopwatch = Stopwatch.StartNew();
+        var now = DateTimeOffset.UtcNow;
+        var settings = request.Settings.Normalize();
+        _state = new WorkflowState(
+            request.WorkflowId,
+            WorkflowStatus.Running,
+            WorkflowStage.Accept,
+            request.CreatedAt,
+            now,
+            CompletedAt: null,
+            RetryCount: 0,
+            FailureCount: 0,
+            Error: null,
+            settings);
+
+        //var writeTask = WriteStateAsync();
+        var scheduleTask = jobManager.ScheduleJobAsync(
+            new ScheduleJobRequest
+            {
+                Target = this.GetGrainId(),
+                JobName = WorkflowJobName,
+                DueTime = now
+            },
+            CancellationToken.None);
+        await scheduleTask;
+    }
+
+    public async Task<WorkflowResult> AwaitCompletionAsync() => await _completion.Task;
+
+    public Task<WorkflowSnapshot> GetSnapshotAsync()
+    {
+        var completionState = _completion;
+        return Task.FromResult(new WorkflowSnapshot(
+            _state,
+            stages.ToArray(),
+            [],
+            completionState.Task.IsCompleted));
+    }
+
+    public Task CancelAsync()
+    {
+        var now = DateTimeOffset.UtcNow;
+        _state = (_state ?? CreateDefaultState(now)) with
+        {
+            Status = WorkflowStatus.Canceled,
+            CompletedAt = now,
+            UpdatedAt = now,
+            Error = "Canceled"
+        };
+
+        _completion.TrySetResult(CreateResult(now, "Canceled"));
+        return Task.CompletedTask;
+    }
+
+    public async Task ExecuteJobAsync(IJobRunContext context, CancellationToken cancellationToken)
+    {
+        var currentState = _state ?? CreateDefaultState(DateTimeOffset.UtcNow);
+        if (currentState.Status is WorkflowStatus.Completed or WorkflowStatus.Failed or WorkflowStatus.Canceled)
+        {
+            return;
+        }
+
+        var transitionTiming = CreateCurrentStageTransitionTiming(context.Job.DueTime, currentState);
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            currentState = _state ?? currentState;
+            if (currentState.Status is WorkflowStatus.Completed or WorkflowStatus.Failed or WorkflowStatus.Canceled)
+            {
+                return;
+            }
+
+            var stage = currentState.ActiveStage;
+            var startedAt = DateTimeOffset.UtcNow;
+            var stageStopwatch = Stopwatch.StartNew();
+            var attempt = CalculateStageAttempt(stage);
+            _state = currentState with
+            {
+                Status = WorkflowStatus.Running,
+                ActiveStage = stage,
+                UpdatedAt = startedAt,
+                RetryCount = CalculateRetryCount(),
+                FailureCount = CalculateFailureCount(),
+                Error = null
+            };
+
+            stageStopwatch.Stop();
+            var completedAt = startedAt.Add(stageStopwatch.Elapsed);
+            stages.Add(CreateStageRecord(
+                stage,
+                attempt,
+                context.Job.Id,
+                transitionTiming,
+                startedAt,
+                completedAt,
+                stageStopwatch.Elapsed,
+                succeeded: true,
+                error: null));
+
+            if (IsTerminalStage(stage))
+            {
+                _state = _state with
+                {
+                    Status = WorkflowStatus.Completed,
+                    CompletedAt = completedAt,
+                    UpdatedAt = completedAt,
+                    RetryCount = CalculateRetryCount(),
+                    FailureCount = CalculateFailureCount(),
+                    Error = null
+                };
+
+                _completion.TrySetResult(CreateResult(completedAt, error: null));
+            }
+            else
+            {
+                var nextStage = GetNextStage(stage);
+                _state = _state with
+                {
+                    ActiveStage = nextStage,
+                    UpdatedAt = completedAt,
+                    RetryCount = CalculateRetryCount(),
+                    FailureCount = CalculateFailureCount(),
+                    Error = null
+                };
+            }
+
+            var stateWriteStartedAt = DateTimeOffset.UtcNow;
+            var stateWriteStopwatch = Stopwatch.StartNew();
+            stateWriteStopwatch.Stop();
+            var stateWriteCompletedAt = stateWriteStartedAt.Add(stateWriteStopwatch.Elapsed);
+            transitionTiming = StageTransitionTiming.ForNextStage(completedAt, stateWriteStartedAt, stateWriteCompletedAt);
+        }
+    }
+
+    private WorkflowResult CreateResult(DateTimeOffset completedAt, string? error)
+    {
+        var currentState = _state ?? CreateDefaultState(completedAt);
+        var status = error is null ? currentState.Status : WorkflowStatus.Failed;
+        var totalLatencyMilliseconds = GetTotalLatencyMilliseconds(currentState, completedAt);
+        return new WorkflowResult(
+            currentState.WorkflowId,
+            status,
+            currentState.CreatedAt,
+            completedAt,
+            totalLatencyMilliseconds,
+            stages.ToArray(),
+            [],
+            CalculateRetryCount(),
+            CalculateFailureCount(),
+            error);
+    }
+
+    private double GetTotalLatencyMilliseconds(WorkflowState currentState, DateTimeOffset completedAt)
+    {
+        if (_workflowStopwatch is { } workflowStopwatch)
+        {
+            workflowStopwatch.Stop();
+            return workflowStopwatch.Elapsed.TotalMilliseconds;
+        }
+
+        return (completedAt - currentState.CreatedAt).TotalMilliseconds;
+    }
+
+    private WorkflowState CreateDefaultState(DateTimeOffset now)
+        => new(this.GetPrimaryKey(), WorkflowStatus.NotStarted, WorkflowStage.Accept, now, now, null, 0, 0, null, LoadSettings.Default);
+
+    private static WorkflowStage GetNextStage(WorkflowStage stage) => stage switch
+    {
+        WorkflowStage.Accept => WorkflowStage.ReserveInventory,
+        WorkflowStage.ReserveInventory => WorkflowStage.ChargePayment,
+        WorkflowStage.ChargePayment => WorkflowStage.PackShipment,
+        WorkflowStage.PackShipment => WorkflowStage.Audit,
+        WorkflowStage.Audit => WorkflowStage.Complete,
+        _ => WorkflowStage.Complete
+    };
+
+    private static bool IsTerminalStage(WorkflowStage stage) => stage is WorkflowStage.Accept or WorkflowStage.Audit or WorkflowStage.Complete;
+
+    private WorkflowStageRecord CreateStageRecord(
+        WorkflowStage stage,
+        int attempt,
+        string jobId,
+        StageTransitionTiming transitionTiming,
+        DateTimeOffset startedAt,
+        DateTimeOffset completedAt,
+        TimeSpan executionElapsed,
+        bool succeeded,
+        string? error)
+        => new(
+            stage,
+            attempt,
+            jobId,
+            transitionTiming.ScheduledAt,
+            startedAt,
+            completedAt,
+            (startedAt - transitionTiming.ScheduledAt).TotalMilliseconds,
+            executionElapsed.TotalMilliseconds,
+            (startedAt - transitionTiming.PreviousStageCompletedAt).TotalMilliseconds,
+            ChildCount: 0,
+            succeeded,
+            error,
+            transitionTiming.PreviousStageCompletedAt,
+            transitionTiming.StateWriteStartedAt,
+            transitionTiming.StateWriteCompletedAt,
+            transitionTiming.ScheduleRequestedAt,
+            transitionTiming.ScheduleCompletedAt);
+
+    private StageTransitionTiming CreateCurrentStageTransitionTiming(DateTimeOffset jobDueTime, WorkflowState currentState)
+    {
+        var previousStage = currentState.ActiveStage is WorkflowStage.Accept
+            ? null
+            : stages.LastOrDefault(static stage => stage.Succeeded);
+        var previousCompletedAt = previousStage?.CompletedAt ?? currentState.CreatedAt;
+        var scheduledAt = jobDueTime > previousCompletedAt ? jobDueTime : previousCompletedAt;
+        return new StageTransitionTiming(
+            scheduledAt,
+            previousCompletedAt,
+            StateWriteStartedAt: default,
+            StateWriteCompletedAt: default,
+            ScheduleRequestedAt: default,
+            ScheduleCompletedAt: default);
+    }
+
+    private int CalculateRetryCount() => stages.Where(static stage => stage.Succeeded).Sum(static stage => Math.Max(0, stage.Attempt - 1));
+
+    private int CalculateFailureCount() => stages.Count(static stage => !stage.Succeeded);
+
+    private int CalculateStageAttempt(WorkflowStage stage) => stages.Count(record => record.Stage == stage && !record.Succeeded) + 1;
+
+    private readonly record struct StageTransitionTiming(
+        DateTimeOffset ScheduledAt,
+        DateTimeOffset PreviousStageCompletedAt,
+        DateTimeOffset StateWriteStartedAt,
+        DateTimeOffset StateWriteCompletedAt,
+        DateTimeOffset ScheduleRequestedAt,
+        DateTimeOffset ScheduleCompletedAt)
+    {
+        public static StageTransitionTiming ForNextStage(
+            DateTimeOffset previousStageCompletedAt,
+            DateTimeOffset stateWriteStartedAt,
+            DateTimeOffset stateWriteCompletedAt)
+            => new(
+                ScheduledAt: stateWriteCompletedAt,
+                previousStageCompletedAt,
+                stateWriteStartedAt,
+                stateWriteCompletedAt,
+                ScheduleRequestedAt: stateWriteCompletedAt,
+                ScheduleCompletedAt: stateWriteCompletedAt);
+    }
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Web/DurableJobsJournaling.Web.csproj
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Web/DurableJobsJournaling.Web.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Azure.Data.Tables" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DurableJobsJournaling.Abstractions\DurableJobsJournaling.Abstractions.csproj" />
+    <ProjectReference Include="..\DurableJobsJournaling.ServiceDefaults\DurableJobsJournaling.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\..\src\Orleans.Client\Orleans.Client.csproj" />
+    <ProjectReference Include="..\..\..\src\Orleans.Sdk\Orleans.Sdk.csproj" />
+    <ProjectReference Include="..\..\..\src\Azure\Orleans.Clustering.AzureStorage\Orleans.Clustering.AzureStorage.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Web/LoadDriver.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Web/LoadDriver.cs
@@ -1,0 +1,250 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using DurableJobsJournaling.Abstractions;
+
+namespace DurableJobsJournaling.Web;
+
+public sealed class LoadDriver(IClusterClient client, WorkflowMetrics metrics, ILogger<LoadDriver> logger) : BackgroundService
+{
+    private readonly ConcurrentDictionary<Guid, Task> _inflight = [];
+    private readonly object _settingsLock = new();
+    private readonly SemaphoreSlim _wakeSignal = new(0);
+    private readonly TokenBucket _tokenBucket = new();
+    private LoadSettings _settings = LoadSettings.Default;
+    private bool _enabled;
+    private DateTimeOffset? _startedAt;
+    private long _started;
+    private long _completed;
+    private long _failed;
+
+    public void Enable()
+    {
+        _enabled = true;
+        _startedAt ??= DateTimeOffset.UtcNow;
+        Wake();
+    }
+
+    public void Disable()
+    {
+        _enabled = false;
+        Wake();
+    }
+
+    public LoadSettings UpdateSettings(LoadSettings settings)
+    {
+        var normalized = settings.Normalize();
+        lock (_settingsLock)
+        {
+            _settings = normalized;
+        }
+
+        Wake();
+        return normalized;
+    }
+
+    public LoadDriverState GetState()
+    {
+        LoadSettings settings;
+        lock (_settingsLock)
+        {
+            settings = _settings;
+        }
+
+        return new LoadDriverState(
+            _enabled,
+            settings,
+            _inflight.Count,
+            Interlocked.Read(ref _started),
+            Interlocked.Read(ref _completed),
+            Interlocked.Read(ref _failed),
+            _startedAt);
+    }
+
+    public async Task DrainAsync(CancellationToken cancellationToken)
+    {
+        Disable();
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var inflight = _inflight.Values.ToArray();
+            if (inflight.Length is 0)
+            {
+                return;
+            }
+
+            await Task.WhenAny(inflight).WaitAsync(cancellationToken);
+        }
+    }
+
+    public async Task ResetAsync(CancellationToken cancellationToken)
+    {
+        await DrainAsync(cancellationToken);
+        Interlocked.Exchange(ref _started, 0);
+        Interlocked.Exchange(ref _completed, 0);
+        Interlocked.Exchange(ref _failed, 0);
+        _startedAt = null;
+        _tokenBucket.Reset();
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var state = GetState();
+            if (state.Enabled && state.Settings.TargetConcurrency > 0)
+            {
+                _tokenBucket.Refill(state.Settings.TargetStartsPerSecond);
+                while (_inflight.Count < state.Settings.TargetConcurrency && _tokenBucket.TryConsume(state.Settings.TargetStartsPerSecond))
+                {
+                    StartWorkflow(state.Settings, stoppingToken);
+                }
+
+                if (_inflight.Count < state.Settings.TargetConcurrency && _tokenBucket.GetDelayUntilNextToken(state.Settings.TargetStartsPerSecond) is { } delay && delay > TimeSpan.Zero)
+                {
+                    await WaitForWakeOrDelayAsync(delay, stoppingToken);
+                    continue;
+                }
+            }
+
+            await WaitForWakeAsync(stoppingToken);
+        }
+    }
+
+    private void StartWorkflow(LoadSettings settings, CancellationToken stoppingToken)
+    {
+        var workflowId = Guid.NewGuid();
+        metrics.RecordStarted();
+        Interlocked.Increment(ref _started);
+
+        var tracker = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _inflight[workflowId] = tracker.Task;
+        _ = RunWorkflowAsync(workflowId, settings, tracker, stoppingToken);
+    }
+
+    private async Task RunWorkflowAsync(
+        Guid workflowId,
+        LoadSettings settings,
+        TaskCompletionSource tracker,
+        CancellationToken stoppingToken)
+    {
+        try
+        {
+            var startedAt = DateTimeOffset.UtcNow;
+            var grain = client.GetGrain<IWorkflowCoordinatorGrain>(workflowId);
+            await grain.StartAsync(new WorkflowStartRequest(workflowId, startedAt, settings));
+            var result = await grain.AwaitCompletionAsync().WaitAsync(stoppingToken);
+            if (result.Status is WorkflowStatus.Completed)
+            {
+                metrics.RecordCompleted(result);
+                Interlocked.Increment(ref _completed);
+            }
+            else
+            {
+                metrics.RecordFailed(result);
+                Interlocked.Increment(ref _failed);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(exception, "Workflow {WorkflowId} failed in the load driver", workflowId);
+            metrics.RecordFailed(workflowId, exception);
+            Interlocked.Increment(ref _failed);
+        }
+        finally
+        {
+            tracker.TrySetResult();
+            _inflight.TryRemove(workflowId, out _);
+            Wake();
+        }
+    }
+
+    private Task WaitForWakeAsync(CancellationToken cancellationToken) => _wakeSignal.WaitAsync(cancellationToken);
+
+    private async Task WaitForWakeOrDelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        using var delayCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var wakeTask = _wakeSignal.WaitAsync(delayCancellation.Token);
+        var delayTask = Task.Delay(delay, cancellationToken);
+        var completedTask = await Task.WhenAny(wakeTask, delayTask);
+        if (completedTask == delayTask)
+        {
+            await delayCancellation.CancelAsync();
+            try
+            {
+                await wakeTask;
+            }
+            catch (OperationCanceledException) when (delayCancellation.IsCancellationRequested)
+            {
+            }
+        }
+    }
+
+    private void Wake()
+        => _wakeSignal.Release();
+
+    private sealed class TokenBucket
+    {
+        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+        private double _tokens;
+        private TimeSpan _lastRefillElapsed;
+        private bool _hasRefillElapsed;
+
+        public bool TryConsume(double targetStartsPerSecond)
+        {
+            if (targetStartsPerSecond <= 0)
+            {
+                return true;
+            }
+
+            if (_tokens < 1)
+            {
+                return false;
+            }
+
+            _tokens -= 1;
+            return true;
+        }
+
+        public void Refill(double targetStartsPerSecond)
+        {
+            if (targetStartsPerSecond <= 0)
+            {
+                return;
+            }
+
+            var elapsed = _stopwatch.Elapsed;
+            if (!_hasRefillElapsed)
+            {
+                _lastRefillElapsed = elapsed;
+                _hasRefillElapsed = true;
+                _tokens = Math.Min(targetStartsPerSecond, 1);
+                return;
+            }
+
+            var elapsedSeconds = (elapsed - _lastRefillElapsed).TotalSeconds;
+            _lastRefillElapsed = elapsed;
+            _tokens = Math.Min(Math.Max(1, targetStartsPerSecond), _tokens + elapsedSeconds * targetStartsPerSecond);
+        }
+
+        public TimeSpan GetDelayUntilNextToken(double targetStartsPerSecond)
+        {
+            if (targetStartsPerSecond <= 0 || _tokens >= 1)
+            {
+                return TimeSpan.Zero;
+            }
+
+            return TimeSpan.FromSeconds((1 - _tokens) / targetStartsPerSecond);
+        }
+
+        public void Reset()
+        {
+            _tokens = 0;
+            _lastRefillElapsed = TimeSpan.Zero;
+            _hasRefillElapsed = false;
+            _stopwatch.Restart();
+        }
+    }
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Web/Program.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Web/Program.cs
@@ -1,0 +1,87 @@
+using System.Text.Json.Serialization;
+using DurableJobsJournaling.Abstractions;
+using DurableJobsJournaling.Web;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Orleans.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+builder.AddKeyedAzureTableServiceClient("tables");
+builder.UseOrleansClient(clientBuilder => clientBuilder.AddActivityPropagation());
+builder.Services.AddSingleton<WorkflowMetrics>();
+builder.Services.AddSingleton<LoadDriver>();
+builder.Services.AddHostedService(static services => services.GetRequiredService<LoadDriver>());
+builder.Services.ConfigureHttpJsonOptions(options => options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
+
+var app = builder.Build();
+app.MapDefaultEndpoints();
+
+var defaultFiles = new DefaultFilesOptions();
+defaultFiles.DefaultFileNames.Clear();
+defaultFiles.DefaultFileNames.Add("index.html");
+
+app.UseDefaultFiles(defaultFiles);
+app.UseStaticFiles();
+
+app.MapGet("/api/load", (LoadDriver driver) => driver.GetState());
+app.MapPut("/api/load", ([FromBody] LoadSettings settings, LoadDriver driver) => Results.Ok(driver.UpdateSettings(settings)));
+app.MapPost("/api/load/start", async (
+    HttpRequest request,
+    LoadDriver driver,
+    IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions> jsonOptions) =>
+{
+    if (request.HasJsonContentType() && request.ContentLength is not 0)
+    {
+        var settings = await request.ReadFromJsonAsync<LoadSettings>(jsonOptions.Value.SerializerOptions, request.HttpContext.RequestAborted);
+        if (settings is not null)
+        {
+            driver.UpdateSettings(settings);
+        }
+    }
+
+    driver.Enable();
+    return Results.Ok(driver.GetState());
+});
+app.MapPost("/api/load/stop", (LoadDriver driver) =>
+{
+    driver.Disable();
+    return Results.Ok(driver.GetState());
+});
+app.MapPost("/api/load/drain", async (LoadDriver driver, CancellationToken cancellationToken) =>
+{
+    await driver.DrainAsync(cancellationToken);
+    return Results.Ok(driver.GetState());
+});
+app.MapPost("/api/load/reset", async (LoadDriver driver, WorkflowMetrics metrics, CancellationToken cancellationToken) =>
+{
+    await driver.ResetAsync(cancellationToken);
+    metrics.Reset();
+    return Results.Ok(driver.GetState());
+});
+
+app.MapGet("/api/metrics/snapshot", (WorkflowMetrics metrics, LoadDriver driver) => metrics.GetSnapshot(driver.GetState()));
+app.MapGet("/api/workflows/recent", (WorkflowMetrics metrics) => metrics.GetRecentWorkflows());
+app.MapGet("/api/workflows/{workflowId:guid}", async (Guid workflowId, IClusterClient client) =>
+{
+    var grain = client.GetGrain<IWorkflowCoordinatorGrain>(workflowId);
+    return Results.Ok(await grain.GetSnapshotAsync());
+});
+app.MapPost("/api/workflows/start", async ([FromBody] LoadSettings settings, IClusterClient client) =>
+{
+    var workflowId = Guid.NewGuid();
+    var normalized = settings.Normalize();
+    var grain = client.GetGrain<IWorkflowCoordinatorGrain>(workflowId);
+    await grain.StartAsync(new WorkflowStartRequest(workflowId, DateTimeOffset.UtcNow, normalized));
+    return Results.Ok(new { workflowId });
+});
+app.MapPost("/api/chaos/silo/kill", async (IClusterClient client, WorkflowMetrics metrics) =>
+{
+    var result = await client.GetGrain<IChaosGrain>("controller").TryKillSiloAsync();
+    metrics.RecordChaos(result);
+    return Results.Ok(result);
+});
+app.MapGet("/api/chaos/last", async (IClusterClient client) => await client.GetGrain<IChaosGrain>("controller").GetLastResultAsync());
+
+app.Run();

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Web/Properties/launchSettings.json
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Web/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "DurableJobsJournaling.Web": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:51141;http://localhost:51142"
+    }
+  }
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Web/WorkflowMetrics.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Web/WorkflowMetrics.cs
@@ -1,0 +1,396 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using DurableJobsJournaling.Abstractions;
+
+namespace DurableJobsJournaling.Web;
+
+public sealed class WorkflowMetrics
+{
+    private static readonly Meter Meter = new("Orleans.Playground.DurableJobsJournaling");
+    private readonly Counter<long> _started = Meter.CreateCounter<long>("playground.workflow.started");
+    private readonly Counter<long> _completed = Meter.CreateCounter<long>("playground.workflow.completed");
+    private readonly Counter<long> _failed = Meter.CreateCounter<long>("playground.workflow.failed");
+    private readonly Counter<long> _retries = Meter.CreateCounter<long>("playground.workflow.retries");
+    private readonly Histogram<double> _endToEndLatency = Meter.CreateHistogram<double>("playground.workflow.duration", unit: "ms");
+    private readonly Histogram<double> _scheduleToStartLatency = Meter.CreateHistogram<double>("playground.stage.schedule_to_start", unit: "ms");
+    private readonly Histogram<double> _stageHandoffLatency = Meter.CreateHistogram<double>("playground.stage.handoff", unit: "ms");
+    private readonly Histogram<double> _stageStateWriteLatency = Meter.CreateHistogram<double>("playground.stage.state_write", unit: "ms");
+    private readonly Histogram<double> _stageScheduleCallLatency = Meter.CreateHistogram<double>("playground.stage.schedule_call", unit: "ms");
+    private readonly Histogram<double> _stageDueWaitLatency = Meter.CreateHistogram<double>("playground.stage.due_wait", unit: "ms");
+    private readonly Histogram<double> _stageQueueLatency = Meter.CreateHistogram<double>("playground.stage.queue_delay", unit: "ms");
+    private readonly Histogram<double> _stageExecutionLatency = Meter.CreateHistogram<double>("playground.stage.execution", unit: "ms");
+    private readonly Histogram<double> _stageTotalLatency = Meter.CreateHistogram<double>("playground.stage.total", unit: "ms");
+    private readonly Histogram<double> _stageWorkflowElapsedLatency = Meter.CreateHistogram<double>("playground.stage.workflow_elapsed", unit: "ms");
+    private readonly Histogram<double> _stageUnaccountedLatency = Meter.CreateHistogram<double>("playground.stage.unaccounted", unit: "ms");
+    private readonly Histogram<double> _rescheduleGapLatency = Meter.CreateHistogram<double>("playground.stage.reschedule_gap", unit: "ms");
+    private readonly object _lock = new();
+    private readonly Queue<EventSample> _events = [];
+    private readonly Queue<double> _endToEndSamples = [];
+    private readonly Queue<double> _scheduleToStartSamples = [];
+    private readonly Queue<double> _stageExecutionSamples = [];
+    private readonly Queue<double> _rescheduleGapSamples = [];
+    private readonly Queue<RecentWorkflowSummary> _recent = [];
+    private readonly Dictionary<WorkflowStage, StageAccumulator> _stageAccumulators = [];
+    private readonly Stopwatch _eventWindowClock = Stopwatch.StartNew();
+    private ChaosResult? _lastChaos;
+
+    public void Reset()
+    {
+        lock (_lock)
+        {
+            _events.Clear();
+            _endToEndSamples.Clear();
+            _scheduleToStartSamples.Clear();
+            _stageExecutionSamples.Clear();
+            _rescheduleGapSamples.Clear();
+            _recent.Clear();
+            _stageAccumulators.Clear();
+            _eventWindowClock.Restart();
+            _lastChaos = null;
+        }
+    }
+
+    public void RecordStarted()
+    {
+        _started.Add(1);
+        AddEvent(EventKind.Started);
+    }
+
+    public void RecordCompleted(WorkflowResult result)
+    {
+        _completed.Add(1);
+        _retries.Add(result.RetryCount);
+        _endToEndLatency.Record(result.TotalLatencyMilliseconds);
+
+        lock (_lock)
+        {
+            AddSample(_endToEndSamples, result.TotalLatencyMilliseconds);
+            AddRecent(new RecentWorkflowSummary(
+                result.WorkflowId,
+                result.Status,
+                result.CompletedAt,
+                result.TotalLatencyMilliseconds,
+                result.RetryCount,
+                result.FailureCount,
+                result.Error));
+
+            foreach (var stage in result.Stages)
+            {
+                RecordStageLocked(result.CreatedAt, stage);
+            }
+        }
+
+        AddEvent(EventKind.Completed);
+        for (var i = 0; i < result.RetryCount; i++)
+        {
+            AddEvent(EventKind.Retry);
+        }
+    }
+
+    public void RecordFailed(WorkflowResult result)
+    {
+        _failed.Add(1);
+        _retries.Add(result.RetryCount);
+        lock (_lock)
+        {
+            AddRecent(new RecentWorkflowSummary(
+                result.WorkflowId,
+                result.Status,
+                result.CompletedAt,
+                result.TotalLatencyMilliseconds,
+                result.RetryCount,
+                result.FailureCount,
+                result.Error));
+
+            foreach (var stage in result.Stages)
+            {
+                RecordStageLocked(result.CreatedAt, stage);
+            }
+        }
+
+        AddEvent(EventKind.Failed);
+    }
+
+    public void RecordFailed(Guid workflowId, Exception exception)
+    {
+        _failed.Add(1);
+        lock (_lock)
+        {
+            AddRecent(new RecentWorkflowSummary(
+                workflowId,
+                WorkflowStatus.Failed,
+                DateTimeOffset.UtcNow,
+                0,
+                0,
+                1,
+                exception.Message));
+        }
+
+        AddEvent(EventKind.Failed);
+    }
+
+    public void RecordChaos(ChaosResult result)
+    {
+        lock (_lock)
+        {
+            _lastChaos = result;
+        }
+    }
+
+    public RecentWorkflowSummary[] GetRecentWorkflows()
+    {
+        lock (_lock)
+        {
+            return _recent.Reverse().ToArray();
+        }
+    }
+
+    public MetricSnapshot GetSnapshot(LoadDriverState load)
+    {
+        lock (_lock)
+        {
+            PruneEvents(_eventWindowClock.Elapsed);
+            var now = DateTimeOffset.UtcNow;
+            return new MetricSnapshot(
+                now,
+                load,
+                CalculateRatesLocked(),
+                Summarize(_endToEndSamples),
+                Summarize(_scheduleToStartSamples),
+                Summarize(_stageExecutionSamples),
+                Summarize(_rescheduleGapSamples),
+                _stageAccumulators
+                    .OrderBy(static item => item.Key)
+                    .Select(static item => item.Value.ToMetric(item.Key))
+                    .ToArray(),
+                _recent.Reverse().ToArray(),
+                _lastChaos);
+        }
+    }
+
+    private void RecordStageLocked(DateTimeOffset workflowCreatedAt, WorkflowStageRecord stage)
+    {
+        var phases = StagePhaseMeasurements.Create(workflowCreatedAt, stage);
+        var tags = new KeyValuePair<string, object?>[] { new("stage", stage.Stage.ToString()) };
+        _scheduleToStartLatency.Record(stage.ScheduleToStartMilliseconds, tags);
+        _stageHandoffLatency.Record(phases.HandoffMilliseconds, tags);
+        _stageStateWriteLatency.Record(phases.StateWriteMilliseconds, tags);
+        _stageScheduleCallLatency.Record(phases.ScheduleCallMilliseconds, tags);
+        _stageDueWaitLatency.Record(phases.DueWaitMilliseconds, tags);
+        _stageQueueLatency.Record(phases.QueueMilliseconds, tags);
+        _stageExecutionLatency.Record(phases.ExecutionMilliseconds, tags);
+        _stageTotalLatency.Record(phases.StageTotalMilliseconds, tags);
+        _stageWorkflowElapsedLatency.Record(phases.WorkflowElapsedMilliseconds, tags);
+        _stageUnaccountedLatency.Record(phases.UnaccountedMilliseconds, tags);
+        _rescheduleGapLatency.Record(stage.RescheduleGapMilliseconds, tags);
+        AddSample(_scheduleToStartSamples, stage.ScheduleToStartMilliseconds);
+        AddSample(_stageExecutionSamples, stage.ExecutionMilliseconds);
+        AddSample(_rescheduleGapSamples, stage.RescheduleGapMilliseconds);
+
+        if (!_stageAccumulators.TryGetValue(stage.Stage, out var accumulator))
+        {
+            accumulator = new StageAccumulator();
+            _stageAccumulators[stage.Stage] = accumulator;
+        }
+
+        accumulator.Record(stage, phases);
+    }
+
+    private void AddRecent(RecentWorkflowSummary summary)
+    {
+        _recent.Enqueue(summary);
+        while (_recent.Count > 50)
+        {
+            _recent.Dequeue();
+        }
+    }
+
+    private static void AddSample(Queue<double> samples, double value)
+    {
+        samples.Enqueue(value);
+        while (samples.Count > 5_000)
+        {
+            samples.Dequeue();
+        }
+    }
+
+    private void AddEvent(EventKind kind)
+    {
+        lock (_lock)
+        {
+            var elapsed = _eventWindowClock.Elapsed;
+            _events.Enqueue(new EventSample(elapsed, kind));
+            PruneEvents(elapsed);
+        }
+    }
+
+    private void PruneEvents(TimeSpan now)
+    {
+        var cutoff = now - TimeSpan.FromSeconds(10);
+        while (_events.TryPeek(out var sample) && sample.Elapsed < cutoff)
+        {
+            _events.Dequeue();
+        }
+    }
+
+    private RateSnapshot CalculateRatesLocked()
+    {
+        var windowSeconds = 10d;
+        return new RateSnapshot(
+            _events.Count(static sample => sample.Kind is EventKind.Started) / windowSeconds,
+            _events.Count(static sample => sample.Kind is EventKind.Completed) / windowSeconds,
+            _events.Count(static sample => sample.Kind is EventKind.Failed) / windowSeconds,
+            _events.Count(static sample => sample.Kind is EventKind.Retry) / windowSeconds);
+    }
+
+    private static LatencySummary Summarize(Queue<double> samples)
+    {
+        if (samples.Count is 0)
+        {
+            return new LatencySummary(0, 0, 0, 0, 0, 0);
+        }
+
+        var values = samples.Order().ToArray();
+        return new LatencySummary(
+            values.Length,
+            values.Average(),
+            Percentile(values, 0.50),
+            Percentile(values, 0.95),
+            Percentile(values, 0.99),
+            values[^1]);
+    }
+
+    private static double Percentile(double[] sortedValues, double percentile)
+    {
+        var index = (int)Math.Ceiling(sortedValues.Length * percentile) - 1;
+        return sortedValues[Math.Clamp(index, 0, sortedValues.Length - 1)];
+    }
+
+    private sealed record EventSample(TimeSpan Elapsed, EventKind Kind);
+
+    private enum EventKind
+    {
+        Started,
+        Completed,
+        Failed,
+        Retry
+    }
+
+    private sealed class StageAccumulator
+    {
+        private long _completed;
+        private long _failed;
+        private double _latencyTotal;
+        private readonly Queue<double> _handoffSamples = [];
+        private readonly Queue<double> _stateWriteSamples = [];
+        private readonly Queue<double> _scheduleCallSamples = [];
+        private readonly Queue<double> _dueWaitSamples = [];
+        private readonly Queue<double> _queueSamples = [];
+        private readonly Queue<double> _executionSamples = [];
+        private readonly Queue<double> _stageTotalSamples = [];
+        private readonly Queue<double> _workflowElapsedSamples = [];
+        private readonly Queue<double> _unaccountedSamples = [];
+
+        public void Record(WorkflowStageRecord stage, StagePhaseMeasurements phases)
+        {
+            if (stage.Succeeded)
+            {
+                _completed++;
+            }
+            else
+            {
+                _failed++;
+            }
+
+            _latencyTotal += stage.ExecutionMilliseconds;
+            AddSample(_handoffSamples, phases.HandoffMilliseconds);
+            AddSample(_stateWriteSamples, phases.StateWriteMilliseconds);
+            AddSample(_scheduleCallSamples, phases.ScheduleCallMilliseconds);
+            AddSample(_dueWaitSamples, phases.DueWaitMilliseconds);
+            AddSample(_queueSamples, phases.QueueMilliseconds);
+            AddSample(_executionSamples, phases.ExecutionMilliseconds);
+            AddSample(_stageTotalSamples, phases.StageTotalMilliseconds);
+            AddSample(_workflowElapsedSamples, phases.WorkflowElapsedMilliseconds);
+            AddSample(_unaccountedSamples, phases.UnaccountedMilliseconds);
+        }
+
+        public WorkflowStageMetric ToMetric(WorkflowStage stage)
+        {
+            var count = _completed + _failed;
+            return new WorkflowStageMetric(
+                stage,
+                _completed,
+                _failed,
+                count is 0 ? 0 : _latencyTotal / count,
+                Summarize(_handoffSamples),
+                Summarize(_stateWriteSamples),
+                Summarize(_scheduleCallSamples),
+                Summarize(_dueWaitSamples),
+                Summarize(_queueSamples),
+                Summarize(_executionSamples),
+                Summarize(_stageTotalSamples),
+                Summarize(_workflowElapsedSamples),
+                Summarize(_unaccountedSamples));
+        }
+    }
+
+    private readonly record struct StagePhaseMeasurements(
+        double HandoffMilliseconds,
+        double StateWriteMilliseconds,
+        double ScheduleCallMilliseconds,
+        double DueWaitMilliseconds,
+        double QueueMilliseconds,
+        double ExecutionMilliseconds,
+        double StageTotalMilliseconds,
+        double WorkflowElapsedMilliseconds,
+        double UnaccountedMilliseconds)
+    {
+        public static StagePhaseMeasurements Create(DateTimeOffset workflowCreatedAt, WorkflowStageRecord stage)
+        {
+            var previousStageCompletedAt = UseTimestamp(
+                stage.PreviousStageCompletedAt,
+                stage.Stage is WorkflowStage.Accept ? workflowCreatedAt : stage.ScheduledAt);
+            var stateWriteStartedAt = UseTimestamp(stage.StateWriteStartedAt, previousStageCompletedAt);
+            var stateWriteCompletedAt = UseTimestamp(stage.StateWriteCompletedAt, stateWriteStartedAt);
+            var scheduleRequestedAt = UseTimestamp(stage.ScheduleRequestedAt, stateWriteCompletedAt);
+            var scheduleCompletedAt = UseTimestamp(stage.ScheduleCompletedAt, scheduleRequestedAt);
+            var readyAt = Max(stage.ScheduledAt, scheduleCompletedAt);
+
+            var handoffMilliseconds = ElapsedMilliseconds(stateWriteStartedAt, previousStageCompletedAt);
+            var stateWriteMilliseconds = ElapsedMilliseconds(stateWriteCompletedAt, stateWriteStartedAt);
+            var scheduleCallMilliseconds = ElapsedMilliseconds(scheduleCompletedAt, scheduleRequestedAt);
+            var dueWaitMilliseconds = ElapsedMilliseconds(readyAt, scheduleCompletedAt);
+            var queueMilliseconds = ElapsedMilliseconds(stage.HandlerStartedAt, readyAt);
+            var executionMilliseconds = Math.Max(0, stage.ExecutionMilliseconds);
+            var stageTotalMilliseconds = ElapsedMilliseconds(stage.CompletedAt, previousStageCompletedAt);
+            var workflowElapsedMilliseconds = ElapsedMilliseconds(stage.CompletedAt, workflowCreatedAt);
+            var unaccountedMilliseconds = Math.Abs(stageTotalMilliseconds - (
+                handoffMilliseconds
+                + stateWriteMilliseconds
+                + scheduleCallMilliseconds
+                + dueWaitMilliseconds
+                + queueMilliseconds
+                + executionMilliseconds));
+
+            return new StagePhaseMeasurements(
+                handoffMilliseconds,
+                stateWriteMilliseconds,
+                scheduleCallMilliseconds,
+                dueWaitMilliseconds,
+                queueMilliseconds,
+                executionMilliseconds,
+                stageTotalMilliseconds,
+                workflowElapsedMilliseconds,
+                unaccountedMilliseconds);
+        }
+
+        private static DateTimeOffset UseTimestamp(DateTimeOffset timestamp, DateTimeOffset fallback)
+            => timestamp == default ? fallback : timestamp;
+
+        private static DateTimeOffset Max(DateTimeOffset first, DateTimeOffset second)
+            => first >= second ? first : second;
+
+        private static double ElapsedMilliseconds(DateTimeOffset end, DateTimeOffset start)
+            => Math.Max(0, (end - start).TotalMilliseconds);
+    }
+}

--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Web/wwwroot/index.html
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Web/wwwroot/index.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DurableJobs + Journaling Playground</title>
+  <style>
+    :root { color-scheme: dark; font-family: "Segoe UI", system-ui, sans-serif; background: #10131a; color: #eef2ff; }
+    body { margin: 0; padding: 24px; }
+    h1 { margin: 0 0 8px; }
+    .subtitle { color: #aab3cf; margin-bottom: 24px; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; }
+    .card { background: #181d29; border: 1px solid #2c3448; border-radius: 14px; padding: 16px; box-shadow: 0 12px 40px rgba(0,0,0,.25); overflow-x: auto; }
+    .metric { font-size: 2rem; font-weight: 700; margin: 8px 0; }
+    label { display: grid; gap: 6px; margin: 10px 0; color: #c8d0ea; }
+    input, select, button { border-radius: 8px; border: 1px solid #39435c; padding: 9px 10px; background: #10131a; color: #eef2ff; }
+    button { cursor: pointer; background: #3654ff; border-color: #5870ff; font-weight: 600; }
+    button.secondary { background: #263044; border-color: #3a465f; }
+    button.danger { background: #b3263b; border-color: #d0475b; }
+    table { width: 100%; border-collapse: collapse; font-size: .92rem; }
+    th, td { border-bottom: 1px solid #2c3448; text-align: left; padding: 8px; }
+    .ok { color: #74e39a; }
+    .bad { color: #ff8194; }
+  </style>
+</head>
+<body>
+  <h1>DurableJobs + Journaling Playground</h1>
+  <div class="subtitle">Azure Blob-backed DurableJobs and journaled grains under controlled workflow load.</div>
+
+  <div class="grid">
+    <section class="card">
+      <h2>Load controls</h2>
+      <label>Target concurrency <input id="concurrency" type="number" min="0" value="16"></label>
+      <label>Target starts/sec (0 = unlimited) <input id="throughput" type="number" min="0" step="0.1" value="8"></label>
+      <button onclick="saveSettings()">Apply</button>
+      <button onclick="startLoad()">Start</button>
+      <button class="secondary" onclick="post('/api/load/stop')">Stop</button>
+      <button class="secondary" onclick="post('/api/load/drain')">Drain</button>
+      <button class="danger" onclick="post('/api/load/reset')">Reset</button>
+      <button class="danger" onclick="post('/api/chaos/silo/kill')">Kill silo membership</button>
+    </section>
+
+    <section class="card">
+      <h2>Throughput</h2>
+      <div>In-flight</div><div id="inflight" class="metric">0</div>
+      <div>Starts/sec</div><div id="starts" class="metric">0</div>
+      <div>Completions/sec</div><div id="completions" class="metric">0</div>
+      <div>Failures/sec</div><div id="failures" class="metric">0</div>
+    </section>
+
+    <section class="card">
+      <h2>Latency</h2>
+      <div>End-to-end p50 / p95 / p99</div><div id="e2e" class="metric">0 / 0 / 0</div>
+      <div>Schedule-to-start p95 (legacy)</div><div id="schedule" class="metric">0</div>
+      <div>Stage execution p95</div><div id="execution" class="metric">0</div>
+      <div>Reschedule gap p95</div><div id="gap" class="metric">0</div>
+    </section>
+
+    <section class="card">
+      <h2>Chaos</h2>
+      <pre id="chaos">No chaos action requested.</pre>
+    </section>
+  </div>
+
+  <section class="card" style="margin-top:16px">
+    <h2>Stages</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Stage</th>
+          <th>Completed</th>
+          <th>Failed</th>
+          <th>Queue p95 / p99</th>
+          <th>Execution p95 / p99</th>
+          <th>Handoff p95</th>
+          <th>State write p95</th>
+          <th>Schedule call p95</th>
+          <th>Stage total p99</th>
+          <th>Workflow elapsed p99</th>
+          <th>Unaccounted p99</th>
+        </tr>
+      </thead>
+      <tbody id="stages"></tbody>
+    </table>
+  </section>
+
+  <section class="card" style="margin-top:16px">
+    <h2>Recent workflows</h2>
+    <table><thead><tr><th>Workflow</th><th>Status</th><th>Latency ms</th><th>Retries</th><th>Failures</th><th>Error</th></tr></thead><tbody id="recent"></tbody></table>
+  </section>
+
+  <script>
+    let controlsInitialized = false;
+
+    async function post(url, body) {
+      const options = { method: 'POST' };
+      if (body !== undefined) {
+        options.headers = { 'content-type': 'application/json' };
+        options.body = JSON.stringify(body);
+      }
+
+      const response = await fetch(url, options);
+      if (!response.ok) {
+        throw new Error(`${url} failed with ${response.status}`);
+      }
+
+      await refresh();
+    }
+
+    async function saveSettings() {
+      const response = await fetch('/api/load', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(settings())
+      });
+      if (!response.ok) {
+        throw new Error(`/api/load failed with ${response.status}`);
+      }
+
+      applySettings(await response.json());
+      await refresh();
+    }
+
+    async function startLoad() {
+      await post('/api/load/start', settings());
+    }
+
+    function settings() {
+      return {
+        targetConcurrency: Number(concurrency.value),
+        targetStartsPerSecond: Number(throughput.value),
+        stageDelayMilliseconds: 0,
+        stageJitterMilliseconds: 0,
+        failureRate: 0,
+        dueTimeMode: 'Immediate',
+        stageDueDelayMilliseconds: 0
+      };
+    }
+
+    function applySettings(settings) {
+      concurrency.value = settings.targetConcurrency;
+      throughput.value = settings.targetStartsPerSecond;
+    }
+
+    function ms(value) { return Math.round(value || 0).toString(); }
+    function p95p99(summary) { return `${ms(summary?.p95Milliseconds)} / ${ms(summary?.p99Milliseconds)}`; }
+
+    async function refresh() {
+      const snapshot = await (await fetch('/api/metrics/snapshot')).json();
+      if (!controlsInitialized) {
+        applySettings(snapshot.load.settings);
+        controlsInitialized = true;
+      }
+
+      inflight.textContent = snapshot.load.inFlight;
+      starts.textContent = snapshot.rates.startsPerSecond.toFixed(1);
+      completions.textContent = snapshot.rates.completionsPerSecond.toFixed(1);
+      failures.textContent = snapshot.rates.failuresPerSecond.toFixed(1);
+      e2e.textContent = `${ms(snapshot.endToEndLatency.p50Milliseconds)} / ${ms(snapshot.endToEndLatency.p95Milliseconds)} / ${ms(snapshot.endToEndLatency.p99Milliseconds)}`;
+      schedule.textContent = ms(snapshot.scheduleToStartLatency.p95Milliseconds);
+      execution.textContent = ms(snapshot.stageExecutionLatency.p95Milliseconds);
+      gap.textContent = ms(snapshot.rescheduleGapLatency.p95Milliseconds);
+      chaos.textContent = snapshot.lastChaos ? JSON.stringify(snapshot.lastChaos, null, 2) : 'No chaos action requested.';
+      stages.innerHTML = snapshot.stages.map(s => `
+        <tr>
+          <td>${s.stage}</td>
+          <td>${s.completed}</td>
+          <td>${s.failed}</td>
+          <td>${p95p99(s.queueLatency)}</td>
+          <td>${p95p99(s.executionLatency)}</td>
+          <td>${ms(s.handoffLatency?.p95Milliseconds)}</td>
+          <td>${ms(s.stateWriteLatency?.p95Milliseconds)}</td>
+          <td>${ms(s.scheduleCallLatency?.p95Milliseconds)}</td>
+          <td>${ms(s.stageTotalLatency?.p99Milliseconds)}</td>
+          <td>${ms(s.workflowElapsedLatency?.p99Milliseconds)}</td>
+          <td>${ms(s.unaccountedLatency?.p99Milliseconds)}</td>
+        </tr>`).join('');
+      recent.innerHTML = snapshot.recent.map(w => `<tr><td>${w.workflowId}</td><td class="${w.status === 'Completed' ? 'ok' : 'bad'}">${w.status}</td><td>${ms(w.totalLatencyMilliseconds)}</td><td>${w.retryCount}</td><td>${w.failureCount}</td><td>${w.error ?? ''}</td></tr>`).join('');
+    }
+
+    refresh();
+    setInterval(refresh, 1000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Depends on #10151.

Adds an Aspire playground for DurableJobs journaling throughput experiments, including Grafana dashboards and dashboard/OTel wiring for the journaling scenario.

This branch is stacked on #10151, so the PR diff is cumulative until earlier PRs land and this branch is rebased.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10152)