### PR TITLE
test: speed up membership health monitor tests

### DIFF
--- a/src/Orleans.Core/Diagnostics/MembershipEvents.cs
+++ b/src/Orleans.Core/Diagnostics/MembershipEvents.cs
@@ -53,6 +53,75 @@ internal static class MembershipEvents
         public readonly SiloAddress? ObserverSiloAddress = observerSiloAddress;
     }
 
+    /// <summary>
+    /// The type of suspect or kill request.
+    /// </summary>
+    public enum SuspectOrKillRequestType
+    {
+        /// <summary>
+        /// Unknown request type.
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// A request to suspect a silo or declare it dead.
+        /// </summary>
+        SuspectOrKill,
+
+        /// <summary>
+        /// A request to declare a silo dead.
+        /// </summary>
+        Kill
+    }
+
+    /// <summary>
+    /// Event payload for when a suspect or kill request completes.
+    /// </summary>
+    /// <param name="observerSiloAddress">The silo which processed the request.</param>
+    /// <param name="siloAddress">The silo targeted by the request.</param>
+    /// <param name="otherSiloAddress">The other silo associated with the request, if any.</param>
+    /// <param name="requestType">The request type.</param>
+    /// <param name="success">Whether the request completed successfully.</param>
+    /// <param name="exception">The exception thrown by the request, if any.</param>
+    public sealed class SuspectOrKillRequestCompleted(
+        SiloAddress observerSiloAddress,
+        SiloAddress siloAddress,
+        SiloAddress? otherSiloAddress,
+        SuspectOrKillRequestType requestType,
+        bool success,
+        Exception? exception) : MembershipEvent
+    {
+        /// <summary>
+        /// The silo which processed the request.
+        /// </summary>
+        public readonly SiloAddress ObserverSiloAddress = observerSiloAddress;
+
+        /// <summary>
+        /// The silo targeted by the request.
+        /// </summary>
+        public readonly SiloAddress SiloAddress = siloAddress;
+
+        /// <summary>
+        /// The other silo associated with the request, if any.
+        /// </summary>
+        public readonly SiloAddress? OtherSiloAddress = otherSiloAddress;
+
+        /// <summary>
+        /// The request type.
+        /// </summary>
+        public readonly SuspectOrKillRequestType RequestType = requestType;
+
+        /// <summary>
+        /// Whether the request completed successfully.
+        /// </summary>
+        public readonly bool Success = success;
+
+        /// <summary>
+        /// The exception thrown by the request, if any.
+        /// </summary>
+        public readonly Exception? Exception = exception;
+    }
+
     internal static void EmitViewChanged(MembershipTableSnapshot newSnapshot, SiloAddress observerAddress)
     {
         if (!Listener.IsEnabled(nameof(ViewChanged)))
@@ -68,6 +137,40 @@ internal static class MembershipEvents
             Listener.Write(nameof(ViewChanged), new ViewChanged(
                 newSnapshot,
                 observerAddress));
+        }
+    }
+
+    internal static void EmitSuspectOrKillRequestCompleted(
+        SiloAddress observerSiloAddress,
+        SiloAddress siloAddress,
+        SiloAddress? otherSiloAddress,
+        SuspectOrKillRequestType requestType,
+        bool success,
+        Exception? exception)
+    {
+        if (!Listener.IsEnabled(nameof(SuspectOrKillRequestCompleted)))
+        {
+            return;
+        }
+
+        Emit(observerSiloAddress, siloAddress, otherSiloAddress, requestType, success, exception);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(
+            SiloAddress observerSiloAddress,
+            SiloAddress siloAddress,
+            SiloAddress? otherSiloAddress,
+            SuspectOrKillRequestType requestType,
+            bool success,
+            Exception? exception)
+        {
+            Listener.Write(nameof(SuspectOrKillRequestCompleted), new SuspectOrKillRequestCompleted(
+                observerSiloAddress,
+                siloAddress,
+                otherSiloAddress,
+                requestType,
+                success,
+                exception));
         }
     }
 

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -43,8 +43,6 @@ namespace Orleans.Runtime.MembershipService
 
         private readonly Task _suspectOrKillsListTask;
         private readonly Channel<SuspectOrKillRequest> _trySuspectOrKillChannel = Channel.CreateBounded<SuspectOrKillRequest>(new BoundedChannelOptions(100) { FullMode = BoundedChannelFullMode.DropOldest });
-        private readonly AsyncEnumerable<SuspectOrKillRequestCompletion> _suspectOrKillRequestCompletions;
-        private long _suspectOrKillRequestCompletionSequence;
 
         private MembershipTableSnapshot snapshot;
 
