### PR TITLE
chore: use meter factory for catalog metrics

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/CatalogInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/CatalogInstruments.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.Metrics;
 
 namespace Orleans.Runtime;
 
-internal static class CatalogInstruments
+internal sealed class CatalogInstruments(OrleansInstruments instruments)
 {
     private const string MillisecondsUnit = "ms";
     private const string StatusTagName = "status";
@@ -27,21 +27,23 @@ internal static class CatalogInstruments
 
     internal struct ActivationMetricTracker
     {
+        private readonly CatalogInstruments _instruments;
         private readonly ValueStopwatch _stopwatch;
         private readonly bool _usesDirectory;
         private string? _status;
 
-        private ActivationMetricTracker(ValueStopwatch stopwatch, bool usesDirectory, string status)
+        private ActivationMetricTracker(CatalogInstruments instruments, ValueStopwatch stopwatch, bool usesDirectory, string status)
         {
+            _instruments = instruments;
             _stopwatch = stopwatch;
             _usesDirectory = usesDirectory;
             _status = status;
         }
 
-        public static ActivationMetricTracker Start(bool usesDirectory)
+        public static ActivationMetricTracker Start(CatalogInstruments instruments, bool usesDirectory)
         {
-            return ActivationLatencyEnabled
-                ? new(ValueStopwatch.StartNew(), usesDirectory, ActivationStatusError)
+            return instruments.ActivationLatencyEnabled
+                ? new(instruments, ValueStopwatch.StartNew(), usesDirectory, ActivationStatusError)
                 : default;
         }
 
@@ -61,12 +63,12 @@ internal static class CatalogInstruments
 
         public void Record()
         {
-            if (_status is null)
+            if (_status is null || _instruments is null)
             {
                 return;
             }
 
-            OnActivationCompleted(_stopwatch.Elapsed, _status, _usesDirectory);
+            _instruments.OnActivationCompleted(_stopwatch.Elapsed, _status, _usesDirectory);
         }
 
         private void SetStatus(string status)
@@ -80,21 +82,23 @@ internal static class CatalogInstruments
 
     internal readonly struct DeactivationMetricTracker
     {
+        private readonly CatalogInstruments _instruments;
         private readonly ValueStopwatch _stopwatch;
         private readonly string? _via;
         private readonly bool _recorded;
 
-        private DeactivationMetricTracker(ValueStopwatch stopwatch, string via, bool recorded)
+        private DeactivationMetricTracker(CatalogInstruments instruments, ValueStopwatch stopwatch, string via, bool recorded)
         {
+            _instruments = instruments;
             _stopwatch = stopwatch;
             _via = via;
             _recorded = recorded;
         }
 
-        public static DeactivationMetricTracker Start()
+        public static DeactivationMetricTracker Start(CatalogInstruments instruments)
         {
-            return DeactivationLatencyEnabled
-                ? new(ValueStopwatch.StartNew(), DeactivationViaUnknown, recorded: false)
+            return instruments.DeactivationLatencyEnabled
+                ? new(instruments, ValueStopwatch.StartNew(), DeactivationViaUnknown, recorded: false)
                 : default;
         }
 
@@ -108,77 +112,77 @@ internal static class CatalogInstruments
 
         public DeactivationMetricTracker Record()
         {
-            if (_via is null || _recorded)
+            if (_via is null || _recorded || _instruments is null)
             {
                 return this;
             }
 
-            OnDeactivationCompleted(_stopwatch.Elapsed, _via);
-            return new(_stopwatch, _via, recorded: true);
+            _instruments.OnDeactivationCompleted(_stopwatch.Elapsed, _via);
+            return new(_instruments, _stopwatch, _via, recorded: true);
         }
 
         public void RecordIfNeeded()
         {
-            if (_via is null || _recorded)
+            if (_via is null || _recorded || _instruments is null)
             {
                 return;
             }
 
-            OnDeactivationCompleted(_stopwatch.Elapsed, _via);
+            _instruments.OnDeactivationCompleted(_stopwatch.Elapsed, _via);
         }
 
-        private DeactivationMetricTracker WithVia(string via) => _via is null ? this : new(_stopwatch, via, _recorded);
+        private DeactivationMetricTracker WithVia(string via) => _via is null ? this : new(_instruments, _stopwatch, via, _recorded);
     }
 
-    internal static Counter<int> ActivationFailedToActivate = Instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_FAILED_TO_ACTIVATE);
+    private readonly Counter<int> _activationFailedToActivate = instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_FAILED_TO_ACTIVATE);
 
