### PR TITLE
chore: use IMeterFactory for MessagingInstruments

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -52,6 +52,7 @@ namespace Orleans
             services.TryAddSingleton<TimeProvider>(TimeProvider.System);
             services.TryAddSingleton<OrleansInstruments>();
             services.TryAddSingleton<ClientInstruments>();
+            services.TryAddSingleton<MessagingInstruments>();
 
             // Options logging
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));

--- a/src/Orleans.Core/Diagnostics/MessagingTrace.cs
+++ b/src/Orleans.Core/Diagnostics/MessagingTrace.cs
@@ -4,9 +4,10 @@ using Orleans.Core.Diagnostics;
 
 namespace Orleans.Runtime;
 
-internal partial class MessagingTrace(ILoggerFactory loggerFactory)
+internal partial class MessagingTrace(ILoggerFactory loggerFactory, MessagingInstruments messagingInstruments)
 {
     protected ILogger Logger { get; } = loggerFactory.CreateLogger(MessagingEvents.ListenerName);
+    protected MessagingInstruments MessagingInstrumentation { get; } = messagingInstruments;
 
     public void OnSendMessage(Message message)
     {
@@ -30,7 +31,7 @@ internal partial class MessagingTrace(ILoggerFactory loggerFactory)
     internal void OnDropExpiredMessage(Message message, MessagingInstruments.Phase phase)
     {
         MessagingEvents.EmitExpired(message, phase);
-        MessagingInstruments.OnMessageExpired(phase);
+        MessagingInstrumentation.OnMessageExpired(phase);
         LogDropExpiredMessage(Logger, message, phase);
     }
 
@@ -43,7 +44,7 @@ internal partial class MessagingTrace(ILoggerFactory loggerFactory)
     internal void OnSiloDropSendingMessage(SiloAddress localSiloAddress, Message message, string reason)
     {
         MessagingEvents.EmitSendingDropped(localSiloAddress, message, reason);
-        MessagingInstruments.OnDroppedSentMessage(message);
+        MessagingInstrumentation.OnDroppedSentMessage(message);
         LogSiloDropSendingMessage(Logger, localSiloAddress, message, reason);
     }
 
@@ -82,7 +83,7 @@ internal partial class MessagingTrace(ILoggerFactory loggerFactory)
 
     public void OnRejectSendMessageToDeadSilo(SiloAddress localSilo, Message message)
     {
-        MessagingInstruments.OnFailedSentMessage(message);
+        MessagingInstrumentation.OnFailedSentMessage(message);
         MessagingEvents.EmitRejectedDeadSilo(localSilo, message);
         LogRejectSendMessageToDeadSilo(
             Logger,

--- a/src/Orleans.Core/Diagnostics/Metrics/MessagingInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/MessagingInstruments.cs
@@ -12,7 +12,7 @@ namespace Orleans.Runtime
         private long _headerBytesSent;
         private long _headerBytesReceived;
 
-        internal MessagingInstruments(OrleansInstruments instruments)
+        public MessagingInstruments(OrleansInstruments instruments)
         {
             HeaderBytesSentCounter = instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_SENT_BYTES_HEADER, () => _headerBytesSent, "bytes");
             HeaderBytesReceivedCounter = instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_RECEIVED_BYTES_HEADER, () => _headerBytesReceived, "bytes");

--- a/src/Orleans.Core/Diagnostics/Metrics/MessagingInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/MessagingInstruments.cs
@@ -7,34 +7,54 @@ using Orleans.Messaging;
 #nullable disable
 namespace Orleans.Runtime
 {
-    internal static class MessagingInstruments
+    internal sealed class MessagingInstruments
     {
-        internal static long _headerBytesSent;
-        internal static long _headerBytesReceived;
-        internal static readonly ObservableCounter<long> HeaderBytesSentCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_SENT_BYTES_HEADER, () => _headerBytesSent, "bytes");
-        internal static readonly ObservableCounter<long> HeaderBytesReceivedCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_RECEIVED_BYTES_HEADER, () => _headerBytesReceived, "bytes");
-        internal static readonly CounterAggregator LocalMessagesSentCounterAggregator = new();
-        private static readonly ObservableCounter<long> LocalMessagesSentCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_SENT_LOCALMESSAGES, LocalMessagesSentCounterAggregator.Collect);
+        private long _headerBytesSent;
+        private long _headerBytesReceived;
 
-        internal static readonly Counter<int> FailedSentMessagesCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_SENT_FAILED);
-        internal static readonly Counter<int> DroppedSentMessagesCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_SENT_DROPPED);
-        internal static readonly Counter<int> RejectedMessagesCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_REJECTED);
-        internal static readonly Counter<int> ReroutedMessagesCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_REROUTED);
-        internal static readonly Counter<int> ExpiredMessagesCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_EXPIRED);
+        internal MessagingInstruments(OrleansInstruments instruments)
+        {
+            HeaderBytesSentCounter = instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_SENT_BYTES_HEADER, () => _headerBytesSent, "bytes");
+            HeaderBytesReceivedCounter = instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_RECEIVED_BYTES_HEADER, () => _headerBytesReceived, "bytes");
+            LocalMessagesSentCounter = instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_SENT_LOCALMESSAGES, LocalMessagesSentCounterAggregator.Collect);
+            FailedSentMessagesCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_SENT_FAILED);
+            DroppedSentMessagesCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_SENT_DROPPED);
+            RejectedMessagesCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_REJECTED);
+            ReroutedMessagesCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_REROUTED);
+            ExpiredMessagesCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_EXPIRED);
+            ConnectedClient = instruments.Meter.CreateUpDownCounter<int>(InstrumentNames.GATEWAY_CONNECTED_CLIENTS);
+            PingSendCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_PINGS_SENT);
+            PingReceivedCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_PINGS_RECEIVED);
+            PingReplyReceivedCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_PINGS_REPLYRECEIVED);
+            PingReplyMissedCounter = instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_PINGS_REPLYMISSED);
+            MessageSentSizeHistogram = instruments.Meter.CreateHistogram<int>(InstrumentNames.MESSAGING_SENT_MESSAGES_SIZE, "bytes");
+            MessageReceivedSizeHistogram = instruments.Meter.CreateHistogram<int>(InstrumentNames.MESSAGING_RECEIVED_MESSAGES_SIZE, "bytes");
+        }
 
