### PR TITLE
test: make delayed queue rebalance waits event-driven

### DIFF
--- a/src/Orleans.Streaming/Diagnostics/StreamingEvents.cs
+++ b/src/Orleans.Streaming/Diagnostics/StreamingEvents.cs
@@ -410,6 +410,61 @@ public static class StreamingEvents
         public readonly IStreamQueueBalancer QueueBalancer = queueBalancer;
     }
 
+    /// <summary>
+    /// Event payload for when a pulling agent manager reports its current queue assignments.
+    /// </summary>
+    /// <param name="streamProvider">The name of the stream provider.</param>
+    /// <param name="siloAddress">The address of the silo.</param>
+    /// <param name="currentQueues">The queues currently owned by the manager.</param>
+    /// <param name="runningAgents">The number of running pulling agents.</param>
+    public sealed class PullingAgentManagerState(
+        string streamProvider,
+        SiloAddress? siloAddress,
+        QueueId[] currentQueues,
+        int runningAgents) : StreamingEvent(streamProvider, siloAddress)
+    {
+        /// <summary>
+        /// The queues currently owned by the manager.
+        /// </summary>
+        public readonly QueueId[] CurrentQueues = currentQueues;
+
+        /// <summary>
+        /// The number of running pulling agents.
+        /// </summary>
+        public readonly int RunningAgents = runningAgents;
+    }
+
+    /// <summary>
+    /// Event payload for when a deployment-based queue balancer completes a silo maturity transition.
+    /// </summary>
+    /// <param name="streamProvider">The name of the stream provider.</param>
+    /// <param name="siloAddress">The address of the silo running the queue balancer.</param>
+    /// <param name="maturedSiloAddress">The silo whose maturity period completed.</param>
+    /// <param name="isLocalSilo">Whether the matured silo is the local silo.</param>
+    /// <param name="queueBalancer">The queue balancer instance.</param>
+    public sealed class QueueBalancerMaturityCompleted(
+        string streamProvider,
+        SiloAddress? siloAddress,
+        SiloAddress maturedSiloAddress,
+        bool isLocalSilo,
+        IStreamQueueBalancer queueBalancer) : StreamingEvent(streamProvider, siloAddress)
+    {
+        /// <summary>
+        /// The silo whose maturity period completed.
+        /// </summary>
+        public readonly SiloAddress MaturedSiloAddress = maturedSiloAddress;
+
+        /// <summary>
+        /// Whether the matured silo is the local silo.
+        /// </summary>
+        public readonly bool IsLocalSilo = isLocalSilo;
+
+        /// <summary>
+        /// The queue balancer instance.
+        /// </summary>
+        public readonly IStreamQueueBalancer QueueBalancer = queueBalancer;
+    }
+
     internal static void EmitMessageDelivered(string streamProviderName, StreamConsumerData consumerData, IBatchContainer batch, SiloAddress? siloAddress)
     {
         if (!Listener.IsEnabled(nameof(MessageDelivered)))
@@ -680,6 +735,57 @@ public static class StreamingEvents
                 siloAddress,
                 oldQueues,
                 newQueues,
+                queueBalancer));
+        }
+    }
+
+    internal static void EmitPullingAgentManagerState(string streamProviderName, SiloAddress? siloAddress, IEnumerable<QueueId> currentQueues, int runningAgents)
+    {
+        if (!Listener.IsEnabled(nameof(PullingAgentManagerState)))
+        {
+            return;
+        }
+
+        Emit(streamProviderName, siloAddress, currentQueues, runningAgents);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(string streamProviderName, SiloAddress? siloAddress, IEnumerable<QueueId> currentQueues, int runningAgents)
+        {
+            Listener.Write(nameof(PullingAgentManagerState), new PullingAgentManagerState(
+                streamProviderName,
+                siloAddress,
+                [.. currentQueues],
+                runningAgents));
+        }
+    }
+
+    internal static void EmitQueueBalancerMaturityCompleted(
+        string streamProviderName,
+        SiloAddress? siloAddress,
+        SiloAddress maturedSiloAddress,
+        bool isLocalSilo,
+        IStreamQueueBalancer queueBalancer)
+    {
+        if (!Listener.IsEnabled(nameof(QueueBalancerMaturityCompleted)))
+        {
+            return;
+        }
+
+        Emit(streamProviderName, siloAddress, maturedSiloAddress, isLocalSilo, queueBalancer);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(
+            string streamProviderName,
+            SiloAddress? siloAddress,
+            SiloAddress maturedSiloAddress,
+            bool isLocalSilo,
+            IStreamQueueBalancer queueBalancer)
+        {
+            Listener.Write(nameof(QueueBalancerMaturityCompleted), new QueueBalancerMaturityCompleted(
+                streamProviderName,
+                siloAddress,
+                maturedSiloAddress,
+                isLocalSilo,
                 queueBalancer));
         }
     }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
