### PR TITLE
chore: use meter factory for stream cache metrics

### DIFF
--- a/src/Orleans.Streaming/Common/Monitors/DefaultBlockPoolMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultBlockPoolMonitor.cs
@@ -27,13 +27,23 @@ namespace Orleans.Providers.Streams.Common
         /// Initializes a new instance of the <see cref="DefaultBlockPoolMonitor"/> class.
         /// </summary>
         protected DefaultBlockPoolMonitor(KeyValuePair<string, object>[] dimensions)
+            : this(dimensions, Instruments.Meter)
+        {
+        }
+
+        internal DefaultBlockPoolMonitor(BlockPoolMonitorDimensions dimensions, OrleansInstruments instruments)
+            : this(new KeyValuePair<string, object>[] { new("BlockPoolId", dimensions.BlockPoolId) }, instruments.Meter)
+        {
+        }
+
+        private DefaultBlockPoolMonitor(KeyValuePair<string, object>[] dimensions, Meter meter)
         {
             _dimensions = dimensions;
-            _totalMemoryCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_TOTAL_MEMORY, GetTotalMemory, unit: "bytes");
-            _availableMemoryCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_AVAILABLE_MEMORY, GetAvailableMemory, unit: "bytes");
-            _claimedMemoryCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_CLAIMED_MEMORY, GetClaimedMemory, unit: "bytes");
-            _releasedMemoryCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_RELEASED_MEMORY, GetReleasedMemory, unit: "bytes");
-            _allocatedMemoryCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_ALLOCATED_MEMORY, GetAllocatedMemory, unit: "bytes");
+            _totalMemoryCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_TOTAL_MEMORY, GetTotalMemory, unit: "bytes");
+            _availableMemoryCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_AVAILABLE_MEMORY, GetAvailableMemory, unit: "bytes");
+            _claimedMemoryCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_CLAIMED_MEMORY, GetClaimedMemory, unit: "bytes");
+            _releasedMemoryCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_RELEASED_MEMORY, GetReleasedMemory, unit: "bytes");
+            _allocatedMemoryCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_ALLOCATED_MEMORY, GetAllocatedMemory, unit: "bytes");
         }
 
         /// <summary>

--- a/src/Orleans.Streaming/Common/Monitors/DefaultCacheMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultCacheMonitor.cs
@@ -39,19 +39,29 @@ namespace Orleans.Providers.Streams.Common
         /// Initializes a new instance of the <see cref="DefaultCacheMonitor"/> class.
         /// </summary>
         protected DefaultCacheMonitor(KeyValuePair<string, object>[] dimensions)
