### PR TITLE
fix(storage): reduce Azure table retry pressure

### DIFF
--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureTableStorageClusteringProviderBuilder.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureTableStorageClusteringProviderBuilder.cs
@@ -36,7 +36,7 @@ internal sealed class AzureTableStorageClusteringProviderBuilder : IProviderBuil
                 }
                 else
                 {
-                    // Construct a connection multiplexer from a connection string.
+                    // Construct a table service client from a connection string.
                     var connectionName = configurationSection["ConnectionName"];
                     var connectionString = configurationSection["ConnectionString"];
                     if (!string.IsNullOrEmpty(connectionName) && string.IsNullOrEmpty(connectionString))
@@ -49,11 +49,11 @@ internal sealed class AzureTableStorageClusteringProviderBuilder : IProviderBuil
                     {
                         if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
                         {
-                            options.TableServiceClient = new TableServiceClient(uri);
+                            options.SetTableServiceClient(uri);
                         }
                         else
                         {
-                            options.TableServiceClient = new TableServiceClient(connectionString);
+                            options.SetTableServiceClient(connectionString);
                         }
                     }
                 }
@@ -79,7 +79,7 @@ internal sealed class AzureTableStorageClusteringProviderBuilder : IProviderBuil
                 }
                 else
                 {
-                    // Construct a connection multiplexer from a connection string.
+                    // Construct a table service client from a connection string.
                     var connectionName = configurationSection["ConnectionName"];
                     var connectionString = configurationSection["ConnectionString"];
                     if (!string.IsNullOrEmpty(connectionName) && string.IsNullOrEmpty(connectionString))
@@ -92,11 +92,11 @@ internal sealed class AzureTableStorageClusteringProviderBuilder : IProviderBuil
                     {
                         if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
                         {
-                            options.TableServiceClient = new TableServiceClient(uri);
+                            options.SetTableServiceClient(uri);
                         }
                         else
                         {
-                            options.TableServiceClient = new TableServiceClient(connectionString);
+                            options.SetTableServiceClient(connectionString);
                         }
                     }
                 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
+++ b/src/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.csproj
@@ -34,4 +34,3 @@
     <InternalsVisibleTo Include="Orleans.Azure.Tests" />
   </ItemGroup>
 </Project>
-

--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/Hosting/AzureTableStorageGrainDirectoryProviderBuilder.cs
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/Hosting/AzureTableStorageGrainDirectoryProviderBuilder.cs
@@ -34,7 +34,7 @@ internal sealed class AzureTableStorageGrainDirectoryProviderBuilder : IProvider
                 }
                 else
                 {
-                    // Construct a connection multiplexer from a connection string.
+                    // Construct a table service client from a connection string.
                     var connectionName = configurationSection["ConnectionName"];
                     var connectionString = configurationSection["ConnectionString"];
                     if (!string.IsNullOrEmpty(connectionName) && string.IsNullOrEmpty(connectionString))
@@ -47,11 +47,11 @@ internal sealed class AzureTableStorageGrainDirectoryProviderBuilder : IProvider
                     {
                         if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
                         {
-                            options.TableServiceClient = new TableServiceClient(uri);
+                            options.SetTableServiceClient(uri);
                         }
                         else
                         {
-                            options.TableServiceClient = new TableServiceClient(connectionString);
+                            options.SetTableServiceClient(connectionString);
                         }
                     }
                 }

--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/Orleans.GrainDirectory.AzureStorage.csproj
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/Orleans.GrainDirectory.AzureStorage.csproj
@@ -35,4 +35,3 @@
     <InternalsVisibleTo Include="Orleans.Azure.Tests" />
   </ItemGroup>
 </Project>
-

--- a/src/Azure/Orleans.Persistence.AzureStorage/Hosting/AzureTableStorageGrainStorageProviderBuilder.cs
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Hosting/AzureTableStorageGrainStorageProviderBuilder.cs
@@ -36,7 +36,7 @@ internal sealed class AzureTableStorageGrainStorageProviderBuilder : IProviderBu
                 }
                 else
                 {
-                    // Construct a connection multiplexer from a connection string.
+                    // Construct a table service client from a connection string.
                     var connectionName = configurationSection["ConnectionName"];
                     var connectionString = configurationSection["ConnectionString"];
                     if (!string.IsNullOrEmpty(connectionName) && string.IsNullOrEmpty(connectionString))
@@ -49,11 +49,11 @@ internal sealed class AzureTableStorageGrainStorageProviderBuilder : IProviderBu
                     {
                         if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
                         {
-                            options.TableServiceClient = new TableServiceClient(uri);
+                            options.SetTableServiceClient(uri);
                         }
                         else
                         {
-                            options.TableServiceClient = new TableServiceClient(connectionString);
+                            options.SetTableServiceClient(connectionString);
                         }
                     }
                 }

--- a/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
+++ b/src/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.csproj
@@ -36,4 +36,3 @@
     <InternalsVisibleTo Include="Orleans.Azure.Tests" />
   </ItemGroup>
 </Project>
-

--- a/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.csproj
+++ b/src/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.csproj
@@ -35,4 +35,3 @@
     <InternalsVisibleTo Include="Orleans.Azure.Tests" />
   </ItemGroup>
 </Project>
-

--- a/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
+++ b/src/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.csproj
@@ -38,4 +38,3 @@
     <InternalsVisibleTo Include="Orleans.Runtime.Tests" />
   </ItemGroup>
 </Project>
-

