### PR TITLE
test: wait for client gateway refresh

### DIFF
--- a/src/Orleans.Core/Diagnostics/GatewayEvents.cs
+++ b/src/Orleans.Core/Diagnostics/GatewayEvents.cs
@@ -16,19 +16,50 @@ internal static class GatewayEvents
 
     internal static bool IsClientDroppedEnabled() => Listener.IsEnabled(nameof(ClientDropped));
 
-    internal abstract class GatewayEvent(SiloAddress siloAddress)
+    internal static bool IsGatewayListUpdatedEnabled() => Listener.IsEnabled(nameof(GatewayListUpdated));
+
+    internal abstract class GatewayEvent
     {
-        public readonly SiloAddress SiloAddress = siloAddress;
+    }
+
+    internal sealed class GatewayListUpdated(
+        object source,
+        IReadOnlyList<SiloAddress> knownGateways,
+        IReadOnlyList<SiloAddress> liveGateways) : GatewayEvent
+    {
+        public readonly object Source = source;
+
+        public readonly IReadOnlyList<SiloAddress> KnownGateways = knownGateways;
+
+        public readonly IReadOnlyList<SiloAddress> LiveGateways = liveGateways;
     }
 
     internal sealed class ClientDropped(
         SiloAddress siloAddress,
         GrainId clientId,
-        TimeSpan disconnectedDuration) : GatewayEvent(siloAddress)
+        TimeSpan disconnectedDuration) : GatewayEvent
     {
+        public readonly SiloAddress SiloAddress = siloAddress;
+
         public readonly GrainId ClientId = clientId;
 
         public readonly TimeSpan DisconnectedDuration = disconnectedDuration;
+    }
+
+    internal static void EmitGatewayListUpdated(object source, IReadOnlyList<SiloAddress> knownGateways, IReadOnlyList<SiloAddress> liveGateways)
+    {
+        if (!IsGatewayListUpdatedEnabled())
+        {
+            return;
+        }
+
+        Emit(source, knownGateways, liveGateways);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Emit(object source, IReadOnlyList<SiloAddress> knownGateways, IReadOnlyList<SiloAddress> liveGateways)
+        {
+            Listener.Write(nameof(GatewayListUpdated), new GatewayListUpdated(source, knownGateways, liveGateways));
+        }
     }
 
     internal static void EmitClientDropped(SiloAddress siloAddress, GrainId clientId, TimeSpan disconnectedDuration)

--- a/src/Orleans.Core/Messaging/GatewayManager.cs
+++ b/src/Orleans.Core/Messaging/GatewayManager.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Core.Diagnostics;
 using Orleans.Runtime;
 using Orleans.Runtime.Messaging;
 using static Orleans.Internal.StandardExtensions;
@@ -92,6 +93,7 @@ namespace Orleans.Messaging
             this.cachedLiveGatewaysSet = new HashSet<SiloAddress>(cachedLiveGateways);
             this.lastRefreshTime = DateTime.UtcNow;
             this.gatewayRefreshTimerTask ??= PeriodicallyRefreshGatewaySnapshot();
+            EmitGatewayListUpdatedIfEnabled(this.knownGateways, this.cachedLiveGateways);
         }
 
         public async Task StopAsync(CancellationToken cancellationToken)
@@ -273,6 +275,8 @@ namespace Orleans.Messaging
         private async Task UpdateLiveGatewaysSnapshot(IEnumerable<SiloAddress> refreshedGateways, TimeSpan maxStaleness)
         {
             List<SiloAddress> connectionsToKeepAlive;
+            List<SiloAddress> knownGatewaysSnapshotSource;
+            List<SiloAddress> liveGatewaysSnapshotSource;
 
             // This is a short lock, protecting the access to knownDead, knownMasked and cachedLiveGateways.
             lock (lockable)
@@ -332,6 +336,8 @@ namespace Orleans.Messaging
                 // swap cachedLiveGateways pointer in one atomic operation
                 cachedLiveGateways = live;
                 cachedLiveGatewaysSet = new HashSet<SiloAddress>(live);
+                knownGatewaysSnapshotSource = knownGateways;
+                liveGatewaysSnapshotSource = live;
 
                 DateTime prevRefresh = lastRefreshTime;
                 lastRefreshTime = now;
@@ -344,7 +350,16 @@ namespace Orleans.Messaging
                 connectionsToKeepAlive.AddRange(knownMasked.Select(e => e.Key));
             }
 
