### PR TITLE
chore: remove static Orleans meter

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCacheFactory.cs
@@ -41,18 +41,6 @@ namespace Orleans.Streaming.EventHubs
         /// </summary>
         public EventHubQueueCacheFactory(
             EventHubStreamCachePressureOptions cacheOptions,
-            StreamCacheEvictionOptions evictionOptions, 
-            StreamStatisticOptions statisticOptions,
-            IEventHubDataAdapter dataAdater,
-            EventHubMonitorAggregationDimensions sharedDimensions,
-            Func<EventHubCacheMonitorDimensions, ILoggerFactory, ICacheMonitor> cacheMonitorFactory = null,
-            Func<EventHubBlockPoolMonitorDimensions, ILoggerFactory, IBlockPoolMonitor> blockPoolMonitorFactory = null)
-            : this(cacheOptions, evictionOptions, statisticOptions, dataAdater, sharedDimensions, null, cacheMonitorFactory, blockPoolMonitorFactory)
-        {
-        }
-
-        internal EventHubQueueCacheFactory(
-            EventHubStreamCachePressureOptions cacheOptions,
             StreamCacheEvictionOptions evictionOptions,
             StreamStatisticOptions statisticOptions,
             IEventHubDataAdapter dataAdater,
@@ -68,15 +56,9 @@ namespace Orleans.Streaming.EventHubs
             this.timePurge = new TimePurgePredicate(evictionOptions.DataMinTimeInCache, evictionOptions.DataMaxAgeInCache);
             this.sharedDimensions = sharedDimensions;
             this.orleansInstruments = instruments;
-            this.CacheMonitorFactory = cacheMonitorFactory ?? CreateDefaultCacheMonitor;
-            this.BlockPoolMonitorFactory = blockPoolMonitorFactory ?? CreateDefaultBlockPoolMonitor;
+            this.CacheMonitorFactory = cacheMonitorFactory ?? ((dimensions, logger) => new DefaultEventHubCacheMonitor(dimensions, this.orleansInstruments));
+            this.BlockPoolMonitorFactory = blockPoolMonitorFactory ?? ((dimensions, logger) => new DefaultEventHubBlockPoolMonitor(dimensions, this.orleansInstruments));
         }
-
-        private ICacheMonitor CreateDefaultCacheMonitor(EventHubCacheMonitorDimensions dimensions, ILoggerFactory logger) =>
-            this.orleansInstruments is not null ? new DefaultEventHubCacheMonitor(dimensions, this.orleansInstruments) : new DefaultEventHubCacheMonitor(dimensions);
-
-        private IBlockPoolMonitor CreateDefaultBlockPoolMonitor(EventHubBlockPoolMonitorDimensions dimensions, ILoggerFactory logger) =>
-            this.orleansInstruments is not null ? new DefaultEventHubBlockPoolMonitor(dimensions, this.orleansInstruments) : new DefaultEventHubBlockPoolMonitor(dimensions);
 
         /// <summary>
         /// Function which create an EventHubQueueCache, which by default will configure the EventHubQueueCache using configuration in CreateBufferPool function

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubBlockPoolMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubBlockPoolMonitor.cs
@@ -13,11 +13,7 @@ namespace Orleans.Streaming.EventHubs.StatisticMonitors
         /// Constructor
         /// </summary>
         /// <param name="dimensions"></param>
-        public DefaultEventHubBlockPoolMonitor(EventHubBlockPoolMonitorDimensions dimensions) : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("ObjectPoolId", dimensions.BlockPoolId) })
-        {
-        }
-
-        internal DefaultEventHubBlockPoolMonitor(EventHubBlockPoolMonitorDimensions dimensions, OrleansInstruments instruments)
+        public DefaultEventHubBlockPoolMonitor(EventHubBlockPoolMonitorDimensions dimensions, OrleansInstruments instruments)
             : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("ObjectPoolId", dimensions.BlockPoolId) }, instruments)
         {
         }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubCacheMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubCacheMonitor.cs
@@ -13,12 +13,7 @@ namespace Orleans.Streaming.EventHubs.StatisticMonitors
         /// Constructor
         /// </summary>
         /// <param name="dimensions"></param>