-        internal static readonly UpDownCounter<int> ConnectedClient = Instruments.Meter.CreateUpDownCounter<int>(InstrumentNames.GATEWAY_CONNECTED_CLIENTS);
-        internal static readonly Counter<int> PingSendCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_PINGS_SENT);
-        internal static readonly Counter<int> PingReceivedCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_PINGS_RECEIVED);
-        internal static readonly Counter<int> PingReplyReceivedCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_PINGS_REPLYRECEIVED);
-        internal static readonly Counter<int> PingReplyMissedCounter = Instruments.Meter.CreateCounter<int>(InstrumentNames.MESSAGING_PINGS_REPLYMISSED);
+        internal readonly ObservableCounter<long> HeaderBytesSentCounter;
+        internal readonly ObservableCounter<long> HeaderBytesReceivedCounter;
+        internal readonly CounterAggregator LocalMessagesSentCounterAggregator = new();
+        private readonly ObservableCounter<long> LocalMessagesSentCounter;
+
+        internal readonly Counter<int> FailedSentMessagesCounter;
+        internal readonly Counter<int> DroppedSentMessagesCounter;
+        internal readonly Counter<int> RejectedMessagesCounter;
+        internal readonly Counter<int> ReroutedMessagesCounter;
+        internal readonly Counter<int> ExpiredMessagesCounter;
+
+        internal readonly UpDownCounter<int> ConnectedClient;
+        internal readonly Counter<int> PingSendCounter;
+        internal readonly Counter<int> PingReceivedCounter;
+        internal readonly Counter<int> PingReplyReceivedCounter;
+        internal readonly Counter<int> PingReplyMissedCounter;
 
         // currently, bucket size need to be configured at collector side
         // [Add "hints" in Metric API to provide things like histogram bounds]
         // https://github.com/dotnet/runtime/issues/63650
         // Histogram of sent  message size, starting from 0 in multiples of 2
         // (1=2^0, 2=2^2, ... , 256=2^8, 512=2^9, 1024==2^10, ... , up to ... 2^30=1GB)
-        internal static readonly Histogram<int> MessageSentSizeHistogram = Instruments.Meter.CreateHistogram<int>(InstrumentNames.MESSAGING_SENT_MESSAGES_SIZE, "bytes");
-        internal static readonly Histogram<int> MessageReceivedSizeHistogram = Instruments.Meter.CreateHistogram<int>(InstrumentNames.MESSAGING_RECEIVED_MESSAGES_SIZE, "bytes");
+        internal readonly Histogram<int> MessageSentSizeHistogram;
+        internal readonly Histogram<int> MessageReceivedSizeHistogram;
 
         internal enum Phase
         {
@@ -45,55 +65,55 @@ namespace Orleans.Runtime
             Respond,
         }
 
-        internal static void OnMessageExpired(Phase phase)
+        internal void OnMessageExpired(Phase phase)
         {
             ExpiredMessagesCounter.Add(1, new KeyValuePair<string, object>("Phase", phase));
         }
 
-        internal static void OnPingSend(SiloAddress destination)
+        internal void OnPingSend(SiloAddress destination)
         {
             PingSendCounter.Add(1, new KeyValuePair<string, object>("Destination", destination.ToString()));
         }
 
-        internal static void OnPingReceive(SiloAddress destination)
+        internal void OnPingReceive(SiloAddress destination)
         {
             PingReceivedCounter.Add(1, new KeyValuePair<string, object>("Destination", destination.ToString()));
         }
 
-        internal static void OnPingReplyReceived(SiloAddress replier)
+        internal void OnPingReplyReceived(SiloAddress replier)
         {
             PingReplyReceivedCounter.Add(1, new KeyValuePair<string, object>("Destination", replier.ToString()));
         }
 
-        internal static void OnPingReplyMissed(SiloAddress replier)
+        internal void OnPingReplyMissed(SiloAddress replier)
         {
             PingReplyMissedCounter.Add(1, new KeyValuePair<string, object>("Destination", replier.ToString()));
         }
 
-        internal static void OnFailedSentMessage(Message msg)
+        internal void OnFailedSentMessage(Message msg)
         {
             if (msg == null || !msg.HasDirection) return;
             FailedSentMessagesCounter.Add(1, new KeyValuePair<string, object>("Direction", msg.Direction.ToString()));
         }
 
-        internal static void OnDroppedSentMessage(Message msg)
+        internal void OnDroppedSentMessage(Message msg)
         {
             if (msg == null || !msg.HasDirection) return;
             DroppedSentMessagesCounter.Add(1, new KeyValuePair<string, object>("Direction", msg.Direction.ToString()));
         }
 
-        internal static void OnRejectedMessage(Message msg)
+        internal void OnRejectedMessage(Message msg)
         {
             if (msg == null || !msg.HasDirection) return;
             RejectedMessagesCounter.Add(1, new KeyValuePair<string, object>("Direction", msg.Direction.ToString()));
         }
 
