### PR TITLE
fix: validate connectivity in explicit ValidateInitialConnectivity stage before BecomeActive

### DIFF
--- a/src/Orleans.Core/Lifecycle/ServiceLifecycleStage.cs
+++ b/src/Orleans.Core/Lifecycle/ServiceLifecycleStage.cs
@@ -50,6 +50,11 @@ namespace Orleans
         public const int BecomeActive = Active-1;
 
         /// <summary>
+        /// Validate connectivity to active cluster members before becoming active.
+        /// </summary>
+        public const int ValidateInitialConnectivity = Active - 100;
+
+        /// <summary>
         /// Service is active.
         /// </summary>
         public const int Active = 20000;

--- a/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs
@@ -158,8 +158,9 @@ namespace Orleans.Runtime.MembershipService
             ImmutableDictionary<SiloAddress, SiloHealthMonitor> monitoredSilos,
             DateTime now)
         {
-            // If I am still not fully functional, I should not be probing others.
-            if (!membership.Entries.TryGetValue(this.localSiloDetails.SiloAddress, out var self) || !IsFunctionalForMembership(self.Status))
+            // If this silo cannot evict peers, it should not be probing others.
+            if (!membership.Entries.TryGetValue(this.localSiloDetails.SiloAddress, out var self)
+                || !CanEvictPeers(self.Status))
             {
                 return ImmutableDictionary<SiloAddress, SiloHealthMonitor>.Empty;
             }
@@ -177,7 +178,7 @@ namespace Orleans.Runtime.MembershipService
             foreach (var (candidate, entry) in membership.Entries)
             {
                 // Watch shutting-down silos as well, so we can properly ensure they become dead.
-                if (!IsFunctionalForMembership(entry.Status))
+                if (!CanBeEvictedByPeers(entry.Status))
                 {
                     continue;
                 }
@@ -211,35 +212,38 @@ namespace Orleans.Runtime.MembershipService
             // silo must be evicted before another failed silo can be detected).
             // The idea to use an expander graph is taken from "Stable and Consistent Membership at Scale with Rapid" by Lalith Suresh et al:
             // https://www.usenix.org/conference/atc18/presentation/suresh
-            for (var ringNum = 0; ringNum < numProbedSilos; ++ringNum)
+            if (self.Status != SiloStatus.Joining)
             {
-                // Update hash values with the current ring number.
-                for (var i = 0; i < tmpList.Count; i++)
+                for (var ringNum = 0; ringNum < numProbedSilos; ++ringNum)
                 {
-                    var siloAddress = tmpList[i].SiloAddress;
-                    tmpList[i] = (siloAddress, siloAddress.GetConsistentHashCode(ringNum));
-                }
-
-                // Sort the candidates based on their updated hash values.
-                tmpList.Sort((x, y) => x.HashCode.CompareTo(y.HashCode));
-
-                var myIndex = tmpList.FindIndex(el => el.SiloAddress.Equals(self.SiloAddress));
-                if (myIndex < 0)
-                {
-                    LogErrorSiloNotInLocalList(log, self.SiloAddress, self.Status);
-                    throw new OrleansMissingMembershipEntryException(
-                        $"This silo {self.SiloAddress} status {self.Status} is not in its own local silo list! This is a bug!");
-                }
-
-                // Starting at the local silo's index, find the first non-monitored silo and add it to the list.
-                for (var i = 0; i < tmpList.Count - 1; i++)
-                {
-                    var candidate = tmpList[(myIndex + i + 1) % tmpList.Count].SiloAddress;
-                    if (!silosToWatch.Contains(candidate))
+                    // Update hash values with the current ring number.
+                    for (var i = 0; i < tmpList.Count; i++)
                     {
-                        Debug.Assert(!candidate.IsSameLogicalSilo(this.localSiloDetails.SiloAddress));
-                        silosToWatch.Add(candidate);
-                        break;
+                        var siloAddress = tmpList[i].SiloAddress;
+                        tmpList[i] = (siloAddress, siloAddress.GetConsistentHashCode(ringNum));
+                    }
+
+                    // Sort the candidates based on their updated hash values.
+                    tmpList.Sort((x, y) => x.HashCode.CompareTo(y.HashCode));
+
+                    var myIndex = tmpList.FindIndex(el => el.SiloAddress.Equals(self.SiloAddress));
+                    if (myIndex < 0)
+                    {
+                        LogErrorSiloNotInLocalList(log, self.SiloAddress, self.Status);
+                        throw new OrleansMissingMembershipEntryException(
+                            $"This silo {self.SiloAddress} status {self.Status} is not in its own local silo list! This is a bug!");
+                    }
+
+                    // Starting at the local silo's index, find the first non-monitored silo and add it to the list.
+                    for (var i = 0; i < tmpList.Count - 1; i++)
+                    {
+                        var candidate = tmpList[(myIndex + i + 1) % tmpList.Count].SiloAddress;
+                        if (!silosToWatch.Contains(candidate))
+                        {
+                            Debug.Assert(!candidate.IsSameLogicalSilo(this.localSiloDetails.SiloAddress));
+                            silosToWatch.Add(candidate);
+                            break;
+                        }
                     }
                 }
             }
@@ -269,23 +273,27 @@ namespace Orleans.Runtime.MembershipService
             static bool AreTheSame<T>(ImmutableDictionary<SiloAddress, T> first, ImmutableDictionary<SiloAddress, T> second)
                 => first.Count == second.Count && first.Count == first.Keys.Intersect(second.Keys).Count();
 
-            static bool IsFunctionalForMembership(SiloStatus status)
-                => status is SiloStatus.Active or SiloStatus.ShuttingDown or SiloStatus.Stopping;
+            static bool CanEvictPeers(SiloStatus status)
+                => status is SiloStatus.Joining or SiloStatus.Active;
+
+            static bool CanBeEvictedByPeers(SiloStatus status)
+                => status is SiloStatus.Joining or SiloStatus.Active or SiloStatus.ShuttingDown or SiloStatus.Stopping;
         }
 
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
         {
             var tasks = new List<Task>();
 
-            lifecycle.Subscribe(nameof(ClusterHealthMonitor), ServiceLifecycleStage.Active, OnActiveStart, OnActiveStop);
+            lifecycle.Subscribe(nameof(ClusterHealthMonitor), ServiceLifecycleStage.ValidateInitialConnectivity, OnValidateInitialConnectivityStart, OnStop);
 
-            Task OnActiveStart(CancellationToken ct)
+            Task OnValidateInitialConnectivityStart(CancellationToken ct)
             {
+                this.monitoredSilos = this.UpdateMonitoredSilos(this.membershipManager.CurrentSnapshot, this.monitoredSilos, DateTime.UtcNow);
                 tasks.Add(Task.Run(() => this.ProcessMembershipUpdates()));
                 return Task.CompletedTask;
             }
 
-            async Task OnActiveStop(CancellationToken ct)
+            async Task OnStop(CancellationToken ct)
             {
                 this.shutdownCancellation.Cancel(throwOnFirstException: false);
 

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -162,8 +162,18 @@ namespace Orleans.Runtime.MembershipService
                     await Task.Delay(retryDelay, ct);
                     await this.membershipManager.Refresh(null, ct);
                 }
-                catch (Exception exception) when (canContinue && exception is not OperationCanceledException)
+                catch (Exception exception)
                 {
+                    if (!canContinue)
+                    {
+                        throw;
+                    }
+
+                    if (exception is OperationCanceledException && ct.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+
                     LogErrorFailedToValidateInitialClusterConnectivity(exception);
                     await Task.Delay(TimeSpan.FromSeconds(1), ct);
                 }

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -101,7 +101,6 @@ namespace Orleans.Runtime.MembershipService
         private async Task BecomeActive()
         {
             LogInformationBecomeActive();
-            await this.ValidateInitialConnectivity();
 
             try
             {
@@ -115,10 +114,14 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        private async Task ValidateInitialConnectivity()
+        private async Task ValidateInitialConnectivity(CancellationToken cancellationToken)
         {
+            using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.cancellation.Token);
+            var ct = linkedCancellation.Token;
+
             // Continue attempting to validate connectivity until some reasonable timeout.
             var maxAttemptTime = this.clusterMembershipOptions.MaxJoinAttemptTime;
+            var retryDelay = this.clusterMembershipOptions.ProbeTimeout;
             var attemptNumber = 1;
             var now = this.getUtcDateTime();
             var attemptUntil = now + maxAttemptTime;
@@ -134,12 +137,11 @@ namespace Orleans.Runtime.MembershipService
                         var entry = item.Value;
                         if (entry.Status != SiloStatus.Active) continue;
                         if (entry.SiloAddress.IsSameLogicalSilo(this.localSilo.SiloAddress)) continue;
-                        if (entry.HasMissedIAmAlives(this.clusterMembershipOptions, now) != default) continue;
 
                         activeSilos.Add(entry.SiloAddress);
                     }
 
-                    var failedSilos = await CheckClusterConnectivity(activeSilos.ToArray());
+                    var failedSilos = await CheckClusterConnectivity(activeSilos.ToArray(), ct);
                     var successfulSilos = activeSilos.Where(s => !failedSilos.Contains(s)).ToList();
 
                     // If there were no failures, terminate the loop and return without error.
@@ -147,30 +149,30 @@ namespace Orleans.Runtime.MembershipService
 
                     LogErrorFailedToGetPingResponses(failedSilos.Count, activeSilos.Count, new(successfulSilos), new(failedSilos), attemptUntil, attemptNumber);
 
-                    if (now + TimeSpan.FromSeconds(5) > attemptUntil)
+                    if (now + retryDelay > attemptUntil)
                     {
                         canContinue = false;
                         var msg = $"Failed to get ping responses from {failedSilos.Count} of {activeSilos.Count} active silos. "
-                            + "Newly joining silos validate connectivity with all active silos that have recently updated their 'I Am Alive' value before joining the cluster. "
+                            + "Newly joining silos validate connectivity with all active silos before joining the cluster. "
                             + $"Successfully contacted: {Utils.EnumerableToString(successfulSilos)}. Failed to get response from: {Utils.EnumerableToString(failedSilos)}";
                         throw new OrleansClusterConnectivityCheckFailedException(msg);
                     }
 
                     // Refresh membership after some delay and retry.
-                    await Task.Delay(TimeSpan.FromSeconds(5));
-                    await this.membershipManager.Refresh(null, this.cancellation.Token);
+                    await Task.Delay(retryDelay, ct);
+                    await this.membershipManager.Refresh(null, ct);
                 }
-                catch (Exception exception) when (canContinue)
+                catch (Exception exception) when (canContinue && exception is not OperationCanceledException)
                 {
                     LogErrorFailedToValidateInitialClusterConnectivity(exception);
-                    await Task.Delay(TimeSpan.FromSeconds(1));
+                    await Task.Delay(TimeSpan.FromSeconds(1), ct);
                 }
 
                 ++attemptNumber;
                 now = this.getUtcDateTime();
             }
 
-            async Task<List<SiloAddress>> CheckClusterConnectivity(SiloAddress[] members)
+            async Task<List<SiloAddress>> CheckClusterConnectivity(SiloAddress[] members, CancellationToken cancellationToken)
             {
                 if (members.Length == 0) return new List<SiloAddress>();
 
@@ -181,7 +183,7 @@ namespace Orleans.Runtime.MembershipService
                 var timeout = this.clusterMembershipOptions.ProbeTimeout;
                 foreach (var silo in members)
                 {
-                    tasks.Add(ProbeSilo(this.siloProber, silo, timeout, this.log));
+                    tasks.Add(ProbeSilo(this.siloProber, silo, timeout, this.log, cancellationToken));
                 }
 
                 try
@@ -205,13 +207,17 @@ namespace Orleans.Runtime.MembershipService
                 return failed;
             }
 
-            static async Task<bool> ProbeSilo(IRemoteSiloProber siloProber, SiloAddress silo, TimeSpan timeout, ILogger log)
+            static async Task<bool> ProbeSilo(IRemoteSiloProber siloProber, SiloAddress silo, TimeSpan timeout, ILogger log, CancellationToken cancellationToken)
             {
                 Exception exception;
                 try
                 {
-                    await siloProber.Probe(silo, 0).WaitAsync(timeout);
+                    await siloProber.Probe(silo, 0).WaitAsync(timeout, cancellationToken);
                     return true;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
                 }
                 catch (Exception ex)
                 {
@@ -321,6 +327,21 @@ namespace Orleans.Runtime.MembershipService
                     ServiceLifecycleStage.AfterRuntimeGrainServices,
                     AfterRuntimeGrainServicesStart,
                     AfterRuntimeGrainServicesStop);
+            }
+
+            {
+                async Task OnValidateInitialConnectivityStart(CancellationToken ct)
+                {
+                    await Task.Run(() => this.ValidateInitialConnectivity(ct));
+                }
+
+                Task OnValidateInitialConnectivityStop(CancellationToken ct) => Task.CompletedTask;
+
+                lifecycle.Subscribe(
+                    nameof(MembershipAgent),
+                    ServiceLifecycleStage.ValidateInitialConnectivity,
+                    OnValidateInitialConnectivityStart,
+                    OnValidateInitialConnectivityStop);
             }
 
             {
@@ -435,7 +456,7 @@ namespace Orleans.Runtime.MembershipService
             EventId = (int)ErrorCode.MembershipJoiningPreconditionFailure,
             Level = LogLevel.Error,
             Message = "Failed to get ping responses from {FailedCount} of {ActiveCount} active silos. " +
-                      "Newly joining silos validate connectivity with all active silos that have recently updated their 'I Am Alive' value before joining the cluster. " +
+                      "Newly joining silos validate connectivity with all active silos before joining the cluster. " +
                       "Successfully contacted: {SuccessfulSilos}. Silos which did not respond successfully are: {FailedSilos}. " +
                       "Will continue attempting to validate connectivity until {Timeout}. Attempt #{Attempt}"
         )]

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -582,14 +582,14 @@ namespace Orleans.Runtime.MembershipService
             {
                 var entry = item.Value;
                 if (entry.SiloAddress.IsSameLogicalSilo(this.myAddress)) continue;
-                if (!IsFunctionalForMembership(entry.Status)) continue;
+                if (!CanReceiveMembershipGossip(entry.Status)) continue;
                 if (entry.HasMissedIAmAlives(this.clusterMembershipOptions, now)) continue;
 
                 gossipPartners.Add(entry.SiloAddress);
 
-                bool IsFunctionalForMembership(SiloStatus status)
+                static bool CanReceiveMembershipGossip(SiloStatus status)
                 {
-                    return status == SiloStatus.Active || status == SiloStatus.ShuttingDown || status == SiloStatus.Stopping;
+                    return status is SiloStatus.Joining or SiloStatus.Active or SiloStatus.ShuttingDown or SiloStatus.Stopping;
                 }
             }
 

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -366,6 +366,7 @@ namespace Orleans
         public const int RuntimeInitialize = 2000;
         public const int RuntimeServices = 4000;
         public const int RuntimeStorageServices = 6000;
+        public const int ValidateInitialConnectivity = 19900;
     }
 
     [GenerateSerializer]

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -88,6 +88,57 @@ namespace NonSilo.Tests.Membership
             await ClusterHealthMonitor_BasicScenario_Runner(enableIndirectProbes: true, numVotesForDeathDeclaration: 2, otherSilosAreStale: true);
         }
 
