### PR TITLE
chore: use IMeterFactory for MessagingProcessingInstruments

### DIFF
--- a/src/Orleans.Core/Core/DefaultClientServices.cs
+++ b/src/Orleans.Core/Core/DefaultClientServices.cs
@@ -53,6 +53,7 @@ namespace Orleans
             services.TryAddSingleton<OrleansInstruments>();
             services.TryAddSingleton<ClientInstruments>();
             services.TryAddSingleton<MessagingInstruments>();
+            services.TryAddSingleton<MessagingProcessingInstruments>();
 
             // Options logging
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));

--- a/src/Orleans.Core/Diagnostics/MessagingTrace.cs
+++ b/src/Orleans.Core/Diagnostics/MessagingTrace.cs
@@ -4,10 +4,11 @@ using Orleans.Core.Diagnostics;
 
 namespace Orleans.Runtime;
 
-internal partial class MessagingTrace(ILoggerFactory loggerFactory, MessagingInstruments messagingInstruments)
+internal partial class MessagingTrace(ILoggerFactory loggerFactory, MessagingInstruments messagingInstruments, MessagingProcessingInstruments messagingProcessingInstruments)
 {
     protected ILogger Logger { get; } = loggerFactory.CreateLogger(MessagingEvents.ListenerName);
     protected MessagingInstruments MessagingInstrumentation { get; } = messagingInstruments;
+    protected MessagingProcessingInstruments MessagingProcessingInstrumentation { get; } = messagingProcessingInstruments;
 
     public void OnSendMessage(Message message)
     {
@@ -18,14 +19,14 @@ internal partial class MessagingTrace(ILoggerFactory loggerFactory, MessagingIns
     {
         MessagingEvents.EmitReceivedByIncomingAgent(message);
         OrleansIncomingMessageAgentEvent.Log.ReceiveMessage(message);
-        MessagingProcessingInstruments.OnImaMessageReceived(message);
+        MessagingProcessingInstrumentation.OnImaMessageReceived(message);
     }
 
     public void OnDispatcherReceiveMessage(Message message)
     {
         MessagingEvents.EmitReceivedByDispatcher(message);
         OrleansDispatcherEvent.Instance.ReceiveMessage(message);
-        MessagingProcessingInstruments.OnDispatcherMessageReceive(message);
+        MessagingProcessingInstrumentation.OnDispatcherMessageReceive(message);
     }
 
     internal void OnDropExpiredMessage(Message message, MessagingInstruments.Phase phase)
@@ -73,7 +74,7 @@ internal partial class MessagingTrace(ILoggerFactory loggerFactory, MessagingIns
     public void OnEnqueueMessageOnActivation(Message message, IGrainContext context)
     {
         MessagingEvents.EmitEnqueuedOnActivation(message, context);
-        MessagingProcessingInstruments.OnImaMessageEnqueued(context);
+        MessagingProcessingInstrumentation.OnImaMessageEnqueued(context);
     }
 
     public void OnInvokeMessage(Message message)

--- a/src/Orleans.Core/Diagnostics/Metrics/MessagingProcessingInstruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/MessagingProcessingInstruments.cs
@@ -4,97 +4,106 @@ using System.Diagnostics.Metrics;
 #nullable disable
 namespace Orleans.Runtime;
 
-internal static class MessagingProcessingInstruments
+internal sealed class MessagingProcessingInstruments
 {
-    private static readonly CounterAggregatorGroup DispatcherMessagesProcessedCounterAggregatorGroup = new();
-    private static readonly ObservableCounter<long> DispatcherMessagesProcessedCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_DISPATCHER_PROCESSED, DispatcherMessagesProcessedCounterAggregatorGroup.Collect);
+    private readonly Meter _meter;
+    private readonly CounterAggregatorGroup _dispatcherMessagesProcessedCounterAggregatorGroup = new();
+    private readonly ObservableCounter<long> _dispatcherMessagesProcessedCounter;
 
-    private static readonly CounterAggregatorGroup DispatcherMessagesReceivedCounterAggregatorGroup = new();
-    private static readonly ObservableCounter<long> DispatcherMessagesReceivedCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_DISPATCHER_RECEIVED, DispatcherMessagesReceivedCounterAggregatorGroup.Collect);
+    private readonly CounterAggregatorGroup _dispatcherMessagesReceivedCounterAggregatorGroup = new();
+    private readonly ObservableCounter<long> _dispatcherMessagesReceivedCounter;
 
-    private static readonly CounterAggregator DispatcherMessagesForwardedCounterAggregator = new();
-    private static readonly ObservableCounter<long> DispatcherMessagesForwardedCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_DISPATCHER_FORWARDED, DispatcherMessagesForwardedCounterAggregator.Collect);
-    private static readonly CounterAggregator ImaReceivedCounterAggregator = new();
-    private static readonly ObservableCounter<long> ImaReceivedCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_IMA_RECEIVED, ImaReceivedCounterAggregator.Collect);
-    private static readonly CounterAggregatorGroup ImaEnqueuedCounterAggregatorGroup = new();
-    private static readonly ObservableCounter<long> ImaEnqueuedCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_IMA_ENQUEUED, ImaEnqueuedCounterAggregatorGroup.Collect);
-    private static readonly CounterAggregator ImaMessageEnqueuedNullContext;
-    private static readonly CounterAggregator ImaMessageEnqueuedSystemTarget;
-    private static readonly CounterAggregator ImaMessageEnqueuedGrain;
-    private static readonly CounterAggregator[] DispatcherMessagesReceivedCounters_NullContext;
-    private static readonly CounterAggregator[] DispatcherMessagesReceivedCounters_Grain;
+    private readonly CounterAggregator _dispatcherMessagesForwardedCounterAggregator = new();
+    private readonly ObservableCounter<long> _dispatcherMessagesForwardedCounter;
+    private readonly CounterAggregator _imaReceivedCounterAggregator = new();
+    private readonly ObservableCounter<long> _imaReceivedCounter;
+    private readonly CounterAggregatorGroup _imaEnqueuedCounterAggregatorGroup = new();
+    private readonly ObservableCounter<long> _imaEnqueuedCounter;
+    private readonly CounterAggregator _imaMessageEnqueuedNullContext;
+    private readonly CounterAggregator _imaMessageEnqueuedSystemTarget;
+    private readonly CounterAggregator _imaMessageEnqueuedGrain;
+    private readonly CounterAggregator[] _dispatcherMessagesReceivedCountersNullContext;
+    private readonly CounterAggregator[] _dispatcherMessagesReceivedCountersGrain;
 
