### PR TITLE
chore: use IMeterFactory for DurableJobsInstruments

### DIFF
--- a/src/Orleans.DurableJobs/DurableJobReceiverExtensionShared.cs
+++ b/src/Orleans.DurableJobs/DurableJobReceiverExtensionShared.cs
@@ -17,7 +17,8 @@ internal sealed class DurableJobReceiverExtensionShared
         ILogger<DurableJobReceiverExtension> logger,
         IOptions<DurableJobsOptions> options,
         IOptions<SiloMessagingOptions> messagingOptions,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        DurableJobsInstruments? durableJobsInstruments = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(options);
@@ -25,6 +26,7 @@ internal sealed class DurableJobReceiverExtensionShared
         Logger = logger;
         MessagingOptions = messagingOptions.Value;
         Options = options.Value;
+        DurableJobsInstruments = durableJobsInstruments ?? DurableJobsInstruments.CreateForDirectConstruction();
         TimeProvider = timeProvider ?? TimeProvider.System;
     }
 
@@ -44,10 +46,11 @@ internal sealed class DurableJobReceiverExtensionShared
     /// Gets the durable jobs options used by every <see cref="DurableJobReceiverExtension"/> instance on the silo.
     /// </summary>
     public DurableJobsOptions Options { get; }
+    public DurableJobsInstruments DurableJobsInstruments { get; }
 
     /// <summary>
     /// Begins tracking an invocation of <see cref="IDurableJobHandler.ExecuteJobAsync"/>, emitting the
     /// corresponding metrics and starting a distributed-tracing activity for the lifetime of the returned tracker.
     /// </summary>
-    public HandlerExecutionTracker BeginHandlerExecution(IJobRunContext context) => new(TimeProvider, context);
+    public HandlerExecutionTracker BeginHandlerExecution(IJobRunContext context) => new(TimeProvider, DurableJobsInstruments, context);
 }

--- a/src/Orleans.DurableJobs/DurableJobsInstruments.cs
+++ b/src/Orleans.DurableJobs/DurableJobsInstruments.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
 
 namespace Orleans.DurableJobs;
 
-internal static class DurableJobsInstruments
+internal sealed class DurableJobsInstruments(OrleansInstruments instruments)
 {
     private const string MillisecondsUnit = "ms";
     private const string BytesUnit = "bytes";
@@ -19,99 +20,108 @@ internal static class DurableJobsInstruments
     private const string StatusOk = "ok";
     private const string StatusNotFound = "not_found";
 
-    private static readonly Counter<long> JobsScheduled = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-scheduled");
-    private static readonly Counter<long> JobAttemptsStarted = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-job-attempts-started");
-    private static readonly Counter<long> JobsCompleted = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-completed");
-    private static readonly Counter<long> JobsFailed = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-failed");
-    private static readonly Counter<long> JobsRetried = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-retried");
-    private static readonly Counter<long> JobsCanceled = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-canceled");
-    private static readonly Counter<long> ShardsProcessed = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-shards-processed");
-    private static readonly Counter<long> ScheduleJobCalls = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-schedule-job-calls");
-    private static readonly Counter<long> CancelJobCalls = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-cancel-job-calls");
-    private static readonly Counter<long> HandlerExecutionsStarted = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-handler-executions-started");
-    private static readonly Counter<long> HandlerExecutions = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-handler-executions");
-    private static readonly Counter<long> StorageBatches = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-storage-batches");
-    private static readonly Counter<long> StripeDistribution = Instruments.Meter.CreateCounter<long>("orleans-durablejobs-stripe-distribution");
+    internal static DurableJobsInstruments CreateForDirectConstruction()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton<DurableJobsInstruments>();
+        return services.BuildServiceProvider().GetRequiredService<DurableJobsInstruments>();
+    }
 
