### PR TITLE
test: stabilize timer tests with FakeTimeProvider

### DIFF
--- a/test/Grains/TestGrainInterfaces/ITimerGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ITimerGrain.cs
@@ -25,6 +25,7 @@ namespace UnitTests.GrainInterfaces
         Task StartTimer(string name, TimeSpan dueTime, string operationType);
         Task RestartTimer(string name, TimeSpan dueTime);
         Task RestartTimer(string name, TimeSpan dueTime, TimeSpan period);
+        Task TestTimerChangeArguments();
         Task StopTimer(string name);
         Task RunSelfDisposingTimer();
     }

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -28,13 +28,13 @@ namespace UnitTestGrains
             public readonly GrainId GrainId = grainId;
         }
 
-        public sealed class DelayStarted(GrainId grainId) : CallbackEvent(grainId)
+        public sealed class DelayScheduled(GrainId grainId) : CallbackEvent(grainId)
         {
         }
 
-        internal static void EmitDelayStarted(GrainId grainId)
+        internal static void EmitDelayScheduled(GrainId grainId)
         {
-            if (!Listener.IsEnabled(nameof(DelayStarted)))
+            if (!Listener.IsEnabled(nameof(DelayScheduled)))
             {
                 return;
             }
@@ -44,7 +44,7 @@ namespace UnitTestGrains
             [MethodImpl(MethodImplOptions.NoInlining)]
             static void Emit(GrainId grainId)
             {
-                Listener.Write(nameof(DelayStarted), new DelayStarted(grainId));
+                Listener.Write(nameof(DelayScheduled), new DelayScheduled(grainId));
             }
         }
 
@@ -311,8 +311,9 @@ namespace UnitTestGrains
                     Assert.NotNull(timer[0]);
                     timer[0].Dispose();
                     Assert.True(ct.IsCancellationRequested);
-                    TimerGrainCallbackEvents.EmitDelayStarted(context.GrainId);
-                    await Task.Delay(TimeSpan.FromMilliseconds(100), timeProvider);
+                    var delay = Task.Delay(TimeSpan.FromMilliseconds(100), timeProvider);
+                    TimerGrainCallbackEvents.EmitDelayScheduled(context.GrainId);
+                    await delay;
                     tcs.TrySetResult();
                 }
                 catch (Exception ex)
@@ -390,8 +391,9 @@ namespace UnitTestGrains
             CheckRuntimeContext(step);
 
             LogStatus("Before Delay");
-            TimerGrainCallbackEvents.EmitDelayStarted(context.GrainId);
-            await Task.Delay(TimerGrainTestConstants.CallbackDelay, timeProvider);
+            var delay = Task.Delay(TimerGrainTestConstants.CallbackDelay, timeProvider);
+            TimerGrainCallbackEvents.EmitDelayScheduled(context.GrainId);
+            await delay;
             step = "After Delay";
             LogStatus(step);
             CheckRuntimeContext(step);
@@ -540,8 +542,9 @@ namespace UnitTestGrains
             CheckReentrancy(step, expectedTickId);
 
             LogStatus("Before Delay", timerName);
-            TimerGrainCallbackEvents.EmitDelayStarted(_context.GrainId);
-            await Task.Delay(TimerGrainTestConstants.CallbackDelay, _timeProvider);
+            var delay = Task.Delay(TimerGrainTestConstants.CallbackDelay, _timeProvider);
+            TimerGrainCallbackEvents.EmitDelayScheduled(_context.GrainId);
+            await delay;
             step = "After Delay";
             LogStatus(step, timerName);
             CheckRuntimeContext(step);
@@ -1004,8 +1007,9 @@ namespace UnitTestGrains
                     Assert.NotNull(timer[0]);
                     timer[0].Dispose();
                     Assert.True(ct.IsCancellationRequested);
-                    TimerGrainCallbackEvents.EmitDelayStarted(context.GrainId);
-                    await Task.Delay(TimeSpan.FromMilliseconds(100), _timeProvider);
+                    var delay = Task.Delay(TimeSpan.FromMilliseconds(100), _timeProvider);
+                    TimerGrainCallbackEvents.EmitDelayScheduled(context.GrainId);
+                    await delay;
                     tcs.TrySetResult();
                 }
                 catch (Exception ex)
@@ -1083,8 +1087,9 @@ namespace UnitTestGrains
             CheckRuntimeContext(step);
 
             LogStatus("Before Delay");
-            TimerGrainCallbackEvents.EmitDelayStarted(context.GrainId);
-            await Task.Delay(TimerGrainTestConstants.CallbackDelay, _timeProvider);
+            var delay = Task.Delay(TimerGrainTestConstants.CallbackDelay, _timeProvider);
+            TimerGrainCallbackEvents.EmitDelayScheduled(context.GrainId);
+            await delay;
             step = "After Delay";
             LogStatus(step);
             CheckRuntimeContext(step);
@@ -1338,8 +1343,9 @@ namespace UnitTestGrains
                     Assert.NotNull(timer[0]);
                     timer[0].Dispose();
                     tcs.TrySetResult();
-                    TimerGrainCallbackEvents.EmitDelayStarted(_context.GrainId);
-                    await Task.Delay(TimeSpan.FromMilliseconds(100), _timeProvider);
+                    var delay = Task.Delay(TimeSpan.FromMilliseconds(100), _timeProvider);
+                    TimerGrainCallbackEvents.EmitDelayScheduled(_context.GrainId);
+                    await delay;
                 }
                 catch (Exception ex)
                 {
@@ -1416,8 +1422,9 @@ namespace UnitTestGrains
             CheckReentrancy(step, expectedTickId);
 
             LogStatus("Before Delay", timerName);
-            TimerGrainCallbackEvents.EmitDelayStarted(_context.GrainId);
-            await Task.Delay(TimerGrainTestConstants.CallbackDelay, _timeProvider);
+            var delay = Task.Delay(TimerGrainTestConstants.CallbackDelay, _timeProvider);
+            TimerGrainCallbackEvents.EmitDelayScheduled(_context.GrainId);
+            await delay;
             step = "After Delay";
             LogStatus(step, timerName);
             CheckRuntimeContext(step);

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Runtime.Scheduler;
@@ -11,6 +13,59 @@ namespace UnitTestGrains
     internal static class TimerGrainTestConstants
     {
         public static readonly TimeSpan CallbackDelay = TimeSpan.FromMilliseconds(50);
+    }
+
+    public static class TimerGrainCallbackEvents
+    {
+        public const string ListenerName = "Orleans.Tests.TimerGrainCallbacks";
+
+        private static readonly DiagnosticListener Listener = new(ListenerName);
+
+        public static IObservable<CallbackEvent> AllEvents { get; } = new Observable();
+
+        public abstract class CallbackEvent(GrainId grainId)
+        {
+            public readonly GrainId GrainId = grainId;
+        }
+
+        public sealed class DelayStarted(GrainId grainId) : CallbackEvent(grainId)
+        {
+        }
+
+        internal static void EmitDelayStarted(GrainId grainId)
+        {
+            if (!Listener.IsEnabled(nameof(DelayStarted)))
+            {
+                return;
+            }
+
+            Emit(grainId);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void Emit(GrainId grainId)
+            {
+                Listener.Write(nameof(DelayStarted), new DelayStarted(grainId));
+            }
+        }
+
+        private sealed class Observable : IObservable<CallbackEvent>
+        {
+            public IDisposable Subscribe(IObserver<CallbackEvent> observer) => Listener.Subscribe(new Observer(observer));
+
+            private sealed class Observer(IObserver<CallbackEvent> observer) : IObserver<KeyValuePair<string, object>>
+            {
+                public void OnCompleted() => observer.OnCompleted();
+                public void OnError(Exception error) => observer.OnError(error);
+
+                public void OnNext(KeyValuePair<string, object> value)
+                {
+                    if (value.Value is CallbackEvent evt)
+                    {
+                        observer.OnNext(evt);
+                    }
+                }
+            }
+        }
     }
 
     public class TimerGrain : Grain, ITimerGrain
@@ -144,10 +199,12 @@ namespace UnitTestGrains
         private TaskScheduler activationTaskScheduler;
 
         private readonly ILogger logger;
+        private readonly TimeProvider timeProvider;
 
-        public TimerCallGrain(ILoggerFactory loggerFactory)
+        public TimerCallGrain(ILoggerFactory loggerFactory, TimeProvider timeProvider)
         {
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.IdentityString}");
+            this.timeProvider = timeProvider;
         }
 
         public Task<int> GetTickCount() { return Task.FromResult(tickCount); }
