### PR TITLE
fix: stabilize activation rebalancing control test

### DIFF
--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
@@ -12,81 +12,179 @@ namespace UnitTests.ActivationRebalancingTests;
 public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper output)
     : RebalancingTestBase<RebalancerFixture>(fixture, output), IClassFixture<RebalancerFixture>
 {
+    private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
+
     [Fact]
     public async Task Rebalancer_Should_Be_Controllable_And_Report_To_Listeners()
     {
         var serviceProvider = Cluster.GetSiloServiceProvider();
         var rebalancer = serviceProvider.GetRequiredService<IActivationRebalancer>();
-        var report = await rebalancer.GetRebalancingReport();
+
+        await rebalancer.ResumeRebalancing();
+        var report = await WaitForReportAsync(
+            rebalancer,
+            static report => report is { Status: RebalancerStatus.Executing, SuspensionDuration: null } &&
+                !report.Host.Equals(SiloAddress.Zero),
+            "an executing report");
+
         var host = report.Host;
 
-        Assert.Equal(RebalancerStatus.Executing, report.Status);
-        Assert.Null(report.SuspensionDuration);
         Assert.NotEqual(SiloAddress.Zero, host);
 
         // Publish-Subscribe
         var listener = new Listener();
         rebalancer.SubscribeToReports(listener);
-        Assert.False(listener.Report.HasValue);
 
-        await rebalancer.ResumeRebalancing();
-        Assert.True(listener.Report.HasValue);
-        Assert.Equal(RebalancerStatus.Executing, listener.Report.Value.Status);
-        Assert.Equal(host, listener.Report.Value.Host);
+        var reportCount = listener.Snapshot.ReportCount;
 
         await rebalancer.SuspendRebalancing();
-        Assert.Equal(RebalancerStatus.Suspended, listener.Report.Value.Status);
-        Assert.True(listener.Report.Value.SuspensionDuration.HasValue);
-        Assert.Equal(host, listener.Report.Value.Host);
+        await WaitForListenerReportAsync(
+            listener,
+            reportCount,
+            report => report.Status == RebalancerStatus.Suspended &&
+                report.SuspensionDuration.HasValue &&
+                report.Host.Equals(host),
+            "a fresh suspended report");
+
+        reportCount = listener.Snapshot.ReportCount;
+        await rebalancer.ResumeRebalancing();
+        await WaitForListenerReportAsync(
+            listener,
+            reportCount,
+            report => report is { Status: RebalancerStatus.Executing, SuspensionDuration: null } &&
+                report.Host.Equals(host),
+            "a fresh executing report");
+
+        reportCount = listener.Snapshot.ReportCount;
+        await rebalancer.SuspendRebalancing();
+        await WaitForListenerReportAsync(
+            listener,
+            reportCount,
+            report => report.Status == RebalancerStatus.Suspended &&
+                report.SuspensionDuration.HasValue &&
+                report.Host.Equals(host),
+            "a fresh suspended report before unsubscribing");
 
         rebalancer.UnsubscribeFromReports(listener);
+        var unsubscribedSnapshot = listener.Snapshot;
         await rebalancer.ResumeRebalancing();
-        while (report.Status == RebalancerStatus.Suspended)
-        {
-            report = await rebalancer.GetRebalancingReport(true);
-            await Task.Delay(100);
-        }
-        // Its actually resumed, but here its still suspended since we unsubscribed
-        Assert.Equal(RebalancerStatus.Suspended, listener.Report.Value.Status); 
+        await WaitForReportAsync(
+            rebalancer,
+            report => report is { Status: RebalancerStatus.Executing, SuspensionDuration: null } &&
+                report.Host.Equals(host),
+            "an executing report after unsubscribing");
+
+        Assert.True(unsubscribedSnapshot.Report.HasValue);
+        Assert.Equal(RebalancerStatus.Suspended, unsubscribedSnapshot.Report.Value.Status);
+        var afterResumeSnapshot = listener.Snapshot;
+        Assert.Equal(unsubscribedSnapshot.ReportCount, afterResumeSnapshot.ReportCount);
+        Assert.Equal(unsubscribedSnapshot.Report, afterResumeSnapshot.Report);
 
         // Request-Reply
         var duration = TimeSpan.FromSeconds(5);
         await rebalancer.SuspendRebalancing(duration); // Suspend for some time
-        while (report.Status == RebalancerStatus.Executing)
-        {
-            report = await rebalancer.GetRebalancingReport(true);
-            await Task.Delay(100);
-        }
+        report = await WaitForReportAsync(
+            rebalancer,
+            report => report.Status == RebalancerStatus.Suspended && report.SuspensionDuration.HasValue,
+            "a suspended report");
 
-        Assert.True(report.SuspensionDuration.HasValue);
         // Must be less than the time it was told to be suspended
         Assert.True(report.SuspensionDuration.Value < duration); 
         Assert.Equal(host, report.Host);
 
-        while (report.Status == RebalancerStatus.Suspended)
-        {
-            report = await rebalancer.GetRebalancingReport(true);
-            await Task.Delay(100);
-        }
-
-        Assert.Equal(RebalancerStatus.Executing, report.Status);
-        Assert.Null(report.SuspensionDuration);
-        Assert.Equal(host, report.Host);
+        await WaitForReportAsync(
+            rebalancer,
+            report => report is { Status: RebalancerStatus.Executing, SuspensionDuration: null } &&
+                report.Host.Equals(host),
+            "an executing report after timed suspension");
 
         await rebalancer.SuspendRebalancing(); // Suspend indefinitely
-        while (report.Status == RebalancerStatus.Executing)
-        {
-            report = await rebalancer.GetRebalancingReport(true);
-            await Task.Delay(100);
-        }
-        report = await rebalancer.GetRebalancingReport(true);
-        Assert.True(report.SuspensionDuration.HasValue);
-        Assert.Equal(host, report.Host);
+        await WaitForReportAsync(
+            rebalancer,
+            report => report.Status == RebalancerStatus.Suspended &&
+                report.SuspensionDuration.HasValue &&
+                report.Host.Equals(host),
+            "an indefinitely suspended report");
     }
+
+    private static async Task<RebalancingReport> WaitForReportAsync(
+        IActivationRebalancer rebalancer,
+        Func<RebalancingReport, bool> predicate,
+        string expectedState)
+    {
+        var deadline = DateTime.UtcNow + WaitTimeout;
+        RebalancingReport report = default;
+        while (DateTime.UtcNow < deadline)
+        {
+            report = await rebalancer.GetRebalancingReport(force: true);
+            if (predicate(report))
+            {
+                return report;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        Assert.Fail($"Timed out waiting for {expectedState}. Last report: {Format(report)}");
+        return report;
+    }
+
+    private static async Task<RebalancingReport> WaitForListenerReportAsync(
+        Listener listener,
+        int previousReportCount,
+        Func<RebalancingReport, bool> predicate,
+        string expectedState)
+    {
+        var deadline = DateTime.UtcNow + WaitTimeout;
+        var snapshot = listener.Snapshot;
+        while (DateTime.UtcNow < deadline)
+        {
+            snapshot = listener.Snapshot;
+            if (snapshot.ReportCount > previousReportCount &&
+                snapshot.Report is { } report &&
+                predicate(report))
+            {
+                return report;
+            }
+
+            await Task.Delay(PollInterval);
+        }
+
+        var lastReport = snapshot.Report is { } value ? Format(value) : "<none>";
+        Assert.Fail(
+            $"Timed out waiting for {expectedState}. Last listener report count: {snapshot.ReportCount}. Last report: {lastReport}");
+
+        return default;
+    }
+
+    private static string Format(RebalancingReport report) =>
+        $"Host={report.Host}, Status={report.Status}, SuspensionDuration={report.SuspensionDuration?.ToString() ?? "<null>"}";
 
     private class Listener : IActivationRebalancerReportListener
     {
-        public RebalancingReport? Report { get; private set; }
-        public void OnReport(RebalancingReport report) => Report = report;
+        private readonly object _lock = new();
+        private RebalancingReport? _report;
+        private int _reportCount;
+
+        public (int ReportCount, RebalancingReport? Report) Snapshot
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return (_reportCount, _report);
+                }
+            }
+        }
+
+        public void OnReport(RebalancingReport report)
+        {
+            lock (_lock)
+            {
+                _report = report;
+                _reportCount++;
+            }
+        }
     }
 }

