### PR TITLE
chore: use meter factory for event hub receiver metrics

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -23,6 +23,7 @@ namespace Orleans.Streaming.EventHubs
     {
         private readonly ILoggerFactory loggerFactory;
         private readonly IEnvironmentStatisticsProvider environmentStatisticsProvider;
+        private readonly OrleansInstruments orleansInstruments;
 
         /// <summary>
         /// Data adapter
@@ -125,6 +126,7 @@ namespace Orleans.Streaming.EventHubs
             this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             this.environmentStatisticsProvider = environmentStatisticsProvider;
+            this.orleansInstruments = serviceProvider.GetService<OrleansInstruments>();
         }
 
         public virtual void Init()
@@ -151,7 +153,7 @@ namespace Orleans.Streaming.EventHubs
 
             if (this.ReceiverMonitorFactory == null)
             {
-                this.ReceiverMonitorFactory = (dimensions, logger) => new DefaultEventHubReceiverMonitor(dimensions);
+                this.ReceiverMonitorFactory = (dimensions, logger) => this.orleansInstruments is not null ? new DefaultEventHubReceiverMonitor(dimensions, this.orleansInstruments) : new DefaultEventHubReceiverMonitor(dimensions);
             }
 
             this.logger = this.loggerFactory.CreateLogger($"{this.GetType().FullName}.{this.ehOptions.EventHubName}");

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -126,7 +126,7 @@ namespace Orleans.Streaming.EventHubs
             this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             this.environmentStatisticsProvider = environmentStatisticsProvider;
-            this.orleansInstruments = serviceProvider.GetService<OrleansInstruments>();
+            this.orleansInstruments = serviceProvider.GetRequiredService<OrleansInstruments>();
         }
 
         public virtual void Init()
@@ -153,7 +153,7 @@ namespace Orleans.Streaming.EventHubs
 
             if (this.ReceiverMonitorFactory == null)
             {
-                this.ReceiverMonitorFactory = (dimensions, logger) => this.orleansInstruments is not null ? new DefaultEventHubReceiverMonitor(dimensions, this.orleansInstruments) : new DefaultEventHubReceiverMonitor(dimensions);
+                this.ReceiverMonitorFactory = (dimensions, logger) => new DefaultEventHubReceiverMonitor(dimensions, this.orleansInstruments);
             }
 
             this.logger = this.loggerFactory.CreateLogger($"{this.GetType().FullName}.{this.ehOptions.EventHubName}");

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubReceiverMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubReceiverMonitor.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
 
 namespace Orleans.Streaming.EventHubs
 {
@@ -14,6 +15,11 @@ namespace Orleans.Streaming.EventHubs
         /// <param name="dimensions">Aggregation Dimension bag for EventhubReceiverMonitor</param>
         public DefaultEventHubReceiverMonitor(EventHubReceiverMonitorDimensions dimensions)
             : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("Partition", dimensions.EventHubPartition) })
+        {
+        }
+
+        internal DefaultEventHubReceiverMonitor(EventHubReceiverMonitorDimensions dimensions, OrleansInstruments instruments)
+            : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("Partition", dimensions.EventHubPartition) }, instruments)
         {
         }
     }

--- a/src/Orleans.Streaming/Common/Monitors/DefaultQueueAdapterReceiverMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultQueueAdapterReceiverMonitor.cs
@@ -30,23 +30,33 @@ namespace Orleans.Providers.Streams.Common
         private long _messagesReceived;
 
         protected DefaultQueueAdapterReceiverMonitor(KeyValuePair<string,object>[] dimensions)
+            : this(dimensions, Instruments.Meter)
+        {
+        }
+
+        protected DefaultQueueAdapterReceiverMonitor(KeyValuePair<string, object>[] dimensions, OrleansInstruments instruments)
+            : this(dimensions, instruments.Meter)
+        {
+        }
+
+        private DefaultQueueAdapterReceiverMonitor(KeyValuePair<string, object>[] dimensions, Meter meter)
         {
             _dimensions = dimensions;
-            _initializationFailureCounter = Instruments.Meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_INITIALIZATION_FAILURES);
-            _initializationCallTimeCounter = Instruments.Meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_INITIALIZATION_DURATION);
-            _initializationExceptionCounter = Instruments.Meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_INITIALIZATION_EXCEPTIONS);
+            _initializationFailureCounter = meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_INITIALIZATION_FAILURES);
+            _initializationCallTimeCounter = meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_INITIALIZATION_DURATION);
+            _initializationExceptionCounter = meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_INITIALIZATION_EXCEPTIONS);
 