-    internal static Counter<int> ActivationCollections = Instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_COLLECTION_NUMBER_OF_COLLECTIONS);
+    private readonly Counter<int> _activationCollections = instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_COLLECTION_NUMBER_OF_COLLECTIONS);
 
-    internal static Counter<int> ActivationShutdown = Instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_SHUTDOWN);
+    private readonly Counter<int> _activationShutdown = instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_SHUTDOWN);
 
-    internal static void ActivationShutdownViaCollection() => OnActivationShutdown(DeactivationViaCollection);
-    internal static void ActivationShutdownViaDeactivateOnIdle() => OnActivationShutdown(DeactivationViaDeactivateOnIdle);
-    internal static void ActivationShutdownViaMigration() => OnActivationShutdown(DeactivationViaMigration);
-    internal static void ActivationShutdownViaDeactivateStuckActivation() => OnActivationShutdown(DeactivationViaDeactivateStuckActivation);
+    internal void ActivationShutdownViaCollection() => OnActivationShutdown(DeactivationViaCollection);
+    internal void ActivationShutdownViaDeactivateOnIdle() => OnActivationShutdown(DeactivationViaDeactivateOnIdle);
+    internal void ActivationShutdownViaMigration() => OnActivationShutdown(DeactivationViaMigration);
+    internal void ActivationShutdownViaDeactivateStuckActivation() => OnActivationShutdown(DeactivationViaDeactivateStuckActivation);
 
-    internal static Histogram<double> DeactivationLatency = Instruments.Meter.CreateHistogram<double>(InstrumentNames.CATALOG_DEACTIVATION_LATENCY, MillisecondsUnit);
-    internal static bool DeactivationLatencyEnabled => DeactivationLatency.Enabled;
+    private readonly Histogram<double> _deactivationLatency = instruments.Meter.CreateHistogram<double>(InstrumentNames.CATALOG_DEACTIVATION_LATENCY, MillisecondsUnit);
+    internal bool DeactivationLatencyEnabled => _deactivationLatency.Enabled;
 
-    internal static void OnDeactivationCompleted(TimeSpan latency, string via)
+    internal void OnDeactivationCompleted(TimeSpan latency, string via)
     {
-        if (DeactivationLatency.Enabled)
+        if (_deactivationLatency.Enabled)
         {
-            DeactivationLatency.Record(latency.TotalMilliseconds, new KeyValuePair<string, object?>(ViaTagName, via));
+            _deactivationLatency.Record(latency.TotalMilliseconds, new KeyValuePair<string, object?>(ViaTagName, via));
         }
     }
 
-    internal static Counter<int> NonExistentActivations = Instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_NON_EXISTENT_ACTIVATIONS);
+    private readonly Counter<int> _nonExistentActivations = instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_NON_EXISTENT_ACTIVATIONS);
 
-    internal static Counter<int> ActivationConcurrentRegistrationAttempts = Instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_CONCURRENT_REGISTRATION_ATTEMPTS);
+    private readonly Counter<int> _activationConcurrentRegistrationAttempts = instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_CONCURRENT_REGISTRATION_ATTEMPTS);
 
-    internal static readonly Counter<int> ActivationsCreated = Instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_CREATED);
-    internal static readonly Counter<int> ActivationsDestroyed = Instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_DESTROYED);
-    private static readonly Histogram<double> ActivationLatency = Instruments.Meter.CreateHistogram<double>(InstrumentNames.CATALOG_ACTIVATION_LATENCY, MillisecondsUnit);
-    internal static bool ActivationLatencyEnabled => ActivationLatency.Enabled;
+    private readonly Counter<int> _activationsCreated = instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_CREATED);
+    private readonly Counter<int> _activationsDestroyed = instruments.Meter.CreateCounter<int>(InstrumentNames.CATALOG_ACTIVATION_DESTROYED);
+    private readonly Histogram<double> _activationLatency = instruments.Meter.CreateHistogram<double>(InstrumentNames.CATALOG_ACTIVATION_LATENCY, MillisecondsUnit);
+    internal bool ActivationLatencyEnabled => _activationLatency.Enabled;
 