@@ -74,10 +72,6 @@ namespace Orleans.Runtime.MembershipService
                 initialValue: this.snapshot,
                 updateValidator: (previous, proposed) => proposed.IsSuccessorTo(previous),
                 onPublished: update => Interlocked.Exchange(ref this.snapshot, update));
-            this._suspectOrKillRequestCompletions = new AsyncEnumerable<SuspectOrKillRequestCompletion>(
-                initialValue: default,
-                updateValidator: (previous, proposed) => proposed.SequenceNumber > previous.SequenceNumber,
-                onPublished: _ => { });
 
             this.membershipUpdateTimer = timerFactory.Create(
                 this.clusterMembershipOptions.TableRefreshTimeout,
@@ -91,8 +85,6 @@ namespace Orleans.Runtime.MembershipService
         public MembershipTableSnapshot MembershipTableSnapshot => this.snapshot;
 
         public IAsyncEnumerable<MembershipTableSnapshot> MembershipTableUpdates => this.updates;
-
-        internal IAsyncEnumerable<SuspectOrKillRequestCompletion> TestingSuspectOrKillRequestCompletions => this._suspectOrKillRequestCompletions;
 
         public SiloStatus CurrentStatus { get; private set; } = SiloStatus.Created;
 
@@ -613,26 +605,11 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        internal enum SuspectOrKillRequestType
-        {
-            Unknown = 0,
-            SuspectOrKill,
-            Kill
-        }
-
-        internal readonly record struct SuspectOrKillRequestCompletion(
-            long SequenceNumber,
-            SiloAddress? SiloAddress,
-            SiloAddress? OtherSilo,
-            SuspectOrKillRequestType RequestType,
-            bool Success,
-            Exception? Exception);
-
         private class SuspectOrKillRequest
         {
             public required SiloAddress SiloAddress { get; init; }
             public SiloAddress? OtherSilo { get; init; }
-            public required SuspectOrKillRequestType Type { get; init; }
+            public required MembershipEvents.SuspectOrKillRequestType Type { get; init; }
             public TaskCompletionSource? Completion { get; init; }
 
             public static SuspectOrKillRequest CreateKillRequest(SiloAddress silo)
@@ -640,7 +617,7 @@ namespace Orleans.Runtime.MembershipService
                 return new SuspectOrKillRequest
                 {
                     SiloAddress = silo,
-                    Type = SuspectOrKillRequestType.Kill
+                    Type = MembershipEvents.SuspectOrKillRequestType.Kill
                 };
             }
 
@@ -650,7 +627,7 @@ namespace Orleans.Runtime.MembershipService
                 var request = new SuspectOrKillRequest
                 {
                     SiloAddress = silo,
-                    Type = SuspectOrKillRequestType.Kill,
+                    Type = MembershipEvents.SuspectOrKillRequestType.Kill,
                     Completion = completion
                 };
                 return (request, completion.Task);
@@ -662,7 +639,7 @@ namespace Orleans.Runtime.MembershipService
                 {
                     SiloAddress = silo,
                     OtherSilo = otherSilo,
-                    Type = SuspectOrKillRequestType.SuspectOrKill
+                    Type = MembershipEvents.SuspectOrKillRequestType.SuspectOrKill
                 };
             }
         }
@@ -696,10 +673,10 @@ namespace Orleans.Runtime.MembershipService
                     {
                         switch (request.Type)
                         {
-                            case SuspectOrKillRequestType.Kill:
+                            case MembershipEvents.SuspectOrKillRequestType.Kill:
                                 success = await InnerTryKill(request.SiloAddress, _shutdownCts.Token);
                                 break;
-                            case SuspectOrKillRequestType.SuspectOrKill:
+                            case MembershipEvents.SuspectOrKillRequestType.SuspectOrKill:
                                 success = await InnerTryToSuspectOrKill(request.SiloAddress, request.OtherSilo, _shutdownCts.Token);
                                 break;
                         }
@@ -734,13 +711,13 @@ namespace Orleans.Runtime.MembershipService
 
         private void PublishSuspectOrKillRequestCompletion(SuspectOrKillRequest request, bool success, Exception? exception)
         {
-            this._suspectOrKillRequestCompletions.TryPublish(new SuspectOrKillRequestCompletion(
-                Interlocked.Increment(ref this._suspectOrKillRequestCompletionSequence),
+            MembershipEvents.EmitSuspectOrKillRequestCompleted(
+                this.myAddress,
                 request.SiloAddress,
                 request.OtherSilo,
                 request.Type,
                 success,
-                exception));
+                exception);
         }
 
         private async Task<bool> InnerTryKill(SiloAddress silo, CancellationToken cancellationToken)
@@ -949,7 +926,6 @@ namespace Orleans.Runtime.MembershipService
         public void Dispose()
         {
             this.updates.Dispose();
-            this._suspectOrKillRequestCompletions.Dispose();
             this.membershipUpdateTimer.Dispose();
             _shutdownCts.Dispose();
         }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -43,9 +43,8 @@ namespace Orleans.Runtime.MembershipService
 
         private readonly Task _suspectOrKillsListTask;
         private readonly Channel<SuspectOrKillRequest> _trySuspectOrKillChannel = Channel.CreateBounded<SuspectOrKillRequest>(new BoundedChannelOptions(100) { FullMode = BoundedChannelFullMode.DropOldest });
-
-        // For testing.
-        internal AutoResetEvent TestingSuspectOrKillIdle = new(false);
+        private readonly AsyncEnumerable<SuspectOrKillRequestCompletion> _suspectOrKillRequestCompletions;
+        private long _suspectOrKillRequestCompletionSequence;
 
         private MembershipTableSnapshot snapshot;
 
@@ -75,6 +74,10 @@ namespace Orleans.Runtime.MembershipService
                 initialValue: this.snapshot,
                 updateValidator: (previous, proposed) => proposed.IsSuccessorTo(previous),
                 onPublished: update => Interlocked.Exchange(ref this.snapshot, update));
