### PR TITLE
chore: use IMeterFactory for GrainInstruments

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/GrainInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/GrainInstruments.cs
@@ -4,30 +4,35 @@ using System.Diagnostics.Metrics;
 #nullable disable
 namespace Orleans.Runtime;
 
-internal static class GrainInstruments
+internal sealed class GrainInstruments
 {
-    static GrainInstruments()
+    private readonly UpDownCounter<int> _grainCounts;
+    private readonly UpDownCounter<int> _systemTargetCounts;
+
+    public GrainInstruments(OrleansInstruments instruments)
     {
         GrainMetricsListener.Start();
+        _grainCounts = instruments.Meter.CreateUpDownCounter<int>(InstrumentNames.GRAIN_COUNTS);
+        _systemTargetCounts = instruments.Meter.CreateUpDownCounter<int>(InstrumentNames.SYSTEM_TARGET_COUNTS);
     }
 
-    internal static UpDownCounter<int> GrainCounts = Instruments.Meter.CreateUpDownCounter<int>(InstrumentNames.GRAIN_COUNTS);
-    internal static void IncrementGrainCounts(string grainTypeName)
+    internal void IncrementGrainCounts(string grainTypeName)
     {
-        GrainCounts.Add(1, new KeyValuePair<string, object>("type", grainTypeName));
-    }
-    internal static void DecrementGrainCounts(string grainTypeName)
-    {
-        GrainCounts.Add(-1, new KeyValuePair<string, object>("type", grainTypeName));
+        _grainCounts.Add(1, new KeyValuePair<string, object>("type", grainTypeName));
     }
 
-    internal static UpDownCounter<int> SystemTargetCounts = Instruments.Meter.CreateUpDownCounter<int>(InstrumentNames.SYSTEM_TARGET_COUNTS);
-    internal static void IncrementSystemTargetCounts(string systemTargetTypeName)
+    internal void DecrementGrainCounts(string grainTypeName)
     {
-        SystemTargetCounts.Add(1, new KeyValuePair<string, object>("type", systemTargetTypeName));
+        _grainCounts.Add(-1, new KeyValuePair<string, object>("type", grainTypeName));
     }
-    internal static void DecrementSystemTargetCounts(string systemTargetTypeName)
+
+    internal void IncrementSystemTargetCounts(string systemTargetTypeName)
     {
-        SystemTargetCounts.Add(-1, new KeyValuePair<string, object>("type", systemTargetTypeName));
+        _systemTargetCounts.Add(1, new KeyValuePair<string, object>("type", systemTargetTypeName));
+    }
+
+    internal void DecrementSystemTargetCounts(string systemTargetTypeName)
+    {
+        _systemTargetCounts.Add(-1, new KeyValuePair<string, object>("type", systemTargetTypeName));
     }
 }

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -59,6 +59,7 @@ public sealed class GrainTypeSharedContext
         Runtime = grainRuntime;
         MigrationManager = _serviceProvider.GetService<IActivationMigrationManager>();
         CatalogInstruments = serviceProvider.GetRequiredService<CatalogInstruments>();
+        GrainInstruments = serviceProvider.GetRequiredService<GrainInstruments>();
 
         CollectionAgeLimit = GetCollectionAgeLimit(
             grainType,
@@ -73,6 +74,7 @@ public sealed class GrainTypeSharedContext
     public string? GrainTypeName { get; }
 
     internal CatalogInstruments CatalogInstruments { get; }
+    internal GrainInstruments GrainInstruments { get; }
 
     private static TimeSpan GetCollectionAgeLimit(GrainType grainType, Type grainClass, GrainManifest siloManifest, GrainCollectionOptions collectionOptions)
     {

--- a/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
+++ b/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
@@ -16,7 +16,8 @@ internal sealed class SystemTargetShared(
     GrainReferenceActivator grainReferenceActivator,
     ITimerRegistry timerRegistry,
     ActivationDirectory activations,
-    SchedulerInstruments schedulerInstruments)
+    SchedulerInstruments schedulerInstruments,
+    GrainInstruments grainInstruments)
 {
     public SiloAddress SiloAddress => localSiloDetails.SiloAddress;
 
@@ -28,6 +29,7 @@ internal sealed class SystemTargetShared(
     public RuntimeMessagingTrace MessagingTrace { get; } = new(loggerFactory);
     public InsideRuntimeClient RuntimeClient => runtimeClient;
     public ActivationDirectory ActivationDirectory => activations;
+    public GrainInstruments GrainInstruments => grainInstruments;
     public WorkItemGroup CreateWorkItemGroup(SystemTarget systemTarget)
     {
         ArgumentNullException.ThrowIfNull(systemTarget);

--- a/src/Orleans.Runtime/Core/SystemTarget.cs
+++ b/src/Orleans.Runtime/Core/SystemTarget.cs
@@ -81,7 +81,7 @@ namespace Orleans.Runtime
             WorkItemGroup = _shared.CreateWorkItemGroup(this);
             if (!Constants.IsSingletonSystemTarget(GrainId.Type))
             {
-                GrainInstruments.IncrementSystemTargetCounts(Constants.SystemTargetName(GrainId.Type));
+                _shared.GrainInstruments.IncrementSystemTargetCounts(Constants.SystemTargetName(GrainId.Type));
             }
         }
 
@@ -390,7 +390,7 @@ namespace Orleans.Runtime
         {
             if (!Constants.IsSingletonSystemTarget(GrainId.Type))
             {
-                GrainInstruments.DecrementSystemTargetCounts(Constants.SystemTargetName(GrainId.Type));
+                _shared.GrainInstruments.DecrementSystemTargetCounts(Constants.SystemTargetName(GrainId.Type));
             }
 
             StopAllTimers();

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -71,6 +71,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<StorageInstruments>();
             services.TryAddSingleton<CatalogInstruments>();
             services.TryAddSingleton<DirectoryInstruments>();
+            services.TryAddSingleton<GrainInstruments>();
 
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -159,7 +159,8 @@ namespace UnitTests.Directory
                 grainReferenceActivator: null,
                 timerRegistry: null,
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
-                schedulerInstruments: CreateSchedulerInstruments());
+                schedulerInstruments: CreateSchedulerInstruments(),
+                grainInstruments: CreateGrainInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -212,7 +213,8 @@ namespace UnitTests.Directory
                 grainReferenceActivator: null,
                 timerRegistry: null,
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
-                schedulerInstruments: CreateSchedulerInstruments());
+                schedulerInstruments: CreateSchedulerInstruments(),
+                grainInstruments: CreateGrainInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -277,7 +279,8 @@ namespace UnitTests.Directory
                 grainReferenceActivator: null,
                 timerRegistry: null,
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
-                schedulerInstruments: CreateSchedulerInstruments());
+                schedulerInstruments: CreateSchedulerInstruments(),
+                grainInstruments: CreateGrainInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -848,6 +851,15 @@ namespace UnitTests.Directory
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<DirectoryInstruments>();
             return services.BuildServiceProvider().GetRequiredService<DirectoryInstruments>();
+        }
+
+        private static GrainInstruments CreateGrainInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<GrainInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<GrainInstruments>();
         }
 
         private int generation = 0;

