### PR TITLE
fix(reminders): allow grains to update reminders during shutdown

### DIFF
--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -147,10 +147,10 @@ namespace Orleans.Runtime.ReminderService
             }
         }
 
-        public override Task Stop()
+        public override async Task Stop()
         {
             CheckRuntimeContext();
-            return StopDeliveringReminders();
+            await StopDeliveringReminders();
         }
 
         private async Task StopDeliveringReminders()
@@ -170,11 +170,6 @@ namespace Orleans.Runtime.ReminderService
             {
                 await deliveryQuiescedTask;
             }
-        }
-
-        private async Task StopReminderService()
-        {
-            await StopDeliveringReminders();
 
             // Stop all reminders.
             var tasks = new List<Task>(localReminders.Count);
@@ -184,6 +179,11 @@ namespace Orleans.Runtime.ReminderService
             }
 
             await Task.WhenAll(tasks);
+        }
+
+        private async Task StopReminderService()
+        {
+            await StopDeliveringReminders();
             await base.Stop();
 
             listRefreshTimer.Dispose();

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -100,12 +100,18 @@ namespace Orleans.Runtime.ReminderService
             {
                 try
                 {
-                    await this.QueueTask(() => reminderTable.StopAsync()).WaitAsync(ct);
+                    await this.QueueTask(StopReminderServiceAndTable).WaitAsync(ct);
                 }
                 catch (Exception exception)
                 {
-                    LogErrorActivatingReminderService(exception);
+                    LogErrorStoppingReminderService(exception);
                     throw;
+                }
+
+                async Task StopReminderServiceAndTable()
+                {
+                    await StopReminderService();
+                    await reminderTable.StopAsync();
                 }
             }
         }
@@ -135,16 +141,20 @@ namespace Orleans.Runtime.ReminderService
             }
             catch (Exception exception)
             {
-                await Stop();
+                await StopReminderService();
                 LogErrorStartingReminderService(exception);
                 throw;
             }
         }
 
-        public override async Task Stop()
+        public override Task Stop()
         {
             CheckRuntimeContext();
+            return StopDeliveringReminders();
+        }
 
+        private async Task StopDeliveringReminders()
+        {
             Task? deliveryQuiescedTask = null;
             lock (_deliveryLock)
             {
@@ -156,13 +166,18 @@ namespace Orleans.Runtime.ReminderService
                 }
             }
 
-            // Stop all reminders.
-            var tasks = new List<Task>(localReminders.Count + (deliveryQuiescedTask is null ? 0 : 1));
             if (deliveryQuiescedTask is not null)
             {
-                tasks.Add(deliveryQuiescedTask);
+                await deliveryQuiescedTask;
             }
+        }
 
+        private async Task StopReminderService()
+        {
+            await StopDeliveringReminders();
+
+            // Stop all reminders.
+            var tasks = new List<Task>(localReminders.Count);
             foreach (var reminderData in localReminders.Values)
             {
                 tasks.Add(reminderData.StopAsync(ReminderEvents.LocalReminderStopReason.ServiceStopped));
@@ -625,8 +640,9 @@ namespace Orleans.Runtime.ReminderService
                     var task = this.startedTask.Task;
                     if (task.IsCompleted)
                     {
-                        // task at this point is already Faulted
+                        // Propagate any initial-load failure before checking the range.
                         task.GetAwaiter().GetResult();
+                        CheckRange();
                     }
                     else
                     {
@@ -642,18 +658,20 @@ namespace Orleans.Runtime.ReminderService
                             {
                                 throw new OrleansException("Reminder Service is still initializing and it is taking a long time. Please retry again later.", ex);
                             }
+
                             CheckRange();
                         }
                     }
                     break;
                 case GrainServiceStatus.Started:
+                    CheckRange();
                     break;
                 case GrainServiceStatus.Stopped:
-                    throw new OperationCanceledException("ReminderService has been stopped.");
+                    return Task.CompletedTask;
                 default:
                     throw new InvalidOperationException("status");
             }
-            CheckRange();
+
             return Task.CompletedTask;
 
             void CheckRange()


### PR DESCRIPTION
The active-stage reminder shutdown currently stops the local reminder service completely, so reminder register/unregister calls during later shutdown cleanup can fail with \ReminderService has been stopped\.\n\nThis changes reminder shutdown so the Active stop only disables new reminder delivery and drains in-flight callbacks. Full service, timer, refresh-loop, and table shutdown is deferred until RuntimeGrainServices stops. Register/unregister operations are allowed to continue after the service is stopped without logging or throwing, relying on reminder table ETags for concurrency safety.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10155)