### PR TITLE
feat(serialization): add type and assembly allow-list helpers

### DIFF
--- a/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
+++ b/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Orleans.Serialization.TypeSystem;
 
 namespace Orleans.Serialization.Configuration
@@ -77,6 +78,11 @@ namespace Orleans.Serialization.Configuration
         public HashSet<string> AllowedTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
+        /// Gets the set of assembly names whose types are allowed.
+        /// </summary>
+        public HashSet<string> AllowedAssemblies { get; } = new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets the mapping from compound type aliases to types.
         /// </summary>
         public CompoundTypeAliasTree CompoundTypeAliases { get; } = CompoundTypeAliasTree.Create();
@@ -91,5 +97,40 @@ namespace Orleans.Serialization.Configuration
         /// Gets the set of type manifest providers which have configured this instance.
         /// </summary>
         internal HashSet<object> TypeManifestProviders { get; } = new();
+
+        /// <summary>
+        /// Adds the type name components for <paramref name="type"/> to <see cref="AllowedTypes"/>.
+        /// </summary>
+        /// <param name="type">The type to allow.</param>
+        public void AddAllowedType(Type type)
+        {
+            if (type is null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            var formatted = RuntimeTypeNameFormatter.FormatInternalNoCache(type, allowAliases: false);
+            var parsed = RuntimeTypeNameParser.Parse(formatted);
+            var options = this;
+            _ = RuntimeTypeNameRewriter.Rewrite(parsed, static (in QualifiedType type, ref TypeManifestOptions options) =>
+            {
+                options.AllowedTypes.Add(type.Type);
+                return type;
+            }, ref options);
+        }
+
+        /// <summary>
+        /// Adds the assembly name for <paramref name="assembly"/> to <see cref="AllowedAssemblies"/>.
+        /// </summary>
+        /// <param name="assembly">The assembly to allow.</param>
+        public void AddAllowedAssembly(Assembly assembly)
+        {
+            if (assembly is null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            AllowedAssemblies.Add(CachedTypeResolver.GetName(assembly));
+        }
     }
 }

--- a/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
+++ b/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
@@ -99,7 +99,7 @@ namespace Orleans.Serialization.Configuration
         internal HashSet<object> TypeManifestProviders { get; } = new();
 
         /// <summary>
-        /// Adds the type name components for <paramref name="type"/> to <see cref="AllowedTypes"/>.
+        /// Adds the formatted type name for <paramref name="type"/> to <see cref="AllowedTypes"/>.
         /// </summary>
         /// <param name="type">The type to allow.</param>
         public void AddAllowedType(Type type)
@@ -109,14 +109,7 @@ namespace Orleans.Serialization.Configuration
                 throw new ArgumentNullException(nameof(type));
             }
 
-            var formatted = RuntimeTypeNameFormatter.FormatInternalNoCache(type, allowAliases: false);
-            var parsed = RuntimeTypeNameParser.Parse(formatted);
-            var options = this;
-            _ = RuntimeTypeNameRewriter.Rewrite(parsed, static (in QualifiedType type, ref TypeManifestOptions options) =>
-            {
-                options.AllowedTypes.Add(type.Type);
-                return type;
-            }, ref options);
+            AllowedTypes.Add(RuntimeTypeNameFormatter.FormatInternalNoCache(type, allowAliases: false));
         }
 
         /// <summary>

--- a/src/Orleans.Serialization/README.md
+++ b/src/Orleans.Serialization/README.md
@@ -44,7 +44,7 @@ public class MyClass
 }
 ```
 
-Enum types are allowed by default by type validation. When fail-closed type validation is enabled, additional non-enum types can be allowed by configuring `TypeManifestOptions.AddAllowedType` or `TypeManifestOptions.AddAllowedAssembly`.
+Enum types are allowed by default by type validation unless explicitly denied by an `ITypeNameFilter`. When fail-closed type validation is enabled, additional non-enum types can be allowed by configuring `TypeManifestOptions.AddAllowedType` or `TypeManifestOptions.AddAllowedAssembly`.
 
 ## Documentation
 For more comprehensive documentation, please refer to:

--- a/src/Orleans.Serialization/README.md
+++ b/src/Orleans.Serialization/README.md
@@ -44,6 +44,8 @@ public class MyClass
 }
 ```
 
+Enum types are always allowed by type validation. When fail-closed type validation is enabled, additional non-enum types can be allowed by configuring `TypeManifestOptions.AddAllowedType` or `TypeManifestOptions.AddAllowedAssembly`.
+
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)

--- a/src/Orleans.Serialization/README.md
+++ b/src/Orleans.Serialization/README.md
@@ -44,7 +44,7 @@ public class MyClass
 }
 ```
 
-Enum types are always allowed by type validation. When fail-closed type validation is enabled, additional non-enum types can be allowed by configuring `TypeManifestOptions.AddAllowedType` or `TypeManifestOptions.AddAllowedAssembly`.
+Enum types are allowed by default by type validation. When fail-closed type validation is enabled, additional non-enum types can be allowed by configuring `TypeManifestOptions.AddAllowedType` or `TypeManifestOptions.AddAllowedAssembly`.
 
 ## Documentation
 For more comprehensive documentation, please refer to:

--- a/src/Orleans.Serialization/README.md
+++ b/src/Orleans.Serialization/README.md
@@ -44,7 +44,7 @@ public class MyClass
 }
 ```
 
