### PR TITLE
feat: prune excess defunct membership entries

### DIFF
--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -97,7 +97,7 @@ namespace Orleans.Configuration
         /// <summary>
         /// Gets or sets a value indicating whether defunct silo entries older than <see cref="DefunctSiloExpiration" /> are removed.
         /// Cleanup is attempted when membership changes are observed and the current membership snapshot contains expired
-        /// non-active entries, or when <see cref="DefunctSiloExpiration" /> has elapsed since the last cleanup call.
+        /// non-active entries, or when this period has elapsed since the last cleanup call.
         /// Set this value to <see langword="null"/> to disable expiration-based cleanup.
         /// </summary>
         /// <value>Expiration-based cleanup is enabled by default.</value>

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -95,8 +95,9 @@ namespace Orleans.Configuration
         public TimeSpan DefunctSiloExpiration { get; set; } = TimeSpan.FromDays(7);
 
         /// <summary>
-        /// Gets or sets a value indicating whether defunct silo entries older than <see cref="DefunctSiloExpiration" /> are removed
-        /// when membership changes are observed.
+        /// Gets or sets a value indicating whether defunct silo entries older than <see cref="DefunctSiloExpiration" /> are removed.
+        /// Cleanup is attempted when membership changes are observed and the current membership snapshot contains expired
+        /// non-active entries, or when <see cref="DefunctSiloExpiration" /> has elapsed since the last cleanup call.
         /// Set this value to <see langword="null"/> to disable expiration-based cleanup.
         /// </summary>
         /// <value>Expiration-based cleanup is enabled by default.</value>

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -95,11 +95,21 @@ namespace Orleans.Configuration
         public TimeSpan DefunctSiloExpiration { get; set; } = TimeSpan.FromDays(7);
 
         /// <summary>
-        /// Gets or sets the duration between membership table cleanup operations. When this period elapses, all defunct silo
-        /// entries older than <see cref="DefunctSiloExpiration" /> are removed. This value is per-silo.
+        /// Gets or sets a value indicating whether defunct silo entries older than <see cref="DefunctSiloExpiration" /> are removed
+        /// when membership changes are observed.
+        /// Set this value to <see langword="null"/> to disable expiration-based cleanup.
         /// </summary>
-        /// <value>Membership is cleared of expired, defunct silos every hour, by default.</value>
+        /// <value>Expiration-based cleanup is enabled by default.</value>
         public TimeSpan? DefunctSiloCleanupPeriod { get; set; } = TimeSpan.FromHours(1);
+
+        /// <summary>
+        /// Gets or sets the maximum number of defunct silo entries to retain in the membership table.
+        /// When this limit is exceeded, the first active silo, selected by natural <see cref="Orleans.Runtime.SiloAddress"/>
+        /// sort order, asynchronously removes the oldest excess defunct entries from the membership table.
+        /// Set this value to <see langword="null"/> to retain all defunct entries and disable threshold-based cleanup.
+        /// </summary>
+        /// <value>Membership retains up to 25 defunct silo entries by default.</value>
+        public int? MaxDefunctSiloEntries { get; set; } = 25;
 
         /// <summary>
         /// Gets the period after which a silo's membership entry is considered stale if it has not updated its heartbeat in the membership table.

--- a/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Validators/SiloClusteringValidator.cs
@@ -46,6 +46,11 @@ namespace Orleans.Runtime.Configuration
             }
 
             var clusterMembershipOptions = this.serviceProvider.GetRequiredService<IOptions<ClusterMembershipOptions>>().Value;