-        internal static void OnMessageReRoute(Message msg)
+        internal void OnMessageReRoute(Message msg)
         {
             ReroutedMessagesCounter.Add(1, new KeyValuePair<string, object>("Direction", msg.Direction.ToString()));
         }
 
-        internal static void OnMessageReceive(Message msg, int numTotalBytes, int headerBytes, ConnectionDirection connectionDirection, SiloAddress remoteSiloAddress = null)
+        internal void OnMessageReceive(Message msg, int numTotalBytes, int headerBytes, ConnectionDirection connectionDirection, SiloAddress remoteSiloAddress = null)
         {
             if (MessageReceivedSizeHistogram.Enabled)
             {
@@ -110,7 +130,7 @@ namespace Orleans.Runtime
             Interlocked.Add(ref _headerBytesReceived, headerBytes);
         }
 
-        internal static void OnMessageSend(Message msg, int numTotalBytes, int headerBytes, ConnectionDirection connectionDirection, SiloAddress remoteSiloAddress = null)
+        internal void OnMessageSend(Message msg, int numTotalBytes, int headerBytes, ConnectionDirection connectionDirection, SiloAddress remoteSiloAddress = null)
         {
             Debug.Assert(numTotalBytes >= 0, $"OnMessageSend(numTotalBytes={numTotalBytes})");
 

--- a/src/Orleans.Core/Messaging/ClientMessageCenter.cs
+++ b/src/Orleans.Core/Messaging/ClientMessageCenter.cs
@@ -67,6 +67,7 @@ namespace Orleans.Messaging
         private int numberOfConnectedGateways = 0;
         private readonly MessageFactory messageFactory;
         private readonly IClusterConnectionStatusListener connectionStatusListener;
+        private readonly MessagingInstruments _messagingInstruments;
         private readonly ConnectionManager connectionManager;
         private readonly LocalClientDetails _localClientDetails;
 
@@ -79,9 +80,11 @@ namespace Orleans.Messaging
             ILoggerFactory loggerFactory,
             ConnectionManager connectionManager,
             ClientInstruments clientInstruments,
+            MessagingInstruments messagingInstruments,
             GatewayManager gatewayManager)
         {
             this.connectionManager = connectionManager;
+            _messagingInstruments = messagingInstruments;
             _localClientDetails = localClientDetails;
             this.RuntimeClient = runtimeClient;
             this.messageFactory = messageFactory;
@@ -384,7 +387,7 @@ namespace Orleans.Messaging
             else
             {
                 LogRejectingMessage(msg, reason);
-                MessagingInstruments.OnRejectedMessage(msg);
+                _messagingInstruments.OnRejectedMessage(msg);
                 var error = this.messageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable, reason, exc);
                 DispatchLocalMessage(error);
             }

--- a/src/Orleans.Core/Networking/ClientOutboundConnection.cs
+++ b/src/Orleans.Core/Networking/ClientOutboundConnection.cs
@@ -46,12 +46,12 @@ namespace Orleans.Runtime.Messaging
 
         protected override void RecordMessageReceive(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstruments.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
+            MessagingInstrumentation.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
         }
 
         protected override void RecordMessageSend(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstruments.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
+            MessagingInstrumentation.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
         }
 
         protected override void OnReceivedMessage(Message message)
@@ -140,7 +140,7 @@ namespace Orleans.Runtime.Messaging
 
         internal void SendRejection(Message msg, Message.RejectionTypes rejectionType, string reason)
         {
-            MessagingInstruments.OnRejectedMessage(msg);
+            MessagingInstrumentation.OnRejectedMessage(msg);
             if (string.IsNullOrEmpty(reason)) reason = "Rejection from silo - Unknown reason.";
             var error = this.MessageFactory.CreateRejectionResponse(msg, rejectionType, reason);
 
@@ -150,7 +150,7 @@ namespace Orleans.Runtime.Messaging
 
         public void FailMessage(Message msg, string reason)
         {
-            MessagingInstruments.OnFailedSentMessage(msg);
+            MessagingInstrumentation.OnFailedSentMessage(msg);
             if (msg.Direction == Message.Directions.Request)
             {
                 LogDebugClientIsRejectingMessage(this.Log, msg, reason);
@@ -160,7 +160,7 @@ namespace Orleans.Runtime.Messaging
             else
             {
                 LogInformationClientIsDroppingMessage(this.Log, msg, reason);
-                MessagingInstruments.OnDroppedSentMessage(msg);
+                MessagingInstrumentation.OnDroppedSentMessage(msg);
             }
         }
 

--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -66,6 +66,7 @@ namespace Orleans.Runtime.Messaging
         protected ConnectionContext Context { get; }
         protected ILogger Log => this.shared.Logger;
         protected MessagingTrace MessagingTrace => this.shared.MessagingTrace;
+        protected MessagingInstruments MessagingInstrumentation => this.shared.MessagingInstruments;
         protected abstract ConnectionDirection ConnectionDirection { get; }
         protected MessageFactory MessageFactory => this.shared.MessageFactory;
         protected abstract IMessageCenter MessageCenter { get; }
@@ -442,7 +443,7 @@ namespace Orleans.Runtime.Messaging
             }
 
             // The message body was not successfully decoded, but the headers were.
-            MessagingInstruments.OnRejectedMessage(message);
+            MessagingInstrumentation.OnRejectedMessage(message);
 
             if (message.HasDirection)
             {
@@ -482,7 +483,7 @@ namespace Orleans.Runtime.Messaging
                 return false;
             }
 
-            MessagingInstruments.OnFailedSentMessage(message);
+            MessagingInstrumentation.OnFailedSentMessage(message);
 
             if (message.Direction == Message.Directions.Request)
             {
@@ -509,7 +510,7 @@ namespace Orleans.Runtime.Messaging
                     exception,
                     message);
 
-                MessagingInstruments.OnDroppedSentMessage(message);
+                MessagingInstrumentation.OnDroppedSentMessage(message);
             }
 
             return true;

--- a/src/Orleans.Core/Networking/ConnectionShared.cs
+++ b/src/Orleans.Core/Networking/ConnectionShared.cs
@@ -9,6 +9,7 @@ namespace Orleans.Runtime.Messaging
         MessageFactory messageFactory,
         MessagingTrace messagingTrace,
         OrleansInstruments orleansInstruments,
+        MessagingInstruments messagingInstruments,
         ILogger<Connection> logger,
         IMessageStatisticsSink messageStatisticsSink)
     {
@@ -18,5 +19,6 @@ namespace Orleans.Runtime.Messaging
         public ILogger<Connection> Logger { get; } = logger;
         public IMessageStatisticsSink MessageStatisticsSink { get; } = messageStatisticsSink;
         public MessagingTrace MessagingTrace { get; } = messagingTrace;
+        public MessagingInstruments MessagingInstruments { get; } = messagingInstruments;
     }
 }