-    private static readonly CounterAggregator[] DispatcherMessagesProcessedCounters_Ok;
-    private static readonly CounterAggregator[] DispatcherMessagesProcessedCounters_Error;
+    private readonly CounterAggregator[] _dispatcherMessagesProcessedCountersOk;
+    private readonly CounterAggregator[] _dispatcherMessagesProcessedCountersError;
+    private ObservableGauge<long> _activationDataAll;
 
-    static MessagingProcessingInstruments()
+    public MessagingProcessingInstruments(OrleansInstruments instruments)
     {
-        ImaMessageEnqueuedNullContext = ImaEnqueuedCounterAggregatorGroup.FindOrCreate(new("Context", "ToNull"));
-        ImaMessageEnqueuedSystemTarget = ImaEnqueuedCounterAggregatorGroup.FindOrCreate(new("Context", "ToSystemTarget"));
-        ImaMessageEnqueuedGrain = ImaEnqueuedCounterAggregatorGroup.FindOrCreate(new("Context", "ToGrain"));
+        _meter = instruments.Meter;
+        _dispatcherMessagesProcessedCounter = _meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_DISPATCHER_PROCESSED, _dispatcherMessagesProcessedCounterAggregatorGroup.Collect);
+        _dispatcherMessagesReceivedCounter = _meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_DISPATCHER_RECEIVED, _dispatcherMessagesReceivedCounterAggregatorGroup.Collect);
+        _dispatcherMessagesForwardedCounter = _meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_DISPATCHER_FORWARDED, _dispatcherMessagesForwardedCounterAggregator.Collect);
+        _imaReceivedCounter = _meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_IMA_RECEIVED, _imaReceivedCounterAggregator.Collect);
+        _imaEnqueuedCounter = _meter.CreateObservableCounter<long>(InstrumentNames.MESSAGING_IMA_ENQUEUED, _imaEnqueuedCounterAggregatorGroup.Collect);
+
+        _imaMessageEnqueuedNullContext = _imaEnqueuedCounterAggregatorGroup.FindOrCreate(new("Context", "ToNull"));
+        _imaMessageEnqueuedSystemTarget = _imaEnqueuedCounterAggregatorGroup.FindOrCreate(new("Context", "ToSystemTarget"));
+        _imaMessageEnqueuedGrain = _imaEnqueuedCounterAggregatorGroup.FindOrCreate(new("Context", "ToGrain"));
         var directionEnumValues = Enum.GetValues<Message.Directions>();
