### PR TITLE
test: speed up runtime timer and collector tests

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Runtime.Diagnostics;
 using Orleans.Runtime.Internal;
 using Orleans.Statistics;
 
@@ -412,7 +413,12 @@ namespace Orleans.Runtime
                     DeactivationReasonCode.HighMemoryPressure,
                     $"Process memory utilization exceeded the configured limit of '{_grainCollectionOptions.MemoryUsageLimitPercentage}'. Detected memory usage is {memBefore} MB.");
 
-                await DeactivateActivationsFromCollector(candidates, cancellationToken, reason);
+                await DeactivateActivationsFromCollector(
+                    candidates,
+                    cancellationToken,
+                    reason,
+                    ActivationCollectionEvents.CollectionSource.MemoryPressure,
+                    ageLimit: default);
             }
 
             long memAfter = GC.GetTotalMemory(false) / (1024 * 1024);
@@ -657,7 +663,12 @@ namespace Orleans.Runtime
             if (list is { Count: > 0 })
             {
                 LogCollectActivations(new(list));
-                await DeactivateActivationsFromCollector(list, cancellationToken);
+                await DeactivateActivationsFromCollector(
+                    list,
+                    cancellationToken,
+                    deactivationReason: null,
+                    collectionSource: scanStale ? ActivationCollectionEvents.CollectionSource.Stale : ActivationCollectionEvents.CollectionSource.AgeLimit,
+                    ageLimit: ageLimit);
             }
 
             long memAfter = GC.GetTotalMemory(false) / (1024 * 1024);
@@ -666,7 +677,12 @@ namespace Orleans.Runtime
             LogAfterCollection(number, memAfter, _activationCount, list?.Count ?? 0, this, watch.Elapsed);
         }
 
-        private async Task DeactivateActivationsFromCollector(List<ICollectibleGrainContext> list, CancellationToken cancellationToken, DeactivationReason? deactivationReason = null)
+        private async Task DeactivateActivationsFromCollector(
+            List<ICollectibleGrainContext> list,
+            CancellationToken cancellationToken,
+            DeactivationReason? deactivationReason,
+            ActivationCollectionEvents.CollectionSource collectionSource,
+            TimeSpan ageLimit)
         {
             LogDeactivateActivationsFromCollector(list.Count);
             _catalogInstruments.ActivationShutdownViaCollection();
@@ -686,6 +702,8 @@ namespace Orleans.Runtime
                 activationData.Deactivate(deactivationReason.Value, cancellationToken);
                 await activationData.Deactivated.ConfigureAwait(false);
             }).WaitAsync(cancellationToken);
+
+            ActivationCollectionEvents.EmitCollectionCompleted(collectionSource, ageLimit, deactivationReason.Value, list);
         }
 
         public void Dispose()

--- a/src/Orleans.Runtime/Diagnostics/ActivationCollectionEvents.cs
+++ b/src/Orleans.Runtime/Diagnostics/ActivationCollectionEvents.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Orleans.Runtime.Diagnostics;
+
+internal static class ActivationCollectionEvents
+{
+    public const string ListenerName = "Orleans.ActivationCollection";
+
+    private static readonly DiagnosticListener Listener = new(ListenerName);
+
+    public static IObservable<CollectionEvent> AllEvents { get; } = new Observable();
+
+    public enum CollectionSource
+    {
+        Stale,
+        AgeLimit,
+        MemoryPressure
+    }
+
+    public abstract class CollectionEvent(CollectionSource source, TimeSpan ageLimit, DeactivationReason reason)
+    {
+        public readonly CollectionSource Source = source;
+        public readonly TimeSpan AgeLimit = ageLimit;
+        public readonly DeactivationReason Reason = reason;
+    }
+
+    public sealed class CollectionCompleted(
+        CollectionSource source,
+        TimeSpan ageLimit,
+        DeactivationReason reason,
+        IReadOnlyList<CollectedActivation> activations) : CollectionEvent(source, ageLimit, reason)
+    {
+        public readonly IReadOnlyList<CollectedActivation> Activations = activations;
+    }
+
+    public readonly struct CollectedActivation(GrainId grainId, ActivationId activationId)
+    {
+        public readonly GrainId GrainId = grainId;
+        public readonly ActivationId ActivationId = activationId;
+    }
+
+    internal static void EmitCollectionCompleted(
+        CollectionSource source,
+        TimeSpan ageLimit,
+        DeactivationReason reason,
+        IReadOnlyList<ICollectibleGrainContext> activations)
+    {
+        if (!Listener.IsEnabled(nameof(CollectionCompleted)))
+        {
+            return;
+        }
+
+        Emit(source, ageLimit, reason, activations);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(
+            CollectionSource source,
+            TimeSpan ageLimit,
+            DeactivationReason reason,
+            IReadOnlyList<ICollectibleGrainContext> activations)
+        {
+            var collectedActivations = new CollectedActivation[activations.Count];
+            for (var i = 0; i < activations.Count; i++)
+            {
+                var activation = activations[i];
+                collectedActivations[i] = new(activation.GrainId, activation.ActivationId);
+            }
+
+            Listener.Write(nameof(CollectionCompleted), new CollectionCompleted(
+                source,
+                ageLimit,
+                reason,
+                collectedActivations));
+        }
+    }
+
+    private sealed class Observable : IObservable<CollectionEvent>
+    {
+        public IDisposable Subscribe(IObserver<CollectionEvent> observer) => Listener.Subscribe(new Observer(observer));
+
+        private sealed class Observer(IObserver<CollectionEvent> observer) : IObserver<KeyValuePair<string, object?>>
+        {
+            public void OnCompleted() => observer.OnCompleted();
+            public void OnError(Exception error) => observer.OnError(error);
+
+            public void OnNext(KeyValuePair<string, object?> value)
+            {
+                if (value.Value is CollectionEvent evt)
+                {
+                    observer.OnNext(evt);
+                }
+            }
+        }
+    }
+}

