### PR TITLE
fix(azure): allow configuring journal blob names

### DIFF
--- a/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Program.cs
+++ b/playground/DurableJobsJournaling/DurableJobsJournaling.Silo/Program.cs
@@ -25,9 +25,10 @@ builder.UseOrleans(siloBuilder =>
             options =>
             {
                 options.ContainerName = storageContainer;
-                options.GetBlobName = journalId => $"{storagePrefix}/{journalId.Value}";
+                options.GetWalBlobName = journalId => $"{storagePrefix}/{journalId.Value}/wal";
+                options.GetCheckpointBlobName = (journalId, snapshotId) => $"{storagePrefix}/{journalId.Value}/chk.{snapshotId}";
             })
-        .Configure<JsonJournalOptions>(options => options.AddTypeInfoResolver(DurableJobsJournalingJsonContext.Default))
+        .UseJsonJournalFormat(DurableJobsJournalingJsonContext.Default)
         .Configure<DurableJobsOptions>(options =>
         {
             options.ShardDuration = TimeSpan.FromMinutes(2);

--- a/samples/JournalingAzureBlobJson/Program.cs
+++ b/samples/JournalingAzureBlobJson/Program.cs
@@ -40,7 +40,8 @@ internal static class Program
         var container = blobServiceClient.GetBlobContainerClient(settings.ContainerName);
         await container.CreateIfNotExistsAsync();
 
-        var blob = container.GetAppendBlobClient(settings.BlobName);
+        var walBlobName = $"{settings.BlobName}/wal";
+        var blob = container.GetAppendBlobClient(walBlobName);
         if (settings.ResetBlob)
         {
             await blob.DeleteIfExistsAsync();
@@ -60,7 +61,8 @@ internal static class Program
                 {
                     options.BlobServiceClient = blobServiceClient;
                     options.ContainerName = settings.ContainerName;
-                    options.GetBlobName = _ => settings.BlobName;
+                    options.GetWalBlobName = _ => walBlobName;
+                    options.GetCheckpointBlobName = (_, snapshotId) => $"{settings.BlobName}/chk.{snapshotId}";
                 })
                 .UseJsonJournalFormat(JournalingSampleJsonContext.Default);
         });
@@ -85,7 +87,7 @@ internal static class Program
         Console.WriteLine(JsonSerializer.Serialize(recovered, JournalingSampleJsonContext.Default.JournaledSampleSummary));
 
         Console.WriteLine();