-Enum types are allowed by default by type validation unless explicitly denied by an `ITypeNameFilter`. When fail-closed type validation is enabled, additional non-enum types can be allowed by configuring `TypeManifestOptions.AddAllowedType` or `TypeManifestOptions.AddAllowedAssembly`.
+When fail-closed type validation is enabled, additional types can be allowed by configuring `TypeManifestOptions.AddAllowedType` or `TypeManifestOptions.AddAllowedAssembly`.
 
 ## Documentation
 For more comprehensive documentation, please refer to:

--- a/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameFormatter.cs
+++ b/src/Orleans.Serialization/TypeSystem/RuntimeTypeNameFormatter.cs
@@ -79,8 +79,8 @@ public static class RuntimeTypeNameFormatter
     {
         if (allowAliases && GetCompoundTypeAlias(type) is { } compoundAlias)
         {
-            AddCompoundTypeAlias(builder, type, compoundAlias.Components);
-            AddGenericParameters(builder, type);
+            AddCompoundTypeAlias(builder, type, compoundAlias.Components, allowAliases);
+            AddGenericParameters(builder, type, allowAliases);
             return;
         }
 
@@ -88,7 +88,7 @@ public static class RuntimeTypeNameFormatter
         if (type.HasElementType)
         {
             // Format the element type.
-            Format(builder, type.GetElementType()!, isElementType: true);
+            Format(builder, type.GetElementType()!, isElementType: true, allowAliases: allowAliases);
 
             // Format this type's adornments to the element type.
             AddArrayRank(builder, type);
@@ -99,7 +99,7 @@ public static class RuntimeTypeNameFormatter
         {
             AddNamespace(builder, type);
             AddClassName(builder, type);
-            AddGenericParameters(builder, type);
+            AddGenericParameters(builder, type, allowAliases);
         }
 
         // Types which are used as elements are not formatted with their assembly name, since that is added after the
@@ -110,7 +110,7 @@ public static class RuntimeTypeNameFormatter
         }
     }
 
-    private static void AddCompoundTypeAlias(StringBuilder builder, Type type, object[] components)
+    private static void AddCompoundTypeAlias(StringBuilder builder, Type type, object[] components, bool allowAliases)
     {
         // Start
         builder.Append('(');
@@ -135,7 +135,7 @@ public static class RuntimeTypeNameFormatter
                 }
 
                 builder.Append('[');
-                Format(builder, t, isElementType: false);
+                Format(builder, t, isElementType: false, allowAliases: allowAliases);
                 builder.Append(']');
             }
             else
@@ -186,7 +186,7 @@ public static class RuntimeTypeNameFormatter
         AddGenericArity(builder, type);
     }
 
-    private static void AddGenericParameters(StringBuilder builder, Type type)
+    private static void AddGenericParameters(StringBuilder builder, Type type, bool allowAliases = true)
     {
         // Generic type definitions (eg, List<> without parameters) and non-generic types do not include any
         // parameters in their formatting.
@@ -200,7 +200,7 @@ public static class RuntimeTypeNameFormatter
         for (var i = 0; i < args.Length; i++)
         {
             _ = builder.Append('[');
-            Format(builder, args[i], isElementType: false);
+            Format(builder, args[i], isElementType: false, allowAliases: allowAliases);
             _ = builder.Append(']');
             if (i + 1 < args.Length)
             {

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -385,11 +385,6 @@ public class TypeConverter
             return false;
         }
 
-        if (IsAssemblyAllowed(type.Assembly))
-        {
-            return true;
-        }
-
         foreach (var (displayName, runtimeName) in WellKnownTypeAliases)
         {
             if (displayName.Equals(type.Type) || runtimeName.Equals(type.Type))

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -379,10 +379,20 @@ public class TypeConverter
             return false;
         }
 
-        var filterResult = InspectTypeNameFilters(type);
-        if (filterResult == false)
+        bool? filterResult = null;
+        foreach (var filter in _typeNameFilters)
         {
-            return false;
+            var isAllowed = filter.IsTypeNameAllowed(type.Type, type.Assembly ?? string.Empty);
+            if (isAllowed == false)
+            {
+                _allowedTypes[type] = false;
+                return false;
+            }
+
+            if (isAllowed == true)
+            {
+                filterResult = true;
+            }
         }
 
         if (_allowedTypes.TryGetValue(type, out var allowed))
@@ -419,27 +429,6 @@ public class TypeConverter
         }
 
         return null;
-    }
-
-    private bool? InspectTypeNameFilters(in QualifiedType type)
-    {
-        bool? result = null;
-        foreach (var filter in _typeNameFilters)
-        {
-            var isAllowed = filter.IsTypeNameAllowed(type.Type, type.Assembly ?? string.Empty);
-            if (isAllowed == false)
-            {
-                _allowedTypes[type] = false;
-                return false;
-            }
-
-            if (isAllowed == true)
-            {
-                result = true;
-            }
-        }
-
-        return result;
     }
 
     private QualifiedType ConvertToDisplayName(in QualifiedType input, ref ValidationResult state)

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -579,17 +579,30 @@ public class TypeConverter
 
         if (type.IsConstructedGenericType)
         {
-            foreach (var parameter in type.GenericTypeArguments)
+            var genericArgumentsResult = InspectGenericArguments(type);
+            if (genericArgumentsResult != true)
             {
-                result = Combine(result, InspectTypeCore(parameter));
-                if (result == false)
-                {
-                    return false;
-                }
+                return genericArgumentsResult;
             }
+
+            result = Combine(result, genericArgumentsResult);
         }
 
         return result;