--- a/src/Orleans.Core/Statistics/SiloRuntimeMetricsListener.cs
+++ b/src/Orleans.Core/Statistics/SiloRuntimeMetricsListener.cs
@@ -31,11 +31,6 @@ public static class SiloRuntimeMetricsListener
     {
         MeterListener.InstrumentPublished = (instrument, listener) =>
         {
-            if (instrument.Meter != Instruments.Meter)
-            {
-                return;
-            }
-
             if (MetricNames.Contains(instrument.Name))
             {
                 listener.EnableMeasurementEvents(instrument);
@@ -51,15 +46,15 @@ public static class SiloRuntimeMetricsListener
 
     private static void OnMeasurementRecorded(Instrument instrument, int measurement, ReadOnlySpan<KeyValuePair<string, object>> tags, object state)
     {
-        if (instrument == MessagingInstruments.ConnectedClient)
+        if (instrument.Name == InstrumentNames.GATEWAY_CONNECTED_CLIENTS)
         {
             Interlocked.Add(ref _connectedClientCount, measurement);
         }
-        if (instrument == MessagingInstruments.MessageReceivedSizeHistogram)
+        if (instrument.Name == InstrumentNames.MESSAGING_RECEIVED_MESSAGES_SIZE)
         {
             Interlocked.Add(ref _messageReceivedTotal, measurement);
         }
-        if (instrument == MessagingInstruments.MessageSentSizeHistogram)
+        if (instrument.Name == InstrumentNames.MESSAGING_SENT_MESSAGES_SIZE)
         {
             Interlocked.Add(ref _messageSentTotal, measurement);
         }

--- a/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
+++ b/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
@@ -17,7 +17,8 @@ internal sealed class SystemTargetShared(
     ITimerRegistry timerRegistry,
     ActivationDirectory activations,
     SchedulerInstruments schedulerInstruments,
-    GrainInstruments grainInstruments)
+    GrainInstruments grainInstruments,
+    MessagingInstruments messagingInstruments)
 {
     public SiloAddress SiloAddress => localSiloDetails.SiloAddress;
 
@@ -26,7 +27,7 @@ internal sealed class SystemTargetShared(
     public GrainReferenceActivator GrainReferenceActivator => grainReferenceActivator;
     public ITimerRegistry TimerRegistry => timerRegistry;
 
-    public RuntimeMessagingTrace MessagingTrace { get; } = new(loggerFactory);
+    public RuntimeMessagingTrace MessagingTrace { get; } = new(loggerFactory, messagingInstruments);
     public InsideRuntimeClient RuntimeClient => runtimeClient;
     public ActivationDirectory ActivationDirectory => activations;
     public GrainInstruments GrainInstruments => grainInstruments;

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -72,6 +72,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<CatalogInstruments>();
             services.TryAddSingleton<DirectoryInstruments>();
             services.TryAddSingleton<GrainInstruments>();
+            services.TryAddSingleton<MessagingInstruments>();
 
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));

--- a/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipSystemTarget.cs
@@ -13,17 +13,20 @@ namespace Orleans.Runtime.MembershipService
         private readonly IMembershipManager membershipManager;
         private readonly ILogger<MembershipSystemTarget> log;
         private readonly IInternalGrainFactory grainFactory;
+        private readonly MessagingInstruments _messagingInstruments;
 
         public MembershipSystemTarget(
             IMembershipManager membershipManager,
             ILogger<MembershipSystemTarget> log,
             IInternalGrainFactory grainFactory,
+            MessagingInstruments messagingInstruments,
             SystemTargetShared shared)
             : base(Constants.MembershipServiceType, shared)
         {
             this.membershipManager = membershipManager;
             this.log = log;
             this.grainFactory = grainFactory;
+            _messagingInstruments = messagingInstruments;
             shared.ActivationDirectory.RecordNewTarget(this);
         }
 
@@ -173,7 +176,7 @@ namespace Orleans.Runtime.MembershipService
                 task = remoteOracle.Ping(probeNumber);
 
                 // Update stats counter. Only count Pings that were successfully sent, but not necessarily replied to.
-                MessagingInstruments.OnPingSend(remoteSilo);
+                _messagingInstruments.OnPingSend(remoteSilo);
             }
             finally
             {

--- a/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
+++ b/src/Orleans.Runtime/MembershipService/SiloHealthMonitor.cs
@@ -23,6 +23,7 @@ namespace Orleans.Runtime.MembershipService
         private readonly IRemoteSiloProber _prober;
         private readonly ILocalSiloHealthMonitor _localSiloHealthMonitor;
         private readonly IMembershipManager _membershipService;
+        private readonly MessagingInstruments? _messagingInstruments;
         private readonly ILocalSiloDetails _localSiloDetails;
         private readonly CancellationTokenSource _stoppingCancellation = new();
 #if NET9_0_OR_GREATER
@@ -64,13 +65,15 @@ namespace Orleans.Runtime.MembershipService
             IAsyncTimerFactory asyncTimerFactory,
             ILocalSiloHealthMonitor localSiloHealthMonitor,
             IMembershipManager membershipService,
-            ILocalSiloDetails localSiloDetails)
+            ILocalSiloDetails localSiloDetails,
+            MessagingInstruments? messagingInstruments = null)
         {
             TargetSiloAddress = siloAddress;
             _clusterMembershipOptions = clusterMembershipOptions;
             _prober = remoteSiloProber;
             _localSiloHealthMonitor = localSiloHealthMonitor;
             _membershipService = membershipService;
+            _messagingInstruments = messagingInstruments;
             _localSiloDetails = localSiloDetails;
             _log = loggerFactory.CreateLogger<SiloHealthMonitor>();
             _pingTimer = asyncTimerFactory.Create(
@@ -284,7 +287,7 @@ namespace Orleans.Runtime.MembershipService
 
             if (failureException is null)
             {
-                MessagingInstruments.OnPingReplyReceived(TargetSiloAddress);
+                _messagingInstruments?.OnPingReplyReceived(TargetSiloAddress);
 
                 LogTraceGotSuccessfulPingResponse(_log, id, TargetSiloAddress, roundTripTimer.Elapsed);
 
@@ -295,7 +298,7 @@ namespace Orleans.Runtime.MembershipService
             }
             else
             {
-                MessagingInstruments.OnPingReplyMissed(TargetSiloAddress);
+                _messagingInstruments?.OnPingReplyMissed(TargetSiloAddress);
 
                 var failedProbes = ++_failedProbes;
                 LogWarningDidNotGetResponseForProbe(_log, failureException, id, TargetSiloAddress, roundTripTimer.Elapsed, failedProbes);
@@ -335,14 +338,14 @@ namespace Orleans.Runtime.MembershipService
                 {
                     LogInformationIndirectProbeSucceeded(_log, id, TargetSiloAddress, intermediary, roundTripTimer.Elapsed, indirectResult.ProbeResponseTime);
 
-                    MessagingInstruments.OnPingReplyReceived(TargetSiloAddress);
+                    _messagingInstruments?.OnPingReplyReceived(TargetSiloAddress);
 
                     _failedProbes = 0;
                     probeResult = ProbeResult.CreateIndirect(0, ProbeResultStatus.Succeeded, indirectResult, intermediary);
                 }
                 else
                 {
-                    MessagingInstruments.OnPingReplyMissed(TargetSiloAddress);
+                    _messagingInstruments?.OnPingReplyMissed(TargetSiloAddress);
 
                     if (indirectResult.IntermediaryHealthScore > 0)
                     {
@@ -360,7 +363,7 @@ namespace Orleans.Runtime.MembershipService
             }
             catch (Exception exception)
             {
-                MessagingInstruments.OnPingReplyMissed(TargetSiloAddress);
+                _messagingInstruments?.OnPingReplyMissed(TargetSiloAddress);
                 LogWarningIndirectProbeRequestFailed(_log, exception);
                 probeResult = ProbeResult.CreateIndirect(_failedProbes, ProbeResultStatus.Unknown, default, intermediary);
             }

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -29,6 +29,7 @@ namespace Orleans.Runtime.Messaging
 
         private readonly ClientsReplyRoutingCache clientsReplyRoutingCache;
         private readonly MessageCenter messageCenter;
+        private readonly MessagingInstruments _messagingInstruments;
 
         private readonly ILogger logger;
         private readonly ILoggerFactory loggerFactory;
@@ -42,9 +43,11 @@ namespace Orleans.Runtime.Messaging
             ILoggerFactory loggerFactory,
             IOptions<SiloMessagingOptions> options,
             IAsyncTimerFactory timerFactory,
-            OrleansInstruments orleansInstruments)
+            OrleansInstruments orleansInstruments,
+            MessagingInstruments messagingInstruments)
         {
             this.messageCenter = messageCenter;
+            _messagingInstruments = messagingInstruments;
             this.messagingOptions = options.Value;
             this.loggerFactory = loggerFactory;
             this.logger = this.loggerFactory.CreateLogger<Gateway>();
@@ -143,7 +146,7 @@ namespace Orleans.Runtime.Messaging
                 {
                     clientState = new ClientState(this, clientId);
                     clients[clientId] = clientState;
-                    MessagingInstruments.ConnectedClient.Add(1);
+                    _messagingInstruments.ConnectedClient.Add(1);
                 }
                 clientState.RecordConnection(connection);
                 clientConnections[connection] = clientState;
@@ -240,7 +243,7 @@ namespace Orleans.Runtime.Messaging
                             }
 
                             clientsCollectionVersion++;
-                            MessagingInstruments.ConnectedClient.Add(-1);
+                            _messagingInstruments.ConnectedClient.Add(-1);
                         }
                     }
                 }

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -19,6 +19,7 @@ namespace Orleans.Runtime.Messaging
         private readonly MessageFactory messageFactory;
         private readonly ConnectionManager connectionManager;
         private readonly RuntimeMessagingTrace messagingTrace;
