### PR TITLE
perf(manifest): reduce cluster manifest payload size

### DIFF
--- a/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Orleans.Runtime;
 
 namespace Orleans.Metadata
@@ -45,6 +46,10 @@ namespace Orleans.Metadata
             ImmutableArray<GrainManifest> allGrainManifests)
         {
             ArgumentNullException.ThrowIfNull(silos);
+            EnsureDefaultKeyComparer(silos, nameof(silos));
+            silos = silos.WithComparers(
+                EqualityComparer<SiloAddress>.Default,
+                EqualityComparer<GrainManifest>.Default);
             var deduplicated = Deduplicate(silos, allGrainManifests);
             Version = version;
             Silos = deduplicated.Silos;
@@ -73,6 +78,7 @@ namespace Orleans.Metadata
             ImmutableDictionary<SiloAddress, GrainManifest> silos,
             ImmutableArray<GrainManifest> allGrainManifests)
         {
+            Debug.Assert(HasDefaultComparers(silos));
             var canonicalGrainProperties = new Dictionary<GrainProperties, GrainProperties>();
             var canonicalInterfaceProperties = new Dictionary<GrainInterfaceProperties, GrainInterfaceProperties>();
             var canonicalManifests = new Dictionary<GrainManifest, GrainManifest>();
@@ -121,6 +127,7 @@ namespace Orleans.Metadata
                 where TKey : notnull
                 where TValue : class
             {
+                Debug.Assert(HasDefaultComparers(properties));
                 ImmutableDictionary<TKey, TValue>.Builder? builder = null;
                 modified = false;
                 foreach (var entry in properties)
@@ -144,6 +151,20 @@ namespace Orleans.Metadata
                 }
 
                 return modified ? builder!.ToImmutable() : properties;
+            }
+        }
+
+        private static bool HasDefaultComparers<TKey, TValue>(ImmutableDictionary<TKey, TValue> dictionary)
+            where TKey : notnull
+            => ReferenceEquals(dictionary.KeyComparer, EqualityComparer<TKey>.Default)
+                && ReferenceEquals(dictionary.ValueComparer, EqualityComparer<TValue>.Default);
+
+        private static void EnsureDefaultKeyComparer<TKey, TValue>(ImmutableDictionary<TKey, TValue> dictionary, string paramName)
+            where TKey : notnull
+        {
+            if (!ReferenceEquals(dictionary.KeyComparer, EqualityComparer<TKey>.Default))
+            {
+                throw new ArgumentException("The dictionary must use the default key comparer.", paramName);
             }
         }
     }

--- a/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using Orleans.Runtime;
 
 namespace Orleans.Metadata
@@ -23,10 +23,32 @@ namespace Orleans.Metadata
         public ClusterManifest(
             MajorMinorVersion version,
             ImmutableDictionary<SiloAddress, GrainManifest> silos)
+            : this(version, silos, silos.Values.ToImmutableArray())
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClusterManifest"/> class.
+        /// </summary>
+        /// <param name="version">
+        /// The manifest version.
+        /// </param>
+        /// <param name="silos">
+        /// The silo manifests.
+        /// </param>
+        /// <param name="allGrainManifests">
+        /// All grain manifests, including manifests which are not associated with entries in <paramref name="silos"/>.
+        /// </param>
+        public ClusterManifest(
+            MajorMinorVersion version,
+            ImmutableDictionary<SiloAddress, GrainManifest> silos,
+            ImmutableArray<GrainManifest> allGrainManifests)
+        {
+            ArgumentNullException.ThrowIfNull(silos);
+            var deduplicated = Deduplicate(silos, allGrainManifests);
             Version = version;
-            Silos = silos;
-            AllGrainManifests = silos.Values.Distinct().ToImmutableArray();
+            Silos = deduplicated.Silos;
+            AllGrainManifests = deduplicated.AllGrainManifests;
         }
 
         /// <summary>
@@ -42,9 +64,85 @@ namespace Orleans.Metadata
         public ImmutableDictionary<SiloAddress, GrainManifest> Silos { get; }
 
         /// <summary>
-        /// Gets all grain manifests.
+        /// Gets all unique grain manifests.
         /// </summary>
         [Id(2)]
         public ImmutableArray<GrainManifest> AllGrainManifests { get; }
+
+        private static (ImmutableDictionary<SiloAddress, GrainManifest> Silos, ImmutableArray<GrainManifest> AllGrainManifests) Deduplicate(
+            ImmutableDictionary<SiloAddress, GrainManifest> silos,
+            ImmutableArray<GrainManifest> allGrainManifests)
+        {
+            var canonicalGrainProperties = new Dictionary<GrainProperties, GrainProperties>();
+            var canonicalInterfaceProperties = new Dictionary<GrainInterfaceProperties, GrainInterfaceProperties>();
+            var canonicalManifests = new Dictionary<GrainManifest, GrainManifest>();
+            var uniqueManifests = ImmutableArray.CreateBuilder<GrainManifest>();
+            var siloBuilder = ImmutableDictionary.CreateBuilder<SiloAddress, GrainManifest>(silos.KeyComparer, silos.ValueComparer);
+
+            foreach (var entry in silos)
+            {
+                siloBuilder[entry.Key] = GetCanonicalManifest(entry.Value);
+            }
+
+            if (!allGrainManifests.IsDefault)
+            {
+                foreach (var manifest in allGrainManifests)
+                {
+                    GetCanonicalManifest(manifest);
+                }
+            }
+
+            return (siloBuilder.ToImmutable(), uniqueManifests.ToImmutable());
+
+            GrainManifest GetCanonicalManifest(GrainManifest manifest)
+            {
+                manifest = DeduplicateManifest(manifest);
+                if (canonicalManifests.TryGetValue(manifest, out var canonicalManifest))
+                {
+                    return canonicalManifest;
+                }
+
+                canonicalManifests.Add(manifest, manifest);
+                uniqueManifests.Add(manifest);
+                return manifest;
+            }
+
+            GrainManifest DeduplicateManifest(GrainManifest manifest)
+            {
+                var grains = DeduplicateProperties(manifest.Grains, canonicalGrainProperties, out var grainsModified);
+                var interfaces = DeduplicateProperties(manifest.Interfaces, canonicalInterfaceProperties, out var interfacesModified);
+                return grainsModified || interfacesModified ? new GrainManifest(grains, interfaces) : manifest;
+            }
+
+            static ImmutableDictionary<TKey, TValue> DeduplicateProperties<TKey, TValue>(
+                ImmutableDictionary<TKey, TValue> properties,
+                Dictionary<TValue, TValue> canonicalProperties,
+                out bool modified)
+                where TKey : notnull
+                where TValue : class
+            {
+                var builder = ImmutableDictionary.CreateBuilder<TKey, TValue>(properties.KeyComparer, properties.ValueComparer);
+                modified = false;
+                foreach (var entry in properties)
+                {
+                    if (canonicalProperties.TryGetValue(entry.Value, out var canonicalProperty))
+                    {
+                        if (!ReferenceEquals(canonicalProperty, entry.Value))
+                        {
+                            modified = true;
+                        }
+
+                        builder[entry.Key] = canonicalProperty;
+                    }
+                    else
+                    {
+                        canonicalProperties.Add(entry.Value, entry.Value);
+                        builder[entry.Key] = entry.Value;
+                    }
+                }
+
+                return modified ? builder.ToImmutable() : properties;
+            }
+        }
     }
 }

--- a/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using Orleans.Runtime;
 
 namespace Orleans.Metadata
@@ -25,7 +26,7 @@ namespace Orleans.Metadata
         {
             Version = version;
             Silos = silos;
-            AllGrainManifests = silos.Values.ToImmutableArray();
+            AllGrainManifests = silos.Values.Distinct().ToImmutableArray();
         }
 
         /// <summary>

--- a/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
@@ -115,21 +115,19 @@ namespace Orleans.Metadata
 
             GrainManifest DeduplicateManifest(GrainManifest manifest)
             {
-                var grains = DeduplicateProperties(manifest.Grains, canonicalGrainProperties, out var grainsModified);
-                var interfaces = DeduplicateProperties(manifest.Interfaces, canonicalInterfaceProperties, out var interfacesModified);
-                return grainsModified || interfacesModified ? new GrainManifest(grains, interfaces) : manifest;
+                var grains = DeduplicateProperties(manifest.Grains, canonicalGrainProperties);
+                var interfaces = DeduplicateProperties(manifest.Interfaces, canonicalInterfaceProperties);
+                return ReferenceEquals(grains, manifest.Grains) && ReferenceEquals(interfaces, manifest.Interfaces) ? manifest : new GrainManifest(grains, interfaces);
             }
 
             static ImmutableDictionary<TKey, TValue> DeduplicateProperties<TKey, TValue>(
                 ImmutableDictionary<TKey, TValue> properties,
-                Dictionary<TValue, TValue> canonicalProperties,
-                out bool modified)
+                Dictionary<TValue, TValue> canonicalProperties)
                 where TKey : notnull
                 where TValue : class
             {
                 Debug.Assert(HasDefaultComparers(properties));
                 ImmutableDictionary<TKey, TValue>.Builder? builder = null;
-                modified = false;
                 foreach (var entry in properties)
                 {
                     if (canonicalProperties.TryGetValue(entry.Value, out var canonicalProperty))
@@ -138,7 +136,6 @@ namespace Orleans.Metadata
                         // canonical replacement is needed.
                         if (!ReferenceEquals(canonicalProperty, entry.Value))
                         {
-                            modified = true;
                             builder ??= properties.ToBuilder();
                             builder.Remove(entry.Key);
                             builder.Add(entry.Key, canonicalProperty);
@@ -150,7 +147,7 @@ namespace Orleans.Metadata
                     }
                 }
 
-                return modified ? builder!.ToImmutable() : properties;
+                return builder?.ToImmutable() ?? properties;
             }
         }
 

--- a/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
@@ -121,7 +121,7 @@ namespace Orleans.Metadata
                 where TKey : notnull
                 where TValue : class
             {
-                var builder = ImmutableDictionary.CreateBuilder<TKey, TValue>(properties.KeyComparer, properties.ValueComparer);
+                ImmutableDictionary<TKey, TValue>.Builder? builder = null;
                 modified = false;
                 foreach (var entry in properties)
                 {
@@ -132,18 +132,18 @@ namespace Orleans.Metadata
                         if (!ReferenceEquals(canonicalProperty, entry.Value))
                         {
                             modified = true;
+                            builder ??= properties.ToBuilder();
+                            builder.Remove(entry.Key);
+                            builder.Add(entry.Key, canonicalProperty);
                         }
-
-                        builder[entry.Key] = canonicalProperty;
                     }
                     else
                     {
                         canonicalProperties.Add(entry.Value, entry.Value);
-                        builder[entry.Key] = entry.Value;
                     }
                 }
 