-    private static readonly Histogram<double> JobScheduleDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-job-schedule-duration", MillisecondsUnit);
-    private static readonly Histogram<double> JobDispatchLag = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-job-dispatch-lag", MillisecondsUnit);
-    private static readonly Histogram<double> JobAttemptDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-job-attempt-duration", MillisecondsUnit);
-    private static readonly Histogram<double> ShardProcessingDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-shard-processing-duration", MillisecondsUnit);
-    private static readonly Histogram<double> ScheduleJobCallDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-schedule-job-call-duration", MillisecondsUnit);
-    private static readonly Histogram<double> CancelJobCallDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-cancel-job-call-duration", MillisecondsUnit);
-    private static readonly Histogram<double> HandlerExecutionDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-handler-execution-duration", MillisecondsUnit);
-    private static readonly Histogram<long> StorageBatchSize = Instruments.Meter.CreateHistogram<long>("orleans-durablejobs-storage-batch-size");
-    private static readonly Histogram<long> ShardBatchMutations = Instruments.Meter.CreateHistogram<long>("orleans-durablejobs-shard-batch-mutations");
-    private static readonly Histogram<long> ShardBatchBytes = Instruments.Meter.CreateHistogram<long>("orleans-durablejobs-shard-batch-bytes", BytesUnit);
-    private static readonly Histogram<long> ShardPendingDepth = Instruments.Meter.CreateHistogram<long>("orleans-durablejobs-shard-pending-depth");
-    private static readonly Histogram<double> OwnershipCheckDuration = Instruments.Meter.CreateHistogram<double>("orleans-durablejobs-ownership-check-duration", MillisecondsUnit);
+    private readonly Counter<long> JobsScheduled = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-scheduled");
+    private readonly Counter<long> JobAttemptsStarted = instruments.Meter.CreateCounter<long>("orleans-durablejobs-job-attempts-started");
+    private readonly Counter<long> JobsCompleted = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-completed");
+    private readonly Counter<long> JobsFailed = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-failed");
+    private readonly Counter<long> JobsRetried = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-retried");
+    private readonly Counter<long> JobsCanceled = instruments.Meter.CreateCounter<long>("orleans-durablejobs-jobs-canceled");
+    private readonly Counter<long> ShardsProcessed = instruments.Meter.CreateCounter<long>("orleans-durablejobs-shards-processed");
+    private readonly Counter<long> ScheduleJobCalls = instruments.Meter.CreateCounter<long>("orleans-durablejobs-schedule-job-calls");
+    private readonly Counter<long> CancelJobCalls = instruments.Meter.CreateCounter<long>("orleans-durablejobs-cancel-job-calls");
+    private readonly Counter<long> HandlerExecutionsStarted = instruments.Meter.CreateCounter<long>("orleans-durablejobs-handler-executions-started");
+    private readonly Counter<long> HandlerExecutions = instruments.Meter.CreateCounter<long>("orleans-durablejobs-handler-executions");
+    private readonly Counter<long> StorageBatches = instruments.Meter.CreateCounter<long>("orleans-durablejobs-storage-batches");
+    private readonly Counter<long> StripeDistribution = instruments.Meter.CreateCounter<long>("orleans-durablejobs-stripe-distribution");
 
-    internal static void OnJobScheduled(TimeSpan latency)
+    private readonly Histogram<double> JobScheduleDuration = instruments.Meter.CreateHistogram<double>("orleans-durablejobs-job-schedule-duration", MillisecondsUnit);
+    private readonly Histogram<double> JobDispatchLag = instruments.Meter.CreateHistogram<double>("orleans-durablejobs-job-dispatch-lag", MillisecondsUnit);
+    private readonly Histogram<double> JobAttemptDuration = instruments.Meter.CreateHistogram<double>("orleans-durablejobs-job-attempt-duration", MillisecondsUnit);
+    private readonly Histogram<double> ShardProcessingDuration = instruments.Meter.CreateHistogram<double>("orleans-durablejobs-shard-processing-duration", MillisecondsUnit);
+    private readonly Histogram<double> ScheduleJobCallDuration = instruments.Meter.CreateHistogram<double>("orleans-durablejobs-schedule-job-call-duration", MillisecondsUnit);
+    private readonly Histogram<double> CancelJobCallDuration = instruments.Meter.CreateHistogram<double>("orleans-durablejobs-cancel-job-call-duration", MillisecondsUnit);
+    private readonly Histogram<double> HandlerExecutionDuration = instruments.Meter.CreateHistogram<double>("orleans-durablejobs-handler-execution-duration", MillisecondsUnit);
+    private readonly Histogram<long> StorageBatchSize = instruments.Meter.CreateHistogram<long>("orleans-durablejobs-storage-batch-size");
+    private readonly Histogram<long> ShardBatchMutations = instruments.Meter.CreateHistogram<long>("orleans-durablejobs-shard-batch-mutations");
+    private readonly Histogram<long> ShardBatchBytes = instruments.Meter.CreateHistogram<long>("orleans-durablejobs-shard-batch-bytes", BytesUnit);
+    private readonly Histogram<long> ShardPendingDepth = instruments.Meter.CreateHistogram<long>("orleans-durablejobs-shard-pending-depth");
+    private readonly Histogram<double> OwnershipCheckDuration = instruments.Meter.CreateHistogram<double>("orleans-durablejobs-ownership-check-duration", MillisecondsUnit);
+
+    internal void OnJobScheduled(TimeSpan latency)
     {
         JobsScheduled.Add(1);
         Record(JobScheduleDuration, latency);
     }
 
-    internal static void OnJobAttemptStarted(TimeSpan dispatchLag)
+    internal void OnJobAttemptStarted(TimeSpan dispatchLag)
     {
         JobAttemptsStarted.Add(1);
         Record(JobDispatchLag, dispatchLag);
     }
 