-        DispatcherMessagesReceivedCounters_NullContext = new CounterAggregator[directionEnumValues.Length + 1];
-        DispatcherMessagesReceivedCounters_Grain = new CounterAggregator[directionEnumValues.Length + 1];
-        DispatcherMessagesProcessedCounters_Ok = new CounterAggregator[directionEnumValues.Length + 1];
-        DispatcherMessagesProcessedCounters_Error = new CounterAggregator[directionEnumValues.Length + 1];
+        _dispatcherMessagesReceivedCountersNullContext = new CounterAggregator[directionEnumValues.Length + 1];
+        _dispatcherMessagesReceivedCountersGrain = new CounterAggregator[directionEnumValues.Length + 1];
+        _dispatcherMessagesProcessedCountersOk = new CounterAggregator[directionEnumValues.Length + 1];
+        _dispatcherMessagesProcessedCountersError = new CounterAggregator[directionEnumValues.Length + 1];
         foreach (var value in directionEnumValues)
         {
-            DispatcherMessagesReceivedCounters_NullContext[(int)value] = DispatcherMessagesReceivedCounterAggregatorGroup.FindOrCreate(new("Context", "None", "Direction", value.ToString()));
-            DispatcherMessagesReceivedCounters_Grain[(int)value] = DispatcherMessagesReceivedCounterAggregatorGroup.FindOrCreate(new("Context", "Grain", "Direction", value.ToString()));
+            _dispatcherMessagesReceivedCountersNullContext[(int)value] = _dispatcherMessagesReceivedCounterAggregatorGroup.FindOrCreate(new("Context", "None", "Direction", value.ToString()));
+            _dispatcherMessagesReceivedCountersGrain[(int)value] = _dispatcherMessagesReceivedCounterAggregatorGroup.FindOrCreate(new("Context", "Grain", "Direction", value.ToString()));
 
-            DispatcherMessagesProcessedCounters_Ok[(int)value] = DispatcherMessagesProcessedCounterAggregatorGroup.FindOrCreate(new("Direction", value.ToString(), "Status", "Ok"));
-            DispatcherMessagesProcessedCounters_Error[(int)value] = DispatcherMessagesProcessedCounterAggregatorGroup.FindOrCreate(new("Direction", value.ToString(), "Status", "Error"));
+            _dispatcherMessagesProcessedCountersOk[(int)value] = _dispatcherMessagesProcessedCounterAggregatorGroup.FindOrCreate(new("Direction", value.ToString(), "Status", "Ok"));
+            _dispatcherMessagesProcessedCountersError[(int)value] = _dispatcherMessagesProcessedCounterAggregatorGroup.FindOrCreate(new("Direction", value.ToString(), "Status", "Error"));
         }
     }
 
-    internal static void OnDispatcherMessageReceive(Message msg)
+    internal void OnDispatcherMessageReceive(Message msg)
     {
-        if (!DispatcherMessagesReceivedCounter.Enabled)
+        if (!_dispatcherMessagesReceivedCounter.Enabled)
             return;
         var context = RuntimeContext.Current;
         var counters = context switch
         {
-            null => DispatcherMessagesReceivedCounters_NullContext,
-            _ => DispatcherMessagesReceivedCounters_Grain,
+            null => _dispatcherMessagesReceivedCountersNullContext,
+            _ => _dispatcherMessagesReceivedCountersGrain,
         };
         counters[(int)msg.Direction].Add(1);
     }
 
-    internal static void OnDispatcherMessageProcessedOk(Message msg)
+    internal void OnDispatcherMessageProcessedOk(Message msg)
     {
-        if (DispatcherMessagesProcessedCounter.Enabled)
+        if (_dispatcherMessagesProcessedCounter.Enabled)
         {
-            DispatcherMessagesProcessedCounters_Ok[(int)msg.Direction].Add(1);
+            _dispatcherMessagesProcessedCountersOk[(int)msg.Direction].Add(1);
         }
     }
 
-    internal static void OnDispatcherMessageProcessedError(Message msg)
+    internal void OnDispatcherMessageProcessedError(Message msg)
     {
-        if (DispatcherMessagesProcessedCounter.Enabled)
+        if (_dispatcherMessagesProcessedCounter.Enabled)
         {
-            DispatcherMessagesProcessedCounters_Error[(int)msg.Direction].Add(1);
+            _dispatcherMessagesProcessedCountersError[(int)msg.Direction].Add(1);
         }
     }
 
