### PR TITLE
chore: use IMeterFactory for JournalingInstruments

### DIFF
--- a/src/Orleans.Journaling/HostingExtensions.cs
+++ b/src/Orleans.Journaling/HostingExtensions.cs
@@ -9,6 +9,7 @@ public static class HostingExtensions
     public static ISiloBuilder AddJournalStorage(this ISiloBuilder builder)
     {
         builder.Services.AddOptions<JournaledStateManagerOptions>();
+        builder.Services.TryAddSingleton<JournalingInstruments>();
         builder.Services.TryAddSingleton<JournaledStateManagerShared>();
         builder.Services.TryAddScoped<IJournaledStateManager, JournaledStateManager>();
         builder.Services.TryAddSingleton<IJournaledStateManagerFactory, JournaledStateManagerFactory>();

--- a/src/Orleans.Journaling/HostingExtensions.cs
+++ b/src/Orleans.Journaling/HostingExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Orleans.Journaling.Json;
+using Orleans.Runtime;
 
 namespace Orleans.Journaling;
 
@@ -9,7 +10,10 @@ public static class HostingExtensions
     public static ISiloBuilder AddJournalStorage(this ISiloBuilder builder)
     {
         builder.Services.AddOptions<JournaledStateManagerOptions>();
-        builder.Services.TryAddSingleton<JournalingInstruments>();
+        builder.Services.TryAddSingleton(static serviceProvider =>
+            serviceProvider.GetService<OrleansInstruments>() is { } instruments
+                ? new JournalingInstruments(instruments)
+                : JournalingInstruments.CreateForDirectConstruction());
         builder.Services.TryAddSingleton<JournaledStateManagerShared>();
         builder.Services.TryAddScoped<IJournaledStateManager, JournaledStateManager>();
         builder.Services.TryAddSingleton<IJournaledStateManagerFactory, JournaledStateManagerFactory>();

--- a/src/Orleans.Journaling/JournaledStateManager.cs
+++ b/src/Orleans.Journaling/JournaledStateManager.cs
@@ -234,9 +234,9 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                                             : _migrationSnapshotRequired
                                                 ? JournalingInstruments.CompactionReasonMigration
                                                 : JournalingInstruments.CompactionReasonStorageRequested;
-                                        JournalingInstruments.OnCompactionTriggered(compactionReason);
+                                        _shared.Instruments.OnCompactionTriggered(compactionReason);
                                     }
-                                    JournalingInstruments.OnWriteCoalesced(operationLabel, workItem.CallerCount);
+                                    _shared.Instruments.OnWriteCoalesced(operationLabel, workItem.CallerCount);
                                     var gatherStartTimestamp = _shared.TimeProvider.GetTimestamp();
                                     var statesScanned = 0L;
                                     ArcBuffer committedBuffer = default;
@@ -334,7 +334,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                                         }
                                     }
 
-                                    JournalingInstruments.OnGather(
+                                    _shared.Instruments.OnGather(
                                         operationLabel,
                                         _shared.TimeProvider.GetElapsedTime(gatherStartTimestamp),
                                         statesScanned);
@@ -495,7 +495,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
 
                         if (recordQueueDuration && queueOperation is not null)
                         {
-                            JournalingInstruments.OnStorageOperationQueued(queueOperation, queueDuration, succeeded: true);
+                            _shared.Instruments.OnStorageOperationQueued(queueOperation, queueDuration, succeeded: true);
                         }
 
                         storageActivity?.SetStatus(ActivityStatusCode.Ok);
@@ -505,7 +505,7 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
                     {
                         if (recordQueueDuration && queueOperation is not null)
                         {
-                            JournalingInstruments.OnStorageOperationQueued(queueOperation, queueDuration, succeeded: false);
+                            _shared.Instruments.OnStorageOperationQueued(queueOperation, queueDuration, succeeded: false);
                         }
 
                         if (storageActivity is not null)
@@ -651,11 +651,11 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         try
         {
             await task;
-            JournalingInstruments.OnStateDeleteRequest(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: true);
+            _shared.Instruments.OnStateDeleteRequest(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: true);
         }
         catch
         {
-            JournalingInstruments.OnStateDeleteRequest(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: false);
+            _shared.Instruments.OnStateDeleteRequest(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: false);
             throw;
         }
     }
@@ -671,11 +671,11 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         try
         {
             await ReadStorageAsync(this, cancellationToken).ConfigureAwait(true);
-            JournalingInstruments.OnRecovery(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: true);
+            _shared.Instruments.OnRecovery(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: true);
         }
         catch
         {
-            JournalingInstruments.OnRecovery(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: false);
+            _shared.Instruments.OnRecovery(_shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: false);
             throw;
         }
 
@@ -829,11 +829,11 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         try
         {
             await pendingWrite.WaitAsync(cancellationToken);
-            JournalingInstruments.OnStateWriteRequest(operation, _shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: true);
+            _shared.Instruments.OnStateWriteRequest(operation, _shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: true);
         }
         catch
         {
-            JournalingInstruments.OnStateWriteRequest(operation, _shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: false);
+            _shared.Instruments.OnStateWriteRequest(operation, _shared.TimeProvider.GetElapsedTime(startTimestamp), succeeded: false);
             throw;
         }
     }
