### PR TITLE
chore: use meter factory for Event Hubs cache metrics

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -265,7 +265,7 @@ namespace Orleans.Streaming.EventHubs
         {
            var eventHubPath = this.ehOptions.EventHubName;
             var sharedDimensions = new EventHubMonitorAggregationDimensions(eventHubPath);
-            return new EventHubQueueCacheFactory(eventHubCacheOptions, cacheEvictionOptions, statisticOptions, this.dataAdapter, sharedDimensions);
+            return new EventHubQueueCacheFactory(eventHubCacheOptions, cacheEvictionOptions, statisticOptions, this.dataAdapter, sharedDimensions, this.orleansInstruments);
         }
 
         private EventHubAdapterReceiver MakeReceiver(QueueId queueId)

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
 using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.Streaming.EventHubs.StatisticMonitors;
 
@@ -19,6 +20,7 @@ namespace Orleans.Streaming.EventHubs
         private readonly IEventHubDataAdapter dataAdater;
         private readonly TimePurgePredicate timePurge;
         private readonly EventHubMonitorAggregationDimensions sharedDimensions;
+        private readonly OrleansInstruments orleansInstruments;
         private IObjectPool<FixedSizeBuffer> bufferPool;
         private string bufferPoolId;
 
@@ -45,6 +47,19 @@ namespace Orleans.Streaming.EventHubs
             EventHubMonitorAggregationDimensions sharedDimensions,
             Func<EventHubCacheMonitorDimensions, ILoggerFactory, ICacheMonitor> cacheMonitorFactory = null,
             Func<EventHubBlockPoolMonitorDimensions, ILoggerFactory, IBlockPoolMonitor> blockPoolMonitorFactory = null)
+            : this(cacheOptions, evictionOptions, statisticOptions, dataAdater, sharedDimensions, null, cacheMonitorFactory, blockPoolMonitorFactory)
+        {
+        }
+
+        internal EventHubQueueCacheFactory(
+            EventHubStreamCachePressureOptions cacheOptions,
+            StreamCacheEvictionOptions evictionOptions,
+            StreamStatisticOptions statisticOptions,
+            IEventHubDataAdapter dataAdater,
+            EventHubMonitorAggregationDimensions sharedDimensions,
+            OrleansInstruments instruments,
+            Func<EventHubCacheMonitorDimensions, ILoggerFactory, ICacheMonitor> cacheMonitorFactory = null,
+            Func<EventHubBlockPoolMonitorDimensions, ILoggerFactory, IBlockPoolMonitor> blockPoolMonitorFactory = null)
         {
             this.cacheOptions = cacheOptions;
             this.evictionOptions = evictionOptions;
@@ -52,9 +67,16 @@ namespace Orleans.Streaming.EventHubs
             this.dataAdater = dataAdater;
             this.timePurge = new TimePurgePredicate(evictionOptions.DataMinTimeInCache, evictionOptions.DataMaxAgeInCache);
             this.sharedDimensions = sharedDimensions;
-            this.CacheMonitorFactory = cacheMonitorFactory ?? ((dimensions, logger) => new DefaultEventHubCacheMonitor(dimensions));
-            this.BlockPoolMonitorFactory = blockPoolMonitorFactory ?? ((dimensions, logger) => new DefaultEventHubBlockPoolMonitor(dimensions));
+            this.orleansInstruments = instruments;
+            this.CacheMonitorFactory = cacheMonitorFactory ?? CreateDefaultCacheMonitor;
+            this.BlockPoolMonitorFactory = blockPoolMonitorFactory ?? CreateDefaultBlockPoolMonitor;
         }