+        private readonly MessagingInstruments _messagingInstruments;
         private readonly SiloAddress _siloAddress;
         private readonly SiloMessagingOptions messagingOptions;
         private readonly PlacementService placementService;
@@ -39,6 +40,7 @@ namespace Orleans.Runtime.Messaging
             ISiloStatusOracle siloStatusOracle,
             ConnectionManager senderManager,
             RuntimeMessagingTrace messagingTrace,
+            MessagingInstruments messagingInstruments,
             IOptions<SiloMessagingOptions> messagingOptions,
             PlacementService placementService,
             GrainLocator grainLocator,
@@ -49,6 +51,7 @@ namespace Orleans.Runtime.Messaging
             this.siloStatusOracle = siloStatusOracle;
             this.connectionManager = senderManager;
             this.messagingTrace = messagingTrace;
+            _messagingInstruments = messagingInstruments;
             this.placementService = placementService;
             _grainLocator = grainLocator;
             _messageObserver = messageStatisticsSink.GetMessageObserver();
@@ -194,7 +197,7 @@ namespace Orleans.Runtime.Messaging
                 {
                     LogTraceMessageLoopedBack(log, msg);
 
-                    MessagingInstruments.LocalMessagesSentCounterAggregator.Add(1);
+                    _messagingInstruments.LocalMessagesSentCounterAggregator.Add(1);
 
                     this.ReceiveMessage(msg, receiverCache);
                 }