--- a/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
@@ -81,7 +81,8 @@ namespace NonSilo.Tests.Directory
                 grainReferenceActivator: null,
                 timerRegistry: null,
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
-                schedulerInstruments: CreateSchedulerInstruments());
+                schedulerInstruments: CreateSchedulerInstruments(),
+                grainInstruments: CreateGrainInstruments());
 
             _directory = new ClientDirectory(
                 grainFactory: _grainFactory,
@@ -114,6 +115,15 @@ namespace NonSilo.Tests.Directory
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<CatalogInstruments>();
             return services.BuildServiceProvider().GetRequiredService<CatalogInstruments>();
+        }
+
+        private static GrainInstruments CreateGrainInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<GrainInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<GrainInstruments>();
         }
 
         /// <summary>

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -610,7 +610,8 @@ public class LocalDurableJobManagerTests
         grainReferenceActivator: null!,
         timerRegistry: null!,
         activations: new ActivationDirectory(CreateCatalogInstruments()),
-        schedulerInstruments: CreateSchedulerInstruments());
+        schedulerInstruments: CreateSchedulerInstruments(),
+        grainInstruments: CreateGrainInstruments());
 
     private static SchedulerInstruments CreateSchedulerInstruments()
     {        var services = new ServiceCollection();
@@ -627,6 +628,15 @@ public class LocalDurableJobManagerTests
         services.AddSingleton<OrleansInstruments>();
         services.AddSingleton<CatalogInstruments>();
         return services.BuildServiceProvider().GetRequiredService<CatalogInstruments>();
+    }
+
+    private static GrainInstruments CreateGrainInstruments()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton<GrainInstruments>();
+        return services.BuildServiceProvider().GetRequiredService<GrainInstruments>();
     }
 
     private static IJobShard CreateSubstituteShard(string id, DateTimeOffset start, DateTimeOffset end)

--- a/test/Orleans.Runtime.Tests/Diagnostics/GrainInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/GrainInstrumentsTests.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class GrainInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void GrainInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new GrainInstruments(new OrleansInstruments(meterFactory));
+        using var grainCountsCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.GRAIN_COUNTS);
+        using var systemTargetCountsCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.SYSTEM_TARGET_COUNTS);
+
+        instruments.IncrementGrainCounts("grain");
+        instruments.DecrementGrainCounts("grain");
+        instruments.IncrementSystemTargetCounts("system-target");
+        instruments.DecrementSystemTargetCounts("system-target");
+
+        Assert.Collection(
+            grainCountsCollector.GetMeasurementSnapshot(),
+            measurement => Assert.Equal(1, measurement.Value),
+            measurement => Assert.Equal(-1, measurement.Value));
+        Assert.Collection(
+            systemTargetCountsCollector.GetMeasurementSnapshot(),
+            measurement => Assert.Equal(1, measurement.Value),
+            measurement => Assert.Equal(-1, measurement.Value));
+    }
+}

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -168,7 +168,8 @@ namespace UnitTests.StreamingTests
                 grainReferenceActivator: null!,
                 timerRegistry: timerRegistry,
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
-                schedulerInstruments: CreateSchedulerInstruments());
+                schedulerInstruments: CreateSchedulerInstruments(),
+                grainInstruments: CreateGrainInstruments());
 
             receiver ??= Substitute.For<IQueueAdapterReceiver>();
             receiver.Initialize(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
@@ -211,6 +212,15 @@ namespace UnitTests.StreamingTests
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<CatalogInstruments>();
             return services.BuildServiceProvider().GetRequiredService<CatalogInstruments>();
+        }
+
+        private static GrainInstruments CreateGrainInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<GrainInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<GrainInstruments>();
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]


### PR DESCRIPTION
Part of #9608.

## Problem
`GrainInstruments` created grain and system-target metrics using the global static `Instruments.Meter`, so those metrics were not scoped to the DI-provided `IMeterFactory` used by the other migrated instruments.

## Solution
Convert `GrainInstruments` to an instance class backed by `OrleansInstruments`. Register it with silo services and pass it through runtime shared context used by grain activations and system targets. Adds a `MetricCollector` BVT covering grain and system-target count metrics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10175)