--- a/src/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.csproj
+++ b/src/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.csproj
@@ -35,4 +35,3 @@
     <InternalsVisibleTo Include="Orleans.Streaming.EventHubs.Tests" />
   </ItemGroup>
 </Project>
-

--- a/src/Azure/Shared/Storage/AzureStorageOperationOptions.cs
+++ b/src/Azure/Shared/Storage/AzureStorageOperationOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
@@ -69,8 +70,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         [Obsolete($"Set the {nameof(TableServiceClient)} property directly.")]
         public void ConfigureTableServiceClient(string connectionString)
         {
-            if (string.IsNullOrWhiteSpace(connectionString)) throw new ArgumentNullException(nameof(connectionString));
-            TableServiceClient = new TableServiceClient(connectionString, ClientOptions);
+            SetTableServiceClient(connectionString);
         }
 
         /// <summary>
@@ -79,8 +79,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         [Obsolete($"Set the {nameof(TableServiceClient)} property directly.")]
         public void ConfigureTableServiceClient(Uri serviceUri)
         {
-            if (serviceUri is null) throw new ArgumentNullException(nameof(serviceUri));
-            TableServiceClient = new TableServiceClient(serviceUri, ClientOptions);
+            SetTableServiceClient(serviceUri);
         }
 
         /// <summary>
@@ -98,7 +97,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         [Obsolete($"Set the {nameof(TableServiceClient)} property directly.")]
         public void ConfigureTableServiceClient(Uri serviceUri, TokenCredential tokenCredential)
         {
-            TableServiceClient = new TableServiceClient(serviceUri, tokenCredential, ClientOptions);
+            SetTableServiceClient(serviceUri, tokenCredential);
         }
 
         /// <summary>
@@ -107,7 +106,7 @@ namespace Orleans.GrainDirectory.AzureStorage
         [Obsolete($"Set the {nameof(TableServiceClient)} property directly.")]
         public void ConfigureTableServiceClient(Uri serviceUri, AzureSasCredential azureSasCredential)
         {
-            TableServiceClient = new TableServiceClient(serviceUri, azureSasCredential, ClientOptions);
+            SetTableServiceClient(serviceUri, azureSasCredential);
         }
 
         /// <summary>
@@ -116,7 +115,69 @@ namespace Orleans.GrainDirectory.AzureStorage
         [Obsolete($"Set the {nameof(TableServiceClient)} property directly.")]
         public void ConfigureTableServiceClient(Uri serviceUri, TableSharedKeyCredential sharedKeyCredential)
         {
-            TableServiceClient = new TableServiceClient(serviceUri, sharedKeyCredential, ClientOptions);
+            SetTableServiceClient(serviceUri, sharedKeyCredential);
+        }
+
+        internal void SetTableServiceClient(string connectionString)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString)) throw new ArgumentNullException(nameof(connectionString));
+            _tableServiceClient = null;
+            CreateClient = () => Task.FromResult(new TableServiceClient(connectionString, GetTableClientOptions()));
+        }
+
+        internal void SetTableServiceClient(Uri serviceUri)
+        {
+            if (serviceUri is null) throw new ArgumentNullException(nameof(serviceUri));
+            _tableServiceClient = null;
+            CreateClient = () => Task.FromResult(new TableServiceClient(serviceUri, GetTableClientOptions()));
+        }
+
+        internal void SetTableServiceClient(Uri serviceUri, TokenCredential tokenCredential)
+        {
+            if (serviceUri is null) throw new ArgumentNullException(nameof(serviceUri));
+            if (tokenCredential is null) throw new ArgumentNullException(nameof(tokenCredential));
+            _tableServiceClient = null;
+            CreateClient = () => Task.FromResult(new TableServiceClient(serviceUri, tokenCredential, GetTableClientOptions()));
+        }
+
+        internal void SetTableServiceClient(Uri serviceUri, AzureSasCredential azureSasCredential)
+        {
+            if (serviceUri is null) throw new ArgumentNullException(nameof(serviceUri));
+            if (azureSasCredential is null) throw new ArgumentNullException(nameof(azureSasCredential));
+            _tableServiceClient = null;
+            CreateClient = () => Task.FromResult(new TableServiceClient(serviceUri, azureSasCredential, GetTableClientOptions()));
+        }
+
+        internal void SetTableServiceClient(Uri serviceUri, TableSharedKeyCredential sharedKeyCredential)
+        {
+            if (serviceUri is null) throw new ArgumentNullException(nameof(serviceUri));
+            if (sharedKeyCredential is null) throw new ArgumentNullException(nameof(sharedKeyCredential));
+            _tableServiceClient = null;
+            CreateClient = () => Task.FromResult(new TableServiceClient(serviceUri, sharedKeyCredential, GetTableClientOptions()));
+        }
+
+        internal TableClientOptions GetTableClientOptions()
+        {
+            var clientOptions = ClientOptions ??= new TableClientOptions();
+            ConfigureRetryOptions(clientOptions.Retry, StoragePolicyOptions);
+            return clientOptions;
+        }
+
+        private static void ConfigureRetryOptions(RetryOptions retryOptions, AzureStoragePolicyOptions storagePolicyOptions)
+        {
+            // Keep this aligned with AzureStoragePolicyOptions defaults, which mirror Azure Storage SDK retry settings.
+            var delay = storagePolicyOptions.PauseBetweenOperationRetries > TimeSpan.Zero
+                ? storagePolicyOptions.PauseBetweenOperationRetries
+                : TimeSpan.FromSeconds(0.8);
+
+            var maxDelay = storagePolicyOptions.MaxPauseBetweenOperationRetries == Timeout.InfiniteTimeSpan
+                ? TimeSpan.FromMinutes(1)
+                : storagePolicyOptions.MaxPauseBetweenOperationRetries;
+
+            retryOptions.Mode = RetryMode.Exponential;
+            retryOptions.Delay = delay;
+            retryOptions.MaxDelay = maxDelay >= delay ? maxDelay : delay;
+            retryOptions.MaxRetries = Math.Max(0, storagePolicyOptions.MaxOperationRetries);
         }
 
         internal void Validate(string name)