@@ -142,6 +142,7 @@ namespace Orleans.Streams
             await AddNewQueues(myQueues, true);
             EmitAgentQueueChange(previousQueues);
             LogInfoStarted();
+            EmitPullingAgentManagerState();
         }
 
         public async Task StopAgents()
@@ -218,6 +219,7 @@ namespace Orleans.Streams
                     notificationSeqNumber,
                     NumberRunningAgents,
                     new(queuesToAgentsMap.Keys));
+                EmitPullingAgentManagerState();
             }
         }
 
@@ -402,6 +404,11 @@ namespace Orleans.Streams
                     NumberRunningAgents,
                     new(queuesToAgentsMap.Keys));
             }
+        }
+
+        private void EmitPullingAgentManagerState()
+        {
+            StreamingEvents.EmitPullingAgentManagerState(streamProviderName, Silo, queuesToAgentsMap.Keys, NumberRunningAgents);
         }
 
         public async Task<object?> ExecuteCommand(PersistentStreamProviderCommand command, object? arg)

--- a/src/Orleans.Streaming/QueueBalancer/DeploymentBasedQueueBalancer.cs
+++ b/src/Orleans.Streaming/QueueBalancer/DeploymentBasedQueueBalancer.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Orleans.Streaming.Diagnostics;
 
 namespace Orleans.Streams
 {
@@ -26,6 +27,7 @@ namespace Orleans.Streams
         private readonly TimeProvider _timeProvider;
         private readonly ConcurrentDictionary<SiloAddress, bool> immatureSilos;
         private List<QueueId> allQueues = null!; // Initialized in Initialize.
+        private string _name;
         private bool isStarting;
         
         public DeploymentBasedQueueBalancer(
@@ -40,6 +42,7 @@ namespace Orleans.Streams
             this.deploymentConfig = deploymentConfig ?? throw new ArgumentNullException(nameof(deploymentConfig));
             this.options = options;
             _timeProvider = services.GetKeyedService<TimeProvider>(StreamingTimeProviderNames.Streaming) ?? TimeProvider.System;
+            _name = string.Empty;
 
             isStarting = true;
 
@@ -54,7 +57,9 @@ namespace Orleans.Streams
         public static IStreamQueueBalancer Create(IServiceProvider services, string name, IDeploymentConfiguration deploymentConfiguration)
         {
             var options = services.GetRequiredService<IOptionsMonitor<DeploymentBasedQueueBalancerOptions>>().Get(name);
-            return ActivatorUtilities.CreateInstance<DeploymentBasedQueueBalancer>(services, options, deploymentConfiguration);
+            var balancer = ActivatorUtilities.CreateInstance<DeploymentBasedQueueBalancer>(services, options, deploymentConfiguration);
+            balancer._name = name;
+            return balancer;
         }
 
         public override Task Initialize(IStreamQueueMapper queueMapper)
@@ -73,13 +78,15 @@ namespace Orleans.Streams
             await Task.Delay(this.options.SiloMaturityPeriod, _timeProvider);
             isStarting = false;
             await NotifyListeners();
+            StreamingEvents.EmitQueueBalancerMaturityCompleted(_name, SiloAddress, siloStatusOracle.SiloAddress, isLocalSilo: true, this);
         }
 
-        private async Task RecordImmatureSilo(SiloAddress updatedSilo)
+        private async Task<SiloAddress> RecordImmatureSilo(SiloAddress updatedSilo)
         {
             immatureSilos[updatedSilo] = true;      // record as immature
             await Task.Delay(this.options.SiloMaturityPeriod, _timeProvider);
             immatureSilos[updatedSilo] = false;     // record as mature
+            return updatedSilo;
         }
 
         public override IEnumerable<QueueId> GetMyQueues()
@@ -159,7 +166,7 @@ namespace Orleans.Streams
 
         private async Task SignalClusterChange(HashSet<SiloAddress> activeSilos)
         {
-            List<Task> tasks = new List<Task>();
+            List<Task<SiloAddress>> tasks = new List<Task<SiloAddress>>();
             // look at all currently active silos not including myself
             foreach (var silo in activeSilos)
             {
@@ -175,8 +182,12 @@ namespace Orleans.Streams
             }
             if (tasks.Count > 0)
             {
-                await Task.WhenAll(tasks);
+                var maturedSilos = await Task.WhenAll(tasks);
                 await this.NotifyListeners(); // notify, uncoditionaly, and deal with changes it in GetMyQueues()
+                foreach (var maturedSilo in maturedSilos)
+                {
+                    StreamingEvents.EmitQueueBalancerMaturityCompleted(_name, SiloAddress, maturedSilo, isLocalSilo: false, this);
+                }
             }
         }
     }

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1179,6 +1179,21 @@ namespace Orleans.Streaming.Diagnostics
             public ProducerUnregistered(string streamProvider, Runtime.StreamId streamId, Runtime.GrainId producerGrainId, Runtime.SiloAddress? siloAddress) : base(default!, default) { }
         }
 