+            this._suspectOrKillRequestCompletions = new AsyncEnumerable<SuspectOrKillRequestCompletion>(
+                initialValue: default,
+                updateValidator: (previous, proposed) => proposed.SequenceNumber > previous.SequenceNumber,
+                onPublished: _ => { });
 
             this.membershipUpdateTimer = timerFactory.Create(
                 this.clusterMembershipOptions.TableRefreshTimeout,
@@ -88,6 +91,8 @@ namespace Orleans.Runtime.MembershipService
         public MembershipTableSnapshot MembershipTableSnapshot => this.snapshot;
 
         public IAsyncEnumerable<MembershipTableSnapshot> MembershipTableUpdates => this.updates;
+
+        internal IAsyncEnumerable<SuspectOrKillRequestCompletion> TestingSuspectOrKillRequestCompletions => this._suspectOrKillRequestCompletions;
 
         public SiloStatus CurrentStatus { get; private set; } = SiloStatus.Created;
 
@@ -608,26 +613,34 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
+        internal enum SuspectOrKillRequestType
+        {
+            Unknown = 0,
+            SuspectOrKill,
+            Kill
+        }
+
+        internal readonly record struct SuspectOrKillRequestCompletion(
+            long SequenceNumber,
+            SiloAddress? SiloAddress,
+            SiloAddress? OtherSilo,
+            SuspectOrKillRequestType RequestType,
+            bool Success,
+            Exception? Exception);
+
         private class SuspectOrKillRequest
         {
             public required SiloAddress SiloAddress { get; init; }
             public SiloAddress? OtherSilo { get; init; }
-            public required RequestType Type { get; init; }
+            public required SuspectOrKillRequestType Type { get; init; }
             public TaskCompletionSource? Completion { get; init; }
-
-            public enum RequestType
-            {
-                Unknown = 0,
-                SuspectOrKill,
-                Kill
-            }
 
             public static SuspectOrKillRequest CreateKillRequest(SiloAddress silo)
             {
                 return new SuspectOrKillRequest
                 {
                     SiloAddress = silo,
-                    Type = RequestType.Kill
+                    Type = SuspectOrKillRequestType.Kill
                 };
             }
 
@@ -637,7 +650,7 @@ namespace Orleans.Runtime.MembershipService
                 var request = new SuspectOrKillRequest
                 {
                     SiloAddress = silo,
-                    Type = RequestType.Kill,
+                    Type = SuspectOrKillRequestType.Kill,
                     Completion = completion
                 };
                 return (request, completion.Task);
@@ -649,7 +662,7 @@ namespace Orleans.Runtime.MembershipService
                 {
                     SiloAddress = silo,
                     OtherSilo = otherSilo,
-                    Type = RequestType.SuspectOrKill
+                    Type = SuspectOrKillRequestType.SuspectOrKill
                 };
             }
         }