@@ -199,6 +256,42 @@ namespace UnitTestGrains
             return Task.CompletedTask;
         }
 
+        public Task TestTimerChangeArguments()
+        {
+            ValidateTimerChangeArguments(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            ValidateTimerChangeArguments(TimeSpan.Zero, Timeout.InfiniteTimeSpan);
+            ValidateTimerChangeArguments(TimeSpan.FromMicroseconds(10), Timeout.InfiniteTimeSpan);
+            ValidateTimerChangeArguments(TimeSpan.Zero, TimeSpan.Zero);
+            ValidateTimerChangeArguments(TimeSpan.FromMicroseconds(10), TimeSpan.FromMicroseconds(10));
+            ValidateTimerChangeArguments(TimeSpan.FromMilliseconds(-0.4), Timeout.InfiniteTimeSpan);
+            ValidateTimerChangeArguments(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(-0.5));
+            ValidateTimerChangeArguments(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => ValidateTimerChangeArguments(TimeSpan.FromSeconds(-5), Timeout.InfiniteTimeSpan));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ValidateTimerChangeArguments(TimeSpan.MaxValue, Timeout.InfiniteTimeSpan));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ValidateTimerChangeArguments(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(-5)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ValidateTimerChangeArguments(TimeSpan.FromSeconds(1), TimeSpan.MaxValue));
+
+            return Task.CompletedTask;
+        }
+
+        private void ValidateTimerChangeArguments(TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = this.RegisterGrainTimer(_ => Task.CompletedTask, new GrainTimerCreationOptions(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan)
+            {
+                Interleave = true
+            });
+
+            try
+            {
+                timer.Change(dueTime, period);
+            }
+            finally
+            {
+                timer.Dispose();
+            }
+        }
+
         public Task StopTimer(string name)
         {
             logger.LogInformation("StopTimer Name={Name}", name);
@@ -225,7 +318,8 @@ namespace UnitTestGrains
                     Assert.NotNull(timer[0]);
                     timer[0].Dispose();
                     Assert.True(ct.IsCancellationRequested);
-                    await Task.Delay(100);
+                    TimerGrainCallbackEvents.EmitDelayStarted(context.GrainId);
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), timeProvider);
                     tcs.TrySetResult();
                 }
                 catch (Exception ex)
@@ -303,7 +397,8 @@ namespace UnitTestGrains
             CheckRuntimeContext(step);
 
             LogStatus("Before Delay");
-            await Task.Delay(TimerGrainTestConstants.CallbackDelay);
+            TimerGrainCallbackEvents.EmitDelayStarted(context.GrainId);
+            await Task.Delay(TimerGrainTestConstants.CallbackDelay, timeProvider);
             step = "After Delay";
             LogStatus(step);
             CheckRuntimeContext(step);
@@ -367,10 +462,12 @@ namespace UnitTestGrains
         private Guid _tickId;
 
         private readonly ILogger _logger;
+        private readonly TimeProvider _timeProvider;
 
-        public NonReentrantTimerCallGrain(ILoggerFactory loggerFactory)
+        public NonReentrantTimerCallGrain(ILoggerFactory loggerFactory, TimeProvider timeProvider)
         {
             _logger = loggerFactory.CreateLogger($"{GetType().Name}-{IdentityString}");
+            _timeProvider = timeProvider;
         }
 
         public Task<int> GetTickCount() => Task.FromResult(_tickCount);
@@ -450,7 +547,8 @@ namespace UnitTestGrains
             CheckReentrancy(step, expectedTickId);
 
             LogStatus("Before Delay", timerName);
-            await Task.Delay(TimerGrainTestConstants.CallbackDelay);
+            TimerGrainCallbackEvents.EmitDelayStarted(_context.GrainId);
+            await Task.Delay(TimerGrainTestConstants.CallbackDelay, _timeProvider);
             step = "After Delay";
             LogStatus(step, timerName);
             CheckRuntimeContext(step);
@@ -797,13 +895,15 @@ namespace UnitTestGrains
 
         private readonly ILogger logger;
         private readonly IGrainFactory _grainFactory;
+        private readonly TimeProvider _timeProvider;
 
         public IGrainContext GrainContext { get; }
 
-        public PocoTimerCallGrain(ILoggerFactory loggerFactory, IGrainContext grainContext, IGrainFactory grainFactory)
+        public PocoTimerCallGrain(ILoggerFactory loggerFactory, IGrainContext grainContext, IGrainFactory grainFactory, TimeProvider timeProvider)
         {
             GrainContext = grainContext;
             _grainFactory = grainFactory;
+            _timeProvider = timeProvider;
             this.logger = loggerFactory.CreateLogger($"{this.GetType().Name}-{this.GrainContext.GrainId}");
         }
 
@@ -821,7 +921,7 @@ namespace UnitTestGrains
         {
             logger.LogInformation("StartTimer Name={Name} Delay={Delay}", name, delay);
             if (timer is not null) throw new InvalidOperationException("Expected timer to be null");
-            this.timer = this.RegisterGrainTimer(TimerTick, name, new(delay, Timeout.InfiniteTimeSpan)); // One shot timer
+            this.timer = this.RegisterGrainTimer(TimerTick, name, new(delay, Timeout.InfiniteTimeSpan) { Interleave = true }); // One shot timer
             this.timerName = name;
 
             return Task.CompletedTask;
@@ -832,7 +932,7 @@ namespace UnitTestGrains
             logger.LogInformation("StartTimer Name={Name} Delay={Delay}", name, delay);
             if (timer is not null) throw new InvalidOperationException("Expected timer to be null");
             var state = Tuple.Create<string, object>(operationType, name);
-            this.timer = this.RegisterGrainTimer(TimerTickAdvanced, state, delay, Timeout.InfiniteTimeSpan); // One shot timer
+            this.timer = this.RegisterGrainTimer(TimerTickAdvanced, state, new(delay, Timeout.InfiniteTimeSpan) { Interleave = true }); // One shot timer
             this.timerName = name;
 
             return Task.CompletedTask;
@@ -854,6 +954,42 @@ namespace UnitTestGrains
             timer.Change(delay, period);
 
             return Task.CompletedTask;
+        }
+
+        public Task TestTimerChangeArguments()
+        {
+            ValidateTimerChangeArguments(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            ValidateTimerChangeArguments(TimeSpan.Zero, Timeout.InfiniteTimeSpan);
+            ValidateTimerChangeArguments(TimeSpan.FromMicroseconds(10), Timeout.InfiniteTimeSpan);
+            ValidateTimerChangeArguments(TimeSpan.Zero, TimeSpan.Zero);
+            ValidateTimerChangeArguments(TimeSpan.FromMicroseconds(10), TimeSpan.FromMicroseconds(10));
+            ValidateTimerChangeArguments(TimeSpan.FromMilliseconds(-0.4), Timeout.InfiniteTimeSpan);
+            ValidateTimerChangeArguments(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(-0.5));
+            ValidateTimerChangeArguments(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => ValidateTimerChangeArguments(TimeSpan.FromSeconds(-5), Timeout.InfiniteTimeSpan));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ValidateTimerChangeArguments(TimeSpan.MaxValue, Timeout.InfiniteTimeSpan));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ValidateTimerChangeArguments(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(-5)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ValidateTimerChangeArguments(TimeSpan.FromSeconds(1), TimeSpan.MaxValue));
+
+            return Task.CompletedTask;
+        }
+
+        private void ValidateTimerChangeArguments(TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = this.RegisterGrainTimer(_ => Task.CompletedTask, new GrainTimerCreationOptions(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan)
+            {
+                Interleave = true
+            });
+
+            try
+            {
+                timer.Change(dueTime, period);
+            }
+            finally
+            {
+                timer.Dispose();
+            }
         }
 
         public Task StopTimer(string name)
@@ -882,7 +1018,8 @@ namespace UnitTestGrains
                     Assert.NotNull(timer[0]);
                     timer[0].Dispose();
                     Assert.True(ct.IsCancellationRequested);
-                    await Task.Delay(100);
+                    TimerGrainCallbackEvents.EmitDelayStarted(context.GrainId);
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), _timeProvider);
                     tcs.TrySetResult();
                 }
                 catch (Exception ex)
@@ -960,7 +1097,8 @@ namespace UnitTestGrains
             CheckRuntimeContext(step);
 
             LogStatus("Before Delay");