--- a/src/Azure/Shared/Storage/AzureStoragePolicyOptions.cs
+++ b/src/Azure/Shared/Storage/AzureStoragePolicyOptions.cs
@@ -25,14 +25,39 @@ namespace Orleans.GrainDirectory.AzureStorage
     {
         private TimeSpan? creationTimeout;
         private TimeSpan? operationTimeout;
+        private TimeSpan? maxPauseBetweenOperationRetries;
 
         public int MaxBulkUpdateRows { get; set; } = 100;
         public int MaxCreationRetries { get; set; } = 60;
+
+        // Defaults match Azure Storage SDK retry settings.
+        /// <summary>
+        /// The maximum number of operation retry attempts.
+        /// </summary>
         public int MaxOperationRetries { get; set; } = 5;
 
         public TimeSpan PauseBetweenCreationRetries { get; set; } = TimeSpan.FromSeconds(1);
 
-        public TimeSpan PauseBetweenOperationRetries { get; set; } = TimeSpan.FromMilliseconds(100);
+        /// <summary>
+        /// The base delay used by the Azure SDK exponential retry policy.
+        /// </summary>
+        public TimeSpan PauseBetweenOperationRetries { get; set; } = TimeSpan.FromSeconds(0.8);
+
+        /// <summary>
+        /// The maximum delay used by the Azure SDK exponential retry policy.
+        /// </summary>
+        public TimeSpan MaxPauseBetweenOperationRetries
+        {
+            get => this.maxPauseBetweenOperationRetries ?? TimeSpan.FromMinutes(1);
+            set
+            {
+                if (value <= TimeSpan.Zero && !value.Equals(Timeout.InfiniteTimeSpan))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(MaxPauseBetweenOperationRetries), value, "Value must be positive or Timeout.InfiniteTimeSpan.");
+                }
+                this.maxPauseBetweenOperationRetries = value;
+            }
+        }
 
         public TimeSpan CreationTimeout
         {
@@ -42,7 +67,7 @@ namespace Orleans.GrainDirectory.AzureStorage
 
         public TimeSpan OperationTimeout
         {
-            get => this.operationTimeout ?? TimeSpan.FromMilliseconds(this.PauseBetweenOperationRetries.TotalMilliseconds * this.MaxOperationRetries * 6);
+            get => this.operationTimeout ?? TimeSpan.FromSeconds(100);
             set => SetIfValidTimeout(ref this.operationTimeout, value, nameof(OperationTimeout));
         }
 

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
-using Orleans.Internal;
 using Orleans.Runtime;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
@@ -492,46 +491,22 @@ namespace Orleans.GrainDirectory.AzureStorage
 
             try
             {
-                try
+                var results = new List<(T, string)>();
+                await foreach (var value in Table.QueryAsync<T>(filter))
                 {
-                    async Task<List<(T Entity, string ETag)>> executeQueryHandleContinuations()
-                    {
-                        var list = new List<(T, string)>();
-                        var results = Table.QueryAsync<T>(filter);
-                        await foreach (var value in results)
-                        {
-                            list.Add((value, value.ETag.ToString()));
-                        }
-
-                        return list;
-                    }
-
-#if !ORLEANS_TRANSACTIONS
-                    IBackoffProvider backoff = new FixedBackoff(this.StoragePolicyOptions.PauseBetweenOperationRetries);
-
-                    List<(T, string)> results = await AsyncExecutorWithRetries.ExecuteWithRetries(
-                        counter => executeQueryHandleContinuations(),
-                        this.StoragePolicyOptions.MaxOperationRetries,
-                        (exc, counter) => AzureTableUtils.AnalyzeReadException(exc.GetBaseException(), counter, TableName, Logger),
-                        this.StoragePolicyOptions.OperationTimeout,
-                        backoff);
-#else
-                    List<(T, string)> results = await executeQueryHandleContinuations();
-#endif
-                    // Data was read successfully if we got to here
-                    return results;
-
+                    results.Add((value, value.ETag.ToString()));
                 }
-                catch (Exception exc)
+
+                return results;
+            }
+            catch (Exception exc)
+            {
+                if (!AzureTableUtils.TableStorageDataNotFound(exc))
                 {
-                    // Out of retries...
-                    if (!AzureTableUtils.TableStorageDataNotFound(exc))
-                    {
-                        LogWarningReadTable(Logger, exc, TableName);
-                    }
-
-                    throw new OrleansException($"Failed to read Azure Storage table {TableName}", exc);
+                    LogWarningReadTable(Logger, exc, TableName);
                 }
+
+                throw new OrleansException($"Failed to read Azure Storage table {TableName}", exc);
             }
             finally
             {

--- a/src/Azure/Shared/Storage/AzureTableUtils.cs
+++ b/src/Azure/Shared/Storage/AzureTableUtils.cs
@@ -4,8 +4,6 @@ using System.Text.RegularExpressions;
 using Azure;
 using Azure.Data.Tables;
 using Azure.Data.Tables.Models;
-using Microsoft.Extensions.Logging;
-using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 //
 // Number of #ifs can be reduced (or removed), once we separate test projects by feature/area, otherwise we are ending up with ambiguous types and build errors.
@@ -222,39 +220,6 @@ namespace Orleans.GrainDirectory.AzureStorage
             return key;
         }
 
-        internal static bool AnalyzeReadException(Exception exc, int iteration, string tableName, ILogger logger)
-        {
-            bool isLastErrorRetriable;
-            var we = exc as WebException;
-            if (we != null)
-            {
-                isLastErrorRetriable = true;
-                LogWarningIntermediateIssue(logger, exc, tableName, we.Status);
-            }
-            else
-            {
-                if (EvaluateException(exc, out var httpStatusCode, out var restStatus, true))
-                {
-                    if (nameof(TableErrorCode.ResourceNotFound).Equals(restStatus))
-                    {
-                        LogDebugDataNotFound(logger, exc, tableName, iteration == 0 ? string.Empty : (" Repeat=" + iteration), httpStatusCode, restStatus);
-                        isLastErrorRetriable = false;
-                    }
-                    else
-                    {
-                        isLastErrorRetriable = IsRetriableHttpError(httpStatusCode, restStatus);
-                        LogWarningIntermediateIssueWithRestStatusCode(logger, exc, tableName, iteration == 0 ? "" : (" Repeat=" + iteration), isLastErrorRetriable, httpStatusCode, restStatus);
-                    }
-                }
-                else
-                {
-                    LogErrorUnexpectedIssue(logger, exc, tableName);
-                    isLastErrorRetriable = false;
-                }
-            }
-            return isLastErrorRetriable;
-        }
-
         internal static string PrintStorageException(Exception exception)
         {
             if (exception is not RequestFailedException storeExc)
@@ -275,32 +240,5 @@ namespace Orleans.GrainDirectory.AzureStorage
             return TableClient.CreateQueryFilter($"((PartitionKey eq {partitionKey}) and (RowKey ge {minRowKey})) and (RowKey le {maxRowKey})");
         }
 
-        [LoggerMessage(
-            Level = LogLevel.Warning,
-            EventId = (int)Utilities.ErrorCode.AzureTable_10,
-            Message = "Intermediate issue reading Azure storage table {TableName}: HTTP status code={StatusCode}"
-        )]
-        private static partial void LogWarningIntermediateIssue(ILogger logger, Exception exception, string tableName, WebExceptionStatus statusCode);
-
-        [LoggerMessage(
-            Level = LogLevel.Debug,
-            EventId = (int)Utilities.ErrorCode.AzureTable_DataNotFound,
-            Message = "DataNotFound reading Azure storage table {TableName}:{Retry} HTTP status code={StatusCode} REST status code={RESTStatusCode}"
-        )]
-        private static partial void LogDebugDataNotFound(ILogger logger, Exception exception, string tableName, string retry, HttpStatusCode statusCode, string restStatusCode);
-
-        [LoggerMessage(
-            Level = LogLevel.Warning,
-            EventId = (int)Utilities.ErrorCode.AzureTable_11,
-            Message = "Intermediate issue reading Azure storage table {TableName}:{Retry} IsRetriable={IsLastErrorRetriable} HTTP status code={StatusCode} REST status code={RestStatusCode}"
-        )]
-        private static partial void LogWarningIntermediateIssueWithRestStatusCode(ILogger logger, Exception exception, string tableName, string retry, bool isLastErrorRetriable, HttpStatusCode statusCode, string restStatusCode);
-
-        [LoggerMessage(
-            Level = LogLevel.Error,
-            EventId = (int)Utilities.ErrorCode.AzureTable_12,
-            Message = "Unexpected issue reading Azure storage table {TableName}"
-        )]
-        private static partial void LogErrorUnexpectedIssue(ILogger logger, Exception exception, string tableName);
     }
 }

