### PR TITLE
chore: use IMeterFactory for StreamInstruments

### DIFF
--- a/src/Orleans.Core/Diagnostics/Metrics/StreamInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/StreamInstruments.cs
@@ -4,26 +4,26 @@ using System.Diagnostics.Metrics;
 #nullable disable
 namespace Orleans.Runtime;
 
-internal static class StreamInstruments
+internal sealed class StreamInstruments(OrleansInstruments instruments)
 {
-    public static Counter<int> PubSubProducersAdded = Instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_PRODUCERS_ADDED);
-    public static Counter<int> PubSubProducersRemoved = Instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_PRODUCERS_REMOVED);
-    public static Counter<int> PubSubProducersTotal = Instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_PRODUCERS_TOTAL);
-    public static Counter<int> PubSubConsumersAdded = Instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_CONSUMERS_ADDED);
-    public static Counter<int> PubSubConsumersRemoved = Instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_CONSUMERS_REMOVED);
-    public static Counter<int> PubSubConsumersTotal = Instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_CONSUMERS_TOTAL);
+    internal readonly Counter<int> PubSubProducersAdded = instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_PRODUCERS_ADDED);
+    internal readonly Counter<int> PubSubProducersRemoved = instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_PRODUCERS_REMOVED);
+    internal readonly Counter<int> PubSubProducersTotal = instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_PRODUCERS_TOTAL);
+    internal readonly Counter<int> PubSubConsumersAdded = instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_CONSUMERS_ADDED);
+    internal readonly Counter<int> PubSubConsumersRemoved = instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_CONSUMERS_REMOVED);
+    internal readonly Counter<int> PubSubConsumersTotal = instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PUBSUB_CONSUMERS_TOTAL);
 
-    public static ObservableGauge<int> PersistentStreamPullingAgents;
-    public static void RegisterPersistentStreamPullingAgentsObserve(Func<Measurement<int>> observeValue)
+    private ObservableGauge<int> _persistentStreamPullingAgents;
+    internal void RegisterPersistentStreamPullingAgentsObserve(Func<Measurement<int>> observeValue)
     {
-        PersistentStreamPullingAgents = Instruments.Meter.CreateObservableGauge<int>(InstrumentNames.STREAMS_PERSISTENT_STREAM_NUM_PULLING_AGENTS, observeValue);
-    }
-    public static Counter<int> PersistentStreamReadMessages = Instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PERSISTENT_STREAM_NUM_READ_MESSAGES);
-    public static Counter<int> PersistentStreamSentMessages = Instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PERSISTENT_STREAM_NUM_SENT_MESSAGES);
-    public static ObservableGauge<int> PersistentStreamPubSubCacheSize;
-    public static void RegisterPersistentStreamPubSubCacheSizeObserve(Func<Measurement<int>> observeValue)
-    {
-        PersistentStreamPubSubCacheSize = Instruments.Meter.CreateObservableGauge<int>(InstrumentNames.STREAMS_PERSISTENT_STREAM_PUBSUB_CACHE_SIZE, observeValue);
+        _persistentStreamPullingAgents = instruments.Meter.CreateObservableGauge<int>(InstrumentNames.STREAMS_PERSISTENT_STREAM_NUM_PULLING_AGENTS, observeValue);
     }
 
+    internal readonly Counter<int> PersistentStreamReadMessages = instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PERSISTENT_STREAM_NUM_READ_MESSAGES);
+    internal readonly Counter<int> PersistentStreamSentMessages = instruments.Meter.CreateCounter<int>(InstrumentNames.STREAMS_PERSISTENT_STREAM_NUM_SENT_MESSAGES);
+    private ObservableGauge<int> _persistentStreamPubSubCacheSize;
+    internal void RegisterPersistentStreamPubSubCacheSizeObserve(Func<Measurement<int>> observeValue)
+    {
+        _persistentStreamPubSubCacheSize = instruments.Meter.CreateObservableGauge<int>(InstrumentNames.STREAMS_PERSISTENT_STREAM_PUBSUB_CACHE_SIZE, observeValue);
+    }
 }

--- a/src/Orleans.Streaming/Hosting/StreamingServiceCollectionExtensions.cs
+++ b/src/Orleans.Streaming/Hosting/StreamingServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration.Internal;
 using Orleans.Providers;