@@ -844,11 +844,11 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         try
         {
             await _storage.ReadAsync(consumer, cancellationToken).ConfigureAwait(true);
-            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationRead, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: true);
+            _shared.Instruments.OnStorageOperation(JournalingInstruments.OperationRead, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: true);
         }
         catch
         {
-            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationRead, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: false);
+            _shared.Instruments.OnStorageOperation(JournalingInstruments.OperationRead, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: false);
             throw;
         }
     }
@@ -859,11 +859,11 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         try
         {
             await _storage.AppendAsync(value, cancellationToken).ConfigureAwait(true);
-            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationAppend, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: true);
+            _shared.Instruments.OnStorageOperation(JournalingInstruments.OperationAppend, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: true);
         }
         catch
         {
-            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationAppend, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: false);
+            _shared.Instruments.OnStorageOperation(JournalingInstruments.OperationAppend, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: false);
             throw;
         }
     }
@@ -874,11 +874,11 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         try
         {
             await _storage.ReplaceAsync(value, cancellationToken).ConfigureAwait(true);
-            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationReplace, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: true);
+            _shared.Instruments.OnStorageOperation(JournalingInstruments.OperationReplace, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: true);
         }
         catch
         {
-            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationReplace, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: false);
+            _shared.Instruments.OnStorageOperation(JournalingInstruments.OperationReplace, _shared.TimeProvider.GetElapsedTime(startTimestamp), value.Length, succeeded: false);
             throw;
         }
     }
@@ -889,11 +889,11 @@ internal sealed partial class JournaledStateManager : IJournaledStateManager, IJ
         try
         {
             await _storage.DeleteAsync(cancellationToken).ConfigureAwait(true);
-            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationDelete, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: true);
+            _shared.Instruments.OnStorageOperation(JournalingInstruments.OperationDelete, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: true);
         }
         catch
         {
-            JournalingInstruments.OnStorageOperation(JournalingInstruments.OperationDelete, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: false);
+            _shared.Instruments.OnStorageOperation(JournalingInstruments.OperationDelete, _shared.TimeProvider.GetElapsedTime(startTimestamp), bytes: 0, succeeded: false);
             throw;
         }
     }

--- a/src/Orleans.Journaling/JournaledStateManagerShared.cs
+++ b/src/Orleans.Journaling/JournaledStateManagerShared.cs
@@ -9,8 +9,9 @@ internal sealed class JournaledStateManagerShared
         ILogger<JournaledStateManager> logger,
         IOptions<JournaledStateManagerOptions> options,
         TimeProvider timeProvider,
-        IServiceProvider serviceProvider)
-        : this(logger, CreateOptions(options), timeProvider, serviceProvider)
+        IServiceProvider serviceProvider,
+        JournalingInstruments? instruments = null)
+        : this(logger, CreateOptions(options), timeProvider, instruments, serviceProvider)
     {
     }
 
@@ -18,6 +19,7 @@ internal sealed class JournaledStateManagerShared
         ILogger<JournaledStateManager> logger,
         JournaledStateManagerOptions options,
         TimeProvider timeProvider,
+        JournalingInstruments? instruments,
         IServiceProvider serviceProvider)
     {
         ArgumentNullException.ThrowIfNull(logger);
@@ -28,6 +30,7 @@ internal sealed class JournaledStateManagerShared
         Logger = logger;
         Options = options;
         TimeProvider = timeProvider;
+        Instruments = instruments ?? JournalingInstruments.CreateForDirectConstruction();
         ServiceProvider = serviceProvider;
         JournalFormat = JournalFormatServices.GetRequiredJournalFormat(serviceProvider, options.JournalFormatKey);
     }