-            _readFailureCounter = Instruments.Meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_READ_FAILURES);
-            _readCallTimeCounter = Instruments.Meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_READ_DURATION);
-            _readExceptionCounter = Instruments.Meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_READ_EXCEPTIONS);
+            _readFailureCounter = meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_READ_FAILURES);
+            _readCallTimeCounter = meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_READ_DURATION);
+            _readExceptionCounter = meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_READ_EXCEPTIONS);
 
-            _shutdownFailureCounter = Instruments.Meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_SHUTDOWN_FAILURES);
-            _shutdownCallTimeCounter = Instruments.Meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_SHUTDOWN_DURATION);
-            _shutdownExceptionCounter = Instruments.Meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_SHUTDOWN_EXCEPTIONS);
+            _shutdownFailureCounter = meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_SHUTDOWN_FAILURES);
+            _shutdownCallTimeCounter = meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_SHUTDOWN_DURATION);
+            _shutdownExceptionCounter = meter.CreateCounter<long>(InstrumentNames.STREAMS_QUEUE_SHUTDOWN_EXCEPTIONS);
 
-            _messagesReceivedCounter = Instruments.Meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_MESSAGES_RECEIVED, GetMessagesReceivedCount);
-            _oldestMessageReadEnqueueTimeToNowCounter = Instruments.Meter.CreateObservableGauge<long>(InstrumentNames.STREAMS_QUEUE_OLDEST_MESSAGE_ENQUEUE_AGE, GetOldestMessageReadEnqueueAge);
-            _newestMessageReadEnqueueTimeToNowCounter = Instruments.Meter.CreateObservableGauge<long>(InstrumentNames.STREAMS_QUEUE_NEWEST_MESSAGE_ENQUEUE_AGE, GetNewestMessageReadEnqueueAge);
+            _messagesReceivedCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_QUEUE_MESSAGES_RECEIVED, GetMessagesReceivedCount);
+            _oldestMessageReadEnqueueTimeToNowCounter = meter.CreateObservableGauge<long>(InstrumentNames.STREAMS_QUEUE_OLDEST_MESSAGE_ENQUEUE_AGE, GetOldestMessageReadEnqueueAge);
+            _newestMessageReadEnqueueTimeToNowCounter = meter.CreateObservableGauge<long>(InstrumentNames.STREAMS_QUEUE_NEWEST_MESSAGE_ENQUEUE_AGE, GetNewestMessageReadEnqueueAge);
         }
 
         /// <summary>

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -587,6 +587,8 @@ namespace Orleans.Providers.Streams.Common
 
         protected DefaultQueueAdapterReceiverMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions) { }
 
+        protected DefaultQueueAdapterReceiverMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions, Runtime.OrleansInstruments instruments) { }
+
         public void TrackInitialization(bool success, System.TimeSpan callTime, System.Exception exception) { }
 
         public void TrackMessagesReceived(long count, System.DateTime? oldestMessageEnqueueTimeUtc, System.DateTime? newestMessageEnqueueTimeUtc) { }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CollectionFixtures.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CollectionFixtures.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
 using Orleans.Runtime;
 using Tester;
 using TestExtensions;
@@ -37,10 +40,26 @@ namespace ServiceBus.Tests
         public override async Task InitializeAsync()
         {
             await base.InitializeAsync();
-            var collector = new Microsoft.Extensions.Diagnostics.Metrics.Testing.MetricCollector<long>(Instruments.Meter, "orleans-streams-queue-read-duration");
+            var collectors = HostedCluster.Silos
+                .Select(silo => HostedCluster.GetSiloServiceProvider(silo.SiloAddress).GetRequiredService<IMeterFactory>())
+                .Select(meterFactory => new MetricCollector<long>(meterFactory, "Microsoft.Orleans", "orleans-streams-queue-read-duration"))
+                .ToArray();
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            // Wait for 10 queue read
-            await collector.WaitForMeasurementsAsync(10, cts.Token);
+            try
+            {
+                // Wait for 10 queue reads across the cluster.
+                while (collectors.Sum(collector => collector.GetMeasurementSnapshot().Count) < 10)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), cts.Token);
+                }
+            }
+            finally
+            {
+                foreach (var collector in collectors)
+                {
+                    collector.Dispose();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Addresses part of #9608 by moving the default EventHubs receiver monitor to the DI-provided Orleans meter when available.

The existing public receiver monitor constructor continues to use the legacy static meter fallback for compatibility. A protected constructor lets EventHubs pass OrleansInstruments without changing EventHubAdapterFactory's public constructor signature.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10195)