### PR TITLE
Fix deterministic reminder scheduling waits

### DIFF
--- a/src/Orleans.Reminders/Diagnostics/ReminderEvents.cs
+++ b/src/Orleans.Reminders/Diagnostics/ReminderEvents.cs
@@ -161,14 +161,14 @@ public static class ReminderEvents
     }
 
     /// <summary>
-    /// Event payload for when a local reminder has armed its next tick wait.
+    /// Event payload for when a local reminder has armed the wait for its next tick.
     /// </summary>
     /// <param name="grainId">The grain associated with the reminder.</param>
     /// <param name="reminderName">The reminder name.</param>
     /// <param name="identity">The object reference used to correlate this local reminder instance across lifecycle events.</param>
     /// <param name="scheduleVersion">The local schedule version associated with the armed wait.</param>
     /// <param name="siloAddress">The address of the silo handling this reminder.</param>
-    public sealed class LocalReminderScheduled(
+    public sealed class LocalReminderTickWaitArmed(
         GrainId grainId,
         string reminderName,
         object identity,
@@ -356,11 +356,11 @@ public static class ReminderEvents
         }
     }
 
-    internal static void EmitLocalReminderScheduled(GrainId grainId, string reminderName, object identity, long scheduleVersion, SiloAddress? siloAddress)
+    internal static void EmitLocalReminderTickWaitArmed(GrainId grainId, string reminderName, object identity, long scheduleVersion, SiloAddress? siloAddress)
     {
         ArgumentNullException.ThrowIfNull(identity);
 
-        if (!Listener.IsEnabled(nameof(LocalReminderScheduled)))
+        if (!Listener.IsEnabled(nameof(LocalReminderTickWaitArmed)))
         {
             return;
         }
@@ -370,7 +370,7 @@ public static class ReminderEvents
         [MethodImpl(MethodImplOptions.NoInlining)]
         static void Emit(GrainId grainId, string reminderName, object identity, long scheduleVersion, SiloAddress? siloAddress)
         {
-            Listener.Write(nameof(LocalReminderScheduled), new LocalReminderScheduled(
+            Listener.Write(nameof(LocalReminderTickWaitArmed), new LocalReminderTickWaitArmed(
                 grainId,
                 reminderName,
                 identity,

--- a/src/Orleans.Reminders/Diagnostics/ReminderEvents.cs
+++ b/src/Orleans.Reminders/Diagnostics/ReminderEvents.cs
@@ -135,6 +135,58 @@ public static class ReminderEvents
     }
 
     /// <summary>
+    /// Event payload for when a local reminder schedule is invalidated and must be re-armed.
+    /// </summary>
+    /// <param name="grainId">The grain associated with the reminder.</param>
+    /// <param name="reminderName">The reminder name.</param>
+    /// <param name="identity">The object reference used to correlate this local reminder instance across lifecycle events.</param>
+    /// <param name="scheduleVersion">The local schedule version associated with the change.</param>
+    /// <param name="siloAddress">The address of the silo handling this reminder.</param>
+    public sealed class LocalReminderScheduleChanged(
+        GrainId grainId,
+        string reminderName,
+        object identity,
+        long scheduleVersion,
+        SiloAddress? siloAddress) : ReminderEvent(grainId, reminderName, siloAddress)
+    {
+        /// <summary>
+        /// The object reference used to correlate this local reminder instance across lifecycle events.
+        /// </summary>
+        public readonly object Identity = identity;
+
+        /// <summary>
+        /// The local schedule version associated with the change.
+        /// </summary>
+        public readonly long ScheduleVersion = scheduleVersion;
+    }
+
+    /// <summary>
+    /// Event payload for when a local reminder has armed its next tick wait.
+    /// </summary>
+    /// <param name="grainId">The grain associated with the reminder.</param>
+    /// <param name="reminderName">The reminder name.</param>
+    /// <param name="identity">The object reference used to correlate this local reminder instance across lifecycle events.</param>
+    /// <param name="scheduleVersion">The local schedule version associated with the armed wait.</param>
+    /// <param name="siloAddress">The address of the silo handling this reminder.</param>
+    public sealed class LocalReminderScheduled(
+        GrainId grainId,
+        string reminderName,
+        object identity,
+        long scheduleVersion,
+        SiloAddress? siloAddress) : ReminderEvent(grainId, reminderName, siloAddress)
+    {
+        /// <summary>
+        /// The object reference used to correlate this local reminder instance across lifecycle events.
+        /// </summary>
+        public readonly object Identity = identity;
+
+        /// <summary>
+        /// The local schedule version associated with the armed wait.
+        /// </summary>
+        public readonly long ScheduleVersion = scheduleVersion;
+    }
+
+    /// <summary>
     /// Event payload for when a reminder tick is about to fire.
     /// </summary>
     /// <param name="grainId">The grain associated with the reminder.</param>
@@ -277,6 +329,52 @@ public static class ReminderEvents
                 reminderName,
                 identity,
                 reason,
+                siloAddress));
+        }
+    }
+
+    internal static void EmitLocalReminderScheduleChanged(GrainId grainId, string reminderName, object identity, long scheduleVersion, SiloAddress? siloAddress)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+
+        if (!Listener.IsEnabled(nameof(LocalReminderScheduleChanged)))
+        {
+            return;
+        }
+
+        Emit(grainId, reminderName, identity, scheduleVersion, siloAddress);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(GrainId grainId, string reminderName, object identity, long scheduleVersion, SiloAddress? siloAddress)
+        {
+            Listener.Write(nameof(LocalReminderScheduleChanged), new LocalReminderScheduleChanged(
+                grainId,
+                reminderName,
+                identity,
+                scheduleVersion,
+                siloAddress));
+        }
+    }
+
+    internal static void EmitLocalReminderScheduled(GrainId grainId, string reminderName, object identity, long scheduleVersion, SiloAddress? siloAddress)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+
+        if (!Listener.IsEnabled(nameof(LocalReminderScheduled)))
+        {
+            return;
+        }
+
+        Emit(grainId, reminderName, identity, scheduleVersion, siloAddress);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(GrainId grainId, string reminderName, object identity, long scheduleVersion, SiloAddress? siloAddress)
+        {
+            Listener.Write(nameof(LocalReminderScheduled), new LocalReminderScheduled(
+                grainId,
+                reminderName,
+                identity,
+                scheduleVersion,
                 siloAddress));
         }
     }

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -999,7 +999,7 @@ namespace Orleans.Runtime.ReminderService
                             var delayTask = Task.Delay(delay, _shared._timeProvider, waitCancellation.Token);
                             if (!scheduleChangedToken.IsCancellationRequested && !_stopCancellation.IsCancellationRequested)
                             {
-                                ReminderEvents.EmitLocalReminderScheduled(grainId, reminderName, this, scheduleVersion, _shared.Silo);
+                                ReminderEvents.EmitLocalReminderTickWaitArmed(grainId, reminderName, this, scheduleVersion, _shared.Silo);
                             }
 
                             await delayTask;
