### PR TITLE
chore: use IMeterFactory for DirectoryInstruments

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/DirectoryInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/DirectoryInstruments.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace Orleans.Runtime;
 
-internal static class DirectoryInstruments
+internal sealed class DirectoryInstruments
 {
     private const string MillisecondsUnit = "ms";
     private const string StatusTagName = "status";
@@ -16,88 +16,123 @@ internal static class DirectoryInstruments
     internal const string RegistrationStatusCanceled = "canceled";
     internal const string RegistrationStatusError = "error";
 
-    private static ImmutableArray<CacheSizeObserverRegistration> CacheSizeObservers = [];
+    private readonly Meter _meter;
+    private ImmutableArray<CacheSizeObserverRegistration> _cacheSizeObservers = [];
 
-    internal static readonly Counter<int> LookupsLocalIssued = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_LOCAL_ISSUED);
-    internal static readonly Counter<int> LookupsLocalSuccesses = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_LOCAL_SUCCESSES);
+    internal readonly Counter<int> LookupsLocalIssued;
+    internal readonly Counter<int> LookupsLocalSuccesses;
 
-    internal static readonly Counter<int> LookupsFullIssued = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_FULL_ISSUED);
+    internal readonly Counter<int> LookupsFullIssued;
 
-    internal static readonly Counter<int> LookupsRemoteSent = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_REMOTE_SENT);
-    internal static readonly Counter<int> LookupsRemoteReceived = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_REMOTE_RECEIVED);
+    internal readonly Counter<int> LookupsRemoteSent;
+    internal readonly Counter<int> LookupsRemoteReceived;
 
-    internal static readonly Counter<int> LookupsLocalDirectoryIssued = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_LOCALDIRECTORY_ISSUED);
-    internal static readonly Counter<int> LookupsLocalDirectorySuccesses = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_LOCALDIRECTORY_SUCCESSES);
+    internal readonly Counter<int> LookupsLocalDirectoryIssued;
+    internal readonly Counter<int> LookupsLocalDirectorySuccesses;
 
-    internal static readonly Counter<int> LookupsCacheIssued = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_CACHE_ISSUED);
-    internal static readonly Counter<int> LookupsCacheSuccesses = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_CACHE_SUCCESSES);
-    internal static readonly Counter<int> ValidationsCacheReceived = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_VALIDATIONS_CACHE_RECEIVED);
+    internal readonly Counter<int> LookupsCacheIssued;
+    internal readonly Counter<int> LookupsCacheSuccesses;
+    internal readonly Counter<int> ValidationsCacheReceived;
 
-    internal static readonly Counter<int> SnapshotTransferCount = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_RANGE_SNAPSHOT_TRANSFER_COUNT);
-    internal static readonly Histogram<long> SnapshotTransferDuration = Instruments.Meter.CreateHistogram<long>(InstrumentNames.DIRECTORY_RANGE_SNAPSHOT_TRANSFER_DURATION);
-    internal static readonly Counter<long> RangeRecoveryCount = Instruments.Meter.CreateCounter<long>(InstrumentNames.DIRECTORY_RANGE_RECOVERY_COUNT);
-    internal static readonly Histogram<long> RangeRecoveryDuration = Instruments.Meter.CreateHistogram<long>(InstrumentNames.DIRECTORY_RANGE_RECOVERY_DURATION);
-    internal static readonly Histogram<long> RangeLockHeldDuration = Instruments.Meter.CreateHistogram<long>(InstrumentNames.DIRECTORY_RANGE_LOCK_HELD_DURATION);
+    internal readonly Counter<int> SnapshotTransferCount;
+    internal readonly Histogram<long> SnapshotTransferDuration;
+    internal readonly Counter<long> RangeRecoveryCount;
+    internal readonly Histogram<long> RangeRecoveryDuration;
+    internal readonly Histogram<long> RangeLockHeldDuration;
 
-    internal static ObservableGauge<int>? DirectoryPartitionSize;
-    internal static void RegisterDirectoryPartitionSizeObserve(Func<int> observeValue)
+    private ObservableGauge<int>? _directoryPartitionSize;
+    internal void RegisterDirectoryPartitionSizeObserve(Func<int> observeValue)
     {
-        DirectoryPartitionSize = Instruments.Meter.CreateObservableGauge<int>(InstrumentNames.DIRECTORY_PARTITION_SIZE, observeValue);
+        _directoryPartitionSize = _meter.CreateObservableGauge<int>(InstrumentNames.DIRECTORY_PARTITION_SIZE, observeValue);
     }
 
-    internal static readonly ObservableGauge<int> CacheSize = Instruments.Meter.CreateObservableGauge<int>(InstrumentNames.DIRECTORY_CACHE_SIZE, ObserveCacheSize);
-    internal static IDisposable RegisterCacheSizeObserve(Func<int> observeValue)
+    private readonly ObservableGauge<int> _cacheSize;
+    internal IDisposable RegisterCacheSizeObserve(Func<int> observeValue)
     {
         ArgumentNullException.ThrowIfNull(observeValue);
 
-        var registration = new CacheSizeObserverRegistration(observeValue);
-        ImmutableInterlocked.Update(ref CacheSizeObservers, static (observers, registration) => observers.Add(registration), registration);
+        var registration = new CacheSizeObserverRegistration(this, observeValue);
+        ImmutableInterlocked.Update(ref _cacheSizeObservers, static (observers, registration) => observers.Add(registration), registration);
         return registration;
     }
 
-    internal static ObservableGauge<int>? RingSize;
-    internal static void RegisterRingSizeObserve(Func<int> observeValue)
+    private ObservableGauge<int>? _ringSize;
+    internal void RegisterRingSizeObserve(Func<int> observeValue)
     {
-        RingSize = Instruments.Meter.CreateObservableGauge<int>(InstrumentNames.DIRECTORY_RING_RINGSIZE, observeValue);
+        _ringSize = _meter.CreateObservableGauge<int>(InstrumentNames.DIRECTORY_RING_RINGSIZE, observeValue);
     }
 