--- a/src/Orleans.Core/Orleans.Core.csproj
+++ b/src/Orleans.Core/Orleans.Core.csproj
@@ -87,4 +87,3 @@
     <InternalsVisibleTo Include="TestInternalGrains" />
   </ItemGroup>
 </Project>
-

--- a/src/Orleans.Core/Utils/BackoffComputation.cs
+++ b/src/Orleans.Core/Utils/BackoffComputation.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Orleans.Internal
+{
+    internal static class BackoffComputation
+    {
+        private const int MaxBoundShift = 30;
+
+        public static TimeSpan ComputeBackoffDelay(int consecutiveFailures, TimeSpan baseMin, TimeSpan baseMax, TimeSpan cap)
+        {
+            if (baseMin <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(baseMin), baseMin, "baseMin must be positive.");
+            if (baseMax <= baseMin) throw new ArgumentOutOfRangeException(nameof(baseMax), baseMax, "baseMax must be greater than baseMin.");
+            if (cap < baseMax) throw new ArgumentOutOfRangeException(nameof(cap), cap, "cap must be greater than or equal to baseMax.");
+
+            var shift = consecutiveFailures <= 1 ? 0 : Math.Min(consecutiveFailures - 1, MaxBoundShift);
+
+            var minTicks = SafeShift(baseMin.Ticks, shift);
+            var maxTicks = SafeShift(baseMax.Ticks, shift);
+
+            if (maxTicks <= 0 || maxTicks >= cap.Ticks)
+            {
+                maxTicks = cap.Ticks;
+                minTicks = cap.Ticks / 2;
+            }
+
+            if (minTicks >= maxTicks)
+            {
+                minTicks = Math.Max(1, maxTicks - 1);
+            }
+
+            return RandomTimeSpan.Next(TimeSpan.FromTicks(minTicks), TimeSpan.FromTicks(maxTicks));
+        }
+
+        private static long SafeShift(long value, int shift)
+        {
+            if (shift <= 0) return value;
+            if (shift >= 63 || value > (long.MaxValue >> shift)) return -1;
+            return value << shift;
+        }
+    }
+}

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -390,6 +390,7 @@ namespace Orleans.Runtime.ReminderService
         {
             await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ContinueOnCapturedContext | ConfigureAwaitOptions.ForceYielding);
             TimeSpan? overrideDelay = RandomTimeSpan.Next(InitialReadRetryPeriod);