-            await Task.Delay(TimerGrainTestConstants.CallbackDelay);
+            TimerGrainCallbackEvents.EmitDelayStarted(context.GrainId);
+            await Task.Delay(TimerGrainTestConstants.CallbackDelay, _timeProvider);
             step = "After Delay";
             LogStatus(step);
             CheckRuntimeContext(step);
@@ -1176,13 +1314,15 @@ namespace UnitTestGrains
 
         private readonly ILogger _logger;
         private readonly IGrainFactory _grainFactory;
+        private readonly TimeProvider _timeProvider;
 
         public IGrainContext GrainContext { get; }
 
-        public PocoNonReentrantTimerCallGrain(ILoggerFactory loggerFactory, IGrainContext grainContext, IGrainFactory grainFactory)
+        public PocoNonReentrantTimerCallGrain(ILoggerFactory loggerFactory, IGrainContext grainContext, IGrainFactory grainFactory, TimeProvider timeProvider)
         {
             GrainContext = grainContext;
             _grainFactory = grainFactory;
+            _timeProvider = timeProvider;
             _logger = loggerFactory.CreateLogger($"{GetType().Name}-{GrainContext.GrainId}");
         }
 
@@ -1212,7 +1352,8 @@ namespace UnitTestGrains
                     Assert.NotNull(timer[0]);
                     timer[0].Dispose();
                     tcs.TrySetResult();
