### PR TITLE
chore: use meter factory for stream receiver metrics

### DIFF
--- a/src/Orleans.Streaming/Common/Monitors/DefaultQueueAdapterReceiverMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultQueueAdapterReceiverMonitor.cs
@@ -39,6 +39,11 @@ namespace Orleans.Providers.Streams.Common
         {
         }
 
+        internal DefaultQueueAdapterReceiverMonitor(ReceiverMonitorDimensions dimensions, OrleansInstruments instruments)
+            : this(new KeyValuePair<string, object>[] { new("QueueId", dimensions.QueueId) }, instruments.Meter)
+        {
+        }
+
         private DefaultQueueAdapterReceiverMonitor(KeyValuePair<string, object>[] dimensions, Meter meter)
         {
             _dimensions = dimensions;

--- a/src/Orleans.Streaming/Generator/GeneratorAdapterFactory.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorAdapterFactory.cs
@@ -90,7 +90,7 @@ namespace Orleans.Providers.Streams.Generator
             this.serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             this.logger = loggerFactory.CreateLogger<GeneratorAdapterFactory>();
-            this.orleansInstruments = serviceProvider.GetService<OrleansInstruments>();
+            this.orleansInstruments = serviceProvider.GetRequiredService<OrleansInstruments>();
         }
 
         /// <summary>
@@ -100,11 +100,11 @@ namespace Orleans.Providers.Streams.Generator
         {
             this.receivers = new ConcurrentDictionary<QueueId, Receiver>();
             if (CacheMonitorFactory == null)
-                this.CacheMonitorFactory = (dimensions) => this.orleansInstruments is not null ? new DefaultCacheMonitor(dimensions, this.orleansInstruments) : new DefaultCacheMonitor(dimensions);
+                this.CacheMonitorFactory = (dimensions) => new DefaultCacheMonitor(dimensions, this.orleansInstruments);
             if (this.BlockPoolMonitorFactory == null)
-                this.BlockPoolMonitorFactory = (dimensions) => this.orleansInstruments is not null ? new DefaultBlockPoolMonitor(dimensions, this.orleansInstruments) : new DefaultBlockPoolMonitor(dimensions);
+                this.BlockPoolMonitorFactory = (dimensions) => new DefaultBlockPoolMonitor(dimensions, this.orleansInstruments);
             if (this.ReceiverMonitorFactory == null)
-                this.ReceiverMonitorFactory = (dimensions) => new DefaultQueueAdapterReceiverMonitor(dimensions);
+                this.ReceiverMonitorFactory = (dimensions) => new DefaultQueueAdapterReceiverMonitor(dimensions, this.orleansInstruments);
             generatorConfig = this.serviceProvider.GetKeyedService<IStreamGeneratorConfig>(this.Name);
             if(generatorConfig == null)
             {

--- a/src/Orleans.Streaming/MemoryStreams/MemoryAdapterFactory.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryAdapterFactory.cs
@@ -91,7 +91,7 @@ namespace Orleans.Providers
             this.loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             this.logger = loggerFactory.CreateLogger<ILogger<MemoryAdapterFactory<TSerializer>>>();
             this.serializer = MemoryMessageBodySerializerFactory<TSerializer>.GetOrCreateSerializer(serviceProvider);
-            this.orleansInstruments = serviceProvider.GetService<OrleansInstruments>();
+            this.orleansInstruments = serviceProvider.GetRequiredService<OrleansInstruments>();
 
             var nameBytes = BitConverter.IsLittleEndian ? MemoryMarshal.AsBytes(Name.AsSpan()) : Encoding.Unicode.GetBytes(Name);
             XxHash64.Hash(nameBytes, MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref _nameHash, 1)));
@@ -104,11 +104,11 @@ namespace Orleans.Providers
         {
             this.queueGrains = new ConcurrentDictionary<QueueId, IMemoryStreamQueueGrain>();
             if (CacheMonitorFactory == null)
-                this.CacheMonitorFactory = (dimensions) => this.orleansInstruments is not null ? new DefaultCacheMonitor(dimensions, this.orleansInstruments) : new DefaultCacheMonitor(dimensions);
+                this.CacheMonitorFactory = (dimensions) => new DefaultCacheMonitor(dimensions, this.orleansInstruments);
             if (this.BlockPoolMonitorFactory == null)
-                this.BlockPoolMonitorFactory = (dimensions) => this.orleansInstruments is not null ? new DefaultBlockPoolMonitor(dimensions, this.orleansInstruments) : new DefaultBlockPoolMonitor(dimensions);
+                this.BlockPoolMonitorFactory = (dimensions) => new DefaultBlockPoolMonitor(dimensions, this.orleansInstruments);
             if (this.ReceiverMonitorFactory == null)
-                this.ReceiverMonitorFactory = (dimensions) => new DefaultQueueAdapterReceiverMonitor(dimensions);
+                this.ReceiverMonitorFactory = (dimensions) => new DefaultQueueAdapterReceiverMonitor(dimensions, this.orleansInstruments);
             this.purgePredicate = new TimePurgePredicate(this.cacheOptions.DataMinTimeInCache, this.cacheOptions.DataMaxAgeInCache);
             this.streamQueueMapper = new HashRingBasedStreamQueueMapper(this.queueMapperOptions, this.Name);
         }


### PR DESCRIPTION
Addresses part of #9608 by moving the default Memory and Generator stream receiver monitors to the DI-provided Orleans meter.

The public direct-construction path remains available for compatibility, while provider-created monitors now require the registered OrleansInstruments service.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10199)