-    internal static ObservableGauge<int>? ActivationCount;
+    private ObservableGauge<int>? _activationCount;
 
-    internal static void RegisterActivationCountObserve(Func<int> observeValue)
+    internal void RegisterActivationCountObserve(Func<int> observeValue)
     {
-        ActivationCount = Instruments.Meter.CreateObservableGauge(InstrumentNames.CATALOG_ACTIVATION_COUNT, observeValue);
+        _activationCount = instruments.Meter.CreateObservableGauge(InstrumentNames.CATALOG_ACTIVATION_COUNT, observeValue);
     }
 
-    internal static ObservableGauge<int>? ActivationWorkingSet;
-    internal static void RegisterActivationWorkingSetObserve(Func<int> observeValue)
+    private ObservableGauge<int>? _activationWorkingSet;
+    internal void RegisterActivationWorkingSetObserve(Func<int> observeValue)
     {
-        ActivationWorkingSet = Instruments.Meter.CreateObservableGauge(InstrumentNames.CATALOG_ACTIVATION_WORKING_SET, observeValue);
+        _activationWorkingSet = instruments.Meter.CreateObservableGauge(InstrumentNames.CATALOG_ACTIVATION_WORKING_SET, observeValue);
     }
 
-    internal static void OnActivationCompleted(TimeSpan latency, string status, bool usesDirectory)
+    internal void OnActivationCompleted(TimeSpan latency, string status, bool usesDirectory)
     {
-        if (ActivationLatency.Enabled)
+        if (_activationLatency.Enabled)
         {
-            ActivationLatency.Record(
+            _activationLatency.Record(
                 Math.Max(0, latency.TotalMilliseconds),
                 [
                     new KeyValuePair<string, object?>(StatusTagName, status),
@@ -187,27 +191,47 @@ internal static class CatalogInstruments
         }
     }
 
-    internal static void OnActivationFailedToActivate()
+    internal void OnActivationFailedToActivate()
     {
-        if (ActivationFailedToActivate.Enabled)
+        if (_activationFailedToActivate.Enabled)
         {
-            ActivationFailedToActivate.Add(1);
+            _activationFailedToActivate.Add(1);
         }
     }
 
-    internal static void OnActivationConcurrentRegistrationAttempt()
+    internal void OnActivationConcurrentRegistrationAttempt()
     {
-        if (ActivationConcurrentRegistrationAttempts.Enabled)
+        if (_activationConcurrentRegistrationAttempts.Enabled)
         {
-            ActivationConcurrentRegistrationAttempts.Add(1);
+            _activationConcurrentRegistrationAttempts.Add(1);
         }
     }
 
-    private static void OnActivationShutdown(string via)
+    internal void OnActivationCollected()
     {
-        if (ActivationShutdown.Enabled)
+        _activationCollections.Add(1);
+    }
+
+    internal void OnActivationCreated()
+    {
+        _activationsCreated.Add(1);
+    }
+
+    internal void OnActivationDestroyed()
+    {
+        _activationsDestroyed.Add(1);
+    }
+
+    internal void OnNonExistentActivation()
+    {
+        _nonExistentActivations.Add(1);
+    }
+
+    private void OnActivationShutdown(string via)
+    {
+        if (_activationShutdown.Enabled)
         {
-            ActivationShutdown.Add(1, new KeyValuePair<string, object?>(ViaTagName, via));
+            _activationShutdown.Add(1, new KeyValuePair<string, object?>(ViaTagName, via));
         }
     }
 }

--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -35,6 +35,7 @@ namespace Orleans.Runtime
 
         private readonly IEnvironmentStatisticsProvider _environmentStatisticsProvider;
         private readonly GrainCollectionOptions _grainCollectionOptions;
+        private readonly CatalogInstruments _catalogInstruments;
         private readonly PeriodicTimer _memBasedDeactivationTimer;
         private Task _memBasedDeactivationLoopTask;
 
@@ -48,9 +49,11 @@ namespace Orleans.Runtime
             TimeProvider timeProvider,
             IOptions<GrainCollectionOptions> options,
             ILogger<ActivationCollector> logger,
-            IEnvironmentStatisticsProvider environmentStatisticsProvider)
+            IEnvironmentStatisticsProvider environmentStatisticsProvider,
+            CatalogInstruments catalogInstruments)
         {
             _grainCollectionOptions = options.Value;
+            _catalogInstruments = catalogInstruments;
 
             shortestAgeLimit = new(_grainCollectionOptions.ClassSpecificCollectionAge.Values.Aggregate(_grainCollectionOptions.CollectionAge.Ticks, (a, v) => Math.Min(a, v.Ticks)));
             nextTicket = MakeTicketFromDateTime(timeProvider.GetUtcNow().UtcDateTime);
@@ -398,7 +401,7 @@ namespace Orleans.Runtime
                 }
             }
 