-                    await Task.Delay(100);
+                    TimerGrainCallbackEvents.EmitDelayStarted(_context.GrainId);
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), _timeProvider);
                 }
                 catch (Exception ex)
                 {
@@ -1289,7 +1430,8 @@ namespace UnitTestGrains
             CheckReentrancy(step, expectedTickId);
 
             LogStatus("Before Delay", timerName);
-            await Task.Delay(TimerGrainTestConstants.CallbackDelay);
+            TimerGrainCallbackEvents.EmitDelayStarted(_context.GrainId);
+            await Task.Delay(TimerGrainTestConstants.CallbackDelay, _timeProvider);
             step = "After Delay";
             LogStatus(step, timerName);
             CheckRuntimeContext(step);

--- a/test/Grains/TestInternalGrains/TimerGrain.cs
+++ b/test/Grains/TestInternalGrains/TimerGrain.cs
@@ -277,19 +277,12 @@ namespace UnitTestGrains
 
         private void ValidateTimerChangeArguments(TimeSpan dueTime, TimeSpan period)
         {
-            var timer = this.RegisterGrainTimer(_ => Task.CompletedTask, new GrainTimerCreationOptions(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan)
+            using var validationTimer = this.RegisterGrainTimer(_ => Task.CompletedTask, new GrainTimerCreationOptions(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan)
             {
                 Interleave = true
             });
 
-            try
-            {
-                timer.Change(dueTime, period);
-            }
-            finally
-            {
-                timer.Dispose();
-            }
+            validationTimer.Change(dueTime, period);
         }
 
         public Task StopTimer(string name)
@@ -977,19 +970,12 @@ namespace UnitTestGrains
 
         private void ValidateTimerChangeArguments(TimeSpan dueTime, TimeSpan period)
         {
-            var timer = this.RegisterGrainTimer(_ => Task.CompletedTask, new GrainTimerCreationOptions(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan)
+            using var validationTimer = this.RegisterGrainTimer(_ => Task.CompletedTask, new GrainTimerCreationOptions(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan)
             {
                 Interleave = true
             });
 
-            try
-            {
-                timer.Change(dueTime, period);
-            }
-            finally
-            {
-                timer.Dispose();
-            }
+            validationTimer.Change(dueTime, period);
         }
 
         public Task StopTimer(string name)

--- a/test/Orleans.DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/Orleans.DefaultCluster.Tests/TimerOrleansTest.cs
@@ -91,13 +91,13 @@ namespace DefaultCluster.Tests.TimerTests
         {
             using var callbackObserver = TimerCallbackDiagnosticObserver.Create();
             var grainId = grain.GetGrainId();
-            var delayStartedCount = callbackObserver.GetDelayStartedCount(grainId);
+            var delayScheduledCount = callbackObserver.GetDelayScheduledCount(grainId);
 
             fixture.AdvanceTime(dueTime);
             for (var tickCount = timerObserver.GetTickCount(grain.GetGrainId()) + 1; tickCount <= expectedTickCount; tickCount++)
             {
                 await timerObserver.WaitForTickStartCountAsync(grain, tickCount, TimerDiagnosticTimeout);
-                await callbackObserver.WaitForDelayStartedCountAsync(grainId, ++delayStartedCount, TimerDiagnosticTimeout);
+                await callbackObserver.WaitForDelayScheduledCountAsync(grainId, ++delayScheduledCount, TimerDiagnosticTimeout);
 
                 var waitForTickStop = timerObserver.WaitForTickCountAsync(grain, tickCount, TimerDiagnosticTimeout);
                 fixture.AdvanceTime(callbackDelay);
@@ -110,7 +110,7 @@ namespace DefaultCluster.Tests.TimerTests
             using var callbackObserver = TimerCallbackDiagnosticObserver.Create();
             var grainId = grain.GetGrainId();
             var externalTick = grain.ExternalTick("external");
-            await callbackObserver.WaitForDelayStartedCountAsync(grainId, callbackObserver.GetDelayStartedCount(grainId) + 1, TimerDiagnosticTimeout);
+            await callbackObserver.WaitForDelayScheduledCountAsync(grainId, callbackObserver.GetDelayScheduledCount(grainId) + 1, TimerDiagnosticTimeout);
             fixture.AdvanceTime(TimerCallbackDelay);
             await externalTick;
             await AdvanceTimerToTickCountAsync(grain, timerObserver, dueTime, TimerCallbackDelay, expectedTimerTicks);
@@ -128,7 +128,7 @@ namespace DefaultCluster.Tests.TimerTests
 
         private sealed class TimerCallbackDiagnosticObserver : IDisposable, IObserver<TimerGrainCallbackEvents.CallbackEvent>
         {
-            private readonly ConcurrentBag<TimerGrainCallbackEvents.DelayStarted> delayStartedEvents = new();
+            private readonly ConcurrentBag<TimerGrainCallbackEvents.DelayScheduled> delayScheduledEvents = new();
             private readonly object changeLock = new();
             private TaskCompletionSource changed = CreateCompletionSource();
             private IDisposable subscription;
@@ -140,12 +140,12 @@ namespace DefaultCluster.Tests.TimerTests
                 return observer;
             }
 
-            public int GetDelayStartedCount(GrainId grainId)
+            public int GetDelayScheduledCount(GrainId grainId)
             {
-                return delayStartedEvents.Count(e => e.GrainId == grainId);
+                return delayScheduledEvents.Count(e => e.GrainId == grainId);
             }
 
-            public async Task WaitForDelayStartedCountAsync(GrainId grainId, int expectedCount, TimeSpan timeout)
+            public async Task WaitForDelayScheduledCountAsync(GrainId grainId, int expectedCount, TimeSpan timeout)
             {
                 using var cts = new CancellationTokenSource(timeout);
 
@@ -154,7 +154,7 @@ namespace DefaultCluster.Tests.TimerTests
                     Task changedTask;
                     lock (changeLock)
                     {
-                        var currentCount = GetDelayStartedCount(grainId);
+                        var currentCount = GetDelayScheduledCount(grainId);
                         if (currentCount >= expectedCount)
                         {
                             return;
@@ -173,20 +173,20 @@ namespace DefaultCluster.Tests.TimerTests
                     }
                 }
 
-                var finalCount = GetDelayStartedCount(grainId);
+                var finalCount = GetDelayScheduledCount(grainId);
                 if (finalCount >= expectedCount)
                 {
                     return;
                 }
 
-                throw new TimeoutException($"Timed out waiting for {expectedCount} timer callbacks to reach their fake delay on grain {grainId}. Current count: {finalCount} after {timeout}");
+                throw new TimeoutException($"Timed out waiting for {expectedCount} timer callbacks to schedule their fake delay on grain {grainId}. Current count: {finalCount} after {timeout}");
             }
 
             void IObserver<TimerGrainCallbackEvents.CallbackEvent>.OnNext(TimerGrainCallbackEvents.CallbackEvent value)
             {
-                if (value is TimerGrainCallbackEvents.DelayStarted delayStarted)
+                if (value is TimerGrainCallbackEvents.DelayScheduled delayScheduled)
                 {
-                    delayStartedEvents.Add(delayStarted);
+                    delayScheduledEvents.Add(delayScheduled);
                     SignalChanged();
                 }
             }

--- a/test/Orleans.DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/Orleans.DefaultCluster.Tests/TimerOrleansTest.cs
@@ -1,12 +1,28 @@
-using System.Diagnostics;
-using Orleans.TestingHost.Utils;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Time.Testing;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.TestingHost;
 using TestExtensions;
+using UnitTestGrains;
 using UnitTests.GrainInterfaces;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace DefaultCluster.Tests.TimerTests
 {
+    public static class TimerOrleansTestCollection
+    {
+        public const string Name = nameof(TimerOrleansTest);
+    }
+
+    [CollectionDefinition(TimerOrleansTestCollection.Name)]
+    public sealed class TimerOrleansTestCollectionDefinition : ICollectionFixture<TimerOrleansTest.Fixture>
+    {
+    }
+
     /// <summary>
     /// Tests for Orleans Timer functionality.
     /// Timers provide grain-local, non-durable periodic callbacks. Unlike reminders,
@@ -15,55 +31,215 @@ namespace DefaultCluster.Tests.TimerTests
     /// timeouts, and other scenarios where persistence isn't required.
     /// Timers are more efficient than reminders for high-frequency operations.
     /// </summary>
-    public class TimerOrleansTest : HostedTestClusterEnsureDefaultStarted
+    [Collection(TimerOrleansTestCollection.Name)]
+    public class TimerOrleansTest : OrleansTestingBase
     {
+        private const int ExpectedDefaultTimerTicks = 10;
         private static readonly TimeSpan OneShotTimerDelay = TimeSpan.FromMilliseconds(100);
+        private static readonly TimeSpan TimerCallbackDelay = TimeSpan.FromMilliseconds(50);
+        private static readonly TimeSpan TimerOverloadDueTime = TimeSpan.FromMilliseconds(25);
         private static readonly TimeSpan TimerDiagnosticTimeout = TimeSpan.FromSeconds(10);
+        private readonly Fixture fixture;
         private readonly ITestOutputHelper output;
 
-        public TimerOrleansTest(ITestOutputHelper output, DefaultClusterFixture fixture)
-            : base(fixture)
+        public TimerOrleansTest(ITestOutputHelper output, Fixture fixture)
         {
+            this.fixture = fixture;
             this.output = output;
         }
 
-        private static async Task<int> WaitForCounterAtLeast(Func<Task<int>> getCounter, int minimumValue, TimeSpan timeout, TimeSpan delay)
+        private IGrainFactory GrainFactory => fixture.GrainFactory;
+
+        private async Task<int> AdvanceDefaultTimerTicksAsync(ITimerGrain grain, TimeSpan period)
         {
-            var last = 0;
-            await TestingUtils.WaitUntilAsync(
-                async lastTry =>
-                {
-                    last = await getCounter();
-                    if (last >= minimumValue)
-                    {
-                        return true;
-                    }
-
-                    if (lastTry)
-                    {
-                        Assert.Fail($"Counter did not reach {minimumValue} within {timeout}. Last value: {last}");
-                    }
-
-                    return false;
-                },
-                timeout,
-                delay);
-
-            return last;
-        }
-
-        private static async Task<int> DriveExternalTicksUntilTimerTicks(INonReentrantTimerCallGrain grain, TimerDiagnosticObserver timerObserver, int expectedTimerTicks)
-        {
-            var waitForTimers = timerObserver.WaitForTickCountAsync(grain, expectedTimerTicks, TimerDiagnosticTimeout);
-            var externalTicks = 0;
-            while (!waitForTimers.IsCompleted)
+            using var timerObserver = TimerDiagnosticObserver.Create();
+            for (var expectedTickCount = 1; expectedTickCount <= ExpectedDefaultTimerTicks; expectedTickCount++)
             {
-                await grain.ExternalTick("external");
-                externalTicks++;
+                await AdvanceTimerToTickCountAsync(grain, timerObserver, period, expectedTickCount);
+                await grain.GetCounter();
             }
 
-            await waitForTimers;
-            return externalTicks;
+            return await grain.GetCounter();
+        }
+
+        private async Task AdvanceDefaultTimerTicksAsync<TGrain>(IReadOnlyList<TGrain> grains, TimeSpan period)
+            where TGrain : ITimerGrain
+        {
+            using var timerObserver = TimerDiagnosticObserver.Create();
+            for (var expectedTickCount = 1; expectedTickCount <= ExpectedDefaultTimerTicks; expectedTickCount++)
+            {
+                var waitForTicks = Task.WhenAll(grains.Select(g => timerObserver.WaitForTickCountAsync(g, expectedTickCount, TimerDiagnosticTimeout)));
+                fixture.AdvanceTime(period);
+                await waitForTicks;
+                await Task.WhenAll(grains.Select(g => g.GetCounter()));
+            }
+        }
+
+        private async Task AdvanceTimerToTickCountAsync(IAddressable grain, TimerDiagnosticObserver timerObserver, TimeSpan dueTime, int expectedTickCount)
+        {
+            var waitForTick = timerObserver.WaitForTickCountAsync(grain, expectedTickCount, TimerDiagnosticTimeout);
+            fixture.AdvanceTime(dueTime);
+            await waitForTick;
+        }
+
+        private async Task AdvanceTimerToTickCountAsync(
+            IAddressable grain,
+            TimerDiagnosticObserver timerObserver,
+            TimeSpan dueTime,
+            TimeSpan callbackDelay,
+            int expectedTickCount)
+        {
+            using var callbackObserver = TimerCallbackDiagnosticObserver.Create();
+            var grainId = grain.GetGrainId();
+            var delayStartedCount = callbackObserver.GetDelayStartedCount(grainId);
+
+            fixture.AdvanceTime(dueTime);
+            for (var tickCount = timerObserver.GetTickCount(grain.GetGrainId()) + 1; tickCount <= expectedTickCount; tickCount++)
+            {
+                await timerObserver.WaitForTickStartCountAsync(grain, tickCount, TimerDiagnosticTimeout);
+                await callbackObserver.WaitForDelayStartedCountAsync(grainId, ++delayStartedCount, TimerDiagnosticTimeout);
+
+                var waitForTickStop = timerObserver.WaitForTickCountAsync(grain, tickCount, TimerDiagnosticTimeout);
+                fixture.AdvanceTime(callbackDelay);
+                await waitForTickStop;
+            }
+        }
+
+        private async Task<int> DriveExternalTickUntilTimerTicks(INonReentrantTimerCallGrain grain, TimerDiagnosticObserver timerObserver, TimeSpan dueTime, int expectedTimerTicks)
+        {
+            using var callbackObserver = TimerCallbackDiagnosticObserver.Create();
+            var grainId = grain.GetGrainId();
+            var externalTick = grain.ExternalTick("external");
+            await callbackObserver.WaitForDelayStartedCountAsync(grainId, callbackObserver.GetDelayStartedCount(grainId) + 1, TimerDiagnosticTimeout);
+            fixture.AdvanceTime(TimerCallbackDelay);
+            await externalTick;
+            await AdvanceTimerToTickCountAsync(grain, timerObserver, dueTime, TimerCallbackDelay, expectedTimerTicks);
+            return 1;
+        }
+
+        private async Task RunSelfDisposingTimerAsync(ITimerCallGrain grain)
+        {
+            using var timerObserver = TimerDiagnosticObserver.Create();
+            var runTimer = grain.RunSelfDisposingTimer();
+            var created = await timerObserver.WaitForTimerCreatedAsync(grain, TimerDiagnosticTimeout);
+            await AdvanceTimerToTickCountAsync(grain, timerObserver, created.DueTime, TimeSpan.FromMilliseconds(100), expectedTickCount: 1);
+            await runTimer;
+        }
+
+        private sealed class TimerCallbackDiagnosticObserver : IDisposable, IObserver<TimerGrainCallbackEvents.CallbackEvent>
+        {
+            private readonly ConcurrentBag<TimerGrainCallbackEvents.DelayStarted> delayStartedEvents = new();
+            private readonly object changeLock = new();
+            private TaskCompletionSource changed = CreateCompletionSource();
+            private IDisposable subscription;
+
+            public static TimerCallbackDiagnosticObserver Create()
+            {
+                var observer = new TimerCallbackDiagnosticObserver();
+                observer.subscription = TimerGrainCallbackEvents.AllEvents.Subscribe(observer);
+                return observer;
+            }
+
+            public int GetDelayStartedCount(GrainId grainId)
+            {
+                return delayStartedEvents.Count(e => e.GrainId == grainId);
+            }
+
+            public async Task WaitForDelayStartedCountAsync(GrainId grainId, int expectedCount, TimeSpan timeout)
+            {
+                using var cts = new CancellationTokenSource(timeout);
+
+                while (true)
+                {
+                    Task changedTask;
+                    lock (changeLock)
+                    {
+                        var currentCount = GetDelayStartedCount(grainId);
+                        if (currentCount >= expectedCount)
+                        {
+                            return;
+                        }
+
+                        changedTask = changed.Task;
+                    }
+
+                    try
+                    {
+                        await changedTask.WaitAsync(cts.Token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                }
+
+                var finalCount = GetDelayStartedCount(grainId);
+                if (finalCount >= expectedCount)
+                {
+                    return;
+                }
+
+                throw new TimeoutException($"Timed out waiting for {expectedCount} timer callbacks to reach their fake delay on grain {grainId}. Current count: {finalCount} after {timeout}");
+            }
+
+            void IObserver<TimerGrainCallbackEvents.CallbackEvent>.OnNext(TimerGrainCallbackEvents.CallbackEvent value)
+            {
+                if (value is TimerGrainCallbackEvents.DelayStarted delayStarted)
+                {
+                    delayStartedEvents.Add(delayStarted);
+                    SignalChanged();
+                }
+            }
+
+            void IObserver<TimerGrainCallbackEvents.CallbackEvent>.OnError(Exception error)
+            {
+            }
+
+            void IObserver<TimerGrainCallbackEvents.CallbackEvent>.OnCompleted()
+            {
+            }
+
+            public void Dispose()
+            {
+                subscription?.Dispose();
+            }
+
+            private static TaskCompletionSource CreateCompletionSource() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            private void SignalChanged()
+            {
+                TaskCompletionSource previous;
+                lock (changeLock)
+                {
+                    previous = changed;
+                    changed = CreateCompletionSource();
+                }
+
+                previous.TrySetResult();
+            }
+        }
+
+        public sealed class Fixture : BaseInProcessTestClusterFixture
+        {
+            private readonly FakeTimeProvider timeProvider = new(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+            protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
+            {
+                builder.ConfigureSilo((_, siloBuilder) =>
+                {
+                    siloBuilder
+                        .Configure<SiloMessagingOptions>(o => o.ClientGatewayShutdownNotificationTimeout = default)
+                        .UseInMemoryReminderService()
+                        .UseInMemoryDurableJobs()
+                        .AddMemoryGrainStorageAsDefault()
+                        .AddMemoryGrainStorage("MemoryStore");
+
+                    siloBuilder.Services.AddSingleton(timeProvider);
+                    siloBuilder.Services.Replace(ServiceDescriptor.Singleton<TimeProvider>(sp => sp.GetRequiredService<FakeTimeProvider>()));
+                });
+            }
+
+            public void AdvanceTime(TimeSpan duration) => timeProvider.Advance(duration);
         }
 
         /// <summary>
@@ -79,16 +255,15 @@ namespace DefaultCluster.Tests.TimerTests
             {
                 var grain = GrainFactory.GetGrain<ITimerGrain>(GetRandomGrainId());
                 var period = await grain.GetTimerPeriod();
-                var timeout = period.Multiply(50);
-                var last = await WaitForCounterAtLeast(grain.GetCounter, 10, timeout, period);
+                var last = await AdvanceDefaultTimerTicksAsync(grain, period);
 
                 output.WriteLine("value = " + last);
-                Assert.True(last >= 10 & last <= 12, last.ToString());
+                Assert.Equal(ExpectedDefaultTimerTicks, last);
 
                 await grain.StopDefaultTimer();
-                await Task.Delay(period.Multiply(2));
+                fixture.AdvanceTime(period.Multiply(2));
                 var curr = await grain.GetCounter();
-                Assert.True(curr == last || curr == last + 1, "curr == last || curr == last + 1");
+                Assert.Equal(last, curr);
             }
         }
 
@@ -110,32 +285,13 @@ namespace DefaultCluster.Tests.TimerTests
                 period = await grain.GetTimerPeriod(); // activate grains
             }
 
-            var tasks = new List<Task>(grains.Count);
+            await AdvanceDefaultTimerTicksAsync(grains, period);
             for (int i = 0; i < grains.Count; i++)
             {
                 ITimerGrain grain = grains[i];
-                tasks.Add(
-                    Task.Run(
-                        async () =>
-                        {
-                            int last = await grain.GetCounter();
-                            var stopwatch = Stopwatch.StartNew();
-                            var timeout = period.Multiply(50);
-                            while (stopwatch.Elapsed < timeout && last < 10)
-                            {
-                                await Task.Delay(period.Divide(2));
-                                last = await grain.GetCounter();
-                            }
-
-                            output.WriteLine("value = " + last);
-                            Assert.True(last >= 10 && last <= 12, "last >= 10 && last <= 12");
-                        }));
-            }
-
-            await Task.WhenAll(tasks);
-            for (int i = 0; i < grains.Count; i++)
-            {
-                ITimerGrain grain = grains[i];
+                var last = await grain.GetCounter();
+                output.WriteLine("value = " + last);
+                Assert.Equal(ExpectedDefaultTimerTicks, last);
                 await grain.StopDefaultTimer();
             }
         }
@@ -153,42 +309,22 @@ namespace DefaultCluster.Tests.TimerTests
             TimeSpan period = await grain.GetTimerPeriod();
 
             // Ensure that the grain works as it should.
-            var last = await grain.GetCounter();
-            var stopwatch = Stopwatch.StartNew();
-            var timeout = period.Multiply(50);
-            while (stopwatch.Elapsed < timeout && last < 10)
-            {
-                await Task.Delay(period.Divide(2));
-                last = await grain.GetCounter();
-            }
-
-            last = await grain.GetCounter();
+            var last = await AdvanceDefaultTimerTicksAsync(grain, period);
+            Assert.Equal(ExpectedDefaultTimerTicks, last);
             output.WriteLine("value = " + last);
 
             // Restart the grain.
             await grain.Deactivate();
-            stopwatch.Restart();
             last = await grain.GetCounter();
             Assert.True(last == 0, "Restarted grains should have zero ticks. Actual: " + last);
             period = await grain.GetTimerPeriod();
 
             // Poke the grain and ensure it still works as it should.
-            while (stopwatch.Elapsed < timeout && last < 10)
-            {
-                await Task.Delay(period.Divide(2));
-                last = await grain.GetCounter();
-            }
-
-            last = await grain.GetCounter();
-            stopwatch.Stop();
-
-            int maximalNumTicks = (int)Math.Round(stopwatch.Elapsed.Divide(period), MidpointRounding.ToPositiveInfinity);
-            Assert.True(
-                last <= maximalNumTicks,
-                $"Assert: last <= maximalNumTicks. Actual: last = {last}, maximalNumTicks = {maximalNumTicks}");
+            last = await AdvanceDefaultTimerTicksAsync(grain, period);
+            Assert.Equal(ExpectedDefaultTimerTicks, last);
 
             output.WriteLine(
-                "Total Elapsed time = " + (stopwatch.Elapsed.TotalSeconds) + " sec. Expected Ticks = " + maximalNumTicks +
+                "Virtual elapsed time = " + (period.Multiply(ExpectedDefaultTimerTicks).TotalSeconds) + " sec. Expected ticks = " + ExpectedDefaultTimerTicks +
                 ". Actual ticks = " + last);
         }
 
@@ -214,7 +350,7 @@ namespace DefaultCluster.Tests.TimerTests
 
                 await grain.StartTimer(testName, delay);
 
-                await timerObserver.WaitForTimerTickAsync(grain, TimerDiagnosticTimeout);
+                await AdvanceTimerToTickCountAsync(grain, timerObserver, delay, TimerCallbackDelay, expectedTickCount: 1);
 
                 int tickCount = await grain.GetTickCount();
                 Assert.Equal(1, tickCount);
@@ -255,19 +391,11 @@ namespace DefaultCluster.Tests.TimerTests
         {
             var grain = GrainFactory.GetGrain<ITimerRequestGrain>(GetRandomGrainId());
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var timerObserver = TimerDiagnosticObserver.Create();
             var numTimers = await grain.TestAllTimerOverloads();
-            while (true)
-            {
-                var completedTimers = await grain.PollCompletedTimers().WaitAsync(cts.Token);
-                if (completedTimers == numTimers)
-                {
-                    break;
-                }
-
-                await Task.Delay(TimeSpan.FromMilliseconds(50), cts.Token);
-            }
-
+            var waitForTimers = timerObserver.WaitForTickCountAsync(grain, numTimers, TimerDiagnosticTimeout);
+            fixture.AdvanceTime(TimerOverloadDueTime);
+            await waitForTimers;
             await grain.TestCompletedTimerResults();
         }
 
@@ -282,10 +410,10 @@ namespace DefaultCluster.Tests.TimerTests
         {
             // Schedule a timer which disposes itself from its own callback.
             var grain = GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
-            await grain.RunSelfDisposingTimer();
+            await RunSelfDisposingTimerAsync(grain);
 
             var pocoGrain = GrainFactory.GetGrain<IPocoTimerCallGrain>(GetRandomGrainId());
-            await pocoGrain.RunSelfDisposingTimer();
+            await RunSelfDisposingTimerAsync(pocoGrain);
         }
 
         /// <summary>
@@ -310,7 +438,7 @@ namespace DefaultCluster.Tests.TimerTests
             await grain.StartTimer($"{testName}_2", delay);
 
             // Invoke some non-interleaving methods while waiting for the timer callbacks.
-            var externalTicks = await DriveExternalTicksUntilTimerTicks(grain, timerObserver, expectedTimerTicks: 3);
+            var externalTicks = await DriveExternalTickUntilTimerTicks(grain, timerObserver, delay, expectedTimerTicks: 3);
 
             var tickCount = await grain.GetTickCount();
 
@@ -342,35 +470,19 @@ namespace DefaultCluster.Tests.TimerTests
 
             await grain.StartTimer(testName, delay);
 
-            await timerObserver.WaitForTickCountAsync(grain, 1, TimerDiagnosticTimeout);
+            await AdvanceTimerToTickCountAsync(grain, timerObserver, delay, TimerCallbackDelay, expectedTickCount: 1);
 
             int tickCount = await grain.GetTickCount();
             Assert.Equal(1, tickCount);
 
             await grain.RestartTimer(testName, delay);
 
-            await timerObserver.WaitForTickCountAsync(grain, 2, TimerDiagnosticTimeout);
+            await AdvanceTimerToTickCountAsync(grain, timerObserver, delay, TimerCallbackDelay, expectedTickCount: 2);
 
             tickCount = await grain.GetTickCount();
             Assert.Equal(2, tickCount);
 
-            // Infinite timeouts should be valid.
-            await grain.RestartTimer(testName, Timeout.InfiniteTimeSpan);
-            await grain.RestartTimer(testName, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-
-            // Zero and sub-ms timeouts should be valid (rounded up to 1ms)
-            await grain.RestartTimer(testName, TimeSpan.Zero);
-            await grain.RestartTimer(testName, TimeSpan.FromMicroseconds(10));
-            await grain.RestartTimer(testName, TimeSpan.Zero, TimeSpan.Zero);
-            await grain.RestartTimer(testName, TimeSpan.FromMicroseconds(10), TimeSpan.FromMicroseconds(10));
-            await grain.RestartTimer(testName, TimeSpan.FromMilliseconds(-0.4));
-            await grain.RestartTimer(testName, TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(-0.5));
-
-            // Invalid values
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await grain.RestartTimer(testName, TimeSpan.FromSeconds(-5)));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await grain.RestartTimer(testName, TimeSpan.MaxValue));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await grain.RestartTimer(testName, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(-5)));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await grain.RestartTimer(testName, TimeSpan.FromSeconds(1), TimeSpan.MaxValue));
+            await grain.TestTimerChangeArguments();
 
             Exception err = await grain.GetException();
             Assert.Null(err); // Should be no exceptions during timer callback
@@ -378,13 +490,13 @@ namespace DefaultCluster.Tests.TimerTests
             // Valid operations called from within a timer: updating the period and disposing the timer.
             var grain2 = GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
             await grain2.StartTimer(testName, delay, "update_period");
-            await timerObserver.WaitForTickCountAsync(grain2, 1, TimerDiagnosticTimeout);
+            await AdvanceTimerToTickCountAsync(grain2, timerObserver, delay, TimerCallbackDelay, expectedTickCount: 1);
             Assert.Null(await grain2.GetException()); // Should be no exceptions during timer callback
             Assert.Equal(1, await grain2.GetTickCount());
 
             var grain3 = GrainFactory.GetGrain<ITimerCallGrain>(GetRandomGrainId());
             await grain3.StartTimer(testName, delay, "dispose_timer");
-            await timerObserver.WaitForTickCountAsync(grain3, 1, TimerDiagnosticTimeout);
+            await AdvanceTimerToTickCountAsync(grain3, timerObserver, delay, TimerCallbackDelay, expectedTickCount: 1);
             var grain3TickCount = await grain3.GetTickCount();
 
             Assert.Null(await grain3.GetException()); // Should be no exceptions during timer callback
@@ -406,16 +518,15 @@ namespace DefaultCluster.Tests.TimerTests
             {
                 var grain = GrainFactory.GetGrain<IPocoTimerGrain>(GetRandomGrainId());
                 var period = await grain.GetTimerPeriod();
-                var timeout = period.Multiply(50);
-                var last = await WaitForCounterAtLeast(grain.GetCounter, 10, timeout, period);
+                var last = await AdvanceDefaultTimerTicksAsync(grain, period);
 
                 output.WriteLine("value = " + last);
-                Assert.True(last >= 10 & last <= 12, last.ToString());
+                Assert.Equal(ExpectedDefaultTimerTicks, last);
 
                 await grain.StopDefaultTimer();
-                await Task.Delay(period.Multiply(2));
+                fixture.AdvanceTime(period.Multiply(2));
                 var curr = await grain.GetCounter();
-                Assert.True(curr == last || curr == last + 1, "curr == last || curr == last + 1");
+                Assert.Equal(last, curr);
             }
         }
 
@@ -437,32 +548,13 @@ namespace DefaultCluster.Tests.TimerTests
                 period = await grain.GetTimerPeriod(); // activate grains
             }
 
-            var tasks = new List<Task>(grains.Count);
+            await AdvanceDefaultTimerTicksAsync(grains, period);
             for (int i = 0; i < grains.Count; i++)
             {
                 IPocoTimerGrain grain = grains[i];
-                tasks.Add(
-                    Task.Run(
-                        async () =>
-                        {
-                            int last = await grain.GetCounter();
-                            var stopwatch = Stopwatch.StartNew();
-                            var timeout = period.Multiply(50);
-                            while (stopwatch.Elapsed < timeout && last < 10)
-                            {
-                                await Task.Delay(period.Divide(2));
-                                last = await grain.GetCounter();
-                            }
-
-                            output.WriteLine("value = " + last);
-                            Assert.True(last >= 10 && last <= 12, "last >= 10 && last <= 12");
-                        }));
-            }
-
-            await Task.WhenAll(tasks);
-            for (int i = 0; i < grains.Count; i++)
-            {
-                IPocoTimerGrain grain = grains[i];
+                var last = await grain.GetCounter();
+                output.WriteLine("value = " + last);
+                Assert.Equal(ExpectedDefaultTimerTicks, last);
                 await grain.StopDefaultTimer();
             }
         }
