### PR TITLE
chore: use IMeterFactory for ReminderInstruments

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/ReminderInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/ReminderInstruments.cs
@@ -4,15 +4,20 @@ using System.Diagnostics.Metrics;
 #nullable disable
 namespace Orleans.Runtime;
 
-internal static class ReminderInstruments
+internal sealed class ReminderInstruments(OrleansInstruments instruments)
 {
-    public static Histogram<double> TardinessSeconds = Instruments.Meter.CreateHistogram<double>(InstrumentNames.REMINDERS_TARDINESS, "seconds");
-    public static ObservableGauge<int> ActiveReminders;
-    public static void RegisterActiveRemindersObserve(Func<int> observeValue)
+    private readonly Histogram<double> _tardinessSeconds = instruments.Meter.CreateHistogram<double>(InstrumentNames.REMINDERS_TARDINESS, "seconds");
+    private readonly Counter<int> _ticksDelivered = instruments.Meter.CreateCounter<int>(InstrumentNames.REMINDERS_COUNTERS_TICKS_DELIVERED);
+    private ObservableGauge<int> _activeReminders;
+
+    internal bool TardinessSecondsEnabled => _tardinessSeconds.Enabled;
+
+    internal void RegisterActiveRemindersObserve(Func<int> observeValue)
     {
-        ActiveReminders = Instruments.Meter.CreateObservableGauge(InstrumentNames.REMINDERS_NUMBER_ACTIVE_REMINDERS, observeValue);
+        _activeReminders = instruments.Meter.CreateObservableGauge(InstrumentNames.REMINDERS_NUMBER_ACTIVE_REMINDERS, observeValue);
     }
 
-    public static Counter<int> TicksDelivered = Instruments.Meter.CreateCounter<int>(InstrumentNames.REMINDERS_COUNTERS_TICKS_DELIVERED);
+    internal void OnTardiness(TimeSpan tardiness) => _tardinessSeconds.Record(tardiness.TotalSeconds);
 
+    internal void OnTickDelivered() => _ticksDelivered.Add(1);
 }

--- a/src/Orleans.Reminders/Hosting/SiloBuilderReminderExtensions.cs
+++ b/src/Orleans.Reminders/Hosting/SiloBuilderReminderExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.Runtime;
 using Orleans.Configuration.Internal;
 using System.Linq;
@@ -28,6 +29,7 @@ public static class SiloBuilderReminderExtensions
             return;
         }
 
+        services.TryAddSingleton<ReminderInstruments>();
         services.AddSingleton<LocalReminderService>();
         services.AddFromExisting<IGrainService, LocalReminderService>();
         services.AddFromExisting<IReminderService, LocalReminderService>();

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -29,6 +29,7 @@ namespace Orleans.Runtime.ReminderService
         private readonly GrainReferenceActivator _referenceActivator;
         private readonly GrainInterfaceType _grainInterfaceType;
         private readonly TimeProvider _timeProvider;
+        private readonly ReminderInstruments _reminderInstruments;
         private long localTableSequence;
         private uint initialReadCallCount = 0;
         private Task? runTask;
@@ -45,6 +46,7 @@ namespace Orleans.Runtime.ReminderService
             IOptions<ReminderOptions> reminderOptions,
             IConsistentRingProvider ringProvider,
             TimeProvider timeProvider,
+            ReminderInstruments reminderInstruments,
             SystemTargetShared shared)
             : base(
                   SystemTargetGrainId.CreateGrainServiceGrainId(GrainInterfaceUtils.GetGrainClassTypeCode(typeof(IReminderService)), null!, shared.SiloAddress),
@@ -57,7 +59,8 @@ namespace Orleans.Runtime.ReminderService
             this.reminderTable = reminderTable;
             this.asyncTimerFactory = asyncTimerFactory;
             _timeProvider = timeProvider;
-            ReminderInstruments.RegisterActiveRemindersObserve(() => localReminders.Count);
+            _reminderInstruments = reminderInstruments;
+            _reminderInstruments.RegisterActiveRemindersObserve(() => localReminders.Count);
             startedTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             this.logger = shared.LoggerFactory.CreateLogger<LocalReminderService>();
             this.listRefreshTimer = asyncTimerFactory.Create(this.reminderOptions.RefreshReminderListPeriod, "ReminderService.ReminderListRefresher");
@@ -905,10 +908,10 @@ namespace Orleans.Runtime.ReminderService
 
                             LogTraceTriggeringTick(_shared.logger, this, status, before);
                             ReminderEvents.EmitTickFiring(entry.GrainId, entry.ReminderName, status, _shared.Silo);
-                            if (ReminderInstruments.TardinessSeconds.Enabled)
+                            if (_shared._reminderInstruments.TardinessSecondsEnabled)
                             {
                                 var tardiness = CalculateTardiness(status);
-                                ReminderInstruments.TardinessSeconds.Record(tardiness.TotalSeconds);
+                                _shared._reminderInstruments.OnTardiness(tardiness);
                             }
 
                             try
@@ -924,7 +927,7 @@ namespace Orleans.Runtime.ReminderService
                                 }
 
                                 ReminderEvents.EmitTickCompleted(entry.GrainId, entry.ReminderName, status, _shared.Silo);
-                                ReminderInstruments.TicksDelivered.Add(1);
+                                _shared._reminderInstruments.OnTickDelivered();
                             }
                             catch (Exception exc)
                             {

--- a/test/Orleans.Runtime.Tests/Diagnostics/ReminderInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/ReminderInstrumentsTests.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class ReminderInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void ReminderInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new ReminderInstruments(new OrleansInstruments(meterFactory));
+        using var activeRemindersCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.REMINDERS_NUMBER_ACTIVE_REMINDERS);
+        using var tardinessCollector = new MetricCollector<double>(meterFactory, "Microsoft.Orleans", InstrumentNames.REMINDERS_TARDINESS);
+        using var ticksDeliveredCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.REMINDERS_COUNTERS_TICKS_DELIVERED);
+
+        instruments.RegisterActiveRemindersObserve(() => 3);
+        instruments.OnTardiness(TimeSpan.FromSeconds(4));
+        instruments.OnTickDelivered();
+
+        activeRemindersCollector.RecordObservableInstruments();
+
+        Assert.Equal(3, Assert.Single(activeRemindersCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(4, Assert.Single(tardinessCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(ticksDeliveredCollector.GetMeasurementSnapshot()).Value);
+    }
+}


### PR DESCRIPTION
Part of #9608.

## Problem
`ReminderInstruments` created reminder metrics using the global static `Instruments.Meter`, so the reminder service metrics were not scoped to the DI-provided `IMeterFactory` used by the other migrated instruments.

## Solution
Convert `ReminderInstruments` to an instance class backed by `OrleansInstruments`. Register it with reminder services, inject it into `LocalReminderService`, and add a `MetricCollector` BVT covering active reminders, tardiness, and delivered tick metrics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10172)