### PR TITLE
test: fix deactivate-on-idle grain selection flake

### DIFF
--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
@@ -2,7 +2,6 @@ using Orleans.Runtime;
 using Orleans.TestingHost;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
-using UnitTests.TestHelper;
 using Xunit;
 using Xunit.Abstractions;
 using Orleans.Internal;
@@ -10,6 +9,7 @@ using Orleans.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Orleans.Runtime.GrainDirectory;
 using Orleans.Runtime.Placement;
 
 namespace UnitTests.ActivationsLifeCycleTests
@@ -238,22 +238,22 @@ namespace UnitTests.ActivationsLifeCycleTests
         private async Task<ICollectionTestGrain> PickGrainInNonPrimary()
         {
             var targetSilo = this.testCluster.SecondarySilos.First().SiloAddress;
+            var directoryView = await WaitForDirectoryView(targetSilo);
+            var grainType = this.testCluster.GrainFactory.GetGrain<ICollectionTestGrain>(0).GetGrainId().Type;
 
-            for (int i = 0; i < 500; i++)
+            const int maxCandidateGrainKeys = 1_000_000;
+            for (int i = 0; i < maxCandidateGrainKeys; i++)
             {
-                if (i % 30 == 29) await Task.Delay(1000); // give some extra time to stabilize if it can't find a suitable grain
-
                 // Create grain such that:
                 // Its directory owner is not the Gateway silo. This way Gateway will use its directory cache.
                 // Its activation is located on the non Gateway silo as well.
-                ICollectionTestGrain grain = this.testCluster.GrainFactory.GetGrain<ICollectionTestGrain>(i);
-                GrainId grainId = grain.GetGrainId();
-                SiloAddress primaryForGrain = (await TestUtils.GetDetailedGrainReport(this.testCluster.InternalGrainFactory, grainId, this.testCluster.Primary)).PrimaryForGrain;
-                if (primaryForGrain.Equals(this.testCluster.Primary.SiloAddress))
+                var grainId = GrainId.Create(grainType, GrainIdKeyExtensions.CreateIntegerKey(i));
+                if (!directoryView.TryGetOwner(grainId, out var primaryForGrain, out _) || !primaryForGrain.Equals(targetSilo))
                 {
                     continue;
                 }
 
+                ICollectionTestGrain grain = this.testCluster.GrainFactory.GetGrain<ICollectionTestGrain>(grainId);
                 string siloHostingActivation;
                 try
                 {
@@ -274,7 +274,27 @@ namespace UnitTests.ActivationsLifeCycleTests
             }
 
             Assert.True(testCluster.GetActiveSilos().Count() > 1, "This logic requires at least 1 non-primary active silo");
-            Assert.Fail("Could not find a grain that activates on a non-primary silo, and has the partition be also managed by a non-primary silo");
+            Assert.Fail($"Could not find a grain that activates on a non-primary silo, and has the partition be also managed by a non-primary silo after checking {maxCandidateGrainKeys} integer keys. Target silo {targetSilo} owns {directoryView.GetMemberRanges(targetSilo)} of the directory ring.");
+            return null;
+        }
+
+        private async Task<DirectoryMembershipSnapshot> WaitForDirectoryView(SiloAddress targetSilo)
+        {
+            var directoryMembership = ((InProcessSiloHandle)this.testCluster.Primary).ServiceProvider.GetRequiredService<DirectoryMembershipService>();
+            var timeout = DateTime.UtcNow.AddSeconds(30);
+            do
+            {
+                var view = directoryMembership.CurrentView;
+                if (view.Members.Contains(targetSilo))
+                {
+                    return view;
+                }
+
+                await Task.Delay(100);
+            }
+            while (DateTime.UtcNow < timeout);
+
+            Assert.Fail($"Timed out waiting for target silo {targetSilo} to join the directory view.");
             return null;
         }
     }

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/DeactivateOnIdleTests.cs
@@ -242,8 +242,14 @@ namespace UnitTests.ActivationsLifeCycleTests
             var grainType = this.testCluster.GrainFactory.GetGrain<ICollectionTestGrain>(0).GetGrainId().Type;
 
             const int maxCandidateGrainKeys = 1_000_000;
+            const int candidateYieldInterval = 4096;
             for (int i = 0; i < maxCandidateGrainKeys; i++)
             {
+                if (i > 0 && i % candidateYieldInterval == 0)
+                {
+                    await Task.Yield();
+                }
+
                 // Create grain such that:
                 // Its directory owner is not the Gateway silo. This way Gateway will use its directory cache.
                 // Its activation is located on the non Gateway silo as well.
@@ -281,20 +287,23 @@ namespace UnitTests.ActivationsLifeCycleTests
         private async Task<DirectoryMembershipSnapshot> WaitForDirectoryView(SiloAddress targetSilo)
         {
             var directoryMembership = ((InProcessSiloHandle)this.testCluster.Primary).ServiceProvider.GetRequiredService<DirectoryMembershipService>();
-            var timeout = DateTime.UtcNow.AddSeconds(30);
-            do
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            try
             {
-                var view = directoryMembership.CurrentView;
-                if (view.Members.Contains(targetSilo))
+                await foreach (var view in directoryMembership.ViewUpdates.WithCancellation(cts.Token))
                 {
-                    return view;
+                    if (view.Members.Contains(targetSilo))
+                    {
+                        return view;
+                    }
                 }
-
-                await Task.Delay(100);
             }
-            while (DateTime.UtcNow < timeout);
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
+            {
+                Assert.Fail($"Timed out waiting for target silo {targetSilo} to join the directory view.");
+            }
 
-            Assert.Fail($"Timed out waiting for target silo {targetSilo} to join the directory view.");
+            Assert.Fail($"Directory view updates completed before target silo {targetSilo} joined the directory view.");
             return null;
         }
     }


### PR DESCRIPTION
Fixes a flaky DeactivateOnIdle test which could fail before exercising the deactivation path. The test now waits for the primary silo's local directory membership view to include the secondary silo, then selects an ordinary integer-key grain whose directory owner is that secondary silo using the actual directory snapshot. This keeps the default directory partitioning intact and avoids timing-prone remote detailed-report probing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10163)