-            CatalogInstruments.ActivationCollections.Add(1);
+            _catalogInstruments.OnActivationCollected();
             if (candidates.Count > 0) 
             {
                 LogCollectActivations(new(candidates));
@@ -648,7 +651,7 @@ namespace Orleans.Runtime
             LogBeforeCollection(number, memBefore, _activationCount, this);
 
             List<ICollectibleGrainContext> list = scanStale ? ScanStale() : ScanAll(ageLimit);
-            CatalogInstruments.ActivationCollections.Add(1);
+            _catalogInstruments.OnActivationCollected();
             if (list is { Count: > 0 })
             {
                 LogCollectActivations(new(list));
@@ -664,7 +667,7 @@ namespace Orleans.Runtime
         private async Task DeactivateActivationsFromCollector(List<ICollectibleGrainContext> list, CancellationToken cancellationToken, DeactivationReason? deactivationReason = null)
         {
             LogDeactivateActivationsFromCollector(list.Count);
-            CatalogInstruments.ActivationShutdownViaCollection();
+            _catalogInstruments.ActivationShutdownViaCollection();
 
             deactivationReason ??= GetDeactivationReason();
 

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1620,7 +1620,7 @@ internal sealed partial class ActivationData :
 
     public void Activate(Dictionary<string, object>? requestContext, CancellationToken cancellationToken)
     {
-        var metrics = CatalogInstruments.ActivationMetricTracker.Start(IsUsingGrainDirectory);
+        var metrics = CatalogInstruments.ActivationMetricTracker.Start(_shared.CatalogInstruments, IsUsingGrainDirectory);
         var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(_shared.InternalRuntime.CollectionOptions.Value.ActivationTimeout);
 
@@ -1708,7 +1708,7 @@ internal sealed partial class ActivationData :
                                 }
 
                                 success = false;
-                                CatalogInstruments.OnActivationConcurrentRegistrationAttempt();
+                                _shared.CatalogInstruments.OnActivationConcurrentRegistrationAttempt();
                                 LogDuplicateActivation(
                                     _shared.Logger,
                                     Address,
@@ -1810,7 +1810,7 @@ internal sealed partial class ActivationData :
                     {
                         if (cancellationToken.IsCancellationRequested && exception is ObjectDisposedException or OperationCanceledException)
                         {
-                            CatalogInstruments.OnActivationFailedToActivate();
+                            _shared.CatalogInstruments.OnActivationFailedToActivate();
 
                             // This captures the case where user code in OnActivateAsync doesn't use the passed cancellation token
                             // and makes a call that tries to resolve the scoped IServiceProvider or other type that has been disposed because of cancellation,
@@ -1864,7 +1864,7 @@ internal sealed partial class ActivationData :
             }
             catch (Exception exception)
             {
-                CatalogInstruments.OnActivationFailedToActivate();
+                _shared.CatalogInstruments.OnActivationFailedToActivate();
                 activationMetrics.Failed(cancellationToken.IsCancellationRequested);
                 var sourceException = (exception as OrleansLifecycleCanceledException)?.InnerException ?? exception;
                 LogErrorActivatingGrain(_shared.Logger, sourceException, this);
@@ -1924,7 +1924,7 @@ internal sealed partial class ActivationData :
     {
         using var _ = deactivateCommand.Activity;
 
-        var deactivationMetrics = CatalogInstruments.DeactivationMetricTracker.Start();
+        var deactivationMetrics = CatalogInstruments.DeactivationMetricTracker.Start(_shared.CatalogInstruments);
         var migrating = false;
         var encounteredError = false;
         try
@@ -2029,22 +2029,22 @@ internal sealed partial class ActivationData :
             if (IsStuckDeactivating)
             {
                 deactivationMetrics = deactivationMetrics.DeactivateStuckActivation();
-                CatalogInstruments.ActivationShutdownViaDeactivateStuckActivation();
+                _shared.CatalogInstruments.ActivationShutdownViaDeactivateStuckActivation();
             }
             else if (migrating)
             {
                 deactivationMetrics = deactivationMetrics.Migration();
-                CatalogInstruments.ActivationShutdownViaMigration();
+                _shared.CatalogInstruments.ActivationShutdownViaMigration();
             }
             else if (_isInWorkingSet)
             {
                 deactivationMetrics = deactivationMetrics.DeactivateOnIdle();
-                CatalogInstruments.ActivationShutdownViaDeactivateOnIdle();
+                _shared.CatalogInstruments.ActivationShutdownViaDeactivateOnIdle();
             }
             else
             {
                 deactivationMetrics = deactivationMetrics.Collection();
-                CatalogInstruments.ActivationShutdownViaCollection();
+                _shared.CatalogInstruments.ActivationShutdownViaCollection();
             }
 
             UnregisterMessageTarget();

--- a/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationDirectory.cs
@@ -13,9 +13,9 @@ internal sealed class ActivationDirectory : IEnumerable<KeyValuePair<GrainId, IG
 
     private readonly ConcurrentDictionary<GrainId, IGrainContext> _activations = new();
 
-    public ActivationDirectory()
+    public ActivationDirectory(CatalogInstruments catalogInstruments)
     {
-        CatalogInstruments.RegisterActivationCountObserve(() => Count);
+        catalogInstruments.RegisterActivationCountObserve(() => Count);
     }
 
     public int Count => _activationsCount;

--- a/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
@@ -33,12 +33,13 @@ namespace Orleans.Runtime
         public ActivationWorkingSet(
             IAsyncTimerFactory asyncTimerFactory,
             ILogger<ActivationWorkingSet> logger,
-            IEnumerable<IActivationWorkingSetObserver> observers)
+            IEnumerable<IActivationWorkingSetObserver> observers,
+            CatalogInstruments catalogInstruments)
         {
             _logger = logger;
             _scanPeriodTimer = asyncTimerFactory.Create(TimeSpan.FromMilliseconds(5_000), nameof(ActivationWorkingSet) + "." + nameof(MonitorWorkingSet));
             _observers = observers.ToList();
-            CatalogInstruments.RegisterActivationWorkingSetObserve(() => Count);
+            catalogInstruments.RegisterActivationWorkingSetObserve(() => Count);
         }
 
         public int Count => _activeCount;

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -16,6 +16,7 @@ namespace Orleans.Runtime
         private readonly IServiceProvider serviceProvider;
         private readonly ILogger logger;
         private readonly GrainContextActivator grainActivator;
+        private readonly CatalogInstruments _catalogInstruments;
         private ISiloStatusOracle _siloStatusOracle;
 
         // Lock striping is used for activation creation to reduce contention
@@ -33,6 +34,7 @@ namespace Orleans.Runtime
             IServiceProvider serviceProvider,
             ILoggerFactory loggerFactory,
             GrainContextActivator grainActivator,
+            CatalogInstruments catalogInstruments,
             SystemTargetShared shared)
             : base(Constants.CatalogType, shared)
         {
@@ -41,6 +43,7 @@ namespace Orleans.Runtime
             this.grainActivator = grainActivator;
             this.logger = loggerFactory.CreateLogger<Catalog>();
             this.activationCollector = activationCollector;
+            _catalogInstruments = catalogInstruments;
 
             // Initialize lock striping array
             for (var i = 0; i < LockCount; i++)
@@ -95,7 +98,7 @@ namespace Orleans.Runtime
 
                 // this should be removed once we've refactored the deactivation code path. For now safe to keep.
                 activationCollector.TryCancelCollection(activation as ICollectibleGrainContext);
-                CatalogInstruments.ActivationsDestroyed.Add(1);
+                _catalogInstruments.OnActivationDestroyed();
             }
         }
 
@@ -188,7 +191,7 @@ namespace Orleans.Runtime
                 }
             }
 
-            CatalogInstruments.ActivationsCreated.Add(1);
+            _catalogInstruments.OnActivationCreated();
 
             // Rehydration occurs before activation.
             if (rehydrationContext is not null)
@@ -215,7 +218,7 @@ namespace Orleans.Runtime
                     self.LogDebugUnableToCreateActivation(grainId);
                 }
 
-                CatalogInstruments.NonExistentActivations.Add(1);
+                self._catalogInstruments.OnNonExistentActivation();
 
                 var grainLocator = self.serviceProvider.GetRequiredService<GrainLocator>();
                 grainLocator.InvalidateCache(grainId);

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -58,6 +58,7 @@ public sealed class GrainTypeSharedContext
         SchedulingOptions = schedulingOptions.Value;
         Runtime = grainRuntime;
         MigrationManager = _serviceProvider.GetService<IActivationMigrationManager>();
+        CatalogInstruments = serviceProvider.GetRequiredService<CatalogInstruments>();
 
         CollectionAgeLimit = GetCollectionAgeLimit(
             grainType,
@@ -70,6 +71,8 @@ public sealed class GrainTypeSharedContext
     /// Gets the grain instance type name, if available.
     /// </summary>
     public string? GrainTypeName { get; }
+
+    internal CatalogInstruments CatalogInstruments { get; }
 
     private static TimeSpan GetCollectionAgeLimit(GrainType grainType, Type grainClass, GrainManifest siloManifest, GrainCollectionOptions collectionOptions)
     {

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -69,6 +69,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<SchedulerInstruments>();
             services.TryAddSingleton<ConsistentRingInstruments>();
             services.TryAddSingleton<StorageInstruments>();
+            services.TryAddSingleton<CatalogInstruments>();
 
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -156,7 +156,7 @@ namespace UnitTests.Directory
                 schedulingOptions: Options.Create(new SchedulingOptions()),
                 grainReferenceActivator: null,
                 timerRegistry: null,
-                activations: new ActivationDirectory(),
+                activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
@@ -208,7 +208,7 @@ namespace UnitTests.Directory
                 schedulingOptions: Options.Create(new SchedulingOptions()),
                 grainReferenceActivator: null,
                 timerRegistry: null,
-                activations: new ActivationDirectory(),
+                activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
@@ -272,7 +272,7 @@ namespace UnitTests.Directory
                 schedulingOptions: Options.Create(new SchedulingOptions()),
                 grainReferenceActivator: null,
                 timerRegistry: null,
-                activations: new ActivationDirectory(),
+                activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
@@ -825,6 +825,15 @@ namespace UnitTests.Directory
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<SchedulerInstruments>();
             return services.BuildServiceProvider().GetRequiredService<SchedulerInstruments>();
+        }
+
+        private static CatalogInstruments CreateCatalogInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<CatalogInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<CatalogInstruments>();
         }
 
         private int generation = 0;

--- a/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
@@ -80,7 +80,7 @@ namespace NonSilo.Tests.Directory
                 schedulingOptions: Options.Create(new SchedulingOptions()),
                 grainReferenceActivator: null,
                 timerRegistry: null,
-                activations: new ActivationDirectory(),
+                activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments());
 
             _directory = new ClientDirectory(
@@ -105,6 +105,15 @@ namespace NonSilo.Tests.Directory
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<SchedulerInstruments>();
             return services.BuildServiceProvider().GetRequiredService<SchedulerInstruments>();
+        }
+
+        private static CatalogInstruments CreateCatalogInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<CatalogInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<CatalogInstruments>();
         }
 
         /// <summary>

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -609,16 +609,24 @@ public class LocalDurableJobManagerTests
         Options.Create(new SchedulingOptions()),
         grainReferenceActivator: null!,
         timerRegistry: null!,
