### PR TITLE
chore: use meter factory for storage metrics

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/StorageInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/StorageInstruments.cs
@@ -5,24 +5,14 @@ using System.Diagnostics.Metrics;
 #nullable disable
 namespace Orleans.Runtime;
 
-internal sealed class StorageInstruments
+internal sealed class StorageInstruments(OrleansInstruments instruments)
 {
-    private readonly Histogram<double> _storageReadHistogram;
-    private readonly Histogram<double> _storageWriteHistogram;
-    private readonly Histogram<double> _storageClearHistogram;
-    private readonly Counter<int> _storageReadErrorsCounter;
-    private readonly Counter<int> _storageWriteErrorsCounter;
-    private readonly Counter<int> _storageClearErrorsCounter;
-
-    public StorageInstruments(OrleansInstruments instruments)
-    {
-        _storageReadHistogram = instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_READ_LATENCY, "ms");
-        _storageWriteHistogram = instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_WRITE_LATENCY, "ms");
-        _storageClearHistogram = instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_CLEAR_LATENCY, "ms");
-        _storageReadErrorsCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_READ_ERRORS);
-        _storageWriteErrorsCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_WRITE_ERRORS);
-        _storageClearErrorsCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_CLEAR_ERRORS);
-    }
+    private readonly Histogram<double> _storageReadHistogram = instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_READ_LATENCY, "ms");
+    private readonly Histogram<double> _storageWriteHistogram = instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_WRITE_LATENCY, "ms");
+    private readonly Histogram<double> _storageClearHistogram = instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_CLEAR_LATENCY, "ms");
+    private readonly Counter<int> _storageReadErrorsCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_READ_ERRORS);
+    private readonly Counter<int> _storageWriteErrorsCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_WRITE_ERRORS);
+    private readonly Counter<int> _storageClearErrorsCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_CLEAR_ERRORS);
 
     internal void OnStorageRead(TimeSpan latency, string providerTypeName, string stateName, string stateTypeName)
     {

--- a/src/Orleans.Core/Diagnostics/Metrics/StorageInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/StorageInstruments.cs
@@ -5,20 +5,30 @@ using System.Diagnostics.Metrics;
 #nullable disable
 namespace Orleans.Runtime;
 
-internal static class StorageInstruments
+internal sealed class StorageInstruments
 {
-    private static readonly Histogram<double> StorageReadHistogram = Instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_READ_LATENCY, "ms");
-    private static readonly Histogram<double> StorageWriteHistogram = Instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_WRITE_LATENCY, "ms");
-    private static readonly Histogram<double> StorageClearHistogram = Instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_CLEAR_LATENCY, "ms");
-    private static readonly Counter<int> StorageReadErrorsCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_READ_ERRORS);
-    private static readonly Counter<int> StorageWriteErrorsCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_WRITE_ERRORS);
-    private static readonly Counter<int> StorageClearErrorsCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_CLEAR_ERRORS);
+    private readonly Histogram<double> _storageReadHistogram;
+    private readonly Histogram<double> _storageWriteHistogram;
+    private readonly Histogram<double> _storageClearHistogram;
+    private readonly Counter<int> _storageReadErrorsCounter;
+    private readonly Counter<int> _storageWriteErrorsCounter;
+    private readonly Counter<int> _storageClearErrorsCounter;
 
