### PR TITLE
chore: use IMeterFactory for ClientInstruments

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -51,6 +51,7 @@ namespace Orleans
             services.AddMetrics();
             services.TryAddSingleton<TimeProvider>(TimeProvider.System);
             services.TryAddSingleton<OrleansInstruments>();
+            services.TryAddSingleton<ClientInstruments>();
 
             // Options logging
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));

--- a/src/Orleans.Core/Diagnostics/Metrics/ClientInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/ClientInstruments.cs
@@ -4,11 +4,11 @@ using System.Diagnostics.Metrics;
 #nullable disable
 namespace Orleans.Runtime;
 
-public static class ClientInstruments
+internal sealed class ClientInstruments(OrleansInstruments instruments)
 {
-    internal static ObservableGauge<int> ConnectedGatewayCount;
-    internal static void RegisterConnectedGatewayCountObserve(Func<int> observeValue)
+    private ObservableGauge<int> _connectedGatewayCount;
+    internal void RegisterConnectedGatewayCountObserve(Func<int> observeValue)
     {
-        ConnectedGatewayCount = Instruments.Meter.CreateObservableGauge(InstrumentNames.CLIENT_CONNECTED_GATEWAY_COUNT, observeValue);
+        _connectedGatewayCount = instruments.Meter.CreateObservableGauge(InstrumentNames.CLIENT_CONNECTED_GATEWAY_COUNT, observeValue);
     }
 }

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -78,6 +78,7 @@ namespace Orleans.Messaging
             IClusterConnectionStatusListener connectionStatusListener,
             ILoggerFactory loggerFactory,
             ConnectionManager connectionManager,
+            ClientInstruments clientInstruments,
             GatewayManager gatewayManager)
         {
             this.connectionManager = connectionManager;
@@ -90,7 +91,7 @@ namespace Orleans.Messaging
             numMessages = 0;
             this.grainBuckets = new WeakReference<ClientOutboundConnection>[clientMessagingOptions.Value.ClientSenderBuckets];
             logger = loggerFactory.CreateLogger<ClientMessageCenter>();
-            ClientInstruments.RegisterConnectedGatewayCountObserve(() => connectionManager.ConnectionCount);
+            clientInstruments.RegisterConnectedGatewayCountObserve(() => connectionManager.ConnectionCount);
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -1254,10 +1254,6 @@ namespace Orleans.Runtime
         public const string WaitMigration = "wait migration";
     }
 
-    public static partial class ClientInstruments
-    {
-    }
-
     [GenerateSerializer]
     [Immutable]
     public partial class ClusterManifestUpdate

--- a/test/Orleans.Runtime.Tests/Diagnostics/ClientInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/ClientInstrumentsTests.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class ClientInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void ClientInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new ClientInstruments(new OrleansInstruments(meterFactory));
+        using var connectedGatewayCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.CLIENT_CONNECTED_GATEWAY_COUNT);
+
+        instruments.RegisterConnectedGatewayCountObserve(() => 5);
+
+        connectedGatewayCollector.RecordObservableInstruments();
+
+        Assert.Equal(5, Assert.Single(connectedGatewayCollector.GetMeasurementSnapshot()).Value);
+    }
+}


### PR DESCRIPTION
Part of #9608.

## Problem
`ClientInstruments` was a static class that created its observable gauge on the global static `Instruments.Meter`, which makes the client's gateway-connection metric impossible to scope to a specific `IMeterFactory` / DI container and inconsistent with the other instruments already migrated.

## Solution
Convert `ClientInstruments` into an `internal sealed` instance class that takes `OrleansInstruments` via its constructor and creates its instrument off `instruments.Meter`, following the established migration pattern. It is registered with `TryAddSingleton` in `DefaultClientServices` and injected into `ClientMessageCenter` instead of being accessed statically. The now-empty public `ClientInstruments` type is removed from the public API surface. Adds a `MetricCollector`-based BVT test.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10169)