@@ -570,7 +573,7 @@ namespace Orleans.Runtime.Messaging
             var target = msg.TargetGrain;
             if (target.IsSystemTarget())
             {
-                MessagingInstruments.OnRejectedMessage(msg);
+                _messagingInstruments.OnRejectedMessage(msg);
                 LogWarningUnknownSystemTarget(log, msg, msg.TargetGrain);
 
                 // Send a rejection only on a request
@@ -596,12 +599,12 @@ namespace Orleans.Runtime.Messaging
 
         internal void SendRejection(Message msg, Message.RejectionTypes rejectionType, string reason, Exception? exception = null)
         {
-            MessagingInstruments.OnRejectedMessage(msg);
+            _messagingInstruments.OnRejectedMessage(msg);
 
             if (msg.Direction is Message.Directions.Response && msg.Result is Message.ResponseTypes.Rejection)
             {
                 // Do not send reject a rejection locally, it will create a stack overflow
-                MessagingInstruments.OnDroppedSentMessage(msg);
+                _messagingInstruments.OnDroppedSentMessage(msg);
                 LogDebugDroppingRejection(log, msg);
             }
             else

--- a/src/Orleans.Runtime/Messaging/RuntimeMessagingTrace.cs
+++ b/src/Orleans.Runtime/Messaging/RuntimeMessagingTrace.cs
@@ -3,7 +3,7 @@ using Orleans.Runtime.Diagnostics;
 
 namespace Orleans.Runtime;
 
-internal sealed partial class RuntimeMessagingTrace(ILoggerFactory loggerFactory) : MessagingTrace(loggerFactory)
+internal sealed partial class RuntimeMessagingTrace(ILoggerFactory loggerFactory, MessagingInstruments messagingInstruments) : MessagingTrace(loggerFactory, messagingInstruments)
 {
     internal void OnDispatcherReceiveInvalidActivation(Message message, ActivationState activationState)
     {
@@ -27,7 +27,7 @@ internal sealed partial class RuntimeMessagingTrace(ILoggerFactory loggerFactory
     internal void OnDispatcherRejectMessage(Message message, Message.RejectionTypes rejectionType, string? reason, Exception? exception)
     {
         DispatcherEvents.EmitRejected(message, rejectionType, reason, exception);
-        MessagingInstruments.OnRejectedMessage(message);
+        MessagingInstrumentation.OnRejectedMessage(message);
         LogDispatcherRejectedMessage(Logger, message, new RejectionReasonLogRecord(reason), rejectionType, exception);
     }
 

--- a/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
+++ b/src/Orleans.Runtime/Networking/GatewayInboundConnection.cs
@@ -49,13 +49,13 @@ namespace Orleans.Runtime.Messaging
 
         protected override void RecordMessageReceive(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstruments.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection);
+            MessagingInstrumentation.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection);
             this.gatewayInstruments.OnGatewayReceived();
         }
 
         protected override void RecordMessageSend(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstruments.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection);
+            MessagingInstrumentation.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection);
             this.gatewayInstruments.OnGatewaySent();
         }
 
@@ -71,7 +71,7 @@ namespace Orleans.Runtime.Messaging
             // Are we overloaded?
             if (this.overloadDetector.IsOverloaded)
             {
-                MessagingInstruments.OnRejectedMessage(msg);
+                MessagingInstrumentation.OnRejectedMessage(msg);
                 Message rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.GatewayTooBusy, "Shedding load");
                 this.messageCenter.TryDeliverToProxy(rejection, targetCache: null);
                 LogRejectingRequestDueToOverloading(this.Log, msg);
@@ -92,7 +92,7 @@ namespace Orleans.Runtime.Messaging
                     msg.TargetGrain = systemTargetId.WithSiloAddress(this.myAddress).GrainId;
                 }
 
-                MessagingInstruments.OnMessageReRoute(msg);
+                MessagingInstrumentation.OnMessageReRoute(msg);
                 this.messageCenter.RerouteMessage(msg);
             }
             else