-        Console.WriteLine($"Raw JSONL blob contents from {settings.ContainerName}/{settings.BlobName}:");
+        Console.WriteLine($"Raw JSONL blob contents from {settings.ContainerName}/{walBlobName}:");
         Console.WriteLine(await DownloadBlobAsText(blob));
 
         await host.StopAsync();

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorage.cs
@@ -1179,11 +1179,13 @@ internal sealed partial class AzureBlobJournalStorage : IJournalStorage
         AzureBlobJournalStorageOptions options) : BlobClientProvider
     {
         public override AppendBlobClient GetWalClient(JournalId journalId)
-            => containerFactory.GetBlobContainerClient(journalId).GetAppendBlobClient(
-                AzureBlobJournalStorageOptions.GetWalBlobNameForJournal(journalId, options.GetBlobNameForJournal(journalId)));
+        {
+            var container = containerFactory.GetBlobContainerClient(journalId);
+            return container.GetAppendBlobClient(options.GetWalBlobNameForJournal(journalId));
+        }
 
         public override string GetCheckpointName(JournalId journalId, string snapshotId)
-            => AzureBlobJournalStorageOptions.GetCheckpointBlobNameForJournal(journalId, options.GetBlobNameForJournal(journalId), snapshotId);
+            => options.GetCheckpointBlobNameForJournal(journalId, snapshotId);
 
         public override BlockBlobClient GetCheckpointClient(JournalId journalId, string checkpointName)
             => containerFactory.GetBlobContainerClient(journalId).GetBlockBlobClient(checkpointName);

--- a/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
+++ b/src/Azure/Orleans.Journaling.AzureStorage/AzureBlobJournalStorageOptions.cs
@@ -17,11 +17,26 @@ public sealed class AzureBlobJournalStorageOptions
     public const string DEFAULT_CONTAINER_NAME = "state";
 
     /// <summary>
-    /// Gets or sets the delegate used to generate the blob name for a journal.
+    /// Gets or sets the delegate used to generate the write-ahead log blob name for a journal.
     /// </summary>
-    public Func<JournalId, string> GetBlobName { get; set; } = DefaultGetBlobName;
+    public Func<JournalId, string> GetWalBlobName { get; set; } = DefaultGetWalBlobName;
 
-    private static readonly Func<JournalId, string> DefaultGetBlobName = static journalId => journalId.Value;
+    private static readonly Func<JournalId, string> DefaultGetWalBlobName =
+        static journalId => GetDefaultWalBlobName(journalId);
+
+    /// <summary>
+    /// Gets or sets the delegate used to generate the checkpoint blob name for a journal snapshot.
+    /// </summary>
+    /// <remarks>
+    /// The delegate receives the journal id and an opaque snapshot id generated for the checkpoint.
+    /// The snapshot id is currently formatted as a 32-character hexadecimal string using <c>Guid.ToString("N")</c>.
+    /// The returned value must be a container-relative blob name. The default value is
+    /// <c>{journalId.Value}/chk.{snapshotId}</c>.
+    /// </remarks>
+    public Func<JournalId, string, string> GetCheckpointBlobName { get; set; } = DefaultGetCheckpointBlobName;
+
+    private static readonly Func<JournalId, string, string> DefaultGetCheckpointBlobName =
+        static (journalId, snapshotId) => GetDefaultCheckpointBlobName(journalId, snapshotId);
 
     /// <summary>
     /// Options to be used when configuring the blob storage client, or <see langword="null"/> to use the default options.
@@ -79,36 +94,51 @@ public sealed class AzureBlobJournalStorageOptions
     /// </summary>
     internal Func<CancellationToken, Task<BlobServiceClient>>? CreateClient { get; private set; }
 
-    internal string GetBlobNameForJournal(JournalId journalId)
+    internal string GetWalBlobNameForJournal(JournalId journalId)
     {
         if (journalId.IsDefault)
         {
             throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
         }
 
-        var blobName = GetBlobName(journalId);
+        var blobName = GetWalBlobName(journalId);
         ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
         return blobName;
     }
 
-    internal static string GetWalBlobNameForJournal(JournalId journalId, string journalBlobName)
+    internal string GetCheckpointBlobNameForJournal(JournalId journalId, string snapshotId)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
-        return GetDefaultWalBlobName(journalBlobName);
-    }
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
 
-    internal static string GetCheckpointBlobNameForJournal(JournalId journalId, string journalBlobName, string snapshotId)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(journalBlobName);
         ArgumentException.ThrowIfNullOrWhiteSpace(snapshotId);
-        return GetDefaultCheckpointBlobName(journalBlobName, snapshotId);
+        var blobName = GetCheckpointBlobName(journalId, snapshotId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
+        return blobName;
     }
 