-                return modified ? builder.ToImmutable() : properties;
+                return modified ? builder!.ToImmutable() : properties;
             }
         }
     }

--- a/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/ClusterManifest.cs
@@ -127,6 +127,8 @@ namespace Orleans.Metadata
                 {
                     if (canonicalProperties.TryGetValue(entry.Value, out var canonicalProperty))
                     {
+                        // The lookup above uses structural equality. Reference equality only tells us whether
+                        // canonical replacement is needed.
                         if (!ReferenceEquals(canonicalProperty, entry.Value))
                         {
                             modified = true;

--- a/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
@@ -76,8 +76,8 @@ namespace Orleans.Metadata
 
         private static bool PropertiesEqual(ImmutableDictionary<string, string> left, ImmutableDictionary<string, string> right)
         {
-            Debug.Assert(HasOrdinalComparers(left));
-            Debug.Assert(HasOrdinalComparers(right));
+            Debug.Assert(HasOrdinalKeyComparer(left));
+            Debug.Assert(HasOrdinalKeyComparer(right));
             if (ReferenceEquals(left, right))
             {
                 return true;
@@ -104,9 +104,12 @@ namespace Orleans.Metadata
             => ReferenceEquals(properties.KeyComparer, StringComparer.Ordinal)
                 && ReferenceEquals(properties.ValueComparer, StringComparer.Ordinal);
 
+        private static bool HasOrdinalKeyComparer(ImmutableDictionary<string, string> properties)
+            => ReferenceEquals(properties.KeyComparer, StringComparer.Ordinal);
+
         private static void EnsureOrdinalKeyComparer(ImmutableDictionary<string, string> properties, string paramName)
         {
-            if (!ReferenceEquals(properties.KeyComparer, StringComparer.Ordinal))
+            if (!HasOrdinalKeyComparer(properties))
             {
                 throw new ArgumentException("The dictionary must use StringComparer.Ordinal as its key comparer.", paramName);
             }

--- a/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
 using Orleans.Runtime;
@@ -25,7 +24,7 @@ namespace Orleans.Metadata
         public GrainInterfaceProperties(ImmutableDictionary<string, string> values)
         {
             ArgumentNullException.ThrowIfNull(values);
-            this.Properties = values;
+            this.Properties = values.WithComparers(StringComparer.Ordinal, StringComparer.Ordinal);
         }
 
         /// <summary>
@@ -83,18 +82,9 @@ namespace Orleans.Metadata
                 return false;
             }
 
-            var rightProperties = new Dictionary<string, string>(right.Count, StringComparer.Ordinal);
-            foreach (var entry in right)
-            {
-                if (!rightProperties.TryAdd(entry.Key, entry.Value))
-                {
-                    return false;
-                }
-            }
-
             foreach (var entry in left)
             {
-                if (!rightProperties.TryGetValue(entry.Key, out var value)
+                if (!right.TryGetValue(entry.Key, out var value)
                     || !string.Equals(entry.Value, value, StringComparison.Ordinal))
                 {
                     return false;

--- a/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -10,8 +11,11 @@ namespace Orleans.Metadata
     /// Information about a communication interface.
     /// </summary>
     [Serializable, GenerateSerializer, Immutable]
-    public sealed class GrainInterfaceProperties
+    public sealed class GrainInterfaceProperties : IEquatable<GrainInterfaceProperties>
     {
+        [NonSerialized]
+        private int? _hashCode;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="GrainInterfaceProperties"/> class.
         /// </summary>
@@ -20,6 +24,7 @@ namespace Orleans.Metadata
         /// </param>
         public GrainInterfaceProperties(ImmutableDictionary<string, string> values)
         {
+            ArgumentNullException.ThrowIfNull(values);
             this.Properties = values;
         }
 
@@ -53,6 +58,42 @@ namespace Orleans.Metadata
             result.Append("]");
 
             return result.ToString();
+        }
+
+        public override bool Equals(object? obj) => obj is GrainInterfaceProperties other && Equals(other);
+
+        public bool Equals(GrainInterfaceProperties? other)
+        {
+            if (ReferenceEquals(this, other)) return true;
+            if (other is null) return false;
+            if (Properties.Count != other.Properties.Count) return false;
+            foreach (var (key, value) in Properties)
+            {
+                if (!other.Properties.TryGetValue(key, out var otherValue) || !string.Equals(otherValue, value, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            if (!_hashCode.HasValue)
+            {
+                var hashCode = new HashCode();
+                hashCode.Add(Properties.Count);
+                foreach (var property in Properties)
+                {
+                    hashCode.Add(property.Key);
+                    hashCode.Add(property.Value);
+                }
+
+                _hashCode = hashCode.ToHashCode();
+            }
+
+            return _hashCode.Value;
         }
     }
 

--- a/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Text;
 using Orleans.Runtime;
 
@@ -25,7 +26,9 @@ namespace Orleans.Metadata
         public GrainInterfaceProperties(ImmutableDictionary<string, string> values)
         {
             ArgumentNullException.ThrowIfNull(values);
+            EnsureOrdinalKeyComparer(values, nameof(values));
             this.Properties = values.WithComparers(StringComparer.Ordinal, StringComparer.Ordinal);
+            Debug.Assert(HasOrdinalComparers(this.Properties));
         }
 
         /// <summary>
@@ -73,6 +76,8 @@ namespace Orleans.Metadata
 
         private static bool PropertiesEqual(ImmutableDictionary<string, string> left, ImmutableDictionary<string, string> right)
         {
+            Debug.Assert(HasOrdinalComparers(left));
+            Debug.Assert(HasOrdinalComparers(right));
             if (ReferenceEquals(left, right))
             {
                 return true;
@@ -93,6 +98,18 @@ namespace Orleans.Metadata
             }
 
             return true;
+        }
+
+        private static bool HasOrdinalComparers(ImmutableDictionary<string, string> properties)
+            => ReferenceEquals(properties.KeyComparer, StringComparer.Ordinal)
+                && ReferenceEquals(properties.ValueComparer, StringComparer.Ordinal);
+
+        private static void EnsureOrdinalKeyComparer(ImmutableDictionary<string, string> properties, string paramName)
+        {
+            if (!ReferenceEquals(properties.KeyComparer, StringComparer.Ordinal))
+            {
+                throw new ArgumentException("The dictionary must use StringComparer.Ordinal as its key comparer.", paramName);
+            }
         }
 
         private static int ComputeHashCode(ImmutableDictionary<string, string> properties)

--- a/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
@@ -66,10 +66,27 @@ namespace Orleans.Metadata
         {
             if (ReferenceEquals(this, other)) return true;
             if (other is null) return false;
-            if (Properties.Count != other.Properties.Count) return false;
-            foreach (var (key, value) in Properties)
+            return PropertiesEqual(Properties, other.Properties);
+        }
+
+        public override int GetHashCode() => _hashCode ??= ComputeHashCode(Properties);
+
+        private static bool PropertiesEqual(ImmutableDictionary<string, string> left, ImmutableDictionary<string, string> right)
+        {
+            if (ReferenceEquals(left, right))
             {
-                if (!other.Properties.TryGetValue(key, out var otherValue) || !string.Equals(otherValue, value, StringComparison.Ordinal))
+                return true;
+            }
+
+            if (left.Count != right.Count)
+            {
+                return false;
+            }
+
+            foreach (var entry in left)
+            {
+                if (!right.TryGetValue(entry.Key, out var value)
+                    || !string.Equals(entry.Value, value, StringComparison.Ordinal))
                 {
                     return false;
                 }
@@ -78,22 +95,17 @@ namespace Orleans.Metadata
             return true;
         }
 
-        public override int GetHashCode()
+        private static int ComputeHashCode(ImmutableDictionary<string, string> properties)
         {
-            if (!_hashCode.HasValue)
+            var hash = 0;
+            foreach (var entry in properties)
             {
-                var hashCode = new HashCode();
-                hashCode.Add(Properties.Count);
-                foreach (var property in Properties)
-                {
-                    hashCode.Add(property.Key);
-                    hashCode.Add(property.Value);
-                }
-
-                _hashCode = hashCode.ToHashCode();
+                hash ^= HashCode.Combine(
+                    StringComparer.Ordinal.GetHashCode(entry.Key),
+                    entry.Value is null ? 0 : StringComparer.Ordinal.GetHashCode(entry.Value));
             }
 
-            return _hashCode.Value;
+            return hash;
         }
     }
 

--- a/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
@@ -83,9 +83,18 @@ namespace Orleans.Metadata
                 return false;
             }
 
+            var rightProperties = new Dictionary<string, string>(right.Count, StringComparer.Ordinal);
+            foreach (var entry in right)
+            {
+                if (!rightProperties.TryAdd(entry.Key, entry.Value))
+                {
+                    return false;
+                }
+            }
+
             foreach (var entry in left)
             {
-                if (!right.TryGetValue(entry.Key, out var value)
+                if (!rightProperties.TryGetValue(entry.Key, out var value)
                     || !string.Equals(entry.Value, value, StringComparison.Ordinal))
                 {
                     return false;

--- a/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainInterfaceProperties.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
 using Orleans.Runtime;

--- a/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
@@ -29,8 +29,12 @@ namespace Orleans.Metadata
         {
             ArgumentNullException.ThrowIfNull(grains);
             ArgumentNullException.ThrowIfNull(interfaces);
-            this.Interfaces = interfaces;
-            this.Grains = grains;
+            this.Interfaces = interfaces.WithComparers(
+                EqualityComparer<GrainInterfaceType>.Default,
+                EqualityComparer<GrainInterfaceProperties>.Default);
+            this.Grains = grains.WithComparers(
+                EqualityComparer<GrainType>.Default,
+                EqualityComparer<GrainProperties>.Default);
         }
 
         /// <summary>
@@ -73,19 +77,10 @@ namespace Orleans.Metadata
                 return false;
             }
 
-            var rightDictionary = new Dictionary<TKey, TValue>(right.Count);
-            foreach (var entry in right)
-            {
-                if (!rightDictionary.TryAdd(entry.Key, entry.Value))
-                {
-                    return false;
-                }
-            }
-
             var comparer = EqualityComparer<TValue>.Default;
             foreach (var entry in left)
             {
-                if (!rightDictionary.TryGetValue(entry.Key, out var value)
+                if (!right.TryGetValue(entry.Key, out var value)
                     || !comparer.Equals(entry.Value, value))
                 {
                     return false;

--- a/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
@@ -8,8 +8,11 @@ namespace Orleans.Metadata
     /// Information about available grains.
     /// </summary>
     [Serializable, GenerateSerializer, Immutable]
-    public sealed class GrainManifest
+    public sealed class GrainManifest : IEquatable<GrainManifest>
     {
+        [NonSerialized]
+        private int? _hashCode;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="GrainManifest"/> class.
         /// </summary>
@@ -38,5 +41,53 @@ namespace Orleans.Metadata
         /// </summary>
         [Id(1)]
         public ImmutableDictionary<GrainType, GrainProperties> Grains { get; }
+
+        public override int GetHashCode()
+        {
+            if (!_hashCode.HasValue)
+            {
+                var hashCode = new HashCode();
+                hashCode.Add(Interfaces.Count);
+                foreach (var (key, value) in Interfaces)
+                {
+                    hashCode.Add(key);
+                    hashCode.Add(value);
+                }
+
+                hashCode.Add(Grains.Count);
+                foreach (var (key, value) in Grains)
+                {
+                    hashCode.Add(key);
+                    hashCode.Add(value);
+                }
+
+                _hashCode = hashCode.ToHashCode();
+            }
+
+            return _hashCode.Value;
+        }
+
+        public override bool Equals(object? obj) => obj is GrainManifest other && Equals(other);
+
+        public bool Equals(GrainManifest? other)
+        {
+            if (ReferenceEquals(this, other)) return true;
+            if (other is null) return false;
+            if (Interfaces.Count != other.Interfaces.Count) return false;
+            if (Grains.Count != other.Grains.Count) return false;
+            foreach (var (key, value) in Interfaces)
+            {
+                if (!other.Interfaces.TryGetValue(key, out var otherValue)) return false;
+                if (!value.Equals(otherValue)) return false;
+            }
+
+            foreach (var (key, value) in Grains)
+            {
+                if (!other.Grains.TryGetValue(key, out var otherValue)) return false;
+                if (!value.Equals(otherValue)) return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Orleans.Runtime;
 
@@ -26,6 +27,8 @@ namespace Orleans.Metadata
             ImmutableDictionary<GrainType, GrainProperties> grains,
             ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties> interfaces)
         {
+            ArgumentNullException.ThrowIfNull(grains);
+            ArgumentNullException.ThrowIfNull(interfaces);
             this.Interfaces = interfaces;
             this.Grains = grains;
         }
@@ -42,30 +45,9 @@ namespace Orleans.Metadata
         [Id(1)]
         public ImmutableDictionary<GrainType, GrainProperties> Grains { get; }
 
-        public override int GetHashCode()
-        {
-            if (!_hashCode.HasValue)
-            {
-                var hashCode = new HashCode();
-                hashCode.Add(Interfaces.Count);
-                foreach (var (key, value) in Interfaces)
-                {
-                    hashCode.Add(key);
-                    hashCode.Add(value);
-                }
-
-                hashCode.Add(Grains.Count);
-                foreach (var (key, value) in Grains)
-                {
-                    hashCode.Add(key);
-                    hashCode.Add(value);
-                }
-
-                _hashCode = hashCode.ToHashCode();
-            }
-
-            return _hashCode.Value;
-        }
+        public override int GetHashCode() => _hashCode ??= HashCode.Combine(
+            ComputeHashCode(Interfaces),
+            ComputeHashCode(Grains));
 
         public override bool Equals(object? obj) => obj is GrainManifest other && Equals(other);
 
@@ -73,21 +55,47 @@ namespace Orleans.Metadata
         {
             if (ReferenceEquals(this, other)) return true;
             if (other is null) return false;
-            if (Interfaces.Count != other.Interfaces.Count) return false;
-            if (Grains.Count != other.Grains.Count) return false;
-            foreach (var (key, value) in Interfaces)
+            return DictionariesEqual(Interfaces, other.Interfaces) && DictionariesEqual(Grains, other.Grains);
+        }
+
+        private static bool DictionariesEqual<TKey, TValue>(
+            ImmutableDictionary<TKey, TValue> left,
+            ImmutableDictionary<TKey, TValue> right)
+            where TKey : notnull
+        {
+            if (ReferenceEquals(left, right))
             {
-                if (!other.Interfaces.TryGetValue(key, out var otherValue)) return false;
-                if (!value.Equals(otherValue)) return false;
+                return true;
             }
 
-            foreach (var (key, value) in Grains)
+            if (left.Count != right.Count)
             {
-                if (!other.Grains.TryGetValue(key, out var otherValue)) return false;
-                if (!value.Equals(otherValue)) return false;
+                return false;
+            }
+
+            var comparer = EqualityComparer<TValue>.Default;
+            foreach (var entry in left)
+            {
+                if (!right.TryGetValue(entry.Key, out var value)
+                    || !comparer.Equals(entry.Value, value))
+                {
+                    return false;
+                }
             }
 
             return true;
+        }
+
+        private static int ComputeHashCode<TKey, TValue>(ImmutableDictionary<TKey, TValue> dictionary)
+            where TKey : notnull
+        {
+            var hash = 0;
+            foreach (var entry in dictionary)
+            {
+                hash ^= HashCode.Combine(entry.Key, entry.Value);
+            }
+
+            return hash;
         }
     }
 }

--- a/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Orleans.Runtime;
 
 namespace Orleans.Metadata
@@ -29,12 +30,16 @@ namespace Orleans.Metadata
         {
             ArgumentNullException.ThrowIfNull(grains);
             ArgumentNullException.ThrowIfNull(interfaces);
+            EnsureDefaultKeyComparer(grains, nameof(grains));
+            EnsureDefaultKeyComparer(interfaces, nameof(interfaces));
             this.Interfaces = interfaces.WithComparers(
                 EqualityComparer<GrainInterfaceType>.Default,
                 EqualityComparer<GrainInterfaceProperties>.Default);
             this.Grains = grains.WithComparers(
                 EqualityComparer<GrainType>.Default,
                 EqualityComparer<GrainProperties>.Default);
+            Debug.Assert(HasDefaultComparers(this.Interfaces));
+            Debug.Assert(HasDefaultComparers(this.Grains));
         }
 
         /// <summary>
@@ -67,6 +72,8 @@ namespace Orleans.Metadata
             ImmutableDictionary<TKey, TValue> right)
             where TKey : notnull
         {
+            Debug.Assert(HasDefaultComparers(left));
+            Debug.Assert(HasDefaultComparers(right));
             if (ReferenceEquals(left, right))
             {
                 return true;
@@ -88,6 +95,20 @@ namespace Orleans.Metadata
             }
 
             return true;
+        }
+
+        private static bool HasDefaultComparers<TKey, TValue>(ImmutableDictionary<TKey, TValue> dictionary)
+            where TKey : notnull
+            => ReferenceEquals(dictionary.KeyComparer, EqualityComparer<TKey>.Default)
+                && ReferenceEquals(dictionary.ValueComparer, EqualityComparer<TValue>.Default);
+
+        private static void EnsureDefaultKeyComparer<TKey, TValue>(ImmutableDictionary<TKey, TValue> dictionary, string paramName)
+            where TKey : notnull
+        {
+            if (!ReferenceEquals(dictionary.KeyComparer, EqualityComparer<TKey>.Default))
+            {
+                throw new ArgumentException("The dictionary must use the default key comparer.", paramName);
+            }
         }
 
         private static int ComputeHashCode<TKey, TValue>(ImmutableDictionary<TKey, TValue> dictionary)

--- a/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
@@ -73,10 +73,19 @@ namespace Orleans.Metadata
                 return false;
             }
 
+            var rightDictionary = new Dictionary<TKey, TValue>(right.Count);
+            foreach (var entry in right)
+            {
+                if (!rightDictionary.TryAdd(entry.Key, entry.Value))
+                {
+                    return false;
+                }
+            }
+
             var comparer = EqualityComparer<TValue>.Default;
             foreach (var entry in left)
             {
-                if (!right.TryGetValue(entry.Key, out var value)
+                if (!rightDictionary.TryGetValue(entry.Key, out var value)
                     || !comparer.Equals(entry.Value, value))
                 {
                     return false;

--- a/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainManifest.cs
@@ -72,8 +72,8 @@ namespace Orleans.Metadata
             ImmutableDictionary<TKey, TValue> right)
             where TKey : notnull
         {
-            Debug.Assert(HasDefaultComparers(left));
-            Debug.Assert(HasDefaultComparers(right));
+            Debug.Assert(HasDefaultKeyComparer(left));
+            Debug.Assert(HasDefaultKeyComparer(right));
             if (ReferenceEquals(left, right))
             {
                 return true;
@@ -102,10 +102,14 @@ namespace Orleans.Metadata
             => ReferenceEquals(dictionary.KeyComparer, EqualityComparer<TKey>.Default)
                 && ReferenceEquals(dictionary.ValueComparer, EqualityComparer<TValue>.Default);
 
+        private static bool HasDefaultKeyComparer<TKey, TValue>(ImmutableDictionary<TKey, TValue> dictionary)
+            where TKey : notnull
+            => ReferenceEquals(dictionary.KeyComparer, EqualityComparer<TKey>.Default);
+
         private static void EnsureDefaultKeyComparer<TKey, TValue>(ImmutableDictionary<TKey, TValue> dictionary, string paramName)
             where TKey : notnull
         {
-            if (!ReferenceEquals(dictionary.KeyComparer, EqualityComparer<TKey>.Default))
+            if (!HasDefaultKeyComparer(dictionary))
             {
                 throw new ArgumentException("The dictionary must use the default key comparer.", paramName);
             }

--- a/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Text;
@@ -26,7 +25,7 @@ namespace Orleans.Metadata
         public GrainProperties(ImmutableDictionary<string, string> values)
         {
             ArgumentNullException.ThrowIfNull(values);
-            this.Properties = values;
+            this.Properties = values.WithComparers(StringComparer.Ordinal, StringComparer.Ordinal);
         }
 
         /// <summary>
@@ -84,18 +83,9 @@ namespace Orleans.Metadata
                 return false;
             }
 
-            var rightProperties = new Dictionary<string, string>(right.Count, StringComparer.Ordinal);
-            foreach (var entry in right)
-            {
-                if (!rightProperties.TryAdd(entry.Key, entry.Value))
-                {
-                    return false;
-                }
-            }
-
             foreach (var entry in left)
             {
-                if (!rightProperties.TryGetValue(entry.Key, out var value)
+                if (!right.TryGetValue(entry.Key, out var value)
                     || !string.Equals(entry.Value, value, StringComparison.Ordinal))
                 {
                     return false;

--- a/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
@@ -84,9 +84,18 @@ namespace Orleans.Metadata
                 return false;
             }
 
+            var rightProperties = new Dictionary<string, string>(right.Count, StringComparer.Ordinal);
+            foreach (var entry in right)
+            {
+                if (!rightProperties.TryAdd(entry.Key, entry.Value))
+                {
+                    return false;
+                }
+            }
+
             foreach (var entry in left)
             {
-                if (!right.TryGetValue(entry.Key, out var value)
+                if (!rightProperties.TryGetValue(entry.Key, out var value)
                     || !string.Equals(entry.Value, value, StringComparison.Ordinal))
                 {
                     return false;

--- a/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -11,8 +12,11 @@ namespace Orleans.Metadata
     /// Information about a logical grain type <see cref="GrainType"/>.
     /// </summary>
     [Serializable, GenerateSerializer, Immutable]
-    public sealed class GrainProperties
+    public sealed class GrainProperties : IEquatable<GrainProperties>
     {
+        [NonSerialized]
+        private int? _hashCode;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="GrainProperties"/> class.
         /// </summary>
@@ -21,6 +25,7 @@ namespace Orleans.Metadata
         /// </param>
         public GrainProperties(ImmutableDictionary<string, string> values)
         {
+            ArgumentNullException.ThrowIfNull(values);
             this.Properties = values;
         }
 
@@ -38,10 +43,10 @@ namespace Orleans.Metadata
         /// </returns>
         public string ToDetailedString()
         {
-            if (this.Properties is null) return string.Empty;
+            if (Properties is null) return string.Empty;
             var result = new StringBuilder("[");
             bool first = true;
-            foreach (var entry in this.Properties)
+            foreach (var entry in Properties)
             {
                 if (!first)
                 {
@@ -54,6 +59,42 @@ namespace Orleans.Metadata
             result.Append("]");
 
             return result.ToString();
+        }
+
+        public override bool Equals(object? obj) => obj is GrainProperties other && Equals(other);
+
+        public bool Equals(GrainProperties? other)
+        {
+            if (ReferenceEquals(this, other)) return true;
+            if (other is null) return false;
+            if (Properties.Count != other.Properties.Count) return false;
+            foreach (var (key, value) in Properties)
+            {
+                if (!other.Properties.TryGetValue(key, out var otherValue) || !string.Equals(otherValue, value, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            if (!_hashCode.HasValue)
+            {
+                var hashCode = new HashCode();
+                hashCode.Add(Properties.Count);
+                foreach (var property in Properties)
+                {
+                    hashCode.Add(property.Key);
+                    hashCode.Add(property.Value);
+                }
+
+                _hashCode = hashCode.ToHashCode();
+            }
+
+            return _hashCode.Value;
         }
     }
 

--- a/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using Orleans.Runtime;
@@ -26,7 +27,9 @@ namespace Orleans.Metadata
         public GrainProperties(ImmutableDictionary<string, string> values)
         {
             ArgumentNullException.ThrowIfNull(values);
+            EnsureOrdinalKeyComparer(values, nameof(values));
             this.Properties = values.WithComparers(StringComparer.Ordinal, StringComparer.Ordinal);
+            Debug.Assert(HasOrdinalComparers(this.Properties));
         }
 
         /// <summary>
@@ -74,6 +77,8 @@ namespace Orleans.Metadata
 
         private static bool PropertiesEqual(ImmutableDictionary<string, string> left, ImmutableDictionary<string, string> right)
         {
+            Debug.Assert(HasOrdinalComparers(left));
+            Debug.Assert(HasOrdinalComparers(right));
             if (ReferenceEquals(left, right))
             {
                 return true;
@@ -94,6 +99,18 @@ namespace Orleans.Metadata
             }
 
             return true;
+        }
+
+        private static bool HasOrdinalComparers(ImmutableDictionary<string, string> properties)
+            => ReferenceEquals(properties.KeyComparer, StringComparer.Ordinal)
+                && ReferenceEquals(properties.ValueComparer, StringComparer.Ordinal);
+
+        private static void EnsureOrdinalKeyComparer(ImmutableDictionary<string, string> properties, string paramName)
+        {
+            if (!ReferenceEquals(properties.KeyComparer, StringComparer.Ordinal))
+            {
+                throw new ArgumentException("The dictionary must use StringComparer.Ordinal as its key comparer.", paramName);
+            }
         }
 
         private static int ComputeHashCode(ImmutableDictionary<string, string> properties)

--- a/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
@@ -77,8 +77,8 @@ namespace Orleans.Metadata
 
         private static bool PropertiesEqual(ImmutableDictionary<string, string> left, ImmutableDictionary<string, string> right)
         {
-            Debug.Assert(HasOrdinalComparers(left));
-            Debug.Assert(HasOrdinalComparers(right));
+            Debug.Assert(HasOrdinalKeyComparer(left));
+            Debug.Assert(HasOrdinalKeyComparer(right));
             if (ReferenceEquals(left, right))
             {
                 return true;
@@ -105,9 +105,12 @@ namespace Orleans.Metadata
             => ReferenceEquals(properties.KeyComparer, StringComparer.Ordinal)
                 && ReferenceEquals(properties.ValueComparer, StringComparer.Ordinal);
 
+        private static bool HasOrdinalKeyComparer(ImmutableDictionary<string, string> properties)
+            => ReferenceEquals(properties.KeyComparer, StringComparer.Ordinal);
+
         private static void EnsureOrdinalKeyComparer(ImmutableDictionary<string, string> properties, string paramName)
         {
-            if (!ReferenceEquals(properties.KeyComparer, StringComparer.Ordinal))
+            if (!HasOrdinalKeyComparer(properties))
             {
                 throw new ArgumentException("The dictionary must use StringComparer.Ordinal as its key comparer.", paramName);
             }

--- a/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
@@ -67,10 +67,27 @@ namespace Orleans.Metadata
         {
             if (ReferenceEquals(this, other)) return true;
             if (other is null) return false;
-            if (Properties.Count != other.Properties.Count) return false;
-            foreach (var (key, value) in Properties)
+            return PropertiesEqual(Properties, other.Properties);
+        }
+
+        public override int GetHashCode() => _hashCode ??= ComputeHashCode(Properties);
+
+        private static bool PropertiesEqual(ImmutableDictionary<string, string> left, ImmutableDictionary<string, string> right)
+        {
+            if (ReferenceEquals(left, right))
             {
-                if (!other.Properties.TryGetValue(key, out var otherValue) || !string.Equals(otherValue, value, StringComparison.Ordinal))
+                return true;
+            }
+
+            if (left.Count != right.Count)
+            {
+                return false;
+            }
+
+            foreach (var entry in left)
+            {
+                if (!right.TryGetValue(entry.Key, out var value)
+                    || !string.Equals(entry.Value, value, StringComparison.Ordinal))
                 {
                     return false;
                 }
@@ -79,22 +96,17 @@ namespace Orleans.Metadata
             return true;
         }
 
-        public override int GetHashCode()
+        private static int ComputeHashCode(ImmutableDictionary<string, string> properties)
         {
-            if (!_hashCode.HasValue)
+            var hash = 0;
+            foreach (var entry in properties)
             {
-                var hashCode = new HashCode();
-                hashCode.Add(Properties.Count);
-                foreach (var property in Properties)
-                {
-                    hashCode.Add(property.Key);
-                    hashCode.Add(property.Value);
-                }
-
-                _hashCode = hashCode.ToHashCode();
+                hash ^= HashCode.Combine(
+                    StringComparer.Ordinal.GetHashCode(entry.Key),
+                    entry.Value is null ? 0 : StringComparer.Ordinal.GetHashCode(entry.Value));
             }
 
-            return _hashCode.Value;
+            return hash;
         }
     }
 

--- a/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
+++ b/src/Orleans.Core.Abstractions/Manifest/GrainProperties.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Text;

--- a/src/Orleans.Core/Manifest/ClientManifestProvider.cs
+++ b/src/Orleans.Core/Manifest/ClientManifestProvider.cs
@@ -35,13 +35,13 @@ namespace Orleans.Runtime
             foreach (var grainInterface in grainTypeOptions.Value.Interfaces)
             {
                 var interfaceId = interfaceTypeResolver.GetGrainInterfaceType(grainInterface);
-                var properties = new Dictionary<string, string>();
+                var properties = new Dictionary<string, string>(StringComparer.Ordinal);
                 foreach (var provider in propertyProviders)
                 {
                     provider.Populate(grainInterface, interfaceId, properties);
                 }
 
-                var result = new GrainInterfaceProperties(properties.ToImmutableDictionary());
+                var result = new GrainInterfaceProperties(ToImmutablePropertyDictionary(properties));
                 if (builder.TryGetValue(interfaceId, out var grainInterfaceProperty))
                 {
                     throw new InvalidOperationException($"An entry with the key {interfaceId} is already present."
@@ -50,6 +50,17 @@ namespace Orleans.Runtime
                 }
 
                 builder.Add(interfaceId, result);
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static ImmutableDictionary<string, string> ToImmutablePropertyDictionary(Dictionary<string, string> properties)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal, StringComparer.Ordinal);
+            foreach (var property in properties)
+            {
+                builder.Add(property.Key, property.Value);
             }
 
             return builder.ToImmutable();

--- a/src/Orleans.Core/Manifest/GrainPropertiesResolver.cs
+++ b/src/Orleans.Core/Manifest/GrainPropertiesResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Orleans.Runtime;
@@ -37,7 +38,7 @@ namespace Orleans.Metadata
             if (!TryGetGrainProperties(grainType, out var result))
             {
                 //ThrowNotFoundException(grainType);
-                result = new GrainProperties(ImmutableDictionary<string, string>.Empty);
+                result = new GrainProperties(ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.Ordinal, StringComparer.Ordinal));
             }
 
             return result;

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -96,6 +97,10 @@ namespace Orleans.Runtime.Metadata
 
         private async Task<bool> UpdateManifest(ClusterMembershipSnapshot clusterMembership)
         {
+            var interfaceProperties = new HashSet<GrainInterfaceProperties>();
+            var grainProperties = new HashSet<GrainProperties>();
+            var manifests = new HashSet<GrainManifest>();
+
             var existingManifest = _current;
             var builder = existingManifest.Silos.ToBuilder();
             var modified = false;
@@ -112,10 +117,40 @@ namespace Orleans.Runtime.Metadata
                     continue;
                 }
 
-                if (status == SiloStatus.None || status == SiloStatus.Dead)
+                if (status is SiloStatus.None or SiloStatus.Dead)
                 {
                     builder.Remove(address);
                     modified = true;
+                }
+            }
+
+            // Populate deduplication structures.
+            foreach (var siloAddress in builder.Keys.ToList())
+            {
+                var siloManifest = builder[siloAddress];
+                if (!manifests.Add(siloManifest))
+                {
+                    if (manifests.TryGetValue(siloManifest, out var existing))
+                    {
+                        builder[siloAddress] = existing;
+                    }
+                    else
+                    {
+                        Debug.Fail("Unable to retrieve an existing manifest from the deduplication set.");
+                    }
+                }
+            }
+
+            foreach (var manifest in manifests)
+            {
+                foreach (var interfaceProps in manifest.Interfaces.Values)
+                {
+                    interfaceProperties.Add(interfaceProps);
+                }
+
+                foreach (var grainProps in manifest.Grains.Values)
+                {
+                    grainProperties.Add(grainProps);
                 }
             }
 
@@ -179,7 +214,7 @@ namespace Orleans.Runtime.Metadata
                     modified = true;
                     if (result.Value is not null)
                     {
-                        builder[result.Key] = result.Value;
+                        builder[result.Key] = DeduplicateManifest(result.Value);
                     }
                 }
             }
@@ -199,6 +234,47 @@ namespace Orleans.Runtime.Metadata
             }
 
             return fetchSuccess;
+
+            GrainManifest DeduplicateManifest(GrainManifest manifest)
+            {
+                // Deduplicate silo manifests.
+                if (manifests.TryGetValue(manifest, out var existing))
+                {
+                    return existing;
+                }
+
+                // Deduplicate interface manifests.
+                var manifestInterfaces = manifest.Interfaces.ToBuilder();
+                foreach (var (key, value) in manifest.Interfaces)
+                {
+                    if (!interfaceProperties.TryGetValue(value, out var existingValue))
+                    {
+                        interfaceProperties.Add(value);
+                    }
+                    else
+                    {
+                        manifestInterfaces[key] = existingValue;
+                    }
+                }
+
+                // Deduplicate grain manifests.
+                var manifestGrains = manifest.Grains.ToBuilder();
+                foreach (var (key, value) in manifest.Grains)
+                {
+                    if (!grainProperties.TryGetValue(value, out var existingValue))
+                    {
+                        grainProperties.Add(value);
+                    }
+                    else
+                    {
+                        manifestGrains[key] = existingValue;
+                    }
+                }
+
+                manifest = new GrainManifest(manifestGrains.ToImmutable(), manifestInterfaces.ToImmutable());
+                manifests.Add(manifest);
+                return manifest;
+            }
         }
 
         [MemberNotNull(nameof(_runTask))]

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -97,10 +96,6 @@ namespace Orleans.Runtime.Metadata
 
         private async Task<bool> UpdateManifest(ClusterMembershipSnapshot clusterMembership)
         {
-            var interfaceProperties = new HashSet<GrainInterfaceProperties>();
-            var grainProperties = new HashSet<GrainProperties>();
-            var manifests = new HashSet<GrainManifest>();
-
             var existingManifest = _current;
             var builder = existingManifest.Silos.ToBuilder();
             var modified = false;
@@ -117,40 +112,10 @@ namespace Orleans.Runtime.Metadata
                     continue;
                 }
 
-                if (status is SiloStatus.None or SiloStatus.Dead)
+                if (status == SiloStatus.None || status == SiloStatus.Dead)
                 {
                     builder.Remove(address);
                     modified = true;
-                }
-            }
-
-            // Populate deduplication structures.
-            foreach (var siloAddress in builder.Keys.ToList())
-            {
-                var siloManifest = builder[siloAddress];
-                if (!manifests.Add(siloManifest))
-                {
-                    if (manifests.TryGetValue(siloManifest, out var existing))
-                    {
-                        builder[siloAddress] = existing;
-                    }
-                    else
-                    {
-                        Debug.Fail("Unable to retrieve an existing manifest from the deduplication set.");
-                    }
-                }
-            }
-
-            foreach (var manifest in manifests)
-            {
-                foreach (var interfaceProps in manifest.Interfaces.Values)
-                {
-                    interfaceProperties.Add(interfaceProps);
-                }
-
-                foreach (var grainProps in manifest.Grains.Values)
-                {
-                    grainProperties.Add(grainProps);
                 }
             }
 
@@ -214,7 +179,7 @@ namespace Orleans.Runtime.Metadata
                     modified = true;
                     if (result.Value is not null)
                     {
-                        builder[result.Key] = DeduplicateManifest(result.Value);
+                        builder[result.Key] = result.Value;
                     }
                 }
             }
@@ -234,47 +199,6 @@ namespace Orleans.Runtime.Metadata
             }
 
             return fetchSuccess;
-
-            GrainManifest DeduplicateManifest(GrainManifest manifest)
-            {
-                // Deduplicate silo manifests.
-                if (manifests.TryGetValue(manifest, out var existing))
-                {
-                    return existing;
-                }
-
-                // Deduplicate interface manifests.
-                var manifestInterfaces = manifest.Interfaces.ToBuilder();
-                foreach (var (key, value) in manifest.Interfaces)
-                {
-                    if (!interfaceProperties.TryGetValue(value, out var existingValue))
-                    {
-                        interfaceProperties.Add(value);
-                    }
-                    else
-                    {
-                        manifestInterfaces[key] = existingValue;
-                    }
-                }
-
-                // Deduplicate grain manifests.
-                var manifestGrains = manifest.Grains.ToBuilder();
-                foreach (var (key, value) in manifest.Grains)
-                {
-                    if (!grainProperties.TryGetValue(value, out var existingValue))
-                    {
-                        grainProperties.Add(value);
-                    }
-                    else
-                    {
-                        manifestGrains[key] = existingValue;
-                    }
-                }
-
-                manifest = new GrainManifest(manifestGrains.ToImmutable(), manifestInterfaces.ToImmutable());
-                manifests.Add(manifest);
-                return manifest;
-            }
         }
 
         [MemberNotNull(nameof(_runTask))]

--- a/src/Orleans.Runtime/Manifest/SiloManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/SiloManifestProvider.cs
@@ -40,13 +40,13 @@ namespace Orleans.Metadata
             foreach (var grainInterface in grainTypeOptions.Value.Interfaces)
             {
                 var interfaceId = grainInterfaceIdProvider.GetGrainInterfaceType(grainInterface);
-                var properties = new Dictionary<string, string>();
+                var properties = new Dictionary<string, string>(StringComparer.Ordinal);
                 foreach (var provider in propertyProviders)
                 {
                     provider.Populate(grainInterface, interfaceId, properties);
                 }
 
-                var result = new GrainInterfaceProperties(properties.ToImmutableDictionary());
+                var result = new GrainInterfaceProperties(ToImmutablePropertyDictionary(properties));
                 if (builder.TryGetValue(interfaceId, out var graintInterfaceProperty))
                 {
                     throw new InvalidOperationException($"An entry with the key {interfaceId} is already present."
@@ -70,13 +70,13 @@ namespace Orleans.Metadata
             foreach (var grainClass in grainTypeOptions.Value.Classes)
             {
                 var grainType = grainTypeProvider.GetGrainType(grainClass);
-                var properties = new Dictionary<string, string>();
+                var properties = new Dictionary<string, string>(StringComparer.Ordinal);
                 foreach (var provider in grainMetadataProviders)
                 {
                     provider.Populate(grainClass, grainType, properties);
                 }
 
-                var result = new GrainProperties(properties.ToImmutableDictionary());
+                var result = new GrainProperties(ToImmutablePropertyDictionary(properties));
                 if (propertiesMap.TryGetValue(grainType, out var grainProperty))
                 {
                     throw new InvalidOperationException($"An entry with the key {grainType} is already present."
@@ -89,6 +89,17 @@ namespace Orleans.Metadata
             }
 
             return (propertiesMap.ToImmutable(), typeMap.ToImmutable());
+        }
+
+        private static ImmutableDictionary<string, string> ToImmutablePropertyDictionary(Dictionary<string, string> properties)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal, StringComparer.Ordinal);
+            foreach (var property in properties)
+            {
+                builder.Add(property.Key, property.Value);
+            }
+
+            return builder.ToImmutable();
         }
     }
 }

--- a/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
+++ b/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
@@ -1575,6 +1575,8 @@ namespace Orleans.Metadata
     {
         public ClusterManifest(MajorMinorVersion version, System.Collections.Immutable.ImmutableDictionary<Runtime.SiloAddress, GrainManifest> silos) { }
 
+        public ClusterManifest(MajorMinorVersion version, System.Collections.Immutable.ImmutableDictionary<Runtime.SiloAddress, GrainManifest> silos, System.Collections.Immutable.ImmutableArray<GrainManifest> allGrainManifests) { }
+
         [Id(2)]
         public System.Collections.Immutable.ImmutableArray<GrainManifest> AllGrainManifests { get { throw null; } }
 
@@ -1595,9 +1597,15 @@ namespace Orleans.Metadata
 
     [GenerateSerializer]
     [Immutable]
-    public sealed partial class GrainInterfaceProperties
+    public sealed partial class GrainInterfaceProperties : System.IEquatable<GrainInterfaceProperties>
     {
         public GrainInterfaceProperties(System.Collections.Immutable.ImmutableDictionary<string, string> values) { }
+
+        public bool Equals(GrainInterfaceProperties? other) { throw null; }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
 
         [Id(0)]
         public System.Collections.Immutable.ImmutableDictionary<string, string> Properties { get { throw null; } }
@@ -1607,9 +1615,15 @@ namespace Orleans.Metadata
 
     [GenerateSerializer]
     [Immutable]
-    public sealed partial class GrainManifest
+    public sealed partial class GrainManifest : System.IEquatable<GrainManifest>
     {
         public GrainManifest(System.Collections.Immutable.ImmutableDictionary<Runtime.GrainType, GrainProperties> grains, System.Collections.Immutable.ImmutableDictionary<Runtime.GrainInterfaceType, GrainInterfaceProperties> interfaces) { }
+
+        public bool Equals(GrainManifest? other) { throw null; }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
 
         [Id(1)]
         public System.Collections.Immutable.ImmutableDictionary<Runtime.GrainType, GrainProperties> Grains { get { throw null; } }
@@ -1620,9 +1634,15 @@ namespace Orleans.Metadata
 
     [GenerateSerializer]
     [Immutable]
-    public sealed partial class GrainProperties
+    public sealed partial class GrainProperties : System.IEquatable<GrainProperties>
     {
         public GrainProperties(System.Collections.Immutable.ImmutableDictionary<string, string> values) { }
+
+        public bool Equals(GrainProperties? other) { throw null; }
+
+        public override bool Equals(object? obj) { throw null; }
+
+        public override int GetHashCode() { throw null; }
 
         [Id(0)]
         public System.Collections.Immutable.ImmutableDictionary<string, string> Properties { get { throw null; } }

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestDeduplicationTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestDeduplicationTests.cs
@@ -171,6 +171,34 @@ namespace UnitTests.Manifest
             Assert.Same(manifest.Silos[silo1].Interfaces[TestInterfaceType], manifest.Silos[silo2].Interfaces[TestInterfaceType]);
         }
 
+        [Fact]
+        public void ClusterManifest_DeduplicatesStringEquivalentProperties()
+        {
+            var silo1 = CreateSiloAddress(11111, 1);
+            var silo2 = CreateSiloAddress(11112, 1);
+            var propertyKey = Copy("property");
+            var propertyValue = Copy("value");
+            var equalPropertyKey = Copy("property");
+            var equalPropertyValue = Copy("value");
+            Assert.NotSame(propertyKey, equalPropertyKey);
+            Assert.NotSame(propertyValue, equalPropertyValue);
+
+            var silo1Manifest = CreateGrainManifest(new KeyValuePair<string, string>(propertyKey, propertyValue));
+            var silo2Manifest = CreateGrainManifest(new KeyValuePair<string, string>(equalPropertyKey, equalPropertyValue));
+
+            var manifest = new ClusterManifest(
+                new MajorMinorVersion(1, 0),
+                ImmutableDictionary.CreateRange(
+                [
+                    new KeyValuePair<SiloAddress, GrainManifest>(silo1, silo1Manifest),
+                    new KeyValuePair<SiloAddress, GrainManifest>(silo2, silo2Manifest)
+                ]));
+
+            Assert.Single(manifest.AllGrainManifests);
+            Assert.Same(manifest.Silos[silo1], manifest.Silos[silo2]);
+            Assert.Same(manifest.Silos[silo1].Grains[TestGrainType], manifest.Silos[silo2].Grains[TestGrainType]);
+        }
+
         private static GrainManifest CreateGrainManifest(params KeyValuePair<string, string>[] additionalGrainProperties)
         {
             var grainProperties = CreatePropertyDictionary(
@@ -215,6 +243,8 @@ namespace UnitTests.Manifest
         {
             return SiloAddress.New(new(System.Net.IPAddress.Loopback, port), generation);
         }
+
+        private static string Copy(string value) => new(value.ToCharArray());
 
         private sealed class ConstantHashStringComparer : IEqualityComparer<string>
         {

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestDeduplicationTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestDeduplicationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -34,6 +35,20 @@ namespace UnitTests.Manifest
         }
 
         [Fact]
+        public void GrainProperties_DoesNotUseDictionaryComparerForKeyEquality()
+        {
+            var properties = new GrainProperties(CreatePropertyDictionary(
+                StringComparer.Ordinal,
+                new KeyValuePair<string, string>("Name", "Value")));
+            var differentProperties = new GrainProperties(CreatePropertyDictionary(
+                StringComparer.OrdinalIgnoreCase,
+                new KeyValuePair<string, string>("name", "Value")));
+
+            Assert.False(properties.Equals(differentProperties));
+            Assert.False(differentProperties.Equals(properties));
+        }
+
+        [Fact]
         public void GrainInterfaceProperties_UsesStructuralEquality()
         {
             var properties = new GrainInterfaceProperties(CreatePropertyDictionary(
@@ -53,6 +68,20 @@ namespace UnitTests.Manifest
         }
 
         [Fact]
+        public void GrainInterfaceProperties_DoesNotUseDictionaryComparerForKeyEquality()
+        {
+            var properties = new GrainInterfaceProperties(CreatePropertyDictionary(
+                StringComparer.Ordinal,
+                new KeyValuePair<string, string>("Name", "Value")));
+            var differentProperties = new GrainInterfaceProperties(CreatePropertyDictionary(
+                StringComparer.OrdinalIgnoreCase,
+                new KeyValuePair<string, string>("name", "Value")));
+
+            Assert.False(properties.Equals(differentProperties));
+            Assert.False(differentProperties.Equals(properties));
+        }
+
+        [Fact]
         public void GrainManifest_UsesStructuralEquality()
         {
             var manifest = CreateGrainManifest();
@@ -64,6 +93,31 @@ namespace UnitTests.Manifest
             Assert.Equal(manifest, equalManifest);
             Assert.Equal(manifest.GetHashCode(), equalManifest.GetHashCode());
             Assert.NotEqual(manifest, differentManifest);
+        }
+
+        [Fact]
+        public void GrainManifest_DoesNotUseDictionaryComparerForKeyEquality()
+        {
+            var grainProperties = new GrainProperties(CreatePropertyDictionary(
+                new KeyValuePair<string, string>(WellKnownGrainTypeProperties.TypeName, "Test")));
+            var manifest = new GrainManifest(
+                ImmutableDictionary.CreateRange(
+                [
+                    new KeyValuePair<GrainType, GrainProperties>(GrainType.Create("Test"), grainProperties)
+                ]),
+                ImmutableDictionary.CreateRange(
+                [
+                    new KeyValuePair<GrainInterfaceType, GrainInterfaceProperties>(
+                        TestInterfaceType,
+                        new GrainInterfaceProperties(CreatePropertyDictionary(
+                            new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.TypeName, "ITest"))))
+                ]));
+            var caseInsensitiveGrains = ImmutableDictionary.CreateBuilder<GrainType, GrainProperties>(CaseInsensitiveGrainTypeComparer.Instance);
+            caseInsensitiveGrains.Add(GrainType.Create("test"), grainProperties);
+            var differentManifest = new GrainManifest(caseInsensitiveGrains.ToImmutable(), manifest.Interfaces);
+
+            Assert.False(manifest.Equals(differentManifest));
+            Assert.False(differentManifest.Equals(manifest));
         }
 
         [Fact]
@@ -229,8 +283,11 @@ namespace UnitTests.Manifest
         }
 
         private static ImmutableDictionary<string, string> CreatePropertyDictionary(params KeyValuePair<string, string>[] properties)
+            => CreatePropertyDictionary(ConstantHashStringComparer.Instance, properties);
+
+        private static ImmutableDictionary<string, string> CreatePropertyDictionary(IEqualityComparer<string> comparer, params KeyValuePair<string, string>[] properties)
         {
-            var builder = ImmutableDictionary.CreateBuilder<string, string>(ConstantHashStringComparer.Instance);
+            var builder = ImmutableDictionary.CreateBuilder<string, string>(comparer);
             foreach (var property in properties)
             {
                 builder.Add(property.Key, property.Value);
@@ -257,6 +314,19 @@ namespace UnitTests.Manifest
             public bool Equals(string x, string y) => string.Equals(x, y, System.StringComparison.Ordinal);
 
             public int GetHashCode(string obj) => 0;
+        }
+
+        private sealed class CaseInsensitiveGrainTypeComparer : IEqualityComparer<GrainType>
+        {
+            public static readonly CaseInsensitiveGrainTypeComparer Instance = new();
+
+            private CaseInsensitiveGrainTypeComparer()
+            {
+            }
+
+            public bool Equals(GrainType x, GrainType y) => string.Equals(x.ToString(), y.ToString(), StringComparison.OrdinalIgnoreCase);
+
+            public int GetHashCode(GrainType obj) => StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ToString());
         }
     }
 }

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestDeduplicationTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestDeduplicationTests.cs
@@ -29,6 +29,8 @@ namespace UnitTests.Manifest
                 new KeyValuePair<string, string>("two", "different")));
 
             Assert.NotSame(properties, equalProperties);
+            Assert.Same(StringComparer.Ordinal, properties.Properties.KeyComparer);
+            Assert.Same(StringComparer.Ordinal, properties.Properties.ValueComparer);
             Assert.Equal(properties, equalProperties);
             Assert.Equal(properties.GetHashCode(), equalProperties.GetHashCode());
             Assert.NotEqual(properties, differentProperties);
@@ -46,6 +48,8 @@ namespace UnitTests.Manifest
 
             Assert.False(properties.Equals(differentProperties));
             Assert.False(differentProperties.Equals(properties));
+            Assert.Same(StringComparer.Ordinal, differentProperties.Properties.KeyComparer);
+            Assert.Same(StringComparer.Ordinal, differentProperties.Properties.ValueComparer);
         }
 
         [Fact]
@@ -62,6 +66,8 @@ namespace UnitTests.Manifest
                 new KeyValuePair<string, string>("two", "different")));
 
             Assert.NotSame(properties, equalProperties);
+            Assert.Same(StringComparer.Ordinal, properties.Properties.KeyComparer);
+            Assert.Same(StringComparer.Ordinal, properties.Properties.ValueComparer);
             Assert.Equal(properties, equalProperties);
             Assert.Equal(properties.GetHashCode(), equalProperties.GetHashCode());
             Assert.NotEqual(properties, differentProperties);
@@ -79,6 +85,8 @@ namespace UnitTests.Manifest
 
             Assert.False(properties.Equals(differentProperties));
             Assert.False(differentProperties.Equals(properties));
+            Assert.Same(StringComparer.Ordinal, differentProperties.Properties.KeyComparer);
+            Assert.Same(StringComparer.Ordinal, differentProperties.Properties.ValueComparer);
         }
 
         [Fact]
@@ -118,6 +126,7 @@ namespace UnitTests.Manifest
 
             Assert.False(manifest.Equals(differentManifest));
             Assert.False(differentManifest.Equals(manifest));
+            Assert.Same(EqualityComparer<GrainType>.Default, differentManifest.Grains.KeyComparer);
         }
 
         [Fact]

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestDeduplicationTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestDeduplicationTests.cs
@@ -1,0 +1,232 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Orleans.Metadata;
+using Orleans.Runtime;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.Manifest
+{
+    [TestCategory("BVT"), TestCategory("Manifest")]
+    public class ClusterManifestDeduplicationTests
+    {
+        private static readonly GrainType TestGrainType = GrainType.Create("test");
+        private static readonly GrainInterfaceType TestInterfaceType = GrainInterfaceType.Create("test.interface");
+
+        [Fact]
+        public void GrainProperties_UsesStructuralEquality()
+        {
+            var properties = new GrainProperties(CreatePropertyDictionary(
+                new KeyValuePair<string, string>("one", "1"),
+                new KeyValuePair<string, string>("two", "2")));
+            var equalProperties = new GrainProperties(CreatePropertyDictionary(
+                new KeyValuePair<string, string>("two", "2"),
+                new KeyValuePair<string, string>("one", "1")));
+            var differentProperties = new GrainProperties(CreatePropertyDictionary(
+                new KeyValuePair<string, string>("one", "1"),
+                new KeyValuePair<string, string>("two", "different")));
+
+            Assert.NotSame(properties, equalProperties);
+            Assert.Equal(properties, equalProperties);
+            Assert.Equal(properties.GetHashCode(), equalProperties.GetHashCode());
+            Assert.NotEqual(properties, differentProperties);
+        }
+
+        [Fact]
+        public void GrainInterfaceProperties_UsesStructuralEquality()
+        {
+            var properties = new GrainInterfaceProperties(CreatePropertyDictionary(
+                new KeyValuePair<string, string>("one", "1"),
+                new KeyValuePair<string, string>("two", "2")));
+            var equalProperties = new GrainInterfaceProperties(CreatePropertyDictionary(
+                new KeyValuePair<string, string>("two", "2"),
+                new KeyValuePair<string, string>("one", "1")));
+            var differentProperties = new GrainInterfaceProperties(CreatePropertyDictionary(
+                new KeyValuePair<string, string>("one", "1"),
+                new KeyValuePair<string, string>("two", "different")));
+
+            Assert.NotSame(properties, equalProperties);
+            Assert.Equal(properties, equalProperties);
+            Assert.Equal(properties.GetHashCode(), equalProperties.GetHashCode());
+            Assert.NotEqual(properties, differentProperties);
+        }
+
+        [Fact]
+        public void GrainManifest_UsesStructuralEquality()
+        {
+            var manifest = CreateGrainManifest();
+            var equalManifest = CreateGrainManifest();
+            var differentManifest = CreateGrainManifest(
+                new KeyValuePair<string, string>("different", "true"));
+
+            Assert.NotSame(manifest, equalManifest);
+            Assert.Equal(manifest, equalManifest);
+            Assert.Equal(manifest.GetHashCode(), equalManifest.GetHashCode());
+            Assert.NotEqual(manifest, differentManifest);
+        }
+
+        [Fact]
+        public void ClusterManifest_DeduplicatesEqualManifests()
+        {
+            var silo1 = CreateSiloAddress(11111, 1);
+            var silo2 = CreateSiloAddress(11112, 1);
+            var silo1Manifest = CreateGrainManifest();
+            var silo2Manifest = CreateGrainManifest();
+            var localManifest = CreateGrainManifest();
+
+            var manifest = new ClusterManifest(
+                new MajorMinorVersion(1, 0),
+                ImmutableDictionary.CreateRange(
+                [
+                    new KeyValuePair<SiloAddress, GrainManifest>(silo1, silo1Manifest),
+                    new KeyValuePair<SiloAddress, GrainManifest>(silo2, silo2Manifest)
+                ]),
+                ImmutableArray.Create(localManifest));
+
+            Assert.Single(manifest.AllGrainManifests);
+            Assert.Same(manifest.Silos[silo1], manifest.Silos[silo2]);
+            Assert.Same(manifest.Silos[silo1], manifest.AllGrainManifests[0]);
+        }
+
+        [Fact]
+        public void ClusterManifest_PreservesDistinctAdditionalManifests()
+        {
+            var silo = CreateSiloAddress(11111, 1);
+            var siloManifest = CreateGrainManifest();
+            var additionalManifest = CreateGrainManifest(
+                new KeyValuePair<string, string>("additional", "true"));
+            var duplicateAdditionalManifest = CreateGrainManifest(
+                new KeyValuePair<string, string>("additional", "true"));
+
+            var manifest = new ClusterManifest(
+                new MajorMinorVersion(1, 0),
+                ImmutableDictionary.CreateRange(
+                [
+                    new KeyValuePair<SiloAddress, GrainManifest>(silo, siloManifest)
+                ]),
+                ImmutableArray.Create(additionalManifest, duplicateAdditionalManifest, siloManifest));
+
+            Assert.Equal(2, manifest.AllGrainManifests.Length);
+            Assert.Same(manifest.Silos[silo], manifest.AllGrainManifests[0]);
+            var preservedAdditionalManifest = Assert.Single(manifest.AllGrainManifests.Skip(1));
+            Assert.Equal(additionalManifest, preservedAdditionalManifest);
+            Assert.NotSame(preservedAdditionalManifest.Grains[TestGrainType], manifest.AllGrainManifests[0].Grains[TestGrainType]);
+            Assert.Same(preservedAdditionalManifest.Interfaces[TestInterfaceType], manifest.AllGrainManifests[0].Interfaces[TestInterfaceType]);
+        }
+
+        [Fact]
+        public void ClusterManifest_DeduplicatesEquivalentManifestEntries()
+        {
+            var silo1 = CreateSiloAddress(11111, 1);
+            var silo2 = CreateSiloAddress(11112, 1);
+            var otherGrainType = GrainType.Create("other");
+            var otherInterfaceType = GrainInterfaceType.Create("other.interface");
+            var sharedGrainProperties = new GrainProperties(CreatePropertyDictionary(
+                new KeyValuePair<string, string>(WellKnownGrainTypeProperties.TypeName, "Test"),
+                new KeyValuePair<string, string>(WellKnownGrainTypeProperties.FullTypeName, "UnitTests.Grains.Test")));
+            var equalSharedGrainProperties = new GrainProperties(CreatePropertyDictionary(
+                new KeyValuePair<string, string>(WellKnownGrainTypeProperties.FullTypeName, "UnitTests.Grains.Test"),
+                new KeyValuePair<string, string>(WellKnownGrainTypeProperties.TypeName, "Test")));
+            var sharedInterfaceProperties = new GrainInterfaceProperties(CreatePropertyDictionary(
+                new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.TypeName, "ITest"),
+                new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.Version, "1")));
+            var equalSharedInterfaceProperties = new GrainInterfaceProperties(CreatePropertyDictionary(
+                new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.Version, "1"),
+                new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.TypeName, "ITest")));
+            var silo1Manifest = new GrainManifest(
+                ImmutableDictionary.CreateRange(
+                [
+                    new KeyValuePair<GrainType, GrainProperties>(TestGrainType, sharedGrainProperties)
+                ]),
+                ImmutableDictionary.CreateRange(
+                [
+                    new KeyValuePair<GrainInterfaceType, GrainInterfaceProperties>(TestInterfaceType, sharedInterfaceProperties)
+                ]));
+            var silo2Manifest = new GrainManifest(
+                ImmutableDictionary.CreateRange(
+                [
+                    new KeyValuePair<GrainType, GrainProperties>(TestGrainType, equalSharedGrainProperties),
+                    new KeyValuePair<GrainType, GrainProperties>(otherGrainType, new GrainProperties(CreatePropertyDictionary(
+                        new KeyValuePair<string, string>(WellKnownGrainTypeProperties.TypeName, "Other"))))
+                ]),
+                ImmutableDictionary.CreateRange(
+                [
+                    new KeyValuePair<GrainInterfaceType, GrainInterfaceProperties>(TestInterfaceType, equalSharedInterfaceProperties),
+                    new KeyValuePair<GrainInterfaceType, GrainInterfaceProperties>(otherInterfaceType, new GrainInterfaceProperties(CreatePropertyDictionary(
+                        new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.TypeName, "IOther"))))
+                ]));
+
+            var manifest = new ClusterManifest(
+                new MajorMinorVersion(1, 0),
+                ImmutableDictionary.CreateRange(
+                [
+                    new KeyValuePair<SiloAddress, GrainManifest>(silo1, silo1Manifest),
+                    new KeyValuePair<SiloAddress, GrainManifest>(silo2, silo2Manifest)
+                ]));
+
+            Assert.Equal(2, manifest.AllGrainManifests.Length);
+            Assert.NotSame(manifest.Silos[silo1], manifest.Silos[silo2]);
+            Assert.Same(manifest.Silos[silo1].Grains[TestGrainType], manifest.Silos[silo2].Grains[TestGrainType]);
+            Assert.Same(manifest.Silos[silo1].Interfaces[TestInterfaceType], manifest.Silos[silo2].Interfaces[TestInterfaceType]);
+        }
+
+        private static GrainManifest CreateGrainManifest(params KeyValuePair<string, string>[] additionalGrainProperties)
+        {
+            var grainProperties = CreatePropertyDictionary(
+                new KeyValuePair<string, string>(WellKnownGrainTypeProperties.TypeName, "Test"),
+                new KeyValuePair<string, string>(WellKnownGrainTypeProperties.FullTypeName, "UnitTests.Grains.Test"),
+                new KeyValuePair<string, string>($"{WellKnownGrainTypeProperties.ImplementedInterfacePrefix}0", TestInterfaceType.ToString()));
+            foreach (var property in additionalGrainProperties)
+            {
+                grainProperties = grainProperties.SetItem(property.Key, property.Value);
+            }
+
+            var grains = ImmutableDictionary.CreateRange(
+            [
+                new KeyValuePair<GrainType, GrainProperties>(
+                    TestGrainType,
+                    new GrainProperties(grainProperties))
+            ]);
+            var interfaces = ImmutableDictionary.CreateRange(
+            [
+                new KeyValuePair<GrainInterfaceType, GrainInterfaceProperties>(
+                    TestInterfaceType,
+                    new GrainInterfaceProperties(CreatePropertyDictionary(
+                        new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.TypeName, "ITest"),
+                        new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.Version, "1"))))
+            ]);
+
+            return new GrainManifest(grains, interfaces);
+        }
+
+        private static ImmutableDictionary<string, string> CreatePropertyDictionary(params KeyValuePair<string, string>[] properties)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, string>(ConstantHashStringComparer.Instance);
+            foreach (var property in properties)
+            {
+                builder.Add(property.Key, property.Value);
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static SiloAddress CreateSiloAddress(int port, int generation)
+        {
+            return SiloAddress.New(new(System.Net.IPAddress.Loopback, port), generation);
+        }
+
+        private sealed class ConstantHashStringComparer : IEqualityComparer<string>
+        {
+            public static readonly ConstantHashStringComparer Instance = new();
+
+            private ConstantHashStringComparer()
+            {
+            }
+
+            public bool Equals(string x, string y) => string.Equals(x, y, System.StringComparison.Ordinal);
+
+            public int GetHashCode(string obj) => 0;
+        }
+    }
+}

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestDeduplicationTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestDeduplicationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Orleans.Metadata;
 using Orleans.Runtime;
 using TestExtensions;
@@ -37,19 +38,25 @@ namespace UnitTests.Manifest
         }
 
         [Fact]
-        public void GrainProperties_DoesNotUseDictionaryComparerForKeyEquality()
+        public void GrainProperties_NormalizesValueComparer()
         {
             var properties = new GrainProperties(CreatePropertyDictionary(
                 StringComparer.Ordinal,
-                new KeyValuePair<string, string>("Name", "Value")));
-            var differentProperties = new GrainProperties(CreatePropertyDictionary(
                 StringComparer.OrdinalIgnoreCase,
-                new KeyValuePair<string, string>("name", "Value")));
+                new KeyValuePair<string, string>("Name", "Value")));
 
-            Assert.False(properties.Equals(differentProperties));
-            Assert.False(differentProperties.Equals(properties));
-            Assert.Same(StringComparer.Ordinal, differentProperties.Properties.KeyComparer);
-            Assert.Same(StringComparer.Ordinal, differentProperties.Properties.ValueComparer);
+            Assert.Same(StringComparer.Ordinal, properties.Properties.KeyComparer);
+            Assert.Same(StringComparer.Ordinal, properties.Properties.ValueComparer);
+        }
+
+        [Fact]
+        public void GrainProperties_RejectsNonOrdinalKeyComparer()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => new GrainProperties(CreatePropertyDictionary(
+                StringComparer.OrdinalIgnoreCase,
+                new KeyValuePair<string, string>("Name", "Value"))));
+
+            Assert.Equal("values", exception.ParamName);
         }
 
         [Fact]
@@ -74,19 +81,25 @@ namespace UnitTests.Manifest
         }
 
         [Fact]
-        public void GrainInterfaceProperties_DoesNotUseDictionaryComparerForKeyEquality()
+        public void GrainInterfaceProperties_NormalizesValueComparer()
         {
             var properties = new GrainInterfaceProperties(CreatePropertyDictionary(
                 StringComparer.Ordinal,
-                new KeyValuePair<string, string>("Name", "Value")));
-            var differentProperties = new GrainInterfaceProperties(CreatePropertyDictionary(
                 StringComparer.OrdinalIgnoreCase,
-                new KeyValuePair<string, string>("name", "Value")));
+                new KeyValuePair<string, string>("Name", "Value")));
 
-            Assert.False(properties.Equals(differentProperties));
-            Assert.False(differentProperties.Equals(properties));
-            Assert.Same(StringComparer.Ordinal, differentProperties.Properties.KeyComparer);
-            Assert.Same(StringComparer.Ordinal, differentProperties.Properties.ValueComparer);
+            Assert.Same(StringComparer.Ordinal, properties.Properties.KeyComparer);
+            Assert.Same(StringComparer.Ordinal, properties.Properties.ValueComparer);
+        }
+
+        [Fact]
+        public void GrainInterfaceProperties_RejectsNonOrdinalKeyComparer()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => new GrainInterfaceProperties(CreatePropertyDictionary(
+                StringComparer.OrdinalIgnoreCase,
+                new KeyValuePair<string, string>("Name", "Value"))));
+
+            Assert.Equal("values", exception.ParamName);
         }
 
         [Fact]