--- a/src/Orleans.Transactions/DistributedTM/TransactionOverloadDetector.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionOverloadDetector.cs
@@ -35,23 +35,31 @@ namespace Orleans.Transactions
         private readonly ITransactionAgentStatistics statistics;
         private readonly TransactionRateLoadSheddingOptions options;
         private readonly PeriodicAction monitor;
+        private readonly TimeProvider timeProvider;
         private ITransactionAgentStatistics lastStatistics;
         private double transactionStartedPerSecond;
         private DateTime lastCheckTime;
         private static readonly TimeSpan MetricsCheck = TimeSpan.FromSeconds(15);
         public TransactionOverloadDetector(ITransactionAgentStatistics statistics, IOptions<TransactionRateLoadSheddingOptions> options)
+            : this(statistics, options, TimeProvider.System)
+        {
+        }
+
+        internal TransactionOverloadDetector(ITransactionAgentStatistics statistics, IOptions<TransactionRateLoadSheddingOptions> options, TimeProvider timeProvider)
         {
             this.statistics = statistics;
             this.options = options.Value;
-            this.monitor = new PeriodicAction(MetricsCheck, this.RecordStatistics);
+            this.timeProvider = timeProvider;
+            var now = this.timeProvider.GetUtcNow().UtcDateTime;
+            this.monitor = new PeriodicAction(MetricsCheck, this.RecordStatistics, now + MetricsCheck);
             this.lastStatistics = TransactionAgentStatistics.Copy(statistics);
-            this.lastCheckTime = DateTime.UtcNow;
+            this.lastCheckTime = now;
         }
 
         private void RecordStatistics()
         {
             ITransactionAgentStatistics current = TransactionAgentStatistics.Copy(this.statistics);
-            DateTime now = DateTime.UtcNow;
+            DateTime now = this.timeProvider.GetUtcNow().UtcDateTime;
 
             this.transactionStartedPerSecond = CalculateTps(this.lastStatistics.TransactionsStarted, this.lastCheckTime, current.TransactionsStarted, now);
             this.lastStatistics = current;
@@ -63,7 +71,7 @@ namespace Orleans.Transactions
             if (!this.options.Enabled)
                 return false;
 
-            DateTime now = DateTime.UtcNow;
+            DateTime now = this.timeProvider.GetUtcNow().UtcDateTime;
             this.monitor.TryAction(now);
             double txPerSecondCurrently = CalculateTps(this.lastStatistics.TransactionsStarted, this.lastCheckTime, this.statistics.TransactionsStarted, now);
             //decaying utilization for tx per second

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -8,13 +8,18 @@ using Xunit;
 
 namespace UnitTestGrains
 {
+    internal static class TimerGrainTestConstants
+    {
+        public static readonly TimeSpan CallbackDelay = TimeSpan.FromMilliseconds(50);
+    }
+
     public class TimerGrain : Grain, ITimerGrain
     {
         private bool deactivating;
         private int counter = 0;
         private Dictionary<string, IDisposable> allTimers;
         private IDisposable defaultTimer;
-        private static readonly TimeSpan period = TimeSpan.FromMilliseconds(100);
+        private static readonly TimeSpan period = TimeSpan.FromMilliseconds(50);
         private readonly string DefaultTimerName = "DEFAULT TIMER";
         private IGrainContext context;
 
@@ -298,7 +303,7 @@ namespace UnitTestGrains
             CheckRuntimeContext(step);
 
             LogStatus("Before Delay");
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimerGrainTestConstants.CallbackDelay);
             step = "After Delay";
             LogStatus(step);
             CheckRuntimeContext(step);
@@ -445,7 +450,7 @@ namespace UnitTestGrains
             CheckReentrancy(step, expectedTickId);
 
             LogStatus("Before Delay", timerName);
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimerGrainTestConstants.CallbackDelay);
             step = "After Delay";
             LogStatus(step, timerName);
             CheckRuntimeContext(step);
@@ -662,7 +667,7 @@ namespace UnitTestGrains
         private int counter = 0;
         private Dictionary<string, IDisposable> allTimers;
         private IDisposable defaultTimer;
-        private static readonly TimeSpan period = TimeSpan.FromMilliseconds(100);
+        private static readonly TimeSpan period = TimeSpan.FromMilliseconds(50);
         private readonly string DefaultTimerName = "DEFAULT TIMER";
         private IGrainContext context;
 
@@ -955,7 +960,7 @@ namespace UnitTestGrains
             CheckRuntimeContext(step);
 
             LogStatus("Before Delay");
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimerGrainTestConstants.CallbackDelay);
             step = "After Delay";
             LogStatus(step);
             CheckRuntimeContext(step);
