### PR TITLE
fix: allow local activation migration

### DIFF
--- a/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
+++ b/src/Orleans.Core.Abstractions/Core/IGrainBase.cs
@@ -47,9 +47,9 @@ namespace Orleans
             grain.GrainContext.Deactivate(new(DeactivationReasonCode.ApplicationRequested, $"{nameof(DeactivateOnIdle)} was called."));
 
         /// <summary>
-        /// Starts an attempt to migrating this instance to another location.
-        /// Migration captures the current <see cref="RequestContext"/>, making it available to the activation's placement director so that it can consider it when selecting a new location.
-        /// Migration will occur asynchronously, when no requests are executing, and will not occur if the activation's placement director does not select an alternative location.
+        /// Starts an attempt to migrate this instance.
+        /// Migration captures the current <see cref="RequestContext"/>, making it available to the activation's placement director so that it can consider it when selecting a destination.
+        /// Migration will occur asynchronously, when no requests are executing, and will not occur if the activation's placement director does not select a location.
         /// </summary>
         public static void MigrateOnIdle(this IGrainBase grain) => grain.GrainContext.Migrate(RequestContext.CallContextData?.Value.Values);
 

--- a/src/Orleans.Core.Abstractions/Core/Internal/IGrainManagementExtension.cs
+++ b/src/Orleans.Core.Abstractions/Core/Internal/IGrainManagementExtension.cs
@@ -15,7 +15,7 @@ namespace Orleans.Core.Internal
         ValueTask DeactivateOnIdle();
 
         /// <summary>
-        /// Attempts to migrate the current instance to a new location once it becomes idle.
+        /// Attempts to migrate the current instance once it becomes idle.
         /// </summary>
         /// <returns>A <see cref="Task"/> which represents the method call.</returns>
         ValueTask MigrateOnIdle();

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -69,6 +69,13 @@ internal sealed partial class ActivationData :
 
     private Activity? _activationActivity;
 
+    private enum MigrationHandoff
+    {
+        None,
+        Completed,
+        WaitingForLocalCatalogRemoval
+    }
+
     /// <summary>
     /// Constants for activity error event names used during activation lifecycle.
     /// </summary>
@@ -1927,6 +1934,9 @@ internal sealed partial class ActivationData :
         var deactivationMetrics = CatalogInstruments.DeactivationMetricTracker.Start(_shared.CatalogInstruments);
         var migrating = false;
         var encounteredError = false;
+        var migrationHandoff = MigrationHandoff.None;
+        DehydrationContextHolder? deferredLocalMigrationContext = null;
+        IActivationMigrationManager? deferredLocalMigrationManager = null;
         try
         {
             try
@@ -1996,7 +2006,14 @@ internal sealed partial class ActivationData :
                     && _shared.MigrationManager is { } migrationManager
                     && !cancellationToken.IsCancellationRequested)
                 {
-                    migrating = await StartMigrationAsync(context, migrationManager, cancellationToken);
+                    migrationHandoff = await StartMigrationAsync(context, migrationManager, cancellationToken);
+                    if (migrationHandoff is MigrationHandoff.WaitingForLocalCatalogRemoval)
+                    {
+                        deferredLocalMigrationContext = context;
+                        deferredLocalMigrationManager = migrationManager;
+                    }
+
+                    migrating = migrationHandoff is not MigrationHandoff.None;
                 }
 
                 // If the instance is being deactivated due to a directory failure, we should not unregister it.