-    internal static void OnJobCompleted(TimeSpan latency)
+    internal void OnJobCompleted(TimeSpan latency)
     {
         JobsCompleted.Add(1);
         Record(JobAttemptDuration, latency, StatusCompleted);
     }
 
-    internal static void OnJobFailed(TimeSpan latency)
+    internal void OnJobFailed(TimeSpan latency)
     {
         JobsFailed.Add(1);
         Record(JobAttemptDuration, latency, StatusFailed);
     }
 
-    internal static void OnJobRetried(TimeSpan latency)
+    internal void OnJobRetried(TimeSpan latency)
     {
         JobsRetried.Add(1);
         Record(JobAttemptDuration, latency, StatusRetried);
     }
 
-    internal static void OnJobCanceled()
+    internal void OnJobCanceled()
     {
         JobsCanceled.Add(1);
     }
 
-    internal static void OnScheduleJobCallSucceeded(TimeSpan latency) => OnScheduleJobCall(latency, StatusOk);
+    internal void OnScheduleJobCallSucceeded(TimeSpan latency) => OnScheduleJobCall(latency, StatusOk);
 
-    internal static void OnScheduleJobCallCanceled(TimeSpan latency) => OnScheduleJobCall(latency, StatusCanceled);
+    internal void OnScheduleJobCallCanceled(TimeSpan latency) => OnScheduleJobCall(latency, StatusCanceled);
 
-    internal static void OnScheduleJobCallFailed(TimeSpan latency) => OnScheduleJobCall(latency, StatusError);
+    internal void OnScheduleJobCallFailed(TimeSpan latency) => OnScheduleJobCall(latency, StatusError);
 
-    internal static void OnCancelJobCall(TimeSpan latency, bool canceledJob) => OnCancelJobCall(latency, canceledJob ? StatusOk : StatusNotFound);
+    internal void OnCancelJobCall(TimeSpan latency, bool canceledJob) => OnCancelJobCall(latency, canceledJob ? StatusOk : StatusNotFound);
 
-    internal static void OnCancelJobCallCanceled(TimeSpan latency) => OnCancelJobCall(latency, StatusCanceled);
+    internal void OnCancelJobCallCanceled(TimeSpan latency) => OnCancelJobCall(latency, StatusCanceled);
 
-    internal static void OnCancelJobCallFailed(TimeSpan latency) => OnCancelJobCall(latency, StatusError);
+    internal void OnCancelJobCallFailed(TimeSpan latency) => OnCancelJobCall(latency, StatusError);
 
-    internal static void OnHandlerExecutionStarted()
+    internal void OnHandlerExecutionStarted()
     {
         HandlerExecutionsStarted.Add(1);
     }
 
-    internal static void OnHandlerExecutionCompleted(TimeSpan latency) => OnHandlerExecution(latency, StatusCompleted);
+    internal void OnHandlerExecutionCompleted(TimeSpan latency) => OnHandlerExecution(latency, StatusCompleted);
 
-    internal static void OnHandlerExecutionCanceled(TimeSpan latency) => OnHandlerExecution(latency, StatusCanceled);
+    internal void OnHandlerExecutionCanceled(TimeSpan latency) => OnHandlerExecution(latency, StatusCanceled);
 
-    internal static void OnHandlerExecutionFailed(TimeSpan latency) => OnHandlerExecution(latency, StatusFailed);
+    internal void OnHandlerExecutionFailed(TimeSpan latency) => OnHandlerExecution(latency, StatusFailed);
 
-    internal static void OnShardProcessed(TimeSpan latency, bool canceled, bool error)
+    internal void OnShardProcessed(TimeSpan latency, bool canceled, bool error)
     {
         var status = error ? StatusError : canceled ? StatusCanceled : StatusCompleted;
         ShardsProcessed.Add(1, [new KeyValuePair<string, object?>(StatusTagName, status)]);
         Record(ShardProcessingDuration, latency, status);
     }
 
-    internal static void OnStorageBatchWritten(long operationCount, bool canceled, bool error)
+    internal void OnStorageBatchWritten(long operationCount, bool canceled, bool error)
     {
         var status = error ? StatusError : canceled ? StatusCanceled : StatusOk;
         var tags = new KeyValuePair<string, object?>[] { new(StatusTagName, status) };
@@ -122,7 +132,7 @@ internal static class DurableJobsInstruments
         }
     }
 
-    internal static void OnShardBatch(long mutationCount)
+    internal void OnShardBatch(long mutationCount)
     {
         if (ShardBatchMutations.Enabled && mutationCount >= 0)
         {
@@ -130,7 +140,7 @@ internal static class DurableJobsInstruments
         }
     }
 
-    internal static void OnShardBatchBytes(long batchBytes)
+    internal void OnShardBatchBytes(long batchBytes)
     {
         if (ShardBatchBytes.Enabled && batchBytes >= 0)
         {
@@ -138,7 +148,7 @@ internal static class DurableJobsInstruments
         }
     }
 