@@ -1019,7 +1019,7 @@ namespace Orleans.Runtime.ReminderService
                         var nextTick = periodicTimer!.WaitForNextTickAsync(waitCancellation.Token);
                         if (!scheduleChangedToken.IsCancellationRequested && !_stopCancellation.IsCancellationRequested)
                         {
-                            ReminderEvents.EmitLocalReminderScheduled(grainId, reminderName, this, scheduleVersion, _shared.Silo);
+                            ReminderEvents.EmitLocalReminderTickWaitArmed(grainId, reminderName, this, scheduleVersion, _shared.Silo);
                         }
 
                         var result = await nextTick;

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -749,6 +749,7 @@ namespace Orleans.Runtime.ReminderService
             private ReminderEntry _entry;
             private CancellationTokenSource _scheduleChangedCancellation = new();
             private bool _isFirstTickPending;
+            private long _scheduleVersion;
 
             private int _stopReason;
             private long _localSequenceNumber;
@@ -833,6 +834,7 @@ namespace Orleans.Runtime.ReminderService
             {
                 ArgumentNullException.ThrowIfNull(entry);
 
+                long scheduleVersion;
                 CancellationTokenSource scheduleChangedCancellation;
                 PeriodicTimer? timerToDispose;
                 lock (_lock)
@@ -846,10 +848,12 @@ namespace Orleans.Runtime.ReminderService
                     _isFirstTickPending = true;
                     timerToDispose = _timer;
                     _timer = null;
+                    scheduleVersion = ++_scheduleVersion;
                     scheduleChangedCancellation = _scheduleChangedCancellation;
                     _scheduleChangedCancellation = new();
                 }
 
+                ReminderEvents.EmitLocalReminderScheduleChanged(entry.GrainId, entry.ReminderName, this, scheduleVersion, _shared.Silo);
                 scheduleChangedCancellation.Cancel();
                 timerToDispose?.Dispose();
             }
@@ -959,6 +963,9 @@ namespace Orleans.Runtime.ReminderService
                     TimeSpan? initialDueTime;
                     PeriodicTimer? periodicTimer;
                     CancellationToken scheduleChangedToken;
+                    GrainId grainId;
+                    string reminderName;
+                    long scheduleVersion;
                     lock (_lock)
                     {
                         if (_stopReason != (int)ReminderEvents.LocalReminderStopReason.Unknown)
@@ -979,6 +986,9 @@ namespace Orleans.Runtime.ReminderService
 
                         periodicTimer = _timer;
                         scheduleChangedToken = _scheduleChangedCancellation.Token;
+                        grainId = _entry.GrainId;
+                        reminderName = _entry.ReminderName;
+                        scheduleVersion = _scheduleVersion;
                     }
 
                     using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(_stopCancellation.Token, scheduleChangedToken);