-        public DefaultEventHubCacheMonitor(EventHubCacheMonitorDimensions dimensions)
-            : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("Partition", dimensions.EventHubPartition) })
-        {
-        }
-
-        internal DefaultEventHubCacheMonitor(EventHubCacheMonitorDimensions dimensions, OrleansInstruments instruments)
+        public DefaultEventHubCacheMonitor(EventHubCacheMonitorDimensions dimensions, OrleansInstruments instruments)
             : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("Partition", dimensions.EventHubPartition) }, instruments)
         {
         }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubReceiverMonitor.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/StatisticMonitors/DefaultEventHubReceiverMonitor.cs
@@ -13,12 +13,7 @@ namespace Orleans.Streaming.EventHubs
         /// Constructor
         /// </summary>
         /// <param name="dimensions">Aggregation Dimension bag for EventhubReceiverMonitor</param>
-        public DefaultEventHubReceiverMonitor(EventHubReceiverMonitorDimensions dimensions)
-            : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("Partition", dimensions.EventHubPartition) })
-        {
-        }
-
-        internal DefaultEventHubReceiverMonitor(EventHubReceiverMonitorDimensions dimensions, OrleansInstruments instruments)
+        public DefaultEventHubReceiverMonitor(EventHubReceiverMonitorDimensions dimensions, OrleansInstruments instruments)
             : base(new KeyValuePair<string, object>[] { new("Path", dimensions.EventHubPath), new("Partition", dimensions.EventHubPartition) }, instruments)
         {
         }

--- a/src/Orleans.Core/Diagnostics/Metrics/Instruments.cs
+++ b/src/Orleans.Core/Diagnostics/Metrics/Instruments.cs
@@ -1,8 +1,0 @@
-using System.Diagnostics.Metrics;
-
-namespace Orleans.Runtime;
-
-public static class Instruments
-{
-    public static readonly Meter Meter = new("Microsoft.Orleans");
-}

--- a/src/Orleans.Streaming/Common/Monitors/DefaultBlockPoolMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultBlockPoolMonitor.cs
@@ -27,7 +27,7 @@ namespace Orleans.Providers.Streams.Common
         /// Initializes a new instance of the <see cref="DefaultBlockPoolMonitor"/> class.
         /// </summary>
         protected DefaultBlockPoolMonitor(KeyValuePair<string, object>[] dimensions)
-            : this(dimensions, Instruments.Meter)
+            : this(dimensions, new Meter("Microsoft.Orleans"))
         {
         }
 

--- a/src/Orleans.Streaming/Common/Monitors/DefaultBlockPoolMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultBlockPoolMonitor.cs
@@ -23,21 +23,13 @@ namespace Orleans.Providers.Streams.Common
         private long _releasedMemory;
         private long _allocatedMemory;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultBlockPoolMonitor"/> class.
-        /// </summary>
-        protected DefaultBlockPoolMonitor(KeyValuePair<string, object>[] dimensions)
-            : this(dimensions, new Meter("Microsoft.Orleans"))
+        public DefaultBlockPoolMonitor(BlockPoolMonitorDimensions dimensions, OrleansInstruments instruments)
+            : this(new KeyValuePair<string, object>[] { new("BlockPoolId", dimensions.BlockPoolId) }, instruments.Meter)
         {
         }
 
         protected DefaultBlockPoolMonitor(KeyValuePair<string, object>[] dimensions, OrleansInstruments instruments)
             : this(dimensions, instruments.Meter)
-        {
-        }
-
-        internal DefaultBlockPoolMonitor(BlockPoolMonitorDimensions dimensions, OrleansInstruments instruments)
-            : this(new KeyValuePair<string, object>[] { new("BlockPoolId", dimensions.BlockPoolId) }, instruments.Meter)
         {
         }
 