@@ -104,29 +117,59 @@ namespace UnitTests.Manifest
         }
 
         [Fact]
-        public void GrainManifest_DoesNotUseDictionaryComparerForKeyEquality()
+        public void GrainManifest_NormalizesValueComparers()
         {
-            var grainProperties = new GrainProperties(CreatePropertyDictionary(
-                new KeyValuePair<string, string>(WellKnownGrainTypeProperties.TypeName, "Test")));
-            var manifest = new GrainManifest(
-                ImmutableDictionary.CreateRange(
-                [
-                    new KeyValuePair<GrainType, GrainProperties>(GrainType.Create("Test"), grainProperties)
-                ]),
-                ImmutableDictionary.CreateRange(
-                [
-                    new KeyValuePair<GrainInterfaceType, GrainInterfaceProperties>(
-                        TestInterfaceType,
-                        new GrainInterfaceProperties(CreatePropertyDictionary(
-                            new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.TypeName, "ITest"))))
-                ]));
-            var caseInsensitiveGrains = ImmutableDictionary.CreateBuilder<GrainType, GrainProperties>(CaseInsensitiveGrainTypeComparer.Instance);
-            caseInsensitiveGrains.Add(GrainType.Create("test"), grainProperties);
-            var differentManifest = new GrainManifest(caseInsensitiveGrains.ToImmutable(), manifest.Interfaces);
+            var manifest = CreateGrainManifest();
+            var grains = manifest.Grains.WithComparers(EqualityComparer<GrainType>.Default, ReferenceComparer<GrainProperties>.Instance);
+            var interfaces = manifest.Interfaces.WithComparers(EqualityComparer<GrainInterfaceType>.Default, ReferenceComparer<GrainInterfaceProperties>.Instance);
 
