### PR TITLE
docs: fix cluster membership heartbeat defaults

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -14,9 +14,9 @@ namespace Orleans.Configuration
         public int NumMissedTableIAmAliveLimit { get; set; } = 3;
 
         /// <summary>
-        /// Gets or sets a value indicating whether to disable silo liveness protocol (should be used only for testing).
-        /// If a silo is suspected to be down, but this attribute is set to <see langword="false"/>, the suspicions will not propagated to the system and enforced.
-        /// This parameter is intended for use only for testing and troubleshooting.
+        /// Gets or sets a value indicating whether the silo liveness protocol is enabled (should be disabled only for testing).
+        /// If a silo is suspected to be down, but this property is set to <see langword="false"/>, the suspicions will not be propagated to the system or enforced.
+        /// This property is intended for use only for testing and troubleshooting.
         /// In production, liveness should always be enabled.
         /// </summary>
         /// <value>Liveness is enabled by default.</value>
@@ -25,7 +25,7 @@ namespace Orleans.Configuration
         /// <summary>
         /// Gets or sets both the period between sending a liveness probe to any given host as well as the timeout for each probe.
         /// </summary>
-        /// <value>Probes timeout and a new probe is sent every 5 seconds by default.</value>
+        /// <value>Probes time out and a new probe is sent every 5 seconds by default.</value>
         public TimeSpan ProbeTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Orleans.Configuration
         public TimeSpan TableRefreshTimeout { get; set; } = TimeSpan.FromSeconds(60);
 
         /// <summary>
-        /// Gets or sets the expiration time in seconds for votes in the membership table.
+        /// Gets or sets the expiration time for votes in the membership table.
         /// </summary>
         /// <value>Votes expire after 2 minutes by default.</value>
         public TimeSpan DeathVoteExpirationTimeout { get; set; } = TimeSpan.FromMinutes(2);
@@ -44,11 +44,11 @@ namespace Orleans.Configuration
         /// Gets or sets the period between updating this silo's heartbeat in the membership table.
         /// </summary>
         /// <remarks>
-        /// These heartbeats are largely for diagnostic purposes, however they are also used to ignore entries
-        /// in the membership table in the event of a total cluster reset. This value multiplied by <see cref="NumMissedTableIAmAliveLimit"/>
-        /// is used to skip hosts in the membership table when performing an initial connectivity check upon startup.
+        /// These heartbeats are largely for diagnostic purposes, however they are also used to identify stale active
+        /// entries in the membership table. This value multiplied by <see cref="NumMissedTableIAmAliveLimit"/>
+        /// determines how long an active membership entry can go without a heartbeat update before it is treated as stale.
         /// </remarks>
-        /// <value>Publish an update every 5 minutes by default.</value>
+        /// <value>Publish an update every 30 seconds by default.</value>
         public TimeSpan IAmAliveTablePublishTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Orleans.Configuration
         public TimeSpan MaxJoinAttemptTime { get; set; } = TimeSpan.FromMinutes(5);
 
         /// <summary>
-        /// Gets or sets a value indicating whether gossip membership updates between hosts.
+        /// Gets or sets a value indicating whether membership updates are disseminated between hosts using gossip.
         /// </summary>
         /// <value>Membership updates are disseminated using gossip by default.</value>
         public bool UseLivenessGossip { get; set; } = true;
@@ -82,7 +82,7 @@ namespace Orleans.Configuration
         public int NumMissedProbesLimit { get; set; } = 3;
 
         /// <summary>
-        /// Gets or sets the number of non-expired votes that are needed to declare some silo as down (should be at most <see cref="NumProbedSilos"/>)
+        /// Gets or sets the number of non-expired votes that are needed to declare some silo as down (should be at most <see cref="NumProbedSilos"/>).
         /// </summary>
         /// <value>Two votes are sufficient for a silo to be declared as down, by default.</value>
         public int NumVotesForDeathDeclaration { get; set; } = 2;
@@ -91,7 +91,7 @@ namespace Orleans.Configuration
         /// Gets or sets the period of time after which membership entries for defunct silos are eligible for removal.
         /// Valid only if <see cref="DefunctSiloCleanupPeriod"/> is not <see langword="null" />.
         /// </summary>
-        /// <value>Defunct silos are removed from membership after one week by default.</value>
+        /// <value>Defunct silos are eligible for removal from membership after one week by default.</value>
         public TimeSpan DefunctSiloExpiration { get; set; } = TimeSpan.FromDays(7);
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace Orleans.Configuration
         public TimeSpan? DefunctSiloCleanupPeriod { get; set; } = TimeSpan.FromHours(1);
 
         /// <summary>
-        /// /// Gets the period after which a silo is ignored for initial connectivity validation if it has not updated its heartbeat in the silo membership table.
+        /// Gets the period after which a silo's membership entry is considered stale if it has not updated its heartbeat in the membership table.
         /// </summary>
         internal TimeSpan AllowedIAmAliveMissPeriod => IAmAliveTablePublishTimeout.Multiply(NumMissedTableIAmAliveLimit);
 
@@ -128,7 +128,7 @@ namespace Orleans.Configuration
         public bool EnableIndirectProbes { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether to enable membership eviction of silos when in a state of `Joining` or `Created` for longer than MaxJoinAttemptTime
+        /// Gets or sets a value indicating whether to enable membership eviction of silos when they remain in the <c>Joining</c> or <c>Created</c> state for longer than <see cref="MaxJoinAttemptTime"/>.
         /// </summary>
         public bool EvictWhenMaxJoinAttemptTimeExceeded { get; set; } = true;
     }


### PR DESCRIPTION
Updates ClusterMembershipOptions documentation so IAmAliveTablePublishTimeout states the actual 30-second default. Also aligns nearby membership option comments with the current behavior and default values.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10197)