-    internal static void OnShardPendingDepth(long depth)
+    internal void OnShardPendingDepth(long depth)
     {
         if (ShardPendingDepth.Enabled && depth >= 0)
         {
@@ -146,7 +156,7 @@ internal static class DurableJobsInstruments
         }
     }
 
-    internal static void OnOwnershipCheck(TimeSpan duration)
+    internal void OnOwnershipCheck(TimeSpan duration)
     {
         if (OwnershipCheckDuration.Enabled)
         {
@@ -154,7 +164,7 @@ internal static class DurableJobsInstruments
         }
     }
 
-    internal static void OnStripeAssigned(int stripe)
+    internal void OnStripeAssigned(int stripe)
     {
         if (StripeDistribution.Enabled)
         {
@@ -162,25 +172,25 @@ internal static class DurableJobsInstruments
         }
     }
 
-    private static void OnScheduleJobCall(TimeSpan latency, string status)
+    private void OnScheduleJobCall(TimeSpan latency, string status)
     {
         ScheduleJobCalls.Add(1, [new KeyValuePair<string, object?>(StatusTagName, status)]);
         Record(ScheduleJobCallDuration, latency, status);
     }
 
-    private static void OnCancelJobCall(TimeSpan latency, string status)
+    private void OnCancelJobCall(TimeSpan latency, string status)
     {
         CancelJobCalls.Add(1, [new KeyValuePair<string, object?>(StatusTagName, status)]);
         Record(CancelJobCallDuration, latency, status);
     }
 
-    private static void OnHandlerExecution(TimeSpan latency, string status)
+    private void OnHandlerExecution(TimeSpan latency, string status)
     {
         HandlerExecutions.Add(1, [new KeyValuePair<string, object?>(StatusTagName, status)]);
         Record(HandlerExecutionDuration, latency, status);
     }
 
-    private static void Record(Histogram<double> histogram, TimeSpan latency)
+    private void Record(Histogram<double> histogram, TimeSpan latency)
     {
         if (histogram.Enabled)
         {
@@ -188,7 +198,7 @@ internal static class DurableJobsInstruments
         }
     }
 
