### PR TITLE
test: make journaling recovery retry tests deterministic

### DIFF
--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -798,14 +798,13 @@ public class StateManagerTests : JournalingTestBase
     public async Task StateManager_RecoveryRetry_ReplaysFixedStorage()
     {
         var validBytes = CreatePersistedValueBytes("value", 42);
-        var storage = new MutableReadStorage([.. validBytes, 1, 2, 3]);
+        var storage = new MutableReadStorage([.. validBytes, 1, 2, 3], validBytes);
         var sut = CreateTestSystem(storage: storage);
         var value = new DurableValue<int>("value", sut.Manager, CreateValueCodec<int>());
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => sut.Lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10)));
 
-        storage.Bytes = validBytes;
         await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
 
         Assert.Equal(42, value.Value);
@@ -816,13 +815,12 @@ public class StateManagerTests : JournalingTestBase
     public async Task StateManager_RecoveryRetry_PreservesUnknownStreamOnce()
     {
         var validBytes = CreateUnknownStreamBytes(new JournalStreamId(99), [1, 2, 3]);
-        var storage = new MutableReadStorage([.. validBytes, 1, 2, 3]) { IsCompactionRequested = true };
+        var storage = new MutableReadStorage([.. validBytes, 1, 2, 3], validBytes) { IsCompactionRequested = true };
         var sut = CreateTestSystem(storage: storage);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => sut.Lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10)));
 
-        storage.Bytes = validBytes;
         await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
 
         var replacement = Assert.Single(storage.Replaces);
@@ -834,13 +832,12 @@ public class StateManagerTests : JournalingTestBase
     [Fact]
     public async Task StateManager_RecoveryRetry_RemovesStaleRetiredPlaceholder()
     {
-        var storage = new MutableReadStorage([.. CreateNamedUnknownStreamBytes("stale", new JournalStreamId(8), [1, 2, 3]), 1, 2, 3]);
+        var storage = new MutableReadStorage([.. CreateNamedUnknownStreamBytes("stale", new JournalStreamId(8), [1, 2, 3]), 1, 2, 3], []);
         var sut = CreateTestSystem(storage: storage);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => sut.Lifecycle.OnStart().WaitAsync(TimeSpan.FromSeconds(10)));
 
-        storage.Bytes = [];
         await sut.Manager.WriteStateAsync(CancellationToken.None).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
 
         Assert.False(sut.Manager.TryGetState("stale", out _));
@@ -1631,10 +1628,27 @@ public class StateManagerTests : JournalingTestBase
         public ValueTask DeleteAsync(CancellationToken cancellationToken) => default;
     }
 