+            EmitGatewayListUpdatedIfEnabled(knownGatewaysSnapshotSource, liveGatewaysSnapshotSource);
             await this.CloseEvictedGatewayConnections(connectionsToKeepAlive);
+        }
+
+        private void EmitGatewayListUpdatedIfEnabled(List<SiloAddress> knownGatewaysSnapshotSource, List<SiloAddress> liveGatewaysSnapshotSource)
+        {
+            if (GatewayEvents.IsGatewayListUpdatedEnabled())
+            {
+                GatewayEvents.EmitGatewayListUpdated(this, knownGatewaysSnapshotSource.ToArray(), liveGatewaysSnapshotSource.ToArray());
+            }
         }
 
         private async Task CloseEvictedGatewayConnections(List<SiloAddress> liveGateways)

--- a/src/Orleans.Runtime/Silo/TestHooks/ITestHooksSystemTarget.cs
+++ b/src/Orleans.Runtime/Silo/TestHooks/ITestHooksSystemTarget.cs
@@ -13,6 +13,7 @@ namespace Orleans.Runtime.TestHooks
         Task<bool> HasStreamProvider(string providerName);
         Task<int> UnregisterGrainForTesting(GrainId grain);
         Task<Dictionary<SiloAddress, SiloStatus>> GetApproximateSiloStatuses();
+        Task<bool> WaitForActiveSilos(SiloAddress[] expectedActiveSilos, TimeSpan timeout);
     }
 
     internal interface ITestHooksSystemTarget : ITestHooks, ISystemTarget

--- a/src/Orleans.Runtime/Silo/TestHooks/TestHooksSystemTarget.cs
+++ b/src/Orleans.Runtime/Silo/TestHooks/TestHooksSystemTarget.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
@@ -89,5 +90,71 @@ namespace Orleans.Runtime.TestHooks
         public Task<int> UnregisterGrainForTesting(GrainId grain) => Task.FromResult(this.serviceProvider.GetRequiredService<Catalog>().UnregisterGrainForTesting(grain));
 
         public Task<Dictionary<SiloAddress, SiloStatus>> GetApproximateSiloStatuses() => Task.FromResult(this.siloStatusOracle.GetApproximateSiloStatuses());
+
+        public async Task<bool> WaitForActiveSilos(SiloAddress[] expectedActiveSilos, TimeSpan timeout)
+        {
+            var expected = expectedActiveSilos.ToHashSet();
+            if (ActiveSilosMatch(this.siloStatusOracle, expected))
+            {
+                return true;
+            }
+
+            if (timeout <= TimeSpan.Zero)
+            {
+                return false;
+            }
+
+            var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var listener = new ActiveSiloSetListener(this.siloStatusOracle, expected, completion);
+            this.siloStatusOracle.SubscribeToSiloStatusEvents(listener);
+            try
+            {
+                if (ActiveSilosMatch(this.siloStatusOracle, expected))
+                {
+                    return true;
+                }
+
+                await completion.Task.WaitAsync(timeout);
+                return true;
+            }
+            catch (TimeoutException)
+            {
+                return ActiveSilosMatch(this.siloStatusOracle, expected);
+            }
+            finally
+            {
+                this.siloStatusOracle.UnSubscribeFromSiloStatusEvents(listener);
+            }
+        }
+
+        private static bool ActiveSilosMatch(ISiloStatusOracle siloStatusOracle, HashSet<SiloAddress> expectedActiveSilos)
+        {
+            return expectedActiveSilos.SetEquals(siloStatusOracle.GetApproximateSiloStatuses(onlyActive: true).Keys);
+        }
+
+        private sealed class ActiveSiloSetListener : ISiloStatusListener
+        {
+            private readonly ISiloStatusOracle siloStatusOracle;
+            private readonly HashSet<SiloAddress> expectedActiveSilos;
+            private readonly TaskCompletionSource completion;
+
+            public ActiveSiloSetListener(
+                ISiloStatusOracle siloStatusOracle,
+                HashSet<SiloAddress> expectedActiveSilos,
+                TaskCompletionSource completion)
+            {
+                this.siloStatusOracle = siloStatusOracle;
+                this.expectedActiveSilos = expectedActiveSilos;
+                this.completion = completion;
+            }
+
+            public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
+            {
+                if (ActiveSilosMatch(this.siloStatusOracle, this.expectedActiveSilos))
+                {
+                    this.completion.TrySetResult();
+                }
+            }
+        }
     }
 }

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -364,10 +364,11 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         TimeSpan stabilizationTime = GetLivenessStabilizationTime(clusterMembershipOptions, didKill);
         var activeSilos = GetActiveSilos().ToArray();
         var testHooks = activeSilos.Select(static silo => (ITestHooks)silo.ServiceProvider.GetRequiredService<TestHooksSystemTarget>()).ToArray();