--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Placement.Rebalancing;
+using TestExtensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -13,67 +14,70 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
     : RebalancingTestBase<RebalancerFixture>(fixture, output), IClassFixture<RebalancerFixture>
 {
     private static readonly TimeSpan WaitTimeout = TimeSpan.FromSeconds(15);
-    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
 
     [Fact]
     public async Task Rebalancer_Should_Be_Controllable_And_Report_To_Listeners()
     {
         var serviceProvider = Cluster.GetSiloServiceProvider();
         var rebalancer = serviceProvider.GetRequiredService<IActivationRebalancer>();
+        using var rebalancerEvents = RebalancerDiagnosticObserver.Create();
 
+        var sessionStarted = rebalancerEvents.WaitForSessionStartAsync(WaitTimeout);
         await rebalancer.ResumeRebalancing();
-        var report = await WaitForReportAsync(
-            rebalancer,
-            static report => report is { Status: RebalancerStatus.Executing, SuspensionDuration: null } &&
-                !report.Host.Equals(SiloAddress.Zero),
-            "an executing report");
-
-        var host = report.Host;
+        var host = (await sessionStarted).SiloAddress;
+        var report = await rebalancer.GetRebalancingReport();
 
         Assert.NotEqual(SiloAddress.Zero, host);
+        Assert.Equal(RebalancerStatus.Executing, report.Status);
+        Assert.Null(report.SuspensionDuration);
+        Assert.Equal(host, report.Host);
 
         // Publish-Subscribe
         var listener = new Listener();
         rebalancer.SubscribeToReports(listener);
+        Assert.Equal(0, listener.Snapshot.ReportCount);
 
         var reportCount = listener.Snapshot.ReportCount;
 
-        await rebalancer.SuspendRebalancing();
-        await WaitForListenerReportAsync(
-            listener,
+        var listenerReport = listener.WaitForReportAsync(
             reportCount,
             report => report.Status == RebalancerStatus.Suspended &&
                 report.SuspensionDuration.HasValue &&
                 report.Host.Equals(host),
             "a fresh suspended report");
+        await rebalancer.SuspendRebalancing();
+        await listenerReport;
 
         reportCount = listener.Snapshot.ReportCount;
-        await rebalancer.ResumeRebalancing();
-        await WaitForListenerReportAsync(
-            listener,
+        var resumed = rebalancerEvents.WaitForSessionStartAsync(
+            sessionStart => sessionStart.SiloAddress.Equals(host),
+            WaitTimeout);
+        listenerReport = listener.WaitForReportAsync(
             reportCount,
             report => report is { Status: RebalancerStatus.Executing, SuspensionDuration: null } &&
                 report.Host.Equals(host),
             "a fresh executing report");
+        await rebalancer.ResumeRebalancing();
+        await resumed;
+        await listenerReport;
 
         reportCount = listener.Snapshot.ReportCount;
-        await rebalancer.SuspendRebalancing();
-        await WaitForListenerReportAsync(
-            listener,
+        listenerReport = listener.WaitForReportAsync(
             reportCount,
             report => report.Status == RebalancerStatus.Suspended &&
                 report.SuspensionDuration.HasValue &&
                 report.Host.Equals(host),
             "a fresh suspended report before unsubscribing");
+        await rebalancer.SuspendRebalancing();
+        await listenerReport;
 
         rebalancer.UnsubscribeFromReports(listener);
         var unsubscribedSnapshot = listener.Snapshot;
+        resumed = rebalancerEvents.WaitForSessionStartAsync(
+            sessionStart => sessionStart.SiloAddress.Equals(host),
+            WaitTimeout);
         await rebalancer.ResumeRebalancing();
-        await WaitForReportAsync(
-            rebalancer,
-            report => report is { Status: RebalancerStatus.Executing, SuspensionDuration: null } &&
-                report.Host.Equals(host),
-            "an executing report after unsubscribing");
+        await resumed;
 
         Assert.True(unsubscribedSnapshot.Report.HasValue);
         Assert.Equal(RebalancerStatus.Suspended, unsubscribedSnapshot.Report.Value.Status);
@@ -82,80 +86,26 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
         Assert.Equal(unsubscribedSnapshot.Report, afterResumeSnapshot.Report);
 
         // Request-Reply
-        var duration = TimeSpan.FromSeconds(5);
+        var duration = TimeSpan.FromSeconds(2);
         await rebalancer.SuspendRebalancing(duration); // Suspend for some time
-        report = await WaitForReportAsync(
-            rebalancer,
-            report => report.Status == RebalancerStatus.Suspended && report.SuspensionDuration.HasValue,
-            "a suspended report");
+        report = await rebalancer.GetRebalancingReport();
 
+        Assert.Equal(RebalancerStatus.Suspended, report.Status);
+        Assert.True(report.SuspensionDuration.HasValue);
         // Must be less than the time it was told to be suspended
         Assert.True(report.SuspensionDuration.Value < duration); 
         Assert.Equal(host, report.Host);
 
-        await WaitForReportAsync(
-            rebalancer,
-            report => report is { Status: RebalancerStatus.Executing, SuspensionDuration: null } &&
-                report.Host.Equals(host),
-            "an executing report after timed suspension");
+        resumed = rebalancerEvents.WaitForSessionStartAsync(
+            sessionStart => sessionStart.SiloAddress.Equals(host),
+            WaitTimeout);
+        await resumed;
 
         await rebalancer.SuspendRebalancing(); // Suspend indefinitely
-        await WaitForReportAsync(
-            rebalancer,
-            report => report.Status == RebalancerStatus.Suspended &&
-                report.SuspensionDuration.HasValue &&
-                report.Host.Equals(host),
-            "an indefinitely suspended report");
-    }
-
-    private static async Task<RebalancingReport> WaitForReportAsync(
-        IActivationRebalancer rebalancer,
-        Func<RebalancingReport, bool> predicate,
-        string expectedState)
-    {
-        var deadline = DateTime.UtcNow + WaitTimeout;
-        RebalancingReport report = default;
-        while (DateTime.UtcNow < deadline)
-        {
-            report = await rebalancer.GetRebalancingReport(force: true);
-            if (predicate(report))
-            {
-                return report;
-            }
-
-            await Task.Delay(PollInterval);
-        }
-
-        Assert.Fail($"Timed out waiting for {expectedState}. Last report: {Format(report)}");
-        return report;
-    }
-
-    private static async Task<RebalancingReport> WaitForListenerReportAsync(
-        Listener listener,
-        int previousReportCount,
-        Func<RebalancingReport, bool> predicate,
-        string expectedState)
-    {
-        var deadline = DateTime.UtcNow + WaitTimeout;
-        var snapshot = listener.Snapshot;
-        while (DateTime.UtcNow < deadline)
-        {
-            snapshot = listener.Snapshot;
-            if (snapshot.ReportCount > previousReportCount &&
-                snapshot.Report is { } report &&
-                predicate(report))
-            {
-                return report;
-            }
-
-            await Task.Delay(PollInterval);
-        }
-
-        var lastReport = snapshot.Report is { } value ? Format(value) : "<none>";
-        Assert.Fail(
-            $"Timed out waiting for {expectedState}. Last listener report count: {snapshot.ReportCount}. Last report: {lastReport}");
-
-        return default;
+        report = await rebalancer.GetRebalancingReport();
+        Assert.Equal(RebalancerStatus.Suspended, report.Status);
+        Assert.True(report.SuspensionDuration.HasValue);
+        Assert.Equal(host, report.Host);
     }
 
     private static string Format(RebalancingReport report) =>
@@ -164,6 +114,7 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
     private class Listener : IActivationRebalancerReportListener
     {
         private readonly object _lock = new();
+        private readonly List<ReportWaiter> _waiters = [];
         private RebalancingReport? _report;
         private int _reportCount;
 
@@ -178,12 +129,77 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
             }
         }
 
+        public Task<RebalancingReport> WaitForReportAsync(
+            int previousReportCount,
+            Func<RebalancingReport, bool> predicate,
+            string expectedState)
+        {
+            lock (_lock)
+            {
+                if (_reportCount > previousReportCount &&
+                    _report is { } report &&
+                    predicate(report))
+                {
+                    return Task.FromResult(report);
+                }
+
+                var waiter = new ReportWaiter(previousReportCount, predicate);
+                _waiters.Add(waiter);
+                return WaitWithTimeoutAsync(waiter, expectedState);
+            }
+        }
+
         public void OnReport(RebalancingReport report)
         {
             lock (_lock)
             {
                 _report = report;
                 _reportCount++;
+
+                for (var i = _waiters.Count - 1; i >= 0; i--)
+                {
+                    if (_waiters[i].TryComplete(_reportCount, report))
+                    {
+                        _waiters.RemoveAt(i);
+                    }
+                }
+            }
+        }
+
+        private async Task<RebalancingReport> WaitWithTimeoutAsync(ReportWaiter waiter, string expectedState)
+        {
+            try
+            {
+                return await waiter.Task.WaitAsync(WaitTimeout);
+            }
+            catch (TimeoutException)
+            {
+                lock (_lock)
+                {
+                    _waiters.Remove(waiter);
+                }
+
+                var snapshot = Snapshot;
+                var lastReport = snapshot.Report is { } value ? Format(value) : "<none>";
+                throw new TimeoutException(
+                    $"Timed out waiting for {expectedState}. Last listener report count: {snapshot.ReportCount}. Last report: {lastReport}");
+            }
+        }
+
+        private sealed class ReportWaiter(int previousReportCount, Func<RebalancingReport, bool> predicate)
+        {
+            private readonly TaskCompletionSource<RebalancingReport> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task<RebalancingReport> Task => _completion.Task;
+
+            public bool TryComplete(int reportCount, RebalancingReport report)
+            {
+                if (reportCount <= previousReportCount || !predicate(report))
+                {
+                    return false;
+                }
+
+                return _completion.TrySetResult(report);
             }
         }
     }

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/RebalancerDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/RebalancerDiagnosticObserver.cs
@@ -19,6 +19,8 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     private readonly ConcurrentQueue<ActivationRebalancerEvents.CycleStop> _cycleStopEvents = new();
     private readonly ConcurrentQueue<ActivationRebalancerEvents.SessionStart> _sessionStartEvents = new();
     private readonly ConcurrentQueue<ActivationRebalancerEvents.SessionStop> _sessionStopEvents = new();
+    private readonly object _waitersLock = new();
+    private readonly List<IWaiter> _waiters = [];
     private IDisposable? _subscription;
 
     /// <summary>
@@ -62,36 +64,13 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     /// <param name="timeout">Maximum time to wait. Defaults to 60 seconds.</param>
     /// <returns>A task that completes when the expected count is reached.</returns>
     /// <exception cref="TimeoutException">Thrown if the expected count is not reached within the timeout.</exception>
-    public async Task WaitForCycleCountAsync(int expectedCount, TimeSpan? timeout = null)
+    public Task WaitForCycleCountAsync(int expectedCount, TimeSpan? timeout = null)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(60);
-        using var cts = new CancellationTokenSource(effectiveTimeout);
-
-        while (!cts.Token.IsCancellationRequested)
-        {
-            var currentCount = GetCycleCount();
-            if (currentCount >= expectedCount)
-            {
-                return;
-            }
-
-            try
-            {
-                await Task.Delay(10, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-
-        var finalCount = GetCycleCount();
-        if (finalCount >= expectedCount)
-        {
-            return;
-        }
-
-        throw new TimeoutException($"Timed out waiting for {expectedCount} rebalancing cycles. Current count: {finalCount} after {effectiveTimeout}");
+        return WaitUntilAsync(
+            () => GetCycleCount() >= expectedCount,
+            effectiveTimeout,
+            () => $"Timed out waiting for {expectedCount} rebalancing cycles. Current count: {GetCycleCount()} after {effectiveTimeout}");
     }
 
     /// <summary>
@@ -102,36 +81,13 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     /// <param name="timeout">Maximum time to wait. Defaults to 60 seconds.</param>
     /// <returns>A task that completes when the expected count is reached.</returns>
     /// <exception cref="TimeoutException">Thrown if the expected count is not reached within the timeout.</exception>
-    public async Task WaitForCycleCountAsync(SiloAddress siloAddress, int expectedCount, TimeSpan? timeout = null)
+    public Task WaitForCycleCountAsync(SiloAddress siloAddress, int expectedCount, TimeSpan? timeout = null)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(60);
-        using var cts = new CancellationTokenSource(effectiveTimeout);
-
-        while (!cts.Token.IsCancellationRequested)
-        {
-            var currentCount = GetCycleCount(siloAddress);
-            if (currentCount >= expectedCount)
-            {
-                return;
-            }
-
-            try
-            {
-                await Task.Delay(10, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-
-        var finalCount = GetCycleCount(siloAddress);
-        if (finalCount >= expectedCount)
-        {
-            return;
-        }
-
-        throw new TimeoutException($"Timed out waiting for {expectedCount} rebalancing cycles on silo {siloAddress}. Current count: {finalCount} after {effectiveTimeout}");
+        return WaitUntilAsync(
+            () => GetCycleCount(siloAddress) >= expectedCount,
+            effectiveTimeout,
+            () => $"Timed out waiting for {expectedCount} rebalancing cycles on silo {siloAddress}. Current count: {GetCycleCount(siloAddress)} after {effectiveTimeout}");
     }
 
     /// <summary>
@@ -139,31 +95,41 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     /// </summary>
     /// <param name="timeout">Maximum time to wait. Defaults to 30 seconds.</param>
     /// <returns>The cycle stop event payload.</returns>
-    public async Task<ActivationRebalancerEvents.CycleStop> WaitForCycleAsync(TimeSpan? timeout = null)
+    public Task<ActivationRebalancerEvents.CycleStop> WaitForCycleAsync(TimeSpan? timeout = null)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
-        using var cts = new CancellationTokenSource(effectiveTimeout);
-        var initialCount = _cycleStopEvents.Count;
+        return WaitForEventAsync<ActivationRebalancerEvents.CycleStop>(
+            static _ => true,
+            effectiveTimeout,
+            () => $"Timed out waiting for rebalancing cycle after {effectiveTimeout}");
+    }
 
-        while (!cts.Token.IsCancellationRequested)
-        {
-            var events = _cycleStopEvents.ToArray();
-            if (events.Length > initialCount)
-            {
-                return events[initialCount];
-            }
+    /// <summary>
+    /// Waits for a rebalancing session to start.
+    /// </summary>
+    /// <param name="timeout">Maximum time to wait. Defaults to 30 seconds.</param>
+    /// <returns>The session start event payload.</returns>
+    public Task<ActivationRebalancerEvents.SessionStart> WaitForSessionStartAsync(TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
+        return WaitForSessionStartAsync(static _ => true, effectiveTimeout);
+    }
 
-            try
-            {
-                await Task.Delay(10, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-
-        throw new TimeoutException($"Timed out waiting for rebalancing cycle after {effectiveTimeout}");
+    /// <summary>
+    /// Waits for a rebalancing session matching the specified predicate to start.
+    /// </summary>
+    /// <param name="predicate">The predicate used to match session start events.</param>
+    /// <param name="timeout">Maximum time to wait. Defaults to 30 seconds.</param>
+    /// <returns>The session start event payload.</returns>
+    public Task<ActivationRebalancerEvents.SessionStart> WaitForSessionStartAsync(
+        Func<ActivationRebalancerEvents.SessionStart, bool> predicate,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
+        return WaitForEventAsync(
+            predicate,
+            effectiveTimeout,
+            () => $"Timed out waiting for rebalancing session start after {effectiveTimeout}");
     }
 
     /// <summary>
@@ -171,31 +137,27 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     /// </summary>
     /// <param name="timeout">Maximum time to wait. Defaults to 60 seconds.</param>
     /// <returns>The session stop event payload.</returns>
-    public async Task<ActivationRebalancerEvents.SessionStop> WaitForSessionStopAsync(TimeSpan? timeout = null)
+    public Task<ActivationRebalancerEvents.SessionStop> WaitForSessionStopAsync(TimeSpan? timeout = null)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(60);
-        using var cts = new CancellationTokenSource(effectiveTimeout);
-        var initialCount = _sessionStopEvents.Count;
+        return WaitForSessionStopAsync(static _ => true, effectiveTimeout);
+    }
 
-        while (!cts.Token.IsCancellationRequested)
-        {
-            var events = _sessionStopEvents.ToArray();
-            if (events.Length > initialCount)
-            {
-                return events[initialCount];
-            }
-
-            try
-            {
-                await Task.Delay(10, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-
-        throw new TimeoutException($"Timed out waiting for rebalancing session stop after {effectiveTimeout}");
+    /// <summary>
+    /// Waits for a rebalancing session matching the specified predicate to complete.
+    /// </summary>
+    /// <param name="predicate">The predicate used to match session stop events.</param>
+    /// <param name="timeout">Maximum time to wait. Defaults to 60 seconds.</param>
+    /// <returns>The session stop event payload.</returns>
+    public Task<ActivationRebalancerEvents.SessionStop> WaitForSessionStopAsync(
+        Func<ActivationRebalancerEvents.SessionStop, bool> predicate,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(60);
+        return WaitForEventAsync(
+            predicate,
+            effectiveTimeout,
+            () => $"Timed out waiting for rebalancing session stop after {effectiveTimeout}");
     }
 
     /// <summary>
@@ -205,36 +167,13 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     /// <param name="timeout">Maximum time to wait. Defaults to 60 seconds.</param>
     /// <returns>A task that completes when the expected count is reached.</returns>
     /// <exception cref="TimeoutException">Thrown if the expected count is not reached within the timeout.</exception>
-    public async Task WaitForSessionStopCountAsync(int expectedCount, TimeSpan? timeout = null)
+    public Task WaitForSessionStopCountAsync(int expectedCount, TimeSpan? timeout = null)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(60);
-        using var cts = new CancellationTokenSource(effectiveTimeout);
-
-        while (!cts.Token.IsCancellationRequested)
-        {
-            var currentCount = _sessionStopEvents.Count;
-            if (currentCount >= expectedCount)
-            {
-                return;
-            }
-
-            try
-            {
-                await Task.Delay(10, cts.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-        }
-
-        var finalCount = _sessionStopEvents.Count;
-        if (finalCount >= expectedCount)
-        {
-            return;
-        }
-
-        throw new TimeoutException($"Timed out waiting for {expectedCount} session stops. Current count: {finalCount} after {effectiveTimeout}");
+        return WaitUntilAsync(
+            () => _sessionStopEvents.Count >= expectedCount,
+            effectiveTimeout,
+            () => $"Timed out waiting for {expectedCount} session stops. Current count: {_sessionStopEvents.Count} after {effectiveTimeout}");
     }
 
     /// <summary>
@@ -286,22 +225,105 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
         _sessionStopEvents.Clear();
     }
 
+    private Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout, Func<string> timeoutMessage)
+    {
+        lock (_waitersLock)
+        {
+            if (predicate())
+            {
+                return Task.CompletedTask;
+            }
+
+            var waiter = new ConditionWaiter(predicate);
+            _waiters.Add(waiter);
+            return WaitWithTimeoutAsync(waiter, timeout, timeoutMessage);
+        }
+    }
+
+    private Task<TEvent> WaitForEventAsync<TEvent>(
+        Func<TEvent, bool> predicate,
+        TimeSpan timeout,
+        Func<string> timeoutMessage)
+        where TEvent : ActivationRebalancerEvents.RebalancerEvent
+    {
+        lock (_waitersLock)
+        {
+            var waiter = new EventWaiter<TEvent>(predicate);
+            _waiters.Add(waiter);
+            return WaitWithTimeoutAsync(waiter, timeout, timeoutMessage);
+        }
+    }
+
+    private async Task WaitWithTimeoutAsync(ConditionWaiter waiter, TimeSpan timeout, Func<string> timeoutMessage)
+    {
+        try
+        {
+            await waiter.Task.WaitAsync(timeout);
+        }
+        catch (TimeoutException)
+        {
+            RemoveWaiter(waiter);
+            throw new TimeoutException(timeoutMessage());
+        }
+    }
+
+    private async Task<TEvent> WaitWithTimeoutAsync<TEvent>(
+        EventWaiter<TEvent> waiter,
+        TimeSpan timeout,
+        Func<string> timeoutMessage)
+        where TEvent : ActivationRebalancerEvents.RebalancerEvent
+    {
+        try
+        {
+            return await waiter.Task.WaitAsync(timeout);
+        }
+        catch (TimeoutException)
+        {
+            RemoveWaiter(waiter);
+            throw new TimeoutException(timeoutMessage());
+        }
+    }
+
+    private void RemoveWaiter(IWaiter waiter)
+    {
+        lock (_waitersLock)
+        {
+            _waiters.Remove(waiter);
+        }
+    }
+
+    private void SignalWaiters(ActivationRebalancerEvents.RebalancerEvent value)
+    {
+        for (var i = _waiters.Count - 1; i >= 0; i--)
+        {
+            if (_waiters[i].TryComplete(value))
+            {
+                _waiters.RemoveAt(i);
+            }
+        }
+    }
+
     void IObserver<ActivationRebalancerEvents.RebalancerEvent>.OnNext(ActivationRebalancerEvents.RebalancerEvent value)
     {
-        switch (value)
+        lock (_waitersLock)
         {
-            case ActivationRebalancerEvents.CycleStart cycleStart:
-                _cycleStartEvents.Enqueue(cycleStart);
-                break;
-            case ActivationRebalancerEvents.CycleStop cycleStop:
-                _cycleStopEvents.Enqueue(cycleStop);
-                break;
-            case ActivationRebalancerEvents.SessionStart sessionStart:
-                _sessionStartEvents.Enqueue(sessionStart);
-                break;
-            case ActivationRebalancerEvents.SessionStop sessionStop:
-                _sessionStopEvents.Enqueue(sessionStop);
-                break;
+            switch (value)
+            {
+                case ActivationRebalancerEvents.CycleStart cycleStart:
+                    _cycleStartEvents.Enqueue(cycleStart);
+                    break;
+                case ActivationRebalancerEvents.CycleStop cycleStop:
+                    _cycleStopEvents.Enqueue(cycleStop);
+                    break;
+                case ActivationRebalancerEvents.SessionStart sessionStart:
+                    _sessionStartEvents.Enqueue(sessionStart);
+                    break;
+                case ActivationRebalancerEvents.SessionStop sessionStop:
+                    _sessionStopEvents.Enqueue(sessionStop);
+                    break;
+            }
+
+            SignalWaiters(value);
         }
     }
 
@@ -316,5 +338,45 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     public void Dispose()
     {
         _subscription?.Dispose();
+    }
+
+    private interface IWaiter
+    {
+        bool TryComplete(ActivationRebalancerEvents.RebalancerEvent value);
+    }
+
+    private sealed class ConditionWaiter(Func<bool> predicate) : IWaiter
+    {
+        private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Task => _completion.Task;
+
+        public bool TryComplete(ActivationRebalancerEvents.RebalancerEvent value)
+        {
+            if (!predicate())
+            {
+                return false;
+            }
+
+            return _completion.TrySetResult();
+        }
+    }
+
+    private sealed class EventWaiter<TEvent>(Func<TEvent, bool> predicate) : IWaiter
+        where TEvent : ActivationRebalancerEvents.RebalancerEvent
+    {
+        private readonly TaskCompletionSource<TEvent> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<TEvent> Task => _completion.Task;
+
+        public bool TryComplete(ActivationRebalancerEvents.RebalancerEvent value)
+        {
+            if (value is not TEvent evt || !predicate(evt))
+            {
+                return false;
+            }
+
+            return _completion.TrySetResult(evt);
+        }
     }
 }


### PR DESCRIPTION
This fixes a flaky activation rebalancing control test that could assert against a stale `Suspended` report immediately after setup or control operations.

The test now subscribes to activation rebalancer diagnostic events and listener callbacks before issuing control operations, then waits on those future events instead of polling for report state. The shared `RebalancerDiagnosticObserver` now completes waits directly from `OnNext`, so rebalancing tests can wait deterministically without delay loops.