-    private static void Record(Histogram<double> histogram, TimeSpan latency, string status)
+    private void Record(Histogram<double> histogram, TimeSpan latency, string status)
     {
         if (histogram.Enabled)
         {

--- a/src/Orleans.DurableJobs/HandlerExecutionTracker.cs
+++ b/src/Orleans.DurableJobs/HandlerExecutionTracker.cs
@@ -12,17 +12,20 @@ namespace Orleans.DurableJobs;
 internal readonly struct HandlerExecutionTracker : IDisposable
 {
     private readonly TimeProvider _timeProvider;
+    private readonly DurableJobsInstruments _durableJobsInstruments;
     private readonly long _startTimestamp;
     private readonly Activity? _activity;
 
-    public HandlerExecutionTracker(TimeProvider timeProvider, IJobRunContext context)
+    public HandlerExecutionTracker(TimeProvider timeProvider, DurableJobsInstruments durableJobsInstruments, IJobRunContext context)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(durableJobsInstruments);
         ArgumentNullException.ThrowIfNull(context);
 
         _timeProvider = timeProvider;
+        _durableJobsInstruments = durableJobsInstruments;
         _startTimestamp = timeProvider.GetTimestamp();
-        DurableJobsInstruments.OnHandlerExecutionStarted();
+        _durableJobsInstruments.OnHandlerExecutionStarted();
         _activity = DurableJobsDiagnostics.StartHandlerActivity(context.Job, context.DequeueCount, context.RunId);
     }
 
@@ -31,7 +34,7 @@ internal readonly struct HandlerExecutionTracker : IDisposable
     /// </summary>
     public void Completed()
     {
-        DurableJobsInstruments.OnHandlerExecutionCompleted(_timeProvider.GetElapsedTime(_startTimestamp));
+        _durableJobsInstruments.OnHandlerExecutionCompleted(_timeProvider.GetElapsedTime(_startTimestamp));
         _activity?.SetStatus(ActivityStatusCode.Ok);
     }
 
@@ -41,7 +44,7 @@ internal readonly struct HandlerExecutionTracker : IDisposable
     /// </summary>
     public void Canceled()
     {
-        DurableJobsInstruments.OnHandlerExecutionCanceled(_timeProvider.GetElapsedTime(_startTimestamp));
+        _durableJobsInstruments.OnHandlerExecutionCanceled(_timeProvider.GetElapsedTime(_startTimestamp));
     }
 
     /// <summary>
@@ -49,7 +52,7 @@ internal readonly struct HandlerExecutionTracker : IDisposable
     /// </summary>
     public void Failed(Exception exception)
     {
-        DurableJobsInstruments.OnHandlerExecutionFailed(_timeProvider.GetElapsedTime(_startTimestamp));
+        _durableJobsInstruments.OnHandlerExecutionFailed(_timeProvider.GetElapsedTime(_startTimestamp));
         DurableJobsDiagnostics.SetError(_activity, exception);
     }
 

--- a/src/Orleans.DurableJobs/Hosting/DurableJobsExtensions.cs
+++ b/src/Orleans.DurableJobs/Hosting/DurableJobsExtensions.cs
@@ -36,6 +36,7 @@ public static class DurableJobsExtensions
             return;
         }
 
+        services.TryAddSingleton<DurableJobsInstruments>();
         services.AddSingleton<IConfigurationValidator, DurableJobsOptionsValidator>();
         services.AddSingleton<IConfigurationValidator, DurableJobsJournalingConfigurationValidator>();
         services.AddSingleton<ShardExecutor>();
@@ -46,7 +47,8 @@ public static class DurableJobsExtensions
             sp.GetRequiredService<ILogger<DurableJobReceiverExtension>>(),
             sp.GetRequiredService<IOptions<DurableJobsOptions>>(),
             sp.GetRequiredService<IOptions<SiloMessagingOptions>>(),
-            sp.GetService<TimeProvider>()));
+            sp.GetService<TimeProvider>(),
+            sp.GetRequiredService<DurableJobsInstruments>()));
         services.AddKeyedTransient<IGrainExtension>(typeof(IDurableJobReceiverExtension), (sp, _) =>
         {
             var grainContextAccessor = sp.GetRequiredService<IGrainContextAccessor>();

--- a/src/Orleans.DurableJobs/JournaledJobShard.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShard.cs
@@ -16,6 +16,7 @@ internal sealed class JournaledJobShard : IJobShard
     private readonly JournaledJobShardState _state;
     private readonly IJournaledStateManager _stateManager;
     private readonly JournaledJobShardManager _shardManager;
+    private readonly DurableJobsInstruments _durableJobsInstruments;
     private readonly TimeProvider _timeProvider;
     private readonly TimeSpan _batchLingerDelay;
     private readonly object _pendingOperationsLock = new();
@@ -51,7 +52,8 @@ internal sealed class JournaledJobShard : IJobShard
         IJournaledStateManager stateManager,
         JournaledJobShardManager shardManager,
         TimeProvider? timeProvider = null,
-        TimeSpan batchLingerDelay = default)
+        TimeSpan batchLingerDelay = default,
+        DurableJobsInstruments? durableJobsInstruments = null)
     {
         ArgumentNullException.ThrowIfNull(state);
         ArgumentNullException.ThrowIfNull(stateManager);
@@ -68,6 +70,7 @@ internal sealed class JournaledJobShard : IJobShard
         _state = state;
         _stateManager = stateManager;
         _shardManager = shardManager;
+        _durableJobsInstruments = durableJobsInstruments ?? DurableJobsInstruments.CreateForDirectConstruction();
         _timeProvider = timeProvider ?? TimeProvider.System;
         _batchLingerDelay = batchLingerDelay;
 
@@ -256,7 +259,7 @@ internal sealed class JournaledJobShard : IJobShard
                         await LingerForMoreMutationsAsync(batch).ConfigureAwait(false);
                         DequeueConsecutiveMutations(batch);
                     }
-                    DurableJobsInstruments.OnShardPendingDepth(batch.Count);
+                    _durableJobsInstruments.OnShardPendingDepth(batch.Count);
                     await ProcessMutationBatchAsync(batch).ConfigureAwait(false);
                     batch.Clear();
                 }
@@ -364,7 +367,7 @@ internal sealed class JournaledJobShard : IJobShard
             }
             finally
             {
-                DurableJobsInstruments.OnOwnershipCheck(Stopwatch.GetElapsedTime(ownershipStartTimestamp));
+                _durableJobsInstruments.OnOwnershipCheck(Stopwatch.GetElapsedTime(ownershipStartTimestamp));
             }
 
             if (!isOwned)
@@ -400,17 +403,17 @@ internal sealed class JournaledJobShard : IJobShard
             }
 
             var pendingBytesAfterApply = _stateManager.PendingWriteByteCount;