+    }
+
+    private bool? InspectGenericArguments(Type type)
+    {
+        foreach (var parameter in type.GenericTypeArguments)
+        {
+            var result = InspectTypeCore(parameter);
+            if (result != true)
+            {
+                return result;
+            }
+        }
+
+        return true;
     }
 
     private bool? IsTypeAllowedByConfiguration(Type type)

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -29,6 +29,7 @@ public class TypeConverter
     private readonly Dictionary<QualifiedType, QualifiedType> _wellKnownAliasToType;
     private readonly Dictionary<QualifiedType, QualifiedType> _wellKnownTypeToAlias;
     private readonly ConcurrentDictionary<QualifiedType, bool> _allowedTypes;
+    private readonly HashSet<string> _allowedAssembliesConfiguration;
     private readonly HashSet<string> _allowedTypesConfiguration;
     private static readonly List<(string DisplayName, string RuntimeName)> WellKnownTypeAliases =
     [
@@ -83,10 +84,16 @@ public class TypeConverter
         _wellKnownTypeToAlias = [];
 
         _allowedTypes = new ConcurrentDictionary<QualifiedType, bool>(QualifiedType.EqualityComparer);
+        _allowedAssembliesConfiguration = new(StringComparer.Ordinal);
         _allowedTypesConfiguration = new(StringComparer.Ordinal);
 
         if (!_allowAllTypes)
         {
+            foreach (var assembly in options.Value.AllowedAssemblies)
+            {
+                _allowedAssembliesConfiguration.Add(assembly);
+            }
+
             foreach (var t in options.Value.AllowedTypes)
             {
                 _allowedTypesConfiguration.Add(t);
@@ -297,7 +304,7 @@ public class TypeConverter
 
         if (!_allowAllTypes && validationState.IsTypeNameAllowed != true)
         {
-            if (!InspectType(_typeFilters, type))
+            if (!InspectType(type))
             {
                 ThrowTypeNotAllowed(type);
             }
@@ -335,7 +342,7 @@ public class TypeConverter
         {
             if (!_allowAllTypes && validationState.IsTypeNameAllowed != true)
             {
-                if (!InspectType(_typeFilters, type))
+                if (!InspectType(type))
                 {
                     ThrowTypeNotAllowed(type);
                 }
@@ -357,6 +364,11 @@ public class TypeConverter
         if (_allowedTypes.TryGetValue(type, out var allowed))
         {
             return allowed;
+        }
+
+        if (IsAssemblyAllowed(type.Assembly))
+        {
+            return true;
         }
 
         foreach (var (displayName, runtimeName) in WellKnownTypeAliases)
@@ -448,21 +460,22 @@ public class TypeConverter
     [DoesNotReturn]
     private static void ThrowTypeNotAllowed(string fullTypeName, List<QualifiedType> errors)
     {
+        const string allowListMessage = $"To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)}, add its assembly to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedAssemblies)}, or register an {nameof(ITypeNameFilter)} instance which allows it.";
         if (errors is { Count: 1 })
         {
             var value = errors[0];
 
             if (!string.IsNullOrWhiteSpace(value.Assembly))
             {
-                throw new InvalidOperationException($"Type \"{value.Type}\" from assembly \"{value.Assembly}\" is not allowed. To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)} or register an {nameof(ITypeNameFilter)} instance which allows it.");
+                throw new InvalidOperationException($"Type \"{value.Type}\" from assembly \"{value.Assembly}\" is not allowed. {allowListMessage}");
             }
             else
             {
-                throw new InvalidOperationException($"Type \"{value.Type}\" is not allowed. To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)} or register an {nameof(ITypeNameFilter)} instance which allows it.");
+                throw new InvalidOperationException($"Type \"{value.Type}\" is not allowed. {allowListMessage}");
             }
         }
 
-        StringBuilder message = new($"Some types in the type string \"{fullTypeName}\" are not allowed by configuration. To allow them, add them to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)} or register an {nameof(ITypeNameFilter)} instance which allows them.");
+        StringBuilder message = new($"Some types in the type string \"{fullTypeName}\" are not allowed by configuration. {allowListMessage}");
         foreach (var value in errors)
         {
             if (!string.IsNullOrWhiteSpace(value.Assembly))
@@ -481,7 +494,7 @@ public class TypeConverter
     [DoesNotReturn]
     private static void ThrowTypeNotAllowed(Type value)
     {
-        var message = $"Type \"{value.FullName}\" is not allowed. To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)} or register an {nameof(ITypeNameFilter)} or {nameof(ITypeFilter)} instance which allows it.";
+        var message = $"Type \"{value.FullName}\" is not allowed. To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)}, add its assembly to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedAssemblies)}, or register an {nameof(ITypeNameFilter)} or {nameof(ITypeFilter)} instance which allows it.";
         throw new InvalidOperationException(message);
     }
 
@@ -501,18 +514,20 @@ public class TypeConverter
                     : null;
     }
 
-    private static bool InspectType(ITypeFilter[] filters, Type type) => InspectTypeCore(filters, type) == true;
+    private bool InspectType(Type type) => InspectTypeCore(type) == true;
 
-    private static bool? InspectTypeCore(ITypeFilter[] filters, Type type)
+    private bool? InspectTypeCore(Type type)
     {
         bool? result = null;
         if (type.HasElementType)
         {
-            result = Combine(result, InspectTypeCore(filters, type.GetElementType()!));
+            result = Combine(result, InspectTypeCore(type.GetElementType()!));
             return result;
         }
 
-        foreach (var filter in filters)
+        result = Combine(result, IsTypeAllowedByConfiguration(type));
+
+        foreach (var filter in _typeFilters)
         {
             result = Combine(result, filter.IsTypeAllowed(type));
             if (result == false)
@@ -531,7 +546,7 @@ public class TypeConverter
         {
             foreach (var parameter in type.GenericTypeArguments)
             {
-                result = Combine(result, InspectTypeCore(filters, parameter));
+                result = Combine(result, InspectTypeCore(parameter));
                 if (result == false)
                 {
                     return false;
@@ -540,20 +555,46 @@ public class TypeConverter
         }
 
         return result;
+    }
 
-        static bool? Combine(bool? left, bool? right)
+    private bool? IsTypeAllowedByConfiguration(Type type)
+    {
+        if (type.IsEnum)
         {
-            if (left == false || right == false)
-            {
-                return false;
-            }
-            else if (left == true || right == true)
-            {
-                return true;
-            }
-
-            return null;
+            return true;
         }
+
+        return IsAssemblyAllowed(CachedTypeResolver.GetName(type.Assembly)) || IsAssemblyAllowed(type.Assembly.FullName) ? true : null;
+    }
+
+    private bool IsAssemblyAllowed(string? assemblyName)
+    {
+        if (string.IsNullOrWhiteSpace(assemblyName))
+        {
+            return false;
+        }
+
+        if (_allowedAssembliesConfiguration.Contains(assemblyName))
+        {
+            return true;
+        }
+
+        var simpleNameEnd = assemblyName.IndexOf(',');
+        return simpleNameEnd > 0 && _allowedAssembliesConfiguration.Contains(assemblyName[..simpleNameEnd].Trim());
+    }
+
+    private static bool? Combine(bool? left, bool? right)
+    {
+        if (left == false || right == false)
+        {
+            return false;
+        }
+        else if (left == true || right == true)
+        {
+            return true;
+        }
+
+        return null;
     }
 
     private TypeSpec ResolveCompoundAliasType<TState>(TupleTypeSpec input, ref TState state)

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -374,6 +374,17 @@ public class TypeConverter
             return true;
         }
 
+        if (_allowedTypes.TryGetValue(type, out var cachedAllowed) && !cachedAllowed)
+        {
+            return false;
+        }
+
+        var filterResult = InspectTypeNameFilters(type);
+        if (filterResult == false)
+        {
+            return false;
+        }
+
         if (_allowedTypes.TryGetValue(type, out var allowed))
         {
             return allowed;
@@ -397,14 +408,9 @@ public class TypeConverter
             return true;
         }
 
-        foreach (var filter in _typeNameFilters)
+        if (filterResult == true)
         {
-            var isAllowed = filter.IsTypeNameAllowed(type.Type, type.Assembly ?? string.Empty);
-            if (isAllowed.HasValue)
-            {
-                allowed = _allowedTypes[type] = isAllowed.Value;
-                return allowed;
-            }
+            return _allowedTypes[type] = true;
         }
 
         if (_wellKnownAliasToType.TryGetValue(type, out var runtimeType))
@@ -413,6 +419,27 @@ public class TypeConverter
         }
 
         return null;
+    }
+
+    private bool? InspectTypeNameFilters(in QualifiedType type)
+    {
+        bool? result = null;
+        foreach (var filter in _typeNameFilters)
+        {
+            var isAllowed = filter.IsTypeNameAllowed(type.Type, type.Assembly ?? string.Empty);
+            if (isAllowed == false)
+            {
+                _allowedTypes[type] = false;
+                return false;
+            }
+
+            if (isAllowed == true)
+            {
+                result = true;
+            }
+        }
+
+        return result;
     }
 
     private QualifiedType ConvertToDisplayName(in QualifiedType input, ref ValidationResult state)

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -2,7 +2,6 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Options;
 using Orleans.Serialization.Activators;
@@ -606,8 +605,9 @@ public class TypeConverter
 
     private bool? InspectGenericArguments(Type type)
     {
-        foreach (var result in type.GenericTypeArguments.Select(InspectTypeCore))
+        foreach (var parameter in type.GenericTypeArguments)
         {
+            var result = InspectTypeCore(parameter);
             if (result != true)
             {
                 return result;

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -594,11 +594,6 @@ public class TypeConverter
 
     private bool? IsTypeAllowedByConfiguration(Type type)
     {
-        if (type.IsEnum)
-        {
-            return true;
-        }
-
         return IsAssemblyAllowed(CachedTypeResolver.GetName(type.Assembly)) || IsAssemblyAllowed(type.Assembly.FullName) ? true : null;
     }
 

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -367,7 +367,7 @@ public class TypeConverter
         return false;
     }
 
-    private bool? IsNameTypeAllowed(in QualifiedType type)
+    private bool? IsNamedTypeAllowed(in QualifiedType type)
     {
         if (_allowAllTypes)
         {
@@ -410,7 +410,7 @@ public class TypeConverter
 
         if (_wellKnownAliasToType.TryGetValue(type, out var runtimeType))
         {
-            return IsNameTypeAllowed(runtimeType);
+            return IsNamedTypeAllowed(runtimeType);
         }
 
         return null;
@@ -479,7 +479,7 @@ public class TypeConverter
 
     private ValidationResult UpdateValidationResult(QualifiedType input, ValidationResult state)
     {
-        switch (IsNameTypeAllowed(input))
+        switch (IsNamedTypeAllowed(input))
         {
             case true:
                 return new(true, state.HasUnknownTypeNames, state.ErrorTypes);

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -374,30 +374,15 @@ public class TypeConverter
             return true;
         }
 
-        if (_allowedTypes.TryGetValue(type, out var cachedAllowed) && !cachedAllowed)
-        {
-            return false;
-        }
-
-        bool? filterResult = null;
-        foreach (var filter in _typeNameFilters)
-        {
-            var isAllowed = filter.IsTypeNameAllowed(type.Type, type.Assembly ?? string.Empty);
-            if (isAllowed == false)
-            {
-                _allowedTypes[type] = false;
-                return false;
-            }
-
-            if (isAllowed == true)
-            {
-                filterResult = true;
-            }
-        }
-
         if (_allowedTypes.TryGetValue(type, out var allowed))
         {
             return allowed;
+        }
+
+        var filterResult = InspectTypeNameFilters(type);
+        if (filterResult == false)
+        {
+            return false;
         }
 
         if (IsAssemblyAllowed(type.Assembly))
@@ -429,6 +414,27 @@ public class TypeConverter
         }
 
         return null;
+    }
+
+    private bool? InspectTypeNameFilters(in QualifiedType type)
+    {
+        bool? result = null;
+        foreach (var filter in _typeNameFilters)
+        {
+            var isAllowed = filter.IsTypeNameAllowed(type.Type, type.Assembly ?? string.Empty);
+            if (isAllowed == false)
+            {
+                _allowedTypes[type] = false;
+                return false;
+            }
+
+            if (isAllowed == true)
+            {
+                result = true;
+            }
+        }
+
+        return result;
     }
 
     private QualifiedType ConvertToDisplayName(in QualifiedType input, ref ValidationResult state)

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Options;
 using Orleans.Serialization.Activators;
@@ -605,9 +606,8 @@ public class TypeConverter
 
     private bool? InspectGenericArguments(Type type)
     {
-        foreach (var parameter in type.GenericTypeArguments)
+        foreach (var result in type.GenericTypeArguments.Select(InspectTypeCore))
         {
-            var result = InspectTypeCore(parameter);
             if (result != true)
             {
                 return result;

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -556,10 +556,17 @@ public class TypeConverter
         }
 
         result = Combine(result, IsTypeAllowedByConfiguration(type));
+        var isAllowedByTypeFilter = false;
 
         foreach (var filter in _typeFilters)
         {
-            result = Combine(result, filter.IsTypeAllowed(type));
+            var filterResult = filter.IsTypeAllowed(type);
+            if (filterResult == true)
+            {
+                isAllowedByTypeFilter = true;
+            }
+
+            result = Combine(result, filterResult);
             if (result == false)
             {
                 return false;
@@ -575,6 +582,16 @@ public class TypeConverter
         if (type.IsConstructedGenericType)
         {
             var genericArgumentsResult = InspectGenericArguments(type);
+            if (genericArgumentsResult == false)
+            {
+                return false;
+            }
+
+            if (isAllowedByTypeFilter)
+            {
+                return true;
+            }
+
             if (genericArgumentsResult != true)
             {
                 return genericArgumentsResult;

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -96,7 +96,7 @@ public class TypeConverter
 
             foreach (var t in options.Value.AllowedTypes)
             {
-                _allowedTypesConfiguration.Add(t);
+                AddConfiguredAllowedType(t);
             }
 
             ConsumeMetadata(options.Value);
@@ -131,6 +131,19 @@ public class TypeConverter
                 }
             }
         }
+    }
+
+    private void AddConfiguredAllowedType(string typeName)
+    {
+        _allowedTypesConfiguration.Add(typeName);
+
+        var parsed = RuntimeTypeNameParser.Parse(typeName);
+        var converter = this;
+        _ = RuntimeTypeNameRewriter.Rewrite(parsed, static (in QualifiedType type, ref TypeConverter converter) =>
+        {
+            converter._allowedTypes[type] = true;
+            return type;
+        }, ref converter);
     }
 
     private void ConsumeMetadata(TypeManifestOptions metadata)

--- a/src/api/Orleans.Serialization/Orleans.Serialization.cs
+++ b/src/api/Orleans.Serialization/Orleans.Serialization.cs
@@ -3275,9 +3275,15 @@ namespace Orleans.Serialization.Configuration
 
     public sealed partial class TypeManifestOptions
     {
+        public void AddAllowedAssembly(System.Reflection.Assembly assembly) { }
+
+        public void AddAllowedType(System.Type type) { }
+
         public System.Collections.Generic.HashSet<System.Type> Activators { get { throw null; } }
 
         public bool AllowAllTypes { get { throw null; } set { } }
+
+        public System.Collections.Generic.HashSet<string> AllowedAssemblies { get { throw null; } }
 
         public System.Collections.Generic.HashSet<string> AllowedTypes { get { throw null; } }
 

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -91,6 +91,11 @@ namespace Orleans.Serialization.UnitTests
         public void TypeConverter_AddAllowedType_FormatsConstructedNestedGenericTypes()
         {
             var type = typeof(Dictionary<TypeConverterTestsUnconfiguredType, TypeConverterTestsNestedAllowedType.Nested>);
+            var options = new TypeManifestOptions();
+            options.AddAllowedType(type);
+
+            Assert.Contains(RuntimeTypeNameFormatter.FormatInternalNoCache(type, allowAliases: false), options.AllowedTypes);
+
             var converter = CreateConverter(configureOptions: options => options.AddAllowedType(type));
 
             AssertRoundTrips(converter, type);

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -239,6 +239,40 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
+        public void TypeConverter_AllowsConstructedGenericTypes_WhenTypeFilterAllowsThem()
+        {
+            var type = typeof(TypeConverterTestsGenericTypeAllowedByTypeFilter<UriBuilder>);
+            var converter = CreateConverter(
+                typeFilters:
+                [
+                    new DelegateTypeFilter(candidate => candidate == type ? true : null)
+                ]);
+
+            AssertRoundTrips(converter, type);
+        }
+
+        [Fact]
+        public void TypeConverter_RejectsConstructedGenericTypes_WhenTypeFilterDeniesGenericArguments()
+        {
+            var type = typeof(TypeConverterTestsGenericTypeAllowedByTypeFilter<UriBuilder>);
+            var converter = CreateConverter(
+                typeFilters:
+                [
+                    new DelegateTypeFilter(candidate =>
+                    {
+                        if (candidate == type)
+                        {
+                            return true;
+                        }
+
+                        return candidate == typeof(UriBuilder) ? false : null;
+                    })
+                ]);
+
+            AssertTypeNotAllowed(converter, type);
+        }
+
+        [Fact]
         public void TypeConverter_UsesTypeFiltersForArrayElementTypes_WhenNameFiltersHaveNoOpinion()
         {
             var converter = CreateConverter(
@@ -408,6 +442,10 @@ namespace Orleans.Serialization.UnitTests
     }
 
     internal sealed class TypeConverterTestsGenericArgumentAllowedByTypeFilter
+    {
+    }
+
+    internal sealed class TypeConverterTestsGenericTypeAllowedByTypeFilter<T>
     {
     }
 

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -148,27 +148,6 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
-        public void TypeConverter_AllowsEnums()
-        {
-            var converter = CreateConverter();
-
-            AssertRoundTrips(converter, typeof(TypeConverterTestsUnconfiguredEnum));
-            AssertRoundTrips(converter, typeof(List<TypeConverterTestsUnconfiguredEnum>));
-        }
-
-        [Fact]
-        public void TypeConverter_RejectsEnums_WhenTypeNameFilterDeniesThem()
-        {
-            var converter = CreateConverter(
-                typeNameFilters:
-                [
-                    new DelegateTypeNameFilter((typeName, _) => typeName == typeof(TypeConverterTestsUnconfiguredEnum).FullName ? false : null)
-                ]);
-
-            AssertTypeNotAllowed(converter, typeof(TypeConverterTestsUnconfiguredEnum));
-        }
-
-        [Fact]
         public void TypeConverter_AllowsBuiltInAliasesUnderFailClosedBehavior()
         {
             var converter = CreateConverter();
@@ -363,12 +342,6 @@ namespace Orleans.Serialization.UnitTests
         internal sealed class Nested
         {
         }
-    }
-
-    internal enum TypeConverterTestsUnconfiguredEnum
-    {
-        One,
-        Two
     }
 
     internal sealed class TypeConverterTestsGenericArgumentAllowedByTypeFilter

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -40,6 +40,30 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
+        public void TypeConverter_UsesCachedTypeNameFilterResults()
+        {
+            var typeNameFilterCalls = 0;
+            var converter = CreateConverter(
+                typeNameFilters:
+                [
+                    new DelegateTypeNameFilter((typeName, _) =>
+                    {
+                        if (typeName == typeof(TypeConverterTestsUnconfiguredType).FullName)
+                        {
+                            typeNameFilterCalls++;
+                            return true;
+                        }
+
+                        return null;
+                    })
+                ]);
+
+            AssertRoundTrips(converter, typeof(TypeConverterTestsUnconfiguredType));
+
+            Assert.Equal(1, typeNameFilterCalls);
+        }
+
+        [Fact]
         public void TypeConverter_AllowsTypes_WhenATypeFilterExplicitlyAllowsThem()
         {
             var converter = CreateConverter(

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -111,12 +111,37 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
+        public void TypeConverter_RejectsAllowedAssemblyType_WhenTypeNameFilterDeniesIt()
+        {
+            var converter = CreateConverter(
+                configureOptions: options => options.AddAllowedAssembly(typeof(TypeConverterTestsAssemblyAllowedType).Assembly),
+                typeNameFilters:
+                [
+                    new DelegateTypeNameFilter((typeName, _) => typeName == typeof(TypeConverterTestsAssemblyAllowedType).FullName ? false : null)
+                ]);
+
+            AssertTypeNotAllowed(converter, typeof(TypeConverterTestsAssemblyAllowedType));
+        }
+
+        [Fact]
         public void TypeConverter_AllowsEnums()
         {
             var converter = CreateConverter();
 
             AssertRoundTrips(converter, typeof(TypeConverterTestsUnconfiguredEnum));
             AssertRoundTrips(converter, typeof(List<TypeConverterTestsUnconfiguredEnum>));
+        }
+
+        [Fact]
+        public void TypeConverter_RejectsEnums_WhenTypeNameFilterDeniesThem()
+        {
+            var converter = CreateConverter(
+                typeNameFilters:
+                [
+                    new DelegateTypeNameFilter((typeName, _) => typeName == typeof(TypeConverterTestsUnconfiguredEnum).FullName ? false : null)
+                ]);
+
+            AssertTypeNotAllowed(converter, typeof(TypeConverterTestsUnconfiguredEnum));
         }
 
         [Fact]

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -126,6 +126,27 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
+        public void TypeConverter_AddAllowedType_FormatsGenericArgumentsWithoutCompoundAliases()
+        {
+            var type = typeof(List<TypeConverterTestsAttributedCompoundAliasedType>);
+            var options = new TypeManifestOptions();
+            options.AddAllowedType(type);
+
+            Assert.DoesNotContain(options.AllowedTypes, allowedType => allowedType.Contains("type_converter_attributed_alias", StringComparison.Ordinal));
+
+            var converter = CreateConverter(
+                configureOptions: options =>
+                {
+                    options.AddAllowedType(type);
+                    options.CompoundTypeAliases
+                        .Add("type_converter_attributed_alias")
+                        .Add("v1", typeof(TypeConverterTestsAttributedCompoundAliasedType));
+                });
+
+            AssertRoundTrips(converter, type);
+        }
+
+        [Fact]
         public void TypeConverter_AllowsConfiguredAllowedAssemblies()
         {
             var converter = CreateConverter(configureOptions: options => options.AddAllowedAssembly(typeof(TypeConverterTestsAssemblyAllowedType).Assembly));
@@ -145,6 +166,28 @@ namespace Orleans.Serialization.UnitTests
                 ]);
 
             AssertTypeNotAllowed(converter, typeof(TypeConverterTestsAssemblyAllowedType));
+        }
+
+        [Fact]
+        public void TypeConverter_RejectsAllowedAssemblyType_WhenTypeFilterDeniesIt()
+        {
+            var converter = CreateConverter(
+                configureOptions: options => options.AddAllowedAssembly(typeof(TypeConverterTestsAssemblyAllowedType).Assembly),
+                typeFilters:
+                [
+                    new DelegateTypeFilter(type => type == typeof(TypeConverterTestsAssemblyAllowedType) ? false : null)
+                ]);
+
+            AssertTypeNotAllowed(converter, typeof(TypeConverterTestsAssemblyAllowedType));
+        }
+
+        [Fact]
+        public void TypeConverter_DoesNotAllowTypesFromSpoofedAllowedAssemblyNames()
+        {
+            var converter = CreateConverter(configureOptions: options => options.AddAllowedAssembly(typeof(TypeConverterTestsAssemblyAllowedType).Assembly));
+            var formatted = $"{typeof(System.Text.StringBuilder).FullName},{CachedTypeResolver.GetName(typeof(TypeConverterTestsAssemblyAllowedType).Assembly)}";
+
+            Assert.Throws<InvalidOperationException>(() => converter.Parse(formatted));
         }
 
         [Fact]
@@ -396,6 +439,11 @@ namespace Orleans.Serialization.UnitTests
     }
 
     internal sealed class TypeConverterTestsCompoundAliasedWithComponentType
+    {
+    }
+
+    [global::Orleans.CompoundTypeAlias("type_converter_attributed_alias", "v1")]
+    internal sealed class TypeConverterTestsAttributedCompoundAliasedType
     {
     }
 

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -148,6 +148,22 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
+        public void TypeConverter_DoesNotAllowGenericArgumentsJustBecauseGenericTypeDefinitionAssemblyIsAllowed()
+        {
+            var converter = CreateConverter(configureOptions: options => options.AddAllowedAssembly(typeof(TypeConverterTestsAssemblyAllowedType<>).Assembly));
+
+            AssertTypeNotAllowed(converter, typeof(TypeConverterTestsAssemblyAllowedType<UriBuilder>));
+        }
+
+        [Fact]
+        public void TypeConverter_DoesNotAllowGenericArgumentsJustBecauseSiblingGenericArgumentAssemblyIsAllowed()
+        {
+            var converter = CreateConverter(configureOptions: options => options.AddAllowedAssembly(typeof(TypeConverterTestsAssemblyAllowedType).Assembly));
+
+            AssertTypeNotAllowed(converter, typeof(Dictionary<TypeConverterTestsAssemblyAllowedType, UriBuilder>));
+        }
+
+        [Fact]
         public void TypeConverter_AllowsBuiltInAliasesUnderFailClosedBehavior()
         {
             var converter = CreateConverter();
@@ -334,6 +350,10 @@ namespace Orleans.Serialization.UnitTests
     }
 
     internal sealed class TypeConverterTestsAssemblyAllowedType
+    {
+    }
+
+    internal sealed class TypeConverterTestsAssemblyAllowedType<T>
     {
     }
 

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -82,9 +82,36 @@ namespace Orleans.Serialization.UnitTests
         [Fact]
         public void TypeConverter_AllowsConfiguredAllowedTypes()
         {
-            var converter = CreateConverter(configureOptions: options => options.AllowedTypes.Add(typeof(TypeConverterTestsUnconfiguredType).FullName!));
+            var converter = CreateConverter(configureOptions: options => options.AddAllowedType(typeof(TypeConverterTestsUnconfiguredType)));
 
             AssertRoundTrips(converter, typeof(TypeConverterTestsUnconfiguredType));
+        }
+
+        [Fact]
+        public void TypeConverter_AddAllowedType_FormatsConstructedNestedGenericTypes()
+        {
+            var type = typeof(Dictionary<TypeConverterTestsUnconfiguredType, TypeConverterTestsNestedAllowedType.Nested>);
+            var converter = CreateConverter(configureOptions: options => options.AddAllowedType(type));
+
+            AssertRoundTrips(converter, type);
+        }
+
+        [Fact]
+        public void TypeConverter_AllowsConfiguredAllowedAssemblies()
+        {
+            var converter = CreateConverter(configureOptions: options => options.AddAllowedAssembly(typeof(TypeConverterTestsAssemblyAllowedType).Assembly));
+
+            AssertRoundTrips(converter, typeof(TypeConverterTestsAssemblyAllowedType));
+            AssertRoundTrips(converter, typeof(List<TypeConverterTestsAssemblyAllowedType>));
+        }
+
+        [Fact]
+        public void TypeConverter_AllowsEnums()
+        {
+            var converter = CreateConverter();
+
+            AssertRoundTrips(converter, typeof(TypeConverterTestsUnconfiguredEnum));
+            AssertRoundTrips(converter, typeof(List<TypeConverterTestsUnconfiguredEnum>));
         }
 
         [Fact]
@@ -199,7 +226,7 @@ namespace Orleans.Serialization.UnitTests
             var converter = CreateConverter(
                 configureOptions: options =>
                 {
-                    options.AllowedTypes.Add(typeof(TypeConverterTestsCompoundAliasedWithComponentType).FullName!);
+                    options.AddAllowedType(typeof(TypeConverterTestsCompoundAliasedWithComponentType));
                     options.WellKnownTypeAliases[componentAlias] = typeof(TypeConverterTestsAliasComponentType);
                     options.CompoundTypeAliases
                         .Add("type_converter_compound_alias_with_component")
@@ -217,7 +244,7 @@ namespace Orleans.Serialization.UnitTests
             var converter = CreateConverter(
                 configureOptions: options =>
                 {
-                    options.AllowedTypes.Add(typeof(TypeConverterTestsCompoundAliasedType).FullName!);
+                    options.AddAllowedType(typeof(TypeConverterTestsCompoundAliasedType));
                     options.CompoundTypeAliases.Add("type_converter_compound_alias").Add("v1", typeof(TypeConverterTestsCompoundAliasedType));
                 });
 
@@ -271,6 +298,23 @@ namespace Orleans.Serialization.UnitTests
 
     internal sealed class TypeConverterTestsUnconfiguredType
     {
+    }
+
+    internal sealed class TypeConverterTestsAssemblyAllowedType
+    {
+    }
+
+    internal sealed class TypeConverterTestsNestedAllowedType
+    {
+        internal sealed class Nested
+        {
+        }
+    }
+
+    internal enum TypeConverterTestsUnconfiguredEnum
+    {
+        One,
+        Two
     }
 
     internal sealed class TypeConverterTestsGenericArgumentAllowedByTypeFilter


### PR DESCRIPTION
`TypeManifestOptions.AllowedTypes` expects Orleans-formatted runtime type names, which is awkward for callers to construct correctly and only covers individual type names.

This adds `AddAllowedType(Type)` and `AddAllowedAssembly(Assembly)` helpers, plus an `AllowedAssemblies` allow-list, so callers can opt in a specific type or an entire assembly using the same formatting Orleans uses internally.

`TypeConverter` now expands configured allowed type names into their component type-name entries and honors configured assembly names during fail-closed validation against the resolved `Type.Assembly`. Type-name filters can still deny uncached names, type filters can still deny resolved types, and constructed generic arguments must be independently allowed.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10228)