+        public sealed partial class PullingAgentManagerState : StreamingEvent
+        {
+            public readonly Streams.QueueId[] CurrentQueues;
+            public readonly int RunningAgents;
+            public PullingAgentManagerState(string streamProvider, Runtime.SiloAddress? siloAddress, Streams.QueueId[] currentQueues, int runningAgents) : base(default!, default) { }
+        }
+
+        public sealed partial class QueueBalancerMaturityCompleted : StreamingEvent
+        {
+            public readonly bool IsLocalSilo;
+            public readonly Runtime.SiloAddress MaturedSiloAddress;
+            public readonly Streams.IStreamQueueBalancer QueueBalancer;
+            public QueueBalancerMaturityCompleted(string streamProvider, Runtime.SiloAddress? siloAddress, Runtime.SiloAddress maturedSiloAddress, bool isLocalSilo, Streams.IStreamQueueBalancer queueBalancer) : base(default!, default) { }
+        }
+
         public sealed partial class StreamInactive : StreamingEvent
         {
             public readonly System.TimeSpan InactivityPeriod;

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
@@ -4,10 +4,9 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Providers.Streams.AzureQueue;
-using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
+using Orleans.Streaming.Diagnostics;
 using Orleans.TestingHost;
-using Orleans.TestingHost.Utils;
 using TestExtensions;
 using UnitTests.StreamingTests;
 using Xunit;
@@ -18,19 +17,21 @@ namespace Tester.AzureUtils.Streaming
     public class DelayedQueueRebalancingTests : TestClusterPerTest
     {
         private const string adapterName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;
-#pragma warning disable 618
-        private readonly string adapterType = typeof(PersistentStreamProvider).FullName!;
-#pragma warning restore 618
         private static readonly TimeSpan SILO_IMMATURE_PERIOD = TimeSpan.FromSeconds(15);
         private static readonly TimeSpan AGENT_STATE_TIMEOUT = SILO_IMMATURE_PERIOD + TimeSpan.FromSeconds(20);
-        private static readonly TimeSpan AGENT_STATE_POLL_INTERVAL = TimeSpan.FromMilliseconds(500);
         private const int queueCount = 8;
+        private StreamQueueDiagnosticObserver diagnosticObserver = null!;
+
+        public override async Task InitializeAsync()
+        {
+            diagnosticObserver = StreamQueueDiagnosticObserver.Create(adapterName);
+            await base.InitializeAsync();
+        }
+
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
             TestUtils.CheckForAzureStorage();
 
-            // Define a cluster of 4, but 2 will be stopped.
-            builder.CreateSiloAsync = StandaloneSiloHandle.CreateForAssembly(this.GetType().Assembly);
             builder.Options.InitialSilosCount = 2;
             builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
         }
@@ -67,72 +68,225 @@ namespace Tester.AzureUtils.Streaming
 
         public override async Task DisposeAsync()
         {
-            await base.DisposeAsync();
+            var cluster = this.HostedCluster;
             try
             {
-                TestUtils.CheckForAzureStorage();
-                await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
-                    AzureQueueUtilities.GenerateQueueNames(this.HostedCluster.Options.ClusterId, queueCount),
-                    new AzureQueueOptions().ConfigureTestDefaults());
+                await base.DisposeAsync();
             }
-            catch (SkipException) { }
+            finally
+            {
+                diagnosticObserver?.Dispose();
+                if (cluster is not null)
+                {
+                    try
+                    {
+                        TestUtils.CheckForAzureStorage();
+                        await AzureQueueStreamProviderUtils.DeleteAllUsedAzureQueues(NullLoggerFactory.Instance,
+                            AzureQueueUtilities.GenerateQueueNames(cluster.Options.ClusterId, queueCount),
+                            new AzureQueueOptions().ConfigureTestDefaults());
+                    }
+                    catch (SkipException) { }
+                }
+            }
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task DelayedQueueRebalancingTests_1()
         {
-            await WaitForAgentsState(2, 2, "1");
+            await WaitForAgentsState(2, "1");
 
-            await WaitForAgentsState(2, 4, "2");
+            await WaitForAgentsState(4, "2");
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task DelayedQueueRebalancingTests_2()
         {
-            await WaitForAgentsState(2, 2, "1");
+            await WaitForAgentsState(2, "1");
 
-            await this.HostedCluster.StartAdditionalSilosAsync(2, true);
-            await WaitForAgentsState(4, 2, "2");
+            var existingSilos = this.HostedCluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToArray();
+            var addedSilos = await this.HostedCluster.StartAdditionalSilosAsync(2, true);
+            var addedSiloAddresses = addedSilos.Select(silo => silo.SiloAddress).ToArray();
+            var activeSiloAddresses = this.HostedCluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToArray();
 
-            // The expected queue distribution is unchanged after maturity, so there is no provider state transition to poll for.
-            await Task.Delay(SILO_IMMATURE_PERIOD);
-            await WaitForAgentsState(4, 2, "3");
+            await WaitForAgentsState(2, "2");
+
+            await diagnosticObserver.WaitForLocalMaturityAsync(activeSiloAddresses, AGENT_STATE_TIMEOUT, "3");
+            await diagnosticObserver.WaitForRemoteMaturityAsync(existingSilos, addedSiloAddresses, AGENT_STATE_TIMEOUT, "3");
+            await WaitForAgentsState(2, "3");
         }
 
-        private Task WaitForAgentsState(int numExpectedSilos, int numExpectedAgentsPerSilo, string callContext)
+        private Task WaitForAgentsState(int numExpectedAgentsPerSilo, string callContext)
         {
-            return TestingUtils.WaitUntilAsync(
-                assertIsTrue => ValidateAgentsState(numExpectedSilos, numExpectedAgentsPerSilo, callContext, assertIsTrue),
-                AGENT_STATE_TIMEOUT,
-                AGENT_STATE_POLL_INTERVAL);
+            var activeSilos = this.HostedCluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToArray();
+            return diagnosticObserver.WaitForAgentsStateAsync(activeSilos, numExpectedAgentsPerSilo, AGENT_STATE_TIMEOUT, callContext);
         }
 
-        private async Task<bool> ValidateAgentsState(int numExpectedSilos, int numExpectedAgentsPerSilo, string callContext, bool assertIsTrue)
+        private sealed class StreamQueueDiagnosticObserver : IDisposable, IObserver<StreamingEvents.StreamingEvent>
         {
-            try
+            private readonly string streamProvider;
+            private readonly IDisposable subscription;
+            private readonly object lockObj = new();
+            private readonly Dictionary<SiloAddress, StreamingEvents.PullingAgentManagerState> agentStates = [];
+            private readonly HashSet<SiloAddress> locallyMaturedSilos = [];
+            private readonly HashSet<(SiloAddress LocalSilo, SiloAddress MaturedSilo)> remotelyMaturedSilos = [];
+            private readonly List<ConditionWaiter> waiters = [];
+
+            private StreamQueueDiagnosticObserver(string streamProvider)
             {
-                var mgmt = this.GrainFactory.GetGrain<IManagementGrain>(0);
+                this.streamProvider = streamProvider;
+                subscription = StreamingEvents.AllEvents.Subscribe(this);
+            }
 
-                object?[] results = await mgmt.SendControlCommandToProvider<PersistentStreamProvider>(adapterName, (int)PersistentStreamProviderCommand.GetNumberRunningAgents, null);
+            public static StreamQueueDiagnosticObserver Create(string streamProvider)
+            {
+                return new StreamQueueDiagnosticObserver(streamProvider);
+            }
 
-                // Convert.ToInt32 is used because of different behavior of the fallback serializers: binary formatter and Json.Net.
-                // The binary one deserializes object[] into array of ints when the latter one - into longs. http://stackoverflow.com/a/17918824
-                var numAgents = results.Select(Convert.ToInt32).ToArray();
-                logger.LogInformation("Call {CallContext}: Got back RunningAgentCounts: {RunningAgentCounts}", callContext, Utils.EnumerableToString(numAgents));
+            public Task WaitForAgentsStateAsync(SiloAddress[] expectedSilos, int expectedAgentsPerSilo, TimeSpan timeout, string callContext)
+            {
+                return WaitUntilAsync(
+                    () => HasAgentState(expectedSilos, expectedAgentsPerSilo),
+                    timeout,
+                    () => $"Call {callContext}: expected silos {Utils.EnumerableToString(expectedSilos)} to have {expectedAgentsPerSilo} agents each, got {FormatAgentStates(expectedSilos)}.");
+            }
 
-                var isValid = results.Length == numExpectedSilos && numAgents.All(agents => agents == numExpectedAgentsPerSilo);
-                if (!isValid && assertIsTrue)
+            public Task WaitForLocalMaturityAsync(SiloAddress[] siloAddresses, TimeSpan timeout, string callContext)
+            {
+                return WaitUntilAsync(
+                    () => siloAddresses.All(locallyMaturedSilos.Contains),
+                    timeout,
+                    () => $"Call {callContext}: timed out waiting for local queue balancer maturity on silos {Utils.EnumerableToString(siloAddresses)}. Matured silos: {Utils.EnumerableToString(locallyMaturedSilos)}.");
+            }
+
+            public Task WaitForRemoteMaturityAsync(SiloAddress[] localSilos, SiloAddress[] maturedSilos, TimeSpan timeout, string callContext)
+            {
+                var expectedMaturities =
+                    (from localSilo in localSilos
+                     from maturedSilo in maturedSilos
+                     select (LocalSilo: localSilo, MaturedSilo: maturedSilo)).ToArray();
+
+                return WaitUntilAsync(
+                    () => expectedMaturities.All(remotelyMaturedSilos.Contains),
+                    timeout,
+                    () => $"Call {callContext}: timed out waiting for remote queue balancer maturity. Expected: {FormatMaturities(expectedMaturities)}. Completed: {FormatMaturities(remotelyMaturedSilos)}.");
+            }
+
+            public void OnNext(StreamingEvents.StreamingEvent value)
+            {
+                if (value.StreamProvider != streamProvider)
                 {
-                    Assert.True(
-                        isValid,
-                        $"Call {callContext}: expected {numExpectedSilos} silos with {numExpectedAgentsPerSilo} agents each, got {results.Length} silos with agents {Utils.EnumerableToString(numAgents)}.");
+                    return;
                 }
 
-                return isValid;
+                lock (lockObj)
+                {
+                    switch (value)
+                    {
+                        case StreamingEvents.PullingAgentManagerState state when state.SiloAddress is not null:
+                            agentStates[state.SiloAddress] = state;
+                            break;
+                        case StreamingEvents.QueueBalancerMaturityCompleted maturity when maturity.SiloAddress is not null:
+                            if (maturity.IsLocalSilo)
+                            {
+                                locallyMaturedSilos.Add(maturity.SiloAddress);
+                            }
+                            else
+                            {
+                                remotelyMaturedSilos.Add((maturity.SiloAddress, maturity.MaturedSiloAddress));
+                            }
+                            break;
+                    }
+
+                    SignalWaiters();
+                }
             }
-            catch when (!assertIsTrue)
+
+            public void OnError(Exception error)
             {
-                return false;
+            }
+
+            public void OnCompleted()
+            {
+            }
+
+            public void Dispose()
+            {
+                subscription.Dispose();
+            }
+
+            private bool HasAgentState(SiloAddress[] expectedSilos, int expectedAgentsPerSilo)
+            {
+                return expectedSilos.All(silo => agentStates.TryGetValue(silo, out var state) && state.RunningAgents == expectedAgentsPerSilo);
+            }
+
+            private Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout, Func<string> timeoutMessage)
+            {
+                lock (lockObj)
+                {
+                    if (predicate())
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    var waiter = new ConditionWaiter(predicate);
+                    waiters.Add(waiter);
+                    return WaitWithTimeoutAsync(waiter, timeout, timeoutMessage);
+                }
+            }
+
+            private async Task WaitWithTimeoutAsync(ConditionWaiter waiter, TimeSpan timeout, Func<string> timeoutMessage)
+            {
+                try
+                {
+                    await waiter.Task.WaitAsync(timeout);
+                }
+                catch (TimeoutException)
+                {
+                    RemoveWaiter(waiter);
+                    throw new TimeoutException(timeoutMessage());
+                }
+            }
+
+            private void RemoveWaiter(ConditionWaiter waiter)
+            {
+                lock (lockObj)
+                {
+                    waiters.Remove(waiter);
+                }
+            }
+
+            private void SignalWaiters()
+            {
+                for (var i = waiters.Count - 1; i >= 0; i--)
+                {
+                    if (waiters[i].TryComplete())
+                    {
+                        waiters.RemoveAt(i);
+                    }
+                }
+            }
+
+            private string FormatAgentStates(SiloAddress[] expectedSilos)
+            {
+                var states = expectedSilos.Select(silo => agentStates.TryGetValue(silo, out var state) ? $"{silo}: {state.RunningAgents}" : $"{silo}: <missing>");
+                return $"{agentStates.Count} silos with agents {Utils.EnumerableToString(states)}";
+            }
+
+            private static string FormatMaturities(IEnumerable<(SiloAddress LocalSilo, SiloAddress MaturedSilo)> maturities)
+            {
+                return Utils.EnumerableToString(maturities.Select(maturity => $"{maturity.LocalSilo}->{maturity.MaturedSilo}"));
+            }
+
+            private sealed class ConditionWaiter(Func<bool> predicate)
+            {
+                private readonly TaskCompletionSource completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                public Task Task => completion.Task;
+
+                public bool TryComplete()
+                {
+                    return predicate() && completion.TrySetResult();
+                }
             }
         }
     }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
