### PR TITLE
test: wait for queue balancer changes

### DIFF
--- a/src/Orleans.Streaming/Diagnostics/StreamingEvents.cs
+++ b/src/Orleans.Streaming/Diagnostics/StreamingEvents.cs
@@ -656,9 +656,11 @@ public static class StreamingEvents
         }
     }
 
-    internal static void EmitQueueChange(string streamProviderName, SiloAddress? siloAddress, HashSet<QueueId> oldQueues, HashSet<QueueId> newQueues, IStreamQueueBalancer queueBalancer)
+    internal static bool IsBalancerChangedEnabled() => Listener.IsEnabled(nameof(BalancerChanged));
+
+    internal static void EmitQueueChange(string streamProviderName, SiloAddress? siloAddress, QueueId[] oldQueues, QueueId[] newQueues, IStreamQueueBalancer queueBalancer)
     {
-        if (!Listener.IsEnabled(nameof(BalancerChanged)))
+        if (!IsBalancerChangedEnabled())
         {
             return;
         }
@@ -669,15 +671,15 @@ public static class StreamingEvents
         static void Emit(
             string streamProviderName,
             SiloAddress? siloAddress,
-            HashSet<QueueId> oldQueues,
-            HashSet<QueueId> newQueues,
+            QueueId[] oldQueues,
+            QueueId[] newQueues,
             IStreamQueueBalancer queueBalancer)
         {
             Listener.Write(nameof(BalancerChanged), new BalancerChanged(
                 streamProviderName,
                 siloAddress,
-                [.. oldQueues],
-                [.. newQueues],
+                oldQueues,
+                newQueues,
                 queueBalancer));
         }
     }

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using Orleans.Streams.Filtering;
 using Orleans.Runtime.Scheduler;
 using System.Diagnostics.Metrics;
+using StreamingEvents = Orleans.Streaming.Diagnostics.StreamingEvents;
 
 #nullable disable
 namespace Orleans.Streams
@@ -130,18 +131,22 @@ namespace Orleans.Streams
         {
             managerState = RunState.AgentsStarted;
             List<QueueId> myQueues = queueBalancer.GetMyQueues().ToList();
+            var previousQueues = GetCurrentAgentQueues();
 
             LogInfoStarting(myQueues.Count, new(myQueues));
             await AddNewQueues(myQueues, true);
+            EmitAgentQueueChange(previousQueues);
             LogInfoStarted();
         }
 
         public async Task StopAgents()
         {
             managerState = RunState.AgentsStopped;
+            var previousQueues = GetCurrentAgentQueues();
             List<QueueId> queuesToRemove = queuesToAgentsMap.Keys.ToList();
             LogInfoStopping(queuesToRemove.Count, new(queuesToRemove));
             await RemoveQueues(queuesToRemove);
+            EmitAgentQueueChange(previousQueues);
             LogInfoStopped();
         }
 
