### PR TITLE
test: avoid eager activation in idle test

### DIFF
--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
@@ -247,7 +247,7 @@ namespace UnitTests.ActivationsLifeCycleTests
                 // Its directory owner is not the Gateway silo. This way Gateway will use its directory cache.
                 // Its activation is located on the non Gateway silo as well.
                 ICollectionTestGrain grain = this.testCluster.GrainFactory.GetGrain<ICollectionTestGrain>(i);
-                GrainId grainId = ((GrainReference)await grain.GetGrainReference()).GrainId;
+                GrainId grainId = grain.GetGrainId();
                 SiloAddress primaryForGrain = (await TestUtils.GetDetailedGrainReport(this.testCluster.InternalGrainFactory, grainId, this.testCluster.Primary)).PrimaryForGrain;
                 if (primaryForGrain.Equals(this.testCluster.Primary.SiloAddress))
                 {


### PR DESCRIPTION
Fixes a flaky DeactivateOnIdle test by deriving the grain id from the grain reference proxy instead of calling into the candidate grain while selecting a non-primary activation. This avoids creating the activation before the test applies its placement hint.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10156)