-            DurableJobsInstruments.OnShardBatch(appliedOperations.Count);
+            _durableJobsInstruments.OnShardBatch(appliedOperations.Count);
             if (pendingBytesBeforeApply >= 0 && pendingBytesAfterApply >= pendingBytesBeforeApply)
             {
-                DurableJobsInstruments.OnShardBatchBytes(pendingBytesAfterApply - pendingBytesBeforeApply);
+                _durableJobsInstruments.OnShardBatchBytes(pendingBytesAfterApply - pendingBytesBeforeApply);
             }
 
             try
             {
                 using var batchActivity = DurableJobsDiagnostics.StartPersistBatchActivity(appliedOperations, Id);
                 await _stateManager.WriteStateAsync(_shutdownCancellation.Token).ConfigureAwait(false);
-                DurableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: false, error: false);
+                _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: false, error: false);
                 batchActivity?.SetStatus(System.Diagnostics.ActivityStatusCode.Ok);
                 foreach (var operation in appliedOperations)
                 {
@@ -419,7 +422,7 @@ internal sealed class JournaledJobShard : IJobShard
             }
             catch (OperationCanceledException exception) when (_shutdownCancellation.IsCancellationRequested)
             {
-                DurableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: true, error: false);
+                _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: true, error: false);
                 foreach (var operation in appliedOperations)
                 {
                     operation.TrySetCanceled(exception.CancellationToken);
@@ -427,7 +430,7 @@ internal sealed class JournaledJobShard : IJobShard
             }
             catch (Exception exception)
             {
-                DurableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: false, error: true);
+                _durableJobsInstruments.OnStorageBatchWritten(appliedOperations.Count, canceled: false, error: true);
                 foreach (var operation in appliedOperations)
                 {
                     operation.TrySetException(exception);

--- a/src/Orleans.DurableJobs/JournaledJobShardManager.cs
+++ b/src/Orleans.DurableJobs/JournaledJobShardManager.cs
@@ -30,6 +30,7 @@ internal sealed class JournaledJobShardManager : JobShardManager
     private readonly IJournalStorageCatalog _catalog;
     private readonly IClusterMembershipService _membershipService;
     private readonly IServiceProvider _serviceProvider;
+    private readonly DurableJobsInstruments _durableJobsInstruments;
     private readonly DurableJobsOptions _options;
     private readonly JournaledStateManagerOptions _journaledStateManagerOptions;
     private readonly TimeProvider _timeProvider;
@@ -48,7 +49,8 @@ internal sealed class JournaledJobShardManager : JobShardManager
         IClusterMembershipService membershipService,
         IServiceProvider serviceProvider,
         IOptions<DurableJobsOptions> options,
-        IOptions<JournaledStateManagerOptions> journaledStateManagerOptions)
+        IOptions<JournaledStateManagerOptions> journaledStateManagerOptions,
+        DurableJobsInstruments? durableJobsInstruments = null)
         : base(GetSiloAddress(localSiloDetails))
     {
         ArgumentNullException.ThrowIfNull(localSiloDetails);
@@ -65,6 +67,7 @@ internal sealed class JournaledJobShardManager : JobShardManager
         _catalog = catalog;
         _membershipService = membershipService;
         _serviceProvider = serviceProvider;
+        _durableJobsInstruments = durableJobsInstruments ?? DurableJobsInstruments.CreateForDirectConstruction();
         _options = options.Value;
         _journaledStateManagerOptions = journaledStateManagerOptions.Value;
         _timeProvider = serviceProvider.GetService<TimeProvider>() ?? TimeProvider.System;
@@ -398,7 +401,8 @@ internal sealed class JournaledJobShardManager : JobShardManager
             manager,
             this,
             _timeProvider,
-            _options.ShardBatchLingerDelay);
+            _options.ShardBatchLingerDelay,
+            _durableJobsInstruments);
     }
 
     private IDurableValueCommandCodec<DurableJobShardJournalRecord> CreateOperationCodec()

--- a/src/Orleans.DurableJobs/LocalDurableJobManager.cs
+++ b/src/Orleans.DurableJobs/LocalDurableJobManager.cs
@@ -29,6 +29,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
     private readonly IAsyncEnumerable<ClusterMembershipSnapshot> _clusterMembershipUpdates;
     private readonly IOverloadDetector _overloadDetector;
     private readonly TimeProvider _timeProvider;
+    private readonly DurableJobsInstruments _durableJobsInstruments;
     private readonly ILogger<LocalDurableJobManager> _logger;
     private readonly DurableJobsOptions _options;
     private readonly CancellationTokenSource _cts = new();
@@ -58,7 +59,8 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         TimeProvider timeProvider,
         IOptions<DurableJobsOptions> options,
         SystemTargetShared shared,
-        ILogger<LocalDurableJobManager> logger)
+        ILogger<LocalDurableJobManager> logger,
+        DurableJobsInstruments? durableJobsInstruments = null)
         : base(JobManagerGrainType, shared)
     {
         _shardManager = shardManager;
@@ -67,6 +69,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         _clusterMembershipUpdates = clusterMembership.MembershipUpdates;
         _overloadDetector = overloadDetector;
         _timeProvider = timeProvider;
+        _durableJobsInstruments = durableJobsInstruments ?? DurableJobsInstruments.CreateForDirectConstruction();
         _logger = logger;
         _options = options.Value;
     }
@@ -82,7 +85,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
             LogSchedulingJob(_logger, request.JobName, request.Target, request.DueTime);
 
             var shardKey = GetWritableShardKey(request);