@@ -670,19 +683,28 @@ namespace Orleans.Runtime.MembershipService
             {
                 while (reader.TryRead(out var request))
                 {
-                    await Task.Delay(backoff.Next(runningFailureCount), _shutdownCts.Token);
+                    var publishCompletion = false;
+                    var success = false;
+                    Exception? exception = null;
+
+                    if (runningFailureCount > 0)
+                    {
+                        await Task.Delay(backoff.Next(runningFailureCount), _shutdownCts.Token);
+                    }
 
                     try
                     {
                         switch (request.Type)
                         {
-                            case SuspectOrKillRequest.RequestType.Kill:
-                                await InnerTryKill(request.SiloAddress, _shutdownCts.Token);
+                            case SuspectOrKillRequestType.Kill:
+                                success = await InnerTryKill(request.SiloAddress, _shutdownCts.Token);
                                 break;
-                            case SuspectOrKillRequest.RequestType.SuspectOrKill:
-                                await InnerTryToSuspectOrKill(request.SiloAddress, request.OtherSilo, _shutdownCts.Token);
+                            case SuspectOrKillRequestType.SuspectOrKill:
+                                success = await InnerTryToSuspectOrKill(request.SiloAddress, request.OtherSilo, _shutdownCts.Token);
                                 break;
                         }
+
+                        publishCompletion = true;
                         runningFailureCount = 0;
                         request.Completion?.TrySetResult();
                     }
@@ -692,6 +714,8 @@ namespace Orleans.Runtime.MembershipService
                         LogErrorProcessingSuspectOrKillLists(this.log, ex, runningFailureCount);
                         if (request.Completion is not null)
                         {
+                            publishCompletion = true;
+                            exception = ex;
                             request.Completion.TrySetException(ex);
                         }
                         else
@@ -700,12 +724,23 @@ namespace Orleans.Runtime.MembershipService
                         }
                     }
 
-                    if (!reader.TryPeek(out _))
+                    if (publishCompletion)
                     {
-                        TestingSuspectOrKillIdle.Set();
+                        this.PublishSuspectOrKillRequestCompletion(request, success, exception);
                     }
                 }
             }
+        }
+
+        private void PublishSuspectOrKillRequestCompletion(SuspectOrKillRequest request, bool success, Exception? exception)
+        {
+            this._suspectOrKillRequestCompletions.TryPublish(new SuspectOrKillRequestCompletion(
+                Interlocked.Increment(ref this._suspectOrKillRequestCompletionSequence),
+                request.SiloAddress,
+                request.OtherSilo,
+                request.Type,
+                success,
+                exception));
         }
 
         private async Task<bool> InnerTryKill(SiloAddress silo, CancellationToken cancellationToken)
@@ -914,6 +949,7 @@ namespace Orleans.Runtime.MembershipService
         public void Dispose()
         {
             this.updates.Dispose();
+            this._suspectOrKillRequestCompletions.Dispose();
             this.membershipUpdateTimer.Dispose();
             _shutdownCts.Dispose();
         }

--- a/test/Orleans.Core.Tests/Diagnostics/MembershipEventsTests.cs
+++ b/test/Orleans.Core.Tests/Diagnostics/MembershipEventsTests.cs
@@ -11,7 +11,7 @@ namespace UnitTests.Diagnostics;
 public class MembershipEventsTests
 {
     [Fact, TestCategory("BVT")]
-    public void EmitChanges_EmitsViewChangedOnly()
+    public void EmitViewChanged_EmitsViewChanged()
     {
         using var observer = new Observer(MembershipEvents.AllEvents);
         var observerSilo = CreateSiloAddress(11111, 1);
@@ -24,6 +24,33 @@ public class MembershipEventsTests
         var typed = Assert.IsType<MembershipEvents.ViewChanged>(viewChanged);
         Assert.Same(snapshot, typed.Snapshot);
         Assert.Same(observerSilo, typed.ObserverSiloAddress);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void EmitSuspectOrKillRequestCompleted_EmitsCompletion()
+    {
+        using var observer = new Observer(MembershipEvents.AllEvents);
+        var observerSilo = CreateSiloAddress(11121, 5);
+        var subjectSilo = CreateSiloAddress(11122, 6);
+        var otherSilo = CreateSiloAddress(11123, 7);
+        var exception = new InvalidOperationException("failed");
+
+        MembershipEvents.EmitSuspectOrKillRequestCompleted(
+            observerSilo,
+            subjectSilo,
+            otherSilo,
+            MembershipEvents.SuspectOrKillRequestType.SuspectOrKill,
+            success: false,
+            exception: exception);
+
+        var completed = Assert.Single(observer.Events);
+        var typed = Assert.IsType<MembershipEvents.SuspectOrKillRequestCompleted>(completed);
+        Assert.Same(observerSilo, typed.ObserverSiloAddress);
+        Assert.Same(subjectSilo, typed.SiloAddress);
+        Assert.Same(otherSilo, typed.OtherSiloAddress);
+        Assert.Equal(MembershipEvents.SuspectOrKillRequestType.SuspectOrKill, typed.RequestType);
+        Assert.False(typed.Success);
+        Assert.Same(exception, typed.Exception);
     }
 
     [Fact, TestCategory("BVT")]

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -342,7 +342,16 @@ namespace NonSilo.Tests.Membership
 
                 if (expectedMissedProbes >= clusterMembershipOptions.NumMissedProbesLimit)
                 {
-                    Assert.True(testRig.Manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(45)));
+                    var expectDead = (clusterMembershipOptions.NumVotesForDeathDeclaration <= 2 && enableIndirectProbes) || numVotesForDeathDeclaration == 1;
+                    await WaitForMembershipSnapshot(testRig.Manager, snapshot =>
+                    {
+                        return monitoredSilos.All(siloMonitor =>
+                        {
+                            var entry = snapshot.Entries[siloMonitor.TargetSiloAddress];
+                            var votes = entry.GetFreshVotes(now.UtcDateTime, clusterMembershipOptions.DeathVoteExpirationTimeout);
+                            return votes.Any(vote => vote.Item1.Equals(localSiloDetails.SiloAddress)) && (!expectDead || entry.Status == SiloStatus.Dead);
+                        });
+                    });
                 }
 
                 // Check that probes match the expected missed probes
@@ -526,7 +535,13 @@ namespace NonSilo.Tests.Membership
 
             if (evictWhenMaxJoinAttemptTimeExceeded)
             {
-                Assert.True(testRig.Manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(45)));
+                await WaitForMembershipSnapshot(testRig.Manager, snapshot =>
+                {
+                    return snapshot.Entries.TryGetValue(Silo(joiningSilo), out var joining)
+                        && joining.Status == SiloStatus.Dead
+                        && snapshot.Entries.TryGetValue(Silo(createdSilo), out var created)
+                        && created.Status == SiloStatus.Dead;
+                });
             }
 
             await Until(() => testRig.TestAccessor.ObservedVersion > lastVersion);