+            : this(dimensions, Instruments.Meter)
+        {
+        }
+
+        internal DefaultCacheMonitor(CacheMonitorDimensions dimensions, OrleansInstruments instruments)
+            : this(new KeyValuePair<string, object>[] { new("QueueId", dimensions.QueueId) }, instruments.Meter)
+        {
+        }
+
+        private DefaultCacheMonitor(KeyValuePair<string, object>[] dimensions, Meter meter)
         {
             _dimensions = dimensions;
-            _queueCacheSizeCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_SIZE, () => new(_totalCacheSize, _dimensions), unit: "bytes");
-            _queueCacheMessageCountCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_LENGTH, () => new(_messageCount, _dimensions), unit: "messages");
-            _queueCacheMessagesAddedCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_MESSAGES_ADDED, () => new(_messagesAdded, _dimensions));
-            _queueCacheMessagesPurgedCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_MESSAGES_PURGED, () => new(_messagesPurged, _dimensions));
-            _queueCacheMemoryAllocatedCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_MEMORY_ALLOCATED, () => new(_memoryAllocated, _dimensions));
-            _queueCacheMemoryReleasedCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_MEMORY_RELEASED, () => new(_memoryReleased, _dimensions));
-            _oldestMessageReadEnqueueTimeToNowCounter = Instruments.Meter.CreateObservableGauge<long>(InstrumentNames.STREAMS_QUEUE_CACHE_OLDEST_TO_NEWEST_DURATION, GetOldestToNewestAge);
-            _newestMessageReadEnqueueTimeToNowCounter = Instruments.Meter.CreateObservableGauge<long>(InstrumentNames.STREAMS_QUEUE_CACHE_OLDEST_AGE, GetOldestAge);
-            _currentPressureCounter = Instruments.Meter.CreateObservableGauge<double>(InstrumentNames.STREAMS_QUEUE_CACHE_PRESSURE, () => GetPressureMonitorMeasurement(monitor => monitor.CurrentPressure));
-            _underPressureCounter = Instruments.Meter.CreateObservableGauge<int>(InstrumentNames.STREAMS_QUEUE_CACHE_UNDER_PRESSURE, () => GetPressureMonitorMeasurement(monitor => monitor.UnderPressure));
-            _pressureContributionCounter = Instruments.Meter.CreateObservableGauge<double>(InstrumentNames.STREAMS_QUEUE_CACHE_PRESSURE_CONTRIBUTION_COUNT, () => GetPressureMonitorMeasurement(monitor => monitor.PressureContributionCount));
+            _queueCacheSizeCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_SIZE, () => new(_totalCacheSize, _dimensions), unit: "bytes");
+            _queueCacheMessageCountCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_LENGTH, () => new(_messageCount, _dimensions), unit: "messages");
+            _queueCacheMessagesAddedCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_MESSAGES_ADDED, () => new(_messagesAdded, _dimensions));
+            _queueCacheMessagesPurgedCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_MESSAGES_PURGED, () => new(_messagesPurged, _dimensions));
+            _queueCacheMemoryAllocatedCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_MEMORY_ALLOCATED, () => new(_memoryAllocated, _dimensions));
+            _queueCacheMemoryReleasedCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_CACHE_MEMORY_RELEASED, () => new(_memoryReleased, _dimensions));
+            _oldestMessageReadEnqueueTimeToNowCounter = meter.CreateObservableGauge<long>(InstrumentNames.STREAMS_QUEUE_CACHE_OLDEST_TO_NEWEST_DURATION, GetOldestToNewestAge);
+            _newestMessageReadEnqueueTimeToNowCounter = meter.CreateObservableGauge<long>(InstrumentNames.STREAMS_QUEUE_CACHE_OLDEST_AGE, GetOldestAge);
+            _currentPressureCounter = meter.CreateObservableGauge<double>(InstrumentNames.STREAMS_QUEUE_CACHE_PRESSURE, () => GetPressureMonitorMeasurement(monitor => monitor.CurrentPressure));
+            _underPressureCounter = meter.CreateObservableGauge<int>(InstrumentNames.STREAMS_QUEUE_CACHE_UNDER_PRESSURE, () => GetPressureMonitorMeasurement(monitor => monitor.UnderPressure));
+            _pressureContributionCounter = meter.CreateObservableGauge<double>(InstrumentNames.STREAMS_QUEUE_CACHE_PRESSURE_CONTRIBUTION_COUNT, () => GetPressureMonitorMeasurement(monitor => monitor.PressureContributionCount));
             IEnumerable<Measurement<T>> GetPressureMonitorMeasurement<T>(Func<PressureMonitorStatistics, T> selector) where T : struct
             {
                 foreach (var monitor in _pressureMonitors)

--- a/src/Orleans.Streaming/Generator/GeneratorAdapterFactory.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorAdapterFactory.cs
@@ -40,6 +40,7 @@ namespace Orleans.Providers.Streams.Generator
         private readonly Serialization.Serializer serializer;
         private readonly ILoggerFactory loggerFactory;
         private readonly ILogger<GeneratorAdapterFactory> logger;
+        private readonly OrleansInstruments orleansInstruments;
         private IStreamGeneratorConfig generatorConfig;
         private IStreamQueueMapper streamQueueMapper;
         private IStreamFailureHandler streamFailureHandler;
@@ -89,6 +90,7 @@ namespace Orleans.Providers.Streams.Generator
             this.serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             this.logger = loggerFactory.CreateLogger<GeneratorAdapterFactory>();
+            this.orleansInstruments = serviceProvider.GetService<OrleansInstruments>();
         }
 
         /// <summary>