-    internal static string GetDefaultWalBlobName(string journalBlobName)
-        => $"{journalBlobName}/wal";
+    internal static string GetDefaultWalBlobName(JournalId journalId)
+    {
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
 
-    internal static string GetDefaultCheckpointBlobName(string journalBlobName, string snapshotId)
-        => $"{journalBlobName}/chk.{snapshotId}";
+        return $"{journalId.Value}/wal";
+    }
+
+    internal static string GetDefaultCheckpointBlobName(JournalId journalId, string snapshotId)
+    {
+        if (journalId.IsDefault)
+        {
+            throw new ArgumentException("The journal id must not be the default value.", nameof(journalId));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(snapshotId);
+        return $"{journalId.Value}/chk.{snapshotId}";
+    }
 
     /// <summary>
     /// A function for building container factory instances.

--- a/src/Azure/Orleans.Journaling.AzureStorage/README.md
+++ b/src/Azure/Orleans.Journaling.AzureStorage/README.md
@@ -5,18 +5,16 @@ Microsoft Orleans Journaling for Azure Storage provides an Azure Storage impleme
 
 Blob names are derived from the configured journal storage identity and do not use journal format file extensions. Azure append blobs store the journal format key in blob metadata and, when the selected journal format provides a MIME type, are created with that content type. The WAL blob name and checkpoint blob name can be customized using `AzureBlobJournalStorageOptions.GetWalBlobName` and `GetCheckpointBlobName`.
 
-## Using an existing blob layout
+## Using an alternative blob layout
 
-Orleans 10.1 stored Azure journaling data in one append blob per grain using the Orleans binary journal format. To read that layout directly, configure the WAL blob name delegate to point at the existing append blob and configure journaling to use the Orleans binary format.
+By default, WAL blobs are named `<journalId>/wal` and checkpoint blobs are named `<journalId>/chk.<snapshotId>`. Configure the blob name delegates to use an alternative layout, such as a shared prefix, file extensions, tenant-specific paths, or names which match an existing storage convention. Each delegate returns a container-relative blob name, and checkpoint names should include the supplied snapshot id to avoid collisions.
 
 ```csharp
 siloBuilder.AddAzureBlobJournalStorage(options =>
 {
-    // Orleans 10.1 default: the single append blob was named "<grainId>.bin".
-    options.GetWalBlobName = static journalId => $"{journalId.Value}.bin";
+    options.GetWalBlobName = static journalId => $"journals/{journalId.Value}.wal";
+    options.GetCheckpointBlobName = static (journalId, snapshotId) => $"journals/{journalId.Value}.{snapshotId}.chk";
 });
-siloBuilder.Services.Configure<JournaledStateManagerOptions>(
-    options => options.JournalFormatKey = "orleans-binary");
 ```
 
 ## Getting Started

--- a/src/Azure/Orleans.Journaling.AzureStorage/README.md
+++ b/src/Azure/Orleans.Journaling.AzureStorage/README.md
@@ -3,7 +3,21 @@
 ## Introduction
 Microsoft Orleans Journaling for Azure Storage provides an Azure Storage implementation of the Orleans Journaling provider. This allows journaling and tracking of grain operations using Azure Storage as a backing store.
 
-Blob names are derived from the configured grain storage identity and do not use journal format file extensions. Azure append blobs store the journal format key in blob metadata and, when the selected journal format provides a MIME type, are created with that content type.
+Blob names are derived from the configured journal storage identity and do not use journal format file extensions. Azure append blobs store the journal format key in blob metadata and, when the selected journal format provides a MIME type, are created with that content type. The WAL blob name and checkpoint blob name can be customized using `AzureBlobJournalStorageOptions.GetWalBlobName` and `GetCheckpointBlobName`.
+
+## Using an existing blob layout
+
+Orleans 10.1 stored Azure journaling data in one append blob per grain using the Orleans binary journal format. To read that layout directly, configure the WAL blob name delegate to point at the existing append blob and configure journaling to use the Orleans binary format.
+
+```csharp
+siloBuilder.AddAzureBlobJournalStorage(options =>
+{
+    // Orleans 10.1 default: the single append blob was named "<grainId>.bin".
+    options.GetWalBlobName = static journalId => $"{journalId.Value}.bin";
+});
+siloBuilder.Services.Configure<JournaledStateManagerOptions>(
+    options => options.JournalFormatKey = "orleans-binary");
+```
 
 ## Getting Started
 To use this package, install it via NuGet:

--- a/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
+++ b/src/api/Azure/Orleans.Journaling.AzureStorage/Orleans.Journaling.AzureStorage.cs
@@ -24,7 +24,9 @@ namespace Orleans.Journaling
 
         public bool DeleteOldCheckpoints { get { throw null; } set { } }
 
-        public System.Func<JournalId, string> GetBlobName { get { throw null; } set { } }
+        public System.Func<JournalId, string, string> GetCheckpointBlobName { get { throw null; } set { } }
+
+        public System.Func<JournalId, string> GetWalBlobName { get { throw null; } set { } }
 
         public int MaxMetadataOnlyConflictRetries { get { throw null; } set { } }
 

--- a/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobCodecRecoveryTests.cs
@@ -233,7 +233,8 @@ public sealed class AzureBlobCodecRecoveryTests : JournalingTestBase, IAsyncLife
         services.Configure<AzureBlobJournalStorageOptions>(options =>
         {
             JournalingAzureStorageTestConfiguration.ConfigureTestDefaults(options);
-            options.GetBlobName = _ => blobName;
+            options.GetWalBlobName = _ => $"{blobName}/wal";
+            options.GetCheckpointBlobName = (_, snapshotId) => $"{blobName}/chk.{snapshotId}";
         });
         services.Configure<JournaledStateManagerOptions>(options => options.JournalFormatKey = journalFormatKey);
         services.AddSerializer();

--- a/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
+++ b/test/Orleans.Journaling.Tests/AzureBlobJournalStorageTests.cs
@@ -16,6 +16,8 @@ namespace Orleans.Journaling.Tests;
 [TestCategory("BVT")]
 public sealed class AzureBlobJournalStorageTests
 {
+    private static readonly JournalId TestJournalId = JournalId.FromGrainId(GrainId.Create("test-grain", "0"));
+
     [Fact]
     public async Task DeleteAsync_AllowsNextAppendToRecreateWal()
     {
@@ -158,33 +160,40 @@ public sealed class AzureBlobJournalStorageTests
     }
 
     [Fact]
-    public void GetBlobNameForJournal_UsesConfiguredBlobNameWithoutAppendingFormatExtension()
+    public void DefaultWalAndCheckpointNames_UseFixedWalAndSnapshotPrefix()
+    {
+        var journalId = new JournalId("journals/test");
+
+        Assert.Equal("journals/test/wal", AzureBlobJournalStorageOptions.GetDefaultWalBlobName(journalId));
+        Assert.Equal("journals/test/chk.snapshot", AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName(journalId, "snapshot"));
+    }
+
+    [Fact]
+    public void GetWalBlobNameForJournal_UsesConfiguredWalBlobName()
     {
         var options = new AzureBlobJournalStorageOptions
         {
-            GetBlobName = _ => "journals/test-grain"
+            GetWalBlobName = static journalId => $"{journalId.Value}.bin",
         };
 
-        var blobName = options.GetBlobNameForJournal(JournalId.FromGrainId(GrainId.Create("test-grain", "0")));
+        var blobName = options.GetWalBlobNameForJournal(TestJournalId);
 
-        Assert.Equal("journals/test-grain", blobName);
+        Assert.Equal($"{TestJournalId.Value}.bin", blobName);
     }
 
     [Fact]
-    public void GetBlobNameForJournal_UsesJournalIdOutsideGrain()
+    public void GetCheckpointBlobNameForJournal_UsesConfiguredCheckpointBlobName()
     {
-        var options = new AzureBlobJournalStorageOptions();
+        var options = new AzureBlobJournalStorageOptions
+        {
+            GetCheckpointBlobName = static (journalId, snapshotId) => $"{journalId.Value}/snapshots/{snapshotId}.chk",
+        };
 
-        var blobName = options.GetBlobNameForJournal(new JournalId("journals/on-demand"));
+        var blobName = options.GetCheckpointBlobNameForJournal(
+            TestJournalId,
+            "snapshot");
 
-        Assert.Equal("journals/on-demand", blobName);
-    }
-
-    [Fact]
-    public void DefaultWalAndCheckpointNames_UseFixedWalAndSnapshotPrefix()
-    {
-        Assert.Equal("journals/test/wal", AzureBlobJournalStorageOptions.GetDefaultWalBlobName("journals/test"));
-        Assert.Equal("journals/test/chk.snapshot", AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName("journals/test", "snapshot"));
+        Assert.Equal($"{TestJournalId.Value}/snapshots/snapshot.chk", blobName);
     }
 
     [Fact]
@@ -255,6 +264,37 @@ public sealed class AzureBlobJournalStorageTests
         Assert.Equal([1, 2], consumer.Bytes.ToArray());
         Assert.Equal(["blob/wal"], appendBlobs.DownloadCalls.Select(static call => call.Name));
         Assert.Empty(checkpoints.DownloadCalls);
+    }
+
+    [Fact]
+    public async Task AppendAsync_WhenWalBlobNameConfigured_UsesConfiguredWalBlob()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var storage = CreateStorage(appendBlobs, walBlobName: "custom/wal.bin");
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+
+        Assert.Equal([1], appendBlobs.GetContent("custom/wal.bin"));
+        Assert.False(appendBlobs.Exists("blob/wal"));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_WhenCheckpointBlobNameConfigured_UsesConfiguredCheckpointBlob()
+    {
+        var appendBlobs = new FakeAppendBlobStore();
+        var checkpoints = new FakeBlockBlobStore();
+        var storage = CreateStorage(
+            appendBlobs,
+            checkpoints,
+            getCheckpointName: static snapshotId => $"custom/checkpoints/{snapshotId}.chk");
+
+        await storage.AppendAsync(new ReadOnlySequence<byte>([1]), CancellationToken.None);
+        await storage.ReplaceAsync(new ReadOnlySequence<byte>([2]), CancellationToken.None);
+
+        var checkpointName = checkpoints.UploadCalls.Single().Name;
+        Assert.StartsWith("custom/checkpoints/", checkpointName);
+        Assert.EndsWith(".chk", checkpointName);
+        Assert.Equal(checkpointName, appendBlobs.CreateCalls.Last().Metadata[AzureBlobJournalStorage.CheckpointMetadataKey]);
     }
 
     [Fact]
@@ -639,18 +679,22 @@ public sealed class AzureBlobJournalStorageTests
         FakeBlockBlobStore? checkpoints = null,
         string? mimeType = null,
         string? journalFormatKey = null,
-        bool deleteOldCheckpoints = true)
+        bool deleteOldCheckpoints = true,
+        string? walBlobName = null,
+        Func<string, string>? getCheckpointName = null)
     {
         checkpoints ??= new FakeBlockBlobStore();
+        walBlobName ??= "blob/wal";
+        getCheckpointName ??= static snapshotId => $"blob/chk.{snapshotId}";
         return new AzureBlobJournalStorage(
             new AzureBlobJournalStorage.AzureBlobJournalStorageShared(
                 NullLogger<AzureBlobJournalStorage>.Instance,
                 Options.Create(new AzureBlobJournalStorageOptions { DeleteOldCheckpoints = deleteOldCheckpoints }),
-                new FakeBlobClientProvider(appendBlobs, checkpoints),
+                new FakeBlobClientProvider(appendBlobs, checkpoints, walBlobName, getCheckpointName),
                 CreateAzureBlobJournalStorageInstruments(),
                 mimeType,
                 journalFormatKey),
-            JournalId.FromGrainId(GrainId.Create("test-grain", "0")));
+            TestJournalId);
     }
 
     private static AzureBlobJournalStorageInstruments CreateAzureBlobJournalStorageInstruments()