@@ -93,7 +93,7 @@ namespace Tester.AzureUtils.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task DelayedQueueRebalancingTests_1()
         {
-            await WaitForAgentsState(2, "1");
+            await WaitForAgentsState(2, "1", includeHistory: true);
 
             await WaitForAgentsState(4, "2");
         }
@@ -101,7 +101,7 @@ namespace Tester.AzureUtils.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task DelayedQueueRebalancingTests_2()
         {
-            await WaitForAgentsState(2, "1");
+            await WaitForAgentsState(2, "1", includeHistory: true);
 
             var existingSilos = this.HostedCluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToArray();
             var addedSilos = await this.HostedCluster.StartAdditionalSilosAsync(2, true);
@@ -115,10 +115,10 @@ namespace Tester.AzureUtils.Streaming
             await WaitForAgentsState(2, "3");
         }
 
-        private Task WaitForAgentsState(int numExpectedAgentsPerSilo, string callContext)
+        private Task WaitForAgentsState(int numExpectedAgentsPerSilo, string callContext, bool includeHistory = false)
         {
             var activeSilos = this.HostedCluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToArray();
-            return diagnosticObserver.WaitForAgentsStateAsync(activeSilos, numExpectedAgentsPerSilo, AGENT_STATE_TIMEOUT, callContext);
+            return diagnosticObserver.WaitForAgentsStateAsync(activeSilos, numExpectedAgentsPerSilo, includeHistory, AGENT_STATE_TIMEOUT, callContext);
         }
 
         private sealed class StreamQueueDiagnosticObserver : IDisposable, IObserver<StreamingEvents.StreamingEvent>
