### PR TITLE
test: remove slow ring cleanup sleep

### DIFF
--- a/test/Orleans.Runtime.Internal.Tests/General/ConsistentRingProviderTests_Silo.cs
+++ b/test/Orleans.Runtime.Internal.Tests/General/ConsistentRingProviderTests_Silo.cs
@@ -145,7 +145,6 @@ namespace UnitTests.General
             {
                 await VerificationScenario(PickKey(sh.SiloAddress));
             }
-            Thread.Sleep(TimeSpan.FromSeconds(15));
         }
 
         [Fact, TestCategory("Functional"), TestCategory("Ring")]


### PR DESCRIPTION
Removes an unconditional sleep from consistent ring tests now that the test already waits for liveness stabilization and validates ring state explicitly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10210)