### PR TITLE
ci: skip external asset builds in provider tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     name: Redis provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         provider: ["Redis"]
@@ -92,6 +94,8 @@ jobs:
     name: Cassandra provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         provider: ["Cassandra"]
@@ -129,6 +133,8 @@ jobs:
     name: PostgreSQL provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         provider: ["PostgreSql"]
@@ -179,6 +185,8 @@ jobs:
     name: MariaDB/MySQL provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         provider: ["MySql"]
@@ -224,6 +232,8 @@ jobs:
     name: Microsoft SQL Server provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         provider: ["SqlServer"]
@@ -271,6 +281,8 @@ jobs:
     name: Azure Storage provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         framework: ["net8.0", "net10.0"]
@@ -326,6 +338,8 @@ jobs:
     name: Azure Event Hubs provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         framework: ["net8.0", "net10.0"]
@@ -401,6 +415,8 @@ jobs:
     name: Azure Cosmos DB provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         framework: ["net8.0", "net10.0"]
@@ -488,6 +504,8 @@ jobs:
     name: Consul provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         provider: ["Consul"]
@@ -522,6 +540,8 @@ jobs:
     name: ZooKeeper provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         provider: ["ZooKeeper"]
@@ -563,6 +583,8 @@ jobs:
     name: AWS DynamoDB provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         provider: ["DynamoDB"]
@@ -614,6 +636,8 @@ jobs:
     name: AWS SQS provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         provider: ["SQS"]
@@ -677,6 +701,8 @@ jobs:
     name: NATS stream provider tests
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      BuildExternalAssets: "false"
     strategy:
       matrix:
         provider: ["NATS"]

--- a/src/Dashboard/Orleans.Dashboard/Orleans.Dashboard.Frontend.targets
+++ b/src/Dashboard/Orleans.Dashboard/Orleans.Dashboard.Frontend.targets
@@ -1,6 +1,7 @@
 <Project>
 
   <PropertyGroup>
+    <BuildExternalAssets Condition="'$(BuildExternalAssets)' == ''">true</BuildExternalAssets>
     <!-- Frontend paths -->
     <NpmAppRootDirectory>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\Orleans.Dashboard.App'))</NpmAppRootDirectory>
     <NpmBuildOutput>$([System.IO.Path]::GetFullPath('$(NpmAppRootDirectory)\dist\'))</NpmBuildOutput>
@@ -8,7 +9,7 @@
   </PropertyGroup>
 
   <!-- Collect frontend source files for incremental build tracking -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(BuildExternalAssets)' != 'false'">
     <NpmAppSources Include="$(NpmAppRootDirectory)\src\**\*" />
     <NpmAppSources Include="$(NpmAppRootDirectory)\public\**\*" />
     <NpmAppSources Include="$(NpmAppRootDirectory)\package.json" />
@@ -32,7 +33,7 @@
   <!-- Build the frontend application.
        This target runs once regardless of how many target frameworks are being built.
        See: https://learn.microsoft.com/visualstudio/msbuild/run-target-exactly-once -->
-  <Target Name="BuildNpmApp" Inputs="@(NpmAppSources)" Outputs="$(NpmAppBuildMarker)">
+  <Target Name="BuildNpmApp" Inputs="@(NpmAppSources)" Outputs="$(NpmAppBuildMarker)" Condition="'$(BuildExternalAssets)' != 'false'">
     <Exec Command="node --version" ConsoleToMsBuild="true" StandardOutputImportance="Low">
       <Output TaskParameter="ConsoleOutput" PropertyName="NodeVersion" />
     </Exec>
@@ -66,6 +67,7 @@
     Name="BuildNpmAppBeforeOuterBuild"
     DependsOnTargets="BuildNpmApp"
     BeforeTargets="DispatchToInnerBuilds"
+    Condition="'$(BuildExternalAssets)' != 'false'"
     />
 
   <!-- Include frontend assets as embedded resources.
@@ -77,7 +79,7 @@
        BeforeTargets="BeforeBuild" ensures items are added early enough to be processed by the compiler.
        We use ItemGroup inside the target to dynamically discover files at target execution time,
        rather than relying on static globs which are evaluated at project load time. -->
-  <Target Name="IncludeFrontendAssets" BeforeTargets="BeforeBuild">
+  <Target Name="IncludeFrontendAssets" BeforeTargets="BeforeBuild" Condition="'$(BuildExternalAssets)' != 'false'">
     <!-- Call BuildNpmApp once via the outer build (without TargetFramework) -->
     <MSBuild
       Projects="$(MSBuildProjectFullPath)"
@@ -109,7 +111,7 @@
        This runs after CreateManifestResourceNames has processed all EmbeddedResource items,
        providing a final check that the resources will be compiled into the assembly.
        Only runs during build (not during pack) by checking that IncludeFrontendAssets ran. -->
-  <Target Name="ValidateFrontendEmbeddedResources" AfterTargets="CreateManifestResourceNames" Condition="'@(_DistFiles)' != ''">
+  <Target Name="ValidateFrontendEmbeddedResources" AfterTargets="CreateManifestResourceNames" Condition="'$(BuildExternalAssets)' != 'false' and '@(_DistFiles)' != ''">
     <ItemGroup>
       <_FrontendEmbeddedResources Include="@(EmbeddedResource)" Condition="'%(Link)' != '' and $([System.String]::Copy('%(Link)').StartsWith('wwwroot'))" />
     </ItemGroup>
@@ -120,4 +122,3 @@
   </Target>
 
 </Project>
-


### PR DESCRIPTION
Provider test jobs build the solution before running provider-specific tests, which can incidentally restore and build Dashboard frontend assets. That makes provider jobs vulnerable to npm network failures before any provider-specific failure evidence is produced.

This adds a default-on `BuildExternalAssets` MSBuild property around the Dashboard frontend targets and disables it only for provider test CI jobs. Normal build and test jobs leave the property enabled, so Dashboard frontend asset generation continues to be validated by the main build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10196)