### PR TITLE
fix: make transaction fault test deterministic

### DIFF
--- a/test/Transactions/Orleans.Transactions.Azure.Test/FaultInjection/ControlledInjection/BankTransferFaultInjectionTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/FaultInjection/ControlledInjection/BankTransferFaultInjectionTests.cs
@@ -30,7 +30,7 @@ public sealed class BankTransferFaultInjectionTests : IClassFixture<ControlledFa
             Type = FaultInjectionType.ExceptionAfterStore
         };
 
-        await RunFaultedDepositManagerTransfer(
+        await RunFaultedTransfer(
             commitFault,
             100,
             0,
@@ -48,7 +48,7 @@ public sealed class BankTransferFaultInjectionTests : IClassFixture<ControlledFa
             Type = FaultInjectionType.GenericExceptionAfterStore
         };
 
-        await RunFaultedDepositManagerTransfer(
+        await RunFaultedTransfer(
             commitFault,
             100,
             0,
@@ -60,24 +60,28 @@ public sealed class BankTransferFaultInjectionTests : IClassFixture<ControlledFa
     [SkippableFact]
     public async Task ExceptionAfterStorageWriteCompleted_CommitsDurableFullBankTransfer()
     {
-        await RunFaultedDepositManagerTransfer(
+        await RunFaultedTransfer(
             commitFault: null,
             100,
             0,
             expectedFrom: 99,
             expectedTo: 1,
             "the storage write returned successfully before a post-store queue step faulted, so recovery must reload and complete the durable commit",
-            to => BankTransferDiagnosticFaults.ThrowOnStorageWriteCompleted(to));
+            (from, to) =>
+            [
+                BankTransferDiagnosticFaults.ThrowOnStorageWriteCompleted(from),
+                BankTransferDiagnosticFaults.ThrowOnStorageWriteCompleted(to)
+            ]);
     }
 
-    private async Task RunFaultedDepositManagerTransfer(
+    private async Task RunFaultedTransfer(
         BankTransferFault commitFault,
         long initialFrom,
         long initialTo,
         long expectedFrom,
         long expectedTo,
         string because,
-        Func<IBankTransferFaultInjectionAccountGrain, StorageWriteCompletedFaultScope> createDiagnosticFault = null)
+        Func<IBankTransferFaultInjectionAccountGrain, IBankTransferFaultInjectionAccountGrain, IReadOnlyList<StorageWriteCompletedFaultScope>> createDiagnosticFaults = null)
     {
         BankTransferTrace.Clear();
 
@@ -88,23 +92,33 @@ public sealed class BankTransferFaultInjectionTests : IClassFixture<ControlledFa
         await from.SetBalance(initialFrom);
         await to.SetBalance(initialTo);
 
-        StorageWriteCompletedFaultScope diagnosticFault = null;
+        IReadOnlyList<StorageWriteCompletedFaultScope> diagnosticFaults = null;
         OrleansTransactionException exception;
         try
         {
-            diagnosticFault = createDiagnosticFault?.Invoke(to);
+            diagnosticFaults = createDiagnosticFaults?.Invoke(from, to);
             exception = await Assert.ThrowsAnyAsync<OrleansTransactionException>(
-                () => teller.TransferReturnBalancesWithDepositAsManager(from, to, 1, commitFault));
+                () => teller.TransferReturnBalances(from, to, 1, commitFault, commitFault));
         }
         finally
         {
-            diagnosticFault?.Dispose();
+            if (diagnosticFaults is not null)
+            {
+                foreach (var diagnosticFault in diagnosticFaults)
+                {
+                    diagnosticFault.Dispose();
+                }
+            }
         }
 
-        if (diagnosticFault is not null)
+        if (diagnosticFaults is not null)
         {
-            diagnosticFault.FaultInjected.Should().BeTrue("the diagnostic fault should be injected exactly once for the target transaction manager");
-            diagnosticFault.ObservedCount.Should().BeGreaterThan(0, "the diagnostic event should be emitted after the target storage write completes");
+            diagnosticFaults.Should().Contain(
+                diagnosticFault => diagnosticFault.FaultInjected,
+                "the diagnostic fault should be injected exactly once for the selected transaction manager");
+            diagnosticFaults.Sum(diagnosticFault => diagnosticFault.ObservedCount).Should().BeGreaterThan(
+                0,
+                "the diagnostic event should be emitted after the selected transaction manager storage write completes");
         }
 
         var committed = await teller.GetBalances(from, to);


### PR DESCRIPTION
Fixes a flaky Azure transactions fault-injection test that assumed the deposit/destination account was always selected as the transaction manager.

Investigation found that both transfer accounts are write-capable transaction managers, and Orleans selects the manager from participant collection ordering. When the source account was selected, the test's post-store diagnostic fault installed only on the destination account never fired, so no OrleansTransactionException was thrown even though the durable transfer committed.

The test now installs diagnostic post-storage faults on both transfer participants and asserts the selected transaction manager observed/injected the fault, preserving the durable commit assertion while removing the nondeterministic manager-selection assumption.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10157)