@@ -986,7 +996,13 @@ namespace Orleans.Runtime.ReminderService
                     {
                         if (initialDueTime is { } delay)
                         {
-                            await Task.Delay(delay, _shared._timeProvider, waitCancellation.Token);
+                            var delayTask = Task.Delay(delay, _shared._timeProvider, waitCancellation.Token);
+                            if (!scheduleChangedToken.IsCancellationRequested && !_stopCancellation.IsCancellationRequested)
+                            {
+                                ReminderEvents.EmitLocalReminderScheduled(grainId, reminderName, this, scheduleVersion, _shared.Silo);
+                            }
+
+                            await delayTask;
                             if (!TryStartPeriodicTimer(scheduleChangedToken))
                             {
                                 if (_stopCancellation.IsCancellationRequested)
@@ -1000,7 +1016,13 @@ namespace Orleans.Runtime.ReminderService
                             return true;
                         }
 
-                        var result = await periodicTimer!.WaitForNextTickAsync(waitCancellation.Token);
+                        var nextTick = periodicTimer!.WaitForNextTickAsync(waitCancellation.Token);
+                        if (!scheduleChangedToken.IsCancellationRequested && !_stopCancellation.IsCancellationRequested)
+                        {
+                            ReminderEvents.EmitLocalReminderScheduled(grainId, reminderName, this, scheduleVersion, _shared.Silo);
+                        }
+
+                        var result = await nextTick;
                         if (!result && scheduleChangedToken.IsCancellationRequested)
                         {
                             continue;

--- a/src/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/src/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -28,9 +28,9 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     private readonly Dictionary<ReminderTickKey, int> _tickCountsByReminder = [];
     private readonly Dictionary<ReminderTickKey, int> _tickAttemptsByReminder = [];
     private readonly Dictionary<ReminderTickKey, HashSet<LocalReminderInstanceKey>> _activeLocalReminders = [];
-    private readonly Dictionary<ReminderTickKey, int> _localReminderScheduleCounts = [];
+    private readonly Dictionary<ReminderTickKey, int> _localReminderTickWaitArmedCounts = [];
     private readonly Dictionary<ReminderTickKey, long> _localReminderScheduleVersions = [];
-    private readonly Dictionary<ReminderTickKey, long> _localReminderScheduledVersions = [];
+    private readonly Dictionary<ReminderTickKey, long> _localReminderTickWaitArmedVersions = [];
     private readonly List<TickCountWaiter> _tickCountWaiters = [];
     private readonly List<ActiveReminderCountWaiter> _activeReminderCountWaiters = [];
     private readonly List<LocalReminderScheduleWaiter> _localReminderScheduleWaiters = [];
@@ -109,15 +109,15 @@ public sealed class ReminderDiagnosticObserver : IDisposable
                     }
 
                     break;
-                case ReminderEvents.LocalReminderScheduled localReminderScheduled:
-                    var scheduledKey = new ReminderTickKey(localReminderScheduled.GrainId, localReminderScheduled.ReminderName);
-                    if (IsActiveLocalReminder(scheduledKey, localReminderScheduled.Identity)
-                        && localReminderScheduled.ScheduleVersion >= _localReminderScheduleVersions.GetValueOrDefault(scheduledKey))
+                case ReminderEvents.LocalReminderTickWaitArmed localReminderTickWaitArmed:
+                    var tickWaitArmedKey = new ReminderTickKey(localReminderTickWaitArmed.GrainId, localReminderTickWaitArmed.ReminderName);
+                    if (IsActiveLocalReminder(tickWaitArmedKey, localReminderTickWaitArmed.Identity)
+                        && localReminderTickWaitArmed.ScheduleVersion >= _localReminderScheduleVersions.GetValueOrDefault(tickWaitArmedKey))
                     {
-                        _localReminderScheduledVersions[scheduledKey] = Math.Max(
-                            _localReminderScheduledVersions.GetValueOrDefault(scheduledKey, -1),
-                            localReminderScheduled.ScheduleVersion);
-                        _localReminderScheduleCounts[scheduledKey] = _localReminderScheduleCounts.GetValueOrDefault(scheduledKey) + 1;
+                        _localReminderTickWaitArmedVersions[tickWaitArmedKey] = Math.Max(
+                            _localReminderTickWaitArmedVersions.GetValueOrDefault(tickWaitArmedKey, -1),
+                            localReminderTickWaitArmed.ScheduleVersion);
+                        _localReminderTickWaitArmedCounts[tickWaitArmedKey] = _localReminderTickWaitArmedCounts.GetValueOrDefault(tickWaitArmedKey) + 1;
                         ReleaseReadyLocalReminderScheduleWaiters(ready);
                     }
 
@@ -422,8 +422,8 @@ public sealed class ReminderDiagnosticObserver : IDisposable
             return false;
         }
 
-        return _localReminderScheduleCounts.GetValueOrDefault(key) > _tickAttemptsByReminder.GetValueOrDefault(key)
-            && _localReminderScheduledVersions.GetValueOrDefault(key, -1) >= _localReminderScheduleVersions.GetValueOrDefault(key);
+        return _localReminderTickWaitArmedCounts.GetValueOrDefault(key) > _tickAttemptsByReminder.GetValueOrDefault(key)
+            && _localReminderTickWaitArmedVersions.GetValueOrDefault(key, -1) >= _localReminderScheduleVersions.GetValueOrDefault(key);
     }
 
     private bool IsActiveLocalReminder(ReminderTickKey key, object identity)
