### PR TITLE
fix: serialize immutable dictionary value comparers

### DIFF
--- a/src/Orleans.Serialization/Codecs/ImmutableDictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ImmutableDictionaryCodec.cs
@@ -25,11 +25,17 @@ namespace Orleans.Serialization.Codecs
 
         /// <inheritdoc/>
         public override ImmutableDictionary<TKey, TValue> ConvertFromSurrogate(ref ImmutableDictionarySurrogate<TKey, TValue> surrogate)
-            => ImmutableDictionary.CreateRange(surrogate.Values.Comparer, surrogate.Values);
+            => ImmutableDictionary.CreateRange(
+                surrogate.Values.Comparer,
+                surrogate.ValueComparer ?? EqualityComparer<TValue>.Default,
+                surrogate.Values);
 
         /// <inheritdoc/>
         public override void ConvertToSurrogate(ImmutableDictionary<TKey, TValue> value, ref ImmutableDictionarySurrogate<TKey, TValue> surrogate)
-            => surrogate.Values = new(value, value.KeyComparer);
+        {
+            surrogate.Values = new(value, value.KeyComparer);
+            surrogate.ValueComparer = value.ValueComparer != EqualityComparer<TValue>.Default ? value.ValueComparer : null;
+        }
     }
 
     /// <summary>
@@ -46,6 +52,12 @@ namespace Orleans.Serialization.Codecs
         /// <value>The values.</value>
         [Id(0)]
         public Dictionary<TKey, TValue> Values;
+
+        /// <summary>
+        /// Gets or sets the value comparer.
+        /// </summary>
+        [Id(1)]
+        public IEqualityComparer<TValue> ValueComparer;
     }
 
     /// <summary>

--- a/src/api/Orleans.Serialization/Orleans.Serialization.cs
+++ b/src/api/Orleans.Serialization/Orleans.Serialization.cs
@@ -1979,6 +1979,8 @@ namespace Orleans.Serialization.Codecs
     {
         [Id(0)]
         public System.Collections.Generic.Dictionary<TKey, TValue> Values;
+        [Id(1)]
+        public System.Collections.Generic.IEqualityComparer<TValue> ValueComparer;
     }
 
     [RegisterSerializer]

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -2948,6 +2948,52 @@ namespace Orleans.Serialization.UnitTests
 
         protected override ImmutableDictionary<string, int>[] TestValues => [null, ImmutableDictionary<string, int>.Empty, CreateValue(), CreateValue(), CreateValue()];
         protected override bool Equals(ImmutableDictionary<string, int> left, ImmutableDictionary<string, int> right) => ReferenceEquals(left, right) || left.SequenceEqual(right);
+
+        [Fact]
+        public void PreservesValueComparer()
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, int>(
+                StringComparer.OrdinalIgnoreCase,
+                ModuloValueComparer.Instance);
+            builder["one"] = 1;
+            var original = builder.ToImmutable();
+
+            var result = RoundTripThroughCodec(original);
+
+            Assert.Equal(original, result);
+            Assert.Same(StringComparer.OrdinalIgnoreCase, result.KeyComparer);
+            Assert.IsType<ModuloValueComparer>(result.ValueComparer);
+            Assert.True(result.ValueComparer.Equals(1, 11));
+        }
+
+        [Fact]
+        public void ConvertFromSurrogate_DefaultsMissingValueComparer()
+        {
+            var surrogate = new ImmutableDictionarySurrogate<string, int>
+            {
+                Values = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["one"] = 1
+                }
+            };
+            var codec = new ImmutableDictionaryCodec<string, int>(null);
+
+            var result = codec.ConvertFromSurrogate(ref surrogate);
+
+            Assert.Same(StringComparer.OrdinalIgnoreCase, result.KeyComparer);
+            Assert.Same(EqualityComparer<int>.Default, result.ValueComparer);
+            Assert.Equal(1, result["ONE"]);
+        }
+
+        [GenerateSerializer]
+        public sealed class ModuloValueComparer : IEqualityComparer<int>
+        {
+            public static readonly ModuloValueComparer Instance = new();
+
+            public bool Equals(int x, int y) => x % 10 == y % 10;
+
+            public int GetHashCode(int obj) => obj % 10;
+        }
     }
 
     public class ImmutableDictionaryCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<ImmutableDictionary<string, int>, ImmutableDictionaryCopier<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>


### PR DESCRIPTION
ImmutableDictionary serialization currently preserves the key comparer but drops the value comparer. This adds a backward-compatible surrogate field for the value comparer and defaults to EqualityComparer<TValue>.Default when reading older payloads.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10225)