@@ -30,6 +31,7 @@ namespace Orleans.Hosting
                 return;
             }
 
+            services.TryAddSingleton<StreamInstruments>();
             services.AddSingleton<PubSubGrainStateStorageFactory>();
             services.AddSingleton<SiloStreamProviderRuntime>();
             services.AddFromExisting<IStreamProviderRuntime, SiloStreamProviderRuntime>();

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -32,6 +32,7 @@ namespace Orleans.Streams
         private readonly IQueueAdapterCache queueAdapterCache;
         private readonly IQueueAdapter queueAdapter;
         private readonly IStreamFailureHandler streamFailureHandler;
+        private readonly StreamInstruments _streamInstruments;
         private readonly TimeProvider _timeProvider;
         internal readonly QueueId QueueId;
 
@@ -68,7 +69,8 @@ namespace Orleans.Streams
             IBackoffProvider deliveryBackoffProvider,
             IBackoffProvider queueReaderBackoffProvider,
             TimeProvider timeProvider,
-            SystemTargetShared shared)
+            SystemTargetShared shared,
+            StreamInstruments streamInstruments = null)
             : base(id, shared)
         {
             if (strProviderName == null) throw new ArgumentNullException("runtime", "PersistentStreamPullingAgent: strProviderName should not be null");
@@ -84,6 +86,7 @@ namespace Orleans.Streams
             this.queueAdapterCache = queueAdapterCache;
             this.deliveryBackoffProvider = deliveryBackoffProvider;
             this.queueReaderBackoffProvider = queueReaderBackoffProvider;
+            _streamInstruments = streamInstruments;
             _timeProvider = timeProvider ?? TimeProvider.System;
             numMessages = 0;
 
@@ -179,7 +182,7 @@ namespace Orleans.Streams
             var randomTimerOffset = RandomTimeSpan.Next(this.options.GetQueueMsgsTimerPeriod);
             timer = RegisterGrainTimer(RunQueuePump, QueueId, randomTimerOffset, this.options.GetQueueMsgsTimerPeriod);
 
-            StreamInstruments.RegisterPersistentStreamPubSubCacheSizeObserve(() => new Measurement<int>(pubSubCache.Count, new KeyValuePair<string, object>("name", StatisticUniquePostfix)));
+            _streamInstruments?.RegisterPersistentStreamPubSubCacheSizeObserve(() => new Measurement<int>(pubSubCache.Count, new KeyValuePair<string, object>("name", StatisticUniquePostfix)));
 
             LogInfoTakingQueue(new(QueueId));
             return Task.CompletedTask;
@@ -530,7 +533,7 @@ namespace Orleans.Streams
 
             queueCache?.AddToCache(multiBatch);
             numMessages += multiBatch.Count;
-            StreamInstruments.PersistentStreamReadMessages.Add(multiBatch.Count);
+            _streamInstruments?.PersistentStreamReadMessages.Add(multiBatch.Count);
 
             LogTraceGotMessages(multiBatch.Count, new(myQueueId), numMessages);
 
@@ -749,7 +752,7 @@ namespace Orleans.Streams
 
                     try
                     {
-                        StreamInstruments.PersistentStreamSentMessages.Add(1);
+                        _streamInstruments?.PersistentStreamSentMessages.Add(1);
                         if (IsShutdown)
                         {
                             break;

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
@@ -39,6 +39,7 @@ namespace Orleans.Streams
         private readonly IStreamFilter streamFilter;
         private readonly IQueueAdapterFactory adapterFactory;
         private readonly TimeProvider _timeProvider;
+        private readonly StreamInstruments _streamInstruments;
         private RunState managerState;
         private IDisposable queuePrintTimer;
         private int nextAgentId;
@@ -57,6 +58,7 @@ namespace Orleans.Streams
             IBackoffProvider deliveryBackoffProvider,
             IBackoffProvider queueReaderBackoffProvider,
             TimeProvider timeProvider,
+            StreamInstruments streamInstruments,
             SystemTargetShared shared)
             : base(managerId, shared)
         {
@@ -89,11 +91,12 @@ namespace Orleans.Streams
             _deliveryBackoffProvider = deliveryBackoffProvider;
             _queueReaderBackoffProvider = queueReaderBackoffProvider;
             _timeProvider = timeProvider ?? TimeProvider.System;
+            _streamInstruments = streamInstruments;
             _systemTargetShared = shared;
             queueAdapterCache = adapterFactory.GetQueueAdapterCache();
             logger = shared.LoggerFactory.CreateLogger($"{GetType().FullName}.{streamProviderName}");
             LogInfoCreated(GetType().Name, streamProviderName);
-            StreamInstruments.RegisterPersistentStreamPullingAgentsObserve(() => new Measurement<int>(queuesToAgentsMap.Count, new KeyValuePair<string, object>("name", streamProviderName)));
+            _streamInstruments.RegisterPersistentStreamPullingAgentsObserve(() => new Measurement<int>(queuesToAgentsMap.Count, new KeyValuePair<string, object>("name", streamProviderName)));
             shared.ActivationDirectory.RecordNewTarget(this);
         }
 
@@ -255,7 +258,8 @@ namespace Orleans.Streams
                             _deliveryBackoffProvider,
                             _queueReaderBackoffProvider,
                             _timeProvider,
-                            _systemTargetShared);
+                            _systemTargetShared,
+                            _streamInstruments);
                         queuesToAgentsMap.Add(queueId, agent);
                         agents.Add(agent);
                     }