-            Assert.False(manifest.Equals(differentManifest));
-            Assert.False(differentManifest.Equals(manifest));
-            Assert.Same(EqualityComparer<GrainType>.Default, differentManifest.Grains.KeyComparer);
+            var normalized = new GrainManifest(grains, interfaces);
+
+            Assert.Same(EqualityComparer<GrainType>.Default, normalized.Grains.KeyComparer);
+            Assert.Same(EqualityComparer<GrainProperties>.Default, normalized.Grains.ValueComparer);
+            Assert.Same(EqualityComparer<GrainInterfaceType>.Default, normalized.Interfaces.KeyComparer);
+            Assert.Same(EqualityComparer<GrainInterfaceProperties>.Default, normalized.Interfaces.ValueComparer);
+        }
+
+        [Fact]
+        public void GrainManifest_RejectsNonDefaultDictionaryComparers()
+        {
+            var manifest = CreateGrainManifest();
+            var caseInsensitiveGrains = ImmutableDictionary.CreateBuilder<GrainType, GrainProperties>(CaseInsensitiveGrainTypeComparer.Instance);
+            caseInsensitiveGrains.Add(TestGrainType, manifest.Grains[TestGrainType]);
+            var grainException = Assert.Throws<ArgumentException>(() => new GrainManifest(caseInsensitiveGrains.ToImmutable(), manifest.Interfaces));
+            var caseInsensitiveInterfaces = ImmutableDictionary.CreateBuilder<GrainInterfaceType, GrainInterfaceProperties>(CaseInsensitiveGrainInterfaceTypeComparer.Instance);
+            caseInsensitiveInterfaces.Add(TestInterfaceType, manifest.Interfaces[TestInterfaceType]);
+            var interfaceException = Assert.Throws<ArgumentException>(() => new GrainManifest(manifest.Grains, caseInsensitiveInterfaces.ToImmutable()));
+
+            Assert.Equal("grains", grainException.ParamName);
+            Assert.Equal("interfaces", interfaceException.ParamName);
+        }
+
+        [Fact]
+        public void ClusterManifest_NormalizesValueComparer()
+        {
+            var silo = CreateSiloAddress(11111, 1);
+            var silos = ImmutableDictionary
+                .CreateRange([new KeyValuePair<SiloAddress, GrainManifest>(silo, CreateGrainManifest())])
+                .WithComparers(EqualityComparer<SiloAddress>.Default, ReferenceComparer<GrainManifest>.Instance);
+
+            var manifest = new ClusterManifest(new MajorMinorVersion(1, 0), silos);
+
+            Assert.Same(EqualityComparer<SiloAddress>.Default, manifest.Silos.KeyComparer);
+            Assert.Same(EqualityComparer<GrainManifest>.Default, manifest.Silos.ValueComparer);
+        }
+
+        [Fact]
+        public void ClusterManifest_RejectsNonDefaultDictionaryComparers()
+        {
+            var silo = CreateSiloAddress(11111, 1);
+            var silos = ImmutableDictionary.CreateBuilder<SiloAddress, GrainManifest>(SiloAddressComparer.Instance);
+            silos.Add(silo, CreateGrainManifest());
+
+            var exception = Assert.Throws<ArgumentException>(() => new ClusterManifest(new MajorMinorVersion(1, 0), silos.ToImmutable()));
+
+            Assert.Equal("silos", exception.ParamName);
         }
 
         [Fact]