@@ -127,6 +127,7 @@ namespace Tester.AzureUtils.Streaming
             private readonly IDisposable subscription;
             private readonly object lockObj = new();
             private readonly Dictionary<SiloAddress, StreamingEvents.PullingAgentManagerState> agentStates = [];
+            private readonly HashSet<(SiloAddress SiloAddress, int RunningAgents)> observedAgentStates = [];
             private readonly HashSet<SiloAddress> locallyMaturedSilos = [];
             private readonly HashSet<(SiloAddress LocalSilo, SiloAddress MaturedSilo)> remotelyMaturedSilos = [];
             private readonly List<ConditionWaiter> waiters = [];
@@ -142,10 +143,10 @@ namespace Tester.AzureUtils.Streaming
                 return new StreamQueueDiagnosticObserver(streamProvider);
             }
 
-            public Task WaitForAgentsStateAsync(SiloAddress[] expectedSilos, int expectedAgentsPerSilo, TimeSpan timeout, string callContext)
+            public Task WaitForAgentsStateAsync(SiloAddress[] expectedSilos, int expectedAgentsPerSilo, bool includeHistory, TimeSpan timeout, string callContext)
             {
                 return WaitUntilAsync(
-                    () => HasAgentState(expectedSilos, expectedAgentsPerSilo),
+                    () => HasAgentState(expectedSilos, expectedAgentsPerSilo, includeHistory),
                     timeout,
                     () => $"Call {callContext}: expected silos {Utils.EnumerableToString(expectedSilos)} to have {expectedAgentsPerSilo} agents each, got {FormatAgentStates(expectedSilos)}.");
             }