-    internal static void OnDispatcherMessageForwared(Message msg)
+    internal void OnDispatcherMessageForwared(Message msg)
     {
-        if (DispatcherMessagesForwardedCounter.Enabled)
+        if (_dispatcherMessagesForwardedCounter.Enabled)
         {
-            DispatcherMessagesForwardedCounterAggregator.Add(1);
+            _dispatcherMessagesForwardedCounterAggregator.Add(1);
         }
     }
 
-    internal static void OnImaMessageReceived(Message msg)
+    internal void OnImaMessageReceived(Message msg)
     {
-        if (ImaReceivedCounter.Enabled)
+        if (_imaReceivedCounter.Enabled)
         {
-            ImaReceivedCounterAggregator.Add(1);
+            _imaReceivedCounterAggregator.Add(1);
         }
     }
 
-    internal static void OnImaMessageEnqueued(IGrainContext context)
+    internal void OnImaMessageEnqueued(IGrainContext context)
     {
-        if (!ImaEnqueuedCounter.Enabled)
+        if (!_imaEnqueuedCounter.Enabled)
         {
             return;
         }
@@ -102,21 +111,19 @@ internal static class MessagingProcessingInstruments
         switch (context)
         {
             case null:
-                ImaMessageEnqueuedNullContext.Add(1);
+                _imaMessageEnqueuedNullContext.Add(1);
                 break;
             case ISystemTargetBase:
-                ImaMessageEnqueuedSystemTarget.Add(1);
+                _imaMessageEnqueuedSystemTarget.Add(1);
                 break;
             default:
-                ImaMessageEnqueuedGrain.Add(1);
+                _imaMessageEnqueuedGrain.Add(1);
                 break;
         }
     }
 
-    internal static ObservableGauge<long> ActivationDataAll;
-
-    internal static void RegisterActivationDataAllObserve(Func<long> observeValue)
+    internal void RegisterActivationDataAllObserve(Func<long> observeValue)
     {
-        ActivationDataAll = Instruments.Meter.CreateObservableGauge(InstrumentNames.MESSAGING_PROCESSING_ACTIVATION_DATA_ALL, observeValue);
+        _activationDataAll = _meter.CreateObservableGauge(InstrumentNames.MESSAGING_PROCESSING_ACTIVATION_DATA_ALL, observeValue);
     }
 }

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1433,7 +1433,7 @@ internal sealed partial class ActivationData :
     /// <param name="message"></param>
     private void InvokeIncomingRequest(Message message)
     {
-        MessagingProcessingInstruments.OnDispatcherMessageProcessedOk(message);
+        _shared.MessagingProcessingInstruments.OnDispatcherMessageProcessedOk(message);
         _shared.InternalRuntime.MessagingTrace.OnScheduleMessage(message);
 
         try
@@ -1514,7 +1514,7 @@ internal sealed partial class ActivationData :
         // Don't process messages that have already timed out
         if (message.IsExpired)
         {
-            MessagingProcessingInstruments.OnDispatcherMessageProcessedError(message);
+            _shared.MessagingProcessingInstruments.OnDispatcherMessageProcessedError(message);
             _shared.InternalRuntime.MessagingTrace.OnDropExpiredMessage(message, MessagingInstruments.Phase.Dispatch);
             return;
         }
@@ -1539,7 +1539,7 @@ internal sealed partial class ActivationData :
         }
         else
         {
-            MessagingProcessingInstruments.OnDispatcherMessageProcessedOk(message);
+            _shared.MessagingProcessingInstruments.OnDispatcherMessageProcessedOk(message);
         }
 
         _shared.InternalRuntime.RuntimeClient.ReceiveResponse(message);
@@ -1550,7 +1550,7 @@ internal sealed partial class ActivationData :
         var overloadException = CheckOverloaded();
         if (overloadException != null && !message.IsLocalOnly)
         {
-            MessagingProcessingInstruments.OnDispatcherMessageProcessedError(message);
+            _shared.MessagingProcessingInstruments.OnDispatcherMessageProcessedError(message);
             _shared.InternalRuntime.MessageCenter.RejectMessage(message, Message.RejectionTypes.Overloaded, overloadException, "Target activation is overloaded " + this);
             return;
         }

--- a/src/Orleans.Runtime/Catalog/Catalog.cs
+++ b/src/Orleans.Runtime/Catalog/Catalog.cs
@@ -17,6 +17,7 @@ namespace Orleans.Runtime
         private readonly ILogger logger;
         private readonly GrainContextActivator grainActivator;
         private readonly CatalogInstruments _catalogInstruments;
