### PR TITLE
chore: use meter factory for environment statistics metrics

### DIFF
--- a/src/Orleans.Core/Statistics/EnvironmentStatisticsProvider.cs
+++ b/src/Orleans.Core/Statistics/EnvironmentStatisticsProvider.cs
@@ -27,11 +27,21 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
     private readonly DualModeKalmanFilter _memoryUsageFilter = new();
 
     public EnvironmentStatisticsProvider()
+        : this(new OrleansInstruments(new DirectMeterFactory()))
+    {
+    }
+
+    public EnvironmentStatisticsProvider(OrleansInstruments instruments)
+        : this(instruments.Meter)
+    {
+    }
+
+    private EnvironmentStatisticsProvider(Meter meter)
     {
         GC.Collect(0, GCCollectionMode.Forced, true); // we make sure the GC structure wont be empty, also performing a blocking GC guarantees immediate collection.
 
-        _availableMemoryGauge = Instruments.Meter.CreateObservableGauge(InstrumentNames.RUNTIME_MEMORY_AVAILABLE_MEMORY_MB, () => (long)(_availableMemoryBytes / OneKiloByte / OneKiloByte), unit: "MB");
-        _maximumAvailableMemoryGauge = Instruments.Meter.CreateObservableGauge(InstrumentNames.RUNTIME_MEMORY_TOTAL_PHYSICAL_MEMORY_MB, () => (long)(_maximumAvailableMemoryBytes / OneKiloByte / OneKiloByte), unit: "MB");
+        _availableMemoryGauge = meter.CreateObservableGauge(InstrumentNames.RUNTIME_MEMORY_AVAILABLE_MEMORY_MB, () => (long)(_availableMemoryBytes / OneKiloByte / OneKiloByte), unit: "MB");
+        _maximumAvailableMemoryGauge = meter.CreateObservableGauge(InstrumentNames.RUNTIME_MEMORY_TOTAL_PHYSICAL_MEMORY_MB, () => (long)(_maximumAvailableMemoryBytes / OneKiloByte / OneKiloByte), unit: "MB");
     }
 
     /// <inheritdoc />
@@ -93,6 +103,15 @@ internal sealed class EnvironmentStatisticsProvider : IEnvironmentStatisticsProv
                     }
                 }
             }
+        }
+    }
+
+    private sealed class DirectMeterFactory : IMeterFactory
+    {
+        public Meter Create(MeterOptions options) => new(options);
+
+        public void Dispose()
+        {
         }
     }
 


### PR DESCRIPTION
Addresses part of #9608 by moving environment statistics metrics to the DI-provided Orleans meter.

This preserves the direct-construction path for tests and static callers while using IMeterFactory when the provider is resolved from Orleans services.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10193)