-    internal static ObservableGauge<long>? MyPortionRingDistance;
-    internal static void RegisterMyPortionRingDistanceObserve(Func<long> observeValue)
+    private ObservableGauge<long>? _myPortionRingDistance;
+    internal void RegisterMyPortionRingDistanceObserve(Func<long> observeValue)
     {
-        MyPortionRingDistance = Instruments.Meter.CreateObservableGauge<long>(InstrumentNames.DIRECTORY_RING_MYPORTION_RINGDISTANCE, observeValue);
+        _myPortionRingDistance = _meter.CreateObservableGauge<long>(InstrumentNames.DIRECTORY_RING_MYPORTION_RINGDISTANCE, observeValue);
     }
 
-    internal static ObservableGauge<float>? MyPortionRingPercentage;
-    internal static void RegisterMyPortionRingPercentageObserve(Func<float> observeValue)
+    private ObservableGauge<float>? _myPortionRingPercentage;
+    internal void RegisterMyPortionRingPercentageObserve(Func<float> observeValue)
     {
-        MyPortionRingPercentage = Instruments.Meter.CreateObservableGauge(InstrumentNames.DIRECTORY_RING_MYPORTION_RINGPERCENTAGE, observeValue);
+        _myPortionRingPercentage = _meter.CreateObservableGauge(InstrumentNames.DIRECTORY_RING_MYPORTION_RINGPERCENTAGE, observeValue);
     }
 
-    internal static ObservableGauge<float>? MyPortionAverageRingPercentage;
-    internal static void RegisterMyPortionAverageRingPercentageObserve(Func<float> observeValue)
+    private ObservableGauge<float>? _myPortionAverageRingPercentage;
+    internal void RegisterMyPortionAverageRingPercentageObserve(Func<float> observeValue)
     {
-        MyPortionAverageRingPercentage = Instruments.Meter.CreateObservableGauge(InstrumentNames.DIRECTORY_RING_MYPORTION_AVERAGERINGPERCENTAGE, observeValue);
+        _myPortionAverageRingPercentage = _meter.CreateObservableGauge(InstrumentNames.DIRECTORY_RING_MYPORTION_AVERAGERINGPERCENTAGE, observeValue);
     }
 
-    internal static readonly Counter<int> RegistrationsSingleActIssued = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_REGISTRATIONS_SINGLE_ACT_ISSUED);
-    internal static readonly Counter<int> RegistrationsSingleActLocal = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_REGISTRATIONS_SINGLE_ACT_LOCAL);
-    internal static readonly Counter<int> RegistrationsSingleActRemoteSent = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_REGISTRATIONS_SINGLE_ACT_REMOTE_SENT);
-    internal static readonly Counter<int> RegistrationsSingleActRemoteReceived = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_REGISTRATIONS_SINGLE_ACT_REMOTE_RECEIVED);
-    internal static readonly Counter<int> Registrations = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_REGISTRATIONS);
-    internal static readonly Histogram<double> RegistrationDuration = Instruments.Meter.CreateHistogram<double>(InstrumentNames.DIRECTORY_REGISTRATION_DURATION, MillisecondsUnit);
-    internal static bool RegistrationMetricsEnabled => Registrations.Enabled || RegistrationDuration.Enabled;
-    internal static readonly Counter<int> UnregistrationsIssued = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_ISSUED);
-    internal static readonly Counter<int> UnregistrationsLocal = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_LOCAL);
-    internal static readonly Counter<int> UnregistrationsRemoteSent = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_REMOTE_SENT);
-    internal static readonly Counter<int> UnregistrationsRemoteReceived = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_REMOTE_RECEIVED);
-    internal static readonly Counter<int> UnregistrationsManyIssued = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_MANY_ISSUED);
-    internal static readonly Counter<int> UnregistrationsManyRemoteSent = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_MANY_REMOTE_SENT);
-    internal static readonly Counter<int> UnregistrationsManyRemoteReceived = Instruments.Meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_MANY_REMOTE_RECEIVED);
+    internal readonly Counter<int> RegistrationsSingleActIssued;
+    internal readonly Counter<int> RegistrationsSingleActLocal;
+    internal readonly Counter<int> RegistrationsSingleActRemoteSent;
+    internal readonly Counter<int> RegistrationsSingleActRemoteReceived;
+    private readonly Counter<int> _registrations;
+    private readonly Histogram<double> _registrationDuration;
+    internal bool RegistrationMetricsEnabled => _registrations.Enabled || _registrationDuration.Enabled;
+    internal readonly Counter<int> UnregistrationsIssued;
+    internal readonly Counter<int> UnregistrationsLocal;
+    internal readonly Counter<int> UnregistrationsRemoteSent;
+    internal readonly Counter<int> UnregistrationsRemoteReceived;
+    internal readonly Counter<int> UnregistrationsManyIssued;
+    internal readonly Counter<int> UnregistrationsManyRemoteSent;
+    internal readonly Counter<int> UnregistrationsManyRemoteReceived;
 