+        var gatewayManager = Client.ServiceProvider.GetRequiredService<GatewayManager>();
         WriteLog(Environment.NewLine + Environment.NewLine + "WaitForLivenessToStabilize is waiting up to {0} for {1} active silo(s)", stabilizationTime, activeSilos.Length);
-        if (await LivenessStabilizationHelper.WaitForExpectedActiveSilosAsync(activeSilos, testHooks, stabilizationTime))
+        if (await LivenessStabilizationHelper.WaitForExpectedActiveSilosAndGatewaysAsync(activeSilos, testHooks, gatewayManager, stabilizationTime))
         {
-            WriteLog("WaitForLivenessToStabilize observed a stable active silo view");
+            WriteLog("WaitForLivenessToStabilize observed stable active silo and gateway views");
         }
         else
         {

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -363,8 +363,9 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
         var clusterMembershipOptions = Client.ServiceProvider.GetRequiredService<IOptions<ClusterMembershipOptions>>().Value;
         TimeSpan stabilizationTime = GetLivenessStabilizationTime(clusterMembershipOptions, didKill);
         var activeSilos = GetActiveSilos().ToArray();
+        var testHooks = activeSilos.Select(static silo => (ITestHooks)silo.ServiceProvider.GetRequiredService<TestHooksSystemTarget>()).ToArray();
         WriteLog(Environment.NewLine + Environment.NewLine + "WaitForLivenessToStabilize is waiting up to {0} for {1} active silo(s)", stabilizationTime, activeSilos.Length);
-        if (await LivenessStabilizationHelper.WaitForExpectedActiveSilosAsync(InternalClient, activeSilos, stabilizationTime))
+        if (await LivenessStabilizationHelper.WaitForExpectedActiveSilosAsync(activeSilos, testHooks, stabilizationTime))
         {
             WriteLog("WaitForLivenessToStabilize observed a stable active silo view");
         }

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -362,9 +362,16 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
     {
         var clusterMembershipOptions = Client.ServiceProvider.GetRequiredService<IOptions<ClusterMembershipOptions>>().Value;
         TimeSpan stabilizationTime = GetLivenessStabilizationTime(clusterMembershipOptions, didKill);
-        WriteLog(Environment.NewLine + Environment.NewLine + "WaitForLivenessToStabilize is about to sleep for {0}", stabilizationTime);
-        await Task.Delay(stabilizationTime);
-        WriteLog("WaitForLivenessToStabilize is done sleeping");
+        var activeSilos = GetActiveSilos().ToArray();
+        WriteLog(Environment.NewLine + Environment.NewLine + "WaitForLivenessToStabilize is waiting up to {0} for {1} active silo(s)", stabilizationTime, activeSilos.Length);
+        if (await LivenessStabilizationHelper.WaitForExpectedActiveSilosAsync(InternalClient, activeSilos, stabilizationTime))
+        {
+            WriteLog("WaitForLivenessToStabilize observed a stable active silo view");
+        }
+        else
+        {
+            WriteLog("WaitForLivenessToStabilize reached the fallback wait of {0}", stabilizationTime);
+        }
     }
 
     /// <summary>

--- a/src/Orleans.TestingHost/LivenessStabilizationHelper.cs
+++ b/src/Orleans.TestingHost/LivenessStabilizationHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Orleans.Runtime;
+using Orleans.Runtime.TestHooks;
 
 #nullable enable
 namespace Orleans.TestingHost;
@@ -10,24 +11,24 @@ namespace Orleans.TestingHost;
 internal static class LivenessStabilizationHelper
 {
     public static async Task<bool> WaitForExpectedActiveSilosAsync(
-        IClusterClient client,
         IReadOnlyCollection<SiloHandle> activeSilos,
-        TimeSpan fallbackTimeout)
+        IReadOnlyCollection<ITestHooks> testHooks,
+        TimeSpan timeout)
     {
-        ArgumentNullException.ThrowIfNull(client);
         ArgumentNullException.ThrowIfNull(activeSilos);
+        ArgumentNullException.ThrowIfNull(testHooks);
 
         if (activeSilos.Count == 0)
         {
-            await Delay(fallbackTimeout);
+            await Task.Delay(timeout);
             return false;
         }
 
         var expectedActiveSilos = activeSilos.Select(static silo => silo.SiloAddress).ToArray();
         try
         {
-            var waitTasks = activeSilos.Select(silo => client.GetTestHooks(silo).WaitForActiveSilos(expectedActiveSilos, fallbackTimeout));
-            var results = await Task.WhenAll(waitTasks).WaitAsync(fallbackTimeout);
+            var waitTasks = testHooks.Select(hooks => hooks.WaitForActiveSilos(expectedActiveSilos, timeout));
+            var results = await Task.WhenAll(waitTasks).WaitAsync(timeout);
             return results.All(static result => result);
         }
         catch (TimeoutException)
@@ -36,5 +37,4 @@ internal static class LivenessStabilizationHelper
         }
     }
 