+
+        private ICacheMonitor CreateDefaultCacheMonitor(EventHubCacheMonitorDimensions dimensions, ILoggerFactory logger) =>
+            this.orleansInstruments is not null ? new DefaultEventHubCacheMonitor(dimensions, this.orleansInstruments) : new DefaultEventHubCacheMonitor(dimensions);
+
+        private IBlockPoolMonitor CreateDefaultBlockPoolMonitor(EventHubBlockPoolMonitorDimensions dimensions, ILoggerFactory logger) =>
+            this.orleansInstruments is not null ? new DefaultEventHubBlockPoolMonitor(dimensions, this.orleansInstruments) : new DefaultEventHubBlockPoolMonitor(dimensions);
 
         /// <summary>
         /// Function which create an EventHubQueueCache, which by default will configure the EventHubQueueCache using configuration in CreateBufferPool function

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubBlockPoolMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubBlockPoolMonitor.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
 
 namespace Orleans.Streaming.EventHubs.StatisticMonitors
 {
@@ -13,6 +14,11 @@ namespace Orleans.Streaming.EventHubs.StatisticMonitors
         /// </summary>
         /// <param name="dimensions"></param>
         public DefaultEventHubBlockPoolMonitor(EventHubBlockPoolMonitorDimensions dimensions) : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("ObjectPoolId", dimensions.BlockPoolId) })
+        {
+        }
+
+        internal DefaultEventHubBlockPoolMonitor(EventHubBlockPoolMonitorDimensions dimensions, OrleansInstruments instruments)
+            : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("ObjectPoolId", dimensions.BlockPoolId) }, instruments)
         {
         }
     }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubCacheMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubCacheMonitor.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
 
 namespace Orleans.Streaming.EventHubs.StatisticMonitors
 {
@@ -14,6 +15,11 @@ namespace Orleans.Streaming.EventHubs.StatisticMonitors
         /// <param name="dimensions"></param>
         public DefaultEventHubCacheMonitor(EventHubCacheMonitorDimensions dimensions)
             : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("Partition", dimensions.EventHubPartition) })
+        {
+        }
+
+        internal DefaultEventHubCacheMonitor(EventHubCacheMonitorDimensions dimensions, OrleansInstruments instruments)
+            : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("Partition", dimensions.EventHubPartition) }, instruments)
         {
         }
     }

--- a/src/Orleans.Streaming/Common/Monitors/DefaultBlockPoolMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultBlockPoolMonitor.cs
@@ -31,6 +31,11 @@ namespace Orleans.Providers.Streams.Common
         {
         }
 
+        protected DefaultBlockPoolMonitor(KeyValuePair<string, object>[] dimensions, OrleansInstruments instruments)
+            : this(dimensions, instruments.Meter)
+        {
+        }
+
         internal DefaultBlockPoolMonitor(BlockPoolMonitorDimensions dimensions, OrleansInstruments instruments)
             : this(new KeyValuePair<string, object>[] { new("BlockPoolId", dimensions.BlockPoolId) }, instruments.Meter)
         {

--- a/src/Orleans.Streaming/Common/Monitors/DefaultCacheMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultCacheMonitor.cs
@@ -43,6 +43,11 @@ namespace Orleans.Providers.Streams.Common
         {
         }
 
+        protected DefaultCacheMonitor(KeyValuePair<string, object>[] dimensions, OrleansInstruments instruments)
+            : this(dimensions, instruments.Meter)
+        {
+        }
+
         internal DefaultCacheMonitor(CacheMonitorDimensions dimensions, OrleansInstruments instruments)
             : this(new KeyValuePair<string, object>[] { new("QueueId", dimensions.QueueId) }, instruments.Meter)
         {

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -553,6 +553,8 @@ namespace Orleans.Providers.Streams.Common
 
         protected DefaultBlockPoolMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions) { }
 
+        protected DefaultBlockPoolMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions, Runtime.OrleansInstruments instruments) { }
+
         public void Report(long totalMemoryInByte, long availableMemoryInByte, long claimedMemoryInByte) { }
 
         public void TrackMemoryAllocated(long allocatedMemoryInByte) { }
@@ -565,6 +567,8 @@ namespace Orleans.Providers.Streams.Common
         public DefaultCacheMonitor(CacheMonitorDimensions dimensions) { }
 
         protected DefaultCacheMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions) { }
+
+        protected DefaultCacheMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions, Runtime.OrleansInstruments instruments) { }
 
         public void ReportCacheSize(long totalCacheSizeInByte) { }
 


### PR DESCRIPTION
Addresses part of #9608 by moving default EventHubs cache and block-pool monitors to the DI-provided Orleans meter.

Existing public constructors remain as compatibility fallbacks. EventHubAdapterFactory now threads OrleansInstruments into the default queue cache factory so provider-created monitors use IMeterFactory-backed meters.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10200)