-    private static int ObserveCacheSize()
+    public DirectoryInstruments(OrleansInstruments instruments)
+    {
+        _meter = instruments.Meter;
+        LookupsLocalIssued = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_LOCAL_ISSUED);
+        LookupsLocalSuccesses = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_LOCAL_SUCCESSES);
+        LookupsFullIssued = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_FULL_ISSUED);
+        LookupsRemoteSent = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_REMOTE_SENT);
+        LookupsRemoteReceived = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_REMOTE_RECEIVED);
+        LookupsLocalDirectoryIssued = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_LOCALDIRECTORY_ISSUED);
+        LookupsLocalDirectorySuccesses = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_LOCALDIRECTORY_SUCCESSES);
+        LookupsCacheIssued = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_CACHE_ISSUED);
+        LookupsCacheSuccesses = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_LOOKUPS_CACHE_SUCCESSES);
+        ValidationsCacheReceived = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_VALIDATIONS_CACHE_RECEIVED);
+        SnapshotTransferCount = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_RANGE_SNAPSHOT_TRANSFER_COUNT);
+        SnapshotTransferDuration = _meter.CreateHistogram<long>(InstrumentNames.DIRECTORY_RANGE_SNAPSHOT_TRANSFER_DURATION);
+        RangeRecoveryCount = _meter.CreateCounter<long>(InstrumentNames.DIRECTORY_RANGE_RECOVERY_COUNT);
+        RangeRecoveryDuration = _meter.CreateHistogram<long>(InstrumentNames.DIRECTORY_RANGE_RECOVERY_DURATION);
+        RangeLockHeldDuration = _meter.CreateHistogram<long>(InstrumentNames.DIRECTORY_RANGE_LOCK_HELD_DURATION);
+        _cacheSize = _meter.CreateObservableGauge<int>(InstrumentNames.DIRECTORY_CACHE_SIZE, ObserveCacheSize);
+        RegistrationsSingleActIssued = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_REGISTRATIONS_SINGLE_ACT_ISSUED);
+        RegistrationsSingleActLocal = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_REGISTRATIONS_SINGLE_ACT_LOCAL);
+        RegistrationsSingleActRemoteSent = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_REGISTRATIONS_SINGLE_ACT_REMOTE_SENT);
+        RegistrationsSingleActRemoteReceived = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_REGISTRATIONS_SINGLE_ACT_REMOTE_RECEIVED);
+        _registrations = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_REGISTRATIONS);
+        _registrationDuration = _meter.CreateHistogram<double>(InstrumentNames.DIRECTORY_REGISTRATION_DURATION, MillisecondsUnit);
+        UnregistrationsIssued = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_ISSUED);
+        UnregistrationsLocal = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_LOCAL);
+        UnregistrationsRemoteSent = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_REMOTE_SENT);
+        UnregistrationsRemoteReceived = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_REMOTE_RECEIVED);
+        UnregistrationsManyIssued = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_MANY_ISSUED);
+        UnregistrationsManyRemoteSent = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_MANY_REMOTE_SENT);
+        UnregistrationsManyRemoteReceived = _meter.CreateCounter<int>(InstrumentNames.DIRECTORY_UNREGISTRATIONS_MANY_REMOTE_RECEIVED);
+    }
+
+    private int ObserveCacheSize()
     {
         var result = 0;
-        foreach (var observer in CacheSizeObservers)
+        foreach (var observer in _cacheSizeObservers)
         {
             result += observer.Observe();
         }
@@ -107,29 +142,31 @@ internal static class DirectoryInstruments
 
     private sealed class CacheSizeObserverRegistration : IDisposable
     {
-        private Func<int>? observeValue;
+        private readonly DirectoryInstruments _owner;
+        private Func<int>? _observeValue;
 
-        public CacheSizeObserverRegistration(Func<int> observeValue)
+        public CacheSizeObserverRegistration(DirectoryInstruments owner, Func<int> observeValue)
         {
-            this.observeValue = observeValue;
+            _owner = owner;
+            _observeValue = observeValue;
         }
 
         public int Observe()
         {
-            var observer = Volatile.Read(ref observeValue);
+            var observer = Volatile.Read(ref _observeValue);
             return observer is null ? 0 : observer();
         }
 
         public void Dispose()
         {
-            if (Interlocked.Exchange(ref observeValue, null) is not null)
+            if (Interlocked.Exchange(ref _observeValue, null) is not null)
             {
-                ImmutableInterlocked.Update(ref CacheSizeObservers, static (observers, registration) => observers.Remove(registration), this);
+                ImmutableInterlocked.Update(ref _owner._cacheSizeObservers, static (observers, registration) => observers.Remove(registration), this);
             }
         }
     }
 
-    internal static void OnRegistrationCompleted(TimeSpan latency, string locator, string status)
+    internal void OnRegistrationCompleted(TimeSpan latency, string locator, string status)
     {
         if (!RegistrationMetricsEnabled)
         {
@@ -137,14 +174,14 @@ internal static class DirectoryInstruments
         }
 
         var tags = CreateRegistrationTags(locator, status);
-        if (Registrations.Enabled)
+        if (_registrations.Enabled)
         {
-            Registrations.Add(1, tags);
+            _registrations.Add(1, tags);
         }
 
-        if (RegistrationDuration.Enabled)
+        if (_registrationDuration.Enabled)
         {
-            RegistrationDuration.Record(Math.Max(0, latency.TotalMilliseconds), tags);
+            _registrationDuration.Record(Math.Max(0, latency.TotalMilliseconds), tags);
         }
     }
 

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -19,6 +19,7 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly GrainDirectoryResolver grainDirectoryResolver;
         private readonly IGrainDirectoryCache cache;
         private readonly bool disposeCache;
+        private readonly DirectoryInstruments _directoryInstruments;
 
         private readonly CancellationTokenSource shutdownToken = new CancellationTokenSource();
         private readonly IClusterMembershipService clusterMembershipService;
@@ -36,11 +37,13 @@ namespace Orleans.Runtime.GrainDirectory
             IServiceProvider serviceProvider,
             GrainDirectoryResolver grainDirectoryResolver,
             IClusterMembershipService clusterMembershipService,
+            DirectoryInstruments directoryInstruments,
             IOptions<GrainDirectoryOptions> grainDirectoryOptions)
         {
             this.grainDirectoryResolver = grainDirectoryResolver;
             this.clusterMembershipService = clusterMembershipService;
-            this.cache = GrainDirectoryCacheFactory.CreateCustomGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value, out this.disposeCache);
+            _directoryInstruments = directoryInstruments;
+            this.cache = GrainDirectoryCacheFactory.CreateCustomGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value, out this.disposeCache, _directoryInstruments);
         }
 
         public async ValueTask<GrainAddress> Lookup(GrainId grainId)
@@ -217,7 +220,7 @@ namespace Orleans.Runtime.GrainDirectory
                 ThrowUnsupportedGrainType(grainId);
             }
 
-            DirectoryInstruments.LookupsCacheIssued.Add(1);
+            _directoryInstruments.LookupsCacheIssued.Add(1);
             if (this.cache.LookUp(grainId, out address, out _))
             {
                 // If the silo is dead, remove the entry
@@ -229,7 +232,7 @@ namespace Orleans.Runtime.GrainDirectory
                 else
                 {
                     // Entry found and valid -> return it
-                    DirectoryInstruments.LookupsCacheSuccesses.Add(1);
+                    _directoryInstruments.LookupsCacheSuccesses.Add(1);
                     return true;
                 }
             }

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -63,8 +63,10 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
     private readonly IServiceProvider _serviceProvider;
     private readonly ImmutableArray<GrainDirectoryPartition> _partitions;
     private readonly CancellationTokenSource _stoppedCts = new();
+    private readonly DirectoryInstruments _directoryInstruments;
 
     internal CancellationToken OnStoppedToken => _stoppedCts.Token;