-    internal static void OnStorageRead(TimeSpan latency, string providerTypeName, string stateName, string stateTypeName)
+    internal StorageInstruments(OrleansInstruments instruments)
     {
-        if (StorageReadHistogram.Enabled)
+        _storageReadHistogram = instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_READ_LATENCY, "ms");
+        _storageWriteHistogram = instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_WRITE_LATENCY, "ms");
+        _storageClearHistogram = instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_CLEAR_LATENCY, "ms");
+        _storageReadErrorsCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_READ_ERRORS);
+        _storageWriteErrorsCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_WRITE_ERRORS);
+        _storageClearErrorsCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.STORAGE_CLEAR_ERRORS);
+    }
+
+    internal void OnStorageRead(TimeSpan latency, string providerTypeName, string stateName, string stateTypeName)
+    {
+        if (_storageReadHistogram.Enabled)
         {
-            StorageReadHistogram.Record(
+            _storageReadHistogram.Record(
                 latency.TotalMilliseconds,
                 [
                     new KeyValuePair<string, object>("provider_type_name", providerTypeName),
@@ -28,11 +38,11 @@ internal static class StorageInstruments
         }
     }
 
-    internal static void OnStorageWrite(TimeSpan latency, string providerTypeName, string stateName, string stateTypeName)
+    internal void OnStorageWrite(TimeSpan latency, string providerTypeName, string stateName, string stateTypeName)
     {
-        if (StorageWriteHistogram.Enabled)
+        if (_storageWriteHistogram.Enabled)
         {
-            StorageWriteHistogram.Record(
+            _storageWriteHistogram.Record(
                 latency.TotalMilliseconds,
                 [
                     new KeyValuePair<string, object>("provider_type_name", providerTypeName),
@@ -42,11 +52,11 @@ internal static class StorageInstruments
         }
     }
 
-    internal static void OnStorageReadError(string providerTypeName, string stateName, string stateTypeName)
+    internal void OnStorageReadError(string providerTypeName, string stateName, string stateTypeName)
     {
-        if (StorageReadErrorsCounter.Enabled)
+        if (_storageReadErrorsCounter.Enabled)
         {
-            StorageReadErrorsCounter.Add(1,
+            _storageReadErrorsCounter.Add(1,
                 [
                     new KeyValuePair<string, object>("provider_type_name", providerTypeName),
                     new KeyValuePair<string, object>("state_name", stateName),
@@ -55,11 +65,11 @@ internal static class StorageInstruments
         }
     }
 
-    internal static void OnStorageWriteError(string providerTypeName, string stateName, string stateTypeName)
+    internal void OnStorageWriteError(string providerTypeName, string stateName, string stateTypeName)
     {
-        if (StorageWriteErrorsCounter.Enabled)
+        if (_storageWriteErrorsCounter.Enabled)
         {
-            StorageWriteErrorsCounter.Add(1,
+            _storageWriteErrorsCounter.Add(1,
                 [
                     new KeyValuePair<string, object>("provider_type_name", providerTypeName),
                     new KeyValuePair<string, object>("state_name", stateName),
@@ -68,11 +78,11 @@ internal static class StorageInstruments
         }
     }
 
-    internal static void OnStorageDelete(TimeSpan latency, string providerTypeName, string stateName, string stateTypeName)
+    internal void OnStorageDelete(TimeSpan latency, string providerTypeName, string stateName, string stateTypeName)
     {
-        if (StorageClearHistogram.Enabled)
+        if (_storageClearHistogram.Enabled)
         {
-            StorageClearHistogram.Record(latency.TotalMilliseconds,
+            _storageClearHistogram.Record(latency.TotalMilliseconds,
                 [
                     new KeyValuePair<string, object>("provider_type_name", providerTypeName),
                     new KeyValuePair<string, object>("state_name", stateName),
@@ -81,11 +91,11 @@ internal static class StorageInstruments
         }
     }
 
-    internal static void OnStorageDeleteError(string providerTypeName, string stateName, string stateTypeName)
+    internal void OnStorageDeleteError(string providerTypeName, string stateName, string stateTypeName)
     {
-        if (StorageClearErrorsCounter.Enabled)
+        if (_storageClearErrorsCounter.Enabled)
         {
-            StorageClearErrorsCounter.Add(1,
+            _storageClearErrorsCounter.Add(1,
                 [
                     new KeyValuePair<string, object>("provider_type_name", providerTypeName),
                     new KeyValuePair<string, object>("state_name", stateName),

--- a/src/Orleans.Core/Diagnostics/Metrics/StorageInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/StorageInstruments.cs
@@ -14,7 +14,7 @@ internal sealed class StorageInstruments
     private readonly Counter<int> _storageWriteErrorsCounter;
     private readonly Counter<int> _storageClearErrorsCounter;
 
-    internal StorageInstruments(OrleansInstruments instruments)
+    public StorageInstruments(OrleansInstruments instruments)
     {
         _storageReadHistogram = instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_READ_LATENCY, "ms");
         _storageWriteHistogram = instruments.Meter.CreateHistogram<double>(InstrumentNames.STORAGE_WRITE_LATENCY, "ms");

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -68,6 +68,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<OrleansInstruments>();
             services.TryAddSingleton<SchedulerInstruments>();
             services.TryAddSingleton<ConsistentRingInstruments>();
+            services.TryAddSingleton<StorageInstruments>();
 
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -68,7 +68,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<OrleansInstruments>();
             services.TryAddSingleton<SchedulerInstruments>();
             services.TryAddSingleton<ConsistentRingInstruments>();
-            services.TryAddSingleton<StorageInstruments>();
+            services.TryAddSingleton<StorageInstruments>(static sp => new StorageInstruments(sp.GetRequiredService<OrleansInstruments>()));
 
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -68,7 +68,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<OrleansInstruments>();
             services.TryAddSingleton<SchedulerInstruments>();
             services.TryAddSingleton<ConsistentRingInstruments>();
-            services.TryAddSingleton<StorageInstruments>(static sp => new StorageInstruments(sp.GetRequiredService<OrleansInstruments>()));
+            services.TryAddSingleton<StorageInstruments>();
 
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));

--- a/src/Orleans.Runtime/Storage/StateStorageBridge.cs
+++ b/src/Orleans.Runtime/Storage/StateStorageBridge.cs
@@ -21,6 +21,7 @@ namespace Orleans.Core
     public partial class StateStorageBridge<TState> : IStorage<TState>, IGrainMigrationParticipant
     {
         private readonly IGrainContext _grainContext;
+        private readonly StorageInstruments _storageInstruments;
         private readonly StateStorageBridgeShared<TState> _shared;
         private GrainState<TState>? _grainState;
 
@@ -71,6 +72,7 @@ namespace Orleans.Core
             ArgumentNullException.ThrowIfNull(store);
 
             _grainContext = grainContext;
+            _storageInstruments = grainContext.ActivationServices.GetRequiredService<StorageInstruments>();
             var sharedInstances = ActivatorUtilities.GetServiceOrCreateInstance<StateStorageBridgeSharedMap>(grainContext.ActivationServices);
             _shared = sharedInstances.Get<TState>(name, store);
         }
@@ -101,11 +103,11 @@ namespace Orleans.Core
                 var sw = ValueStopwatch.StartNew();
                 await _shared.Store.ReadStateAsync(_shared.Name, _grainContext.GrainId, GrainState);
                 IsStateInitialized = true;
-                StorageInstruments.OnStorageRead(sw.Elapsed, _shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
+                _storageInstruments.OnStorageRead(sw.Elapsed, _shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
             }
             catch (Exception exc)
             {
-                StorageInstruments.OnStorageReadError(_shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
+                _storageInstruments.OnStorageReadError(_shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
                 OnError(exc, ErrorCode.StorageProvider_ReadFailed, nameof(ReadStateAsync));
             }
         }
@@ -134,11 +136,11 @@ namespace Orleans.Core
 
                 var sw = ValueStopwatch.StartNew();
                 await _shared.Store.WriteStateAsync(_shared.Name, _grainContext.GrainId, GrainState);
-                StorageInstruments.OnStorageWrite(sw.Elapsed, _shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
+                _storageInstruments.OnStorageWrite(sw.Elapsed, _shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
             }
             catch (Exception exc)
             {
-                StorageInstruments.OnStorageWriteError(_shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
+                _storageInstruments.OnStorageWriteError(_shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
                 OnError(exc, ErrorCode.StorageProvider_WriteFailed, nameof(WriteStateAsync));
             }
         }
@@ -172,11 +174,11 @@ namespace Orleans.Core
                 sw.Stop();
 
                 // Update counters
-                StorageInstruments.OnStorageDelete(sw.Elapsed, _shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
+                _storageInstruments.OnStorageDelete(sw.Elapsed, _shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
             }
             catch (Exception exc)
             {
-                StorageInstruments.OnStorageDeleteError(_shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
+                _storageInstruments.OnStorageDeleteError(_shared.ProviderTypeName, _shared.Name, _shared.StateTypeName);
                 OnError(exc, ErrorCode.StorageProvider_DeleteFailed, nameof(ClearStateAsync));
             }
         }

--- a/test/Orleans.Runtime.Tests/Diagnostics/StorageInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/StorageInstrumentsTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class StorageInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void StorageInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new StorageInstruments(new OrleansInstruments(meterFactory));
+        using var readLatencyCollector = new MetricCollector<double>(meterFactory, "Microsoft.Orleans", InstrumentNames.STORAGE_READ_LATENCY);
+        using var writeLatencyCollector = new MetricCollector<double>(meterFactory, "Microsoft.Orleans", InstrumentNames.STORAGE_WRITE_LATENCY);
+        using var clearLatencyCollector = new MetricCollector<double>(meterFactory, "Microsoft.Orleans", InstrumentNames.STORAGE_CLEAR_LATENCY);
+        using var readErrorCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.STORAGE_READ_ERRORS);
+        using var writeErrorCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.STORAGE_WRITE_ERRORS);
+        using var clearErrorCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.STORAGE_CLEAR_ERRORS);
+
+        instruments.OnStorageRead(TimeSpan.FromMilliseconds(12), "provider", "state", "stateType");
+        instruments.OnStorageWrite(TimeSpan.FromMilliseconds(34), "provider", "state", "stateType");
+        instruments.OnStorageDelete(TimeSpan.FromMilliseconds(56), "provider", "state", "stateType");
+        instruments.OnStorageReadError("provider", "state", "stateType");
+        instruments.OnStorageWriteError("provider", "state", "stateType");
+        instruments.OnStorageDeleteError("provider", "state", "stateType");
+
+        Assert.Equal(12, Assert.Single(readLatencyCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(34, Assert.Single(writeLatencyCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(56, Assert.Single(clearLatencyCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(readErrorCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(writeErrorCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(clearErrorCollector.GetMeasurementSnapshot()).Value);
+    }
+}


### PR DESCRIPTION
## Problem
Storage metrics still used static instruments via Instruments.Meter.

## Solution
Migrate StorageInstruments to a DI-backed wrapper using OrleansInstruments/IMeterFactory, wire it into StateStorageBridge, register it in default silo services, and add focused diagnostics coverage for metric emission.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10162)