@@ -583,6 +598,26 @@ namespace NonSilo.Tests.Membership
             var maxTimeout = 40_000;
             while (!condition() && (maxTimeout -= 10) > 0) await Task.Delay(10);
             Assert.True(maxTimeout > 0);
+        }
+
+        private static async Task<MembershipTableSnapshot> WaitForMembershipSnapshot(MembershipTableManager manager, Func<MembershipTableSnapshot, bool> condition)
+        {
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(40));
+            try
+            {
+                await foreach (var snapshot in manager.MembershipTableUpdates.WithCancellation(cancellation.Token))
+                {
+                    if (condition(snapshot))
+                    {
+                        return snapshot;
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+            }
+
+            throw new TimeoutException("Timed out waiting for a matching membership update.");
         }
 
         private async Task StopLifecycle(CancellationToken cancellation = default)

--- a/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
+++ b/test/Orleans.Core.Tests/Membership/ClusterHealthMonitorTests.cs
@@ -4,7 +4,9 @@ using Microsoft.Extensions.Options;
 using NonSilo.Tests.Utilities;
 using NSubstitute;
 using Orleans.Configuration;
+using Orleans.Core.Diagnostics;
 using Orleans.Runtime.MembershipService;
+using Orleans.TestingHost.Diagnostics;
 using TestExtensions;
 using Xunit;
 using Xunit.Abstractions;
@@ -217,6 +219,7 @@ namespace NonSilo.Tests.Membership
             }
 
             var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions);