@@ -184,6 +185,7 @@ namespace Tester.AzureUtils.Streaming
                     {
                         case StreamingEvents.PullingAgentManagerState state when state.SiloAddress is not null:
                             agentStates[state.SiloAddress] = state;
+                            observedAgentStates.Add((state.SiloAddress, state.RunningAgents));
                             break;
                         case StreamingEvents.QueueBalancerMaturityCompleted maturity when maturity.SiloAddress is not null:
                             if (maturity.IsLocalSilo)
@@ -214,9 +216,12 @@ namespace Tester.AzureUtils.Streaming
                 subscription.Dispose();
             }
 
-            private bool HasAgentState(SiloAddress[] expectedSilos, int expectedAgentsPerSilo)
+            private bool HasAgentState(SiloAddress[] expectedSilos, int expectedAgentsPerSilo, bool includeHistory)
             {
-                return expectedSilos.All(silo => agentStates.TryGetValue(silo, out var state) && state.RunningAgents == expectedAgentsPerSilo);
+                return expectedSilos.All(silo =>
+                    includeHistory
+                        ? observedAgentStates.Contains((silo, expectedAgentsPerSilo))
+                        : agentStates.TryGetValue(silo, out var state) && state.RunningAgents == expectedAgentsPerSilo);
             }
 
             private Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout, Func<string> timeoutMessage)