+        [Fact]
+        public async Task ClusterHealthMonitor_JoiningSiloMonitorsStaleAndSuspectedEvictableSilos()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var clusterMembershipOptions = new ClusterMembershipOptions
+            {
+                NumProbedSilos = 3,
+            };
+
+            var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions);
+            await this.lifecycle.OnStart();
+
+            var staleSilo = Silo("127.0.0.200:100@100");
+            var freshSilo = Silo("127.0.0.200:200@100");
+            var suspectedSilo = Silo("127.0.0.200:300@100");
+            var shuttingDownSilo = Silo("127.0.0.200:500@100");
+            var suspectedEntry = Entry(suspectedSilo, SiloStatus.Active, now);
+            suspectedEntry.AddSuspector(Silo("127.0.0.200:400@100"), now.UtcDateTime);
+
+            var otherSilos = new[]
+            {
+                Entry(staleSilo, SiloStatus.Active, now.Subtract(TimeSpan.FromHours(1))),
+                Entry(freshSilo, SiloStatus.Active, now),
+                suspectedEntry,
+                Entry(shuttingDownSilo, SiloStatus.ShuttingDown, now.Subtract(TimeSpan.FromHours(1)))
+            };
+
+            var lastVersion = testRig.TestAccessor.ObservedVersion;
+            foreach (var entry in otherSilos)
+            {
+                var table = await this.membershipTable.ReadAll();
+                Assert.True(await this.membershipTable.InsertRow(entry, table.Version.Next()));
+            }
+
+            await testRig.Manager.Refresh();
+            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion);
+            Assert.Empty(testRig.TestAccessor.MonitoredSilos);
+
+            lastVersion = testRig.TestAccessor.ObservedVersion;
+            await testRig.Manager.UpdateStatus(SiloStatus.Joining);
+            await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion);
+            await Until(() => testRig.TestAccessor.MonitoredSilos.Count == 3);
+
+            Assert.Contains(testRig.TestAccessor.MonitoredSilos, pair => pair.Key.Equals(staleSilo));
+            Assert.Contains(testRig.TestAccessor.MonitoredSilos, pair => pair.Key.Equals(suspectedSilo));
+            Assert.Contains(testRig.TestAccessor.MonitoredSilos, pair => pair.Key.Equals(shuttingDownSilo));
+            Assert.DoesNotContain(testRig.TestAccessor.MonitoredSilos, pair => pair.Key.Equals(freshSilo));
+
+            await StopLifecycle();
+        }
+
         /// <summary>
         /// Tests basic operation of <see cref="ClusterHealthMonitor"/> and <see cref="SiloHealthMonitor"/>, but with indirect probes disabled.
         /// </summary>