+            using var membershipEvents = new DiagnosticEventCollector(MembershipEvents.ListenerName);
             var probeCalls = new ConcurrentQueue<(SiloAddress Target, int ProbeNumber, bool IsIndirect)>();
             this.prober.Probe(default, default).ReturnsForAnyArgs(info =>
             {
@@ -343,11 +346,15 @@ namespace NonSilo.Tests.Membership
                 if (expectedMissedProbes >= clusterMembershipOptions.NumMissedProbesLimit)
                 {
                     var expectDead = (clusterMembershipOptions.NumVotesForDeathDeclaration <= 2 && enableIndirectProbes) || numVotesForDeathDeclaration == 1;
-                    await WaitForMembershipSnapshot(testRig.Manager, snapshot =>
+                    await WaitForMembershipSnapshot(membershipEvents, snapshot =>
                     {
                         return monitoredSilos.All(siloMonitor =>
                         {
-                            var entry = snapshot.Entries[siloMonitor.TargetSiloAddress];
+                            if (!snapshot.Entries.TryGetValue(siloMonitor.TargetSiloAddress, out var entry))
+                            {
+                                return false;
+                            }
+
                             var votes = entry.GetFreshVotes(now.UtcDateTime, clusterMembershipOptions.DeathVoteExpirationTimeout);
                             return votes.Any(vote => vote.Item1.Equals(localSiloDetails.SiloAddress)) && (!expectDead || entry.Status == SiloStatus.Dead);
                         });
@@ -450,6 +457,7 @@ namespace NonSilo.Tests.Membership
             }
 
             var testRig = CreateClusterHealthMonitorTestRig(clusterMembershipOptions);
+            using var membershipEvents = new DiagnosticEventCollector(MembershipEvents.ListenerName);
 
             var otherSilos = new[]
             {
@@ -535,7 +543,7 @@ namespace NonSilo.Tests.Membership
 
             if (evictWhenMaxJoinAttemptTimeExceeded)
             {
-                await WaitForMembershipSnapshot(testRig.Manager, snapshot =>
+                await WaitForMembershipSnapshot(membershipEvents, snapshot =>
                 {
                     return snapshot.Entries.TryGetValue(Silo(joiningSilo), out var joining)
                         && joining.Status == SiloStatus.Dead
@@ -600,24 +608,14 @@ namespace NonSilo.Tests.Membership
             Assert.True(maxTimeout > 0);
         }
 
-        private static async Task<MembershipTableSnapshot> WaitForMembershipSnapshot(MembershipTableManager manager, Func<MembershipTableSnapshot, bool> condition)
+        private static async Task<MembershipTableSnapshot> WaitForMembershipSnapshot(DiagnosticEventCollector membershipEvents, Func<MembershipTableSnapshot, bool> condition)
         {
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(40));
-            try
-            {
-                await foreach (var snapshot in manager.MembershipTableUpdates.WithCancellation(cancellation.Token))
-                {
-                    if (condition(snapshot))
-                    {
-                        return snapshot;
-                    }
-                }
-            }
-            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
-            {
-            }
+            var diagnosticEvent = await membershipEvents.WaitForEventAsync(
+                nameof(MembershipEvents.ViewChanged),
+                evt => evt.Payload is MembershipEvents.ViewChanged viewChanged && condition(viewChanged.Snapshot),
+                TimeSpan.FromSeconds(40));
 
-            throw new TimeoutException("Timed out waiting for a matching membership update.");
+            return Assert.IsType<MembershipEvents.ViewChanged>(diagnosticEvent.Payload).Snapshot;
         }
 
         private async Task StopLifecycle(CancellationToken cancellation = default)

--- a/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
@@ -1,15 +1,17 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Orleans.Configuration;
-using Orleans.Runtime.MembershipService;
-using Xunit;
-using NSubstitute;
-using Orleans.Runtime;
-using Orleans;
-using Xunit.Abstractions;
-using TestExtensions;
-using System.Collections.Concurrent;
 using NonSilo.Tests.Utilities;
+using NSubstitute;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Core.Diagnostics;
+using Orleans.Runtime;
+using Orleans.Runtime.MembershipService;
+using Orleans.TestingHost.Diagnostics;
+using TestExtensions;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace NonSilo.Tests.Membership
 {
@@ -450,6 +452,7 @@ namespace NonSilo.Tests.Membership
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
             await this.lifecycle.OnStart();
             await manager.UpdateStatus(SiloStatus.Active);
+            using var membershipEvents = new DiagnosticEventCollector(MembershipEvents.ListenerName);
 
             // Mark the silo as dead
             while (true)
@@ -462,7 +465,7 @@ namespace NonSilo.Tests.Membership
 
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
             var victim = otherSilos.First().SiloAddress;
-            var completion = WaitForSuspectOrKillCompletion(manager, victim);
+            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim);
             await manager.TryToSuspectOrKill(victim);
             Assert.True((await completion).Success);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
@@ -526,9 +529,10 @@ namespace NonSilo.Tests.Membership
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
             await this.lifecycle.OnStart();
             await manager.UpdateStatus(SiloStatus.Active);
+            using var membershipEvents = new DiagnosticEventCollector(MembershipEvents.ListenerName);
 
             var victim = otherSilos.First().SiloAddress;
-            var completion = WaitForSuspectOrKillCompletion(manager, victim);
+            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim);
             await manager.TryToSuspectOrKill(victim);
             Assert.True((await completion).Success);
             Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.GetSiloStatus(victim));
@@ -642,10 +646,11 @@ namespace NonSilo.Tests.Membership
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
             await this.lifecycle.OnStart();
             await manager.UpdateStatus(SiloStatus.Active);
+            using var membershipEvents = new DiagnosticEventCollector(MembershipEvents.ListenerName);
 
             // Multiple votes from the same node should not result in the node being declared dead.
             var victim = otherSilos.First().SiloAddress;
-            var completions = WaitForSuspectOrKillCompletions(manager, victim, expectedCount: 3);
+            var completions = WaitForSuspectOrKillCompletions(membershipEvents, victim, expectedCount: 3);
             await manager.TryToSuspectOrKill(victim);
             await manager.TryToSuspectOrKill(victim);
             await manager.TryToSuspectOrKill(victim);
@@ -663,7 +668,7 @@ namespace NonSilo.Tests.Membership
                 if (await membershipTable.UpdateRow(entry, row.Item2, table.Version.Next())) break;
             }
 
-            var completion = WaitForSuspectOrKillCompletion(manager, victim);
+            var completion = WaitForSuspectOrKillCompletion(membershipEvents, victim);
             await manager.TryToSuspectOrKill(victim);
             Assert.True((await completion).Success);
             Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.GetSiloStatus(victim));
@@ -683,7 +688,7 @@ namespace NonSilo.Tests.Membership
             }
 
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
-            completion = WaitForSuspectOrKillCompletion(manager, victim);
+            completion = WaitForSuspectOrKillCompletion(membershipEvents, victim);
             await manager.TryToSuspectOrKill(victim);
             Assert.False((await completion).Success);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
@@ -763,55 +768,36 @@ namespace NonSilo.Tests.Membership
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
 
-        private static async Task<MembershipTableManager.SuspectOrKillRequestCompletion> WaitForSuspectOrKillCompletion(MembershipTableManager manager, SiloAddress silo)
+        private static async Task<MembershipEvents.SuspectOrKillRequestCompleted> WaitForSuspectOrKillCompletion(DiagnosticEventCollector membershipEvents, SiloAddress silo)
         {
-            var completions = await WaitForSuspectOrKillCompletions(manager, silo, expectedCount: 1);
+            var completions = await WaitForSuspectOrKillCompletions(membershipEvents, silo, expectedCount: 1);
             return completions[0];
         }
 
-        private static async Task<List<MembershipTableManager.SuspectOrKillRequestCompletion>> WaitForSuspectOrKillCompletions(
-            MembershipTableManager manager,
+        private static async Task<List<MembershipEvents.SuspectOrKillRequestCompleted>> WaitForSuspectOrKillCompletions(
+            DiagnosticEventCollector membershipEvents,
             SiloAddress silo,
             int expectedCount)
         {
             Assert.True(expectedCount > 0);
 
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(40));
-            await using var enumerator = manager.TestingSuspectOrKillRequestCompletions.GetAsyncEnumerator(cancellation.Token);
-            var completions = new List<MembershipTableManager.SuspectOrKillRequestCompletion>(expectedCount);
+            membershipEvents.Clear();
+            var completions = new List<MembershipEvents.SuspectOrKillRequestCompleted>(expectedCount);
 
-            try
+            while (completions.Count < expectedCount)
             {
-                if (!await enumerator.MoveNextAsync())
-                {
-                    throw new TimeoutException("Suspect/kill completion stream ended before the initial item.");
-                }
+                var diagnosticEvent = await membershipEvents.WaitForEventAsync(
+                    nameof(MembershipEvents.SuspectOrKillRequestCompleted),
+                    evt => evt.Payload is MembershipEvents.SuspectOrKillRequestCompleted completed
+                        && completed.RequestType == MembershipEvents.SuspectOrKillRequestType.SuspectOrKill
+                        && completed.SiloAddress.Equals(silo)
+                        && !completions.Contains(completed),
+                    TimeSpan.FromSeconds(40));
 
-                var startSequence = enumerator.Current.SequenceNumber;
-                while (await enumerator.MoveNextAsync())
-                {
-                    var completion = enumerator.Current;
-                    if (completion.SequenceNumber <= startSequence)
-                    {
-                        continue;
-                    }
-
-                    if (completion.RequestType == MembershipTableManager.SuspectOrKillRequestType.SuspectOrKill
-                        && completion.SiloAddress?.Equals(silo) == true)
-                    {
-                        completions.Add(completion);
-                        if (completions.Count == expectedCount)
-                        {
-                            return completions;
-                        }
-                    }
-                }
-            }
-            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
-            {
+                completions.Add(Assert.IsType<MembershipEvents.SuspectOrKillRequestCompleted>(diagnosticEvent.Payload));
             }
 
-            throw new TimeoutException($"Timed out waiting for {expectedCount} suspect/kill completion(s) for {silo}.");
+            return completions;
         }
 
         private static MembershipEntry Entry(SiloAddress address, SiloStatus status, DateTimeOffset iAmAliveTime)

--- a/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
@@ -461,8 +461,10 @@ namespace NonSilo.Tests.Membership
             }
 
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
-            await manager.TryToSuspectOrKill(otherSilos.First().SiloAddress);
-            manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(45));
+            var victim = otherSilos.First().SiloAddress;
+            var completion = WaitForSuspectOrKillCompletion(manager, victim);
+            await manager.TryToSuspectOrKill(victim);
+            Assert.True((await completion).Success);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
         }
 