@@ -435,9 +435,9 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     private void ResetLocalReminderScheduleState(ReminderTickKey key)
     {
         _tickAttemptsByReminder.Remove(key);
-        _localReminderScheduleCounts.Remove(key);
+        _localReminderTickWaitArmedCounts.Remove(key);
         _localReminderScheduleVersions.Remove(key);
-        _localReminderScheduledVersions.Remove(key);
+        _localReminderTickWaitArmedVersions.Remove(key);
     }
 
     private void ReleaseReadyTickWaiters(List<TaskCompletionSource<bool>> ready)

--- a/src/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/src/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -26,9 +26,14 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     private readonly IDisposable _storageSubscription;
     private readonly Dictionary<GrainId, int> _tickCountsByGrain = [];
     private readonly Dictionary<ReminderTickKey, int> _tickCountsByReminder = [];
+    private readonly Dictionary<ReminderTickKey, int> _tickAttemptsByReminder = [];
     private readonly Dictionary<ReminderTickKey, HashSet<LocalReminderInstanceKey>> _activeLocalReminders = [];
+    private readonly Dictionary<ReminderTickKey, int> _localReminderScheduleCounts = [];
+    private readonly Dictionary<ReminderTickKey, long> _localReminderScheduleVersions = [];
+    private readonly Dictionary<ReminderTickKey, long> _localReminderScheduledVersions = [];
     private readonly List<TickCountWaiter> _tickCountWaiters = [];
     private readonly List<ActiveReminderCountWaiter> _activeReminderCountWaiters = [];
+    private readonly List<LocalReminderScheduleWaiter> _localReminderScheduleWaiters = [];
 
     /// <summary>
     /// Creates a new instance of the observer and starts listening for reminder diagnostic events.
@@ -55,6 +60,10 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         {
             switch (value)
             {
+                case ReminderEvents.TickFiring tickFiring:
+                    var tickFiringKey = new ReminderTickKey(tickFiring.GrainId, tickFiring.ReminderName);
+                    _tickAttemptsByReminder[tickFiringKey] = _tickAttemptsByReminder.GetValueOrDefault(tickFiringKey) + 1;
+                    break;
                 case ReminderEvents.TickCompleted tickCompleted:
                     _tickCountsByGrain[tickCompleted.GrainId] = _tickCountsByGrain.GetValueOrDefault(tickCompleted.GrainId) + 1;
                     var reminderKey = new ReminderTickKey(tickCompleted.GrainId, tickCompleted.ReminderName);
@@ -65,6 +74,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
                     var startedKey = new ReminderTickKey(localReminderStarted.GrainId, localReminderStarted.ReminderName);
                     if (!_activeLocalReminders.TryGetValue(startedKey, out var startedInstances))
                     {
+                        ResetLocalReminderScheduleState(startedKey);
                         startedInstances = [];
                         _activeLocalReminders[startedKey] = startedInstances;
                     }
@@ -83,10 +93,34 @@ public sealed class ReminderDiagnosticObserver : IDisposable
                         if (stoppedInstances.Count == 0)
                         {
                             _activeLocalReminders.Remove(stoppedKey);
+                            ResetLocalReminderScheduleState(stoppedKey);
                         }
                     }
 
                     ReleaseReadyActiveReminderWaiters(ready);
+                    break;
+                case ReminderEvents.LocalReminderScheduleChanged localReminderScheduleChanged:
+                    var changedKey = new ReminderTickKey(localReminderScheduleChanged.GrainId, localReminderScheduleChanged.ReminderName);
+                    if (IsActiveLocalReminder(changedKey, localReminderScheduleChanged.Identity))
+                    {
+                        _localReminderScheduleVersions[changedKey] = Math.Max(
+                            _localReminderScheduleVersions.GetValueOrDefault(changedKey),
+                            localReminderScheduleChanged.ScheduleVersion);
+                    }
+
+                    break;
+                case ReminderEvents.LocalReminderScheduled localReminderScheduled:
+                    var scheduledKey = new ReminderTickKey(localReminderScheduled.GrainId, localReminderScheduled.ReminderName);
+                    if (IsActiveLocalReminder(scheduledKey, localReminderScheduled.Identity)
+                        && localReminderScheduled.ScheduleVersion >= _localReminderScheduleVersions.GetValueOrDefault(scheduledKey))
+                    {
+                        _localReminderScheduledVersions[scheduledKey] = Math.Max(
+                            _localReminderScheduledVersions.GetValueOrDefault(scheduledKey, -1),
+                            localReminderScheduled.ScheduleVersion);
+                        _localReminderScheduleCounts[scheduledKey] = _localReminderScheduleCounts.GetValueOrDefault(scheduledKey) + 1;
+                        ReleaseReadyLocalReminderScheduleWaiters(ready);
+                    }
+
                     break;
             }
         }