@@ -242,16 +247,14 @@ namespace Tester.AzureUtils.Streaming
                 }
                 catch (TimeoutException)
                 {
-                    RemoveWaiter(waiter);
-                    throw new TimeoutException(timeoutMessage());
-                }
-            }
+                    string message;
+                    lock (lockObj)
+                    {
+                        waiters.Remove(waiter);
+                        message = timeoutMessage();
+                    }
 
-            private void RemoveWaiter(ConditionWaiter waiter)
-            {
-                lock (lockObj)
-                {
-                    waiters.Remove(waiter);
+                    throw new TimeoutException(message);
                 }
             }
 

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
@@ -25,7 +25,15 @@ namespace Tester.AzureUtils.Streaming
         public override async Task InitializeAsync()
         {
             diagnosticObserver = StreamQueueDiagnosticObserver.Create(adapterName);
-            await base.InitializeAsync();
+            try
+            {
+                await base.InitializeAsync();
+            }
+            catch
+            {
+                diagnosticObserver.Dispose();
+                throw;
+            }
         }
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
@@ -7,6 +7,7 @@ using Orleans.Providers.Streams.AzureQueue;
 using Orleans.Providers.Streams.Common;
 using Orleans.Runtime;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using TestExtensions;
 using UnitTests.StreamingTests;
 using Xunit;
@@ -20,8 +21,9 @@ namespace Tester.AzureUtils.Streaming
 #pragma warning disable 618
         private readonly string adapterType = typeof(PersistentStreamProvider).FullName!;
 #pragma warning restore 618