@@ -2004,25 +2021,27 @@ internal sealed partial class ActivationData :
 
                 if (!migrating && IsUsingGrainDirectory && !cancellationToken.IsCancellationRequested && !isDirectoryFailure)
                 {
-                    // Unregister from directory.
-                    // If the grain was migrated, the new activation will perform a check-and-set on the registration itself.
-                    try
-                    {
-                        await _shared.InternalRuntime.GrainLocator.Unregister(Address, UnregistrationCause.Force).WaitAsync(cancellationToken);
-                    }
-                    catch (Exception exception)
-                    {
-                        if (!cancellationToken.IsCancellationRequested)
-                        {
-                            LogFailedToUnregisterActivation(_shared.Logger, exception, this);
-                        }
-                    }
+                    await UnregisterFromDirectoryAsync(cancellationToken);
                 }
             }
             catch (Exception ex)
             {
                 SetActivityError(deactivateCommand.Activity, ex, "Error in FinishDeactivating");
                 LogErrorDeactivating(_shared.Logger, ex, this);
+            }
+
+            UnregisterMessageTarget();
+
+            if (migrationHandoff is MigrationHandoff.WaitingForLocalCatalogRemoval
+                && deferredLocalMigrationContext is not null
+                && deferredLocalMigrationManager is not null
+                && !cancellationToken.IsCancellationRequested)
+            {
+                migrating = await CompleteMigrationAsync(deferredLocalMigrationContext, deferredLocalMigrationManager, cancellationToken);
+                if (!migrating && IsUsingGrainDirectory && !cancellationToken.IsCancellationRequested && DeactivationReason.ReasonCode is not DeactivationReasonCode.DirectoryFailure)
+                {
+                    await UnregisterFromDirectoryAsync(cancellationToken);
+                }
             }
 
             if (IsStuckDeactivating)
@@ -2045,8 +2064,6 @@ internal sealed partial class ActivationData :
                 deactivationMetrics = deactivationMetrics.Collection();
                 _shared.CatalogInstruments.ActivationShutdownViaCollection();
             }
-
-            UnregisterMessageTarget();
 
             try
             {
@@ -2074,7 +2091,24 @@ internal sealed partial class ActivationData :
             deactivationMetrics.RecordIfNeeded();
         }
 
-        async ValueTask<bool> StartMigrationAsync(DehydrationContextHolder context, IActivationMigrationManager migrationManager, CancellationToken cancellationToken)
+        async ValueTask UnregisterFromDirectoryAsync(CancellationToken cancellationToken)
+        {
+            // Unregister from directory.
+            // If the grain was migrated, the new activation will perform a check-and-set on the registration itself.
+            try
+            {
+                await _shared.InternalRuntime.GrainLocator.Unregister(Address, UnregistrationCause.Force).WaitAsync(cancellationToken);
+            }
+            catch (Exception exception)
+            {
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    LogFailedToUnregisterActivation(_shared.Logger, exception, this);
+                }
+            }
+        }
+
+        async ValueTask<MigrationHandoff> StartMigrationAsync(DehydrationContextHolder context, IActivationMigrationManager migrationManager, CancellationToken cancellationToken)
         {
             try
             {
@@ -2083,7 +2117,7 @@ internal sealed partial class ActivationData :
                     var selectedAddress = await PlaceMigratingGrainAsync(context.RequestContext, cancellationToken);
                     if (selectedAddress is null)
                     {
-                        return false;
+                        return MigrationHandoff.None;
                     }
 
                     ForwardingAddress = selectedAddress;
@@ -2096,10 +2130,39 @@ internal sealed partial class ActivationData :
                 }
 
                 OnDehydrate(context.MigrationContext);
+                if (ForwardingAddress is not { } forwardingAddress)
+                {
+                    return MigrationHandoff.None;
+                }
+
+                if (forwardingAddress.Equals(_shared.Runtime.SiloAddress))
+                {
+                    return MigrationHandoff.WaitingForLocalCatalogRemoval;
+                }
 
                 // Send the dehydration context to the target host.
-                await migrationManager.MigrateAsync(ForwardingAddress, GrainId, context.MigrationContext).AsTask().WaitAsync(cancellationToken);
-                _shared.InternalRuntime.GrainLocator.UpdateCache(GrainId, ForwardingAddress);
+                return await CompleteMigrationAsync(context, migrationManager, cancellationToken)
+                    ? MigrationHandoff.Completed
+                    : MigrationHandoff.None;
+            }
+            catch (Exception exception)
+            {
+                LogFailedToMigrateActivation(_shared.Logger, exception, this);
+                return MigrationHandoff.None;
+            }
+        }
+
+        async ValueTask<bool> CompleteMigrationAsync(DehydrationContextHolder context, IActivationMigrationManager migrationManager, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (ForwardingAddress is not { } forwardingAddress)
+                {
+                    throw new InvalidOperationException("Migration target was not selected.");
+                }
+
+                await migrationManager.MigrateAsync(forwardingAddress, GrainId, context.MigrationContext).AsTask().WaitAsync(cancellationToken);
+                _shared.InternalRuntime.GrainLocator.UpdateCache(GrainId, forwardingAddress);
                 return true;
             }
             catch (Exception exception)