@@ -526,8 +528,9 @@ namespace NonSilo.Tests.Membership
             await manager.UpdateStatus(SiloStatus.Active);
 
             var victim = otherSilos.First().SiloAddress;
+            var completion = WaitForSuspectOrKillCompletion(manager, victim);
             await manager.TryToSuspectOrKill(victim);
-            manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(45));
+            Assert.True((await completion).Success);
             Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.GetSiloStatus(victim));
         }
 
@@ -642,10 +645,11 @@ namespace NonSilo.Tests.Membership
 
             // Multiple votes from the same node should not result in the node being declared dead.
             var victim = otherSilos.First().SiloAddress;
+            var completions = WaitForSuspectOrKillCompletions(manager, victim, expectedCount: 3);
             await manager.TryToSuspectOrKill(victim);
             await manager.TryToSuspectOrKill(victim);
             await manager.TryToSuspectOrKill(victim);
-            manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(45));
+            Assert.All(await completions, completion => Assert.True(completion.Success));
             Assert.Equal(SiloStatus.Active, manager.MembershipTableSnapshot.GetSiloStatus(victim));
 
             // Manually remove our vote and add another silo's vote so we can be the one to kill the silo.
@@ -659,8 +663,9 @@ namespace NonSilo.Tests.Membership
                 if (await membershipTable.UpdateRow(entry, row.Item2, table.Version.Next())) break;
             }
 