@@ -49,14 +41,6 @@ namespace Orleans.Providers.Streams.Common
             _claimedMemoryCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_CLAIMED_MEMORY, GetClaimedMemory, unit: "bytes");
             _releasedMemoryCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_RELEASED_MEMORY, GetReleasedMemory, unit: "bytes");
             _allocatedMemoryCounter = meter.CreateObservableCounter<long>(InstrumentNames.STREAMS_BLOCK_POOL_ALLOCATED_MEMORY, GetAllocatedMemory, unit: "bytes");
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultBlockPoolMonitor"/> class.
-        /// </summary>
-        /// <param name="dimensions">The dimensions.</param>
-        public DefaultBlockPoolMonitor(BlockPoolMonitorDimensions dimensions) : this(new KeyValuePair<string, object>[] { new ("BlockPoolId", dimensions.BlockPoolId) })
-        {
         }
 
         private Measurement<long> GetTotalMemory() => new(_totalMemory, _dimensions);

--- a/src/Orleans.Streaming/Common/Monitors/DefaultCacheMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultCacheMonitor.cs
@@ -35,21 +35,13 @@ namespace Orleans.Providers.Streams.Common
         private ValueStopwatch _oldestMessageDequeueAgo;
         private ValueStopwatch _oldestToNewestAge;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultCacheMonitor"/> class.
-        /// </summary>
-        protected DefaultCacheMonitor(KeyValuePair<string, object>[] dimensions)
-            : this(dimensions, new Meter("Microsoft.Orleans"))
+        public DefaultCacheMonitor(CacheMonitorDimensions dimensions, OrleansInstruments instruments)
+            : this(new KeyValuePair<string, object>[] { new("QueueId", dimensions.QueueId) }, instruments.Meter)
         {
         }
 
         protected DefaultCacheMonitor(KeyValuePair<string, object>[] dimensions, OrleansInstruments instruments)
             : this(dimensions, instruments.Meter)
-        {
-        }
-
-        internal DefaultCacheMonitor(CacheMonitorDimensions dimensions, OrleansInstruments instruments)
-            : this(new KeyValuePair<string, object>[] { new("QueueId", dimensions.QueueId) }, instruments.Meter)
         {
         }
 
@@ -74,14 +66,6 @@ namespace Orleans.Providers.Streams.Common
                     yield return new Measurement<T>(selector(monitor.Value), monitor.Value.Dimensions);
                 }
             }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultCacheMonitor"/> class.
-        /// </summary>
-        /// <param name="dimensions">The dimensions.</param>
-        public DefaultCacheMonitor(CacheMonitorDimensions dimensions) : this(new KeyValuePair<string, object>[] { new("QueueId", dimensions.QueueId) })
-        {
         }
 
         private Measurement<long> GetOldestToNewestAge() => new(_oldestToNewestAge.ElapsedTicks, _dimensions);

--- a/src/Orleans.Streaming/Common/Monitors/DefaultCacheMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultCacheMonitor.cs
@@ -39,7 +39,7 @@ namespace Orleans.Providers.Streams.Common
         /// Initializes a new instance of the <see cref="DefaultCacheMonitor"/> class.
         /// </summary>
         protected DefaultCacheMonitor(KeyValuePair<string, object>[] dimensions)
-            : this(dimensions, Instruments.Meter)
+            : this(dimensions, new Meter("Microsoft.Orleans"))
         {
         }
 

--- a/src/Orleans.Streaming/Common/Monitors/DefaultQueueAdapterReceiverMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultQueueAdapterReceiverMonitor.cs
@@ -30,7 +30,7 @@ namespace Orleans.Providers.Streams.Common
         private long _messagesReceived;
 
         protected DefaultQueueAdapterReceiverMonitor(KeyValuePair<string,object>[] dimensions)
-            : this(dimensions, Instruments.Meter)
+            : this(dimensions, new Meter("Microsoft.Orleans"))
         {
         }
 

--- a/src/Orleans.Streaming/Common/Monitors/DefaultQueueAdapterReceiverMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultQueueAdapterReceiverMonitor.cs
@@ -34,11 +34,6 @@ namespace Orleans.Providers.Streams.Common
         {
         }
 