--- a/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
@@ -127,6 +127,7 @@ namespace NonSilo.Tests.Membership
             foreach (var l in new[] {
                 ServiceLifecycleStage.RuntimeInitialize,
                 ServiceLifecycleStage.AfterRuntimeGrainServices,
+                ServiceLifecycleStage.ValidateInitialConnectivity,
                 ServiceLifecycleStage.BecomeActive})
             {
                 // After start
@@ -147,11 +148,13 @@ namespace NonSilo.Tests.Membership
             await this.lifecycle.OnStart();
             Assert.Equal(SiloStatus.Created, levels[ServiceLifecycleStage.RuntimeInitialize + 1]);
             Assert.Equal(SiloStatus.Joining, levels[ServiceLifecycleStage.AfterRuntimeGrainServices + 1]);
+            Assert.Equal(SiloStatus.Joining, levels[ServiceLifecycleStage.ValidateInitialConnectivity + 1]);
             Assert.Equal(SiloStatus.Active, levels[ServiceLifecycleStage.BecomeActive + 1]);
 
             await StopLifecycle();
 
             Assert.Equal(SiloStatus.ShuttingDown, levels[ServiceLifecycleStage.BecomeActive - 1]);
+            Assert.Equal(SiloStatus.ShuttingDown, levels[ServiceLifecycleStage.ValidateInitialConnectivity - 1]);
             Assert.Equal(SiloStatus.ShuttingDown, levels[ServiceLifecycleStage.AfterRuntimeGrainServices - 1]);
             Assert.Equal(SiloStatus.Dead, levels[ServiceLifecycleStage.RuntimeInitialize - 1]);
         }