@@ -211,6 +245,15 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     }
 
     /// <summary>
+    /// Waits until an active local owner has armed the next tick wait for a reminder.
+    /// </summary>
+    public Task WaitForLocalReminderScheduleAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(reminderName);
+        return WaitForLocalReminderScheduleCoreAsync(grainId, reminderName, cancellationToken);
+    }
+
+    /// <summary>
     /// Waits until there are no active local reminder owners for a reminder.
     /// </summary>
     public Task WaitForReminderQuiescenceAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken)
@@ -269,11 +312,44 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         return WaitAsync(waiter, cancellationToken);
     }
 
+    private Task WaitForLocalReminderScheduleCoreAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        LocalReminderScheduleWaiter? waiter;
+        lock (_lock)
+        {
+            if (IsLocalReminderScheduleReadyCore(grainId, reminderName))
+            {
+                return Task.CompletedTask;
+            }
+
+            waiter = new LocalReminderScheduleWaiter(grainId, reminderName);
+            _localReminderScheduleWaiters.Add(waiter);
+        }
+
+        return WaitAsync(waiter, cancellationToken);
+    }
+
     private async Task WaitAsync(TickCountWaiter waiter, CancellationToken cancellationToken)
     {
         using var registration = cancellationToken.Register(static state =>
         {
             var (observer, pendingWaiter, token) = ((ReminderDiagnosticObserver Observer, TickCountWaiter Waiter, CancellationToken Token))state!;
+            observer.CancelWaiter(pendingWaiter, token);
+        }, (this, waiter, cancellationToken));
+
+        await waiter.TaskSource.Task.ConfigureAwait(false);
+    }
+
+    private async Task WaitAsync(LocalReminderScheduleWaiter waiter, CancellationToken cancellationToken)
+    {
+        using var registration = cancellationToken.Register(static state =>
+        {
+            var (observer, pendingWaiter, token) = ((ReminderDiagnosticObserver Observer, LocalReminderScheduleWaiter Waiter, CancellationToken Token))state!;
             observer.CancelWaiter(pendingWaiter, token);
         }, (this, waiter, cancellationToken));
 
@@ -296,6 +372,16 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         lock (_lock)
         {
             _tickCountWaiters.Remove(waiter);
+        }
+
+        waiter.TaskSource.TrySetCanceled(cancellationToken);
+    }
+
+    private void CancelWaiter(LocalReminderScheduleWaiter waiter, CancellationToken cancellationToken)
+    {
+        lock (_lock)
+        {
+            _localReminderScheduleWaiters.Remove(waiter);
         }
 
         waiter.TaskSource.TrySetCanceled(cancellationToken);
@@ -328,6 +414,32 @@ public sealed class ReminderDiagnosticObserver : IDisposable
             : 0;
     }
 
+    private bool IsLocalReminderScheduleReadyCore(GrainId grainId, string reminderName)
+    {
+        var key = new ReminderTickKey(grainId, reminderName);
+        if (GetActiveReminderCountCore(grainId, reminderName) == 0)
+        {
+            return false;
+        }
+
+        return _localReminderScheduleCounts.GetValueOrDefault(key) > _tickAttemptsByReminder.GetValueOrDefault(key)
+            && _localReminderScheduledVersions.GetValueOrDefault(key, -1) >= _localReminderScheduleVersions.GetValueOrDefault(key);
+    }
+
+    private bool IsActiveLocalReminder(ReminderTickKey key, object identity)
+    {
+        return _activeLocalReminders.TryGetValue(key, out var instances)
+            && instances.Contains(new LocalReminderInstanceKey(identity));
+    }
+
+    private void ResetLocalReminderScheduleState(ReminderTickKey key)
+    {
+        _tickAttemptsByReminder.Remove(key);
+        _localReminderScheduleCounts.Remove(key);
+        _localReminderScheduleVersions.Remove(key);
+        _localReminderScheduledVersions.Remove(key);
+    }
+
     private void ReleaseReadyTickWaiters(List<TaskCompletionSource<bool>> ready)
     {
         for (var i = _tickCountWaiters.Count - 1; i >= 0; i--)
@@ -358,6 +470,21 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         }
     }
 