-            DurableJobsInstruments.OnStripeAssigned(shardKey.Stripe);
+            _durableJobsInstruments.OnStripeAssigned(shardKey.Stripe);
 
             while (true)
             {
@@ -104,8 +107,8 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
                     {
                         var elapsed = _timeProvider.GetElapsedTime(startTimestamp);
                         LogJobScheduled(_logger, request.JobName, job.Id, existingShard.Id, request.Target);
-                        DurableJobsInstruments.OnJobScheduled(elapsed);
-                        DurableJobsInstruments.OnScheduleJobCallSucceeded(elapsed);
+                        _durableJobsInstruments.OnJobScheduled(elapsed);
+                        _durableJobsInstruments.OnScheduleJobCallSucceeded(elapsed);
                         DurableJobsDiagnostics.SetScheduledJobTags(activity, job);
                         return job;
                     }
@@ -144,12 +147,12 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
         }
         catch (OperationCanceledException)
         {
-            DurableJobsInstruments.OnScheduleJobCallCanceled(_timeProvider.GetElapsedTime(startTimestamp));
+            _durableJobsInstruments.OnScheduleJobCallCanceled(_timeProvider.GetElapsedTime(startTimestamp));
             throw;
         }
         catch (Exception ex)
         {
-            DurableJobsInstruments.OnScheduleJobCallFailed(_timeProvider.GetElapsedTime(startTimestamp));
+            _durableJobsInstruments.OnScheduleJobCallFailed(_timeProvider.GetElapsedTime(startTimestamp));
             DurableJobsDiagnostics.SetError(activity, ex);
             throw;
         }
@@ -252,7 +255,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
                 if (!await _shardManager.IsShardOwnedByLocalSiloAsync(job.ShardId, cancellationToken))
                 {
                     LogJobCancellationFailed(_logger, job.Id, job.Name, job.ShardId);
-                    DurableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), canceledJob: false);
+                    _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), canceledJob: false);
                     return false;
                 }
 
@@ -261,10 +264,10 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
                 LogJobCancelled(_logger, job.Id, job.Name, job.ShardId);
                 if (wasRemoved)
                 {
-                    DurableJobsInstruments.OnJobCanceled();
+                    _durableJobsInstruments.OnJobCanceled();
                 }
 
-                DurableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), wasRemoved);
+                _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), wasRemoved);
                 return wasRemoved;
             }
 
@@ -272,7 +275,7 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
             if (owner is null || owner.Equals(Silo))
             {
                 LogJobCancellationFailed(_logger, job.Id, job.Name, job.ShardId);
-                DurableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), canceledJob: false);
+                _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), canceledJob: false);
                 return false;
             }
 
@@ -283,17 +286,17 @@ internal partial class LocalDurableJobManager : SystemTarget, ILocalDurableJobMa
                 LogJobCancellationFailed(_logger, job.Id, job.Name, job.ShardId);
             }
 
-            DurableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), routed);
+            _durableJobsInstruments.OnCancelJobCall(_timeProvider.GetElapsedTime(startTimestamp), routed);
             return routed;
         }
         catch (OperationCanceledException)
         {
-            DurableJobsInstruments.OnCancelJobCallCanceled(_timeProvider.GetElapsedTime(startTimestamp));
+            _durableJobsInstruments.OnCancelJobCallCanceled(_timeProvider.GetElapsedTime(startTimestamp));
             throw;
         }
         catch
         {
-            DurableJobsInstruments.OnCancelJobCallFailed(_timeProvider.GetElapsedTime(startTimestamp));
+            _durableJobsInstruments.OnCancelJobCallFailed(_timeProvider.GetElapsedTime(startTimestamp));
             throw;
         }
     }

--- a/src/Orleans.DurableJobs/ShardExecutor.cs
+++ b/src/Orleans.DurableJobs/ShardExecutor.cs
@@ -22,6 +22,7 @@ internal sealed partial class ShardExecutor
     private readonly ILogger<ShardExecutor> _logger;
     private readonly DurableJobsOptions _options;
     private readonly TimeProvider _timeProvider;
+    private readonly DurableJobsInstruments _durableJobsInstruments;
     private readonly SemaphoreSlim _jobConcurrencyLimiter;
     private readonly IOverloadDetector _overloadDetector;
     private int _currentCapacity;
@@ -39,12 +40,14 @@ internal sealed partial class ShardExecutor
         IOptions<DurableJobsOptions> options,
         IOverloadDetector overloadDetector,
         ILogger<ShardExecutor> logger,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        DurableJobsInstruments? durableJobsInstruments = null)
     {
         _grainFactory = grainFactory;
         _logger = logger;
         _options = options.Value;
         _overloadDetector = overloadDetector;
+        _durableJobsInstruments = durableJobsInstruments ?? DurableJobsInstruments.CreateForDirectConstruction();
         _timeProvider = timeProvider ?? TimeProvider.System;
 
         _currentCapacity = _options.ConcurrencySlowStartEnabled && _options.SlowStartInitialConcurrency < _options.MaxConcurrentJobsPerSilo
@@ -127,7 +130,7 @@ internal sealed partial class ShardExecutor
             {
                 if (processingStarted)
                 {
-                    DurableJobsInstruments.OnShardProcessed(_timeProvider.GetElapsedTime(processingStartTimestamp), canceled, error);
+                    _durableJobsInstruments.OnShardProcessed(_timeProvider.GetElapsedTime(processingStartTimestamp), canceled, error);
                 }
             }
         }
