### PR TITLE
test: stabilize prefer-local placement migration test

### DIFF
--- a/test/Orleans.Placement.Tests/General/GrainPlacementClusterChangeTests.cs
+++ b/test/Orleans.Placement.Tests/General/GrainPlacementClusterChangeTests.cs
@@ -56,6 +56,7 @@ namespace UnitTests.General
             SiloHandle siloToKill = HostedCluster.GetActiveSilos().First(s => s.SiloAddress.Endpoint.Equals(expected));
             output.WriteLine("Killing silo {0} hosting locally placed grain", siloToKill);
             await HostedCluster.StopSiloAsync(siloToKill);
+            await HostedCluster.WaitForLivenessToStabilizeAsync();
 
             IPEndPoint newActual = await grain.GetEndpoint();
             output.WriteLine("PreferLocalPlacement grain was recreated on silo {0}", newActual);


### PR DESCRIPTION
Fixes a flaky `PreferLocalPlacement` cluster-change test by waiting for liveness stabilization after stopping the silo that hosted the original activation before reusing the grain reference. Without that wait, the client can still route through stale cluster state during membership propagation and hit the response timeout.

This is only a test stabilization, not a full runtime mitigation. Correct mitigation would track gateway-forwarded client requests in gateway per-client state (`ClientState`/ClientData), including the final destination silo selected after addressing. Dead-silo notifications should use that tracking to complete affected client requests with a transient rejection/`SiloUnavailableException` instead of waiting for the response timeout.

That design also means gateway responses/rejections should not fast-path directly back to the client and bypass the per-client outstanding-request accounting. They need to flow through the same tracking path so completed entries are removed, failed entries are rejected, and state does not leak.

Follow-up issue: #10165

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10166)