+            int consecutiveFailures = 0;
             while (await listRefreshTimer.NextTick(overrideDelay))
             {
                 try
@@ -409,11 +410,18 @@ namespace Orleans.Runtime.ReminderService
                             listRefreshTimer.Dispose();
                             return;
                     }
+
+                    consecutiveFailures = 0;
                 }
                 catch (Exception exception)
                 {
                     LogWarningReadingReminders(exception);
-                    overrideDelay = RandomTimeSpan.Next(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20));
+
+                    overrideDelay = BackoffComputation.ComputeBackoffDelay(
+                        ++consecutiveFailures,
+                        baseMin: TimeSpan.FromSeconds(10),
+                        baseMax: TimeSpan.FromSeconds(20),
+                        cap: TimeSpan.FromSeconds(80));
                 }
             }
         }

--- a/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipAgent.cs
@@ -16,9 +16,9 @@ namespace Orleans.Runtime.MembershipService
     /// </summary>
     internal partial class MembershipAgent : IHealthCheckParticipant, ILifecycleParticipant<ISiloLifecycle>, IDisposable, MembershipAgent.ITestAccessor
     {
-        private static readonly TimeSpan EXP_BACKOFF_CONTENTION_MIN = TimeSpan.FromMilliseconds(200);
-        private static readonly TimeSpan EXP_BACKOFF_CONTENTION_MAX = TimeSpan.FromMinutes(2);
-        private static readonly TimeSpan EXP_BACKOFF_STEP = TimeSpan.FromMilliseconds(1000);
+        private static readonly TimeSpan EXP_BACKOFF_CONTENTION_MIN = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan EXP_BACKOFF_CONTENTION_MAX = TimeSpan.FromSeconds(64);
+        private static readonly TimeSpan EXP_BACKOFF_STEP = TimeSpan.FromSeconds(2);
         private readonly CancellationTokenSource cancellation = new CancellationTokenSource();
         private readonly IMembershipManager membershipManager;
         private readonly ILocalSiloDetails localSilo;
@@ -63,9 +63,7 @@ namespace Orleans.Runtime.MembershipService
             LogDebugStartingPeriodicMembershipLivenessTimestampUpdates();
             try
             {
-                // jitter for initial
                 TimeSpan? overrideDelayPeriod = RandomTimeSpan.Next(this.clusterMembershipOptions.IAmAliveTablePublishTimeout);
-                var exponentialBackoff = new ExponentialBackoff(EXP_BACKOFF_CONTENTION_MIN, EXP_BACKOFF_CONTENTION_MAX, EXP_BACKOFF_STEP);
                 var runningFailures = 0;
                 while (await this.iAmAliveTimer.NextTick(overrideDelayPeriod) && !this.membershipManager.LocalSiloStatus.IsTerminating())
                 {
@@ -82,8 +80,12 @@ namespace Orleans.Runtime.MembershipService
                     {
                         runningFailures += 1;
                         LogWarningFailedToUpdateTableEntryForThisSilo(exception);
-                        // Retry quickly and then exponentially back off
-                        overrideDelayPeriod = exponentialBackoff.Next(runningFailures);
+
+                        overrideDelayPeriod = BackoffComputation.ComputeBackoffDelay(
+                            runningFailures,
+                            baseMin: EXP_BACKOFF_CONTENTION_MIN,
+                            baseMax: EXP_BACKOFF_CONTENTION_MIN + EXP_BACKOFF_STEP,
+                            cap: EXP_BACKOFF_CONTENTION_MAX);
                     }
                 }
             }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -21,10 +21,10 @@ namespace Orleans.Runtime.MembershipService
         private const int NUM_CONDITIONAL_WRITE_CONTENTION_ATTEMPTS = -1; // unlimited
         private const int NUM_CONDITIONAL_WRITE_ERROR_ATTEMPTS = -1;
         private static readonly TimeSpan EXP_BACKOFF_ERROR_MIN = TimeSpan.FromMilliseconds(1000);
-        private static readonly TimeSpan EXP_BACKOFF_CONTENTION_MIN = TimeSpan.FromMilliseconds(100);
+        private static readonly TimeSpan EXP_BACKOFF_CONTENTION_MIN = TimeSpan.FromSeconds(2);
         private static readonly TimeSpan EXP_BACKOFF_ERROR_MAX = TimeSpan.FromMinutes(1);
-        private static readonly TimeSpan EXP_BACKOFF_CONTENTION_MAX = TimeSpan.FromMinutes(1);
-        private static readonly TimeSpan EXP_BACKOFF_STEP = TimeSpan.FromMilliseconds(1000);
+        private static readonly TimeSpan EXP_BACKOFF_CONTENTION_MAX = TimeSpan.FromSeconds(64);
+        private static readonly TimeSpan EXP_BACKOFF_STEP = TimeSpan.FromSeconds(2);
         private static readonly TimeSpan GossipTimeout = TimeSpan.FromMilliseconds(3000);
         private static readonly string RoleName = CachedTypeResolver.GetName(Assembly.GetEntryAssembly() ?? typeof(MembershipTableManager).Assembly);
 
@@ -255,9 +255,7 @@ namespace Orleans.Runtime.MembershipService
             LogDebugStartingPeriodicMembershipTableRefreshes(this.log);
             try
             {
-                // jitter for initial
                 TimeSpan? overrideDelayPeriod = RandomTimeSpan.Next(this.clusterMembershipOptions.TableRefreshTimeout);
-                var exponentialBackoff = new ExponentialBackoff(EXP_BACKOFF_CONTENTION_MIN, EXP_BACKOFF_CONTENTION_MAX, EXP_BACKOFF_STEP);
                 var runningFailures = 0;
                 while (await this.membershipUpdateTimer.NextTick(overrideDelayPeriod))
                 {
@@ -267,7 +265,6 @@ namespace Orleans.Runtime.MembershipService
 
                         await this.Refresh();
                         LogTraceRefreshingMembershipTableTook(this.log, stopwatch.Elapsed);
-                        // reset to allow normal refresh period after success
                         overrideDelayPeriod = default;
                         runningFailures = 0;
                     }
@@ -276,8 +273,7 @@ namespace Orleans.Runtime.MembershipService
                         runningFailures += 1;
                         LogWarningFailedToRefreshMembershipTable(this.log, exception, runningFailures);
 
-                        // Retry quickly and then exponentially back off
-                        overrideDelayPeriod = exponentialBackoff.Next(runningFailures);
+                        overrideDelayPeriod = ComputeMembershipBackoffDelay(runningFailures);
                     }
                 }
             }