@@ -292,11 +335,17 @@ namespace UnitTests.Manifest
         }
 
         private static ImmutableDictionary<string, string> CreatePropertyDictionary(params KeyValuePair<string, string>[] properties)
-            => CreatePropertyDictionary(ConstantHashStringComparer.Instance, properties);
+            => CreatePropertyDictionary(StringComparer.Ordinal, StringComparer.Ordinal, properties);
 
         private static ImmutableDictionary<string, string> CreatePropertyDictionary(IEqualityComparer<string> comparer, params KeyValuePair<string, string>[] properties)
+            => CreatePropertyDictionary(comparer, StringComparer.Ordinal, properties);
+
+        private static ImmutableDictionary<string, string> CreatePropertyDictionary(
+            IEqualityComparer<string> keyComparer,
+            IEqualityComparer<string> valueComparer,
+            params KeyValuePair<string, string>[] properties)
         {
-            var builder = ImmutableDictionary.CreateBuilder<string, string>(comparer);
+            var builder = ImmutableDictionary.CreateBuilder<string, string>(keyComparer, valueComparer);
             foreach (var property in properties)
             {
                 builder.Add(property.Key, property.Value);
@@ -312,19 +361,6 @@ namespace UnitTests.Manifest
 
         private static string Copy(string value) => new(value.ToCharArray());
 
-        private sealed class ConstantHashStringComparer : IEqualityComparer<string>
-        {
-            public static readonly ConstantHashStringComparer Instance = new();
-
-            private ConstantHashStringComparer()
-            {
-            }
-
-            public bool Equals(string x, string y) => string.Equals(x, y, System.StringComparison.Ordinal);
-
-            public int GetHashCode(string obj) => 0;
-        }
-
         private sealed class CaseInsensitiveGrainTypeComparer : IEqualityComparer<GrainType>
         {
             public static readonly CaseInsensitiveGrainTypeComparer Instance = new();
@@ -336,6 +372,46 @@ namespace UnitTests.Manifest
             public bool Equals(GrainType x, GrainType y) => string.Equals(x.ToString(), y.ToString(), StringComparison.OrdinalIgnoreCase);
 
             public int GetHashCode(GrainType obj) => StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ToString());
+        }
+
+        private sealed class CaseInsensitiveGrainInterfaceTypeComparer : IEqualityComparer<GrainInterfaceType>
+        {
+            public static readonly CaseInsensitiveGrainInterfaceTypeComparer Instance = new();
+
+            private CaseInsensitiveGrainInterfaceTypeComparer()
+            {
+            }
+
+            public bool Equals(GrainInterfaceType x, GrainInterfaceType y) => string.Equals(x.ToString(), y.ToString(), StringComparison.OrdinalIgnoreCase);
+
+            public int GetHashCode(GrainInterfaceType obj) => StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ToString());
+        }
+
+        private sealed class ReferenceComparer<T> : IEqualityComparer<T>
+            where T : class
+        {
+            public static readonly ReferenceComparer<T> Instance = new();
+
+            private ReferenceComparer()
+            {
+            }
+
+            public bool Equals(T x, T y) => ReferenceEquals(x, y);
+
+            public int GetHashCode(T obj) => RuntimeHelpers.GetHashCode(obj);
+        }
+
+        private sealed class SiloAddressComparer : IEqualityComparer<SiloAddress>
+        {
+            public static readonly SiloAddressComparer Instance = new();
+
+            private SiloAddressComparer()
+            {
+            }
+
+            public bool Equals(SiloAddress x, SiloAddress y) => EqualityComparer<SiloAddress>.Default.Equals(x, y);
+
+            public int GetHashCode(SiloAddress obj) => EqualityComparer<SiloAddress>.Default.GetHashCode(obj);
         }
     }
 }


### PR DESCRIPTION
Cluster manifests are transmitted between hosts and can contain repeated silo manifests and repeated nested grain/interface property payloads. This reduces that payload size by canonicalizing equal manifests and nested manifest properties, while keeping AllGrainManifests unique.

The change also adds focused coverage for structural equality, order-independent cached hash codes, whole-manifest deduplication, nested property canonicalization, and distinct additional manifests used by active-silo placement flows.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10224)