+        private readonly MessagingProcessingInstruments _messagingProcessingInstruments;
         private ISiloStatusOracle _siloStatusOracle;
 
         // Lock striping is used for activation creation to reduce contention
@@ -35,6 +36,7 @@ namespace Orleans.Runtime
             ILoggerFactory loggerFactory,
             GrainContextActivator grainActivator,
             CatalogInstruments catalogInstruments,
+            MessagingProcessingInstruments messagingProcessingInstruments,
             SystemTargetShared shared)
             : base(Constants.CatalogType, shared)
         {
@@ -44,6 +46,7 @@ namespace Orleans.Runtime
             this.logger = loggerFactory.CreateLogger<Catalog>();
             this.activationCollector = activationCollector;
             _catalogInstruments = catalogInstruments;
+            _messagingProcessingInstruments = messagingProcessingInstruments;
 
             // Initialize lock striping array
             for (var i = 0; i < LockCount; i++)
@@ -53,7 +56,7 @@ namespace Orleans.Runtime
 
             GC.GetTotalMemory(true); // need to call once w/true to ensure false returns OK value
 
-            MessagingProcessingInstruments.RegisterActivationDataAllObserve(() =>
+            _messagingProcessingInstruments.RegisterActivationDataAllObserve(() =>
             {
                 long counter = 0;
                 foreach (var activation in activations)

--- a/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
+++ b/src/Orleans.Runtime/Catalog/GrainTypeSharedContext.cs
@@ -60,6 +60,7 @@ public sealed class GrainTypeSharedContext
         MigrationManager = _serviceProvider.GetService<IActivationMigrationManager>();
         CatalogInstruments = serviceProvider.GetRequiredService<CatalogInstruments>();
         GrainInstruments = serviceProvider.GetRequiredService<GrainInstruments>();
+        MessagingProcessingInstruments = serviceProvider.GetRequiredService<MessagingProcessingInstruments>();
 
         CollectionAgeLimit = GetCollectionAgeLimit(
             grainType,
@@ -75,6 +76,7 @@ public sealed class GrainTypeSharedContext
 
     internal CatalogInstruments CatalogInstruments { get; }
     internal GrainInstruments GrainInstruments { get; }
+    internal MessagingProcessingInstruments MessagingProcessingInstruments { get; }
 
     private static TimeSpan GetCollectionAgeLimit(GrainType grainType, Type grainClass, GrainManifest siloManifest, GrainCollectionOptions collectionOptions)
     {

--- a/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
+++ b/src/Orleans.Runtime/Catalog/SystemTargetShared.cs
@@ -18,7 +18,8 @@ internal sealed class SystemTargetShared(
     ActivationDirectory activations,
     SchedulerInstruments schedulerInstruments,
     GrainInstruments grainInstruments,
-    MessagingInstruments messagingInstruments)
+    MessagingInstruments messagingInstruments,
+    MessagingProcessingInstruments messagingProcessingInstruments)
 {
     public SiloAddress SiloAddress => localSiloDetails.SiloAddress;
 
@@ -27,7 +28,7 @@ internal sealed class SystemTargetShared(
     public GrainReferenceActivator GrainReferenceActivator => grainReferenceActivator;
     public ITimerRegistry TimerRegistry => timerRegistry;
 
-    public RuntimeMessagingTrace MessagingTrace { get; } = new(loggerFactory, messagingInstruments);
+    public RuntimeMessagingTrace MessagingTrace { get; } = new(loggerFactory, messagingInstruments, messagingProcessingInstruments);
     public InsideRuntimeClient RuntimeClient => runtimeClient;
     public ActivationDirectory ActivationDirectory => activations;
     public GrainInstruments GrainInstruments => grainInstruments;

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -73,6 +73,7 @@ namespace Orleans.Hosting
             services.TryAddSingleton<DirectoryInstruments>();
             services.TryAddSingleton<GrainInstruments>();
             services.TryAddSingleton<MessagingInstruments>();
+            services.TryAddSingleton<MessagingProcessingInstruments>();
 
             services.TryAddSingleton(typeof(IOptionFormatter<>), typeof(DefaultOptionsFormatter<>));
             services.TryAddSingleton(typeof(IOptionFormatterResolver<>), typeof(DefaultOptionsFormatterResolver<>));

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -20,6 +20,7 @@ namespace Orleans.Runtime.Messaging
         private readonly ConnectionManager connectionManager;
         private readonly RuntimeMessagingTrace messagingTrace;
         private readonly MessagingInstruments _messagingInstruments;
+        private readonly MessagingProcessingInstruments _messagingProcessingInstruments;
         private readonly SiloAddress _siloAddress;
         private readonly SiloMessagingOptions messagingOptions;
         private readonly PlacementService placementService;
@@ -41,6 +42,7 @@ namespace Orleans.Runtime.Messaging
             ConnectionManager senderManager,
             RuntimeMessagingTrace messagingTrace,
             MessagingInstruments messagingInstruments,
+            MessagingProcessingInstruments messagingProcessingInstruments,
             IOptions<SiloMessagingOptions> messagingOptions,
             PlacementService placementService,
             GrainLocator grainLocator,
@@ -52,6 +54,7 @@ namespace Orleans.Runtime.Messaging
             this.connectionManager = senderManager;
             this.messagingTrace = messagingTrace;
             _messagingInstruments = messagingInstruments;
+            _messagingProcessingInstruments = messagingProcessingInstruments;
             this.placementService = placementService;
             _grainLocator = grainLocator;
             _messageObserver = messageStatisticsSink.GetMessageObserver();
@@ -430,7 +433,7 @@ namespace Orleans.Runtime.Messaging
             if (!MayForward(message, this.messagingOptions)) return false;
 
             message.ForwardCount = message.ForwardCount + 1;
-            MessagingProcessingInstruments.OnDispatcherMessageForwared(message);
+            _messagingProcessingInstruments.OnDispatcherMessageForwared(message);
 
             ResendMessageImpl(message, forwardingAddress);
             return true;
@@ -561,7 +564,7 @@ namespace Orleans.Runtime.Messaging
 
             void HandleReceiveFailure(Message msg, Exception ex)
             {
-                MessagingProcessingInstruments.OnDispatcherMessageProcessedError(msg);
+                _messagingProcessingInstruments.OnDispatcherMessageProcessedError(msg);
                 LogErrorCreatingActivation(log, ex, msg.TargetGrain, msg.InterfaceType, msg);
 
                 this.RejectMessage(msg, Message.RejectionTypes.Transient, ex);

--- a/src/Orleans.Runtime/Messaging/RuntimeMessagingTrace.cs
+++ b/src/Orleans.Runtime/Messaging/RuntimeMessagingTrace.cs
@@ -3,12 +3,15 @@ using Orleans.Runtime.Diagnostics;
 
 namespace Orleans.Runtime;
 
-internal sealed partial class RuntimeMessagingTrace(ILoggerFactory loggerFactory, MessagingInstruments messagingInstruments) : MessagingTrace(loggerFactory, messagingInstruments)
+internal sealed partial class RuntimeMessagingTrace(
+    ILoggerFactory loggerFactory,
+    MessagingInstruments messagingInstruments,
+    MessagingProcessingInstruments messagingProcessingInstruments) : MessagingTrace(loggerFactory, messagingInstruments, messagingProcessingInstruments)
 {
     internal void OnDispatcherReceiveInvalidActivation(Message message, ActivationState activationState)
     {
         DispatcherEvents.EmitReceivedInvalidActivation(message, activationState);
-        MessagingProcessingInstruments.OnDispatcherMessageProcessedError(message);
+        MessagingProcessingInstrumentation.OnDispatcherMessageProcessedError(message);
         LogDispatcherReceiveInvalidActivation(Logger, activationState, message);
     }
 
@@ -42,7 +45,7 @@ internal sealed partial class RuntimeMessagingTrace(ILoggerFactory loggerFactory
             failedOperation,
             message.ForwardCount,
             exception);
-        MessagingProcessingInstruments.OnDispatcherMessageForwared(message);
+        MessagingProcessingInstrumentation.OnDispatcherMessageForwared(message);
     }
 
     internal void OnDispatcherForwardingFailed(Message message, GrainAddress? oldAddress, SiloAddress? forwardingAddress, string failedOperation, Exception? exception)
@@ -73,7 +76,7 @@ internal sealed partial class RuntimeMessagingTrace(ILoggerFactory loggerFactory
     internal void OnDispatcherSelectTargetFailed(Message message, Exception exception)
     {
         DispatcherEvents.EmitSelectTargetFailed(message, exception);
-        MessagingProcessingInstruments.OnDispatcherMessageProcessedError(message);
+        MessagingProcessingInstrumentation.OnDispatcherMessageProcessedError(message);
         if (ShouldLogError(exception))
         {
             LogDispatcherSelectTargetFailed(Logger, message, exception);

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -161,7 +161,8 @@ namespace UnitTests.Directory
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments(),
                 grainInstruments: CreateGrainInstruments(),
-                messagingInstruments: CreateMessagingInstruments());
+                messagingInstruments: CreateMessagingInstruments(),
+                messagingProcessingInstruments: CreateMessagingProcessingInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -216,7 +217,8 @@ namespace UnitTests.Directory
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments(),
                 grainInstruments: CreateGrainInstruments(),
-                messagingInstruments: CreateMessagingInstruments());
+                messagingInstruments: CreateMessagingInstruments(),
+                messagingProcessingInstruments: CreateMessagingProcessingInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -283,7 +285,8 @@ namespace UnitTests.Directory
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments(),
                 grainInstruments: CreateGrainInstruments(),
-                messagingInstruments: CreateMessagingInstruments());
+                messagingInstruments: CreateMessagingInstruments(),
+                messagingProcessingInstruments: CreateMessagingProcessingInstruments());
             var localGrainDirectory = new LocalGrainDirectory(
                 serviceProvider: services,
                 siloDetails: localSiloDetails,
@@ -872,6 +875,15 @@ namespace UnitTests.Directory
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<MessagingInstruments>();
             return services.BuildServiceProvider().GetRequiredService<MessagingInstruments>();
+        }
+
+        private static MessagingProcessingInstruments CreateMessagingProcessingInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<MessagingProcessingInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<MessagingProcessingInstruments>();
         }
 
         private int generation = 0;

--- a/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Directory/ClientDirectoryTests.cs
@@ -83,7 +83,8 @@ namespace NonSilo.Tests.Directory
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments(),
                 grainInstruments: CreateGrainInstruments(),
-                messagingInstruments: CreateMessagingInstruments());
+                messagingInstruments: CreateMessagingInstruments(),
+                messagingProcessingInstruments: CreateMessagingProcessingInstruments());
 
             _directory = new ClientDirectory(
                 grainFactory: _grainFactory,
@@ -134,6 +135,15 @@ namespace NonSilo.Tests.Directory
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<MessagingInstruments>();
             return services.BuildServiceProvider().GetRequiredService<MessagingInstruments>();
+        }
+
+        private static MessagingProcessingInstruments CreateMessagingProcessingInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<MessagingProcessingInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<MessagingProcessingInstruments>();
         }
 
         /// <summary>

--- a/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/LocalDurableJobManagerTests.cs
@@ -612,7 +612,8 @@ public class LocalDurableJobManagerTests
         activations: new ActivationDirectory(CreateCatalogInstruments()),
         schedulerInstruments: CreateSchedulerInstruments(),
         grainInstruments: CreateGrainInstruments(),
-        messagingInstruments: CreateMessagingInstruments());
+        messagingInstruments: CreateMessagingInstruments(),
+        messagingProcessingInstruments: CreateMessagingProcessingInstruments());
 
     private static SchedulerInstruments CreateSchedulerInstruments()
     {        var services = new ServiceCollection();
@@ -647,6 +648,15 @@ public class LocalDurableJobManagerTests
         services.AddSingleton<OrleansInstruments>();
         services.AddSingleton<MessagingInstruments>();
         return services.BuildServiceProvider().GetRequiredService<MessagingInstruments>();
+    }
+
+    private static MessagingProcessingInstruments CreateMessagingProcessingInstruments()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton<MessagingProcessingInstruments>();
+        return services.BuildServiceProvider().GetRequiredService<MessagingProcessingInstruments>();
     }
 
     private static IJobShard CreateSubstituteShard(string id, DateTimeOffset start, DateTimeOffset end)