@@ -1284,7 +1289,7 @@ namespace UnitTestGrains
             CheckReentrancy(step, expectedTickId);
 
             LogStatus("Before Delay", timerName);
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimerGrainTestConstants.CallbackDelay);
             step = "After Delay";
             LogStatus(step, timerName);
             CheckRuntimeContext(step);

--- a/test/Orleans.DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/Orleans.DefaultCluster.Tests/TimerOrleansTest.cs
@@ -17,6 +17,8 @@ namespace DefaultCluster.Tests.TimerTests
     /// </summary>
     public class TimerOrleansTest : HostedTestClusterEnsureDefaultStarted
     {
+        private static readonly TimeSpan OneShotTimerDelay = TimeSpan.FromMilliseconds(100);
+        private static readonly TimeSpan TimerDiagnosticTimeout = TimeSpan.FromSeconds(10);
         private readonly ITestOutputHelper output;
 
         public TimerOrleansTest(ITestOutputHelper output, DefaultClusterFixture fixture)
@@ -48,6 +50,20 @@ namespace DefaultCluster.Tests.TimerTests
                 delay);
 
             return last;
+        }
+
+        private static async Task<int> DriveExternalTicksUntilTimerTicks(INonReentrantTimerCallGrain grain, TimerDiagnosticObserver timerObserver, int expectedTimerTicks)
+        {
+            var waitForTimers = timerObserver.WaitForTickCountAsync(grain, expectedTimerTicks, TimerDiagnosticTimeout);
+            var externalTicks = 0;
+            while (!waitForTimers.IsCompleted)
+            {
+                await grain.ExternalTick("external");
+                externalTicks++;
+            }
+
+            await waitForTimers;
+            return externalTicks;
         }
 
         /// <summary>