+    internal DirectoryInstruments DirectoryInstruments => _directoryInstruments;
     internal ClusterMembershipSnapshot ClusterMembershipSnapshot => _membershipService.CurrentView.ClusterMembershipSnapshot;
 
     // The recovery membership value is used to avoid a race between concurrent registration & recovery operations which could lead to lost registrations.
@@ -85,17 +87,19 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         ILogger<DistributedGrainDirectory> logger,
         IServiceProvider serviceProvider,
         IInternalGrainFactory grainFactory,
+        DirectoryInstruments directoryInstruments,
         SystemTargetShared shared) : base(Constants.GrainDirectoryType, shared)
     {
         _localActivations = shared.ActivationDirectory;
         _serviceProvider = serviceProvider;
         _membershipService = membershipService;
         _logger = logger;
+        _directoryInstruments = directoryInstruments;
         var partitionsPerSilo = membershipService.PartitionsPerSilo;
         var partitions = ImmutableArray.CreateBuilder<GrainDirectoryPartition>(partitionsPerSilo);
         for (var i = 0; i < partitionsPerSilo; i++)
         {
-            partitions.Add(new GrainDirectoryPartition(i, this, grainFactory, shared));
+            partitions.Add(new GrainDirectoryPartition(i, this, grainFactory, directoryInstruments, shared));
         }
 
         _partitions = partitions.ToImmutable();

--- a/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
@@ -25,6 +25,7 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
     private readonly DistributedGrainDirectory _directory;
     private readonly ILogger<DistributedRemoteGrainDirectory> _logger;
     private readonly DirectoryMembershipService _membershipService;
+    private readonly DirectoryInstruments _directoryInstruments;
     private readonly Queue<(string Name, object State, Func<DistributedRemoteGrainDirectory, object, Task> Action)> _pendingOperations = new();
     private readonly AsyncLock _executorLock = new();
 
@@ -38,6 +39,7 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
         _directory = directory;
         _logger = shared.LoggerFactory.CreateLogger<DistributedRemoteGrainDirectory>();
         _membershipService = membershipService;
+        _directoryInstruments = directory.DirectoryInstruments;
         shared.ActivationDirectory.RecordNewTarget(this);
     }
 
@@ -312,7 +314,7 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
 
     public async Task<List<AddressAndTag>> LookUpMany(List<(GrainId GrainId, int Version)> grainAndETagList)
     {
-        DirectoryInstruments.ValidationsCacheReceived.Add(1);
+        _directoryInstruments.ValidationsCacheReceived.Add(1);
         LogInformationLookUpManyReceived(_logger, Silo, grainAndETagList.Count);
 
         using (var cts = CreateTimeoutCts(_directory.OnStoppedToken))

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
@@ -80,7 +80,7 @@ namespace Orleans.Runtime.GrainDirectory
         private static IGrainDirectoryCache CreateLruGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options, DirectoryInstruments directoryInstruments)
         {
             var timeProvider = services?.GetService<TimeProvider>() ?? TimeProvider.System;
-            directoryInstruments ??= services.GetRequiredService<DirectoryInstruments>();
+            directoryInstruments ??= services?.GetService<DirectoryInstruments>();
             return new LruGrainDirectoryCache(options.CacheSize, options.MaximumCacheTTL, timeProvider, directoryInstruments);
         }
     }

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryCacheFactory.cs
@@ -21,7 +21,7 @@ namespace Orleans.Runtime.GrainDirectory
         public static IGrainDirectoryCache CreateGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options)
             => CreateGrainDirectoryCache(services, options, out _);
 
-        internal static IGrainDirectoryCache CreateGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options, out bool disposeCache)
+        internal static IGrainDirectoryCache CreateGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options, out bool disposeCache, DirectoryInstruments directoryInstruments = null)
         {
             if (options.CacheSize <= 0)
             {
@@ -39,7 +39,7 @@ namespace Orleans.Runtime.GrainDirectory
                 case GrainDirectoryOptions.CachingStrategyType.Adaptive:
 #pragma warning restore CS0618 // Type or member is obsolete
                     disposeCache = true;
-                    return CreateLruGrainDirectoryCache(services, options);
+                    return CreateLruGrainDirectoryCache(services, options, directoryInstruments);
                 case GrainDirectoryOptions.CachingStrategyType.Custom:
                 default:
                     disposeCache = false;
@@ -50,7 +50,7 @@ namespace Orleans.Runtime.GrainDirectory
         internal static IGrainDirectoryCache CreateCustomGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options)
             => CreateCustomGrainDirectoryCache(services, options, out _);
 
-        internal static IGrainDirectoryCache CreateCustomGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options, out bool disposeCache)
+        internal static IGrainDirectoryCache CreateCustomGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options, out bool disposeCache, DirectoryInstruments directoryInstruments = null)
         {
             var grainDirectoryCache = services.GetService<IGrainDirectoryCache>();
             if (grainDirectoryCache is not null)
@@ -60,7 +60,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
 
             disposeCache = true;
-            return CreateLruGrainDirectoryCache(services, options);
+            return CreateLruGrainDirectoryCache(services, options, directoryInstruments);
         }
 
         internal static ValueTask DisposeGrainDirectoryCacheAsync(IGrainDirectoryCache cache)
@@ -77,10 +77,11 @@ namespace Orleans.Runtime.GrainDirectory
             return default;
         }
 
-        private static IGrainDirectoryCache CreateLruGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options)
+        private static IGrainDirectoryCache CreateLruGrainDirectoryCache(IServiceProvider services, GrainDirectoryOptions options, DirectoryInstruments directoryInstruments)
         {
             var timeProvider = services?.GetService<TimeProvider>() ?? TimeProvider.System;
-            return new LruGrainDirectoryCache(options.CacheSize, options.MaximumCacheTTL, timeProvider);
+            directoryInstruments ??= services.GetRequiredService<DirectoryInstruments>();
+            return new LruGrainDirectoryCache(options.CacheSize, options.MaximumCacheTTL, timeProvider, directoryInstruments);
         }
     }
 
@@ -111,4 +112,3 @@ namespace Orleans.Runtime.GrainDirectory
         }
     }
 }
-

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -29,6 +29,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
     private readonly int _partitionIndex;
     private readonly DistributedGrainDirectory _owner;
     private readonly IInternalGrainFactory _grainFactory;
+    private readonly DirectoryInstruments _directoryInstruments;
     private readonly CancellationTokenSource _drainSnapshotsCts = new();
     private readonly SiloAddress _id;
     private readonly ILogger<GrainDirectoryPartition> _logger;