@@ -480,42 +572,22 @@ namespace DefaultCluster.Tests.TimerTests
             TimeSpan period = await grain.GetTimerPeriod();
 
             // Ensure that the grain works as it should.
-            var last = await grain.GetCounter();
-            var stopwatch = Stopwatch.StartNew();
-            var timeout = period.Multiply(50);
-            while (stopwatch.Elapsed < timeout && last < 10)
-            {
-                await Task.Delay(period.Divide(2));
-                last = await grain.GetCounter();
-            }
-
-            last = await grain.GetCounter();
+            var last = await AdvanceDefaultTimerTicksAsync(grain, period);
+            Assert.Equal(ExpectedDefaultTimerTicks, last);
             output.WriteLine("value = " + last);
 
             // Restart the grain.
             await grain.Deactivate();
-            stopwatch.Restart();
             last = await grain.GetCounter();
             Assert.True(last == 0, "Restarted grains should have zero ticks. Actual: " + last);
             period = await grain.GetTimerPeriod();
 
             // Poke the grain and ensure it still works as it should.
-            while (stopwatch.Elapsed < timeout && last < 10)
-            {
-                await Task.Delay(period.Divide(2));
-                last = await grain.GetCounter();
-            }
-
-            last = await grain.GetCounter();
-            stopwatch.Stop();
-
-            int maximalNumTicks = (int)Math.Round(stopwatch.Elapsed.Divide(period), MidpointRounding.ToPositiveInfinity);
-            Assert.True(
-                last <= maximalNumTicks,
-                $"Assert: last <= maximalNumTicks. Actual: last = {last}, maximalNumTicks = {maximalNumTicks}");
+            last = await AdvanceDefaultTimerTicksAsync(grain, period);
+            Assert.Equal(ExpectedDefaultTimerTicks, last);
 
             output.WriteLine(
-                "Total Elapsed time = " + (stopwatch.Elapsed.TotalSeconds) + " sec. Expected Ticks = " + maximalNumTicks +
+                "Virtual elapsed time = " + (period.Multiply(ExpectedDefaultTimerTicks).TotalSeconds) + " sec. Expected ticks = " + ExpectedDefaultTimerTicks +
                 ". Actual ticks = " + last);
         }
 