-    private sealed class MutableReadStorage(byte[] bytes) : IJournalStorage
+    private sealed class MutableReadStorage : IJournalStorage
     {
         private readonly object _lock = new();
-        private byte[] _bytes = bytes.ToArray();
+        private readonly Queue<byte[]> _readSnapshots = [];
+        private byte[] _bytes;
+
+        public MutableReadStorage(params byte[][] readSnapshots)
+        {
+            if (readSnapshots.Length == 0)
+            {
+                throw new ArgumentException("At least one read snapshot is required.", nameof(readSnapshots));
+            }
+
+            foreach (var readSnapshot in readSnapshots)
+            {
+                ArgumentNullException.ThrowIfNull(readSnapshot);
+                _readSnapshots.Enqueue(readSnapshot.ToArray());
+            }
+
+            _bytes = readSnapshots[^1].ToArray();
+        }
 
         public byte[] Bytes
         {
@@ -1651,6 +1665,7 @@ public class StateManagerTests : JournalingTestBase
                 ArgumentNullException.ThrowIfNull(value);
                 lock (_lock)
                 {
+                    _readSnapshots.Clear();
                     _bytes = value.ToArray();
                 }
             }
@@ -1667,7 +1682,15 @@ public class StateManagerTests : JournalingTestBase
             byte[] snapshot;
             lock (_lock)
             {
-                snapshot = _bytes.ToArray();
+                if (_readSnapshots.TryDequeue(out var readSnapshot))
+                {
+                    _bytes = readSnapshot.ToArray();
+                    snapshot = readSnapshot.ToArray();
+                }
+                else
+                {
+                    snapshot = _bytes.ToArray();
+                }
             }
 
             consumer.Read(snapshot, metadata: null, complete: true);

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -1688,7 +1688,7 @@ public class StateManagerTests : JournalingTestBase
             {
                 if (_readSnapshots.TryDequeue(out var readSnapshot))
                 {
-                    _bytes = readSnapshot.ToArray();
+                    _bytes = readSnapshot;
                     snapshot = readSnapshot.ToArray();
                 }
                 else

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -798,6 +798,8 @@ public class StateManagerTests : JournalingTestBase
     public async Task StateManager_RecoveryRetry_ReplaysFixedStorage()
     {
         var validBytes = CreatePersistedValueBytes("value", 42);
+        // The manager retries recovery on its background work loop, so the repaired
+        // storage state must be available on the retry without depending on test-thread timing.
         var storage = new MutableReadStorage([.. validBytes, 1, 2, 3], validBytes);
         var sut = CreateTestSystem(storage: storage);
         var value = new DurableValue<int>("value", sut.Manager, CreateValueCodec<int>());
@@ -1636,6 +1638,8 @@ public class StateManagerTests : JournalingTestBase
 
         public MutableReadStorage(params byte[][] readSnapshots)
         {
+            // Recovery retry tests model storage being repaired after a failed read.
+            // The sequence makes that repair deterministic instead of racing the manager's retry.
             if (readSnapshots.Length == 0)
             {
                 throw new ArgumentException("At least one read snapshot is required.", nameof(readSnapshots));


### PR DESCRIPTION
## Problem
The journaling recovery retry tests mutated `MutableReadStorage.Bytes` from the test thread after the initial recovery failure. The state manager can retry recovery in its background work loop before that mutation is observed, causing the retry to read the original malformed bytes again.

This showed up as a recurring CI flake. In the past week, 11 `.NET CI` failed job attempts contained `StateManager_RecoveryRetry_ReplaysFixedStorage` before passing after reruns:

| Time | Failed job | Matrix | Run title |
| --- | --- | --- | --- |
| 2026-05-29 19:24 UTC | [26665261736](https://github.com/dotnet/orleans/actions/runs/26665261736/job/78597134378) | Test (BVT, macos-latest, net10.0) | fix(reminders): gate delivery on active silo |
| 2026-05-30 12:36 UTC | [26687810549](https://github.com/dotnet/orleans/actions/runs/26687810549/job/78658951131) | Test (BVT, macos-latest, net8.0) | feat(journaling-azure): add instrumentation and retry tuning (#10149) |
| 2026-05-30 20:13 UTC | [26697488492](https://github.com/dotnet/orleans/actions/runs/26697488492/job/78684373153) | Test (BVT, macos-latest, net10.0) | test: avoid eager activation in idle test (#10156) |
| 2026-05-31 01:36 UTC | [26703356881](https://github.com/dotnet/orleans/actions/runs/26703356881/job/78700102803) | Test (BVT, macos-latest, net8.0) | .NET CI |
| 2026-05-31 01:37 UTC | [26703366433](https://github.com/dotnet/orleans/actions/runs/26703366433/job/78700128530) | Test (BVT, macos-latest, net8.0) | Fix deterministic reminder scheduling waits (#10159) |
| 2026-05-31 17:33 UTC | [26723729898](https://github.com/dotnet/orleans/actions/runs/26723729898/job/78755282894) | Test (BVT, macos-latest, net8.0) | .NET CI |
| 2026-06-01 01:31 UTC | [26735270629](https://github.com/dotnet/orleans/actions/runs/26735270629/job/78787134649) | Test (BVT, macos-latest, net10.0) | chore(playground): add DurableJobs journaling playground (#10152) |
| 2026-06-01 14:24 UTC | [26770648378](https://github.com/dotnet/orleans/actions/runs/26770648378/job/78908906412) | Test (BVT, macos-latest, net10.0) | test: fix deactivate-on-idle grain selection flake |
| 2026-06-01 15:19 UTC | [26773467210](https://github.com/dotnet/orleans/actions/runs/26773467210/job/78918772705) | Test (BVT, macos-latest, net10.0) | .NET CI |
| 2026-06-01 15:19 UTC | [26773495508](https://github.com/dotnet/orleans/actions/runs/26773495508/job/78918874711) | Test (BVT, macos-latest, net8.0) | .NET CI |
| 2026-06-03 12:42 UTC | [26895882577](https://github.com/dotnet/orleans/actions/runs/26895882577/job/79334610710) | Test (BVT, macos-latest, net8.0) | .NET CI |

## Solution
Make `MutableReadStorage` support a deterministic queue of read snapshots. The recovery retry tests now configure the first read to return malformed bytes and the retry to return the repaired bytes, removing the scheduler race while preserving the behavior under test.