@@ -37,6 +40,7 @@ internal sealed class JournaledStateManagerShared
     public JournaledStateManagerOptions Options { get; }
 
     public TimeProvider TimeProvider { get; }
+    public JournalingInstruments Instruments { get; }
 
     public IServiceProvider ServiceProvider { get; }
 

--- a/src/Orleans.Journaling/JournalingInstruments.cs
+++ b/src/Orleans.Journaling/JournalingInstruments.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
-using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
 
 namespace Orleans.Journaling;
@@ -27,14 +26,7 @@ internal sealed class JournalingInstruments(OrleansInstruments instruments)
     internal const string CompactionReasonStorageRequested = "storage_requested";
     internal const string CompactionReasonMigration = "migration";
 
-    internal static JournalingInstruments CreateForDirectConstruction()
-    {
-        var services = new ServiceCollection();
-        services.AddMetrics();
-        services.AddSingleton<OrleansInstruments>();
-        services.AddSingleton<JournalingInstruments>();
-        return services.BuildServiceProvider().GetRequiredService<JournalingInstruments>();
-    }
+    internal static JournalingInstruments CreateForDirectConstruction() => new(new OrleansInstruments(new DirectMeterFactory()));
 
     private readonly Counter<long> StateWriteRequests = instruments.Meter.CreateCounter<long>("orleans-journaling-state-write-requests");
     private readonly Counter<long> StateDeleteRequests = instruments.Meter.CreateCounter<long>("orleans-journaling-state-delete-requests");
@@ -145,4 +137,13 @@ internal sealed class JournalingInstruments(OrleansInstruments instruments)
             new(OperationTagName, operation),
             new(StatusTagName, succeeded ? StatusOk : StatusError)
         ];
+
+    private sealed class DirectMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new(options);
+
+        public void Dispose()
+        {
+        }
+    }
 }

--- a/src/Orleans.Journaling/JournalingInstruments.cs
+++ b/src/Orleans.Journaling/JournalingInstruments.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
 
 namespace Orleans.Journaling;
 
-internal static class JournalingInstruments
+internal sealed class JournalingInstruments(OrleansInstruments instruments)
 {
     private const string MillisecondsUnit = "ms";
     private const string BytesUnit = "bytes";
@@ -26,42 +27,51 @@ internal static class JournalingInstruments
     internal const string CompactionReasonStorageRequested = "storage_requested";
     internal const string CompactionReasonMigration = "migration";
 
-    private static readonly Counter<long> StateWriteRequests = Instruments.Meter.CreateCounter<long>("orleans-journaling-state-write-requests");
-    private static readonly Counter<long> StateDeleteRequests = Instruments.Meter.CreateCounter<long>("orleans-journaling-state-delete-requests");
-    private static readonly Counter<long> Recoveries = Instruments.Meter.CreateCounter<long>("orleans-journaling-recoveries");
-    private static readonly Counter<long> StorageOperations = Instruments.Meter.CreateCounter<long>("orleans-journaling-storage-operations");
-    private static readonly Counter<long> StorageBytes = Instruments.Meter.CreateCounter<long>("orleans-journaling-storage-bytes", BytesUnit);
-    private static readonly Counter<long> CompactionTriggers = Instruments.Meter.CreateCounter<long>("orleans-journaling-compaction-triggers");
+    internal static JournalingInstruments CreateForDirectConstruction()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton<JournalingInstruments>();
+        return services.BuildServiceProvider().GetRequiredService<JournalingInstruments>();
+    }
 
-    private static readonly Histogram<double> StateWriteDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-state-write-duration", MillisecondsUnit);
-    private static readonly Histogram<double> StateDeleteDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-state-delete-duration", MillisecondsUnit);
-    private static readonly Histogram<double> RecoveryDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-recovery-duration", MillisecondsUnit);
-    private static readonly Histogram<double> StorageOperationDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-storage-operation-duration", MillisecondsUnit);
-    private static readonly Histogram<long> StorageOperationBytes = Instruments.Meter.CreateHistogram<long>("orleans-journaling-storage-operation-bytes", BytesUnit);
-    private static readonly Histogram<double> StorageOperationQueueDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-storage-operation-queue-duration", MillisecondsUnit);
-    private static readonly Histogram<long> WriteCoalescedCallers = Instruments.Meter.CreateHistogram<long>("orleans-journaling-write-coalesced-callers");
-    private static readonly Histogram<double> GatherDuration = Instruments.Meter.CreateHistogram<double>("orleans-journaling-gather-duration", MillisecondsUnit);
-    private static readonly Histogram<long> StateScanCount = Instruments.Meter.CreateHistogram<long>("orleans-journaling-state-scan-count");
+    private readonly Counter<long> StateWriteRequests = instruments.Meter.CreateCounter<long>("orleans-journaling-state-write-requests");
+    private readonly Counter<long> StateDeleteRequests = instruments.Meter.CreateCounter<long>("orleans-journaling-state-delete-requests");
+    private readonly Counter<long> Recoveries = instruments.Meter.CreateCounter<long>("orleans-journaling-recoveries");
+    private readonly Counter<long> StorageOperations = instruments.Meter.CreateCounter<long>("orleans-journaling-storage-operations");
+    private readonly Counter<long> StorageBytes = instruments.Meter.CreateCounter<long>("orleans-journaling-storage-bytes", BytesUnit);
+    private readonly Counter<long> CompactionTriggers = instruments.Meter.CreateCounter<long>("orleans-journaling-compaction-triggers");
 