@@ -541,7 +613,7 @@ namespace DefaultCluster.Tests.TimerTests
 
                 await grain.StartTimer(testName, delay);
 
-                await timerObserver.WaitForTimerTickAsync(grain, TimerDiagnosticTimeout);
+                await AdvanceTimerToTickCountAsync(grain, timerObserver, delay, TimerCallbackDelay, expectedTickCount: 1);
 
                 int tickCount = await grain.GetTickCount();
                 Assert.Equal(1, tickCount);
@@ -582,19 +654,11 @@ namespace DefaultCluster.Tests.TimerTests
         {
             var grain = GrainFactory.GetGrain<IPocoTimerRequestGrain>(GetRandomGrainId());
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var timerObserver = TimerDiagnosticObserver.Create();
             var numTimers = await grain.TestAllTimerOverloads();
-            while (true)
-            {
-                var completedTimers = await grain.PollCompletedTimers().WaitAsync(cts.Token);
-                if (completedTimers == numTimers)
-                {
-                    break;
-                }
-
-                await Task.Delay(TimeSpan.FromMilliseconds(50), cts.Token);
-            }
-
+            var waitForTimers = timerObserver.WaitForTickCountAsync(grain, numTimers, TimerDiagnosticTimeout);
+            fixture.AdvanceTime(TimerOverloadDueTime);
+            await waitForTimers;
             await grain.TestCompletedTimerResults();
         }
 