@@ -169,6 +172,7 @@ namespace NonSilo.Tests.Membership
             foreach (var l in new[] {
                 ServiceLifecycleStage.RuntimeInitialize,
                 ServiceLifecycleStage.AfterRuntimeGrainServices,
+                ServiceLifecycleStage.ValidateInitialConnectivity,
                 ServiceLifecycleStage.BecomeActive})
             {
                 // After start
@@ -189,6 +193,7 @@ namespace NonSilo.Tests.Membership
             await this.lifecycle.OnStart();
             Assert.Equal(SiloStatus.Created, levels[ServiceLifecycleStage.RuntimeInitialize + 1]);
             Assert.Equal(SiloStatus.Joining, levels[ServiceLifecycleStage.AfterRuntimeGrainServices + 1]);
+            Assert.Equal(SiloStatus.Joining, levels[ServiceLifecycleStage.ValidateInitialConnectivity + 1]);
             Assert.Equal(SiloStatus.Active, levels[ServiceLifecycleStage.BecomeActive + 1]);
 
             using var cancellation = new CancellationTokenSource();
@@ -196,6 +201,7 @@ namespace NonSilo.Tests.Membership
             await StopLifecycle(cancellation.Token);
 
             Assert.Equal(SiloStatus.Stopping, levels[ServiceLifecycleStage.BecomeActive - 1]);
+            Assert.Equal(SiloStatus.Stopping, levels[ServiceLifecycleStage.ValidateInitialConnectivity - 1]);
             Assert.Equal(SiloStatus.Stopping, levels[ServiceLifecycleStage.AfterRuntimeGrainServices - 1]);
             Assert.Equal(SiloStatus.Dead, levels[ServiceLifecycleStage.RuntimeInitialize - 1]);
         }