@@ -161,7 +161,7 @@ namespace Orleans.Runtime.Messaging
 
         public void FailMessage(Message msg, string reason)
         {
-            MessagingInstruments.OnFailedSentMessage(msg);
+            MessagingInstrumentation.OnFailedSentMessage(msg);
             if (msg.Direction == Message.Directions.Request)
             {
                 LogSiloRejectingMessage(this.Log, this.myAddress, msg, reason);
@@ -176,7 +176,7 @@ namespace Orleans.Runtime.Messaging
             else
             {
                 LogSiloDroppingMessage(this.Log, this.myAddress, msg, reason);
-                MessagingInstruments.OnDroppedSentMessage(msg);
+                MessagingInstrumentation.OnDroppedSentMessage(msg);
             }
         }
 

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -57,12 +57,12 @@ namespace Orleans.Runtime.Messaging
 
         protected override void RecordMessageReceive(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstruments.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
+            MessagingInstrumentation.OnMessageReceive(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
         }
 
         protected override void RecordMessageSend(Message msg, int numTotalBytes, int headerBytes)
         {
-            MessagingInstruments.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
+            MessagingInstrumentation.OnMessageSend(msg, numTotalBytes, headerBytes, ConnectionDirection, RemoteSiloAddress);
         }
 
         protected override void OnReceivedMessage(Message msg)
@@ -95,7 +95,7 @@ namespace Orleans.Runtime.Messaging
                     return;
                 }
 
-                MessagingInstruments.OnRejectedMessage(msg);
+                MessagingInstrumentation.OnRejectedMessage(msg);
                 var rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable, "Silo stopping", new SiloUnavailableException());
                 this.Send(rejection);
                 return;
@@ -121,7 +121,7 @@ namespace Orleans.Runtime.Messaging
             // (if it was a request), or drop it on the floor if it was a response or one-way.
             if (msg.Direction == Message.Directions.Request)
             {
-                MessagingInstruments.OnRejectedMessage(msg);
+                MessagingInstrumentation.OnRejectedMessage(msg);
                 var rejection = this.MessageFactory.CreateRejectionResponse(
                     msg,
                     Message.RejectionTypes.Transient,
@@ -141,7 +141,7 @@ namespace Orleans.Runtime.Messaging
 
         private void HandlePingMessage(Message msg)
         {
-            MessagingInstruments.OnPingReceive(msg.SendingSilo);
+            MessagingInstrumentation.OnPingReceive(msg.SendingSilo);
 
             var objectId = RuntimeHelpers.GetHashCode(msg);
             LogTraceRespondingToPing(this.Log, msg.SendingSilo!, objectId, msg);
@@ -149,7 +149,7 @@ namespace Orleans.Runtime.Messaging
             if (!this.LocalSiloAddress.Equals(msg.TargetSilo))
             {
                 // Got ping that is not destined to me. For example, got a ping to my older incarnation.
-                MessagingInstruments.OnRejectedMessage(msg);
+                MessagingInstrumentation.OnRejectedMessage(msg);
                 Message rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable,
                     $"The target silo is no longer active: target was {msg.TargetSilo}, but this silo is {LocalSiloAddress}. The rejected ping message is {msg}.");
                 this.Send(rejection);
@@ -266,7 +266,7 @@ namespace Orleans.Runtime.Messaging
                 LogWarningFailedPingMessage(this.Log, msg);
             }
 
-            MessagingInstruments.OnFailedSentMessage(msg);
+            MessagingInstrumentation.OnFailedSentMessage(msg);
             if (msg.Direction == Message.Directions.Request)
             {
                 LogDebugSiloRejectingMessage(this.Log, this.LocalSiloAddress, msg, reason);

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -160,7 +160,8 @@ namespace UnitTests.Directory
                 timerRegistry: null,
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments(),
-                grainInstruments: CreateGrainInstruments());
+                grainInstruments: CreateGrainInstruments(),
+                messagingInstruments: CreateMessagingInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -214,7 +215,8 @@ namespace UnitTests.Directory
                 timerRegistry: null,
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments(),
-                grainInstruments: CreateGrainInstruments());
+                grainInstruments: CreateGrainInstruments(),
+                messagingInstruments: CreateMessagingInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -280,7 +282,8 @@ namespace UnitTests.Directory
                 timerRegistry: null,
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments(),
-                grainInstruments: CreateGrainInstruments());
+                grainInstruments: CreateGrainInstruments(),
+                messagingInstruments: CreateMessagingInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -860,6 +863,15 @@ namespace UnitTests.Directory
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<GrainInstruments>();
             return services.BuildServiceProvider().GetRequiredService<GrainInstruments>();
+        }
+
+        private static MessagingInstruments CreateMessagingInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<MessagingInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<MessagingInstruments>();
         }
 
         private int generation = 0;

--- a/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
@@ -82,7 +82,8 @@ namespace NonSilo.Tests.Directory
                 timerRegistry: null,
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments(),
-                grainInstruments: CreateGrainInstruments());
+                grainInstruments: CreateGrainInstruments(),
+                messagingInstruments: CreateMessagingInstruments());
 
             _directory = new ClientDirectory(
                 grainFactory: _grainFactory,
@@ -124,6 +125,15 @@ namespace NonSilo.Tests.Directory
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<GrainInstruments>();
             return services.BuildServiceProvider().GetRequiredService<GrainInstruments>();
+        }
+
+        private static MessagingInstruments CreateMessagingInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<MessagingInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<MessagingInstruments>();
         }
 
         /// <summary>

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -611,7 +611,8 @@ public class LocalDurableJobManagerTests
         timerRegistry: null!,
         activations: new ActivationDirectory(CreateCatalogInstruments()),
         schedulerInstruments: CreateSchedulerInstruments(),