+    private void ReleaseReadyLocalReminderScheduleWaiters(List<TaskCompletionSource<bool>> ready)
+    {
+        for (var i = _localReminderScheduleWaiters.Count - 1; i >= 0; i--)
+        {
+            var waiter = _localReminderScheduleWaiters[i];
+            if (!IsLocalReminderScheduleReadyCore(waiter.GrainId, waiter.ReminderName))
+            {
+                continue;
+            }
+
+            _localReminderScheduleWaiters.RemoveAt(i);
+            ready.Add(waiter.TaskSource);
+        }
+    }
+
     private readonly record struct ReminderTickKey(GrainId GrainId, string ReminderName);
     private readonly record struct LocalReminderInstanceKey(object Identity)
     {
@@ -379,6 +506,13 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         public GrainId GrainId { get; } = grainId;
         public string ReminderName { get; } = reminderName;
         public int TargetCount { get; } = targetCount;
+        public TaskCompletionSource<bool> TaskSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    private sealed class LocalReminderScheduleWaiter(GrainId grainId, string reminderName)
+    {
+        public GrainId GrainId { get; } = grainId;
+        public string ReminderName { get; } = reminderName;
         public TaskCompletionSource<bool> TaskSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
@@ -425,6 +559,14 @@ public static class ReminderDiagnosticExtensions
     public static Task WaitForActiveReminderCountAsync(this ReminderDiagnosticObserver observer, IAddressable grain, int expectedCount, CancellationToken cancellationToken, string reminderName)
     {
         return observer.WaitForActiveReminderCountAsync(grain.GetGrainId(), expectedCount, cancellationToken, reminderName);
+    }
+
+    /// <summary>
+    /// Waits until an active local owner has armed the next tick wait for a grain reminder.
+    /// </summary>
+    public static Task WaitForLocalReminderScheduleAsync(this ReminderDiagnosticObserver observer, IAddressable grain, string reminderName, CancellationToken cancellationToken)
+    {
+        return observer.WaitForLocalReminderScheduleAsync(grain.GetGrainId(), reminderName, cancellationToken);
     }
 
     /// <summary>

--- a/src/api/Orleans.Reminders/Orleans.Reminders.cs
+++ b/src/api/Orleans.Reminders/Orleans.Reminders.cs
@@ -186,11 +186,11 @@ namespace Orleans.Reminders.Diagnostics
             public LocalReminderScheduleChanged(Runtime.GrainId grainId, string reminderName, object identity, long scheduleVersion, Runtime.SiloAddress? siloAddress) : base(default, default!, default) { }
         }
 
-        public sealed partial class LocalReminderScheduled : ReminderEvent
+        public sealed partial class LocalReminderTickWaitArmed : ReminderEvent
         {
             public readonly object Identity;
             public readonly long ScheduleVersion;
-            public LocalReminderScheduled(Runtime.GrainId grainId, string reminderName, object identity, long scheduleVersion, Runtime.SiloAddress? siloAddress) : base(default, default!, default) { }
+            public LocalReminderTickWaitArmed(Runtime.GrainId grainId, string reminderName, object identity, long scheduleVersion, Runtime.SiloAddress? siloAddress) : base(default, default!, default) { }
         }
 
         public enum LocalReminderStopReason

--- a/src/api/Orleans.Reminders/Orleans.Reminders.cs
+++ b/src/api/Orleans.Reminders/Orleans.Reminders.cs
@@ -179,6 +179,20 @@ namespace Orleans.Reminders.Diagnostics
             public LocalReminderStopped(Runtime.GrainId grainId, string reminderName, object identity, LocalReminderStopReason reason, Runtime.SiloAddress? siloAddress) : base(default, default!, default) { }
         }
 
+        public sealed partial class LocalReminderScheduleChanged : ReminderEvent
+        {
+            public readonly object Identity;
+            public readonly long ScheduleVersion;
+            public LocalReminderScheduleChanged(Runtime.GrainId grainId, string reminderName, object identity, long scheduleVersion, Runtime.SiloAddress? siloAddress) : base(default, default!, default) { }
+        }
+
+        public sealed partial class LocalReminderScheduled : ReminderEvent
+        {
+            public readonly object Identity;
+            public readonly long ScheduleVersion;
+            public LocalReminderScheduled(Runtime.GrainId grainId, string reminderName, object identity, long scheduleVersion, Runtime.SiloAddress? siloAddress) : base(default, default!, default) { }
+        }
+
         public enum LocalReminderStopReason
         {
             Unknown = 0,

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -97,14 +97,14 @@ namespace Tester.AzureUtils.TimerTests
             TimeSpan period = await grain.GetReminderPeriod(DR);
             // start up the 'DR' reminder and wait for two ticks to pass.
             await grain.StartReminder(DR);
-            Thread.Sleep(period.Multiply(2) + LEEWAY); // giving some leeway
+            await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 2);
             // retrieve the value of the counter-- it should match the sequence number which is the number of periods
             // we've waited.
             long last = await grain.GetCounter(DR);
             Assert.Equal(2, last);
             // stop the timer and wait for a whole period.