-        activations: new ActivationDirectory(),
+        activations: new ActivationDirectory(CreateCatalogInstruments()),
         schedulerInstruments: CreateSchedulerInstruments());
 
     private static SchedulerInstruments CreateSchedulerInstruments()
-    {
-        var services = new ServiceCollection();
+    {        var services = new ServiceCollection();
         services.AddMetrics();
         services.AddSingleton<OrleansInstruments>();
         services.AddSingleton<SchedulerInstruments>();
         return services.BuildServiceProvider().GetRequiredService<SchedulerInstruments>();
+    }
+
+    private static CatalogInstruments CreateCatalogInstruments()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton<CatalogInstruments>();
+        return services.BuildServiceProvider().GetRequiredService<CatalogInstruments>();
     }
 
     private static IJobShard CreateSubstituteShard(string id, DateTimeOffset start, DateTimeOffset end)

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
@@ -26,7 +27,7 @@ namespace UnitTests.Runtime
             var logger = NullLogger<ActivationCollector>.Instance;
 
             this.timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2025-01-01T00:00:00.000+00:00"));
-            this.collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, new EnvironmentStatisticsProvider());
+            this.collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, new EnvironmentStatisticsProvider(), CreateCatalogInstruments());
         }
 
         [Theory, TestCategory("Activation")]