@@ -290,6 +286,15 @@ namespace Orleans.Runtime.MembershipService
             {
                 LogDebugStoppingPeriodicMembershipTableRefreshes(this.log);
             }
+        }
+
+        internal static TimeSpan ComputeMembershipBackoffDelay(int consecutiveFailures)
+        {
+            return BackoffComputation.ComputeBackoffDelay(
+                consecutiveFailures,
+                baseMin: EXP_BACKOFF_CONTENTION_MIN,
+                baseMax: EXP_BACKOFF_CONTENTION_MIN + EXP_BACKOFF_STEP,
+                cap: EXP_BACKOFF_CONTENTION_MAX);
         }
 
         private static Task<bool> MembershipExecuteWithRetries(

--- a/src/api/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Clustering.AzureStorage/Orleans.Clustering.AzureStorage.cs
@@ -79,6 +79,8 @@ namespace Orleans.Clustering.AzureStorage
 
         public int MaxOperationRetries { get { throw null; } set { } }
 
+        public System.TimeSpan MaxPauseBetweenOperationRetries { get { throw null; } set { } }
+
         public System.TimeSpan OperationTimeout { get { throw null; } set { } }
 
         public System.TimeSpan PauseBetweenCreationRetries { get { throw null; } set { } }

--- a/src/api/Azure/Orleans.GrainDirectory.AzureStorage/Orleans.GrainDirectory.AzureStorage.cs
+++ b/src/api/Azure/Orleans.GrainDirectory.AzureStorage/Orleans.GrainDirectory.AzureStorage.cs
@@ -72,6 +72,8 @@ namespace Orleans.GrainDirectory.AzureStorage
 
         public int MaxOperationRetries { get { throw null; } set { } }
 
+        public System.TimeSpan MaxPauseBetweenOperationRetries { get { throw null; } set { } }
+
         public System.TimeSpan OperationTimeout { get { throw null; } set { } }
 
         public System.TimeSpan PauseBetweenCreationRetries { get { throw null; } set { } }

--- a/src/api/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Persistence.AzureStorage/Orleans.Persistence.AzureStorage.cs
@@ -161,6 +161,8 @@ namespace Orleans.Persistence.AzureStorage
 
         public int MaxOperationRetries { get { throw null; } set { } }
 
+        public System.TimeSpan MaxPauseBetweenOperationRetries { get { throw null; } set { } }
+
         public System.TimeSpan OperationTimeout { get { throw null; } set { } }
 
         public System.TimeSpan PauseBetweenCreationRetries { get { throw null; } set { } }

--- a/src/api/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Reminders.AzureStorage/Orleans.Reminders.AzureStorage.cs
@@ -79,6 +79,8 @@ namespace Orleans.Reminders.AzureStorage
 
         public int MaxOperationRetries { get { throw null; } set { } }
 
+        public System.TimeSpan MaxPauseBetweenOperationRetries { get { throw null; } set { } }
+
         public System.TimeSpan OperationTimeout { get { throw null; } set { } }
 
         public System.TimeSpan PauseBetweenCreationRetries { get { throw null; } set { } }

--- a/src/api/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Streaming.AzureStorage/Orleans.Streaming.AzureStorage.cs
@@ -357,6 +357,8 @@ namespace Orleans.Streaming.AzureStorage
 
         public int MaxOperationRetries { get { throw null; } set { } }
 
+        public System.TimeSpan MaxPauseBetweenOperationRetries { get { throw null; } set { } }
+
         public System.TimeSpan OperationTimeout { get { throw null; } set { } }
 
         public System.TimeSpan PauseBetweenCreationRetries { get { throw null; } set { } }

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -238,6 +238,8 @@ namespace Orleans.Streaming.EventHubs
 
         public int MaxOperationRetries { get { throw null; } set { } }
 
+        public System.TimeSpan MaxPauseBetweenOperationRetries { get { throw null; } set { } }
+
         public System.TimeSpan OperationTimeout { get { throw null; } set { } }
 
         public System.TimeSpan PauseBetweenCreationRetries { get { throw null; } set { } }

--- a/src/api/Azure/Orleans.Transactions.AzureStorage/Orleans.Transactions.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Transactions.AzureStorage/Orleans.Transactions.AzureStorage.cs
@@ -92,6 +92,8 @@ namespace Orleans.Transactions.AzureStorage
 
         public int MaxOperationRetries { get { throw null; } set { } }
 
+        public System.TimeSpan MaxPauseBetweenOperationRetries { get { throw null; } set { } }
+
         public System.TimeSpan OperationTimeout { get { throw null; } set { } }
 
         public System.TimeSpan PauseBetweenCreationRetries { get { throw null; } set { } }

--- a/test/Orleans.Core.Tests/General/BackoffComputationTests.cs
+++ b/test/Orleans.Core.Tests/General/BackoffComputationTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using Orleans.Internal;
+using Xunit;
+
+namespace UnitTests.General
+{
+    [TestCategory("BVT"), TestCategory("Functional")]
+    public class BackoffComputationTests
+    {
+        private static readonly TimeSpan BaseMin = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan BaseMax = TimeSpan.FromSeconds(20);
+        private static readonly TimeSpan Cap = TimeSpan.FromSeconds(80);
+
+        [Fact]
+        public void ComputeBackoffDelay_FirstFailure_IsBetweenBaseMinAndBaseMax()
+        {
+            for (var i = 0; i < 50; i++)
+            {
+                var delay = BackoffComputation.ComputeBackoffDelay(1, BaseMin, BaseMax, Cap);
+                Assert.InRange(delay, BaseMin, BaseMax);
+            }
+        }
+
+        [Fact]
+        public void ComputeBackoffDelay_ZeroOrNegativeFailureCount_TreatedAsFirstFailure()
+        {
+            foreach (var count in new[] { 0, -1, -100, int.MinValue })
+            {
+                var delay = BackoffComputation.ComputeBackoffDelay(count, BaseMin, BaseMax, Cap);
+                Assert.InRange(delay, BaseMin, BaseMax);
+            }
+        }
+
+        [Fact]
+        public void ComputeBackoffDelay_BothBoundsDoubleEachFailure_UntilCap()
+        {
+            var expectations = new (int failures, TimeSpan min, TimeSpan max)[]
+            {
+                (1, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(20)),
+                (2, TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(40)),
+                (3, TimeSpan.FromSeconds(40), TimeSpan.FromSeconds(80)),
+            };
+
+            foreach (var (failures, min, max) in expectations)
+            {
+                for (var i = 0; i < 30; i++)
+                {
+                    var delay = BackoffComputation.ComputeBackoffDelay(failures, BaseMin, BaseMax, Cap);
+                    Assert.InRange(delay, min, max);
+                }
+            }
+        }
+
+        [Fact]
+        public void ComputeBackoffDelay_SaturatesAtCappedWindow()
+        {
+            foreach (var failures in new[] { 3, 4, 9, 20, 100, 1_000_000, int.MaxValue })
+            {
+                for (var i = 0; i < 20; i++)
+                {
+                    var delay = BackoffComputation.ComputeBackoffDelay(failures, BaseMin, BaseMax, Cap);
+                    Assert.InRange(delay, TimeSpan.FromTicks(Cap.Ticks / 2), Cap);
+                }
+            }
+        }
+
+        [Fact]
+        public void ComputeBackoffDelay_ProducesJitterAcrossInvocations()
+        {
+            var observed = new HashSet<TimeSpan>();
+            for (var i = 0; i < 50; i++)
+            {
+                observed.Add(BackoffComputation.ComputeBackoffDelay(3, BaseMin, BaseMax, Cap));
+            }
+
+            Assert.True(observed.Count > 1, "Expected multiple distinct delays due to jitter.");
+        }
+
+        [Fact]
+        public void ComputeBackoffDelay_LowerBoundShiftsUpward_DefeatsThunderingHerd()
+        {
+            for (var i = 0; i < 100; i++)
+            {
+                var delay = BackoffComputation.ComputeBackoffDelay(2, BaseMin, BaseMax, Cap);
+                Assert.True(delay >= BaseMax, $"Expected delay >= {BaseMax}, but got {delay}.");
+            }
+        }
+
+        [Fact]
+        public void ComputeBackoffDelay_InvalidArguments_Throw()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                BackoffComputation.ComputeBackoffDelay(1, TimeSpan.Zero, BaseMax, Cap));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                BackoffComputation.ComputeBackoffDelay(1, TimeSpan.FromSeconds(-1), BaseMax, Cap));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                BackoffComputation.ComputeBackoffDelay(1, BaseMin, BaseMin, Cap));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                BackoffComputation.ComputeBackoffDelay(1, BaseMin, BaseMax, TimeSpan.FromSeconds(5)));
+        }
+
+        [Fact]
+        public void ComputeBackoffDelay_BoundsEqualCap_SaturatesImmediately()
+        {
+            var min = TimeSpan.FromSeconds(5);
+            var max = TimeSpan.FromSeconds(10);
+            var cap = TimeSpan.FromSeconds(10);
+
+            for (var failures = 1; failures < 5; failures++)
+            {
+                for (var i = 0; i < 20; i++)
+                {
+                    var delay = BackoffComputation.ComputeBackoffDelay(failures, min, max, cap);
+                    if (failures == 1)
+                    {
+                        Assert.InRange(delay, min, cap);
+                    }
+                    else
+                    {
+                        Assert.InRange(delay, TimeSpan.FromTicks(cap.Ticks / 2), cap);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -340,7 +340,11 @@ namespace NonSilo.Tests.Membership
 
                 while (probeCalls.TryDequeue(out var call)) ;
 
-                testRig.Manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(45));
+                if (expectedMissedProbes >= clusterMembershipOptions.NumMissedProbesLimit)
+                {
+                    Assert.True(testRig.Manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(45)));
+                }
+
                 // Check that probes match the expected missed probes
                 table = await this.membershipTable.ReadAll();
                 foreach (var siloMonitor in monitoredSilos)
@@ -520,7 +524,11 @@ namespace NonSilo.Tests.Membership
 
             await testRig.Manager.Refresh();
 
-            testRig.Manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(45));
+            if (evictWhenMaxJoinAttemptTimeExceeded)
+            {
+                Assert.True(testRig.Manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(45)));
+            }
+
             await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion);
             
             lastVersion = testRig.TestAccessor.ObservedVersion;