-    private static Task Delay(TimeSpan delay) => delay > TimeSpan.Zero ? Task.Delay(delay) : Task.CompletedTask;
 }

--- a/src/Orleans.TestingHost/LivenessStabilizationHelper.cs
+++ b/src/Orleans.TestingHost/LivenessStabilizationHelper.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Orleans.Core.Diagnostics;
+using Orleans.Messaging;
 using Orleans.Runtime;
 using Orleans.Runtime.TestHooks;
 
@@ -10,6 +13,26 @@ namespace Orleans.TestingHost;
 
 internal static class LivenessStabilizationHelper
 {
+    public static async Task<bool> WaitForExpectedActiveSilosAndGatewaysAsync(
+        IReadOnlyCollection<SiloHandle> activeSilos,
+        IReadOnlyCollection<ITestHooks> testHooks,
+        GatewayManager gatewayManager,
+        TimeSpan timeout)
+    {
+        ArgumentNullException.ThrowIfNull(gatewayManager);
+
+        var stopwatch = Stopwatch.StartNew();
+        if (!await WaitForExpectedActiveSilosAsync(activeSilos, testHooks, timeout))
+        {
+            return false;
+        }
+
+        var remaining = timeout - stopwatch.Elapsed;
+        return remaining <= TimeSpan.Zero
+            ? ActiveGatewaysMatch(gatewayManager, activeSilos)
+            : await WaitForExpectedActiveGatewaysAsync(activeSilos, gatewayManager, remaining);
+    }
+
     public static async Task<bool> WaitForExpectedActiveSilosAsync(
         IReadOnlyCollection<SiloHandle> activeSilos,
         IReadOnlyCollection<ITestHooks> testHooks,
@@ -37,4 +60,82 @@ internal static class LivenessStabilizationHelper
         }
     }
 