@@ -146,7 +147,8 @@ namespace UnitTests.Runtime
                 timeProvider,
                 grainCollectionOptions,
                 logger,
-                statsProvider
+                statsProvider,
+                CreateCatalogInstruments()
             );
 
             collector._activationCount = activationCount;
@@ -170,7 +172,7 @@ namespace UnitTests.Runtime
             var statsProvider = Substitute.For<IEnvironmentStatisticsProvider>();
             var logger = NullLogger<ActivationCollector>.Instance;
             var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
-            var collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, statsProvider);
+            var collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, statsProvider, CreateCatalogInstruments());
 
             collector._activationCount = 0;
             var overloaded = collector.IsMemoryOverloaded(out var surplusActivations);
@@ -189,14 +191,14 @@ namespace UnitTests.Runtime
             var statsProvider = Substitute.For<IEnvironmentStatisticsProvider>();
             var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
 
-            var collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, statsProvider);
+            var collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, statsProvider, CreateCatalogInstruments());
             var timer = Substitute.For<IAsyncTimer>();
             timer.NextTick().Returns(Task.FromResult(false));
             var timerFactory = Substitute.For<IAsyncTimerFactory>();
             timerFactory.Create(Arg.Any<TimeSpan>(), Arg.Any<string>()).Returns(timer);
 
             var wsLogger = NullLogger<ActivationWorkingSet>.Instance;