-        private static readonly TimeSpan SILO_IMMATURE_PERIOD = TimeSpan.FromSeconds(40); // matches the config
-        private static readonly TimeSpan LEEWAY = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan SILO_IMMATURE_PERIOD = TimeSpan.FromSeconds(15);
+        private static readonly TimeSpan AGENT_STATE_TIMEOUT = SILO_IMMATURE_PERIOD + TimeSpan.FromSeconds(20);
+        private static readonly TimeSpan AGENT_STATE_POLL_INTERVAL = TimeSpan.FromMilliseconds(500);
         private const int queueCount = 8;
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
         {
@@ -79,42 +81,58 @@ namespace Tester.AzureUtils.Streaming
         [SkippableFact, TestCategory("Functional")]
         public async Task DelayedQueueRebalancingTests_1()
         {
-            await ValidateAgentsState(2, 2, "1");
+            await WaitForAgentsState(2, 2, "1");
 
-            await Task.Delay(SILO_IMMATURE_PERIOD + LEEWAY);
-
-            await ValidateAgentsState(2, 4, "2");
+            await WaitForAgentsState(2, 4, "2");
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task DelayedQueueRebalancingTests_2()
         {
-            await ValidateAgentsState(2, 2, "1");
+            await WaitForAgentsState(2, 2, "1");
 
             await this.HostedCluster.StartAdditionalSilosAsync(2, true);
-            await ValidateAgentsState(4, 2, "2");
+            await WaitForAgentsState(4, 2, "2");
 
-            await Task.Delay(SILO_IMMATURE_PERIOD + LEEWAY);
-
-            await ValidateAgentsState(4, 2, "3");
+            // The expected queue distribution is unchanged after maturity, so there is no provider state transition to poll for.
+            await Task.Delay(SILO_IMMATURE_PERIOD);
+            await WaitForAgentsState(4, 2, "3");
         }
 
-        private async Task ValidateAgentsState(int numExpectedSilos, int numExpectedAgentsPerSilo, string callContext)
+        private Task WaitForAgentsState(int numExpectedSilos, int numExpectedAgentsPerSilo, string callContext)
         {
-            var mgmt = this.GrainFactory.GetGrain<IManagementGrain>(0);
+            return TestingUtils.WaitUntilAsync(
+                assertIsTrue => ValidateAgentsState(numExpectedSilos, numExpectedAgentsPerSilo, callContext, assertIsTrue),
+                AGENT_STATE_TIMEOUT,
+                AGENT_STATE_POLL_INTERVAL);
+        }
 
-            object?[] results = await mgmt.SendControlCommandToProvider<PersistentStreamProvider>(adapterName, (int)PersistentStreamProviderCommand.GetNumberRunningAgents, null);
-            Assert.Equal(numExpectedSilos, results.Length);
-
-            // Convert.ToInt32 is used because of different behavior of the fallback serializers: binary formatter and Json.Net.
-            // The binary one deserializes object[] into array of ints when the latter one - into longs. http://stackoverflow.com/a/17918824
-            var numAgents = results.Select(Convert.ToInt32).ToArray();
-            logger.LogInformation("Got back RunningAgentCounts: {RunningAgentCounts}", Utils.EnumerableToString(numAgents));
-            int i = 0;
-            foreach (var agents in numAgents)
+        private async Task<bool> ValidateAgentsState(int numExpectedSilos, int numExpectedAgentsPerSilo, string callContext, bool assertIsTrue)
+        {
+            try
             {
-                logger.LogCritical($"Silo {i++} get agents {agents}");
-                Assert.Equal(numExpectedAgentsPerSilo, agents);
+                var mgmt = this.GrainFactory.GetGrain<IManagementGrain>(0);
+
+                object?[] results = await mgmt.SendControlCommandToProvider<PersistentStreamProvider>(adapterName, (int)PersistentStreamProviderCommand.GetNumberRunningAgents, null);
+
+                // Convert.ToInt32 is used because of different behavior of the fallback serializers: binary formatter and Json.Net.
+                // The binary one deserializes object[] into array of ints when the latter one - into longs. http://stackoverflow.com/a/17918824
+                var numAgents = results.Select(Convert.ToInt32).ToArray();
+                logger.LogInformation("Call {CallContext}: Got back RunningAgentCounts: {RunningAgentCounts}", callContext, Utils.EnumerableToString(numAgents));
+
+                var isValid = results.Length == numExpectedSilos && numAgents.All(agents => agents == numExpectedAgentsPerSilo);
+                if (!isValid && assertIsTrue)
+                {
+                    Assert.True(
+                        isValid,
+                        $"Call {callContext}: expected {numExpectedSilos} silos with {numExpectedAgentsPerSilo} agents each, got {results.Length} silos with agents {Utils.EnumerableToString(numAgents)}.");
+                }
+
+                return isValid;
+            }
+            catch when (!assertIsTrue)
+            {
+                return false;
             }
         }
     }

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/StreamingEventsTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/StreamingEventsTests.cs
@@ -36,6 +36,45 @@ namespace UnitTests.OrleansRuntime.Streams
             Assert.Same(queueBalancer, changed.QueueBalancer);
         }
 
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void StreamingEvents_EmitPullingAgentManagerState_EmitsState()
+        {
+            using var observer = new Observer(StreamingEvents.AllEvents);
+            var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13000), 1);
+            var queue = QueueId.GetQueueId("queue", 1, 1);
+
+            StreamingEvents.EmitPullingAgentManagerState("provider", siloAddress, [queue], runningAgents: 1);
+
+            var state = Assert.IsType<StreamingEvents.PullingAgentManagerState>(Assert.Single(observer.Events));
+            Assert.Equal("provider", state.StreamProvider);
+            Assert.Same(siloAddress, state.SiloAddress);
+            Assert.Equal(queue, Assert.Single(state.CurrentQueues));
+            Assert.Equal(1, state.RunningAgents);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void StreamingEvents_EmitQueueBalancerMaturityCompleted_EmitsMaturityCompleted()
+        {
+            using var observer = new Observer(StreamingEvents.AllEvents);
+            var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13000), 1);
+            var maturedSiloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13001), 1);
+            var queueBalancer = new TestQueueBalancer();
+
+            StreamingEvents.EmitQueueBalancerMaturityCompleted(
+                "provider",
+                siloAddress,
+                maturedSiloAddress,
+                isLocalSilo: false,
+                queueBalancer);
+
+            var completed = Assert.IsType<StreamingEvents.QueueBalancerMaturityCompleted>(Assert.Single(observer.Events));
+            Assert.Equal("provider", completed.StreamProvider);
+            Assert.Same(siloAddress, completed.SiloAddress);
+            Assert.Same(maturedSiloAddress, completed.MaturedSiloAddress);
+            Assert.False(completed.IsLocalSilo);
+            Assert.Same(queueBalancer, completed.QueueBalancer);
+        }
+
         private sealed class TestQueueBalancer : IStreamQueueBalancer
         {
             public IEnumerable<QueueId> GetMyQueues() => [];


### PR DESCRIPTION
Makes the delayed Azure queue rebalancing tests faster and more reliable by replacing fixed delays and provider polling with streaming diagnostic events.

Adds diagnostics for pulling-agent state and deployment-based queue-balancer maturity, then uses those events to wait for the expected transitions with bounded timeouts. The test observer retains startup states so a fast maturity transition cannot race the initial assertion.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10211)