+            if (clusterMembershipOptions.MaxDefunctSiloEntries < 0)
+            {
+                throw new OrleansConfigurationException($"{nameof(ClusterMembershipOptions)}.{nameof(ClusterMembershipOptions.MaxDefunctSiloEntries)} ({clusterMembershipOptions.MaxDefunctSiloEntries}) must be greater than or equal to 0, or null.");
+            }
+
             if (clusterMembershipOptions.LivenessEnabled)
             {
                 if (clusterMembershipOptions.NumVotesForDeathDeclaration > clusterMembershipOptions.NumProbedSilos)

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -194,7 +194,6 @@ namespace Orleans.Hosting
             services.AddFromExisting<IHealthCheckParticipant, MembershipAgent>();
             services.AddSingleton<MembershipTableCleanupAgent>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, MembershipTableCleanupAgent>();
-            services.AddFromExisting<IHealthCheckParticipant, MembershipTableCleanupAgent>();
             services.AddSingleton<SiloStatusListenerManager>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, SiloStatusListenerManager>();
             services.AddSingleton<ClusterMembershipService>();

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -204,7 +204,7 @@ namespace Orleans.Runtime.MembershipService
             foreach (var tuple in table.Members)
             {
                 var entry = tuple.Item1;
-                if (!IsDefunctSiloEntry(entry))
+                if (entry.Status != SiloStatus.Dead)
                 {
                     continue;
                 }
@@ -239,8 +239,6 @@ namespace Orleans.Runtime.MembershipService
             return result != 0 ? result : left.SiloAddress.CompareTo(right.SiloAddress);
         }
 
-        private static bool IsDefunctSiloEntry(MembershipEntry entry) => entry.Status == SiloStatus.Dead;
-
         private static DateTimeOffset GetDefunctSiloCleanupCutoff(DateTime effectiveIAmAliveTime)
         {
             var effectiveIAmAliveTimeUtc = DateTime.SpecifyKind(effectiveIAmAliveTime, DateTimeKind.Utc);
@@ -251,14 +249,9 @@ namespace Orleans.Runtime.MembershipService
 
         private readonly struct DefunctSiloEntryPriority(MembershipEntry entry) : IComparable<DefunctSiloEntryPriority>
         {
-            private readonly DateTime _effectiveIAmAliveTime = entry.EffectiveIAmAliveTime;
-            private readonly SiloAddress _siloAddress = entry.SiloAddress;
+            private readonly MembershipEntry _entry = entry;
 
-            public int CompareTo(DefunctSiloEntryPriority other)
-            {
-                var result = _effectiveIAmAliveTime.CompareTo(other._effectiveIAmAliveTime);
-                return result != 0 ? result : _siloAddress.CompareTo(other._siloAddress);
-            }
+            public int CompareTo(DefunctSiloEntryPriority other) => CompareDefunctSiloEntries(_entry, other._entry);
         }
 
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -113,10 +113,10 @@ namespace Orleans.Runtime.MembershipService
                 var now = _timeProvider.GetUtcNow();
                 DateTimeOffset? beforeDate = default;
 
-                if (_clusterMembershipOptions.DefunctSiloCleanupPeriod.HasValue)
+                if (_clusterMembershipOptions.DefunctSiloCleanupPeriod is { } cleanupPeriod)
                 {
                     var expirationBeforeDate = now - _clusterMembershipOptions.DefunctSiloExpiration;
-                    if (ShouldCleanupExpiredSilos(membership, now, expirationBeforeDate))
+                    if (ShouldCleanupExpiredSilos(membership, now, expirationBeforeDate, cleanupPeriod))
                     {
                         beforeDate = expirationBeforeDate;
                     }
@@ -183,9 +183,9 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        private bool ShouldCleanupExpiredSilos(MembershipTableSnapshot membership, DateTimeOffset now, DateTimeOffset beforeDate)
+        private bool ShouldCleanupExpiredSilos(MembershipTableSnapshot membership, DateTimeOffset now, DateTimeOffset beforeDate, TimeSpan cleanupPeriod)
         {
-            if (!_lastDefunctSiloCleanupTime.HasValue || now - _lastDefunctSiloCleanupTime.Value >= _clusterMembershipOptions.DefunctSiloExpiration)
+            if (!_lastDefunctSiloCleanupTime.HasValue || now - _lastDefunctSiloCleanupTime.Value >= cleanupPeriod)
             {
                 return true;
             }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -124,8 +124,6 @@ namespace Orleans.Runtime.MembershipService
 
                 if (_clusterMembershipOptions.MaxDefunctSiloEntries is { } maxDefunctSiloEntries)
                 {
-                    ArgumentOutOfRangeException.ThrowIfNegative(maxDefunctSiloEntries, nameof(ClusterMembershipOptions.MaxDefunctSiloEntries));
-
                     var defunctSiloEntryCount = 0;
                     var trackedEntryCount = (long)maxDefunctSiloEntries + 1;
                     var newestDefunctEntries = new PriorityQueue<MembershipEntry, DefunctSiloEntryPriority>();

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -1,12 +1,12 @@
 using System;
-using Orleans.Configuration;
-using System.Threading.Tasks;
-using System.Threading;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Logging;
-using Orleans.Internal;
-using System.Diagnostics;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Internal;
 
 namespace Orleans.Runtime.MembershipService
 {
@@ -17,72 +17,247 @@ namespace Orleans.Runtime.MembershipService
     {
         private readonly ClusterMembershipOptions _clusterMembershipOptions;
         private readonly IMembershipTable _membershipTableProvider;
+        private readonly IMembershipManager _membershipManager;
+        private readonly ILocalSiloDetails _localSiloDetails;
+        private readonly TimeProvider _timeProvider;
         private readonly ILogger<MembershipTableCleanupAgent> _logger;
-        private readonly IAsyncTimer? _cleanupDefunctSilosTimer;
+        private readonly CancellationTokenSource _shutdownCts = new();
+        private readonly object _shutdownLock = new();
+        private bool _disposed;
+        private bool _cleanupDefunctSiloEntriesUnsupported;
 
         public MembershipTableCleanupAgent(
             IOptions<ClusterMembershipOptions> clusterMembershipOptions,
             IMembershipTable membershipTableProvider,
-            ILogger<MembershipTableCleanupAgent> log,
-            IAsyncTimerFactory timerFactory)
+            IMembershipManager membershipManager,
+            ILocalSiloDetails localSiloDetails,
+            TimeProvider timeProvider,
+            ILogger<MembershipTableCleanupAgent> log)
         {
             _clusterMembershipOptions = clusterMembershipOptions.Value;
             _membershipTableProvider = membershipTableProvider;
+            _membershipManager = membershipManager;
+            _localSiloDetails = localSiloDetails;
+            _timeProvider = timeProvider;
             _logger = log;
-            if (_clusterMembershipOptions.DefunctSiloCleanupPeriod.HasValue)
-            {
-                _cleanupDefunctSilosTimer = timerFactory.Create(
-                    _clusterMembershipOptions.DefunctSiloCleanupPeriod.Value,
-                    nameof(CleanupDefunctSilos));
-            }
         }
 
         public void Dispose()
         {
-            _cleanupDefunctSilosTimer?.Dispose();
+            lock (_shutdownLock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _shutdownCts.Cancel();
+                _shutdownCts.Dispose();
+            }
         }
 
-        private async Task CleanupDefunctSilos()
+        private void CancelShutdown()
         {
-            if (!_clusterMembershipOptions.DefunctSiloCleanupPeriod.HasValue)
+            lock (_shutdownLock)
+            {
+                if (!_disposed)
+                {
+                    _shutdownCts.Cancel();
+                }
+            }
+        }
+
+        private async Task ProcessMembershipUpdates(CancellationToken cancellationToken)
+        {
+            if (!_clusterMembershipOptions.DefunctSiloCleanupPeriod.HasValue
+                && !_clusterMembershipOptions.MaxDefunctSiloEntries.HasValue)
             {
                 LogDebugMembershipTableCleanupDisabled(_logger);
                 return;
             }
 
-            Debug.Assert(_cleanupDefunctSilosTimer is not null);
             LogDebugStartingMembershipTableCleanupAgent(_logger);
             try
             {
-                var period = _clusterMembershipOptions.DefunctSiloCleanupPeriod.Value;
-
-                // The first cleanup should be scheduled for shortly after silo startup.
-                var delay = RandomTimeSpan.Next(TimeSpan.FromMinutes(2), TimeSpan.FromMinutes(10));
-                while (await _cleanupDefunctSilosTimer.NextTick(delay))
+                await foreach (var membership in _membershipManager.MembershipUpdates.WithCancellation(cancellationToken))
                 {
-                    // Select a random time within the next window.
-                    // The purpose of this is to add jitter to a process which could be affected by contention with other silos.
-                    delay = RandomTimeSpan.Next(period, period + TimeSpan.FromMinutes(5));
-                    try
+                    if (_cleanupDefunctSiloEntriesUnsupported)
                     {
-                        var dateLimit = DateTime.UtcNow - _clusterMembershipOptions.DefunctSiloExpiration;
-                        await _membershipTableProvider.CleanupDefunctSiloEntries(dateLimit);
-                    }
-                    catch (Exception exception) when (exception is NotImplementedException or MissingMethodException)
-                    {
-                        _cleanupDefunctSilosTimer.Dispose();
-                        LogWarningCleanupDefunctSiloEntriesNotSupported(_logger);
                         return;
                     }
-                    catch (Exception exception)
+
+                    if (!IsFirstActiveSilo(membership))
                     {
-                        LogErrorFailedToCleanUpDefunctMembershipTableEntries(_logger, exception);
+                        continue;
                     }
+
+                    await CleanupDefunctSilos(cancellationToken);
                 }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Ignore and continue shutting down.
             }
             finally
             {
                 LogDebugStoppedMembershipTableCleanupAgent(_logger);
+            }
+        }
+
+        private async Task CleanupDefunctSilos(CancellationToken cancellationToken)
+        {
+            try
+            {
+                DateTimeOffset? beforeDate = default;
+                var defunctSiloEntryCount = 0;
+                var defunctSiloEntriesToRemove = 0;
+
+                if (_clusterMembershipOptions.DefunctSiloCleanupPeriod.HasValue)
+                {
+                    beforeDate = _timeProvider.GetUtcNow() - _clusterMembershipOptions.DefunctSiloExpiration;
+                }
+
+                if (_clusterMembershipOptions.MaxDefunctSiloEntries is { } maxDefunctSiloEntries)
+                {
+                    var table = await _membershipTableProvider.ReadAll().WaitAsync(cancellationToken);
+                    if (TryGetDefunctSiloCleanupInfo(
+                        table,
+                        maxDefunctSiloEntries,
+                        out var excessBeforeDate,
+                        out defunctSiloEntryCount,
+                        out defunctSiloEntriesToRemove)
+                        && (!beforeDate.HasValue || excessBeforeDate > beforeDate.Value))
+                    {
+                        beforeDate = excessBeforeDate;
+                    }
+                }
+
+                if (!beforeDate.HasValue)
+                {
+                    return;
+                }
+
+                LogDebugCleaningUpDefunctMembershipTableEntries(_logger, defunctSiloEntriesToRemove, defunctSiloEntryCount, _clusterMembershipOptions.MaxDefunctSiloEntries, beforeDate.Value);
+                await _membershipTableProvider.CleanupDefunctSiloEntries(beforeDate.Value).WaitAsync(cancellationToken);
+            }
+            catch (Exception exception) when (exception is NotImplementedException or MissingMethodException)
+            {
+                _cleanupDefunctSiloEntriesUnsupported = true;
+                LogWarningCleanupDefunctSiloEntriesNotSupported(_logger);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                LogErrorFailedToCleanUpDefunctMembershipTableEntries(_logger, exception);
+            }
+        }
+
+        private bool IsFirstActiveSilo(MembershipTableSnapshot membership)
+        {
+            var localSiloIsActive = false;
+            foreach (var entry in membership.Entries.Values)
+            {
+                if (entry.Status != SiloStatus.Active)
+                {
+                    continue;
+                }
+
+                var comparison = entry.SiloAddress.CompareTo(_localSiloDetails.SiloAddress);
+                if (comparison < 0)
+                {
+                    return false;
+                }
+
+                if (comparison == 0)
+                {
+                    localSiloIsActive = true;
+                }
+            }
+
+            return localSiloIsActive;
+        }
+
+        private static bool TryGetDefunctSiloCleanupInfo(
+            MembershipTableData table,
+            int maxDefunctSiloEntries,
+            out DateTimeOffset beforeDate,
+            out int defunctSiloEntryCount,
+            out int defunctSiloEntriesToRemove)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(maxDefunctSiloEntries, nameof(ClusterMembershipOptions.MaxDefunctSiloEntries));
+
+            beforeDate = default;
+            defunctSiloEntryCount = 0;
+            defunctSiloEntriesToRemove = 0;
+
+            if (maxDefunctSiloEntries == int.MaxValue)
+            {
+                return false;
+            }
+
+            var trackedEntryCount = maxDefunctSiloEntries + 1;
+            var newestDefunctEntries = new PriorityQueue<MembershipEntry, DefunctSiloEntryPriority>();
+            foreach (var tuple in table.Members)
+            {
+                var entry = tuple.Item1;
+                if (!IsDefunctSiloEntry(entry))
+                {
+                    continue;
+                }
+
+                defunctSiloEntryCount++;
+                if (newestDefunctEntries.Count < trackedEntryCount)
+                {
+                    newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
+                }
+                else if (newestDefunctEntries.TryPeek(out var oldestTrackedEntry, out _)
+                    && CompareDefunctSiloEntries(entry, oldestTrackedEntry) > 0)
+                {
+                    newestDefunctEntries.Dequeue();
+                    newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
+                }
+            }
+
+            if (defunctSiloEntryCount <= maxDefunctSiloEntries)
+            {
+                return false;
+            }
+
+            var newestEntryToRemove = newestDefunctEntries.Peek();
+            beforeDate = GetDefunctSiloCleanupCutoff(newestEntryToRemove.EffectiveIAmAliveTime);
+            defunctSiloEntriesToRemove = defunctSiloEntryCount - maxDefunctSiloEntries;
+            return true;
+        }
+
+        private static int CompareDefunctSiloEntries(MembershipEntry left, MembershipEntry right)
+        {
+            var result = left.EffectiveIAmAliveTime.CompareTo(right.EffectiveIAmAliveTime);
+            return result != 0 ? result : left.SiloAddress.CompareTo(right.SiloAddress);
+        }
+
+        private static bool IsDefunctSiloEntry(MembershipEntry entry) => entry.Status == SiloStatus.Dead;
+
+        private static DateTimeOffset GetDefunctSiloCleanupCutoff(DateTime effectiveIAmAliveTime)
+        {
+            var effectiveIAmAliveTimeUtc = DateTime.SpecifyKind(effectiveIAmAliveTime, DateTimeKind.Utc);
+            return effectiveIAmAliveTimeUtc == DateTime.MaxValue
+                ? DateTimeOffset.MaxValue
+                : new DateTimeOffset(effectiveIAmAliveTimeUtc.AddTicks(1));
+        }
+
+        private readonly struct DefunctSiloEntryPriority(MembershipEntry entry) : IComparable<DefunctSiloEntryPriority>
+        {
+            private readonly DateTime _effectiveIAmAliveTime = entry.EffectiveIAmAliveTime;
+            private readonly SiloAddress _siloAddress = entry.SiloAddress;
+
+            public int CompareTo(DefunctSiloEntryPriority other)
+            {
+                var result = _effectiveIAmAliveTime.CompareTo(other._effectiveIAmAliveTime);
+                return result != 0 ? result : _siloAddress.CompareTo(other._siloAddress);
             }
         }
 
@@ -93,13 +268,13 @@ namespace Orleans.Runtime.MembershipService
 
             Task OnStart(CancellationToken ct)
             {
-                task = Task.Run(CleanupDefunctSilos);
+                task = Task.Run(() => ProcessMembershipUpdates(_shutdownCts.Token));
                 return Task.CompletedTask;
             }
 
             async Task OnStop(CancellationToken ct)
             {
-                _cleanupDefunctSilosTimer?.Dispose();
+                CancelShutdown();
                 if (task is { })
                 {
                     await task.WaitAsync(ct).SuppressThrowing();
@@ -109,18 +284,13 @@ namespace Orleans.Runtime.MembershipService
 
         bool IHealthCheckable.CheckHealth(DateTime lastCheckTime, [NotNullWhen(false)] out string? reason)
         {
-            if (_cleanupDefunctSilosTimer is IAsyncTimer timer)
-            {
-                return timer.CheckHealth(lastCheckTime, out reason);
-            }
-
             reason = default;
             return true;
         }
 
         [LoggerMessage(
             Level = LogLevel.Debug,
-            Message = "Membership table cleanup is disabled due to ClusterMembershipOptions.DefunctSiloCleanupPeriod not being specified"
+            Message = "Membership table cleanup is disabled due to ClusterMembershipOptions.DefunctSiloCleanupPeriod and ClusterMembershipOptions.MaxDefunctSiloEntries not being specified"
         )]
         private static partial void LogDebugMembershipTableCleanupDisabled(ILogger logger);
 
@@ -131,8 +301,14 @@ namespace Orleans.Runtime.MembershipService
         private static partial void LogDebugStartingMembershipTableCleanupAgent(ILogger logger);
 
         [LoggerMessage(
+            Level = LogLevel.Debug,
+            Message = "Cleaning up {DefunctSiloEntriesToRemove} excess defunct membership table entries out of {DefunctSiloEntryCount} total defunct entries with configured maximum {MaxDefunctSiloEntries}. Removing entries older than {BeforeDate}"
+        )]
+        private static partial void LogDebugCleaningUpDefunctMembershipTableEntries(ILogger logger, int defunctSiloEntriesToRemove, int defunctSiloEntryCount, int? maxDefunctSiloEntries, DateTimeOffset beforeDate);
+
+        [LoggerMessage(
             Level = LogLevel.Warning,
-            Message = "IMembershipTable.CleanupDefunctSiloEntries operation is not supported by the current implementation of IMembershipTable. Disabling the timer now."
+            Message = "IMembershipTable.CleanupDefunctSiloEntries operation is not supported by the current implementation of IMembershipTable. Disabling defunct membership table cleanup."
         )]
         private static partial void LogWarningCleanupDefunctSiloEntriesNotSupported(ILogger logger);
 

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -22,6 +22,7 @@ namespace Orleans.Runtime.MembershipService
         private readonly ILogger<MembershipTableCleanupAgent> _logger;
         private readonly CancellationTokenSource _shutdownCts = new();
         private readonly object _shutdownLock = new();
+        private DateTimeOffset? _lastDefunctSiloCleanupTime;
         private bool _disposed;
         private bool _cleanupDefunctSiloEntriesUnsupported;
 
@@ -109,11 +110,16 @@ namespace Orleans.Runtime.MembershipService
         {
             try
             {
+                var now = _timeProvider.GetUtcNow();
                 DateTimeOffset? beforeDate = default;
 
                 if (_clusterMembershipOptions.DefunctSiloCleanupPeriod.HasValue)
                 {
-                    beforeDate = _timeProvider.GetUtcNow() - _clusterMembershipOptions.DefunctSiloExpiration;
+                    var expirationBeforeDate = now - _clusterMembershipOptions.DefunctSiloExpiration;
+                    if (ShouldCleanupExpiredSilos(membership, now, expirationBeforeDate))
+                    {
+                        beforeDate = expirationBeforeDate;
+                    }
                 }
 
                 if (_clusterMembershipOptions.MaxDefunctSiloEntries is { } maxDefunctSiloEntries)
@@ -162,6 +168,7 @@ namespace Orleans.Runtime.MembershipService
 
                 LogDebugCleaningUpDefunctMembershipTableEntries(_logger, beforeDate.Value);
                 await _membershipTableProvider.CleanupDefunctSiloEntries(beforeDate.Value).WaitAsync(cancellationToken);
+                _lastDefunctSiloCleanupTime = now;
             }
             catch (Exception exception) when (exception is NotImplementedException or MissingMethodException)
             {
@@ -176,6 +183,24 @@ namespace Orleans.Runtime.MembershipService
             {
                 LogErrorFailedToCleanUpDefunctMembershipTableEntries(_logger, exception);
             }
+        }
+
+        private bool ShouldCleanupExpiredSilos(MembershipTableSnapshot membership, DateTimeOffset now, DateTimeOffset beforeDate)
+        {
+            if (!_lastDefunctSiloCleanupTime.HasValue || now - _lastDefunctSiloCleanupTime.Value >= _clusterMembershipOptions.DefunctSiloExpiration)
+            {
+                return true;
+            }
+
+            foreach (var entry in membership.Entries.Values)
+            {
+                if (entry.Status != SiloStatus.Active && entry.EffectiveIAmAliveTime < beforeDate.UtcDateTime)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private bool IsFirstActiveSilo(MembershipTableSnapshot membership)

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -13,7 +12,7 @@ namespace Orleans.Runtime.MembershipService
     /// <summary>
     /// Responsible for cleaning up dead membership table entries.
     /// </summary>
-    internal partial class MembershipTableCleanupAgent : IHealthCheckParticipant, ILifecycleParticipant<ISiloLifecycle>, IDisposable
+    internal partial class MembershipTableCleanupAgent : ILifecycleParticipant<ISiloLifecycle>, IDisposable
     {
         private readonly ClusterMembershipOptions _clusterMembershipOptions;
         private readonly IMembershipTable _membershipTableProvider;
@@ -131,15 +130,16 @@ namespace Orleans.Runtime.MembershipService
                         }
 
                         defunctSiloEntryCount++;
+                        var entryPriority = new DefunctSiloEntryPriority(entry);
                         if (newestDefunctEntries.Count < trackedEntryCount)
                         {
-                            newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
+                            newestDefunctEntries.Enqueue(entry, entryPriority);
                         }
-                        else if (newestDefunctEntries.TryPeek(out var oldestTrackedEntry, out _)
-                            && CompareDefunctSiloEntries(entry, oldestTrackedEntry) > 0)
+                        else if (newestDefunctEntries.TryPeek(out _, out var oldestTrackedEntryPriority)
+                            && entryPriority > oldestTrackedEntryPriority)
                         {
                             newestDefunctEntries.Dequeue();
-                            newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
+                            newestDefunctEntries.Enqueue(entry, entryPriority);
                         }
                     }
 
@@ -202,12 +202,6 @@ namespace Orleans.Runtime.MembershipService
             return localSiloIsActive;
         }
 
-        private static int CompareDefunctSiloEntries(MembershipEntry left, MembershipEntry right)
-        {
-            var result = left.EffectiveIAmAliveTime.CompareTo(right.EffectiveIAmAliveTime);
-            return result != 0 ? result : left.SiloAddress.CompareTo(right.SiloAddress);
-        }
-
         private static DateTimeOffset GetDefunctSiloCleanupCutoff(DateTime effectiveIAmAliveTime)
         {
             var effectiveIAmAliveTimeUtc = DateTime.SpecifyKind(effectiveIAmAliveTime, DateTimeKind.Utc);
@@ -220,7 +214,17 @@ namespace Orleans.Runtime.MembershipService
         {
             private readonly MembershipEntry _entry = entry;
 
-            public int CompareTo(DefunctSiloEntryPriority other) => CompareDefunctSiloEntries(_entry, other._entry);
+            public static bool operator >(DefunctSiloEntryPriority left, DefunctSiloEntryPriority right) => Compare(left, right) > 0;
+
+            public static bool operator <(DefunctSiloEntryPriority left, DefunctSiloEntryPriority right) => Compare(left, right) < 0;
+
+            public int CompareTo(DefunctSiloEntryPriority other) => Compare(this, other);
+
+            private static int Compare(DefunctSiloEntryPriority left, DefunctSiloEntryPriority right)
+            {
+                var result = left._entry.EffectiveIAmAliveTime.CompareTo(right._entry.EffectiveIAmAliveTime);
+                return result != 0 ? result : left._entry.SiloAddress.CompareTo(right._entry.SiloAddress);
+            }
         }
 
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
@@ -242,12 +246,6 @@ namespace Orleans.Runtime.MembershipService
                     await task.WaitAsync(ct).SuppressThrowing();
                 }
             }
-        }
-
-        bool IHealthCheckable.CheckHealth(DateTime lastCheckTime, [NotNullWhen(false)] out string? reason)
-        {
-            reason = default;
-            return true;
         }
 
         [LoggerMessage(

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -57,7 +57,7 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        private void CancelShutdown()
+        private void SignalShutdown()
         {
             lock (_shutdownLock)
             {
@@ -110,8 +110,6 @@ namespace Orleans.Runtime.MembershipService
             try
             {
                 DateTimeOffset? beforeDate = default;
-                var defunctSiloEntryCount = 0;
-                var defunctSiloEntriesToRemove = 0;
 
                 if (_clusterMembershipOptions.DefunctSiloCleanupPeriod.HasValue)
                 {
@@ -120,16 +118,44 @@ namespace Orleans.Runtime.MembershipService
 
                 if (_clusterMembershipOptions.MaxDefunctSiloEntries is { } maxDefunctSiloEntries)
                 {
-                    var table = await _membershipTableProvider.ReadAll().WaitAsync(cancellationToken);
-                    if (TryGetDefunctSiloCleanupInfo(
-                        table,
-                        maxDefunctSiloEntries,
-                        out var excessBeforeDate,
-                        out defunctSiloEntryCount,
-                        out defunctSiloEntriesToRemove)
-                        && (!beforeDate.HasValue || excessBeforeDate > beforeDate.Value))
+                    ArgumentOutOfRangeException.ThrowIfNegative(maxDefunctSiloEntries, nameof(ClusterMembershipOptions.MaxDefunctSiloEntries));
+
+                    if (maxDefunctSiloEntries != int.MaxValue)
                     {
-                        beforeDate = excessBeforeDate;
+                        var table = await _membershipTableProvider.ReadAll().WaitAsync(cancellationToken);
+                        var defunctSiloEntryCount = 0;
+                        var trackedEntryCount = maxDefunctSiloEntries + 1;
+                        var newestDefunctEntries = new PriorityQueue<MembershipEntry, DefunctSiloEntryPriority>();
+                        foreach (var tuple in table.Members)
+                        {
+                            var entry = tuple.Item1;
+                            if (entry.Status != SiloStatus.Dead)
+                            {
+                                continue;
+                            }
+
+                            defunctSiloEntryCount++;
+                            if (newestDefunctEntries.Count < trackedEntryCount)
+                            {
+                                newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
+                            }
+                            else if (newestDefunctEntries.TryPeek(out var oldestTrackedEntry, out _)
+                                && CompareDefunctSiloEntries(entry, oldestTrackedEntry) > 0)
+                            {
+                                newestDefunctEntries.Dequeue();
+                                newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
+                            }
+                        }
+
+                        if (defunctSiloEntryCount > maxDefunctSiloEntries)
+                        {
+                            var newestEntryToRemove = newestDefunctEntries.Peek();
+                            var excessBeforeDate = GetDefunctSiloCleanupCutoff(newestEntryToRemove.EffectiveIAmAliveTime);
+                            if (!beforeDate.HasValue || excessBeforeDate > beforeDate.Value)
+                            {
+                                beforeDate = excessBeforeDate;
+                            }
+                        }
                     }
                 }
 
@@ -138,7 +164,7 @@ namespace Orleans.Runtime.MembershipService
                     return;
                 }
 
-                LogDebugCleaningUpDefunctMembershipTableEntries(_logger, defunctSiloEntriesToRemove, defunctSiloEntryCount, _clusterMembershipOptions.MaxDefunctSiloEntries, beforeDate.Value);
+                LogDebugCleaningUpDefunctMembershipTableEntries(_logger, beforeDate.Value);
                 await _membershipTableProvider.CleanupDefunctSiloEntries(beforeDate.Value).WaitAsync(cancellationToken);
             }
             catch (Exception exception) when (exception is NotImplementedException or MissingMethodException)
@@ -181,58 +207,6 @@ namespace Orleans.Runtime.MembershipService
             return localSiloIsActive;
         }
 
-        private static bool TryGetDefunctSiloCleanupInfo(
-            MembershipTableData table,
-            int maxDefunctSiloEntries,
-            out DateTimeOffset beforeDate,
-            out int defunctSiloEntryCount,
-            out int defunctSiloEntriesToRemove)
-        {
-            ArgumentOutOfRangeException.ThrowIfNegative(maxDefunctSiloEntries, nameof(ClusterMembershipOptions.MaxDefunctSiloEntries));
-
-            beforeDate = default;
-            defunctSiloEntryCount = 0;
-            defunctSiloEntriesToRemove = 0;
-
-            if (maxDefunctSiloEntries == int.MaxValue)
-            {
-                return false;
-            }
-
-            var trackedEntryCount = maxDefunctSiloEntries + 1;
-            var newestDefunctEntries = new PriorityQueue<MembershipEntry, DefunctSiloEntryPriority>();
-            foreach (var tuple in table.Members)
-            {
-                var entry = tuple.Item1;
-                if (entry.Status != SiloStatus.Dead)
-                {
-                    continue;
-                }
-
-                defunctSiloEntryCount++;
-                if (newestDefunctEntries.Count < trackedEntryCount)
-                {
-                    newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
-                }
-                else if (newestDefunctEntries.TryPeek(out var oldestTrackedEntry, out _)
-                    && CompareDefunctSiloEntries(entry, oldestTrackedEntry) > 0)
-                {
-                    newestDefunctEntries.Dequeue();
-                    newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
-                }
-            }
-
-            if (defunctSiloEntryCount <= maxDefunctSiloEntries)
-            {
-                return false;
-            }
-
-            var newestEntryToRemove = newestDefunctEntries.Peek();
-            beforeDate = GetDefunctSiloCleanupCutoff(newestEntryToRemove.EffectiveIAmAliveTime);
-            defunctSiloEntriesToRemove = defunctSiloEntryCount - maxDefunctSiloEntries;
-            return true;
-        }
-
         private static int CompareDefunctSiloEntries(MembershipEntry left, MembershipEntry right)
         {
             var result = left.EffectiveIAmAliveTime.CompareTo(right.EffectiveIAmAliveTime);
@@ -267,7 +241,7 @@ namespace Orleans.Runtime.MembershipService
 
             async Task OnStop(CancellationToken ct)
             {
-                CancelShutdown();
+                SignalShutdown();
                 if (task is { })
                 {
                     await task.WaitAsync(ct).SuppressThrowing();
@@ -295,9 +269,9 @@ namespace Orleans.Runtime.MembershipService
 
         [LoggerMessage(
             Level = LogLevel.Debug,
-            Message = "Cleaning up {DefunctSiloEntriesToRemove} excess defunct membership table entries out of {DefunctSiloEntryCount} total defunct entries with configured maximum {MaxDefunctSiloEntries}. Removing entries older than {BeforeDate}"
+            Message = "Cleaning up defunct membership table entries older than {BeforeDate}"
         )]
-        private static partial void LogDebugCleaningUpDefunctMembershipTableEntries(ILogger logger, int defunctSiloEntriesToRemove, int defunctSiloEntryCount, int? maxDefunctSiloEntries, DateTimeOffset beforeDate);
+        private static partial void LogDebugCleaningUpDefunctMembershipTableEntries(ILogger logger, DateTimeOffset beforeDate);
 
         [LoggerMessage(
             Level = LogLevel.Warning,

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -79,13 +79,14 @@ namespace Orleans.Runtime.MembershipService
             LogDebugStartingMembershipTableCleanupAgent(_logger);
             try
             {
-                await foreach (var membership in _membershipManager.MembershipUpdates.WithCancellation(cancellationToken))
+                await foreach (var _ in _membershipManager.MembershipUpdates.WithCancellation(cancellationToken))
                 {
                     if (_cleanupDefunctSiloEntriesUnsupported)
                     {
                         return;
                     }
 
+                    var membership = _membershipManager.CurrentSnapshot;
                     if (!IsFirstActiveSilo(membership))
                     {
                         continue;

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -92,7 +92,7 @@ namespace Orleans.Runtime.MembershipService
                         continue;
                     }
 
-                    await CleanupDefunctSilos(cancellationToken);
+                    await CleanupDefunctSilos(membership, cancellationToken);
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -105,7 +105,7 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        private async Task CleanupDefunctSilos(CancellationToken cancellationToken)
+        private async Task CleanupDefunctSilos(MembershipTableSnapshot membership, CancellationToken cancellationToken)
         {
             try
             {
@@ -120,41 +120,36 @@ namespace Orleans.Runtime.MembershipService
                 {
                     ArgumentOutOfRangeException.ThrowIfNegative(maxDefunctSiloEntries, nameof(ClusterMembershipOptions.MaxDefunctSiloEntries));
 
-                    if (maxDefunctSiloEntries != int.MaxValue)
+                    var defunctSiloEntryCount = 0;
+                    var trackedEntryCount = (long)maxDefunctSiloEntries + 1;
+                    var newestDefunctEntries = new PriorityQueue<MembershipEntry, DefunctSiloEntryPriority>();
+                    foreach (var entry in membership.Entries.Values)
                     {
-                        var table = await _membershipTableProvider.ReadAll().WaitAsync(cancellationToken);
-                        var defunctSiloEntryCount = 0;
-                        var trackedEntryCount = maxDefunctSiloEntries + 1;
-                        var newestDefunctEntries = new PriorityQueue<MembershipEntry, DefunctSiloEntryPriority>();
-                        foreach (var tuple in table.Members)
+                        if (entry.Status != SiloStatus.Dead)
                         {
-                            var entry = tuple.Item1;
-                            if (entry.Status != SiloStatus.Dead)
-                            {
-                                continue;
-                            }
-
-                            defunctSiloEntryCount++;
-                            if (newestDefunctEntries.Count < trackedEntryCount)
-                            {
-                                newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
-                            }
-                            else if (newestDefunctEntries.TryPeek(out var oldestTrackedEntry, out _)
-                                && CompareDefunctSiloEntries(entry, oldestTrackedEntry) > 0)
-                            {
-                                newestDefunctEntries.Dequeue();
-                                newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
-                            }
+                            continue;
                         }
 
-                        if (defunctSiloEntryCount > maxDefunctSiloEntries)
+                        defunctSiloEntryCount++;
+                        if (newestDefunctEntries.Count < trackedEntryCount)
                         {
-                            var newestEntryToRemove = newestDefunctEntries.Peek();
-                            var excessBeforeDate = GetDefunctSiloCleanupCutoff(newestEntryToRemove.EffectiveIAmAliveTime);
-                            if (!beforeDate.HasValue || excessBeforeDate > beforeDate.Value)
-                            {
-                                beforeDate = excessBeforeDate;
-                            }
+                            newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
+                        }
+                        else if (newestDefunctEntries.TryPeek(out var oldestTrackedEntry, out _)
+                            && CompareDefunctSiloEntries(entry, oldestTrackedEntry) > 0)
+                        {
+                            newestDefunctEntries.Dequeue();
+                            newestDefunctEntries.Enqueue(entry, new DefunctSiloEntryPriority(entry));
+                        }
+                    }
+
+                    if (defunctSiloEntryCount > maxDefunctSiloEntries)
+                    {
+                        var newestEntryToRemove = newestDefunctEntries.Peek();
+                        var excessBeforeDate = GetDefunctSiloCleanupCutoff(newestEntryToRemove.EffectiveIAmAliveTime);
+                        if (!beforeDate.HasValue || excessBeforeDate > beforeDate.Value)
+                        {
+                            beforeDate = excessBeforeDate;
                         }
                     }
                 }

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -441,6 +441,8 @@ namespace Orleans.Configuration
 
         public System.TimeSpan LocalHealthDegradationMonitoringPeriod { get { throw null; } set { } }
 
+        public int? MaxDefunctSiloEntries { get { throw null; } set { } }
+
         public System.TimeSpan MaxJoinAttemptTime { get { throw null; } set { } }
 
         public int NumMissedProbesLimit { get { throw null; } set { } }

--- a/test/Orleans.Core.Tests/Membership/InMemoryMembershipTable.cs
+++ b/test/Orleans.Core.Tests/Membership/InMemoryMembershipTable.cs
@@ -36,6 +36,7 @@ namespace NonSilo.Tests.Membership
         }
 
         public Action OnReadAll { get; set; }
+        public Action<DateTimeOffset> OnCleanupDefunctSiloEntries { get; set; }
         public TableVersion Version { get; set; } = new TableVersion(0, "0");
 
         public void ClearCalls()
@@ -54,6 +55,7 @@ namespace NonSilo.Tests.Membership
 
         public Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
+            this.OnCleanupDefunctSiloEntries?.Invoke(beforeDate);
             lock (this.tableLock)
             {
                 this.calls.Add((nameof(CleanupDefunctSiloEntries), beforeDate));

--- a/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
@@ -112,7 +112,7 @@ namespace NonSilo.Tests.Membership
         }
 
         [Fact]
-        public async Task MembershipTableCleanupAgent_ExpirationCleanup_SkipsUntilExpiredNonActiveEntryOrExpirationElapsed()
+        public async Task MembershipTableCleanupAgent_ExpirationCleanup_SkipsUntilExpiredNonActiveEntryOrCleanupPeriodElapsed()
         {
             var options = new ClusterMembershipOptions
             {
@@ -146,7 +146,7 @@ namespace NonSilo.Tests.Membership
             await Until(() => CleanupCallCount(table) == 1);
 
             table.ClearCalls();
-            this.timeProvider.Advance(options.DefunctSiloExpiration);
+            this.timeProvider.Advance(options.DefunctSiloCleanupPeriod.Value);
             var later = this.timeProvider.GetUtcNow();
             membershipManager.Publish(Snapshot(Entry(this.localSilo, SiloStatus.Active, later)));
             await Until(() => CleanupCallCount(table) == 1);

--- a/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
@@ -111,6 +111,49 @@ namespace NonSilo.Tests.Membership
             await lifecycle.OnStop();
         }
 
+        [Fact]
+        public async Task MembershipTableCleanupAgent_ExpirationCleanup_SkipsUntilExpiredNonActiveEntryOrExpirationElapsed()
+        {
+            var options = new ClusterMembershipOptions
+            {
+                DefunctSiloCleanupPeriod = TimeSpan.FromMinutes(90),
+                DefunctSiloExpiration = TimeSpan.FromDays(1),
+                MaxDefunctSiloEntries = null
+            };
+            var membershipManager = new TestMembershipManager();
+            var table = new InMemoryMembershipTable();
+            var cleanupAgent = this.CreateCleanupAgent(options, table, membershipManager);
+            var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
+            ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
+
+            await lifecycle.OnStart();
+            var now = this.timeProvider.GetUtcNow();
+            membershipManager.Publish(Snapshot(Entry(this.localSilo, SiloStatus.Active, now)));
+            await Until(() => CleanupCallCount(table) == 1);
+
+            table.ClearCalls();
+            membershipManager.Publish(Snapshot(Entry(this.localSilo, SiloStatus.Active, now)));
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
+            Assert.Equal(0, CleanupCallCount(table));
+
+            var expiredNonActiveEntry = Entry(
+                Silo("127.0.0.1:500@100"),
+                SiloStatus.Joining,
+                now - options.DefunctSiloExpiration - TimeSpan.FromTicks(1));
+            membershipManager.Publish(Snapshot(
+                Entry(this.localSilo, SiloStatus.Active, now),
+                expiredNonActiveEntry));
+            await Until(() => CleanupCallCount(table) == 1);
+
+            table.ClearCalls();
+            this.timeProvider.Advance(options.DefunctSiloExpiration);
+            var later = this.timeProvider.GetUtcNow();
+            membershipManager.Publish(Snapshot(Entry(this.localSilo, SiloStatus.Active, later)));
+            await Until(() => CleanupCallCount(table) == 1);
+
+            await lifecycle.OnStop();
+        }
+
         private async Task BasicScenario(bool enabled)
         {
             var options = new ClusterMembershipOptions
@@ -171,6 +214,8 @@ namespace NonSilo.Tests.Membership
             while (!condition() && (maxTimeout -= 10) > 0) await Task.Delay(10);
             Assert.True(maxTimeout > 0);
         }
+
+        private static int CleanupCallCount(InMemoryMembershipTable table) => table.Calls.Count(call => call.Method == nameof(IMembershipTable.CleanupDefunctSiloEntries));
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
 

--- a/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
@@ -1,7 +1,9 @@
-using System.Collections.Concurrent;
+using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using NonSilo.Tests.Utilities;
+using NSubstitute;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Runtime;
@@ -20,11 +22,18 @@ namespace NonSilo.Tests.Membership
     {
         private readonly ITestOutputHelper output;
         private readonly LoggerFactory loggerFactory;
+        private readonly SiloAddress localSilo;
+        private readonly ILocalSiloDetails localSiloDetails;
+        private readonly FakeTimeProvider timeProvider;
 
         public MembershipTableCleanupAgentTests(ITestOutputHelper output)
         {
             this.output = output;
             this.loggerFactory = new LoggerFactory(new[] { new XunitLoggerProvider(this.output) });
+            this.localSilo = Silo("127.0.0.1:100@100");
+            this.localSiloDetails = Substitute.For<ILocalSiloDetails>();
+            this.localSiloDetails.SiloAddress.Returns(this.localSilo);
+            this.timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 1, 1, 12, 30, 0, TimeSpan.Zero));
         }
 
         [Fact]
@@ -39,62 +48,114 @@ namespace NonSilo.Tests.Membership
             await this.BasicScenario(enabled: false);
         }
 
+        [Fact]
+        public async Task MembershipTableCleanupAgent_NonFirstActiveSilo_DoesNotCleanup()
+        {
+            var options = new ClusterMembershipOptions { DefunctSiloCleanupPeriod = TimeSpan.FromMinutes(90), MaxDefunctSiloEntries = null };
+            var membershipManager = new TestMembershipManager();
+            var cleanupCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var now = this.timeProvider.GetUtcNow();
+            var table = new InMemoryMembershipTable
+            {
+                OnCleanupDefunctSiloEntries = _ => cleanupCalled.TrySetResult()
+            };
+            var cleanupAgent = this.CreateCleanupAgent(options, table, membershipManager);
+            var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
+            ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
+
+            await lifecycle.OnStart();
+            membershipManager.Publish(Snapshot(
+                Entry(Silo("127.0.0.1:200@1"), SiloStatus.Active, now),
+                Entry(this.localSilo, SiloStatus.Active, now)));
+            var completed = await Task.WhenAny(cleanupCalled.Task, Task.Delay(TimeSpan.FromMilliseconds(200)));
+
+            Assert.NotSame(cleanupCalled.Task, completed);
+            Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
+
+            await lifecycle.OnStop();
+        }
+
+        [Fact]
+        public async Task MembershipTableCleanupAgent_ThresholdCleanup_RemovesExcessDefunctEntries()
+        {
+            var now = this.timeProvider.GetUtcNow();
+            var retainedDefunctSilo = Silo("127.0.0.1:700@100");
+            var options = new ClusterMembershipOptions { DefunctSiloCleanupPeriod = null, MaxDefunctSiloEntries = 1 };
+            var membershipManager = new TestMembershipManager();
+            var table = new InMemoryMembershipTable(
+                new TableVersion(123, "123"),
+                Entry(Silo("127.0.0.1:500@100"), SiloStatus.Dead, now.AddMinutes(-3)),
+                Entry(Silo("127.0.0.1:600@100"), SiloStatus.Dead, now.AddMinutes(-2)),
+                Entry(retainedDefunctSilo, SiloStatus.Dead, now.AddMinutes(-1)));
+            var cleanupAgent = this.CreateCleanupAgent(options, table, membershipManager);
+            var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
+            ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
+
+            await lifecycle.OnStart();
+            membershipManager.Publish(Snapshot(
+                Entry(this.localSilo, SiloStatus.Active, now),
+                Entry(Silo("127.0.0.1:200@200"), SiloStatus.Active, now)));
+            await Until(() => table.Calls.Any(call => call.Method == nameof(IMembershipTable.CleanupDefunctSiloEntries)));
+
+            var updatedTable = await table.ReadAll();
+            Assert.Single(updatedTable.Members, member => member.Item1.Status == SiloStatus.Dead);
+            Assert.Contains(updatedTable.Members, member => member.Item1.SiloAddress.Equals(retainedDefunctSilo));
+
+            await lifecycle.OnStop();
+        }
+
         private async Task BasicScenario(bool enabled)
         {
-            var options = new ClusterMembershipOptions { DefunctSiloCleanupPeriod = enabled ? new TimeSpan?(TimeSpan.FromMinutes(90)) : null, DefunctSiloExpiration = TimeSpan.FromDays(1) };
-            var timers = new List<DelegateAsyncTimer>();
-            var timerCalls = new ConcurrentQueue<(TimeSpan? DelayOverride, TaskCompletionSource<bool> Completion)>();
-            var timerFactory = new DelegateAsyncTimerFactory(
-                (period, name) =>
-                {
-                    Assert.Equal(options.DefunctSiloCleanupPeriod.Value, period);
-                    var t = new DelegateAsyncTimer(
-                        overridePeriod =>
-                        {
-                            var task = new TaskCompletionSource<bool>();
-                            timerCalls.Enqueue((overridePeriod, task));
-                            return task.Task;
-                        });
-                    timers.Add(t);
-                    return t;
-                });
-
-            var table = new InMemoryMembershipTable();
-            var cleanupAgent = new MembershipTableCleanupAgent(
-                Options.Create(options),
-                table,
-                this.loggerFactory.CreateLogger<MembershipTableCleanupAgent>(),
-                timerFactory);
+            var options = new ClusterMembershipOptions
+            {
+                DefunctSiloCleanupPeriod = enabled ? TimeSpan.FromMinutes(90) : null,
+                DefunctSiloExpiration = TimeSpan.FromDays(1),
+                MaxDefunctSiloEntries = null
+            };
+            var membershipManager = new TestMembershipManager();
+            var cleanupCalled = new TaskCompletionSource<DateTimeOffset>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var now = this.timeProvider.GetUtcNow();
+            var table = new InMemoryMembershipTable
+            {
+                OnCleanupDefunctSiloEntries = beforeDate => cleanupCalled.TrySetResult(beforeDate)
+            };
+            var cleanupAgent = this.CreateCleanupAgent(options, table, membershipManager);
             var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
             ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
 
             await lifecycle.OnStart();
             Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
 
-            if (enabled) await Until(() => timerCalls.Count > 0);
+            membershipManager.Publish(Snapshot(Entry(this.localSilo, SiloStatus.Active, now)));
+            var completed = await Task.WhenAny(cleanupCalled.Task, Task.Delay(TimeSpan.FromMilliseconds(200)));
 
-            Assert.Equal(enabled, timerCalls.TryDequeue(out var timer));
-            timer.Completion?.TrySetResult(true);
-
-            var stopped = lifecycle.OnStop();
-            if (enabled) await Until(() => timerCalls.Count > 0);
-            while (timerCalls.TryDequeue(out timer)) timer.Completion.TrySetResult(false);
             if (enabled)
             {
+                Assert.Same(cleanupCalled.Task, completed);
+                Assert.Equal(now - options.DefunctSiloExpiration, cleanupCalled.Task.Result);
                 Assert.Contains(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
             }
             else
             {
+                Assert.NotSame(cleanupCalled.Task, completed);
                 Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
             }
 
-            while (!stopped.IsCompleted)
-            {
-                while (timerCalls.TryDequeue(out var call)) call.Completion.TrySetResult(false);
-                await Task.Delay(15);
-            }
+            await lifecycle.OnStop();
+        }
 
-            await stopped;
+        private MembershipTableCleanupAgent CreateCleanupAgent(
+            ClusterMembershipOptions options,
+            InMemoryMembershipTable table,
+            IMembershipManager membershipManager)
+        {
+            return new MembershipTableCleanupAgent(
+                Options.Create(options),
+                table,
+                membershipManager,
+                this.localSiloDetails,
+                this.timeProvider,
+                this.loggerFactory.CreateLogger<MembershipTableCleanupAgent>());
         }
 
         private static async Task Until(Func<bool> condition)
@@ -102,6 +163,48 @@ namespace NonSilo.Tests.Membership
             var maxTimeout = 40_000;
             while (!condition() && (maxTimeout -= 10) > 0) await Task.Delay(10);
             Assert.True(maxTimeout > 0);
+        }
+
+        private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
+
+        private static MembershipEntry Entry(SiloAddress address, SiloStatus status, DateTimeOffset iAmAliveTime)
+        {
+            return new MembershipEntry { SiloAddress = address, Status = status, IAmAliveTime = iAmAliveTime.UtcDateTime, StartTime = iAmAliveTime.UtcDateTime };
+        }
+
+        private static MembershipTableSnapshot Snapshot(params MembershipEntry[] entries)
+        {
+            var entryList = entries.Select(e => Tuple.Create(e, "test")).ToList();
+            return MembershipTableSnapshot.Create(new MembershipTableData(entryList, new TableVersion(12, "test")));
+        }
+
+        private sealed class TestMembershipManager : IMembershipManager
+        {
+            private readonly Channel<MembershipTableSnapshot> updates = Channel.CreateUnbounded<MembershipTableSnapshot>();
+
+            public MembershipTableSnapshot CurrentSnapshot { get; private set; } = Snapshot();
+            public IAsyncEnumerable<MembershipTableSnapshot> MembershipUpdates => this.updates.Reader.ReadAllAsync();
+            public SiloStatus LocalSiloStatus => SiloStatus.Active;
+
+            public void Publish(MembershipTableSnapshot snapshot)
+            {
+                this.CurrentSnapshot = snapshot;
+                Assert.True(this.updates.Writer.TryWrite(snapshot));
+            }
+
+            public Task UpdateLocalStatus(SiloStatus status, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task<bool> TryKillSilo(SiloAddress silo, CancellationToken cancellationToken) => Task.FromResult(false);
+            public Task<bool> TrySuspectSilo(SiloAddress silo, SiloAddress indirectProbingSilo, CancellationToken cancellationToken) => Task.FromResult(false);
+            public Task Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task UpdateIAmAlive(CancellationToken cancellationToken) => Task.CompletedTask;
+            public void Participate(ISiloLifecycle lifecycle) { }
+
+            public bool CheckHealth(DateTime lastCheckTime, out string reason)
+            {
+                reason = default;
+                return true;
+            }
         }
     }
 }

--- a/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
@@ -82,11 +82,14 @@ namespace NonSilo.Tests.Membership
             var retainedDefunctSilo = Silo("127.0.0.1:700@100");
             var options = new ClusterMembershipOptions { DefunctSiloCleanupPeriod = null, MaxDefunctSiloEntries = 1 };
             var membershipManager = new TestMembershipManager();
+            var oldestDefunctEntry = Entry(Silo("127.0.0.1:500@100"), SiloStatus.Dead, now.AddMinutes(-3));
+            var removedDefunctEntry = Entry(Silo("127.0.0.1:600@100"), SiloStatus.Dead, now.AddMinutes(-2));
+            var retainedDefunctEntry = Entry(retainedDefunctSilo, SiloStatus.Dead, now.AddMinutes(-1));
             var table = new InMemoryMembershipTable(
                 new TableVersion(123, "123"),
-                Entry(Silo("127.0.0.1:500@100"), SiloStatus.Dead, now.AddMinutes(-3)),
-                Entry(Silo("127.0.0.1:600@100"), SiloStatus.Dead, now.AddMinutes(-2)),
-                Entry(retainedDefunctSilo, SiloStatus.Dead, now.AddMinutes(-1)));
+                oldestDefunctEntry,
+                removedDefunctEntry,
+                retainedDefunctEntry);
             var cleanupAgent = this.CreateCleanupAgent(options, table, membershipManager);
             var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
             ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
@@ -94,8 +97,12 @@ namespace NonSilo.Tests.Membership
             await lifecycle.OnStart();
             membershipManager.Publish(Snapshot(
                 Entry(this.localSilo, SiloStatus.Active, now),
-                Entry(Silo("127.0.0.1:200@200"), SiloStatus.Active, now)));
+                Entry(Silo("127.0.0.1:200@200"), SiloStatus.Active, now),
+                oldestDefunctEntry,
+                removedDefunctEntry,
+                retainedDefunctEntry));
             await Until(() => table.Calls.Any(call => call.Method == nameof(IMembershipTable.CleanupDefunctSiloEntries)));
+            Assert.DoesNotContain(table.Calls, call => call.Method == nameof(IMembershipTable.ReadAll));
 
             var updatedTable = await table.ReadAll();
             Assert.Single(updatedTable.Members, member => member.Item1.Status == SiloStatus.Dead);

--- a/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
@@ -177,16 +177,15 @@ namespace NonSilo.Tests.Membership
             Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
 
             membershipManager.Publish(Snapshot(Entry(this.localSilo, SiloStatus.Active, now)));
-            var completed = await Task.WhenAny(cleanupCalled.Task, Task.Delay(TimeSpan.FromMilliseconds(200)));
-
             if (enabled)
             {
-                Assert.Same(cleanupCalled.Task, completed);
+                await Until(() => cleanupCalled.Task.IsCompleted);
                 Assert.Equal(now - options.DefunctSiloExpiration, cleanupCalled.Task.Result);
                 Assert.Contains(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
             }
             else
             {
+                var completed = await Task.WhenAny(cleanupCalled.Task, Task.Delay(TimeSpan.FromMilliseconds(200)));
                 Assert.NotSame(cleanupCalled.Task, completed);
                 Assert.DoesNotContain(table.Calls, c => c.Method.Equals(nameof(IMembershipTable.CleanupDefunctSiloEntries)));
             }

--- a/test/Orleans.Core.Tests/SiloBuilderTests.cs
+++ b/test/Orleans.Core.Tests/SiloBuilderTests.cs
@@ -140,6 +140,16 @@ namespace NonSilo.Tests
                         .Configure<ClusterMembershipOptions>(options => { options.NumVotesForDeathDeclaration = 0; });
                 }).RunConsoleAsync();
             });
+
+            await Assert.ThrowsAsync<OrleansConfigurationException>(async () =>
+            {
+                await new HostBuilder().UseOrleans((ctx, siloBuilder) =>
+                {
+                    siloBuilder
+                        .UseLocalhostClustering()
+                        .Configure<ClusterMembershipOptions>(options => options.MaxDefunctSiloEntries = -1);
+                }).RunConsoleAsync();
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
Large numbers of dead silo entries can cause membership tables to grow before age-based cleanup removes them.

This adds a nullable maximum retained-defunct-entry option and has MembershipTableCleanupAgent perform threshold-based asynchronous cleanup on membership changes. Cleanup is owned by the first active silo by natural SiloAddress sort order, reuses the existing membership table cleanup API, and can be disabled by setting the option to null.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10231)