-            await grain.StopReminder(DR);
-            Thread.Sleep(period.Multiply(1) + LEEWAY); // giving some leeway
+            await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder);
+            await AdvanceReminderTimeAsync(period);
             // the counter should not have changed.
             long curr = await grain.GetCounter(DR);
             Assert.Equal(last, curr);
@@ -116,13 +116,13 @@ namespace Tester.AzureUtils.TimerTests
             IReminderTestGrain2 grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             TimeSpan period = await grain.GetReminderPeriod(DR);
             await grain.StartReminder(DR);
-            Thread.Sleep(period.Multiply(2) + LEEWAY); // giving some leeway
+            await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 2);
             long last = await grain.GetCounter(DR);
             Assert.Equal(2, last);
 
-            await grain.StopReminder(DR);
+            await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder);
             TimeSpan sleepFor = period.Multiply(1) + LEEWAY;
-            Thread.Sleep(sleepFor); // giving some leeway
+            await AdvanceReminderTimeAsync(sleepFor);
             long curr = await grain.GetCounter(DR);
             Assert.Equal(last, curr);
             AssertIsInRange(curr, last, last + 1, grain, DR, sleepFor);
@@ -130,10 +130,9 @@ namespace Tester.AzureUtils.TimerTests
             // start the same reminder again
             await grain.StartReminder(DR);
             sleepFor = period.Multiply(2) + LEEWAY;
-            Thread.Sleep(sleepFor); // giving some leeway
-            curr = await grain.GetCounter(DR);
+            curr = await WaitForAdditionalReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 1);
             AssertIsInRange(curr, 2, 3, grain, DR, sleepFor);
-            await grain.StopReminder(DR); // cleanup
+            await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder); // cleanup
         }
 
         [SkippableFact, TestCategory("Functional")]
@@ -314,20 +313,20 @@ namespace Tester.AzureUtils.TimerTests
         {
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestCopyGrain g2 = this.GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
-            TimeSpan period = await g1.GetReminderPeriod(DR); // using same period
 
             await g1.StartReminder(DR);
-            Thread.Sleep(period.Multiply(2) + LEEWAY); // giving some leeway
+            await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), 2);
             await g2.StartReminder(DR);
-            Thread.Sleep(period.Multiply(2) + LEEWAY); // giving some leeway
+            await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), 4);
+            await WaitForReminderCounterAsync(g2, DR, () => g2.GetCounter(DR), 2);
             long last1 = await g1.GetCounter(DR);
             Assert.Equal(4, last1);
             long last2 = await g2.GetCounter(DR);
             Assert.Equal(2, last2); // CopyGrain fault
 
-            await g1.StopReminder(DR);
-            Thread.Sleep(period.Multiply(2) + LEEWAY); // giving some leeway
-            await g2.StopReminder(DR);
+            await StopReminderAndWaitForQuiescenceAsync(g1, DR, g1.StopReminder);
+            await WaitForReminderCounterAsync(g2, DR, () => g2.GetCounter(DR), 4);
+            await StopReminderAndWaitForQuiescenceAsync(g2, DR, g2.StopReminder);
             long curr1 = await g1.GetCounter(DR);
             Assert.Equal(last1, curr1);
             long curr2 = await g2.GetCounter(DR);
@@ -346,8 +345,6 @@ namespace Tester.AzureUtils.TimerTests
             IReminderTestCopyGrain g4 = this.GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
             using var cts = new CancellationTokenSource(ENDWAIT);
 
-            TimeSpan period = await g1.GetReminderPeriod(DR);
-
             Task[] tasks =
             {
                 Task.Run(() => PerGrainFailureTest(g1, cts.Token), cts.Token),
@@ -356,14 +353,17 @@ namespace Tester.AzureUtils.TimerTests
                 Task.Run(() => PerCopyGrainFailureTest(g4, cts.Token), cts.Token),
             };
 
-            Thread.Sleep(period.Multiply(failAfter));
+            await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), failAfter, cts.Token);
 
             var siloToKill = silos[Random.Shared.Next(silos.Count)];
             // stop a silo and join a new one in parallel