-            var workingSet = new ActivationWorkingSet(timerFactory, wsLogger, new[] { collector });
+            var workingSet = new ActivationWorkingSet(timerFactory, wsLogger, new[] { collector }, CreateCatalogInstruments());
 
             var activation1 = PrepareActivation(1, collector);
             var activation2 = PrepareActivation(1, collector);
@@ -224,14 +226,14 @@ namespace UnitTests.Runtime
             var statsProvider = Substitute.For<IEnvironmentStatisticsProvider>();
             var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
 
-            var collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, statsProvider);
+            var collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, statsProvider, CreateCatalogInstruments());
             var timer = Substitute.For<IAsyncTimer>();
             timer.NextTick().Returns(Task.FromResult(false));
             var timerFactory = Substitute.For<IAsyncTimerFactory>();
             timerFactory.Create(Arg.Any<TimeSpan>(), Arg.Any<string>()).Returns(timer);
 
             var wsLogger = NullLogger<ActivationWorkingSet>.Instance;
-            var workingSet = new ActivationWorkingSet(timerFactory, wsLogger, new[] { collector });
+            var workingSet = new ActivationWorkingSet(timerFactory, wsLogger, new[] { collector }, CreateCatalogInstruments());
 
             var totalActivations = 500;
             var activations = new List<IActivationWorkingSetMember>();
@@ -335,14 +337,14 @@ namespace UnitTests.Runtime
             var statsProvider = Substitute.For<IEnvironmentStatisticsProvider>();
             var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
 
-            var collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, statsProvider);
+            var collector = new ActivationCollector(timeProvider, grainCollectionOptions, logger, statsProvider, CreateCatalogInstruments());
             var timer = Substitute.For<IAsyncTimer>();
             timer.NextTick().Returns(Task.FromResult(false));
             var timerFactory = Substitute.For<IAsyncTimerFactory>();
             timerFactory.Create(Arg.Any<TimeSpan>(), Arg.Any<string>()).Returns(timer);
 
             var wsLogger = NullLogger<ActivationWorkingSet>.Instance;