--- a/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
@@ -86,6 +86,7 @@ namespace Orleans.Runtime.Providers
                 deliveryProvider,
                 queueReaderProvider,
                 timeProvider,
+                ServiceProvider.GetRequiredService<StreamInstruments>(),
                 ServiceProvider.GetRequiredService<SystemTargetShared>());
 
             // Init the manager only after it was registered locally.

--- a/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
+++ b/src/Orleans.Streaming/PubSub/PubSubRendezvousGrain.cs
@@ -83,13 +83,15 @@ namespace Orleans.Streams
 
         private readonly PubSubGrainStateStorageFactory _storageFactory;
         private readonly StateStorageBridge<PubSubGrainState> _storage;
+        private readonly StreamInstruments _streamInstruments;
 
         private PubSubGrainState State => _storage.State;
 
-        public PubSubRendezvousGrain(PubSubGrainStateStorageFactory storageFactory, ILogger<PubSubRendezvousGrain> logger)
+        public PubSubRendezvousGrain(PubSubGrainStateStorageFactory storageFactory, ILogger<PubSubRendezvousGrain> logger, StreamInstruments streamInstruments)
         {
             _storageFactory = storageFactory;
             _logger = logger;
+            _streamInstruments = streamInstruments;
             _storage = _storageFactory.GetStorage(this);
         }
 