@@ -757,15 +801,17 @@ public sealed class AzureBlobJournalStorageTests
         }
     }
 
-    private sealed class FakeBlobClientProvider(FakeAppendBlobStore appendBlobs, FakeBlockBlobStore blockBlobs) : AzureBlobJournalStorage.BlobClientProvider
+    private sealed class FakeBlobClientProvider(
+        FakeAppendBlobStore appendBlobs,
+        FakeBlockBlobStore blockBlobs,
+        string walBlobName,
+        Func<string, string> getCheckpointName) : AzureBlobJournalStorage.BlobClientProvider
     {
-        private const string JournalBlobName = "blob";
-
         public override AppendBlobClient GetWalClient(JournalId journalId)
-            => appendBlobs.GetAppendBlobClient(AzureBlobJournalStorageOptions.GetDefaultWalBlobName(JournalBlobName));
+            => appendBlobs.GetAppendBlobClient(walBlobName);
 
         public override string GetCheckpointName(JournalId journalId, string snapshotId)
-            => AzureBlobJournalStorageOptions.GetDefaultCheckpointBlobName(JournalBlobName, snapshotId);
+            => getCheckpointName(snapshotId);
 
         public override BlockBlobClient GetCheckpointClient(JournalId journalId, string checkpointName)
             => blockBlobs.GetBlockBlobClient(checkpointName);


### PR DESCRIPTION
Azure journal storage changed blob layout between Orleans 10.1 and 10.2, so deployments with existing blobs may need to keep using previous or custom names.

This exposes separate WAL and checkpoint blob-name delegates on `AzureBlobJournalStorageOptions` and routes storage through them. The defaults preserve the current layout, while callers can explicitly configure legacy `.bin` WAL names or other layouts without automatic fallback probing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10230)