-        internal DefaultQueueAdapterReceiverMonitor(ReceiverMonitorDimensions dimensions, OrleansInstruments instruments)
-            : this(new KeyValuePair<string, object>[] { new("QueueId", dimensions.QueueId) }, instruments.Meter)
-        {
-        }
-
         private DefaultQueueAdapterReceiverMonitor(KeyValuePair<string, object>[] dimensions, Meter meter)
         {
             _dimensions = dimensions;

--- a/src/Orleans.Streaming/Common/Monitors/DefaultQueueAdapterReceiverMonitor.cs
+++ b/src/Orleans.Streaming/Common/Monitors/DefaultQueueAdapterReceiverMonitor.cs
@@ -29,11 +29,6 @@ namespace Orleans.Providers.Streams.Common
         private ValueStopwatch _newestMessageReadEnqueueAge;
         private long _messagesReceived;
 
-        protected DefaultQueueAdapterReceiverMonitor(KeyValuePair<string,object>[] dimensions)
-            : this(dimensions, new Meter("Microsoft.Orleans"))
-        {
-        }
-
         protected DefaultQueueAdapterReceiverMonitor(KeyValuePair<string, object>[] dimensions, OrleansInstruments instruments)
             : this(dimensions, instruments.Meter)
         {
@@ -64,11 +59,8 @@ namespace Orleans.Providers.Streams.Common
             _newestMessageReadEnqueueTimeToNowCounter = meter.CreateObservableGauge<long>(InstrumentNames.STREAMS_QUEUE_NEWEST_MESSAGE_ENQUEUE_AGE, GetNewestMessageReadEnqueueAge);
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultQueueAdapterReceiverMonitor"/> class.
-        /// </summary>
-        /// <param name="dimensions">The dimensions.</param>
-        public DefaultQueueAdapterReceiverMonitor(ReceiverMonitorDimensions dimensions) : this(new KeyValuePair<string,object>[] { new("QueueId", dimensions.QueueId) })
+        public DefaultQueueAdapterReceiverMonitor(ReceiverMonitorDimensions dimensions, OrleansInstruments instruments)
+            : this(new KeyValuePair<string, object>[] { new("QueueId", dimensions.QueueId) }, instruments.Meter)
         {
         }
 

--- a/src/Orleans.Transactions/DistributedTM/TransactionAgentStatistics.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionAgentStatistics.cs
@@ -1,13 +1,12 @@
 using System.Diagnostics.Metrics;
 using System.Threading;
+using Orleans.Runtime;
 using Orleans.Transactions.Abstractions;
 
 namespace Orleans.Transactions
 {
     public class TransactionAgentStatistics : ITransactionAgentStatistics
     {
-        private static readonly Meter Meter = new("Orleans");
-
         private const string TRANSACTIONS_STARTED = "orleans-transactions-started";
         private const string TRANSACTIONS_SUCCESSFUL = "orleans-transactions-successful";
         private const string TRANSACTIONS_FAILED = "orleans-transactions-failed";
@@ -23,11 +22,21 @@ namespace Orleans.Transactions
         private long _transactionsThrottled;
 
         public TransactionAgentStatistics()
+            : this(new Meter("Microsoft.Orleans"))
         {
-            _transactionsStartedCounter = Meter.CreateObservableCounter<long>(TRANSACTIONS_STARTED, () => new(TransactionsStarted));
-            _transactionsSuccessfulCounter = Meter.CreateObservableCounter<long>(TRANSACTIONS_SUCCESSFUL, () => new(TransactionsSucceeded));
-            _transactionsFailedCounter = Meter.CreateObservableCounter<long>(TRANSACTIONS_FAILED, () => new(TransactionsFailed));
-            _transactionsThrottledCounter = Meter.CreateObservableCounter<long>(TRANSACTIONS_THROTTLED, () => new(TransactionsThrottled));
+        }
+
+        public TransactionAgentStatistics(OrleansInstruments instruments)
+            : this(instruments.Meter)
+        {
+        }
+
+        private TransactionAgentStatistics(Meter meter)
+        {
+            _transactionsStartedCounter = meter.CreateObservableCounter<long>(TRANSACTIONS_STARTED, () => new(TransactionsStarted));
+            _transactionsSuccessfulCounter = meter.CreateObservableCounter<long>(TRANSACTIONS_SUCCESSFUL, () => new(TransactionsSucceeded));
+            _transactionsFailedCounter = meter.CreateObservableCounter<long>(TRANSACTIONS_FAILED, () => new(TransactionsFailed));
+            _transactionsThrottledCounter = meter.CreateObservableCounter<long>(TRANSACTIONS_THROTTLED, () => new(TransactionsThrottled));
         }
 
         public long TransactionsStarted => _transactionsStarted;
@@ -57,13 +66,39 @@ namespace Orleans.Transactions
 
         public static ITransactionAgentStatistics Copy(ITransactionAgentStatistics initialStatistics)
         {
-            return new TransactionAgentStatistics
+            return new TransactionAgentStatisticsSnapshot(initialStatistics);
+        }
+
+        private sealed class TransactionAgentStatisticsSnapshot : ITransactionAgentStatistics
+        {
+            private long _transactionsStarted;
+            private long _transactionsSucceeded;
+            private long _transactionsFailed;
+            private long _transactionsThrottled;
+
+            public TransactionAgentStatisticsSnapshot(ITransactionAgentStatistics statistics)
             {
-                _transactionsStarted = initialStatistics.TransactionsStarted,
-                _transactionsSucceeded = initialStatistics.TransactionsSucceeded,
-                _transactionsFailed = initialStatistics.TransactionsFailed,
-                _transactionsThrottled = initialStatistics.TransactionsThrottled
-            };
+                _transactionsStarted = statistics.TransactionsStarted;
+                _transactionsSucceeded = statistics.TransactionsSucceeded;
+                _transactionsFailed = statistics.TransactionsFailed;
+                _transactionsThrottled = statistics.TransactionsThrottled;
+            }
+
+            public long TransactionsStarted => _transactionsStarted;
+
+            public long TransactionsSucceeded => _transactionsSucceeded;
+
+            public long TransactionsFailed => _transactionsFailed;
+
+            public long TransactionsThrottled => _transactionsThrottled;
+
+            public void TrackTransactionStarted() => Interlocked.Increment(ref _transactionsStarted);
+
+            public void TrackTransactionSucceeded() => Interlocked.Increment(ref _transactionsSucceeded);
+
+            public void TrackTransactionFailed() => Interlocked.Increment(ref _transactionsFailed);
+
+            public void TrackTransactionThrottled() => Interlocked.Increment(ref _transactionsThrottled);
         }
     }
 }

--- a/src/Orleans.Transactions/Hosting/TransactionsServiceCollectionExtensions.cs
+++ b/src/Orleans.Transactions/Hosting/TransactionsServiceCollectionExtensions.cs
@@ -28,6 +28,8 @@ namespace Orleans.Hosting
 
         internal static IServiceCollection AddTransactionsBaseline(this IServiceCollection services)
         {
+            services.AddMetrics();
+            services.TryAddSingleton<OrleansInstruments>();
             services.TryAddSingleton<IClock, Clock>();
             services.AddSingleton<ITransactionAgent, TransactionAgent>();
             services.AddSingleton<ITransactionClient, TransactionClient>();

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -247,7 +247,7 @@ namespace Orleans.Streaming.EventHubs
 
     public partial class DefaultEventHubReceiverMonitor : Providers.Streams.Common.DefaultQueueAdapterReceiverMonitor
     {
-        public DefaultEventHubReceiverMonitor(EventHubReceiverMonitorDimensions dimensions) : base(default(System.Collections.Generic.KeyValuePair<string, object>[])!) { }
+        public DefaultEventHubReceiverMonitor(EventHubReceiverMonitorDimensions dimensions, Runtime.OrleansInstruments instruments) : base(default(System.Collections.Generic.KeyValuePair<string, object>[])!, default(Runtime.OrleansInstruments)!) { }
     }
 
     public static partial class EventDataExtensions
@@ -467,7 +467,7 @@ namespace Orleans.Streaming.EventHubs
 
     public partial class EventHubQueueCacheFactory : IEventHubQueueCacheFactory
     {
-        public EventHubQueueCacheFactory(Configuration.EventHubStreamCachePressureOptions cacheOptions, Configuration.StreamCacheEvictionOptions evictionOptions, Configuration.StreamStatisticOptions statisticOptions, IEventHubDataAdapter dataAdater, EventHubMonitorAggregationDimensions sharedDimensions, System.Func<EventHubCacheMonitorDimensions, Microsoft.Extensions.Logging.ILoggerFactory, Providers.Streams.Common.ICacheMonitor> cacheMonitorFactory = null, System.Func<EventHubBlockPoolMonitorDimensions, Microsoft.Extensions.Logging.ILoggerFactory, Providers.Streams.Common.IBlockPoolMonitor> blockPoolMonitorFactory = null) { }
+        public EventHubQueueCacheFactory(Configuration.EventHubStreamCachePressureOptions cacheOptions, Configuration.StreamCacheEvictionOptions evictionOptions, Configuration.StreamStatisticOptions statisticOptions, IEventHubDataAdapter dataAdater, EventHubMonitorAggregationDimensions sharedDimensions, Runtime.OrleansInstruments instruments, System.Func<EventHubCacheMonitorDimensions, Microsoft.Extensions.Logging.ILoggerFactory, Providers.Streams.Common.ICacheMonitor> cacheMonitorFactory = null, System.Func<EventHubBlockPoolMonitorDimensions, Microsoft.Extensions.Logging.ILoggerFactory, Providers.Streams.Common.IBlockPoolMonitor> blockPoolMonitorFactory = null) { }
 
         public System.Func<EventHubBlockPoolMonitorDimensions, Microsoft.Extensions.Logging.ILoggerFactory, Providers.Streams.Common.IBlockPoolMonitor> BlockPoolMonitorFactory { get { throw null; } set { } }
 
@@ -585,12 +585,12 @@ namespace Orleans.Streaming.EventHubs.StatisticMonitors
 {
     public partial class DefaultEventHubBlockPoolMonitor : Providers.Streams.Common.DefaultBlockPoolMonitor
     {
-        public DefaultEventHubBlockPoolMonitor(EventHubBlockPoolMonitorDimensions dimensions) : base(default(System.Collections.Generic.KeyValuePair<string, object>[])!) { }
+        public DefaultEventHubBlockPoolMonitor(EventHubBlockPoolMonitorDimensions dimensions, Runtime.OrleansInstruments instruments) : base(default(System.Collections.Generic.KeyValuePair<string, object>[])!, default(Runtime.OrleansInstruments)!) { }
     }
 
     public partial class DefaultEventHubCacheMonitor : Providers.Streams.Common.DefaultCacheMonitor
     {
-        public DefaultEventHubCacheMonitor(EventHubCacheMonitorDimensions dimensions) : base(default(System.Collections.Generic.KeyValuePair<string, object>[])!) { }
+        public DefaultEventHubCacheMonitor(EventHubCacheMonitorDimensions dimensions, Runtime.OrleansInstruments instruments) : base(default(System.Collections.Generic.KeyValuePair<string, object>[])!, default(Runtime.OrleansInstruments)!) { }
     }
 }
 

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -1425,11 +1425,6 @@ namespace Orleans.Runtime
         public override readonly string ToString() { throw null; }
     }
 
-    public static partial class Instruments
-    {
-        public static readonly System.Diagnostics.Metrics.Meter Meter;
-    }
-
     public partial interface IRingRange
     {
         bool InRange(GrainId grainId);

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -549,9 +549,7 @@ namespace Orleans.Providers.Streams.Common
     public partial class DefaultBlockPoolMonitor : IBlockPoolMonitor
     {
         protected System.Collections.Generic.KeyValuePair<string, object>[] _dimensions;
-        public DefaultBlockPoolMonitor(BlockPoolMonitorDimensions dimensions) { }
-
-        protected DefaultBlockPoolMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions) { }
+        public DefaultBlockPoolMonitor(BlockPoolMonitorDimensions dimensions, Runtime.OrleansInstruments instruments) { }
 
         protected DefaultBlockPoolMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions, Runtime.OrleansInstruments instruments) { }
 
@@ -564,9 +562,7 @@ namespace Orleans.Providers.Streams.Common
 
     public partial class DefaultCacheMonitor : ICacheMonitor
     {
-        public DefaultCacheMonitor(CacheMonitorDimensions dimensions) { }
-
-        protected DefaultCacheMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions) { }
+        public DefaultCacheMonitor(CacheMonitorDimensions dimensions, Runtime.OrleansInstruments instruments) { }
 
         protected DefaultCacheMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions, Runtime.OrleansInstruments instruments) { }
 
@@ -587,9 +583,7 @@ namespace Orleans.Providers.Streams.Common
 
     public partial class DefaultQueueAdapterReceiverMonitor : IQueueAdapterReceiverMonitor
     {
-        public DefaultQueueAdapterReceiverMonitor(ReceiverMonitorDimensions dimensions) { }
-
-        protected DefaultQueueAdapterReceiverMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions) { }
+        public DefaultQueueAdapterReceiverMonitor(ReceiverMonitorDimensions dimensions, Runtime.OrleansInstruments instruments) { }
 
         protected DefaultQueueAdapterReceiverMonitor(System.Collections.Generic.KeyValuePair<string, object>[] dimensions, Runtime.OrleansInstruments instruments) { }
 

--- a/src/api/Orleans.Transactions/Orleans.Transactions.cs
+++ b/src/api/Orleans.Transactions/Orleans.Transactions.cs
@@ -453,6 +453,10 @@ namespace Orleans.Transactions
 
     public partial class TransactionAgentStatistics : Abstractions.ITransactionAgentStatistics
     {
+        public TransactionAgentStatistics() { }
+
+        public TransactionAgentStatistics(Runtime.OrleansInstruments instruments) { }
+
         public long TransactionsFailed { get { throw null; } }
 
         public long TransactionsStarted { get { throw null; } }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/EvictionStrategyTests/EHPurgeLogicTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 using Orleans.Streaming.EventHubs.Testing;
 using Azure.Messaging.EventHubs;
 using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Statistics;
 using System.Globalization;
@@ -29,6 +30,7 @@ namespace ServiceBus.Tests.EvictionStrategyTests
         private readonly ObjectPool<FixedSizeBuffer> bufferPool;
         private readonly TimeSpan timeOut = TimeSpan.FromSeconds(30);
         private readonly EventHubPartitionSettings ehSettings;
+        private readonly OrleansInstruments instruments;
         private IEnvironmentStatisticsProvider environmentStatisticsProvider;
         private ConcurrentBag<EventHubQueueCacheForTesting> cacheList;
         private List<EHEvictionStrategyForTesting> evictionStrategyList;
@@ -50,9 +52,12 @@ namespace ServiceBus.Tests.EvictionStrategyTests
 
             // set up serialization env
             var serviceProvider = new ServiceCollection()
+                .AddMetrics()
+                .AddSingleton<OrleansInstruments>()
                 .AddSerializer()
                 .BuildServiceProvider();
             this.serializer = serviceProvider.GetRequiredService<Serializer>();
+            this.instruments = serviceProvider.GetRequiredService<OrleansInstruments>();
 
             //set up buffer pool, small buffer size make it easy for cache to allocate multiple buffers
             var oneKB = 1024;
@@ -202,9 +207,9 @@ namespace ServiceBus.Tests.EvictionStrategyTests
             };
 
             this.receiver1 = new EventHubAdapterReceiver(this.ehSettings, this.CacheFactory, this.CheckPointerFactory, NullLoggerFactory.Instance,
-                new DefaultEventHubReceiverMonitor(monitorDimensions), new LoadSheddingOptions(), environmentStatisticsProvider);
+                new DefaultEventHubReceiverMonitor(monitorDimensions, this.instruments), new LoadSheddingOptions(), environmentStatisticsProvider);
             this.receiver2 = new EventHubAdapterReceiver(this.ehSettings, this.CacheFactory, this.CheckPointerFactory, NullLoggerFactory.Instance,
-                new DefaultEventHubReceiverMonitor(monitorDimensions), new LoadSheddingOptions(), environmentStatisticsProvider);
+                new DefaultEventHubReceiverMonitor(monitorDimensions, this.instruments), new LoadSheddingOptions(), environmentStatisticsProvider);
             this.receiver1.Initialize(this.timeOut);
             this.receiver2.Initialize(this.timeOut);
         }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/TestStreamProviders/EHStreamProviderForMonitorTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/TestStreamProviders/EHStreamProviderForMonitorTests.cs