@@ -619,7 +683,7 @@ namespace DefaultCluster.Tests.TimerTests
             await grain.StartTimer($"{testName}_2", delay);
 
             // Invoke some non-interleaving methods while waiting for the timer callbacks.
-            var externalTicks = await DriveExternalTicksUntilTimerTicks(grain, timerObserver, expectedTimerTicks: 3);
+            var externalTicks = await DriveExternalTickUntilTimerTicks(grain, timerObserver, delay, expectedTimerTicks: 3);
 
             var tickCount = await grain.GetTickCount();
 
@@ -650,35 +714,19 @@ namespace DefaultCluster.Tests.TimerTests
 
             await grain.StartTimer(testName, delay);
 
-            await timerObserver.WaitForTickCountAsync(grain, 1, TimerDiagnosticTimeout);
+            await AdvanceTimerToTickCountAsync(grain, timerObserver, delay, TimerCallbackDelay, expectedTickCount: 1);
 
             int tickCount = await grain.GetTickCount();
             Assert.Equal(1, tickCount);
 
             await grain.RestartTimer(testName, delay);
 
-            await timerObserver.WaitForTickCountAsync(grain, 2, TimerDiagnosticTimeout);
+            await AdvanceTimerToTickCountAsync(grain, timerObserver, delay, TimerCallbackDelay, expectedTickCount: 2);
 
             tickCount = await grain.GetTickCount();
             Assert.Equal(2, tickCount);
 
-            // Infinite timeouts should be valid.
-            await grain.RestartTimer(testName, Timeout.InfiniteTimeSpan);
-            await grain.RestartTimer(testName, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-
-            // Zero and sub-ms timeouts should be valid (rounded up to 1ms)
-            await grain.RestartTimer(testName, TimeSpan.Zero);
-            await grain.RestartTimer(testName, TimeSpan.FromMicroseconds(10));
-            await grain.RestartTimer(testName, TimeSpan.Zero, TimeSpan.Zero);
-            await grain.RestartTimer(testName, TimeSpan.FromMicroseconds(10), TimeSpan.FromMicroseconds(10));
-            await grain.RestartTimer(testName, TimeSpan.FromMilliseconds(-0.4));
-            await grain.RestartTimer(testName, TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(-0.5));
-
-            // Invalid values
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await grain.RestartTimer(testName, TimeSpan.FromSeconds(-5)));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await grain.RestartTimer(testName, TimeSpan.MaxValue));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await grain.RestartTimer(testName, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(-5)));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await grain.RestartTimer(testName, TimeSpan.FromSeconds(1), TimeSpan.MaxValue));
+            await grain.TestTimerChangeArguments();
 
             Exception err = await grain.GetException();
             Assert.Null(err); // Should be no exceptions during timer callback
@@ -686,13 +734,13 @@ namespace DefaultCluster.Tests.TimerTests
             // Valid operations called from within a timer: updating the period and disposing the timer.
             var grain2 = GrainFactory.GetGrain<IPocoTimerCallGrain>(GetRandomGrainId());
             await grain2.StartTimer(testName, delay, "update_period");
-            await timerObserver.WaitForTickCountAsync(grain2, 1, TimerDiagnosticTimeout);
+            await AdvanceTimerToTickCountAsync(grain2, timerObserver, delay, TimerCallbackDelay, expectedTickCount: 1);
             Assert.Null(await grain2.GetException()); // Should be no exceptions during timer callback
             Assert.Equal(1, await grain2.GetTickCount());
 
             var grain3 = GrainFactory.GetGrain<IPocoTimerCallGrain>(GetRandomGrainId());
             await grain3.StartTimer(testName, delay, "dispose_timer");
-            await timerObserver.WaitForTickCountAsync(grain3, 1, TimerDiagnosticTimeout);
+            await AdvanceTimerToTickCountAsync(grain3, timerObserver, delay, TimerCallbackDelay, expectedTickCount: 1);
             Assert.Null(await grain3.GetException()); // Should be no exceptions during timer callback
             Assert.Equal(1, await grain3.GetTickCount());
 

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/TimerDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/TimerDiagnosticObserver.cs
@@ -18,6 +18,8 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
     private readonly ConcurrentBag<GrainTimerEvents.TickStart> _tickStartEvents = new();
     private readonly ConcurrentBag<GrainTimerEvents.TickStop> _tickStopEvents = new();
     private readonly ConcurrentBag<GrainTimerEvents.Disposed> _disposedEvents = new();
+    private readonly object _changeLock = new();
+    private TaskCompletionSource _changed = CreateCompletionSource();
     private IDisposable? _subscription;
 
     /// <summary>
@@ -65,27 +67,27 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
         using var cts = new CancellationTokenSource(effectiveTimeout);
 
-        var existingMatch = _createdEvents.FirstOrDefault(e => e.GrainContext.GrainId == grainId);
-        if (existingMatch is not null)
+        while (true)
         {
-            return existingMatch;
-        }
+            Task changed;
+            lock (_changeLock)
+            {
+                var existingMatch = _createdEvents.FirstOrDefault(e => e.GrainContext.GrainId == grainId);
+                if (existingMatch is not null)
+                {
+                    return existingMatch;
+                }
 
-        while (!cts.Token.IsCancellationRequested)
-        {
+                changed = _changed.Task;
+            }
+
             try
             {
-                await Task.Delay(10, cts.Token);
+                await changed.WaitAsync(cts.Token);
             }
             catch (OperationCanceledException)
             {
                 break;
-            }
-
-            var match = _createdEvents.FirstOrDefault(e => e.GrainContext.GrainId == grainId);
-            if (match is not null)
-            {
-                return match;
             }
         }
 
@@ -103,27 +105,27 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
         using var cts = new CancellationTokenSource(effectiveTimeout);
 
-        var existingMatch = _tickStopEvents.FirstOrDefault(e => e.GrainContext.GrainId == grainId);
-        if (existingMatch is not null)
+        while (true)
         {
-            return existingMatch;
-        }
+            Task changed;
+            lock (_changeLock)
+            {
+                var existingMatch = _tickStopEvents.FirstOrDefault(e => e.GrainContext.GrainId == grainId);
+                if (existingMatch is not null)
+                {
+                    return existingMatch;
+                }
 
-        while (!cts.Token.IsCancellationRequested)
-        {
+                changed = _changed.Task;
+            }
+
             try
             {
-                await Task.Delay(10, cts.Token);
+                await changed.WaitAsync(cts.Token);
             }
             catch (OperationCanceledException)
             {
                 break;
-            }
-
-            var match = _tickStopEvents.FirstOrDefault(e => e.GrainContext.GrainId == grainId);
-            if (match is not null)
-            {
-                return match;
             }
         }
 
