### PR TITLE
ci: make MariaDB CI pulls resilient to timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,9 +232,8 @@ jobs:
         framework: ["net8.0", "net10.0"]
     env:
       # The official MariaDB 10.6 image is not published to GHCR. Use Google's Docker Hub mirror
-      # pinned to the official Docker Hub digest; the fallback keeps the same digest if the mirror misses.
+      # pinned to the official Docker Hub digest.
       MARIADB_IMAGE: mirror.gcr.io/library/mariadb:10.6@sha256:daacc2f260f8ec999daa5e03a017a23a7e6fa3fb982aaf26e8b72f24daf03bc9
-      MARIADB_FALLBACK_IMAGE: docker.io/library/mariadb:10.6@sha256:daacc2f260f8ec999daa5e03a017a23a7e6fa3fb982aaf26e8b72f24daf03bc9
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
       MARIADB_ROOT_PASSWORD: "mariadb"
     steps:
@@ -248,12 +247,7 @@ jobs:
       run: |
         set -euo pipefail
 
-        mariadb_image="$MARIADB_IMAGE"
-        if ! bash .github/scripts/docker-pull-with-retry.sh "$mariadb_image"; then
-          echo "Mirror pull failed; trying Docker Hub fallback pinned to the same digest."
-          mariadb_image="$MARIADB_FALLBACK_IMAGE"
-          bash .github/scripts/docker-pull-with-retry.sh "$mariadb_image"
-        fi
+        bash .github/scripts/docker-pull-with-retry.sh "$MARIADB_IMAGE"
 
         docker run -d --pull=never --name mariadb \
           -p 3306:3306 \
@@ -262,7 +256,7 @@ jobs:
           --health-interval 5s \
           --health-timeout 5s \
           --health-retries 24 \
-          "$mariadb_image"
+          "$MARIADB_IMAGE"
 
         for attempt in $(seq 1 60); do
           status="$(docker inspect --format '{{.State.Health.Status}}' mariadb)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,16 +226,15 @@ jobs:
     continue-on-error: true
     env:
       BuildExternalAssets: "false"
-    strategy:
-      matrix:
-        provider: ["MySql"]
-        framework: ["net8.0", "net10.0"]
-    env:
       # The official MariaDB 10.6 image is not published to GHCR. Use Google's Docker Hub mirror
       # pinned to the official Docker Hub digest.
       MARIADB_IMAGE: mirror.gcr.io/library/mariadb:10.6@sha256:daacc2f260f8ec999daa5e03a017a23a7e6fa3fb982aaf26e8b72f24daf03bc9
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
       MARIADB_ROOT_PASSWORD: "mariadb"
+    strategy:
+      matrix:
+        provider: ["MySql"]
+        framework: ["net8.0", "net10.0"]
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Setup .NET

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,20 +230,77 @@ jobs:
       matrix:
         provider: ["MySql"]
         framework: ["net8.0", "net10.0"]
-    services:
-      mariadb:
-        image: mariadb:10.6
-        ports:
-          - 3306:3306
-        env:
-# [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="False positive")]
-          MARIADB_ROOT_PASSWORD: "mariadb"
+    env:
+      # The official MariaDB 10.6 image is not published to GHCR. Use Google's Docker Hub mirror
+      # pinned to the official Docker Hub digest; the fallback keeps the same digest if the mirror misses.
+      MARIADB_IMAGE: mirror.gcr.io/library/mariadb:10.6@sha256:daacc2f260f8ec999daa5e03a017a23a7e6fa3fb982aaf26e8b72f24daf03bc9
+      MARIADB_FALLBACK_IMAGE: docker.io/library/mariadb:10.6@sha256:daacc2f260f8ec999daa5e03a017a23a7e6fa3fb982aaf26e8b72f24daf03bc9
+# [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
+      MARIADB_ROOT_PASSWORD: "mariadb"
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
         global-json-file: global.json
