### PR TITLE
fix: clear stale message receiver cache for forwarded silo messages

### DIFF
--- a/src/Orleans.Core/Networking/Connection.cs
+++ b/src/Orleans.Core/Networking/Connection.cs
@@ -270,6 +270,8 @@ namespace Orleans.Runtime.Messaging
         protected abstract void OnReceivedMessage(Message message);
         protected abstract void OnSendMessageFailure(Message message, string error);
 
+        protected virtual bool ShouldSetMessageReceiver(Message message) => true;
+
         private async Task ProcessIncoming()
         {
             await Task.Yield();
@@ -297,7 +299,11 @@ namespace Orleans.Runtime.Messaging
                                 if (requiredBytes == 0)
                                 {
                                     Debug.Assert(message is not null);
-                                    message.MessageReceiver = this;
+                                    if (ShouldSetMessageReceiver(message))
+                                    {
+                                        message.MessageReceiver = this;
+                                    }
+
                                     RecordMessageReceive(message, bodyLength + headerLength, headerLength);
                                     var handler = MessageHandlerPool.Get();
                                     handler.Set(message, this);

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -432,6 +432,8 @@ namespace Orleans.Runtime.Messaging
         {
             if (!MayForward(message, this.messagingOptions)) return false;
 
+            // Clear the receiver cache so placement can find the correct destination.
+            message.MessageReceiver = null;
             message.ForwardCount = message.ForwardCount + 1;
             _messagingProcessingInstruments.OnDispatcherMessageForwared(message);
 

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -259,6 +259,20 @@ namespace Orleans.Runtime.Messaging
             return true;
         }
 
+        protected override bool ShouldSetMessageReceiver(Message message)
+        {
+            if (message.Direction is Message.Directions.Request or Message.Directions.OneWay
+                && message.SendingSilo is { } sendingSilo
+                && this.RemoteSiloAddress is { } remoteSiloAddress
+                && !remoteSiloAddress.Matches(sendingSilo))
+            {
+                // Avoid caching the previous-hop connection for forwarded messages.
+                return false;
+            }
+
+            return true;
+        }
+
         public void FailMessage(Message msg, string reason)
         {
             if (msg.IsPing())
@@ -310,6 +324,15 @@ namespace Orleans.Runtime.Messaging
 
         public override void ReceiveMessage(Message message, IMessageReceiverCache cache)
         {
+            if (message.TargetSilo is { } targetSilo
+                && this.RemoteSiloAddress is { } remoteSiloAddress
+                && !remoteSiloAddress.Matches(targetSilo))
+            {
+                cache.MessageReceiver = null;
+                this.messageCenter.SendMessage(message, receiverCache: null);
+                return;
+            }
+
             message.TargetSilo ??= this.RemoteSiloAddress;
             base.ReceiveMessage(message, cache);
         }


### PR DESCRIPTION
Forwarded silo messages can arrive over a previous-hop connection. The receive path cached that connection as the message receiver, so responses could reuse a stale route and trigger wrong-target connection warnings.

This change only caches inbound silo connections when they match the sender, clears receiver caches before forwarding/rerouting, and reroutes stale cached connections through normal target placement.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10235)