@@ -86,6 +86,7 @@ namespace ServiceBus.Tests.TestStreamProviders
                 base.dataAdapter,
                 sharedDimensions,
                 loggerFactory,
+                this.serviceProvider.GetRequiredService<OrleansInstruments>(),
                 cacheMonitorFactory,
                 blockPoolMonitorFactory);
         }
@@ -101,9 +102,10 @@ namespace ServiceBus.Tests.TestStreamProviders
                 IEventHubDataAdapter dataAdater,
                 EventHubMonitorAggregationDimensions sharedDimensions,
                 ILoggerFactory loggerFactory,
+                OrleansInstruments instruments,
                 Func<EventHubCacheMonitorDimensions, ILoggerFactory, ICacheMonitor> cacheMonitorFactory = null,
                 Func<EventHubBlockPoolMonitorDimensions, ILoggerFactory, IBlockPoolMonitor> blockPoolMonitorFactory = null)
-                : base(cacheOptions, streamCacheEviction, statisticOptions, dataAdater, sharedDimensions, cacheMonitorFactory, blockPoolMonitorFactory)
+                : base(cacheOptions, streamCacheEviction, statisticOptions, dataAdater, sharedDimensions, instruments, cacheMonitorFactory, blockPoolMonitorFactory)
             {
                 this.cachePressureInjectionMonitor = cachePressureInjectionMonitor;
             }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/TestStreamProviders/EHStreamProviderWithCreatedCacheList.cs
