### PR TITLE
ci: make Azure emulator Docker pulls resilient

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,6 @@
 *.verified.cs text eol=lf working-tree-encoding=UTF-8
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.jsonl text eol=lf working-tree-encoding=UTF-8
+
+# GitHub Actions helper scripts run under Bash on Linux.
+.github/scripts/*.sh text eol=lf

--- a/.github/scripts/docker-pull-with-retry.sh
+++ b/.github/scripts/docker-pull-with-retry.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <image>" >&2
+  exit 2
+fi
+
+image="$1"
+attempt=1
+
+for delay in 10 30 60; do
+  if docker pull "$image"; then
+    exit 0
+  fi
+
+  echo "Docker pull failed for ${image} on attempt ${attempt}; retrying in ${delay}s..." >&2
+  sleep "$delay"
+  attempt=$((attempt + 1))
+done
+
+docker pull "$image"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ permissions:
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
+  # Manual docker-run images are centralized so they can be switched to GHCR mirrors if MCR access flakes.
+  AZURITE_IMAGE: mcr.microsoft.com/azure-storage/azurite:3.35.0@sha256:647c63a91102a9d8e8000aab803436e1fc85fbb285e7ce830a82ee5d6661cf37
+  EVENTHUBS_EMULATOR_IMAGE: mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.2.0@sha256:2c8e0d4dd93a5fc078df2721eeb3e211442d555d61293ac3972df931c6d9333a
+  COSMOSDB_EMULATOR_IMAGE: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview@sha256:bf3bd3cbe3fae2005a0745f77b01d1fc8cd04112193f3ee32289ee15ee9ae5fa
 jobs:
   build:
     name: Build
@@ -279,11 +283,15 @@ jobs:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Start Azurite
       run: |
-        docker run -d --name azurite \
+        set -euo pipefail
+
+        bash .github/scripts/docker-pull-with-retry.sh "$AZURITE_IMAGE"
+
+        docker run -d --pull=never --name azurite \
           -p 10000:10000 \
           -p 10001:10001 \
           -p 10002:10002 \
-          mcr.microsoft.com/azure-storage/azurite:latest \
+          "$AZURITE_IMAGE" \
           azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
     - name: Wait for Azurite
       run: |
@@ -311,7 +319,7 @@ jobs:
         ORLEANSDATACONNECTIONSTRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
     - name: Clean up Azurite
       if: always()
-      run: docker rm -f azurite
+      run: docker rm -f azurite || true
     - name: Archive Test Results
       if: always()
       continue-on-error: true
@@ -334,11 +342,15 @@ jobs:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Start Azurite
       run: |
-        docker run -d --name azurite \
+        set -euo pipefail
+
+        bash .github/scripts/docker-pull-with-retry.sh "$AZURITE_IMAGE"
+
+        docker run -d --pull=never --name azurite \
           -p 10000:10000 \
           -p 10001:10001 \
           -p 10002:10002 \
-          mcr.microsoft.com/azure-storage/azurite:latest \
+          "$AZURITE_IMAGE" \
           azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck
     - name: Wait for Azurite
       run: |
@@ -347,14 +359,18 @@ jobs:
         echo "Azurite is ready"
     - name: Start Event Hubs emulator
       run: |
-        docker run -d --name eventhubs-emulator \
+        set -euo pipefail
+
+        bash .github/scripts/docker-pull-with-retry.sh "$EVENTHUBS_EMULATOR_IMAGE"
+
+        docker run -d --pull=never --name eventhubs-emulator \
           -v ${{ github.workspace }}/.github/eventhubs-emulator/Config.json:/Eventhubs_Emulator/ConfigFiles/Config.json \
           -p 5672:5672 \
           -e BLOB_SERVER=host.docker.internal \
           -e METADATA_SERVER=host.docker.internal \
           -e ACCEPT_EULA=Y \
           --add-host=host.docker.internal:host-gateway \
-          mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest
+          "$EVENTHUBS_EMULATOR_IMAGE"
     - name: Wait for Event Hubs emulator
       run: |
         echo "Waiting for Event Hubs emulator to be ready..."
@@ -383,10 +399,10 @@ jobs:
         ORLEANSDATACONNECTIONSTRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
     - name: Clean up Event Hubs emulator
       if: always()
-      run: docker rm -f eventhubs-emulator
+      run: docker rm -f eventhubs-emulator || true
     - name: Clean up Azurite
       if: always()
-      run: docker rm -f azurite
+      run: docker rm -f azurite || true
     - name: Archive Test Results
       if: always()
       continue-on-error: true
@@ -413,13 +429,17 @@ jobs:
         global-json-file: global.json
     - name: Start Azure Cosmos DB emulator
       run: |
-        docker run -d --name cosmosdb-emulator \
+        set -euo pipefail
+
+        bash .github/scripts/docker-pull-with-retry.sh "$COSMOSDB_EMULATOR_IMAGE"
+
+        docker run -d --pull=never --name cosmosdb-emulator \
           -p 8081:8081 \
           -e PROTOCOL=https \
           -e ENABLE_EXPLORER=false \
           -e ENABLE_TELEMETRY=false \
           -e LOG_LEVEL=warn \
-          mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview@sha256:bf3bd3cbe3fae2005a0745f77b01d1fc8cd04112193f3ee32289ee15ee9ae5fa
+          "$COSMOSDB_EMULATOR_IMAGE"
     - name: Wait for Azure Cosmos DB emulator
       run: |
         endpoint="https://localhost:8081/"


### PR DESCRIPTION
This fixes CI flakes in Azure provider jobs caused by blocked or denied Microsoft Container Registry pulls for emulator images.

The workflow now centralizes the Docker image references at the workflow env level, pins Azurite and the Event Hubs emulator by digest, preserves the existing Cosmos DB emulator digest pin, and pulls each manual `docker run` image through a shared retry/backoff helper before starting containers with `--pull=never`.

Cleanup remains best-effort so teardown errors do not mask the original startup or test failure, and the centralized image variables make it straightforward to switch to GHCR mirrors later.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10191)