@@ -107,7 +109,7 @@ namespace Orleans.Streams
 
         public async Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, GrainId streamProducer)
         {
-            StreamInstruments.PubSubProducersAdded.Add(1);
+            _streamInstruments.PubSubProducersAdded.Add(1);
 
             try
             {
@@ -116,7 +118,7 @@ namespace Orleans.Streams
                 LogPubSubCounts("RegisterProducer {0}", streamProducer);
                 await WriteStateAsync();
                 StreamingEvents.EmitProducerRegistered(streamId.ProviderName, streamId.StreamId, streamProducer, GrainContext.Address.SiloAddress);
-                StreamInstruments.PubSubProducersTotal.Add(1);
+                _streamInstruments.PubSubProducersTotal.Add(1);
             }
             catch (Exception exc)
             {
@@ -131,7 +133,7 @@ namespace Orleans.Streams
 
         public async Task UnregisterProducer(QualifiedStreamId streamId, GrainId streamProducer)
         {
-            StreamInstruments.PubSubProducersRemoved.Add(1);
+            _streamInstruments.PubSubProducersRemoved.Add(1);
             try
             {
                 int numRemoved = State.Producers.RemoveWhere(s => s.Equals(streamId, streamProducer));
@@ -145,7 +147,7 @@ namespace Orleans.Streams
                     await updateStorageTask;
                     StreamingEvents.EmitProducerUnregistered(streamId.ProviderName, streamId.StreamId, streamProducer, GrainContext.Address.SiloAddress);
                 }
-                StreamInstruments.PubSubProducersTotal.Add(-numRemoved);
+                _streamInstruments.PubSubProducersTotal.Add(-numRemoved);
             }
             catch (Exception exc)
             {
@@ -167,7 +169,7 @@ namespace Orleans.Streams
             GrainId streamConsumer,
             string filterData)
         {
-            StreamInstruments.PubSubConsumersAdded.Add(1);
+            _streamInstruments.PubSubConsumersAdded.Add(1);
             var pubSubState = State.Consumers.FirstOrDefault(s => s.Equals(subscriptionId));
             if (pubSubState != null && pubSubState.IsFaulted)
                 throw new FaultedSubscriptionException(subscriptionId, streamId);
@@ -185,7 +187,7 @@ namespace Orleans.Streams
                 LogPubSubCounts("RegisterConsumer {0}", streamConsumer);
                 await WriteStateAsync();
                 StreamingEvents.EmitSubscriptionRegistered(streamId.ProviderName, streamId.StreamId, subscriptionId.Guid, streamConsumer, GrainContext.Address.SiloAddress);
-                StreamInstruments.PubSubConsumersTotal.Add(1);
+                _streamInstruments.PubSubConsumersTotal.Add(1);
             }
             catch (Exception exc)
             {
@@ -227,7 +229,7 @@ namespace Orleans.Streams
                 if (State.Producers.Count != initialProducerCount)
                 {
                     await WriteStateAsync();
-                    StreamInstruments.PubSubConsumersTotal.Add(-(initialProducerCount - State.Producers.Count));
+                    _streamInstruments.PubSubConsumersTotal.Add(-(initialProducerCount - State.Producers.Count));
                 }
 
                 if (exception != null)
@@ -258,7 +260,7 @@ namespace Orleans.Streams
 
         public async Task UnregisterConsumer(GuidId subscriptionId, QualifiedStreamId streamId)
         {
-            StreamInstruments.PubSubConsumersRemoved.Add(1);
+            _streamInstruments.PubSubConsumersRemoved.Add(1);
 
             try
             {
@@ -280,7 +282,7 @@ namespace Orleans.Streams
                     }
                     await NotifyProducersOfRemovedSubscription(subscriptionId, streamId);
                 }
-                StreamInstruments.PubSubConsumersTotal.Add(-numRemoved);
+                _streamInstruments.PubSubConsumersTotal.Add(-numRemoved);
             }
             catch (Exception exc)
             {

--- a/test/Orleans.Runtime.Tests/Diagnostics/StreamInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/StreamInstrumentsTests.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class StreamInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void StreamInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new StreamInstruments(new OrleansInstruments(meterFactory));
+        using var producersAddedCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.STREAMS_PUBSUB_PRODUCERS_ADDED);
+        using var pullingAgentsCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.STREAMS_PERSISTENT_STREAM_NUM_PULLING_AGENTS);
+        using var readMessagesCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.STREAMS_PERSISTENT_STREAM_NUM_READ_MESSAGES);
+        using var pubSubCacheSizeCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.STREAMS_PERSISTENT_STREAM_PUBSUB_CACHE_SIZE);
+
+        instruments.RegisterPersistentStreamPullingAgentsObserve(() => new Measurement<int>(2));
+        instruments.RegisterPersistentStreamPubSubCacheSizeObserve(() => new Measurement<int>(3));
+        instruments.PubSubProducersAdded.Add(1);
+        instruments.PersistentStreamReadMessages.Add(4);
+
+        pullingAgentsCollector.RecordObservableInstruments();
+        pubSubCacheSizeCollector.RecordObservableInstruments();
+
+        Assert.Equal(1, Assert.Single(producersAddedCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(2, Assert.Single(pullingAgentsCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(4, Assert.Single(readMessagesCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(3, Assert.Single(pubSubCacheSizeCollector.GetMeasurementSnapshot()).Value);
+    }
+}


### PR DESCRIPTION
Part of #9608.

## Problem
`StreamInstruments` created streaming metrics using the global static `Instruments.Meter`, so streaming metrics were not scoped to the DI-provided `IMeterFactory` used by the other migrated instruments.

## Solution
Convert `StreamInstruments` to an instance class backed by `OrleansInstruments`. Register it with silo streaming services and inject it into pub-sub and persistent stream pulling components. Adds a `MetricCollector` BVT covering pub-sub, persistent stream counters, and observable gauges.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10177)