@@ -186,19 +202,19 @@ namespace DefaultCluster.Tests.TimerTests
         public async Task AsyncTimerTest_GrainCall()
         {
             const string testName = "AsyncTimerTest_GrainCall";
-            TimeSpan delay = TimeSpan.FromSeconds(5);
-            TimeSpan wait = delay.Multiply(2);
+            TimeSpan delay = OneShotTimerDelay;
 
             ITimerCallGrain grain = null;
 
             Exception error = null;
+            using var timerObserver = TimerDiagnosticObserver.Create();
             try
             {
                 grain = GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
 
                 await grain.StartTimer(testName, delay);
 
-                await Task.Delay(wait);
+                await timerObserver.WaitForTimerTickAsync(grain, TimerDiagnosticTimeout);
 
                 int tickCount = await grain.GetTickCount();
                 Assert.Equal(1, tickCount);
@@ -283,9 +299,9 @@ namespace DefaultCluster.Tests.TimerTests
         public async Task NonReentrantGrainTimer_Test()
         {
             const string testName = "NonReentrantGrainTimer_Test";
-            var delay = TimeSpan.FromSeconds(5);
-            var wait = delay.Multiply(2);
+            var delay = OneShotTimerDelay;
 
+            using var timerObserver = TimerDiagnosticObserver.Create();
             var grain = GrainFactory.GetGrain<INonReentrantTimerCallGrain>(GetRandomGrainId());
 
             // Schedule multiple timers with the same delay
@@ -293,14 +309,8 @@ namespace DefaultCluster.Tests.TimerTests
             await grain.StartTimer($"{testName}_1", delay);
             await grain.StartTimer($"{testName}_2", delay);
 
-            // Invoke some non-interleaving methods.
-            var externalTicks = 0;
-            var stopwatch = Stopwatch.StartNew();
-            while (stopwatch.Elapsed < wait)
-            {
-                await grain.ExternalTick("external");
-                externalTicks++;
-            }
+            // Invoke some non-interleaving methods while waiting for the timer callbacks.
+            var externalTicks = await DriveExternalTicksUntilTimerTicks(grain, timerObserver, expectedTimerTicks: 3);
 
             var tickCount = await grain.GetTickCount();
 
@@ -325,21 +335,21 @@ namespace DefaultCluster.Tests.TimerTests
         public async Task GrainTimer_Change()
         {
             const string testName = nameof(GrainTimer_Change);
-            TimeSpan delay = TimeSpan.FromSeconds(5);
-            TimeSpan wait = delay.Multiply(2);
+            TimeSpan delay = OneShotTimerDelay;
 
+            using var timerObserver = TimerDiagnosticObserver.Create();
             var grain = GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
 
             await grain.StartTimer(testName, delay);
 
-            await Task.Delay(wait);
+            await timerObserver.WaitForTickCountAsync(grain, 1, TimerDiagnosticTimeout);
 
             int tickCount = await grain.GetTickCount();
             Assert.Equal(1, tickCount);
 
             await grain.RestartTimer(testName, delay);
 
-            await Task.Delay(wait);
+            await timerObserver.WaitForTickCountAsync(grain, 2, TimerDiagnosticTimeout);
 
             tickCount = await grain.GetTickCount();
             Assert.Equal(2, tickCount);
@@ -368,20 +378,14 @@ namespace DefaultCluster.Tests.TimerTests
             // Valid operations called from within a timer: updating the period and disposing the timer.
             var grain2 = GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
             await grain2.StartTimer(testName, delay, "update_period");
-            await Task.Delay(wait);
+            await timerObserver.WaitForTickCountAsync(grain2, 1, TimerDiagnosticTimeout);
             Assert.Null(await grain2.GetException()); // Should be no exceptions during timer callback
             Assert.Equal(1, await grain2.GetTickCount());
 
             var grain3 = GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
             await grain3.StartTimer(testName, delay, "dispose_timer");
-            var grain3Timeout = wait.Multiply(2);
-            var grain3Stopwatch = Stopwatch.StartNew();
+            await timerObserver.WaitForTickCountAsync(grain3, 1, TimerDiagnosticTimeout);
             var grain3TickCount = await grain3.GetTickCount();
-            while (grain3Stopwatch.Elapsed < grain3Timeout && grain3TickCount < 1)
-            {
-                await Task.Delay(TimeSpan.FromMilliseconds(200));
-                grain3TickCount = await grain3.GetTickCount();
-            }
 
             Assert.Null(await grain3.GetException()); // Should be no exceptions during timer callback
             Assert.Equal(1, grain3TickCount);
@@ -525,19 +529,19 @@ namespace DefaultCluster.Tests.TimerTests
         public async Task AsyncTimerTest_GrainCall_Poco()
         {
             const string testName = "AsyncTimerTest_GrainCall";
-            TimeSpan delay = TimeSpan.FromSeconds(5);
-            TimeSpan wait = delay.Multiply(2);
+            TimeSpan delay = OneShotTimerDelay;
 
             IPocoTimerCallGrain grain = null;
 
             Exception error = null;
+            using var timerObserver = TimerDiagnosticObserver.Create();
             try
             {
                 grain = GrainFactory.GetGrain<IPocoTimerCallGrain>(GetRandomGrainId());
 
                 await grain.StartTimer(testName, delay);
 
-                await Task.Delay(wait);
+                await timerObserver.WaitForTimerTickAsync(grain, TimerDiagnosticTimeout);
 
                 int tickCount = await grain.GetTickCount();
                 Assert.Equal(1, tickCount);
@@ -604,9 +608,9 @@ namespace DefaultCluster.Tests.TimerTests
         public async Task NonReentrantGrainTimer_Test_Poco()
         {
             const string testName = "NonReentrantGrainTimer_Test";
-            var delay = TimeSpan.FromSeconds(5);
-            var wait = delay.Multiply(2);
+            var delay = OneShotTimerDelay;
 
+            using var timerObserver = TimerDiagnosticObserver.Create();
             var grain = GrainFactory.GetGrain<IPocoNonReentrantTimerCallGrain>(GetRandomGrainId());
 
             // Schedule multiple timers with the same delay
@@ -614,14 +618,8 @@ namespace DefaultCluster.Tests.TimerTests
             await grain.StartTimer($"{testName}_1", delay);
             await grain.StartTimer($"{testName}_2", delay);
 
-            // Invoke some non-interleaving methods.
-            var externalTicks = 0;
-            var stopwatch = Stopwatch.StartNew();
-            while (stopwatch.Elapsed < wait)
-            {
-                await grain.ExternalTick("external");
-                externalTicks++;
-            }
+            // Invoke some non-interleaving methods while waiting for the timer callbacks.
+            var externalTicks = await DriveExternalTicksUntilTimerTicks(grain, timerObserver, expectedTimerTicks: 3);
 
             var tickCount = await grain.GetTickCount();
 
@@ -645,21 +643,21 @@ namespace DefaultCluster.Tests.TimerTests
         public async Task GrainTimer_Change_Poco()
         {
             const string testName = nameof(GrainTimer_Change);
-            TimeSpan delay = TimeSpan.FromSeconds(5);
-            TimeSpan wait = delay.Multiply(2);
+            TimeSpan delay = OneShotTimerDelay;
 
+            using var timerObserver = TimerDiagnosticObserver.Create();
             var grain = GrainFactory.GetGrain<IPocoTimerCallGrain>(GetRandomGrainId());
 
             await grain.StartTimer(testName, delay);
 
-            await Task.Delay(wait);
+            await timerObserver.WaitForTickCountAsync(grain, 1, TimerDiagnosticTimeout);
 
             int tickCount = await grain.GetTickCount();
             Assert.Equal(1, tickCount);
 
             await grain.RestartTimer(testName, delay);
 
-            await Task.Delay(wait);
+            await timerObserver.WaitForTickCountAsync(grain, 2, TimerDiagnosticTimeout);
 
             tickCount = await grain.GetTickCount();
             Assert.Equal(2, tickCount);
@@ -688,13 +686,13 @@ namespace DefaultCluster.Tests.TimerTests
             // Valid operations called from within a timer: updating the period and disposing the timer.
             var grain2 = GrainFactory.GetGrain<IPocoTimerCallGrain>(GetRandomGrainId());
             await grain2.StartTimer(testName, delay, "update_period");
-            await Task.Delay(wait);
+            await timerObserver.WaitForTickCountAsync(grain2, 1, TimerDiagnosticTimeout);
             Assert.Null(await grain2.GetException()); // Should be no exceptions during timer callback
             Assert.Equal(1, await grain2.GetTickCount());
 
             var grain3 = GrainFactory.GetGrain<IPocoTimerCallGrain>(GetRandomGrainId());
             await grain3.StartTimer(testName, delay, "dispose_timer");
-            await Task.Delay(wait);
+            await timerObserver.WaitForTickCountAsync(grain3, 1, TimerDiagnosticTimeout);
             Assert.Null(await grain3.GetException()); // Should be no exceptions during timer callback
             Assert.Equal(1, await grain3.GetTickCount());
 

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationCollectorTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationCollectorTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Orleans.Configuration;
 using Orleans.Runtime;
+using Orleans.Runtime.Diagnostics;
 using Orleans.Serialization.TypeSystem;
 using Orleans.TestingHost;
 using Tester;
@@ -19,10 +20,12 @@ namespace UnitTests.ActivationsLifeCycleTests
     /// </summary>
     public class ActivationCollectorTests : OrleansTestingBase, IAsyncLifetime
     {
-        private static readonly TimeSpan DEFAULT_COLLECTION_QUANTUM = TimeSpan.FromSeconds(10);
-        private static readonly TimeSpan DEFAULT_IDLE_TIMEOUT = DEFAULT_COLLECTION_QUANTUM + TimeSpan.FromSeconds(1);
-        private static readonly TimeSpan WAIT_TIME = DEFAULT_IDLE_TIMEOUT.Multiply(3.0);
-        private static readonly TimeSpan COLLECTION_SPECIFIC_AGE_LIMIT = TimeSpan.FromSeconds(12);
+        private static readonly TimeSpan DEFAULT_COLLECTION_QUANTUM = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan DEFAULT_IDLE_TIMEOUT = TimeSpan.FromSeconds(3);
+        private static readonly TimeSpan WAIT_TIME = DEFAULT_IDLE_TIMEOUT + DEFAULT_COLLECTION_QUANTUM.Multiply(2.0);
+        private static readonly TimeSpan COLLECTION_SPECIFIC_AGE_LIMIT = TimeSpan.FromSeconds(3);
+        private static readonly TimeSpan FORCED_COLLECTION_AGE_LIMIT = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan FORCED_COLLECTION_WAIT_TIME = FORCED_COLLECTION_AGE_LIMIT + TimeSpan.FromMilliseconds(250);
 
         private TestCluster testCluster;
 
@@ -105,16 +108,22 @@ namespace UnitTests.ActivationsLifeCycleTests
             }
             await Task.WhenAll(tasks);
 
-            await Task.Delay(TimeSpan.FromSeconds(5));
+            await Task.Delay(FORCED_COLLECTION_WAIT_TIME);
 
             var grain = this.testCluster.GrainFactory.GetGrain<IManagementGrain>(0);
 
-            await grain.ForceActivationCollection(TimeSpan.FromSeconds(4));
+            using var collectionObserver = ActivationCollectionObserver.Create();
+            await grain.ForceActivationCollection(FORCED_COLLECTION_AGE_LIMIT);
+            await collectionObserver.WaitForCollectedCountAsync(
+                fullGrainTypeName,
+                grainCount,
+                DeactivationReasonCode.ActivationIdle,
+                TestConstants.InitTimeout);
 
             int activationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, fullGrainTypeName);
             Assert.Equal(0, activationsNotCollected);
 
-            await grain.ForceActivationCollection(TimeSpan.FromSeconds(4));
+            await grain.ForceActivationCollection(FORCED_COLLECTION_AGE_LIMIT);
         }
 
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
@@ -138,10 +147,9 @@ namespace UnitTests.ActivationsLifeCycleTests
             Assert.Equal(grainCount, activationsCreated);
 
             logger.LogInformation(
-                "IdleActivationCollectorShouldCollectIdleActivations: grains activated; waiting {WaitSeconds} sec (activation GC idle timeout is {DefaultIdleTime} sec).",
-                WAIT_TIME.TotalSeconds,
+                "IdleActivationCollectorShouldCollectIdleActivations: grains activated; waiting for activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
                 DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-            await Task.Delay(WAIT_TIME);
+            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0);
 
             int activationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, fullGrainTypeName);
             Assert.Equal(0, activationsNotCollected);
@@ -171,9 +179,9 @@ namespace UnitTests.ActivationsLifeCycleTests
             async Task busyWorker()
             {
                 logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivations: busyWorker started");
-                List<Task> tasks1 = new List<Task>();
                 while (!quit[0])
                 {
+                    List<Task> tasks1 = new List<Task>(busyGrains.Count);
                     foreach (var g in busyGrains)
                         tasks1.Add(g.Nop());
                     await Task.WhenAll(tasks1);
@@ -194,10 +202,9 @@ namespace UnitTests.ActivationsLifeCycleTests
             Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
 
             logger.LogInformation(
-                "ActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting {WaitSeconds} sec (activation GC idle timeout is {DefaultIdleTime} sec).",
-                WAIT_TIME.TotalSeconds,
+                "ActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
                 DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-            await Task.Delay(WAIT_TIME);
+            await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
 
             // we should have only collected grains from the idle category (IdleActivationGcTestGrain1).
             int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, idleGrainTypeName);
@@ -213,7 +220,7 @@ namespace UnitTests.ActivationsLifeCycleTests
         {
             await Initialize(DEFAULT_IDLE_TIMEOUT);
 
-            TimeSpan shortIdleTimeout = TimeSpan.FromSeconds(1);
+            TimeSpan shortIdleTimeout = FORCED_COLLECTION_WAIT_TIME;
             const int idleGrainCount = 500;
             const int busyGrainCount = 500;
             var idleGrainTypeName = RuntimeTypeNameFormatter.Format(typeof(IdleActivationGcTestGrain1));
@@ -233,9 +240,9 @@ namespace UnitTests.ActivationsLifeCycleTests
             async Task busyWorker()
             {
                 logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: busyWorker started");
-                List<Task> tasks1 = new List<Task>();
                 while (!quit[0])
                 {
+                    List<Task> tasks1 = new List<Task>(busyGrains.Count);
                     foreach (var g in busyGrains)
                         tasks1.Add(g.Nop());
                     await Task.WhenAll(tasks1);
@@ -268,10 +275,9 @@ namespace UnitTests.ActivationsLifeCycleTests
 
 
             logger.LogInformation(
-                "ManualCollectionShouldNotCollectBusyActivations: waiting {WaitSeconds} sec (activation GC idle timeout is {DefaultIdleTime} sec).",
-                WAIT_TIME.TotalSeconds,
+                "ManualCollectionShouldNotCollectBusyActivations: waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
                 DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-            await Task.Delay(WAIT_TIME);
+            await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
 
             // we should have only collected grains from the idle category (IdleActivationGcTestGrain).
             int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, idleGrainTypeName);
@@ -305,10 +311,9 @@ namespace UnitTests.ActivationsLifeCycleTests
             Assert.Equal(grainCount, activationsCreated);
 
             logger.LogInformation(
-                "ActivationCollectorShouldCollectIdleActivationsSpecifiedInPerTypeConfiguration: grains activated; waiting {WaitSeconds} sec (activation GC idle timeout is {DefaultIdleTime} sec).",
-                WAIT_TIME.TotalSeconds,
+                "ActivationCollectorShouldCollectIdleActivationsSpecifiedInPerTypeConfiguration: grains activated; waiting for activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
                 DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-            await Task.Delay(WAIT_TIME);
+            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0);
 
             int activationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, fullGrainTypeName);
             Assert.Equal(0, activationsNotCollected);
@@ -340,9 +345,9 @@ namespace UnitTests.ActivationsLifeCycleTests
             async Task busyWorker()
             {
                 logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: busyWorker started");
-                List<Task> tasks1 = new List<Task>();
                 while (!quit[0])
                 {
+                    List<Task> tasks1 = new List<Task>(busyGrains.Count);
                     foreach (var g in busyGrains)
                         tasks1.Add(g.Nop());
                     await Task.WhenAll(tasks1);
@@ -363,10 +368,9 @@ namespace UnitTests.ActivationsLifeCycleTests
             Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
 
             logger.LogInformation(
-                "IdleActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting {WaitSeconds} sec (activation GC idle timeout is {DefaultIdleTime} sec).",
-                WAIT_TIME.TotalSeconds,
+                "IdleActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
                 DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-            await Task.Delay(WAIT_TIME);
+            await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
 
             // we should have only collected grains from the idle category (IdleActivationGcTestGrain2).
             int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, idleGrainTypeName);
@@ -494,7 +498,7 @@ namespace UnitTests.ActivationsLifeCycleTests
         }
 
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
-        public async Task ActivationCollectorShouldCollectByCollectionSpecificAgeLimitForTwelveSeconds()
+        public async Task ActivationCollectorShouldCollectByCollectionSpecificAgeLimit()
         {
             var defaultCollectionAge = COLLECTION_SPECIFIC_AGE_LIMIT.Multiply(4);
             //make sure defaultCollectionAge value won't cause activation collection before the per-type limit
@@ -502,7 +506,7 @@ namespace UnitTests.ActivationsLifeCycleTests
 
             const int grainCount = 1000;
 
-            // CollectionAgeLimit = 12 seconds
+            // CollectionAgeLimit is configured per type.
             var fullGrainTypeName = RuntimeTypeNameFormatter.Format(typeof(CollectionSpecificAgeLimitForTenSecondsActivationGcTestGrain));
 
             List<Task> tasks = new List<Task>();
@@ -526,28 +530,162 @@ namespace UnitTests.ActivationsLifeCycleTests
             int activationsAfterDefaultCollection = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, fullGrainTypeName);
             Assert.Equal(grainCount, activationsAfterDefaultCollection);
 
-            await WaitForActivationCountToConverge(fullGrainTypeName, activationCollector, expectedCount: 0);
+            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0);
         }
 
-        private async Task WaitForActivationCountToConverge(string grainTypeName, ActivationCollector activationCollector, int expectedCount)
+        private async Task WaitForActivationCountToConverge(string grainTypeName, int expectedCount)
         {
-            var deadline = DateTime.UtcNow + TestConstants.InitTimeout;
+            using var collectionObserver = ActivationCollectionObserver.Create();
             var activationCount = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, grainTypeName);
-
-            while (activationCount != expectedCount && DateTime.UtcNow < deadline)
+            if (activationCount == expectedCount)
             {
-                await activationCollector.CollectStaleActivations(CancellationToken.None);
-                activationCount = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, grainTypeName);
+                return;
+            }
 
-                if (activationCount == expectedCount)
+            var expectedCollectedCount = activationCount - expectedCount;
+            Assert.True(expectedCollectedCount > 0, $"Expected activation count for {grainTypeName} to decrease from {activationCount} to {expectedCount}.");
+
+            await collectionObserver.WaitForCollectedCountAsync(
+                grainTypeName,
+                expectedCollectedCount,
+                DeactivationReasonCode.ActivationIdle,
+                TestConstants.InitTimeout);
+
+            activationCount = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, grainTypeName);
+            Assert.Equal(expectedCount, activationCount);
+        }
+
+        private sealed class ActivationCollectionObserver : IDisposable, IObserver<ActivationCollectionEvents.CollectionEvent>
+        {
+            private readonly object _lock = new();
+            private readonly List<ActivationCollectionEvents.CollectionCompleted> _completedEvents = [];
+            private readonly List<Waiter> _waiters = [];
+            private IDisposable _subscription;
+
+            public static ActivationCollectionObserver Create()
+            {
+                var observer = new ActivationCollectionObserver();
+                observer._subscription = ActivationCollectionEvents.AllEvents.Subscribe(observer);
+                return observer;
+            }
+
+            public async Task WaitForCollectedCountAsync(
+                string grainTypeName,
+                int expectedCount,
+                DeactivationReasonCode reasonCode,
+                TimeSpan timeout)
+            {
+                var waiter = new Waiter(grainTypeName, expectedCount, reasonCode);
+                lock (_lock)
+                {
+                    if (GetCollectedCount(waiter) >= expectedCount)
+                    {
+                        return;
+                    }
+
+                    _waiters.Add(waiter);
+                }
+
+                using var cancellation = new CancellationTokenSource(timeout);
+                using var registration = cancellation.Token.Register(static state => ((Waiter)state!).TrySetCanceled(), waiter);
+
+                try
+                {
+                    await waiter.Task;
+                }
+                catch (OperationCanceledException)
+                {
+                    var count = GetCollectedCount(waiter);
+                    throw new TimeoutException($"Timed out waiting for {expectedCount} collected activations of grain type '{grainTypeName}' with reason {reasonCode}. Current count: {count} after {timeout}.");
+                }
+                finally
+                {
+                    lock (_lock)
+                    {
+                        _waiters.Remove(waiter);
+                    }
+                }
+            }
+
+            void IObserver<ActivationCollectionEvents.CollectionEvent>.OnNext(ActivationCollectionEvents.CollectionEvent value)
+            {
+                if (value is not ActivationCollectionEvents.CollectionCompleted completed)
                 {
                     return;
                 }
 
-                await Task.Delay(TimeSpan.FromMilliseconds(250));
+                lock (_lock)
+                {
+                    _completedEvents.Add(completed);
+                    foreach (var waiter in _waiters)
+                    {
+                        if (GetCollectedCount(waiter) >= waiter.ExpectedCount)
+                        {
+                            waiter.TrySetResult();
+                        }
+                    }
+
+                    _waiters.RemoveAll(static waiter => waiter.IsCompleted);
+                }
             }
 
-            Assert.Equal(expectedCount, activationCount);
+            void IObserver<ActivationCollectionEvents.CollectionEvent>.OnError(Exception error)
+            {
+            }
+
+            void IObserver<ActivationCollectionEvents.CollectionEvent>.OnCompleted()
+            {
+            }
+
+            public void Dispose()
+            {
+                _subscription?.Dispose();
+            }
+
+            private int GetCollectedCount(Waiter waiter)
+            {
+                lock (_lock)
+                {
+                    var result = 0;
+                    foreach (var completed in _completedEvents)
+                    {
+                        if (completed.Reason.ReasonCode != waiter.ReasonCode)
+                        {
+                            continue;
+                        }
+
+                        foreach (var activation in completed.Activations)
+                        {
+                            if (MatchesGrainType(activation.GrainId, waiter.GrainTypeName))
+                            {
+                                result++;
+                            }
+                        }
+                    }
+
+                    return result;
+                }
+            }
+
+            private static bool MatchesGrainType(GrainId grainId, string grainTypeName)
+            {
+                var eventGrainTypeName = grainId.Type.ToString()!;
+                return eventGrainTypeName.Contains(grainTypeName, StringComparison.OrdinalIgnoreCase)
+                    || grainTypeName.Contains(eventGrainTypeName, StringComparison.OrdinalIgnoreCase);
+            }
+
+            private sealed class Waiter(string grainTypeName, int expectedCount, DeactivationReasonCode reasonCode)
+            {
+                private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                public string GrainTypeName { get; } = grainTypeName;
+                public int ExpectedCount { get; } = expectedCount;
+                public DeactivationReasonCode ReasonCode { get; } = reasonCode;
+                public Task Task => _completion.Task;
+                public bool IsCompleted => _completion.Task.IsCompleted;
+                public void TrySetResult() => _completion.TrySetResult();
+                public void TrySetCanceled() => _completion.TrySetCanceled();
+            }
         }
 
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
@@ -562,19 +700,15 @@ namespace UnitTests.ActivationsLifeCycleTests
             await grain.SetKeepAlive(TimeSpan.FromMinutes(5));
 
             // Verify the grain is not collected while it has an active keep-alive.
-            await Task.Delay(WAIT_TIME);
+            var mgmtGrain = this.testCluster.GrainFactory.GetGrain<IManagementGrain>(0);
+            await mgmtGrain.ForceActivationCollection(TimeSpan.Zero);
             int activationsWithKeepAlive = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, fullGrainTypeName);
             Assert.Equal(1, activationsWithKeepAlive);
 
             // Cancel the keep-alive. The grain should now be collectable after the standard idle timeout.
             await grain.CancelKeepAlive();
 
-            // Wait for the grain to become idle past the collection age limit.
-            await Task.Delay(DEFAULT_IDLE_TIMEOUT + DEFAULT_COLLECTION_QUANTUM);
-
-            // Force collection to deterministically verify the grain is now collectable.
-            var mgmtGrain = this.testCluster.GrainFactory.GetGrain<IManagementGrain>(0);
-            await mgmtGrain.ForceActivationCollection(DEFAULT_IDLE_TIMEOUT);
+            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0);
 
             int activationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory, fullGrainTypeName);
             Assert.Equal(0, activationsNotCollected);
@@ -583,15 +717,16 @@ namespace UnitTests.ActivationsLifeCycleTests
         [Fact, TestCategory("SlowBVT"), TestCategory("Timers")]
         public async Task NonReentrantGrainTimer_NoKeepAlive_Test()
         {
-            await Initialize(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1));
+            await Initialize(DEFAULT_IDLE_TIMEOUT, DEFAULT_COLLECTION_QUANTUM);
 
             const string testName = "NonReentrantGrainTimer_NoKeepAlive_Test";
 
             var grain = this.testCluster.GrainFactory.GetGrain<INonReentrantTimerCallGrain>(GetRandomGrainId());
+            var fullGrainTypeName = RuntimeTypeNameFormatter.Format(typeof(NonReentrantTimerCallGrain));
 
             // Schedule a timer to fire at the 30s mark which will not extend the grain's lifetime.
             await grain.StartTimer(testName, TimeSpan.FromSeconds(30), keepAlive: false);
-            await Task.Delay(TimeSpan.FromSeconds(7));
+            await WaitForActivationCountToConverge(fullGrainTypeName, expectedCount: 0);
 
             var tickCount = await grain.GetTickCount();
 

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionOverloadDetectorTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionOverloadDetectorTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 using Xunit.Abstractions;
 using Xunit;
 using Orleans.Transactions.Abstractions;
@@ -25,23 +24,37 @@ namespace Orleans.Transactions.Tests
             TimeSpan runTime = TimeSpan.FromSeconds(runTimeInSeconds);
             TransactionRateLoadSheddingOptions options = new TransactionRateLoadSheddingOptions { Enabled = true, Limit = limit };
             ITransactionAgentStatistics statistics = new TransactionAgentStatistics();
-            ITransactionOverloadDetector detector = new TransactionOverloadDetector(statistics, Options.Create(options));
-            Stopwatch sw = Stopwatch.StartNew();
+            var timeProvider = new TestTimeProvider(DateTimeOffset.UtcNow);
+            ITransactionOverloadDetector detector = new TransactionOverloadDetector(statistics, Options.Create(options), timeProvider);
+            var start = timeProvider.GetUtcNow();
+            var attemptInterval = TimeSpan.FromTicks(TimeSpan.TicksPerSecond / 10_000);
             long total = 0;
-            while (sw.Elapsed < runTime)
+            while (timeProvider.GetUtcNow() - start < runTime)
             {
                 total++;
                 if (!detector.IsOverloaded())
                 {
                     statistics.TrackTransactionStarted();
                 }
+
+                timeProvider.Advance(attemptInterval);
             }
-            sw.Stop();
-            double averageRate = (statistics.TransactionsStarted * 1000) / sw.ElapsedMilliseconds;
-            this.output.WriteLine($"Average of {averageRate}, with target of {options.Limit}.  Performed {statistics.TransactionsStarted} transactions of a max of {total} in {sw.ElapsedMilliseconds}ms.");
+
+            var elapsed = timeProvider.GetUtcNow() - start;
+            double averageRate = statistics.TransactionsStarted / elapsed.TotalSeconds;
+            this.output.WriteLine($"Average of {averageRate}, with target of {options.Limit}. Performed {statistics.TransactionsStarted} transactions of a max of {total} in {elapsed.TotalMilliseconds} simulated ms.");
             // check to make sure average rate is withing rate +- 10%
             Assert.True(options.Limit * 0.9 <= averageRate);
             Assert.True(options.Limit * 1.1 >= averageRate);
+        }
+
+        private sealed class TestTimeProvider(DateTimeOffset utcNow) : TimeProvider
+        {
+            private DateTimeOffset _utcNow = utcNow;
+
+            public override DateTimeOffset GetUtcNow() => _utcNow;
+
+            public void Advance(TimeSpan timeSpan) => _utcNow += timeSpan;
         }
     }
 }


### PR DESCRIPTION
Speeds up runtime timer, activation collection, and transaction overload tests using timer diagnostics, activation collection completion diagnostics, and TimeProvider-driven simulated time.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10209)