-        grainInstruments: CreateGrainInstruments());
+        grainInstruments: CreateGrainInstruments(),
+        messagingInstruments: CreateMessagingInstruments());
 
     private static SchedulerInstruments CreateSchedulerInstruments()
     {        var services = new ServiceCollection();
@@ -637,6 +638,15 @@ public class LocalDurableJobManagerTests
         services.AddSingleton<OrleansInstruments>();
         services.AddSingleton<GrainInstruments>();
         return services.BuildServiceProvider().GetRequiredService<GrainInstruments>();
+    }
+
+    private static MessagingInstruments CreateMessagingInstruments()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton<MessagingInstruments>();
+        return services.BuildServiceProvider().GetRequiredService<MessagingInstruments>();
     }
 
     private static IJobShard CreateSubstituteShard(string id, DateTimeOffset start, DateTimeOffset end)

--- a/test/Orleans.Runtime.Internal.Tests/Diagnostics/DispatcherEventsTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Diagnostics/DispatcherEventsTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Net;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using TestExtensions;
 using Xunit;
@@ -14,7 +15,7 @@ public class DispatcherEventsTests
     public void RuntimeMessagingTrace_OnDispatcherRejectMessage_EmitsRejected()
     {
         using var observer = new Observer(DispatcherEvents.AllEvents);
-        var trace = new RuntimeMessagingTrace(NullLoggerFactory.Instance);
+        var trace = new RuntimeMessagingTrace(NullLoggerFactory.Instance, CreateMessagingInstruments());
         var message = new Message();
         var exception = new InvalidOperationException("boom");
 
@@ -30,7 +31,7 @@ public class DispatcherEventsTests
     public void RuntimeMessagingTrace_OnDispatcherForwardingMultiple_EmitsForwardingMultiple()
     {
         using var observer = new Observer(DispatcherEvents.AllEvents);
-        var trace = new RuntimeMessagingTrace(NullLoggerFactory.Instance);
+        var trace = new RuntimeMessagingTrace(NullLoggerFactory.Instance, CreateMessagingInstruments());
         var oldAddress = new GrainAddress
         {
             GrainId = GrainId.Create("test", "grain"),
@@ -71,5 +72,14 @@ public class DispatcherEventsTests
         }
 
         public void OnNext(DispatcherEvents.DispatcherEvent value) => _events.Enqueue(value);
+    }
+
+    private static MessagingInstruments CreateMessagingInstruments()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton<MessagingInstruments>();
+        return services.BuildServiceProvider().GetRequiredService<MessagingInstruments>();
     }
 }

--- a/test/Orleans.Runtime.Tests/Diagnostics/MessagingInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/MessagingInstrumentsTests.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Messaging;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class MessagingInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void MessagingInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new MessagingInstruments(new OrleansInstruments(meterFactory));
+        using var rejectedCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.MESSAGING_REJECTED);
+        using var expiredCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.MESSAGING_EXPIRED);
+        using var sentSizeCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.MESSAGING_SENT_MESSAGES_SIZE);
+        using var receivedSizeCollector = new MetricCollector<int>(meterFactory, "Microsoft.Orleans", InstrumentNames.MESSAGING_RECEIVED_MESSAGES_SIZE);
+        using var sentHeaderCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", InstrumentNames.MESSAGING_SENT_BYTES_HEADER);
+        using var receivedHeaderCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", InstrumentNames.MESSAGING_RECEIVED_BYTES_HEADER);
+
+        var message = new Message { Direction = Message.Directions.Request };
+
+        instruments.OnRejectedMessage(message);
+        instruments.OnMessageExpired(MessagingInstruments.Phase.Send);
+        instruments.OnMessageSend(message, numTotalBytes: 12, headerBytes: 5, ConnectionDirection.SiloToSilo);
+        instruments.OnMessageReceive(message, numTotalBytes: 17, headerBytes: 7, ConnectionDirection.SiloToSilo);
+
+        sentHeaderCollector.RecordObservableInstruments();
+        receivedHeaderCollector.RecordObservableInstruments();
+
+        Assert.Equal(1, Assert.Single(rejectedCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(expiredCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(12, Assert.Single(sentSizeCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(17, Assert.Single(receivedSizeCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(5, Assert.Single(sentHeaderCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(7, Assert.Single(receivedHeaderCollector.GetMeasurementSnapshot()).Value);
+    }
+}

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -169,7 +169,8 @@ namespace UnitTests.StreamingTests
                 timerRegistry: timerRegistry,
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments(),
-                grainInstruments: CreateGrainInstruments());
+                grainInstruments: CreateGrainInstruments(),
+                messagingInstruments: CreateMessagingInstruments());
 
             receiver ??= Substitute.For<IQueueAdapterReceiver>();
             receiver.Initialize(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
@@ -221,6 +222,15 @@ namespace UnitTests.StreamingTests
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<GrainInstruments>();
             return services.BuildServiceProvider().GetRequiredService<GrainInstruments>();
+        }
+
+        private static MessagingInstruments CreateMessagingInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<MessagingInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<MessagingInstruments>();
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]


### PR DESCRIPTION
Part of #9608.

## Problem
`MessagingInstruments` created messaging metrics using the global static `Instruments.Meter`, so messaging metrics were not scoped to the DI-provided `IMeterFactory` used by the other migrated instruments.

## Solution
Convert `MessagingInstruments` to an instance class backed by `OrleansInstruments`. Register it with client and silo services and route messaging components through the DI singleton. `SiloRuntimeMetricsListener` now matches messaging instruments by instrument name instead of the old static meter/instrument identity. Adds a `MetricCollector` BVT covering rejected/expired messages, send/receive histograms, and header-byte observable counters.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10179)