+    private static async Task<bool> WaitForExpectedActiveGatewaysAsync(
+        IReadOnlyCollection<SiloHandle> activeSilos,
+        GatewayManager gatewayManager,
+        TimeSpan timeout)
+    {
+        var expectedGateways = GetExpectedGatewayAddresses(activeSilos);
+        if (GatewaysMatch(gatewayManager.GetLiveGateways(), expectedGateways))
+        {
+            return true;
+        }
+
+        if (timeout <= TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = GatewayEvents.AllEvents.Subscribe(new GatewayListUpdatedObserver(gatewayManager, expectedGateways, completion));
+
+        if (GatewaysMatch(gatewayManager.GetLiveGateways(), expectedGateways))
+        {
+            return true;
+        }
+
+        gatewayManager.ExpediteUpdateLiveGatewaysSnapshot();
+
+        try
+        {
+            await completion.Task.WaitAsync(timeout);
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            return GatewaysMatch(gatewayManager.GetLiveGateways(), expectedGateways);
+        }
+    }
+
+    private static bool ActiveGatewaysMatch(GatewayManager gatewayManager, IReadOnlyCollection<SiloHandle> activeSilos)
+    {
+        return GatewaysMatch(gatewayManager.GetLiveGateways(), GetExpectedGatewayAddresses(activeSilos));
+    }
+
+    private static HashSet<SiloAddress> GetExpectedGatewayAddresses(IReadOnlyCollection<SiloHandle> activeSilos)
+    {
+        return activeSilos
+            .Select(static silo => silo.GatewayAddress)
+            .OfType<SiloAddress>()
+            .Where(static gateway => gateway.Endpoint.Port > 0)
+            .Select(static gateway => SiloAddress.New(gateway.Endpoint, 0))
+            .ToHashSet();
+    }
+
+    private static bool GatewaysMatch(IEnumerable<SiloAddress> liveGateways, HashSet<SiloAddress> expectedGateways)
+    {
+        return expectedGateways.SetEquals(liveGateways);
+    }
+
+    private sealed class GatewayListUpdatedObserver(
+        GatewayManager gatewayManager,
+        HashSet<SiloAddress> expectedGateways,
+        TaskCompletionSource completion) : IObserver<GatewayEvents.GatewayEvent>
+    {
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error) => completion.TrySetException(error);
+
+        public void OnNext(GatewayEvents.GatewayEvent value)
+        {
+            if (value is GatewayEvents.GatewayListUpdated update
+                && ReferenceEquals(update.Source, gatewayManager)
+                && GatewaysMatch(update.LiveGateways, expectedGateways))
+            {
+                completion.TrySetResult();
+            }
+        }
+    }
 }