@@ -2134,7 +2197,6 @@ internal sealed partial class ActivationData :
             return;
         }
 
-        // Only migrate if a different silo was selected.
         ForwardingAddress = selectedAddress;
         LogDebugMigrating(_shared.Logger, GrainId, ForwardingAddress);
         Migrate(requestContextData, cancellationToken: CancellationToken.None);
@@ -2158,7 +2220,6 @@ internal sealed partial class ActivationData :
                 // This could be because this is the only (compatible) silo for the grain or because the placement director chose this
                 // silo for some other reason.
                 LogDebugPlacementStrategySelectedCurrentSilo(_shared.Logger, PlacementStrategy, GrainId);
-                return null;
             }
 
             return selectedAddress;

--- a/src/Orleans.Runtime/Catalog/ActivationMigrationManager.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationMigrationManager.cs
@@ -148,8 +148,13 @@ internal sealed partial class ActivationMigrationManager : SystemTarget, IActiva
 
     public ValueTask MigrateAsync(SiloAddress targetSilo, GrainId grainId, MigrationContext migrationContext)
     {
-        var workItem = _workItemPool.Get();
         var migrationPackage = new GrainMigrationPackage { GrainId = grainId, MigrationContext = migrationContext };
+        if (targetSilo.Equals(Silo))
+        {
+            return AcceptMigratingGrains([migrationPackage]);
+        }
+
+        var workItem = _workItemPool.Get();
         workItem.Initialize(migrationPackage);
         var workItemWriter = GetOrCreateWorker(targetSilo);
         if (!workItemWriter.TryWrite(workItem))

--- a/test/Orleans.DefaultCluster.Tests/Migration/MigrationTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/Migration/MigrationTests.cs
@@ -113,6 +113,35 @@ namespace DefaultCluster.Tests.General
         }
 
         /// <summary>
+        /// Tests that grain migration runs through dehydrate and rehydrate when the placement director selects the current silo.
+        /// </summary>
+        [Fact, TestCategory("BVT")]
+        public async Task DirectedLocalGrainMigrationTest()
+        {
+            var grain = GrainFactory.GetGrain<IMigrationTestGrain>(GetRandomGrainId());
+            var expectedState = Random.Shared.Next(1, int.MaxValue);
+            await grain.SetState(expectedState);
+            var originalAddress = await grain.GetGrainAddress();
+
+            RequestContext.Set(IPlacementDirector.PlacementHintKey, originalAddress.SiloAddress);
+            await grain.Cast<IGrainManagementExtension>().MigrateOnIdle().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+
+            GrainAddress newAddress;
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
+            {
+                do
+                {
+                    cts.Token.ThrowIfCancellationRequested();
+                    newAddress = await grain.GetGrainAddress();
+                } while (newAddress.ActivationId == originalAddress.ActivationId);
+            }
+
+            Assert.NotEqual(originalAddress.ActivationId, newAddress.ActivationId);
+            Assert.Equal(originalAddress.SiloAddress, newAddress.SiloAddress);
+            Assert.Equal(expectedState, await grain.GetState());
+        }
+
+        /// <summary>
         /// Tests that multiple grains can be migrated simultaneously.
         /// </summary>
         [Fact, TestCategory("BVT")]


### PR DESCRIPTION
Activation migration could deadlock or skip the regular flow when placement selected the local silo, because the replacement activation could not be created until the old activation was removed from the local catalog.

This change lets migration to the local silo still dehydrate first, then defers the local handoff until after `UnregisterMessageTarget()` removes the old activation from the catalog. The migration manager accepts same-silo handoffs directly, and the migration APIs/docs no longer imply that same-silo placement is ignored.

A regression test forces migration back to the current silo and verifies that a new activation is created on the same silo with migrated state preserved.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10218)