-    internal static void OnStateWriteRequest(string operation, TimeSpan latency, bool succeeded)
+    private readonly Histogram<double> StateWriteDuration = instruments.Meter.CreateHistogram<double>("orleans-journaling-state-write-duration", MillisecondsUnit);
+    private readonly Histogram<double> StateDeleteDuration = instruments.Meter.CreateHistogram<double>("orleans-journaling-state-delete-duration", MillisecondsUnit);
+    private readonly Histogram<double> RecoveryDuration = instruments.Meter.CreateHistogram<double>("orleans-journaling-recovery-duration", MillisecondsUnit);
+    private readonly Histogram<double> StorageOperationDuration = instruments.Meter.CreateHistogram<double>("orleans-journaling-storage-operation-duration", MillisecondsUnit);
+    private readonly Histogram<long> StorageOperationBytes = instruments.Meter.CreateHistogram<long>("orleans-journaling-storage-operation-bytes", BytesUnit);
+    private readonly Histogram<double> StorageOperationQueueDuration = instruments.Meter.CreateHistogram<double>("orleans-journaling-storage-operation-queue-duration", MillisecondsUnit);
+    private readonly Histogram<long> WriteCoalescedCallers = instruments.Meter.CreateHistogram<long>("orleans-journaling-write-coalesced-callers");
+    private readonly Histogram<double> GatherDuration = instruments.Meter.CreateHistogram<double>("orleans-journaling-gather-duration", MillisecondsUnit);
+    private readonly Histogram<long> StateScanCount = instruments.Meter.CreateHistogram<long>("orleans-journaling-state-scan-count");
+
+    internal void OnStateWriteRequest(string operation, TimeSpan latency, bool succeeded)
     {
         Add(StateWriteRequests, operation, succeeded);
         Record(StateWriteDuration, operation, latency, succeeded);
     }
 
-    internal static void OnStateDeleteRequest(TimeSpan latency, bool succeeded)
+    internal void OnStateDeleteRequest(TimeSpan latency, bool succeeded)
     {
         Add(StateDeleteRequests, OperationDelete, succeeded);
         Record(StateDeleteDuration, OperationDelete, latency, succeeded);
     }
 
-    internal static void OnRecovery(TimeSpan latency, bool succeeded)
+    internal void OnRecovery(TimeSpan latency, bool succeeded)
     {
         Add(Recoveries, OperationRecovery, succeeded);
         Record(RecoveryDuration, OperationRecovery, latency, succeeded);
     }
 
-    internal static void OnStorageOperation(string operation, TimeSpan latency, long bytes, bool succeeded)
+    internal void OnStorageOperation(string operation, TimeSpan latency, long bytes, bool succeeded)
     {
         Add(StorageOperations, operation, succeeded);
         Record(StorageOperationDuration, operation, latency, succeeded);
@@ -72,12 +82,12 @@ internal static class JournalingInstruments
         }
     }
 
-    internal static void OnStorageOperationQueued(string operation, TimeSpan latency, bool succeeded)
+    internal void OnStorageOperationQueued(string operation, TimeSpan latency, bool succeeded)
     {
         Record(StorageOperationQueueDuration, operation, latency, succeeded);
     }
 
-    internal static void OnWriteCoalesced(string operation, long callerCount)
+    internal void OnWriteCoalesced(string operation, long callerCount)
     {
         if (WriteCoalescedCallers.Enabled && callerCount > 0)
         {
@@ -85,7 +95,7 @@ internal static class JournalingInstruments
         }
     }
 