+    - name: Start MariaDB
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        pull_image() {
+          local image="$1"
+          local attempts="$2"
+
+          for attempt in $(seq 1 "$attempts"); do
+            if docker pull "$image"; then
+              return 0
+            fi
+
+            if [ "$attempt" -eq "$attempts" ]; then
+              return 1
+            fi
+
+            local delay=$((attempt * 15))
+            echo "MariaDB image pull failed (attempt ${attempt}/${attempts}); retrying in ${delay}s..."
+            sleep "$delay"
+          done
+        }
+
+        mariadb_image="$MARIADB_IMAGE"
+        if ! pull_image "$mariadb_image" 5; then
+          echo "Mirror pull failed; trying Docker Hub fallback pinned to the same digest."
+          mariadb_image="$MARIADB_FALLBACK_IMAGE"
+          pull_image "$mariadb_image" 3
+        fi
+
+        docker run -d --name mariadb \
+          -p 3306:3306 \
+          -e MARIADB_ROOT_PASSWORD="$MARIADB_ROOT_PASSWORD" \
+          --health-cmd "mariadb-admin ping -h 127.0.0.1 -uroot -p${MARIADB_ROOT_PASSWORD} --silent" \
+          --health-interval 5s \
+          --health-timeout 5s \
+          --health-retries 24 \
+          "$mariadb_image"
+
+        for attempt in $(seq 1 60); do
+          status="$(docker inspect --format '{{.State.Health.Status}}' mariadb)"
+          case "$status" in
+            healthy)
+              exit 0
+              ;;
+            unhealthy)
+              docker logs mariadb
+              exit 1
+              ;;
+          esac
+
+          sleep 2
+        done
+
+        echo "MariaDB did not become healthy in time."
+        docker logs mariadb
+        exit 1
     - name: Test
       run: dotnet test
         --framework ${{ matrix.framework }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,33 +248,14 @@ jobs:
       run: |
         set -euo pipefail
 
-        pull_image() {
-          local image="$1"
-          local attempts="$2"
-
-          for attempt in $(seq 1 "$attempts"); do
-            if docker pull "$image"; then
-              return 0
-            fi
-
-            if [ "$attempt" -eq "$attempts" ]; then
-              return 1
-            fi
-
-            local delay=$((attempt * 15))
-            echo "MariaDB image pull failed (attempt ${attempt}/${attempts}); retrying in ${delay}s..."
-            sleep "$delay"
-          done
-        }
-
         mariadb_image="$MARIADB_IMAGE"
-        if ! pull_image "$mariadb_image" 5; then
+        if ! bash .github/scripts/docker-pull-with-retry.sh "$mariadb_image"; then
           echo "Mirror pull failed; trying Docker Hub fallback pinned to the same digest."
           mariadb_image="$MARIADB_FALLBACK_IMAGE"
-          pull_image "$mariadb_image" 3
+          bash .github/scripts/docker-pull-with-retry.sh "$mariadb_image"
         fi
 
-        docker run -d --name mariadb \
+        docker run -d --pull=never --name mariadb \
           -p 3306:3306 \
           -e MARIADB_ROOT_PASSWORD="$MARIADB_ROOT_PASSWORD" \
           --health-cmd "mariadb-admin ping -h 127.0.0.1 -uroot -p${MARIADB_ROOT_PASSWORD} --silent" \


### PR DESCRIPTION
The MariaDB/MySQL provider job could fail before any job step ran when GitHub Actions tried to start the `services:` container and Docker Hub timed out. Because service startup is not retryable from the workflow, the job needed to move the pull/startup path into explicit steps.

This replaces the MariaDB service container with an explicit pull and `docker run` step. The image is the official MariaDB 10.6 manifest served through `mirror.gcr.io` and pinned by digest, and pulling is handled by the shared `.github/scripts/docker-pull-with-retry.sh` helper from the stacked CI change. The job still exposes port 3306, uses the same root password, waits on MariaDB health, and keeps the existing `ORLEANSMYSQLCONNECTIONSTRING` used by `TestDefaultConfiguration` unchanged.

No official GHCR-hosted MariaDB 10.6 image appears to be available, so this uses a single pinned mirror image rather than a Docker Hub service container.