@@ -56,11 +57,13 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         int partitionIndex,
         DistributedGrainDirectory owner,
         IInternalGrainFactory grainFactory,
+        DirectoryInstruments directoryInstruments,
         SystemTargetShared shared) : base(CreateGrainId(shared.SiloAddress, partitionIndex), shared)
     {
         _partitionIndex = partitionIndex;
         _owner = owner;
         _grainFactory = grainFactory;
+        _directoryInstruments = directoryInstruments;
         _id = shared.SiloAddress;
         _logger = shared.LoggerFactory.CreateLogger<GrainDirectoryPartition>();
         shared.ActivationDirectory.RecordNewTarget(this);
@@ -493,7 +496,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
     private void UnlockRange(RingRange range, MembershipVersion version, TaskCompletionSource tcs, TimeSpan heldDuration, string operationName)
     {
-        DirectoryInstruments.RangeLockHeldDuration.Record((long)heldDuration.TotalMilliseconds);
+        _directoryInstruments.RangeLockHeldDuration.Record((long)heldDuration.TotalMilliseconds);
         var canceled = ShutdownToken.IsCancellationRequested;
         if (canceled)
         {
@@ -580,8 +583,8 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                 false,
                 nameof(IGrainDirectoryPartition.AcknowledgeSnapshotTransferAsync)).Ignore();
 
-            DirectoryInstruments.SnapshotTransferCount.Add(1);
-            DirectoryInstruments.SnapshotTransferDuration.Record((long)stopwatch.Elapsed.TotalMilliseconds);
+            _directoryInstruments.SnapshotTransferCount.Add(1);
+            _directoryInstruments.SnapshotTransferDuration.Record((long)stopwatch.Elapsed.TotalMilliseconds);
 
             return true;
         }
@@ -617,8 +620,8 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
             }
         }
 