-    internal static void OnGather(string operation, TimeSpan duration, long stateScanCount)
+    internal void OnGather(string operation, TimeSpan duration, long stateScanCount)
     {
         if (GatherDuration.Enabled)
         {
@@ -98,7 +108,7 @@ internal static class JournalingInstruments
         }
     }
 
-    internal static void OnCompactionTriggered(string reason)
+    internal void OnCompactionTriggered(string reason)
     {
         if (CompactionTriggers.Enabled)
         {
@@ -106,7 +116,7 @@ internal static class JournalingInstruments
         }
     }
 
-    private static void Add(Counter<long> counter, string operation, bool succeeded)
+    private void Add(Counter<long> counter, string operation, bool succeeded)
     {
         if (counter.Enabled)
         {
@@ -114,7 +124,7 @@ internal static class JournalingInstruments
         }
     }
 
-    private static void Record(Histogram<double> histogram, string operation, TimeSpan latency, bool succeeded)
+    private void Record(Histogram<double> histogram, string operation, TimeSpan latency, bool succeeded)
     {
         if (histogram.Enabled)
         {
@@ -122,7 +132,7 @@ internal static class JournalingInstruments
         }
     }
 
-    private static void Record(Histogram<long> histogram, string operation, long value, bool succeeded)
+    private void Record(Histogram<long> histogram, string operation, long value, bool succeeded)
     {
         if (histogram.Enabled)
         {

--- a/test/Orleans.Journaling.Tests/JournalingInstrumentsTests.cs
+++ b/test/Orleans.Journaling.Tests/JournalingInstrumentsTests.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+
+namespace Orleans.Journaling.Tests;
+
+[TestCategory("BVT")]
+public class JournalingInstrumentsTests
+{
+    [Fact]
+    public void JournalingInstruments_RecordsMetricsUsingMeterFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var meterFactory = serviceProvider.GetRequiredService<IMeterFactory>();
+        var instruments = new JournalingInstruments(new OrleansInstruments(meterFactory));
+        using var writeCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-journaling-state-write-requests");
+        using var storageBytesCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-journaling-storage-bytes");
+        using var compactionCollector = new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-journaling-compaction-triggers");
+
+        instruments.OnStateWriteRequest(JournalingInstruments.OperationAppend, TimeSpan.FromMilliseconds(5), succeeded: true);
+        instruments.OnStorageOperation(JournalingInstruments.OperationAppend, TimeSpan.FromMilliseconds(7), bytes: 9, succeeded: true);
+        instruments.OnCompactionTriggered(JournalingInstruments.CompactionReasonUserSnapshot);
+
+        Assert.Equal(1, Assert.Single(writeCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(9, Assert.Single(storageBytesCollector.GetMeasurementSnapshot()).Value);
+        Assert.Equal(1, Assert.Single(compactionCollector.GetMeasurementSnapshot()).Value);
+    }
+}

--- a/test/Orleans.Journaling.Tests/StateManagerTests.cs
+++ b/test/Orleans.Journaling.Tests/StateManagerTests.cs
@@ -286,9 +286,10 @@ public class StateManagerTests : JournalingTestBase
         var observedBytes = new ConcurrentBag<MetricMeasurement<long>>();
         using var listener = CreateMetricListener("orleans-journaling-storage-operation-bytes", observedBytes);
         var operation = $"test-{Guid.NewGuid():N}";
+        var instruments = JournalingInstruments.CreateForDirectConstruction();
 
-        JournalingInstruments.OnStorageOperation(operation, TimeSpan.Zero, bytes: 0, succeeded: true);
-        JournalingInstruments.OnStorageOperation(operation, TimeSpan.Zero, bytes: 1, succeeded: false);
+        instruments.OnStorageOperation(operation, TimeSpan.Zero, bytes: 0, succeeded: true);
+        instruments.OnStorageOperation(operation, TimeSpan.Zero, bytes: 1, succeeded: false);
 
         Assert.DoesNotContain(observedBytes, measurement => measurement.Operation == operation);
     }


### PR DESCRIPTION
Part of #9608

## Problem
`JournalingInstruments` created core journaling metrics using the global static `Instruments.Meter`, so journaling metrics were not scoped to the DI-provided `IMeterFactory` used by migrated runtime instruments.

## Solution
Convert `JournalingInstruments` to an instance class backed by `OrleansInstruments`. Register it with journaling services and route `JournaledStateManager` metrics through the shared instrumentation instance. Adds a `MetricCollector` BVT covering state write, storage bytes, and compaction trigger metrics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10184)