### PR TITLE
chore: use IMeterFactory for AzureBlobJournalStorageInstruments

### DIFF
--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -87,7 +87,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
         finally
         {
-            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+            _shared.Instruments.OnOperationCompleted(
                 AzureBlobJournalStorageInstruments.OperationCreate,
                 Stopwatch.GetElapsedTime(startTimestamp),
                 bytes: 0,
@@ -109,7 +109,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
         finally
         {
-            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+            _shared.Instruments.OnOperationCompleted(
                 AzureBlobJournalStorageInstruments.OperationGetMetadata,
                 Stopwatch.GetElapsedTime(startTimestamp),
                 bytes: 0,
@@ -187,7 +187,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
         finally
         {
-            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+            _shared.Instruments.OnOperationCompleted(
                 AzureBlobJournalStorageInstruments.OperationUpdateMetadata,
                 Stopwatch.GetElapsedTime(startTimestamp),
                 bytes: 0,
@@ -270,7 +270,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
         finally
         {
-            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+            _shared.Instruments.OnOperationCompleted(
                 AzureBlobJournalStorageInstruments.OperationAppend,
                 Stopwatch.GetElapsedTime(startTimestamp),
                 value.Length,
@@ -364,7 +364,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
         finally
         {
-            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+            _shared.Instruments.OnOperationCompleted(
                 AzureBlobJournalStorageInstruments.OperationDelete,
                 Stopwatch.GetElapsedTime(startTimestamp),
                 bytes: 0,
@@ -454,7 +454,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
         finally
         {
-            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+            _shared.Instruments.OnOperationCompleted(
                 AzureBlobJournalStorageInstruments.OperationRead,
                 Stopwatch.GetElapsedTime(startTimestamp),
                 bytes,
@@ -572,7 +572,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         }
         finally
         {
-            AzureBlobJournalStorageInstruments.OnOperationCompleted(
+            _shared.Instruments.OnOperationCompleted(
                 AzureBlobJournalStorageInstruments.OperationReplace,
                 Stopwatch.GetElapsedTime(startTimestamp),
                 value.Length,
@@ -1121,6 +1121,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             ILogger<AzureBlobJournalStorage> logger,
             IOptions<AzureBlobJournalStorageOptions> options,
             BlobClientProvider blobClientProvider,
+            AzureBlobJournalStorageInstruments instruments,
             string? mimeType = null,
             string? journalFormatKey = null)
         {
@@ -1149,6 +1150,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
             MimeType = mimeType;
             JournalFormatKey = journalFormatKey;
             BlobClientProvider = blobClientProvider;
+            Instruments = instruments;
         }
 
         public ILogger<AzureBlobJournalStorage> Logger { get; }
@@ -1160,6 +1162,7 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         public string? JournalFormatKey { get; }
 
         public BlobClientProvider BlobClientProvider { get; }
+        public AzureBlobJournalStorageInstruments Instruments { get; }
     }
 
     internal abstract class BlobClientProvider

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageInstruments.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageInstruments.cs
@@ -3,7 +3,7 @@ using Orleans.Runtime;
 
 namespace Orleans.Journaling;
 
-internal static class AzureBlobJournalStorageInstruments
+internal sealed class AzureBlobJournalStorageInstruments(OrleansInstruments instruments)
 {
     private const string MillisecondsUnit = "ms";
     private const string BytesUnit = "bytes";
@@ -20,26 +20,26 @@ internal static class AzureBlobJournalStorageInstruments
     internal const string OperationRead = "read";
     internal const string OperationReplace = "replace";
 
-    private static readonly Counter<long> Operations = Instruments.Meter.CreateCounter<long>("orleans-journaling-azure-blob-operations");
-    private static readonly Counter<long> OperationBytes = Instruments.Meter.CreateCounter<long>("orleans-journaling-azure-blob-operation-bytes", BytesUnit);
-    private static readonly Histogram<double> OperationDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-azure-blob-operation-duration", MillisecondsUnit);
+    private readonly Counter<long> _operations = instruments.Meter.CreateCounter<long>("orleans-journaling-azure-blob-operations");
+    private readonly Counter<long> _operationBytes = instruments.Meter.CreateCounter<long>("orleans-journaling-azure-blob-operation-bytes", BytesUnit);
+    private readonly Histogram<double> _operationDuration = instruments.Meter.CreateHistogram<double>("orleans-journaling-azure-blob-operation-duration", MillisecondsUnit);
 
-    internal static void OnOperationCompleted(string operation, TimeSpan latency, long bytes, bool succeeded)
+    internal void OnOperationCompleted(string operation, TimeSpan latency, long bytes, bool succeeded)
     {
         var tags = CreateTags(operation, succeeded);
-        if (Operations.Enabled)
+        if (_operations.Enabled)
         {
-            Operations.Add(1, tags);
+            _operations.Add(1, tags);
         }
 
-        if (OperationDuration.Enabled)
+        if (_operationDuration.Enabled)
         {
-            OperationDuration.Record(Math.Max(0, latency.TotalMilliseconds), tags);
+            _operationDuration.Record(Math.Max(0, latency.TotalMilliseconds), tags);
         }
 
-        if (succeeded && bytes > 0 && OperationBytes.Enabled)
+        if (succeeded && bytes > 0 && _operationBytes.Enabled)
         {
-            OperationBytes.Add(bytes, [new KeyValuePair<string, object?>(OperationTagName, operation)]);
+            _operationBytes.Add(bytes, [new KeyValuePair<string, object?>(OperationTagName, operation)]);
         }
     }
 

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageInstruments.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageInstruments.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
 
 namespace Orleans.Journaling;
@@ -19,6 +20,15 @@ internal sealed class AzureBlobJournalStorageInstruments(OrleansInstruments inst
     internal const string OperationDelete = "delete";
     internal const string OperationRead = "read";
     internal const string OperationReplace = "replace";
+
+    internal static AzureBlobJournalStorageInstruments CreateForDirectConstruction()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton<AzureBlobJournalStorageInstruments>();
+        return services.BuildServiceProvider().GetRequiredService<AzureBlobJournalStorageInstruments>();
+    }
 
     private readonly Counter<long> _operations = instruments.Meter.CreateCounter<long>("orleans-journaling-azure-blob-operations");
     private readonly Counter<long> _operationBytes = instruments.Meter.CreateCounter<long>("orleans-journaling-azure-blob-operation-bytes", BytesUnit);

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
@@ -21,6 +21,7 @@ internal sealed class AzureBlobJournalStorageProvider : ILifecycleParticipant<IS
         IOptions<AzureBlobJournalStorageOptions> options,
         IOptions<JournaledStateManagerOptions> managerOptions,
         IServiceProvider serviceProvider,
+        AzureBlobJournalStorageInstruments instruments,
         ILogger<AzureBlobJournalStorage> logger)
     {
         _options = options.Value;
@@ -31,6 +32,7 @@ internal sealed class AzureBlobJournalStorageProvider : ILifecycleParticipant<IS
             logger,
             options,
             new AzureBlobJournalStorage.OptionsBlobClientProvider(_containerFactory, _options),
+            instruments,
             mimeType: journalFormat.MimeType,
             journalFormatKey: journalFormatKey);
     }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageProvider.cs
@@ -21,8 +21,8 @@ internal sealed class AzureBlobJournalStorageProvider : ILifecycleParticipant<IS
         IOptions<AzureBlobJournalStorageOptions> options,
         IOptions<JournaledStateManagerOptions> managerOptions,
         IServiceProvider serviceProvider,
-        AzureBlobJournalStorageInstruments instruments,
-        ILogger<AzureBlobJournalStorage> logger)
+        ILogger<AzureBlobJournalStorage> logger,
+        AzureBlobJournalStorageInstruments? instruments = null)
     {
         _options = options.Value;
         _containerFactory = _options.BuildContainerFactory(serviceProvider, _options);
@@ -32,7 +32,7 @@ internal sealed class AzureBlobJournalStorageProvider : ILifecycleParticipant<IS
             logger,
             options,
             new AzureBlobJournalStorage.OptionsBlobClientProvider(_containerFactory, _options),
-            instruments,
+            instruments ?? AzureBlobJournalStorageInstruments.CreateForDirectConstruction(),
             mimeType: journalFormat.MimeType,
             journalFormatKey: journalFormatKey);
     }

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobStorageHostingExtensions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobStorageHostingExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.Configuration.Internal;
 
 namespace Orleans.Journaling;
@@ -20,6 +21,7 @@ public static class AzureBlobStorageHostingExtensions
 
         if (!services.Any(service => service.ServiceType.Equals(typeof(AzureBlobJournalStorageProvider))))
         {
+            builder.Services.TryAddSingleton<AzureBlobJournalStorageInstruments>();
             builder.Services.AddSingleton<AzureBlobJournalStorageProvider>();
             builder.Services.AddFromExisting<IJournalStorageProvider, AzureBlobJournalStorageProvider>();
             builder.Services.AddFromExisting<IJournalStorageCatalog, AzureBlobJournalStorageProvider>();

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageInstrumentsTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageInstrumentsTests.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+
+namespace Orleans.Journaling.Tests;
+
+[TestCategory("BVT")]
+public class AzureBlobJournalStorageInstrumentsTests
+{
+    [Fact]
+    public void AzureBlobJournalStorageInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new AzureBlobJournalStorageInstruments(new OrleansInstruments(meterFactory));
+        using var operationsCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-journaling-azure-blob-operations");
+        using var bytesCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-journaling-azure-blob-operation-bytes");
+        using var durationCollector = new MetricCollector<double>(meterFactory, "Microsoft.Orleans", "orleans-journaling-azure-blob-operation-duration");
+
+        instruments.OnOperationCompleted(AzureBlobJournalStorageInstruments.OperationAppend, TimeSpan.FromMilliseconds(8), bytes: 12, succeeded: true);
+
+        Assert.Equal(1, Assert.Single(operationsCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(12, Assert.Single(bytesCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(8, Assert.Single(durationCollector.GetMeasurementSnapshot()).Value);
+    }
+}

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -4,8 +4,10 @@ using Azure;
 using Azure.Core;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Orleans.Runtime;
 using Orleans.Storage;
 using Xunit;
 
@@ -645,9 +647,19 @@ public sealed class AzureBlobJournalStorageTests
                 NullLogger<AzureBlobJournalStorage>.Instance,
                 Options.Create(new AzureBlobJournalStorageOptions { DeleteOldCheckpoints = deleteOldCheckpoints }),
                 new FakeBlobClientProvider(appendBlobs, checkpoints),
+                CreateAzureBlobJournalStorageInstruments(),
                 mimeType,
                 journalFormatKey),
             JournalId.FromGrainId(GrainId.Create("test-grain", "0")));
+    }
+
+    private static AzureBlobJournalStorageInstruments CreateAzureBlobJournalStorageInstruments()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton<AzureBlobJournalStorageInstruments>();
+        return services.BuildServiceProvider().GetRequiredService<AzureBlobJournalStorageInstruments>();
     }
 
     private static Dictionary<string, string> WalMetadata(string? format = null, string? generation = null)


### PR DESCRIPTION
Part of #9608

## Problem
`AzureBlobJournalStorageInstruments` created Azure Blob journaling metrics using the global static `Instruments.Meter`, so Azure Blob journal storage metrics were not scoped to the DI-provided `IMeterFactory` used by migrated runtime instruments.

## Solution
Convert `AzureBlobJournalStorageInstruments` to an instance class backed by `OrleansInstruments`. Register it with Azure Blob journaling services and route storage operation metrics through the shared instrumentation instance. Adds a `MetricCollector` BVT covering operation count, duration, and bytes metrics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10183)