### PR TITLE
fix(nats): Validate StorageType and pin NATS test endpoint (follow-up to #10028)

### DIFF
--- a/src/Orleans.Streaming.NATS/NatsOptions.cs
+++ b/src/Orleans.Streaming.NATS/NatsOptions.cs
@@ -91,5 +91,12 @@ public class NatsStreamOptionsValidator(NatsOptions options, string? name = null
             throw new OrleansConfigurationException(
                 $"The {nameof(NatsOptions.NumReplicas)} must be at least 1 for the NATS stream provider '{name}'.");
         }
+
+        if (!Enum.IsDefined(typeof(StreamConfigStorage), options.StorageType))
+        {
+            throw new OrleansConfigurationException(
+                $"The {nameof(NatsOptions.StorageType)} value '{options.StorageType}' is not valid for the NATS stream provider '{name}'. " +
+                $"Valid values are {nameof(StreamConfigStorage.File)} and {nameof(StreamConfigStorage.Memory)}.");
+        }
     }
 }

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsOptionsTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsOptionsTests.cs
@@ -160,13 +160,14 @@ public sealed class NatsOptionsTests
             NumReplicas = 1,
             PartitionCount = 2,
             ProducerCount = 1,
-            StorageType = storageType
+            StorageType = storageType,
+            NatsClientOptions = NatsTestConstants.NatsClientOptions
         };
 
         var connectionManager = new NatsConnectionManager(providerName, NullLoggerFactory.Instance, options);
         await connectionManager.Initialize();
 
-        await using var natsConnection = new NatsConnection();
+        await using var natsConnection = new NatsConnection(NatsTestConstants.NatsClientOptions);
         var natsContext = new NatsJSContext(natsConnection);
         await natsConnection.ConnectAsync();
 


### PR DESCRIPTION
Follow-up to #10028, addressing review comments.

### Changes

1. `NatsStreamOptionsValidator` now rejects undefined `StreamConfigStorage` enum values.

2. Use `NatsTestConstants.NatsClientOptions` to align with existing tests.