-            log.LogInformation("Stopping a silo and joining a silo");
-            Task t1 = this.StopSiloAsync(siloToKill);
-            Task t2 = this.StartAdditionalSilosAsync(1);
-            await Task.WhenAll(new[] { t1, t2 }).WaitAsync(cts.Token);
+            await using (await PauseReminderTimeAsync(cts.Token))
+            {
+                log.LogInformation("Stopping a silo and joining a silo");
+                Task t1 = this.StopSiloAsync(siloToKill);
+                Task t2 = this.StartAdditionalSilosAsync(1);
+                await Task.WhenAll(new[] { t1, t2 }).WaitAsync(cts.Token);
+            }
 
             await Task.WhenAll(tasks).WaitAsync(cts.Token); // Block until all tasks complete.
         }

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -37,7 +37,6 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
     protected const long failAfter = 2; // NOTE: match this sleep with 'failCheckAfter' used in PerGrainFailureTest() so you dont try to get counter immediately after failure as new activation may not have the reminder statistics
     protected const long failCheckAfter = 6; // safe value: 9
-
     protected ILogger log;
     protected ReminderDiagnosticObserver observer;
     private ReminderTestClock ReminderClock { get; }
@@ -216,6 +215,8 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), firstTickCount + 1, cts.Token);
 
             Assert.Contains(recorder.Events, evt => evt is ReminderEvents.Registered registered && registered.GrainId == grainId && registered.ReminderName == DR);
+            Assert.Contains(recorder.Events, evt => evt is ReminderEvents.LocalReminderScheduleChanged { GrainId: var eventGrainId, ReminderName: DR } && eventGrainId == grainId);
+            Assert.Contains(recorder.Events, evt => evt is ReminderEvents.LocalReminderScheduled { GrainId: var eventGrainId, ReminderName: DR } && eventGrainId == grainId);
             Assert.DoesNotContain(recorder.Events, evt => evt is ReminderEvents.LocalReminderStarted { GrainId: var eventGrainId, ReminderName: DR } && eventGrainId == grainId);
             Assert.DoesNotContain(recorder.Events, evt => evt is ReminderEvents.LocalReminderStopped { GrainId: var eventGrainId, ReminderName: DR } && eventGrainId == grainId);
         }
@@ -345,6 +346,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         ArgumentNullException.ThrowIfNull(getCounter);
         ArgumentOutOfRangeException.ThrowIfNegative(minimumCount);
 
+        var grainId = grain.GetGrainId();
         long result = 0;
         async Task<bool> Condition(CancellationToken ct)
         {
@@ -367,9 +369,11 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                 return result;
             }
 
-            var nextTickTarget = observer.GetTickCount(grain.GetGrainId(), reminderName) + 1;
-            var waitTask = observer.WaitForTickCountAsync(grain, nextTickTarget, cancellationToken, reminderName);
-            await AdvanceReminderTimeAsync(await GetReminderPeriodAsync(grain, reminderName), cancellationToken);
+            await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cancellationToken);
+            var nextTickTarget = observer.GetTickCount(grainId, reminderName) + 1;
+            var waitTask = observer.WaitForTickCountAsync(grainId, nextTickTarget, cancellationToken, reminderName);
+            var reminderPeriod = await GetReminderPeriodAsync(grain, reminderName);
+            await AdvanceReminderTimeAsync(reminderPeriod, cancellationToken);
             await waitTask;
         }
     }
@@ -594,7 +598,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         if (ex is ReminderException)
         {
             this.log.LogInformation(ex, "Retryable operation failed on attempt {Attempt}", i);
-            await Task.Delay(TimeSpan.FromMilliseconds(10)); // sleep a bit before retrying
+            await AdvanceReminderTimeAsync(TimeSpan.FromMilliseconds(10));
             return true;
         }
 

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -216,7 +216,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
             Assert.Contains(recorder.Events, evt => evt is ReminderEvents.Registered registered && registered.GrainId == grainId && registered.ReminderName == DR);
             Assert.Contains(recorder.Events, evt => evt is ReminderEvents.LocalReminderScheduleChanged { GrainId: var eventGrainId, ReminderName: DR } && eventGrainId == grainId);
-            Assert.Contains(recorder.Events, evt => evt is ReminderEvents.LocalReminderScheduled { GrainId: var eventGrainId, ReminderName: DR } && eventGrainId == grainId);
+            Assert.Contains(recorder.Events, evt => evt is ReminderEvents.LocalReminderTickWaitArmed { GrainId: var eventGrainId, ReminderName: DR } && eventGrainId == grainId);
             Assert.DoesNotContain(recorder.Events, evt => evt is ReminderEvents.LocalReminderStarted { GrainId: var eventGrainId, ReminderName: DR } && eventGrainId == grainId);
             Assert.DoesNotContain(recorder.Events, evt => evt is ReminderEvents.LocalReminderStopped { GrainId: var eventGrainId, ReminderName: DR } && eventGrainId == grainId);
         }


### PR DESCRIPTION
Fixes a race in reminder tests where fake time could be advanced before the local reminder loop had armed its next wait.

Adds local reminder diagnostic events for schedule changes and scheduled waits, tracks them in the reminder diagnostic observer, and updates reminder tests to wait for the schedule event before advancing FakeTimeProvider.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10159)