--- a/test/Orleans.Runtime.Internal.Tests/Diagnostics/DispatcherEventsTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Diagnostics/DispatcherEventsTests.cs
@@ -15,7 +15,7 @@ public class DispatcherEventsTests
     public void RuntimeMessagingTrace_OnDispatcherRejectMessage_EmitsRejected()
     {
         using var observer = new Observer(DispatcherEvents.AllEvents);
-        var trace = new RuntimeMessagingTrace(NullLoggerFactory.Instance, CreateMessagingInstruments());
+        var trace = new RuntimeMessagingTrace(NullLoggerFactory.Instance, CreateMessagingInstruments(), CreateMessagingProcessingInstruments());
         var message = new Message();
         var exception = new InvalidOperationException("boom");
 
@@ -31,7 +31,7 @@ public class DispatcherEventsTests
     public void RuntimeMessagingTrace_OnDispatcherForwardingMultiple_EmitsForwardingMultiple()
     {
         using var observer = new Observer(DispatcherEvents.AllEvents);
-        var trace = new RuntimeMessagingTrace(NullLoggerFactory.Instance, CreateMessagingInstruments());
+        var trace = new RuntimeMessagingTrace(NullLoggerFactory.Instance, CreateMessagingInstruments(), CreateMessagingProcessingInstruments());
         var oldAddress = new GrainAddress
         {
             GrainId = GrainId.Create("test", "grain"),
@@ -81,5 +81,14 @@ public class DispatcherEventsTests
         services.AddSingleton<OrleansInstruments>();
         services.AddSingleton<MessagingInstruments>();
         return services.BuildServiceProvider().GetRequiredService<MessagingInstruments>();
+    }
+
+    private static MessagingProcessingInstruments CreateMessagingProcessingInstruments()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton<MessagingProcessingInstruments>();
+        return services.BuildServiceProvider().GetRequiredService<MessagingProcessingInstruments>();
     }
 }