@@ -141,27 +143,27 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
         using var cts = new CancellationTokenSource(effectiveTimeout);
 
-        var existingMatch = _tickStopEvents.FirstOrDefault(e => GetGrainTypeName(e.GrainContext).Contains(grainTypeName, StringComparison.OrdinalIgnoreCase));
-        if (existingMatch is not null)
+        while (true)
         {
-            return existingMatch;
-        }
+            Task changed;
+            lock (_changeLock)
+            {
+                var existingMatch = _tickStopEvents.FirstOrDefault(e => GetGrainTypeName(e.GrainContext).Contains(grainTypeName, StringComparison.OrdinalIgnoreCase));
+                if (existingMatch is not null)
+                {
+                    return existingMatch;
+                }
 
-        while (!cts.Token.IsCancellationRequested)
-        {
+                changed = _changed.Task;
+            }
+
             try
             {
-                await Task.Delay(10, cts.Token);
+                await changed.WaitAsync(cts.Token);
             }
             catch (OperationCanceledException)
             {
                 break;
-            }
-
-            var match = _tickStopEvents.FirstOrDefault(e => GetGrainTypeName(e.GrainContext).Contains(grainTypeName, StringComparison.OrdinalIgnoreCase));
-            if (match is not null)
-            {
-                return match;
             }
         }
 
@@ -179,27 +181,27 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
         using var cts = new CancellationTokenSource(effectiveTimeout);
 
-        var existingMatch = _disposedEvents.FirstOrDefault(e => e.GrainContext.GrainId == grainId);
-        if (existingMatch is not null)
+        while (true)
         {
-            return existingMatch;
-        }
+            Task changed;
+            lock (_changeLock)
+            {
+                var existingMatch = _disposedEvents.FirstOrDefault(e => e.GrainContext.GrainId == grainId);
+                if (existingMatch is not null)
+                {
+                    return existingMatch;
+                }
 
-        while (!cts.Token.IsCancellationRequested)
-        {
+                changed = _changed.Task;
+            }
+
             try
             {
-                await Task.Delay(10, cts.Token);
+                await changed.WaitAsync(cts.Token);
             }
             catch (OperationCanceledException)
             {
                 break;
-            }
-
-            var match = _disposedEvents.FirstOrDefault(e => e.GrainContext.GrainId == grainId);
-            if (match is not null)
-            {
-                return match;
             }
         }
 
@@ -219,17 +221,23 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(60);
         using var cts = new CancellationTokenSource(effectiveTimeout);
 
-        while (!cts.Token.IsCancellationRequested)
+        while (true)
         {
-            var currentCount = GetTickCount(grainId);
-            if (currentCount >= expectedCount)
+            Task changed;
+            lock (_changeLock)
             {
-                return;
+                var currentCount = GetTickCount(grainId);
+                if (currentCount >= expectedCount)
+                {
+                    return;
+                }
+
+                changed = _changed.Task;
             }
 
             try
             {
-                await Task.Delay(10, cts.Token);
+                await changed.WaitAsync(cts.Token);
             }
             catch (OperationCanceledException)
             {
@@ -247,6 +255,52 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
     }
 
     /// <summary>
+    /// Waits for a specific number of timer ticks to start on a grain.
+    /// </summary>
+    /// <param name="grainId">The grain ID to wait for.</param>
+    /// <param name="expectedCount">The minimum number of tick starts to wait for.</param>
+    /// <param name="timeout">Maximum time to wait. Defaults to 60 seconds.</param>
+    /// <returns>A task that completes when the expected count is reached.</returns>
+    /// <exception cref="TimeoutException">Thrown if the expected count is not reached within the timeout.</exception>
+    public async Task WaitForTickStartCountAsync(GrainId grainId, int expectedCount, TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(60);
+        using var cts = new CancellationTokenSource(effectiveTimeout);
+
+        while (true)
+        {
+            Task changed;
+            lock (_changeLock)
+            {
+                var currentCount = GetTickStartCount(grainId);
+                if (currentCount >= expectedCount)
+                {
+                    return;
+                }
+
+                changed = _changed.Task;
+            }
+
+            try
+            {
+                await changed.WaitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        var finalCount = GetTickStartCount(grainId);
+        if (finalCount >= expectedCount)
+        {
+            return;
+        }
+
+        throw new TimeoutException($"Timed out waiting for {expectedCount} timer tick starts on grain {grainId}. Current count: {finalCount} after {effectiveTimeout}");
+    }
+
+    /// <summary>
     /// Waits for a specific number of timer ticks to complete on any grain of the specified type.
     /// </summary>
     /// <param name="grainTypeName">The grain type name to match (partial match supported).</param>
@@ -259,17 +313,23 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(60);
         using var cts = new CancellationTokenSource(effectiveTimeout);
 
-        while (!cts.Token.IsCancellationRequested)
+        while (true)
         {
-            var currentCount = GetTickCountByGrainType(grainTypeName);
-            if (currentCount >= expectedCount)
+            Task changed;
+            lock (_changeLock)
             {
-                return;
+                var currentCount = GetTickCountByGrainType(grainTypeName);
+                if (currentCount >= expectedCount)
+                {
+                    return;
+                }
+
+                changed = _changed.Task;
             }
 
             try
             {
-                await Task.Delay(10, cts.Token);
+                await changed.WaitAsync(cts.Token);
             }
             catch (OperationCanceledException)
             {
@@ -294,6 +354,16 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
     public int GetTickCount(GrainId grainId)
     {
         return _tickStopEvents.Count(e => e.GrainContext.GrainId == grainId);
+    }
+
+    /// <summary>
+    /// Gets the count of timer tick starts for a specific grain.
+    /// </summary>
+    /// <param name="grainId">The grain ID to filter by.</param>
+    /// <returns>The count of timer tick start events.</returns>
+    public int GetTickStartCount(GrainId grainId)
+    {
+        return _tickStartEvents.Count(e => e.GrainContext.GrainId == grainId);
     }
 
     /// <summary>
@@ -325,6 +395,7 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
         _tickStartEvents.Clear();
         _tickStopEvents.Clear();
         _disposedEvents.Clear();
+        SignalChanged();
     }
 
     void IObserver<GrainTimerEvents.TimerEvent>.OnNext(GrainTimerEvents.TimerEvent value)
@@ -344,6 +415,8 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
                 _disposedEvents.Add(disposed);
                 break;
         }
+
+        SignalChanged();
     }
 
     void IObserver<GrainTimerEvents.TimerEvent>.OnError(Exception error)
@@ -360,6 +433,20 @@ public sealed class TimerDiagnosticObserver : IDisposable, IObserver<GrainTimerE
     }
 
     private static string GetGrainTypeName(IGrainContext grainContext) => grainContext.GrainId.Type.ToString()!;
+
+    private static TaskCompletionSource CreateCompletionSource() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private void SignalChanged()
+    {
+        TaskCompletionSource changed;
+        lock (_changeLock)
+        {
+            changed = _changed;
+            _changed = CreateCompletionSource();
+        }
+
+        changed.TrySetResult();
+    }
 }
 
 /// <summary>
@@ -389,6 +476,14 @@ public static class TimerDiagnosticExtensions
     public static Task WaitForTickCountAsync(this TimerDiagnosticObserver observer, IAddressable grain, int expectedCount, TimeSpan? timeout = null)
     {
         return observer.WaitForTickCountAsync(grain.GetGrainId(), expectedCount, timeout);
+    }
+
+    /// <summary>
+    /// Waits for a specific number of timer ticks to start on a grain.
+    /// </summary>
+    public static Task WaitForTickStartCountAsync(this TimerDiagnosticObserver observer, IAddressable grain, int expectedCount, TimeSpan? timeout = null)
+    {
+        return observer.WaitForTickStartCountAsync(grain.GetGrainId(), expectedCount, timeout);
     }
 
     /// <summary>


### PR DESCRIPTION
This fixes the timer test flake by removing wall-clock waits from the timer test flow. The timer test cluster now uses a FakeTimeProvider for grain timers, timer callback delays consume the injected TimeProvider, and tests drive callbacks using timer and callback diagnostic events so fake time is advanced only after the callback delay is registered.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10216)