### PR TITLE
test: add event waits for streaming client drops

### DIFF
--- a/src/Orleans.Core/Diagnostics/GatewayEvents.cs
+++ b/src/Orleans.Core/Diagnostics/GatewayEvents.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Orleans.Runtime;
+
+namespace Orleans.Core.Diagnostics;
+
+internal static class GatewayEvents
+{
+    internal const string ListenerName = "Orleans.Gateway";
+
+    private static readonly DiagnosticListener Listener = new(ListenerName);
+
+    internal static IObservable<GatewayEvent> AllEvents { get; } = new Observable();
+
+    internal abstract class GatewayEvent(SiloAddress siloAddress)
+    {
+        public readonly SiloAddress SiloAddress = siloAddress;
+    }
+
+    internal sealed class ClientDropped(
+        SiloAddress siloAddress,
+        GrainId clientId,
+        TimeSpan disconnectedDuration) : GatewayEvent(siloAddress)
+    {
+        public readonly GrainId ClientId = clientId;
+
+        public readonly TimeSpan DisconnectedDuration = disconnectedDuration;
+    }
+
+    internal static void EmitClientDropped(SiloAddress siloAddress, GrainId clientId, TimeSpan disconnectedDuration)
+    {
+        if (!Listener.IsEnabled(nameof(ClientDropped)))
+        {
+            return;
+        }
+
+        Emit(siloAddress, clientId, disconnectedDuration);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(SiloAddress siloAddress, GrainId clientId, TimeSpan disconnectedDuration)
+        {
+            Listener.Write(nameof(ClientDropped), new ClientDropped(siloAddress, clientId, disconnectedDuration));
+        }
+    }
+
+    private sealed class Observable : IObservable<GatewayEvent>
+    {
+        public IDisposable Subscribe(IObserver<GatewayEvent> observer) => Listener.Subscribe(new Observer(observer));
+
+        private sealed class Observer(IObserver<GatewayEvent> observer) : IObserver<KeyValuePair<string, object?>>
+        {
+            public void OnCompleted() => observer.OnCompleted();
+            public void OnError(Exception error) => observer.OnError(error);
+
+            public void OnNext(KeyValuePair<string, object?> value)
+            {
+                if (value.Value is GatewayEvent evt)
+                {
+                    observer.OnNext(evt);
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Core/Diagnostics/GatewayEvents.cs
+++ b/src/Orleans.Core/Diagnostics/GatewayEvents.cs
@@ -14,6 +14,8 @@ internal static class GatewayEvents
 
     internal static IObservable<GatewayEvent> AllEvents { get; } = new Observable();
 
+    internal static bool IsClientDroppedEnabled() => Listener.IsEnabled(nameof(ClientDropped));
+
     internal abstract class GatewayEvent(SiloAddress siloAddress)
     {
         public readonly SiloAddress SiloAddress = siloAddress;
@@ -31,7 +33,7 @@ internal static class GatewayEvents
 
     internal static void EmitClientDropped(SiloAddress siloAddress, GrainId clientId, TimeSpan disconnectedDuration)
     {
-        if (!Listener.IsEnabled(nameof(ClientDropped)))
+        if (!IsClientDroppedEnabled())
         {
             return;
         }

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -229,6 +229,7 @@ namespace Orleans.Runtime.Messaging
         // There is NO need to acquire individual ClientState lock, since we only close an older socket.
         internal void DropDisconnectedClients()
         {
+            var trackDroppedClients = GatewayEvents.IsClientDroppedEnabled();
             List<(GrainId ClientId, TimeSpan DisconnectedDuration)> droppedClients = null;
             foreach (var kv in clients)
             {
@@ -245,8 +246,11 @@ namespace Orleans.Runtime.Messaging
                             {
                                 // Reject all pending messages from the client.
                                 client.Drop();
-                                droppedClients ??= [];
-                                droppedClients.Add((kv.Key.GrainId, disconnectedDuration));
+                                if (trackDroppedClients)
+                                {
+                                    droppedClients ??= [];
+                                    droppedClients.Add((kv.Key.GrainId, disconnectedDuration));
+                                }
                             }
 
                             clientsCollectionVersion++;

--- a/src/Orleans.Runtime/Messaging/Gateway.cs
+++ b/src/Orleans.Runtime/Messaging/Gateway.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.ClientObservers;
 using Orleans.Configuration;
+using Orleans.Core.Diagnostics;
 using Orleans.Runtime.Internal;
 
 #nullable disable
@@ -23,6 +24,7 @@ namespace Orleans.Runtime.Messaging
         // Anything that appears in those 2 collections should also appear in the main clients collection.
         private readonly ConcurrentDictionary<ClientGrainId, ClientState> clients = new();
         private readonly Dictionary<GatewayInboundConnection, ClientState> clientConnections = new();
+        private readonly SiloAddress siloAddress;
         private readonly SiloAddress gatewayAddress;
         private readonly IAsyncTimer gatewayMaintenanceTimer;
         private readonly Task gatewayMaintenanceTask;
@@ -53,6 +55,7 @@ namespace Orleans.Runtime.Messaging
             this.logger = this.loggerFactory.CreateLogger<Gateway>();
             this.clientDropTimeout = messagingOptions.ClientDropTimeout;
             clientsReplyRoutingCache = new ClientsReplyRoutingCache(messagingOptions.ResponseTimeout);
+            this.siloAddress = siloDetails.SiloAddress;
             this.gatewayAddress = siloDetails.GatewayAddress;
             this.GatewayInstruments = new(orleansInstruments);
             this.gatewayMaintenanceTimer = timerFactory.Create(messagingOptions.ClientDropTimeout, nameof(PerformGatewayMaintenance));
@@ -226,6 +229,7 @@ namespace Orleans.Runtime.Messaging
         // There is NO need to acquire individual ClientState lock, since we only close an older socket.
         internal void DropDisconnectedClients()
         {
+            List<(GrainId ClientId, TimeSpan DisconnectedDuration)> droppedClients = null;
             foreach (var kv in clients)
             {
                 if (kv.Value.ReadyToDrop())
@@ -234,18 +238,29 @@ namespace Orleans.Runtime.Messaging
                     {
                         if (clients.TryGetValue(kv.Key, out var client) && client.ReadyToDrop())
                         {
-                            LogInformationGatewayDroppingClient(logger, kv.Key, client.DisconnectedSince);
+                            var disconnectedDuration = client.DisconnectedSince;
+                            LogInformationGatewayDroppingClient(logger, kv.Key, disconnectedDuration);
 
                             if (clients.TryRemove(kv.Key, out _))
                             {
                                 // Reject all pending messages from the client.
                                 client.Drop();
+                                droppedClients ??= [];
+                                droppedClients.Add((kv.Key.GrainId, disconnectedDuration));
                             }
 
                             clientsCollectionVersion++;
                             _messagingInstruments.ConnectedClient.Add(-1);
                         }
                     }
+                }
+            }
+
+            if (droppedClients is not null)
+            {
+                foreach (var droppedClient in droppedClients)
+                {
+                    GatewayEvents.EmitClientDropped(siloAddress, droppedClient.ClientId, droppedClient.DisconnectedDuration);
                 }
             }
         }

--- a/test/Orleans.Streaming.Tests/StreamingTests/ClientStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ClientStreamTestRunner.cs
@@ -1,7 +1,9 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestingHost;
-using Orleans.TestingHost.Utils;
 using TestExtensions;
 using UnitTests.GrainInterfaces;
 using Xunit;
@@ -28,10 +30,10 @@ namespace Tester.StreamingTests
             await ProduceEventsFromClient(streamProviderName, streamGuid, streamNamespace, eventsProduced);
 
             // Hard kill client
+            var droppedClients = GetConnectedClients();
+            using var gatewayObserver = GatewayDiagnosticObserver.Create();
             await testHost.KillClientAsync();
-            
-            // make sure dead client has had time to drop
-            await Task.Delay(Constants.DEFAULT_CLIENT_DROP_TIMEOUT + TimeSpan.FromSeconds(5));
+            await WaitForDroppedClientsAsync(droppedClients, gatewayObserver);
 
             // initialize new client
             await testHost.InitializeClientAsync();
@@ -42,18 +44,21 @@ namespace Tester.StreamingTests
 
         public async Task StreamConsumerOnDroppedClientTest(string streamProviderName, string streamNamespace, ITestOutputHelper output, Func<Task<int>> getDeliveryFailureCount = null, bool waitForRetryTimeouts = false)
         {
-            getDeliveryFailureCount = getDeliveryFailureCount ?? DefaultDeliveryFailureCount;
+            var hasDeliveryFailureCounter = getDeliveryFailureCount is not null;
+            getDeliveryFailureCount ??= DefaultDeliveryFailureCount;
 
             Guid streamGuid = Guid.NewGuid();
+            var streamId = StreamId.Create(streamNamespace, streamGuid);
             int[] eventCount = {0};
 
-            await ProduceEventsToClient(streamProviderName, streamGuid, streamNamespace, 10, eventCount);
+            var droppedSubscriptionId = await ProduceEventsToClient(streamProviderName, streamGuid, streamNamespace, 10, eventCount);
 
             // Hard kill client
+            var droppedClients = GetConnectedClients();
+            using var gatewayObserver = GatewayDiagnosticObserver.Create();
+            using var streamingObserver = StreamingDiagnosticObserver.Create();
             await testHost.KillClientAsync();
-
-            // Not all providers emit subscription-removal diagnostics for client disconnect cleanup.
-            await Task.Delay(Constants.DEFAULT_CLIENT_DROP_TIMEOUT + TimeSpan.FromSeconds(5));
+            await WaitForDroppedClientsAsync(droppedClients, gatewayObserver);
 
             // initialize new client
             await testHost.InitializeClientAsync();
@@ -62,17 +67,18 @@ namespace Tester.StreamingTests
 
             await ProduceEventsToClient(streamProviderName, streamGuid, streamNamespace, 10, eventCount);
 
-            // give strem retry policy time to fail
-            if (waitForRetryTimeouts)
+            // Wait for the dropped client's subscription to be removed after delivery fails.
+            if (waitForRetryTimeouts && hasDeliveryFailureCounter)
             {
-                await Task.Delay(TimeSpan.FromSeconds(90));
+                using var cts = new CancellationTokenSource(_timeout);
+                await streamingObserver.WaitForSubscriptionUnregisteredAsync(streamId, droppedSubscriptionId, streamProviderName, cts.Token);
             }
 
             int deliveryFailureCount = await getDeliveryFailureCount();
             Assert.Equal(0, deliveryFailureCount);
         }
 
-        private Task SubscribeToStream(string streamProviderName, Guid streamGuid, string streamNamespace,
+        private Task<StreamSubscriptionHandle<int>> SubscribeToStream(string streamProviderName, Guid streamGuid, string streamNamespace,
             Func<int, StreamSequenceToken, Task> onNextAsync)
         {
             IStreamProvider streamProvider = this.testHost.Client.GetStreamProvider(streamProviderName);
@@ -116,13 +122,13 @@ namespace Tester.StreamingTests
             }
         }
 
-        private async Task ProduceEventsToClient(string streamProviderName, Guid streamGuid, string streamNamespace, int eventsProduced, int[] eventCount)
+        private async Task<Guid> ProduceEventsToClient(string streamProviderName, Guid streamGuid, string streamNamespace, int eventsProduced, int[] eventCount)
         {
             using var observer = StreamingDiagnosticObserver.Create();
             using var cts = new CancellationTokenSource(_timeout);
             var streamId = StreamId.Create(streamNamespace, streamGuid);
 
-            await SubscribeToStream(streamProviderName, streamGuid, streamNamespace,
+            var subscription = await SubscribeToStream(streamProviderName, streamGuid, streamNamespace,
                 (e, t) =>
                 {
                     eventCount[0]++;
@@ -137,6 +143,52 @@ namespace Tester.StreamingTests
 
             Assert.Equal(eventsProduced, eventCount[0]);
             Assert.Equal(eventsProduced, await producer.GetNumberProduced());
+            return subscription.HandleId;
+        }
+
+        private async Task WaitForDroppedClientsAsync(HashSet<ConnectedClient> droppedClients, GatewayDiagnosticObserver observer)
+        {
+            if (droppedClients.Count == 0)
+            {
+                return;
+            }
+
+            using var cts = new CancellationTokenSource(GetClientDropWaitTimeout());
+            await observer.WaitForClientsDroppedAsync(droppedClients.Select(client => (client.SiloAddress, client.ClientId)), cts.Token);
+
+            var remainingClients = GetConnectedClients();
+            remainingClients.IntersectWith(droppedClients);
+            Assert.Empty(remainingClients);
+        }
+
+        private HashSet<ConnectedClient> GetConnectedClients()
+        {
+            var result = new HashSet<ConnectedClient>();
+            foreach (var silo in testHost.Silos)
+            {
+                var connectedClients = testHost.GetSiloServiceProvider(silo.SiloAddress).GetRequiredService<IConnectedClientCollection>();
+                foreach (var clientId in connectedClients.GetConnectedClientIds())
+                {
+                    result.Add(new ConnectedClient(silo.SiloAddress, clientId));
+                }
+            }
+
+            return result;
+        }
+
+        private TimeSpan GetClientDropWaitTimeout()
+        {
+            var maxDropTimeout = TimeSpan.Zero;
+            foreach (var silo in testHost.Silos)
+            {
+                var options = testHost.GetSiloServiceProvider(silo.SiloAddress).GetRequiredService<IOptions<SiloMessagingOptions>>().Value;
+                if (options.ClientDropTimeout > maxDropTimeout)
+                {
+                    maxDropTimeout = options.ClientDropTimeout;
+                }
+            }
+
+            return (maxDropTimeout * 2) + TimeSpan.FromSeconds(10);
         }
 
         private static async Task ProduceExactCountAsync(ISampleStreaming_ProducerGrain producer, int count)
@@ -146,5 +198,7 @@ namespace Tester.StreamingTests
                 await producer.Produce();
             }
         }
+
+        private readonly record struct ConnectedClient(SiloAddress SiloAddress, GrainId ClientId);
     }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/GeneratedStreamRecoveryTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/GeneratedStreamRecoveryTests.cs
@@ -3,6 +3,7 @@ using Orleans.Configuration;
 using Orleans.Providers.Streams.Common;
 using Orleans.Providers.Streams.Generator;
 using Orleans.Runtime;
+using Orleans.Runtime.Providers;
 using Orleans.Streams;
 using Orleans.TestingHost;
 using Tester.StreamingTests;
@@ -26,7 +27,7 @@ namespace UnitTests.StreamingTests
         public class Fixture : BaseTestClusterFixture
         {
             public const string StreamProviderName = GeneratedStreamTestConstants.StreamProviderName;
-
+            private static readonly TimeSpan DeliveryRetryBackoff = TimeSpan.FromMilliseconds(100);
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
                 builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
@@ -45,9 +46,16 @@ namespace UnitTests.StreamingTests
                             {
                                 b.ConfigureStreamPubSub(StreamPubSubType.ImplicitOnly);
                                 b.Configure<HashRingStreamQueueMapperOptions>(ob => ob.Configure(options => options.TotalQueueCount = TotalQueueCount));
+                                b.ConfigurePullingAgent(ob => ob.Configure(options => options.MaxEventDeliveryTime = TimeSpan.FromSeconds(2)));
+                                b.ConfigureBackoffProvider((_, _) => new FixedMessageDeliveryBackoffProvider(DeliveryRetryBackoff));
                                 b.UseDynamicClusterConfigDeploymentBalancer();
                             });
                 }
+            }
+
+            private sealed class FixedMessageDeliveryBackoffProvider(TimeSpan delay) : IMessageDeliveryBackoffProvider
+            {
+                public TimeSpan Next(int attempt) => delay;
             }
         }
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamProviderBatchedClientTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamProviderBatchedClientTests.cs
@@ -40,7 +40,7 @@ namespace Tester.StreamingTests
                     .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(
                         StreamProviderName,
                         b => b.ConfigurePartitioning(partitionCount))
-                    .Configure<SiloMessagingOptions>(options => options.ClientDropTimeout = TimeSpan.FromSeconds(5));
+                    .Configure<SiloMessagingOptions>(options => options.ClientDropTimeout = TimeSpan.FromSeconds(1));
             }
         }
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamProviderClientTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamProviderClientTests.cs
@@ -56,7 +56,7 @@ namespace Tester.StreamingTests
                 public void Configure(ISiloBuilder hostBuilder)=> hostBuilder.AddMemoryGrainStorage("PubSubStore")
                         .AddMemoryStreams<DefaultMemoryMessageBodySerializer>(StreamProviderName, b=>b
                     .ConfigurePartitioning(partitionCount))
-                    .Configure<SiloMessagingOptions>(options => options.ClientDropTimeout = TimeSpan.FromSeconds(5));
+                    .Configure<SiloMessagingOptions>(options => options.ClientDropTimeout = TimeSpan.FromSeconds(1));
             }
         }
 

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/GatewayDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/GatewayDiagnosticObserver.cs
@@ -1,0 +1,42 @@
+#nullable enable
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using Orleans.Core.Diagnostics;
+using Orleans.Runtime;
+
+namespace TestExtensions;
+
+public sealed class GatewayDiagnosticObserver : IDisposable
+{
+    private readonly IConnectableObservable<GatewayEvents.GatewayEvent> _events;
+    private readonly IDisposable _connection;
+
+    public static GatewayDiagnosticObserver Create() => new();
+
+    private GatewayDiagnosticObserver()
+    {
+        _events = GatewayEvents.AllEvents.Replay();
+        _connection = _events.Connect();
+    }
+
+    public async Task WaitForClientDroppedAsync(SiloAddress siloAddress, GrainId clientId, CancellationToken cancellationToken)
+    {
+        await _events
+            .OfType<GatewayEvents.ClientDropped>()
+            .FirstAsync(e => e.SiloAddress.Equals(siloAddress) && e.ClientId == clientId)
+            .ToTask(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task WaitForClientsDroppedAsync(IEnumerable<(SiloAddress SiloAddress, GrainId ClientId)> clients, CancellationToken cancellationToken)
+    {
+        var tasks = clients
+            .Distinct()
+            .Select(client => WaitForClientDroppedAsync(client.SiloAddress, client.ClientId, cancellationToken));
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    public void Dispose() => _connection.Dispose();
+}

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/StreamingDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/StreamingDiagnosticObserver.cs
@@ -252,6 +252,18 @@ public sealed class StreamingDiagnosticObserver : IDisposable
     }
 
     /// <summary>
+    /// Waits for a specific subscription to be durably removed from a specific stream.
+    /// </summary>
+    public async Task<StreamingEvents.SubscriptionUnregistered> WaitForSubscriptionUnregisteredAsync(StreamId streamId, Guid subscriptionId, string? streamProvider, CancellationToken cancellationToken)
+    {
+        return await _events
+            .OfType<StreamingEvents.SubscriptionUnregistered>()
+            .FirstAsync(e => MatchesSubscription(e.StreamId, e.SubscriptionId, e.StreamProvider, streamId, subscriptionId, streamProvider))
+            .ToTask(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Waits for a specific number of subscriptions to be durably removed from a stream.
     /// </summary>
     public async Task WaitForSubscriptionUnregisteredCountAsync(StreamId streamId, int expectedCount, string? streamProvider, CancellationToken cancellationToken)


### PR DESCRIPTION
Speeds up streaming client-drop tests by adding gateway client-drop diagnostics, waiting on subscription-unregistered events where applicable, and reducing test-only retry/drop timing while preserving cleanup assertions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10208)