@@ -186,6 +191,7 @@ namespace Orleans.Streams
         private async Task QueueDistributionChangeNotification(int notificationSeqNumber)
         {
             HashSet<QueueId> currentQueues = queueBalancer.GetMyQueues().ToSet();
+            HashSet<QueueId> previousQueues = GetCurrentAgentQueues();
             LogInfoExecutingQueueChangeNotification(
                 notificationSeqNumber,
                 currentQueues.Count,
@@ -202,10 +208,27 @@ namespace Orleans.Streams
             }
             finally
             {
+                EmitAgentQueueChange(previousQueues);
                 LogInfoDoneExecutingQueueChangeNotification(
                     notificationSeqNumber,
                     NumberRunningAgents,
                     new(queuesToAgentsMap.Keys));
+            }
+        }
+
+        private HashSet<QueueId> GetCurrentAgentQueues() => queuesToAgentsMap.Keys.ToHashSet();
+
+        private void EmitAgentQueueChange(HashSet<QueueId> previousQueues)
+        {
+            if (queueBalancer is null)
+            {
+                return;
+            }
+
+            var currentQueues = GetCurrentAgentQueues();
+            if (!previousQueues.SetEquals(currentQueues))
+            {
+                StreamingEvents.EmitQueueChange(streamProviderName, Silo, previousQueues, currentQueues, queueBalancer);
             }
         }
 

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
@@ -131,7 +131,7 @@ namespace Orleans.Streams
         {
             managerState = RunState.AgentsStarted;
             List<QueueId> myQueues = queueBalancer.GetMyQueues().ToList();
-            var previousQueues = GetCurrentAgentQueues();
+            var previousQueues = CaptureAgentQueuesIfDiagnosticsEnabled();
 
             LogInfoStarting(myQueues.Count, new(myQueues));
             await AddNewQueues(myQueues, true);
@@ -142,11 +142,10 @@ namespace Orleans.Streams
         public async Task StopAgents()
         {
             managerState = RunState.AgentsStopped;
-            var previousQueues = GetCurrentAgentQueues();
             List<QueueId> queuesToRemove = queuesToAgentsMap.Keys.ToList();
             LogInfoStopping(queuesToRemove.Count, new(queuesToRemove));
             await RemoveQueues(queuesToRemove);
-            EmitAgentQueueChange(previousQueues);
+            EmitAgentQueueChange(queuesToRemove);
             LogInfoStopped();
         }
 
@@ -191,7 +190,7 @@ namespace Orleans.Streams
         private async Task QueueDistributionChangeNotification(int notificationSeqNumber)
         {
             HashSet<QueueId> currentQueues = queueBalancer.GetMyQueues().ToSet();
-            HashSet<QueueId> previousQueues = GetCurrentAgentQueues();
+            IReadOnlyCollection<QueueId> previousQueues = CaptureAgentQueuesIfDiagnosticsEnabled();
             LogInfoExecutingQueueChangeNotification(
                 notificationSeqNumber,
                 currentQueues.Count,
@@ -216,20 +215,39 @@ namespace Orleans.Streams
             }
         }
 
-        private HashSet<QueueId> GetCurrentAgentQueues() => queuesToAgentsMap.Keys.ToHashSet();
+        private QueueId[] CaptureAgentQueuesIfDiagnosticsEnabled() => StreamingEvents.IsBalancerChangedEnabled() ? queuesToAgentsMap.Keys.ToArray() : null;
 
-        private void EmitAgentQueueChange(HashSet<QueueId> previousQueues)
+        private void EmitAgentQueueChange(IReadOnlyCollection<QueueId> previousQueues)
         {
-            if (queueBalancer is null)
+            if (previousQueues is null || !StreamingEvents.IsBalancerChangedEnabled())
             {
                 return;
             }
 
-            var currentQueues = GetCurrentAgentQueues();
-            if (!previousQueues.SetEquals(currentQueues))
+            if (HasSameAgentQueues(previousQueues))
             {
-                StreamingEvents.EmitQueueChange(streamProviderName, Silo, previousQueues, currentQueues, queueBalancer);
+                return;
             }
+
+            StreamingEvents.EmitQueueChange(streamProviderName, Silo, previousQueues as QueueId[] ?? [.. previousQueues], queuesToAgentsMap.Keys.ToArray(), queueBalancer);
+        }
+
+        private bool HasSameAgentQueues(IReadOnlyCollection<QueueId> previousQueues)
+        {
+            if (previousQueues.Count != queuesToAgentsMap.Count)
+            {
+                return false;
+            }
+
+            foreach (var queueId in previousQueues)
+            {
+                if (!queuesToAgentsMap.ContainsKey(queueId))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -391,7 +391,7 @@ public partial class LeaseBasedQueueBalancer(
         // If queue changed, notify listeners.
         if (!oldQueues.SetEquals(newQueues))
         {
-            StreamingEvents.EmitQueueChange(_name, SiloAddress, oldQueues, newQueues, this);
+            StreamingEvents.EmitQueueChange(_name, SiloAddress, [.. oldQueues], [.. newQueues], this);
             return NotifyListeners();
         }
 

--- a/test/Extensions/Orleans.Azure.Tests/Lease/LeaseBasedQueueBalancerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Lease/LeaseBasedQueueBalancerTests.cs
@@ -1,10 +1,11 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Providers;
 using Orleans.Providers.Streams.Common;
+using Orleans.Streaming.Diagnostics;
 using Orleans.TestingHost;
-using Orleans.TestingHost.Utils;
 using TestExtensions;
 using Xunit;
 
@@ -20,7 +21,7 @@ namespace Tester.AzureUtils.Lease
         private static readonly int totalQueueCount = 6;
         private static readonly short siloCount = 4;
 
-        //since lease length is 1 min, so set time out to be two minutes to fulfill some test scenario
+        // Azure Blob leases must be at least 15 seconds, so keep the timeout long enough for lease expiry scenarios.
         public static readonly TimeSpan TimeOut = TimeSpan.FromMinutes(2);
 
         protected override void ConfigureTestCluster(TestClusterBuilder builder)
@@ -47,8 +48,8 @@ namespace Tester.AzureUtils.Lease
                         b.UseLeaseBasedQueueBalancer(ob => ob.Configure(options =>
                         {
                             options.LeaseLength = TimeSpan.FromSeconds(15);
-                            options.LeaseRenewPeriod = TimeSpan.FromSeconds(10);
-                            options.LeaseAcquisitionPeriod = TimeSpan.FromSeconds(10);
+                            options.LeaseRenewPeriod = TimeSpan.FromSeconds(2);
+                            options.LeaseAcquisitionPeriod = TimeSpan.FromSeconds(1);
                         }));
                     })
                     .ConfigureLogging(builder => builder.AddFilter($"LeaseBasedQueueBalancer-{StreamProviderName}", LogLevel.Trace))
@@ -61,16 +62,16 @@ namespace Tester.AzureUtils.Lease
         {
             var mgmtGrain = this.GrainFactory.GetGrain<IManagementGrain>(0);
             //6 queue and 4 silo, then each agent manager should own queues/agents in range of [1, 2]
-            await TestingUtils.WaitUntilAsync(lastTry => AgentManagerOwnCorrectAmountOfAgents(1, 2, mgmtGrain, lastTry), TimeOut);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(1, 2, mgmtGrain);
             //stop one silo, 6 queues, 3 silo, then each agent manager should own 2 queues 
             await this.HostedCluster.StopSiloAsync(this.HostedCluster.SecondarySilos[0]);
-            await TestingUtils.WaitUntilAsync(lastTry => AgentManagerOwnCorrectAmountOfAgents(2, 2, mgmtGrain, lastTry), TimeOut);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(2, 2, mgmtGrain);
             //stop another silo, 6 queues, 2 silo, then each agent manager should own 3 queues
             await this.HostedCluster.StopSiloAsync(this.HostedCluster.SecondarySilos[0]);
-            await TestingUtils.WaitUntilAsync(lastTry => AgentManagerOwnCorrectAmountOfAgents(3, 3, mgmtGrain, lastTry), TimeOut);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(3, 3, mgmtGrain);
             //start one silo, 6 queues, 3 silo, then each agent manager should own 2 queues
             this.HostedCluster.StartAdditionalSilo(true);
-            await TestingUtils.WaitUntilAsync(lastTry => AgentManagerOwnCorrectAmountOfAgents(2, 2, mgmtGrain, lastTry), TimeOut);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(2, 2, mgmtGrain);
         }
 
         [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/9559")]
@@ -78,39 +79,168 @@ namespace Tester.AzureUtils.Lease
         {
             var mgmtGrain = this.GrainFactory.GetGrain<IManagementGrain>(0);
             //6 queue and 4 silo, then each agent manager should own queues/agents in range of [1, 2]
-            await TestingUtils.WaitUntilAsync(lastTry => AgentManagerOwnCorrectAmountOfAgents(1, 2, mgmtGrain, lastTry), TimeOut);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(1, 2, mgmtGrain);
             //stop one silo, 6 queues, 3 silo, then each agent manager should own 2 queues 
             await this.HostedCluster.KillSiloAsync(this.HostedCluster.SecondarySilos[0]);
-            await TestingUtils.WaitUntilAsync(lastTry => AgentManagerOwnCorrectAmountOfAgents(2, 2, mgmtGrain, lastTry), TimeOut);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(2, 2, mgmtGrain);
             //stop another silo, 6 queues, 2 silo, then each agent manager should own 3 queues
             await this.HostedCluster.KillSiloAsync(this.HostedCluster.SecondarySilos[0]);
-            await TestingUtils.WaitUntilAsync(lastTry => AgentManagerOwnCorrectAmountOfAgents(3, 3, mgmtGrain, lastTry), TimeOut);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(3, 3, mgmtGrain);
             //start one silo, 6 queues, 3 silo, then each agent manager should own 2 queues
             this.HostedCluster.StartAdditionalSilo(true);
-            await TestingUtils.WaitUntilAsync(lastTry => AgentManagerOwnCorrectAmountOfAgents(2, 2, mgmtGrain, lastTry), TimeOut);
+            await WaitUntilAgentManagersOwnCorrectAmountOfAgents(2, 2, mgmtGrain);
         }
 
-        private static async Task<bool> AgentManagerOwnCorrectAmountOfAgents(int expectedAgentCountMin, int expectedAgentCountMax, IManagementGrain mgmtGrain, bool assertIsTrue)
+        private static async Task WaitUntilAgentManagersOwnCorrectAmountOfAgents(int expectedAgentCountMin, int expectedAgentCountMax, IManagementGrain mgmtGrain)
         {
-            await Task.Delay(TimeSpan.FromSeconds(10));
-            bool pass;
+            int[] lastObservedCounts = null;
+            Exception lastException = null;
+            using var queueChanges = new StreamProviderQueueChangeSignal(StreamProviderName);
+            var stopwatch = Stopwatch.StartNew();
+
+            while (stopwatch.Elapsed < TimeOut)
+            {
+                var observedVersion = queueChanges.Version;
+                try
+                {
+                    lastObservedCounts = await GetRunningAgentCounts(mgmtGrain);
+                    lastException = null;
+                    if (AgentManagersOwnCorrectAmountOfAgents(expectedAgentCountMin, expectedAgentCountMax, lastObservedCounts))
+                    {
+                        return;
+                    }
+                }
+                catch (Exception exception)
+                {
+                    lastException = exception;
+                }
+
+                var remaining = TimeOut - stopwatch.Elapsed;
+                if (remaining <= TimeSpan.Zero || !await queueChanges.WaitForNextChangeAsync(observedVersion, remaining))
+                {
+                    break;
+                }
+            }
+
             try
             {
-                object[] agentStarted = await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName, (int)PersistentStreamProviderCommand.GetNumberRunningAgents, null);
-                int[] counts = agentStarted.Select(startedAgentInEachSilo => Convert.ToInt32(startedAgentInEachSilo)).ToArray();
-                int sum = counts.Sum();
-                pass = totalQueueCount == sum &&
-                    counts.All(startedAgentInEachSilo => startedAgentInEachSilo <= expectedAgentCountMax && startedAgentInEachSilo >= expectedAgentCountMin);
-                if(!pass && assertIsTrue)
-                    throw new OrleansException($"AgentManager doesn't own correct amount of agents: {string.Join(",", counts.Select(startedAgentInEachSilo => startedAgentInEachSilo.ToString()))}");
+                lastObservedCounts = await GetRunningAgentCounts(mgmtGrain);
+                lastException = null;
+                if (AgentManagersOwnCorrectAmountOfAgents(expectedAgentCountMin, expectedAgentCountMax, lastObservedCounts))
+                {
+                    return;
+                }
             }
-            catch
+            catch (Exception exception)
             {
-                pass = false;
-                if (assertIsTrue)
-                    throw;
+                lastException = exception;
+                throw new OrleansException(CreateUnexpectedAgentCountMessage(expectedAgentCountMin, expectedAgentCountMax, lastObservedCounts, exception), exception);
             }
-            return pass;
+
+            throw new OrleansException(CreateUnexpectedAgentCountMessage(expectedAgentCountMin, expectedAgentCountMax, lastObservedCounts, lastException));
+        }
+
+        private static async Task<int[]> GetRunningAgentCounts(IManagementGrain mgmtGrain)
+        {
+            object[] agentStarted = await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName, (int)PersistentStreamProviderCommand.GetNumberRunningAgents, null);
+            return agentStarted.Select(startedAgentInEachSilo => Convert.ToInt32(startedAgentInEachSilo)).ToArray();
+        }
+
+        private static bool AgentManagersOwnCorrectAmountOfAgents(int expectedAgentCountMin, int expectedAgentCountMax, int[] counts)
+        {
+            return totalQueueCount == counts.Sum() &&
+                counts.All(startedAgentInEachSilo => startedAgentInEachSilo <= expectedAgentCountMax && startedAgentInEachSilo >= expectedAgentCountMin);
+        }
+
+        private static string CreateUnexpectedAgentCountMessage(int expectedAgentCountMin, int expectedAgentCountMax, int[] counts, Exception exception = null)
+        {
+            var message =
+                $"Agent managers don't own the expected amount of agents. Expected total: {totalQueueCount}; " +
+                $"expected per manager range: [{expectedAgentCountMin}, {expectedAgentCountMax}]; " +
+                $"observed counts: {FormatAgentCounts(counts)}.";
+            return exception is null ? message : $"{message} Last query error: {exception.Message}";
+        }
+
+        private static string FormatAgentCounts(int[] counts) => counts is null ? "<none>" : $"[{string.Join(", ", counts)}] (sum: {counts.Sum()})";
+
+        private sealed class StreamProviderQueueChangeSignal : IObserver<StreamingEvents.StreamingEvent>, IDisposable
+        {
+            private readonly string streamProviderName;
+            private readonly IDisposable subscription;
+            private readonly object lockObj = new();
+            private TaskCompletionSource completion = CreateCompletion();
+            private long version;
+
+            public StreamProviderQueueChangeSignal(string streamProviderName)
+            {
+                this.streamProviderName = streamProviderName;
+                this.subscription = StreamingEvents.AllEvents.Subscribe(this);
+            }
+
+            public long Version
+            {
+                get
+                {
+                    lock (lockObj)
+                    {
+                        return version;
+                    }
+                }
+            }
+
+            public async Task<bool> WaitForNextChangeAsync(long observedVersion, TimeSpan timeout)
+            {
+                Task task;
+                lock (lockObj)
+                {
+                    if (version != observedVersion)
+                    {
+                        return true;
+                    }
+
+                    task = completion.Task;
+                }
+
+                try
+                {
+                    await task.WaitAsync(timeout);
+                    return true;
+                }
+                catch (TimeoutException)
+                {
+                    return false;
+                }
+            }
+
+            public void Dispose() => subscription.Dispose();
+
+            public void OnCompleted()
+            {
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+            public void OnNext(StreamingEvents.StreamingEvent value)
+            {
+                if (value is not StreamingEvents.BalancerChanged || value.StreamProvider != streamProviderName)
+                {
+                    return;
+                }
+
+                TaskCompletionSource toComplete;
+                lock (lockObj)
+                {
+                    version++;
+                    toComplete = completion;
+                    completion = CreateCompletion();
+                }
+
+                toComplete.TrySetResult();
+            }
+
+            private static TaskCompletionSource CreateCompletion() => new(TaskCreationOptions.RunContinuationsAsynchronously);
         }
     }
 }


### PR DESCRIPTION
Speeds up lease-based queue balancer tests by emitting queue ownership change diagnostics from the pulling manager and waiting for those events before rechecking agent ownership.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10212)