### PR TITLE
fix(runtime): unregister shutdown activations from directory

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -2001,9 +2001,8 @@ internal sealed partial class ActivationData :
 
                 // If the instance is being deactivated due to a directory failure, we should not unregister it.
                 var isDirectoryFailure = DeactivationReason.ReasonCode is DeactivationReasonCode.DirectoryFailure;
-                var isShuttingDown = DeactivationReason.ReasonCode is DeactivationReasonCode.ShuttingDown;
 
-                if (!migrating && IsUsingGrainDirectory && !cancellationToken.IsCancellationRequested && !isDirectoryFailure && !isShuttingDown)
+                if (!migrating && IsUsingGrainDirectory && !cancellationToken.IsCancellationRequested && !isDirectoryFailure)
                 {
                     // Unregister from directory.
                     // If the grain was migrated, the new activation will perform a check-and-set on the registration itself.


### PR DESCRIPTION
During graceful silo shutdown, directory-backed activations could remain registered after their catalog target had been removed. Calls resolving through that stale directory entry could be forwarded to a terminating silo, fail to create a local activation, exhaust forwarding, and surface as transient RPC failures during shutdown.

This unregisters directory-backed activations once shutdown deactivation completes, while preserving the existing migration and directory-failure exceptions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10206)