@@ -6,6 +6,7 @@ using Orleans.Streaming.EventHubs;
 using Orleans.Streams;
 using Orleans.Streaming.EventHubs.Testing;
 using Orleans.Configuration;
+using Orleans.Runtime;
 using Orleans.Statistics;
 
 namespace ServiceBus.Tests.TestStreamProviders
@@ -43,7 +44,7 @@ namespace ServiceBus.Tests.TestStreamProviders
         {
             var eventHubPath = this.ehOptions.EventHubName;
             var sharedDimensions = new EventHubMonitorAggregationDimensions(eventHubPath);
-            return new CacheFactoryForTesting(this.Name, this.cacheOptions, this.evictionOptions,this.staticticOptions, base.dataAdapter, this.createdCaches, sharedDimensions, this.serviceProvider.GetRequiredService<ILoggerFactory>());
+            return new CacheFactoryForTesting(this.Name, this.cacheOptions, this.evictionOptions, this.staticticOptions, base.dataAdapter, this.createdCaches, sharedDimensions, this.serviceProvider.GetRequiredService<ILoggerFactory>(), this.serviceProvider.GetRequiredService<OrleansInstruments>());
         }
 
         private class CacheFactoryForTesting : EventHubQueueCacheFactory
@@ -54,9 +55,10 @@ namespace ServiceBus.Tests.TestStreamProviders
             public CacheFactoryForTesting(string name, EventHubStreamCachePressureOptions cacheOptions, StreamCacheEvictionOptions evictionOptions, StreamStatisticOptions statisticOptions,
                 IEventHubDataAdapter dataAdapter, ConcurrentBag<QueueCacheForTesting> caches, EventHubMonitorAggregationDimensions sharedDimensions,
                 ILoggerFactory loggerFactory,
+                OrleansInstruments instruments,
                 Func<EventHubCacheMonitorDimensions, ILoggerFactory, ICacheMonitor> cacheMonitorFactory = null,
                 Func<EventHubBlockPoolMonitorDimensions, ILoggerFactory, IBlockPoolMonitor> blockPoolMonitorFactory = null)
-                : base(cacheOptions, evictionOptions, statisticOptions, dataAdapter, sharedDimensions, cacheMonitorFactory, blockPoolMonitorFactory)
+                : base(cacheOptions, evictionOptions, statisticOptions, dataAdapter, sharedDimensions, instruments, cacheMonitorFactory, blockPoolMonitorFactory)
             {
                 this.name = name;
                 this.caches = caches;


### PR DESCRIPTION
closes #9608 by removing the static Orleans meter entirely.

This deletes `Orleans.Runtime.Instruments`, removes the generated API surface for it, converts transaction statistics to use `OrleansInstruments` when resolved from DI, and leaves direct-construction compatibility paths on per-instance meters instead of a shared static meter.

Depends on #10199 and #10200 to finish moving the remaining provider-created stream monitors to DI-created meters.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10201)