--- a/src/Orleans.TestingHost/LivenessStabilizationHelper.cs
+++ b/src/Orleans.TestingHost/LivenessStabilizationHelper.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+
+#nullable enable
+namespace Orleans.TestingHost;
+
+internal static class LivenessStabilizationHelper
+{
+    public static async Task<bool> WaitForExpectedActiveSilosAsync(
+        IClusterClient client,
+        IReadOnlyCollection<SiloHandle> activeSilos,
+        TimeSpan fallbackTimeout)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(activeSilos);
+
+        if (activeSilos.Count == 0)
+        {
+            await Delay(fallbackTimeout);
+            return false;
+        }
+
+        var expectedActiveSilos = activeSilos.Select(static silo => silo.SiloAddress).ToArray();
+        try
+        {
+            var waitTasks = activeSilos.Select(silo => client.GetTestHooks(silo).WaitForActiveSilos(expectedActiveSilos, fallbackTimeout));
+            var results = await Task.WhenAll(waitTasks).WaitAsync(fallbackTimeout);
+            return results.All(static result => result);
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static Task Delay(TimeSpan delay) => delay > TimeSpan.Zero ? Task.Delay(delay) : Task.CompletedTask;
+}

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -420,9 +420,16 @@ namespace Orleans.TestingHost
         {
             var clusterMembershipOptions = this.ServiceProvider.GetRequiredService<IOptions<ClusterMembershipOptions>>().Value;
             TimeSpan stabilizationTime = GetLivenessStabilizationTime(clusterMembershipOptions, didKill);
-            WriteLog(Environment.NewLine + Environment.NewLine + "WaitForLivenessToStabilize is about to sleep for {0}", stabilizationTime);
-            await Task.Delay(stabilizationTime);
-            WriteLog("WaitForLivenessToStabilize is done sleeping");
+            var activeSilos = GetActiveSilos().ToArray();
+            WriteLog(Environment.NewLine + Environment.NewLine + "WaitForLivenessToStabilize is waiting up to {0} for {1} active silo(s)", stabilizationTime, activeSilos.Length);
+            if (await LivenessStabilizationHelper.WaitForExpectedActiveSilosAsync(this.InternalClient, activeSilos, stabilizationTime))
+            {
+                WriteLog("WaitForLivenessToStabilize observed a stable active silo view");
+            }
+            else
+            {
+                WriteLog("WaitForLivenessToStabilize reached the fallback wait of {0}", stabilizationTime);
+            }
         }
 
         /// <summary>

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -21,6 +21,7 @@ using Orleans.TestingHost.UnixSocketTransport;
 using System.Net;
 using Orleans.Statistics;
 using Orleans.Runtime.TestHooks;
+using Orleans.Messaging;
 
 #nullable disable
 namespace Orleans.TestingHost
@@ -423,10 +424,11 @@ namespace Orleans.TestingHost
             TimeSpan stabilizationTime = GetLivenessStabilizationTime(clusterMembershipOptions, didKill);
             var activeSilos = GetActiveSilos().ToArray();
             var testHooks = activeSilos.Select(GetTestHooks).ToArray();
+            var gatewayManager = this.InternalClient.ServiceProvider.GetRequiredService<GatewayManager>();
             WriteLog(Environment.NewLine + Environment.NewLine + "WaitForLivenessToStabilize is waiting up to {0} for {1} active silo(s)", stabilizationTime, activeSilos.Length);
-            if (await LivenessStabilizationHelper.WaitForExpectedActiveSilosAsync(activeSilos, testHooks, stabilizationTime))
+            if (await LivenessStabilizationHelper.WaitForExpectedActiveSilosAndGatewaysAsync(activeSilos, testHooks, gatewayManager, stabilizationTime))
             {
-                WriteLog("WaitForLivenessToStabilize observed a stable active silo view");
+                WriteLog("WaitForLivenessToStabilize observed stable active silo and gateway views");
             }
             else
             {

--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -20,6 +20,7 @@ using Orleans.TestingHost.InMemoryTransport;
 using Orleans.TestingHost.UnixSocketTransport;
 using System.Net;
 using Orleans.Statistics;
+using Orleans.Runtime.TestHooks;
 
 #nullable disable
 namespace Orleans.TestingHost
@@ -421,8 +422,9 @@ namespace Orleans.TestingHost
             var clusterMembershipOptions = this.ServiceProvider.GetRequiredService<IOptions<ClusterMembershipOptions>>().Value;
             TimeSpan stabilizationTime = GetLivenessStabilizationTime(clusterMembershipOptions, didKill);
             var activeSilos = GetActiveSilos().ToArray();
+            var testHooks = activeSilos.Select(GetTestHooks).ToArray();
             WriteLog(Environment.NewLine + Environment.NewLine + "WaitForLivenessToStabilize is waiting up to {0} for {1} active silo(s)", stabilizationTime, activeSilos.Length);
-            if (await LivenessStabilizationHelper.WaitForExpectedActiveSilosAsync(this.InternalClient, activeSilos, stabilizationTime))
+            if (await LivenessStabilizationHelper.WaitForExpectedActiveSilosAsync(activeSilos, testHooks, stabilizationTime))
             {
                 WriteLog("WaitForLivenessToStabilize observed a stable active silo view");
             }
@@ -430,6 +432,16 @@ namespace Orleans.TestingHost
             {
                 WriteLog("WaitForLivenessToStabilize reached the fallback wait of {0}", stabilizationTime);
             }
+        }
+
+        private ITestHooks GetTestHooks(SiloHandle silo)
+        {
+            if (silo is InProcessSiloHandle inProcessSilo)
+            {
+                return inProcessSilo.ServiceProvider.GetRequiredService<TestHooksSystemTarget>();
+            }
+
+            return this.InternalClient.GetTestHooks(silo);
         }
 
         /// <summary>

--- a/test/Orleans.Runtime.Internal.Tests/GatewaySelectionTest.cs
+++ b/test/Orleans.Runtime.Internal.Tests/GatewaySelectionTest.cs
@@ -3,6 +3,7 @@ using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Core.Diagnostics;
 using Orleans.Messaging;
 using Orleans.Runtime;
 using Orleans.Internal;
@@ -57,6 +58,23 @@ namespace UnitTests.MessageCenterTests
             await Test_GatewaySelection(listProvider);
         }
 