@@ -98,9 +100,9 @@ namespace Orleans.Providers.Streams.Generator
         {
             this.receivers = new ConcurrentDictionary<QueueId, Receiver>();
             if (CacheMonitorFactory == null)
-                this.CacheMonitorFactory = (dimensions) => new DefaultCacheMonitor(dimensions);
+                this.CacheMonitorFactory = (dimensions) => this.orleansInstruments is not null ? new DefaultCacheMonitor(dimensions, this.orleansInstruments) : new DefaultCacheMonitor(dimensions);
             if (this.BlockPoolMonitorFactory == null)
-                this.BlockPoolMonitorFactory = (dimensions) => new DefaultBlockPoolMonitor(dimensions);
+                this.BlockPoolMonitorFactory = (dimensions) => this.orleansInstruments is not null ? new DefaultBlockPoolMonitor(dimensions, this.orleansInstruments) : new DefaultBlockPoolMonitor(dimensions);
             if (this.ReceiverMonitorFactory == null)
                 this.ReceiverMonitorFactory = (dimensions) => new DefaultQueueAdapterReceiverMonitor(dimensions);
             generatorConfig = this.serviceProvider.GetKeyedService<IStreamGeneratorConfig>(this.Name);

--- a/src/Orleans.Streaming/MemoryStreams/MemoryAdapterFactory.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryAdapterFactory.cs
@@ -33,6 +33,7 @@ namespace Orleans.Providers
         private readonly ILoggerFactory loggerFactory;
         private readonly ILogger logger;
         private readonly TSerializer serializer;
+        private readonly OrleansInstruments orleansInstruments;
         private readonly ulong _nameHash;
         private IStreamQueueMapper streamQueueMapper;
         private ConcurrentDictionary<QueueId, IMemoryStreamQueueGrain> queueGrains;
@@ -90,6 +91,7 @@ namespace Orleans.Providers
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             this.logger = loggerFactory.CreateLogger<ILogger<MemoryAdapterFactory<TSerializer>>>();
             this.serializer = MemoryMessageBodySerializerFactory<TSerializer>.GetOrCreateSerializer(serviceProvider);
+            this.orleansInstruments = serviceProvider.GetService<OrleansInstruments>();
 
             var nameBytes = BitConverter.IsLittleEndian ? MemoryMarshal.AsBytes(Name.AsSpan()) : Encoding.Unicode.GetBytes(Name);
             XxHash64.Hash(nameBytes, MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref _nameHash, 1)));
@@ -102,9 +104,9 @@ namespace Orleans.Providers
         {
             this.queueGrains = new ConcurrentDictionary<QueueId, IMemoryStreamQueueGrain>();
             if (CacheMonitorFactory == null)
-                this.CacheMonitorFactory = (dimensions) => new DefaultCacheMonitor(dimensions);
+                this.CacheMonitorFactory = (dimensions) => this.orleansInstruments is not null ? new DefaultCacheMonitor(dimensions, this.orleansInstruments) : new DefaultCacheMonitor(dimensions);
             if (this.BlockPoolMonitorFactory == null)
-                this.BlockPoolMonitorFactory = (dimensions) => new DefaultBlockPoolMonitor(dimensions);
+                this.BlockPoolMonitorFactory = (dimensions) => this.orleansInstruments is not null ? new DefaultBlockPoolMonitor(dimensions, this.orleansInstruments) : new DefaultBlockPoolMonitor(dimensions);
             if (this.ReceiverMonitorFactory == null)
                 this.ReceiverMonitorFactory = (dimensions) => new DefaultQueueAdapterReceiverMonitor(dimensions);
             this.purgePredicate = new TimePurgePredicate(this.cacheOptions.DataMinTimeInCache, this.cacheOptions.DataMaxAgeInCache);


### PR DESCRIPTION
Addresses part of #9608 by moving the default Memory and Generator stream cache/block-pool monitors to the DI-provided Orleans meter.

Existing public and protected constructors continue to use the legacy static meter fallback for compatibility, while default provider factories use OrleansInstruments when available.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10194)