### PR TITLE
ci: update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
-        node-version: '20.x'
+        node-version: '24.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
@@ -899,7 +899,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
-        node-version: '20.x'
+        node-version: '24.x'
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:


### PR DESCRIPTION
Updates GitHub Actions `setup-node` from Node.js 20 to Node.js 24.

Node.js 24 is the current LTS line, while Node.js 20 is EOL according to the Node.js release schedule. This should avoid merge-queue/setup-node runs using the EOL Node 20 runtime, such as the setup-node issue seen while validating #10200.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10203)