--- a/test/Orleans.Runtime.Tests/Diagnostics/MessagingProcessingInstrumentsTests.cs
+++ b/test/Orleans.Runtime.Tests/Diagnostics/MessagingProcessingInstrumentsTests.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace Tester.Diagnostics;
+
+public class MessagingProcessingInstrumentsTests
+{
+    [Fact, TestCategory("BVT")]
+    public void MessagingProcessingInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new MessagingProcessingInstruments(new OrleansInstruments(meterFactory));
+        using var forwardedCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", InstrumentNames.MESSAGING_DISPATCHER_FORWARDED);
+        using var receivedCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", InstrumentNames.MESSAGING_IMA_RECEIVED);
+        using var activationDataCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", InstrumentNames.MESSAGING_PROCESSING_ACTIVATION_DATA_ALL);
+
+        var message = new Message { Direction = Message.Directions.Request };
+
+        instruments.RegisterActivationDataAllObserve(() => 9);
+        instruments.OnDispatcherMessageForwared(message);
+        instruments.OnImaMessageReceived(message);
+
+        forwardedCollector.RecordObservableInstruments();
+        receivedCollector.RecordObservableInstruments();
+        activationDataCollector.RecordObservableInstruments();
+
+        Assert.Equal(1, Assert.Single(forwardedCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(receivedCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(9, Assert.Single(activationDataCollector.GetMeasurementSnapshot()).Value);
+    }
+}

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -170,7 +170,8 @@ namespace UnitTests.StreamingTests
                 activations: new ActivationDirectory(CreateCatalogInstruments()),
                 schedulerInstruments: CreateSchedulerInstruments(),
                 grainInstruments: CreateGrainInstruments(),
-                messagingInstruments: CreateMessagingInstruments());
+                messagingInstruments: CreateMessagingInstruments(),
+                messagingProcessingInstruments: CreateMessagingProcessingInstruments());
 
             receiver ??= Substitute.For<IQueueAdapterReceiver>();
             receiver.Initialize(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
@@ -231,6 +232,15 @@ namespace UnitTests.StreamingTests
             services.AddSingleton<OrleansInstruments>();
             services.AddSingleton<MessagingInstruments>();
             return services.BuildServiceProvider().GetRequiredService<MessagingInstruments>();
+        }
+
+        private static MessagingProcessingInstruments CreateMessagingProcessingInstruments()
+        {
+            var services = new ServiceCollection();
+            services.AddMetrics();
+            services.AddSingleton<OrleansInstruments>();
+            services.AddSingleton<MessagingProcessingInstruments>();
+            return services.BuildServiceProvider().GetRequiredService<MessagingProcessingInstruments>();
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]


### PR DESCRIPTION
Part of #9608.

## Problem
`MessagingProcessingInstruments` created dispatcher and incoming-message-agent metrics using the global static `Instruments.Meter`, so those metrics were not scoped to the DI-provided `IMeterFactory` used by the other migrated instruments.

## Solution
Convert `MessagingProcessingInstruments` to an instance class backed by `OrleansInstruments`. Register it with client and silo services and route messaging processing components through the DI singleton. Adds a `MetricCollector` BVT covering dispatcher-forwarded, IMA-received, and activation-data observable metrics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10180)