--- a/test/Orleans.Core.Tests/Membership/MembershipBackoffTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipBackoffTests.cs
@@ -1,0 +1,70 @@
+using System;
+using Orleans.Runtime.MembershipService;
+using Xunit;
+
+namespace NonSilo.Tests.Membership
+{
+    [TestCategory("BVT"), TestCategory("Membership")]
+    public class MembershipBackoffTests
+    {
+        private static readonly TimeSpan ExpectedFirstFailureMin = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan ExpectedFirstFailureMax = TimeSpan.FromSeconds(4);
+        private static readonly TimeSpan ExpectedSaturatedMin = TimeSpan.FromSeconds(32);
+        private static readonly TimeSpan ExpectedSaturatedMax = TimeSpan.FromSeconds(64);
+
+        [Fact]
+        public void MembershipTableManager_FirstFailure_BacksOffAtLeastTwoSeconds()
+        {
+            for (var i = 0; i < 50; i++)
+            {
+                var delay = MembershipTableManager.ComputeMembershipBackoffDelay(consecutiveFailures: 1);
+                Assert.InRange(delay, ExpectedFirstFailureMin, ExpectedFirstFailureMax);
+            }
+        }
+
+        [Fact]
+        public void MembershipTableManager_GrowsExponentially_DoublingBothBounds()
+        {
+            var expectations = new (int failures, TimeSpan min, TimeSpan max)[]
+            {
+                (1, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4)),
+                (2, TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(8)),
+                (3, TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(16)),
+                (4, TimeSpan.FromSeconds(16), TimeSpan.FromSeconds(32)),
+                (5, TimeSpan.FromSeconds(32), TimeSpan.FromSeconds(64)),
+            };
+
+            foreach (var (failures, min, max) in expectations)
+            {
+                for (var i = 0; i < 20; i++)
+                {
+                    var delay = MembershipTableManager.ComputeMembershipBackoffDelay(failures);
+                    Assert.InRange(delay, min, max);
+                }
+            }
+        }
+
+        [Fact]
+        public void MembershipTableManager_SaturatesAtBoundedCap()
+        {
+            foreach (var failures in new[] { 5, 6, 10, 100, int.MaxValue })
+            {
+                for (var i = 0; i < 20; i++)
+                {
+                    var delay = MembershipTableManager.ComputeMembershipBackoffDelay(failures);
+                    Assert.InRange(delay, ExpectedSaturatedMin, ExpectedSaturatedMax);
+                }
+            }
+        }
+
+        [Fact]
+        public void MembershipTableManager_ZeroOrNegativeFailureCount_TreatedAsFirstFailure()
+        {
+            foreach (var count in new[] { 0, -1, -100 })
+            {
+                var delay = MembershipTableManager.ComputeMembershipBackoffDelay(count);
+                Assert.InRange(delay, ExpectedFirstFailureMin, ExpectedFirstFailureMax);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reduces Azure Table Storage pressure when many silos experience storage failures by applying bounded jittered backoff to the outer membership and reminder refresh loops, while delegating Azure Table per-operation retries to the Azure SDK exponential retry policy instead of layering an additional Orleans retry wrapper.

This keeps the retry layers separate: Orleans backs off periodic background loops after failures, and the Azure SDK handles per-call retries, server retry hints, and network timeouts.

Azure Table client retry defaults mirror Azure Storage SDK defaults where applicable, while keeping storage max retries at 5. References:

- https://learn.microsoft.com/en-us/azure/storage/blobs/storage-retry-policy
- https://github.com/Azure/azure-sdk-for-net/blob/37a51a869edf1fe90005641dc6355bd53d3a02bf/sdk/storage/Azure.Storage.Common/src/Shared/Constants.cs#L18
- https://github.com/Azure/azure-sdk-for-net/blob/37a51a869edf1fe90005641dc6355bd53d3a02bf/sdk/core/Azure.Core/src/RetryOptions.cs#L13