-        DirectoryInstruments.RangeRecoveryCount.Add(1);
-        DirectoryInstruments.RangeRecoveryDuration.Record((long)stopwatch.Elapsed.TotalMilliseconds);
+        _directoryInstruments.RangeRecoveryCount.Add(1);
+        _directoryInstruments.RangeRecoveryDuration.Record((long)stopwatch.Elapsed.TotalMilliseconds);
         LogDebugCompletedRecoveringActivations(_logger, addedRange, current.Version, stopwatch.Elapsed);
     }
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainLocator.cs
@@ -12,10 +12,12 @@ namespace Orleans.Runtime.GrainDirectory
     internal class GrainLocator
     {
         private readonly GrainLocatorResolver _grainLocatorResolver;
+        private readonly DirectoryInstruments _directoryInstruments;
 
-        public GrainLocator(GrainLocatorResolver grainLocatorResolver)
+        public GrainLocator(GrainLocatorResolver grainLocatorResolver, DirectoryInstruments directoryInstruments)
         {
             _grainLocatorResolver = grainLocatorResolver;
+            _directoryInstruments = directoryInstruments;
         }
 
         public ValueTask<GrainAddress?> Lookup(GrainId grainId) => GetGrainLocator(grainId.Type).Lookup(grainId);
@@ -23,7 +25,7 @@ namespace Orleans.Runtime.GrainDirectory
         public async Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousRegistration)
         {
             var grainLocator = GetGrainLocator(address.GrainId.Type);
-            var metrics = RegistrationMetricTracker.Start(grainLocator);
+            var metrics = RegistrationMetricTracker.Start(_directoryInstruments, grainLocator);
             try
             {
                 var result = await grainLocator.Register(address, previousRegistration);
@@ -62,19 +64,21 @@ namespace Orleans.Runtime.GrainDirectory
 
         private readonly struct RegistrationMetricTracker
         {
+            private readonly DirectoryInstruments? _directoryInstruments;
             private readonly ValueStopwatch _stopwatch;
             private readonly string? _locator;
 
-            private RegistrationMetricTracker(ValueStopwatch stopwatch, string locator)
+            private RegistrationMetricTracker(DirectoryInstruments directoryInstruments, ValueStopwatch stopwatch, string locator)
             {
+                _directoryInstruments = directoryInstruments;
                 _stopwatch = stopwatch;
                 _locator = locator;
             }
 
-            public static RegistrationMetricTracker Start(IGrainLocator grainLocator)
+            public static RegistrationMetricTracker Start(DirectoryInstruments directoryInstruments, IGrainLocator grainLocator)
             {
-                return DirectoryInstruments.RegistrationMetricsEnabled
-                    ? new(ValueStopwatch.StartNew(), GetLocatorTag(grainLocator))
+                return directoryInstruments.RegistrationMetricsEnabled
+                    ? new(directoryInstruments, ValueStopwatch.StartNew(), GetLocatorTag(grainLocator))
                     : default;
             }
 
@@ -86,12 +90,12 @@ namespace Orleans.Runtime.GrainDirectory
 
             private void Record(string status)
             {
-                if (_locator is null)
+                if (_directoryInstruments is null || _locator is null)
                 {
                     return;
                 }
 
-                DirectoryInstruments.OnRegistrationCompleted(_stopwatch.Elapsed, _locator, status);
+                _directoryInstruments.OnRegistrationCompleted(_stopwatch.Elapsed, _locator, status);
             }
         }
 

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs
@@ -25,6 +25,7 @@ namespace Orleans.Runtime.GrainDirectory
         private readonly IInternalGrainFactory grainFactory;
         private readonly ActivationDirectory localActivations;
         private readonly IServiceProvider _serviceProvider;
+        private readonly DirectoryInstruments _directoryInstruments;
         private readonly CancellationTokenSource _membershipUpdatesCancellation = new();
         private DirectoryMembership directoryMembership = DirectoryMembership.Default;
         private ClusterMembershipSnapshot appliedClusterMembershipSnapshot = ClusterMembershipSnapshot.Default;
@@ -49,6 +50,7 @@ namespace Orleans.Runtime.GrainDirectory
         internal ImmutableArray<LocalGrainDirectoryPartitionCompatibility> DistributedGrainDirectoryPartitionCompatibilities { get; }
 
         internal GrainDirectoryHandoffManager HandoffManager { get; }
+        internal DirectoryInstruments DirectoryInstruments => _directoryInstruments;
 
         public LocalGrainDirectory(
             IServiceProvider serviceProvider,
@@ -60,9 +62,11 @@ namespace Orleans.Runtime.GrainDirectory
             IOptions<DevelopmentClusterMembershipOptions> developmentClusterMembershipOptions,
             IOptions<GrainDirectoryOptions> grainDirectoryOptions,
             ILoggerFactory loggerFactory,
+            DirectoryInstruments directoryInstruments,
             SystemTargetShared systemTargetShared)
         {
             this.log = loggerFactory.CreateLogger<LocalGrainDirectory>();
+            _directoryInstruments = directoryInstruments;
 
             MyAddress = siloDetails.SiloAddress;
 
@@ -71,7 +75,7 @@ namespace Orleans.Runtime.GrainDirectory
             this.grainFactory = grainFactory;
             this.localActivations = systemTargetShared.ActivationDirectory;
 
-            DirectoryCache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value, out this.disposeDirectoryCache);
+            DirectoryCache = GrainDirectoryCacheFactory.CreateGrainDirectoryCache(serviceProvider, grainDirectoryOptions.Value, out this.disposeDirectoryCache, _directoryInstruments);
 
             var primarySiloEndPoint = developmentClusterMembershipOptions.Value.PrimarySiloEndpoint;
             if (primarySiloEndPoint != null)
@@ -104,15 +108,15 @@ namespace Orleans.Runtime.GrainDirectory
 
             this.directoryMembership = DirectoryMembership.Create([MyAddress]);
 
-            DirectoryInstruments.RegisterDirectoryPartitionSizeObserve(() => DirectoryPartition.Count);
-            DirectoryInstruments.RegisterMyPortionRingDistanceObserve(() => RingDistanceToSuccessor());
-            DirectoryInstruments.RegisterMyPortionRingPercentageObserve(() => this.RingDistanceToSuccessor() / (float)(int.MaxValue * 2L) * 100);
-            DirectoryInstruments.RegisterMyPortionAverageRingPercentageObserve(() =>
+            _directoryInstruments.RegisterDirectoryPartitionSizeObserve(() => DirectoryPartition.Count);
+            _directoryInstruments.RegisterMyPortionRingDistanceObserve(() => RingDistanceToSuccessor());
+            _directoryInstruments.RegisterMyPortionRingPercentageObserve(() => this.RingDistanceToSuccessor() / (float)(int.MaxValue * 2L) * 100);
+            _directoryInstruments.RegisterMyPortionAverageRingPercentageObserve(() =>
             {
                 var ring = this.directoryMembership.MembershipRingList;
                 return ring.Count == 0 ? 0 : (100 / (float)ring.Count);
             });
-            DirectoryInstruments.RegisterRingSizeObserve(() => this.directoryMembership.MembershipRingList.Count);
+            _directoryInstruments.RegisterRingSizeObserve(() => this.directoryMembership.MembershipRingList.Count);
             _serviceProvider = serviceProvider;
         }
 
@@ -589,11 +593,11 @@ namespace Orleans.Runtime.GrainDirectory
         {
             if (hopCount > 0)
             {
-                DirectoryInstruments.RegistrationsSingleActRemoteReceived.Add(1);
+                _directoryInstruments.RegistrationsSingleActRemoteReceived.Add(1);
             }
             else
             {
-                DirectoryInstruments.RegistrationsSingleActIssued.Add(1);
+                _directoryInstruments.RegistrationsSingleActIssued.Add(1);
             }
 
             await RefreshMembershipIfNewer(address.MembershipVersion);
@@ -620,7 +624,7 @@ namespace Orleans.Runtime.GrainDirectory
 
             if (forwardAddress == null)
             {
-                DirectoryInstruments.RegistrationsSingleActLocal.Add(1);
+                _directoryInstruments.RegistrationsSingleActLocal.Add(1);
 
                 var result = DirectoryPartition.AddSingleActivation(address, previousAddress);
 
@@ -630,7 +634,7 @@ namespace Orleans.Runtime.GrainDirectory
             }
             else
             {
-                DirectoryInstruments.RegistrationsSingleActRemoteSent.Add(1);
+                _directoryInstruments.RegistrationsSingleActRemoteSent.Add(1);
 
                 // otherwise, notify the owner
                 AddressAndTag result = await GetDirectoryReference(forwardAddress).RegisterAsync(address, previousAddress, hopCount + 1);
@@ -672,11 +676,11 @@ namespace Orleans.Runtime.GrainDirectory
         {
             if (hopCount > 0)
             {
-                DirectoryInstruments.UnregistrationsRemoteReceived.Add(1);
+                _directoryInstruments.UnregistrationsRemoteReceived.Add(1);
             }
             else
             {
-                DirectoryInstruments.UnregistrationsIssued.Add(1);
+                _directoryInstruments.UnregistrationsIssued.Add(1);
             }
 
             if (hopCount == 0)
@@ -702,12 +706,12 @@ namespace Orleans.Runtime.GrainDirectory
             if (forwardAddress == null)
             {
                 // we are the owner
-                DirectoryInstruments.UnregistrationsLocal.Add(1);
+                _directoryInstruments.UnregistrationsLocal.Add(1);
                 DirectoryPartition.RemoveActivation(address.GrainId, address.ActivationId, cause);
             }
             else
             {
-                DirectoryInstruments.UnregistrationsRemoteSent.Add(1);
+                _directoryInstruments.UnregistrationsRemoteSent.Add(1);
                 // otherwise, notify the owner
                 await GetDirectoryReference(forwardAddress).UnregisterAsync(address, cause, hopCount + 1);
             }
@@ -732,7 +736,7 @@ namespace Orleans.Runtime.GrainDirectory
                 else
                 {
                     // we are the owner
-                    DirectoryInstruments.UnregistrationsLocal.Add(1);
+                    _directoryInstruments.UnregistrationsLocal.Add(1);
 
                     DirectoryPartition.RemoveActivation(address.GrainId, address.ActivationId, cause);
                 }
@@ -743,11 +747,11 @@ namespace Orleans.Runtime.GrainDirectory
         {
             if (hopCount > 0)
             {
-                DirectoryInstruments.UnregistrationsManyRemoteReceived.Add(1);
+                _directoryInstruments.UnregistrationsManyRemoteReceived.Add(1);
             }
             else
             {
-                DirectoryInstruments.UnregistrationsManyIssued.Add(1);
+                _directoryInstruments.UnregistrationsManyIssued.Add(1);
             }
 
             await RefreshMembershipIfNewer(addresses);
@@ -778,7 +782,7 @@ namespace Orleans.Runtime.GrainDirectory
                 var tasks = new List<Task>();
                 foreach (var kvp in forwardlist)
                 {
-                    DirectoryInstruments.UnregistrationsManyRemoteSent.Add(1);
+                    _directoryInstruments.UnregistrationsManyRemoteSent.Add(1);
                     tasks.Add(GetDirectoryReference(kvp.Key).UnregisterManyAsync(kvp.Value, cause, hopCount + 1));
                 }
 
@@ -792,10 +796,10 @@ namespace Orleans.Runtime.GrainDirectory
 
         public bool TryLocalLookup(GrainId grainId, [NotNullWhen(true)] out GrainAddress? address)
         {
-            DirectoryInstruments.LookupsLocalIssued.Add(1);
+            _directoryInstruments.LookupsLocalIssued.Add(1);
             if (TryCachedLookup(grainId, out address))
             {
-                DirectoryInstruments.LookupsLocalSuccesses.Add(1);
+                _directoryInstruments.LookupsLocalSuccesses.Add(1);
                 return true;
             }
 
@@ -806,7 +810,7 @@ namespace Orleans.Runtime.GrainDirectory
                 return false;
             }
 
-            DirectoryInstruments.LookupsLocalDirectoryIssued.Add(1);
+            _directoryInstruments.LookupsLocalDirectoryIssued.Add(1);
             var localResult = DirectoryPartition.LookUpActivation(grainId);
             if (localResult.Address is null)
             {
@@ -815,8 +819,8 @@ namespace Orleans.Runtime.GrainDirectory
             }
 
             address = localResult.Address;
-            DirectoryInstruments.LookupsLocalDirectorySuccesses.Add(1);
-            DirectoryInstruments.LookupsLocalSuccesses.Add(1);
+            _directoryInstruments.LookupsLocalDirectorySuccesses.Add(1);
+            _directoryInstruments.LookupsLocalSuccesses.Add(1);
             return true;
         }
 
@@ -834,11 +838,11 @@ namespace Orleans.Runtime.GrainDirectory
         {
             if (hopCount > 0)
             {
-                DirectoryInstruments.LookupsRemoteReceived.Add(1);
+                _directoryInstruments.LookupsRemoteReceived.Add(1);
             }
             else
             {
-                DirectoryInstruments.LookupsFullIssued.Add(1);
+                _directoryInstruments.LookupsFullIssued.Add(1);
             }
 
             // see if the owner is somewhere else (returns null if we are owner)
@@ -864,7 +868,7 @@ namespace Orleans.Runtime.GrainDirectory
             if (forwardAddress == null)
             {
                 // we are the owner
-                DirectoryInstruments.LookupsLocalDirectoryIssued.Add(1);
+                _directoryInstruments.LookupsLocalDirectoryIssued.Add(1);
                 var localResult = DirectoryPartition.LookUpActivation(grainId);
                 if (localResult.Address == null)
                 {
@@ -875,7 +879,7 @@ namespace Orleans.Runtime.GrainDirectory
                 }
 
                 LogTraceFullLookupMine(grainId, localResult.Address);
-                DirectoryInstruments.LookupsLocalDirectorySuccesses.Add(1);
+                _directoryInstruments.LookupsLocalDirectorySuccesses.Add(1);
                 return localResult;
             }
             else
@@ -886,7 +890,7 @@ namespace Orleans.Runtime.GrainDirectory
                     throw new OrleansException($"Current directory at {MyAddress} is not stable to perform the lookup for grainId {grainId} (it maps to {forwardAddress}, which is not a valid silo). Retry later.");
                 }
 
-                DirectoryInstruments.LookupsRemoteSent.Add(1);
+                _directoryInstruments.LookupsRemoteSent.Add(1);
                 var result = await GetDirectoryReference(forwardAddress).LookupAsync(grainId, hopCount + 1);
 
                 // update the cache
@@ -983,13 +987,13 @@ namespace Orleans.Runtime.GrainDirectory
         public void AddOrUpdateCacheEntry(GrainId grainId, SiloAddress siloAddress) => this.DirectoryCache.AddOrUpdate(new GrainAddress { GrainId = grainId, SiloAddress = siloAddress }, 0);
         public bool TryCachedLookup(GrainId grainId, [NotNullWhen(true)] out GrainAddress? address)
         {
-            DirectoryInstruments.LookupsCacheIssued.Add(1);
+            _directoryInstruments.LookupsCacheIssued.Add(1);
             if ((address = GetLocalCacheData(grainId)) is null)
             {
                 return false;
             }
 
-            DirectoryInstruments.LookupsCacheSuccesses.Add(1);
+            _directoryInstruments.LookupsCacheSuccesses.Add(1);
             return true;
         }
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)

--- a/src/Orleans.Runtime/GrainDirectory/LruGrainDirectoryCache.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LruGrainDirectoryCache.cs
@@ -15,14 +15,16 @@ internal sealed class LruGrainDirectoryCache : ConcurrentLruCache<GrainId, (Grai
         int maxCacheSize,
         TimeSpan maxCacheTTL,
         TimeProvider timeProvider,
-        DirectoryInstruments directoryInstruments)
+        DirectoryInstruments directoryInstruments = null)
         : base(
             capacity: maxCacheSize,
             comparer: null,
             timeToLive: maxCacheTTL,
             timeProvider: timeProvider)
     {
-        _cacheSizeRegistration = directoryInstruments.RegisterCacheSizeObserve(() => Count);
+        _cacheSizeRegistration = directoryInstruments is null
+            ? NoOpDisposable.Instance
+            : directoryInstruments.RegisterCacheSizeObserve(() => Count);
     }
 
     public void AddOrUpdate(GrainAddress activationAddress, int version) => AddOrUpdate(activationAddress.GrainId, (activationAddress, version));
@@ -63,4 +65,13 @@ internal sealed class LruGrainDirectoryCache : ConcurrentLruCache<GrainId, (Grai
     }
 
     async ValueTask IAsyncDisposable.DisposeAsync() => await DisposeAsync();
+
+    private sealed class NoOpDisposable : IDisposable
+    {
+        public static readonly NoOpDisposable Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
 }

--- a/src/Orleans.Runtime/GrainDirectory/LruGrainDirectoryCache.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LruGrainDirectoryCache.cs
@@ -14,14 +14,15 @@ internal sealed class LruGrainDirectoryCache : ConcurrentLruCache<GrainId, (Grai
     public LruGrainDirectoryCache(
         int maxCacheSize,
         TimeSpan maxCacheTTL,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        DirectoryInstruments directoryInstruments)
         : base(
             capacity: maxCacheSize,
             comparer: null,
             timeToLive: maxCacheTTL,
             timeProvider: timeProvider)
     {
-        _cacheSizeRegistration = DirectoryInstruments.RegisterCacheSizeObserve(() => Count);
+        _cacheSizeRegistration = directoryInstruments.RegisterCacheSizeObserve(() => Count);
     }
 
     public void AddOrUpdate(GrainAddress activationAddress, int version) => AddOrUpdate(activationAddress.GrainId, (activationAddress, version));

--- a/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/RemoteGrainDirectory.cs
@@ -27,7 +27,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public Task<AddressAndTag> RegisterAsync(GrainAddress address, GrainAddress? previousAddress, int hopCount)
         {
-            DirectoryInstruments.RegistrationsSingleActRemoteReceived.Add(1);
+            router.DirectoryInstruments.RegistrationsSingleActRemoteReceived.Add(1);
 
             return router.RegisterAsync(address, previousAddress, hopCount);
         }
@@ -69,7 +69,7 @@ namespace Orleans.Runtime.GrainDirectory
 
         public Task<List<AddressAndTag>> LookUpMany(List<(GrainId GrainId, int Version)> grainAndETagList)
         {
-            DirectoryInstruments.ValidationsCacheReceived.Add(1);
+            router.DirectoryInstruments.ValidationsCacheReceived.Add(1);
             LogLookUpMany(grainAndETagList.Count);
 
             var result = new List<AddressAndTag>();

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -70,6 +70,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<ConsistentRingInstruments>();
             services.TryAddSingleton<StorageInstruments>();
             services.TryAddSingleton<CatalogInstruments>();
+            services.TryAddSingleton<DirectoryInstruments>();
 
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -56,6 +56,7 @@ namespace UnitTests.Directory
                 services,
                 this.grainDirectoryResolver, 
                 this.mockMembershipService.Target,
+                CreateDirectoryInstruments(),
                 grainDirectoryOptions);
 
             this.grainLocator.Participate(this.lifecycle);
@@ -117,6 +118,7 @@ namespace UnitTests.Directory
                 services,
                 grainDirectoryResolver,
                 membershipService.Target,
+                CreateDirectoryInstruments(),
                 Options.Create(new GrainDirectoryOptions()));
 
             grainLocator.Participate(lifecycle);
@@ -168,6 +170,7 @@ namespace UnitTests.Directory
                 developmentClusterMembershipOptions: Options.Create(new DevelopmentClusterMembershipOptions()),
                 grainDirectoryOptions: Options.Create(new GrainDirectoryOptions { CachingStrategy = GrainDirectoryOptions.CachingStrategyType.Custom }),
                 loggerFactory: this.loggerFactory,
+                directoryInstruments: CreateDirectoryInstruments(),
                 systemTargetShared: systemTargetShared);
 
             await localGrainDirectory.StopAsync();
@@ -220,6 +223,7 @@ namespace UnitTests.Directory
                 developmentClusterMembershipOptions: Options.Create(new DevelopmentClusterMembershipOptions()),
                 grainDirectoryOptions: Options.Create(new GrainDirectoryOptions()),
                 loggerFactory: this.loggerFactory,
+                directoryInstruments: CreateDirectoryInstruments(),
                 systemTargetShared: systemTargetShared)
             {
                 Running = true
@@ -284,6 +288,7 @@ namespace UnitTests.Directory
                 developmentClusterMembershipOptions: Options.Create(new DevelopmentClusterMembershipOptions()),
                 grainDirectoryOptions: Options.Create(new GrainDirectoryOptions()),
                 loggerFactory: this.loggerFactory,
+                directoryInstruments: CreateDirectoryInstruments(),
                 systemTargetShared: systemTargetShared)
             {
                 Running = true
@@ -834,6 +839,15 @@ namespace UnitTests.Directory
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<CatalogInstruments>();
             return services.BuildServiceProvider().GetRequiredService<CatalogInstruments>();
+        }
+
+        private static DirectoryInstruments CreateDirectoryInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<DirectoryInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<DirectoryInstruments>();
         }
 
         private int generation = 0;