+            var completion = WaitForSuspectOrKillCompletion(manager, victim);
             await manager.TryToSuspectOrKill(victim);
-            manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(45));
+            Assert.True((await completion).Success);
             Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.GetSiloStatus(victim));
 
             // One down, one to go. Now overshoot votes and kill ourselves instead (due to internal error).
@@ -678,8 +683,9 @@ namespace NonSilo.Tests.Membership
             }
 
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
+            completion = WaitForSuspectOrKillCompletion(manager, victim);
             await manager.TryToSuspectOrKill(victim);
-            manager.TestingSuspectOrKillIdle.WaitOne(TimeSpan.FromSeconds(45));
+            Assert.False((await completion).Success);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
 
             // We killed ourselves and should not have marked the other silo as dead.
@@ -756,6 +762,57 @@ namespace NonSilo.Tests.Membership
         }
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
+
+        private static async Task<MembershipTableManager.SuspectOrKillRequestCompletion> WaitForSuspectOrKillCompletion(MembershipTableManager manager, SiloAddress silo)
+        {
+            var completions = await WaitForSuspectOrKillCompletions(manager, silo, expectedCount: 1);
+            return completions[0];
+        }
+
+        private static async Task<List<MembershipTableManager.SuspectOrKillRequestCompletion>> WaitForSuspectOrKillCompletions(
+            MembershipTableManager manager,
+            SiloAddress silo,
+            int expectedCount)
+        {
+            Assert.True(expectedCount > 0);
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(40));
+            await using var enumerator = manager.TestingSuspectOrKillRequestCompletions.GetAsyncEnumerator(cancellation.Token);
+            var completions = new List<MembershipTableManager.SuspectOrKillRequestCompletion>(expectedCount);
+
+            try
+            {
+                if (!await enumerator.MoveNextAsync())
+                {
+                    throw new TimeoutException("Suspect/kill completion stream ended before the initial item.");
+                }
+
+                var startSequence = enumerator.Current.SequenceNumber;
+                while (await enumerator.MoveNextAsync())
+                {
+                    var completion = enumerator.Current;
+                    if (completion.SequenceNumber <= startSequence)
+                    {
+                        continue;
+                    }
+
+                    if (completion.RequestType == MembershipTableManager.SuspectOrKillRequestType.SuspectOrKill
+                        && completion.SiloAddress?.Equals(silo) == true)
+                    {
+                        completions.Add(completion);
+                        if (completions.Count == expectedCount)
+                        {
+                            return completions;
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+            }
+
+            throw new TimeoutException($"Timed out waiting for {expectedCount} suspect/kill completion(s) for {silo}.");
+        }
 
         private static MembershipEntry Entry(SiloAddress address, SiloStatus status, DateTimeOffset iAmAliveTime)
         {


### PR DESCRIPTION
Speeds up membership health monitor and membership table manager tests by removing hidden suspect/kill backoff from the normal path and replacing coarse waits with membership update and completion signals.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10207)