### PR TITLE
serialization: Allow enums when no type filter has an opinion

### DIFF
--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -521,6 +521,12 @@ public class TypeConverter
             }
         }
 
+        // Enums carry no behavior and are serialized via their underlying integral type, so allow them absent an explicit opinion.
+        if (result is null && type.IsEnum)
+        {
+            result = true;
+        }
+
         if (type.IsConstructedGenericType)
         {
             foreach (var parameter in type.GenericTypeArguments)

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -132,6 +132,42 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
+        public void TypeConverter_AllowsEnums_WhenAllFiltersHaveNoOpinion()
+        {
+            var converter = CreateConverter();
+
+            AssertRoundTrips(converter, typeof(TypeConverterTestsEnum));
+        }
+
+        [Fact]
+        public void TypeConverter_AllowsEnums_AsGenericArguments_WhenAllFiltersHaveNoOpinion()
+        {
+            var converter = CreateConverter();
+
+            AssertRoundTrips(converter, typeof(List<TypeConverterTestsEnum>));
+        }
+
+        [Fact]
+        public void TypeConverter_AllowsEnums_AsArrayElements_WhenAllFiltersHaveNoOpinion()
+        {
+            var converter = CreateConverter();
+
+            AssertRoundTrips(converter, typeof(TypeConverterTestsEnum[]));
+        }
+
+        [Fact]
+        public void TypeConverter_RejectsEnums_WhenATypeFilterExplicitlyDeniesThem()
+        {
+            var converter = CreateConverter(
+                typeFilters:
+                [
+                    new DelegateTypeFilter(type => type == typeof(TypeConverterTestsEnum) ? false : null)
+                ]);
+
+            AssertTypeNotAllowed(converter, typeof(TypeConverterTestsEnum));
+        }
+
+        [Fact]
         public void TypeConverter_AllowsMetadataRegisteredTypes()
         {
             var converter = CreateConverter(configureOptions: options => options.Activators.Add(typeof(TypeConverterTestsMetadataAllowedTypeActivator)));
@@ -251,6 +287,13 @@ namespace Orleans.Serialization.UnitTests
 
     internal sealed class TypeConverterTestsAliasedType
     {
+    }
+
+    internal enum TypeConverterTestsEnum
+    {
+        None,
+        First,
+        Second,
     }
 
     internal sealed class TypeConverterTestsCompoundAliasedType


### PR DESCRIPTION
The TypeConverter rewrite in 10.2.0 (#10032) split InspectType into a bool? core and a bool wrapper and changed the call sites from "throw on explicit deny" (== false) to "throw unless explicitly allowed". That flipped filter silence from allow to deny, so any enum that is not in TypeManifestOptions.AllowedTypes and matched by no filter now fails type validation, even though enums need no registration to round-trip.

Enums carry no behavior and are serialized through their underlying integral type, so they cannot act as deserialization gadgets. Treat a filter-silent enum as allowed while still honoring an explicit filter deny, which short-circuits before this check. Fixes #10227.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10234)