-            var workingSet = new ActivationWorkingSet(timerFactory, wsLogger, new[] { collector });
+            var workingSet = new ActivationWorkingSet(timerFactory, wsLogger, new[] { collector }, CreateCatalogInstruments());
 
             var inactiveActivation1 = PrepareActivation(1, collector);
             var activeActivation = PrepareActivation(1, collector);
@@ -373,6 +375,15 @@ namespace UnitTests.Runtime
 
         private IActivationWorkingSetMember PrepareActivation(int collectionAgeLimitMinutes, ActivationCollector collector)
             => PrepareActivation(TimeSpan.FromMinutes(collectionAgeLimitMinutes), collector);
+
+        private static CatalogInstruments CreateCatalogInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<CatalogInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<CatalogInstruments>();
+        }
 
         private IActivationWorkingSetMember PrepareActivation(TimeSpan collectionAgeLimit, ActivationCollector collector)
         {

--- a/test/Orleans.Core.Tests/Runtime/CatalogInstrumentsTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/CatalogInstrumentsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
 using Xunit;
 
@@ -10,6 +11,13 @@ public class CatalogInstrumentsTests
     [Fact, TestCategory("BVT"), TestCategory("Runtime")]
     public void ActivationLifecycleLatencyMetrics_AreHistograms()
     {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new CatalogInstruments(new OrleansInstruments(meterFactory));
+
         Instrument activationLatencyInstrument = null!;
         Instrument deactivationLatencyInstrument = null!;
         var activationLatencyMeasurement = 0d;
@@ -46,8 +54,8 @@ public class CatalogInstrumentsTests
 
         listener.Start();
 
-        CatalogInstruments.OnActivationCompleted(TimeSpan.FromMilliseconds(12), CatalogInstruments.ActivationStatusSuccess, usesDirectory: true);
-        CatalogInstruments.OnDeactivationCompleted(TimeSpan.FromMilliseconds(34), CatalogInstruments.DeactivationViaCollection);
+        instruments.OnActivationCompleted(TimeSpan.FromMilliseconds(12), CatalogInstruments.ActivationStatusSuccess, usesDirectory: true);
+        instruments.OnDeactivationCompleted(TimeSpan.FromMilliseconds(34), CatalogInstruments.DeactivationViaCollection);
 
         Assert.IsType<Histogram<double>>(activationLatencyInstrument);
         Assert.IsType<Histogram<double>>(deactivationLatencyInstrument);

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -167,7 +167,7 @@ namespace UnitTests.StreamingTests
                 Options.Create(new SchedulingOptions()),
                 grainReferenceActivator: null!,
                 timerRegistry: timerRegistry,
-                activations: new ActivationDirectory(),
+                activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments());
 
             receiver ??= Substitute.For<IQueueAdapterReceiver>();
@@ -202,6 +202,15 @@ namespace UnitTests.StreamingTests
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<SchedulerInstruments>();
             return services.BuildServiceProvider().GetRequiredService<SchedulerInstruments>();
+        }
+
+        private static CatalogInstruments CreateCatalogInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<CatalogInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<CatalogInstruments>();
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]


### PR DESCRIPTION
Related to #9608.

## Problem
Catalog metrics still used the static global `Instruments.Meter` instead of flowing through `IMeterFactory`.

## Solution
Migrate `CatalogInstruments` to a DI-backed instance class created from `OrleansInstruments`/`IMeterFactory`, following the pattern already used for storage and consistent-ring metrics. The nested `ActivationMetricTracker`/`DeactivationMetricTracker` structs now carry the `CatalogInstruments` instance so they record through the injected meter. Consumers (`Catalog`, `ActivationDirectory`, `ActivationCollector`, `ActivationWorkingSet`, and `ActivationData` via `GrainTypeSharedContext`) receive the instance through constructor injection, and `CatalogInstruments` is registered as a singleton in `DefaultSiloServices`. Updates the focused diagnostics test to verify emission through `IMeterFactory`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10168)