@@ -290,6 +296,53 @@ namespace NonSilo.Tests.Membership
         }
 
         [Fact]
+        public async Task MembershipAgent_LifecycleStages_ValidateInitialConnectivity_WaitsForStaleSilosToBeEvicted()
+        {
+            this.clusterMembershipOptions.Value.NumMissedProbesLimit = 1;
+            this.clusterMembershipOptions.Value.NumVotesForDeathDeclaration = 1;
+            this.clusterMembershipOptions.Value.ProbeTimeout = TimeSpan.FromMilliseconds(20);
+            this.remoteSiloProber.Probe(default, default).ReturnsForAnyArgs(Task.FromException(new Exception("no")));
+
+            var staleSilo = Silo("127.0.0.200:100@100");
+            var staleEntry = Entry(staleSilo, SiloStatus.Active, DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
+            var table = await this.membershipTable.ReadAll();
+            Assert.True(await this.membershipTable.InsertRow(staleEntry, table.Version.Next()));
+
+            var clusterHealthMonitorTestAccessor = (ClusterHealthMonitor.ITestAccessor)this.clusterHealthMonitor;
+            clusterHealthMonitorTestAccessor.CreateMonitor = silo => new SiloHealthMonitor(
+                silo,
+                clusterHealthMonitorTestAccessor.OnProbeResult,
+                this.optionsMonitor,
+                this.loggerFactory,
+                this.remoteSiloProber,
+                this.timerFactory,
+                this.localSiloHealthMonitor,
+                manager,
+                this.localSiloDetails);
+
+            var started = this.lifecycle.OnStart();
+            await Until(() => this.timerCalls.ContainsKey(nameof(SiloHealthMonitor)));
+
+            while (!started.IsCompleted)
+            {
+                if (this.timerCalls[nameof(SiloHealthMonitor)].TryDequeue(out var timer))
+                {
+                    timer.Completion.TrySetResult(true);
+                }
+
+                await Task.Delay(1);
+            }
+
+            await started;
+
+            table = await this.membershipTable.ReadAll();
+            Assert.Equal(SiloStatus.Dead, table.Members.Single(member => member.Item1.SiloAddress.Equals(staleSilo)).Item1.Status);
+            Assert.Equal(SiloStatus.Active, this.manager.CurrentStatus);
+
+            await StopLifecycle();
+        }
+
+        [Fact]
         public async Task MembershipAgent_LifecycleStages_ValidateInitialConnectivity_Failure()
         {
             this.timerFactory.CreateDelegate = (period, name) => new DelegateAsyncTimer(_ => Task.FromResult(false));
@@ -344,7 +397,12 @@ namespace NonSilo.Tests.Membership
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
 
-        private static MembershipEntry Entry(SiloAddress address, SiloStatus status) => new MembershipEntry { SiloAddress = address, Status = status, StartTime = DateTime.UtcNow, IAmAliveTime = DateTime.UtcNow };
+        private static MembershipEntry Entry(SiloAddress address, SiloStatus status, DateTime? iAmAliveTime = null)
+        {
+            var now = DateTime.UtcNow;
+            var entryTime = iAmAliveTime ?? now;
+            return new MembershipEntry { SiloAddress = address, Status = status, StartTime = entryTime, IAmAliveTime = entryTime };
+        }
 
         private static async Task Until(Func<bool> condition)
         {


### PR DESCRIPTION
Silos currently transition to Active before initial connectivity checks have proven that known peers are reachable or marked Dead. That can cause a burst of communication errors during startup when membership still contains hosts which are already down.

This change adds a dedicated `ValidateInitialConnectivity` lifecycle stage before `BecomeActive`, keeping the local silo in `Joining` while initial connectivity validation runs. Joining silos now participate in membership health monitoring for stale peers, can receive membership gossip, and can be evicted by peers if they stop refreshing `IAmAlive`, so crashed or unreachable joining silos are cleaned up through the normal membership process.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10153)