+        [Fact, TestCategory("BVT"), TestCategory("Gateway")]
+        public async Task GatewayListUpdatedDiagnosticEventEmittedOnStart()
+        {
+            var gatewayUris = new List<Uri> { new("gwy.tcp://127.0.0.1:12345/42") };
+            var listProvider = new TestListProvider(gatewayUris);
+            using var observer = new Observer(GatewayEvents.AllEvents);
+            using var gatewayManager = new GatewayManager(Options.Create(new GatewayOptions()), listProvider, NullLoggerFactory.Instance, null, TimeProvider.System);
+
+            await gatewayManager.StartAsync(CancellationToken.None);
+
+            var evt = Assert.Single(observer.Events.OfType<GatewayEvents.GatewayListUpdated>());
+            Assert.Same(gatewayManager, evt.Source);
+            var expectedGateway = SiloAddress.New(IPAddress.Loopback, 12345, 0);
+            Assert.Equal(expectedGateway, Assert.Single(evt.KnownGateways));
+            Assert.Equal(expectedGateway, Assert.Single(evt.LiveGateways));
+        }
+
         /// <summary>
         /// Core test logic for gateway selection distribution.
         /// Simulates 2300 gateway selections and verifies they are evenly distributed.
@@ -100,6 +118,31 @@ namespace UnitTests.MessageCenterTests
             Assert.True((low <= counts[1]) && (counts[1] <= up), "Gateway selection is incorrectly skewed. " + counts[1]);
             Assert.True((low <= counts[2]) && (counts[2] <= up), "Gateway selection is incorrectly skewed. " + counts[2]);
             Assert.True((low <= counts[3]) && (counts[3] <= up), "Gateway selection is incorrectly skewed. " + counts[3]);
+        }
+
+        private sealed class Observer : IObserver<GatewayEvents.GatewayEvent>, IDisposable
+        {
+            private readonly IDisposable _subscription;
+            private readonly List<GatewayEvents.GatewayEvent> _events = [];
+
+            public Observer(IObservable<GatewayEvents.GatewayEvent> observable)
+            {
+                _subscription = observable.Subscribe(this);
+            }
+
+            public GatewayEvents.GatewayEvent[] Events => _events.ToArray();
+
+            public void Dispose() => _subscription.Dispose();
+
+            public void OnCompleted()
+            {
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+            public void OnNext(GatewayEvents.GatewayEvent value) => _events.Add(value);
         }
 
         /// <summary>


### PR DESCRIPTION
Liveness stabilization can complete once silos agree on the active silo set while the client still has a stale gateway snapshot. If a test kills a silo and immediately sends grain calls, the client can still route through the stopped silo's gateway and fail with a connection-refused error.\n\nThis adds a GatewayManager diagnostic event for applied gateway-list updates and uses it from TestingHost liveness stabilization. The helper now waits for both the active silo view and the client gateway list to match the expected active silos, while still expediting the client refresh to avoid restoring the previous broad sleep.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10221)