--- a/test/Orleans.Runtime.Tests/Diagnostics/DirectoryInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/DirectoryInstrumentsTests.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class DirectoryInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void DirectoryInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new DirectoryInstruments(new OrleansInstruments(meterFactory));
+        using var localLookupsCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.DIRECTORY_LOOKUPS_LOCAL_ISSUED);
+        using var cacheSizeCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.DIRECTORY_CACHE_SIZE);
+        using var registrationsCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.DIRECTORY_REGISTRATIONS);
+        using var registrationDurationCollector = new MetricCollector<double>(meterFactory, "Microsoft.Orleans", InstrumentNames.DIRECTORY_REGISTRATION_DURATION);
+
+        using var cacheRegistration = instruments.RegisterCacheSizeObserve(() => 7);
+        instruments.LookupsLocalIssued.Add(1);
+        instruments.OnRegistrationCompleted(TimeSpan.FromMilliseconds(12), "dht", DirectoryInstruments.RegistrationStatusSuccess);
+
+        cacheSizeCollector.RecordObservableInstruments();
+
+        Assert.Equal(1, Assert.Single(localLookupsCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(7, Assert.Single(cacheSizeCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(registrationsCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(12, Assert.Single(registrationDurationCollector.GetMeasurementSnapshot()).Value);
+    }
+}


### PR DESCRIPTION
Part of #9608.

## Problem
`DirectoryInstruments` created directory metrics using the global static `Instruments.Meter`, so directory metrics were not scoped to the DI-provided `IMeterFactory` used by the other migrated instruments.

## Solution
Convert `DirectoryInstruments` to an instance class backed by `OrleansInstruments`. Register it with silo services and inject it through grain directory components, including local/remote directory targets, directory partitions, cache creation, and registration tracking. Adds a `MetricCollector` BVT covering counters, observable cache size, and registration metrics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10173)