@@ -220,7 +223,7 @@ internal sealed partial class ShardExecutor
 
         Exception? failureException = null;
         var attemptStartTimestamp = _timeProvider.GetTimestamp();
-        DurableJobsInstruments.OnJobAttemptStarted(_timeProvider.GetUtcNow() - jobContext.Job.DueTime);
+        _durableJobsInstruments.OnJobAttemptStarted(_timeProvider.GetUtcNow() - jobContext.Job.DueTime);
 
         using var activity = DurableJobsDiagnostics.StartExecuteActivity(jobContext.Job, jobContext.DequeueCount, jobContext.RunId);
         try
@@ -248,7 +251,7 @@ internal sealed partial class ShardExecutor
                 {
                     await shard.RemoveJobAsync(jobContext.Job.Id, cancellationToken);
                     LogJobExecutedSuccessfully(_logger, jobContext.Job.Id, jobContext.Job.Name);
-                    DurableJobsInstruments.OnJobCompleted(_timeProvider.GetElapsedTime(attemptStartTimestamp));
+                    _durableJobsInstruments.OnJobCompleted(_timeProvider.GetElapsedTime(attemptStartTimestamp));
                     activity?.SetTag(ActivityTagKeys.DurableJobStatus, "completed");
                     activity?.SetStatus(ActivityStatusCode.Ok);
                 }
@@ -273,14 +276,14 @@ internal sealed partial class ShardExecutor
                 {
                     LogRetryingJob(_logger, jobContext.Job.Id, jobContext.Job.Name, retryTime.Value, jobContext.DequeueCount);
                     await shard.RetryJobLaterAsync(jobContext, retryTime.Value, cancellationToken);
-                    DurableJobsInstruments.OnJobRetried(_timeProvider.GetElapsedTime(attemptStartTimestamp));
+                    _durableJobsInstruments.OnJobRetried(_timeProvider.GetElapsedTime(attemptStartTimestamp));
                     activity?.SetTag(ActivityTagKeys.DurableJobStatus, "retried");
                     DurableJobsDiagnostics.SetError(activity, failureException);
                 }
                 else
                 {
                     LogJobFailedNoRetry(_logger, jobContext.Job.Id, jobContext.Job.Name, jobContext.DequeueCount);
-                    DurableJobsInstruments.OnJobFailed(_timeProvider.GetElapsedTime(attemptStartTimestamp));
+                    _durableJobsInstruments.OnJobFailed(_timeProvider.GetElapsedTime(attemptStartTimestamp));
                     activity?.SetTag(ActivityTagKeys.DurableJobStatus, "failed");
                     DurableJobsDiagnostics.SetError(activity, failureException);
                 }

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobsInstrumentsTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobsInstrumentsTests.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Orleans.DurableJobs;
+using Orleans.Runtime;
+using Xunit;
+
+namespace NonSilo.Tests.DurableJobs;
+
+[TestCategory("BVT")]
+public class DurableJobsInstrumentsTests
+{
+    [Fact]
+    public void DurableJobsInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new DurableJobsInstruments(new OrleansInstruments(meterFactory));
+        using var scheduledCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-durablejobs-jobs-scheduled");
+        using var scheduleDurationCollector = new MetricCollector<double>(meterFactory, "Microsoft.Orleans", "orleans-durablejobs-job-schedule-duration");
+        using var stripeCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-durablejobs-stripe-distribution");
+
+        instruments.OnJobScheduled(TimeSpan.FromMilliseconds(12));
+        instruments.OnStripeAssigned(3);
+
+        Assert.Equal(1, Assert.Single(scheduledCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(12, Assert.Single(scheduleDurationCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(stripeCollector.GetMeasurementSnapshot()).Value);
+    }
+}


### PR DESCRIPTION
## Problem
`DurableJobsInstruments` created durable jobs metrics using the global static `Instruments.Meter`, so durable jobs metrics were not scoped to the DI-provided `IMeterFactory` used by migrated runtime instruments.

## Solution
Convert `DurableJobsInstruments` to an instance class backed by `OrleansInstruments`. Register it with durable jobs services and pass it through the manager, shard executor, journaled shard, and handler execution tracker. Adds a `MetricCollector` BVT covering job scheduling, schedule duration, and stripe distribution metrics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10181)