### PR TITLE
fix(streaming): use overflow-safe comparison for cached message sequence numbers

### DIFF
--- a/src/Orleans.Streaming/Common/PooledCache/CachedMessage.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/CachedMessage.cs
@@ -56,7 +56,7 @@ namespace Orleans.Providers.Streams.Common
         public static int Compare(this ref CachedMessage cachedMessage, StreamSequenceToken token)
         {
             return cachedMessage.SequenceNumber != token.SequenceNumber
-                ? (int)(cachedMessage.SequenceNumber - token.SequenceNumber)
+                ? cachedMessage.SequenceNumber.CompareTo(token.SequenceNumber)
                 : cachedMessage.EventIndex - token.EventIndex;
         }
 

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -348,6 +348,132 @@ namespace UnitTests.OrleansRuntime.Streams
             }
         }
 
+        /// <summary>
+        /// Sequence number gaps can exceed int.MaxValue: MemoryStreamQueueGrain seeds its counter
+        /// with DateTime.UtcNow.Ticks on every activation, so a queue grain deactivation moves the
+        /// numbering far ahead in a single step. Compare must not truncate the difference to 32 bits.
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void CompareHandlesSequenceNumberGapsLargerThanIntMaxValue()
+        {
+            // Gaps chosen so that the truncated 32 bit difference has the wrong sign or is zero.
+            var olderMessage = new CachedMessage { SequenceNumber = 100 };
+            Assert.True(olderMessage.Compare(new EventSequenceTokenV2(100L + int.MaxValue + 2)) < 0);
+            Assert.True(olderMessage.Compare(new EventSequenceTokenV2(100 + (1L << 32))) < 0);
+
+            var newerMessage = new CachedMessage { SequenceNumber = 100L + int.MaxValue + 2 };
+            Assert.True(newerMessage.Compare(new EventSequenceTokenV2(100)) > 0);
+
+            // Equal sequence numbers still compare by event index.
+            var message = new CachedMessage { SequenceNumber = 100, EventIndex = 1 };
+            Assert.True(message.Compare(new EventSequenceTokenV2(100, 0)) > 0);
+            Assert.True(message.Compare(new EventSequenceTokenV2(100, 2)) < 0);
+            Assert.Equal(0, message.Compare(new EventSequenceTokenV2(100, 1)));
+        }
+
+        /// <summary>
+        /// An idle cursor must see messages published after a sequence number jump larger than
+        /// int.MaxValue (e.g. the queue grain was deactivated and re-seeded its counter from
+        /// DateTime.UtcNow.Ticks). With an overflowing compare the new message looks older than
+        /// the cursor and delivery silently stalls.
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void IdleCursorContinuesAfterLargeSequenceNumberJump()
+        {
+            var bufferPool = new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(PooledBufferSize));
+            var dataAdapter = new TestCacheDataAdapter();
+            var cache = new PooledQueueCache(dataAdapter, NullLogger.Instance, null, null);
+            var evictionStrategy = new ChronologicalEvictionStrategy(NullLogger.Instance, new TimePurgePredicate(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(10)), null, null);
+            evictionStrategy.PurgeObservable = cache;
+            var converter = new CachedMessageConverter(bufferPool, evictionStrategy);
+
+            var stream = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
+            const long firstEpochSequenceNumber = 1000;
+            // Larger than int.MaxValue, chosen so the truncated 32 bit difference flips sign.
+            const long secondEpochSequenceNumber = firstEpochSequenceNumber + 5 + (3L << 30);
+
+            // Add messages from the first epoch and consume them all, leaving the cursor idle.
+            for (var i = 0; i < 5; i++)
+            {
+                EnqueueMessage(firstEpochSequenceNumber + i);
+            }
+            var cursor = cache.GetCursor(stream, new EventSequenceTokenV2(firstEpochSequenceNumber));
+            for (var i = 0; i < 5; i++)
+            {
+                Assert.True(cache.TryGetNextMessage(cursor, out _));
+            }
+            Assert.False(cache.TryGetNextMessage(cursor, out _));
+
+            // The queue grain is reactivated and its numbering jumps far ahead of the previous epoch.
+            EnqueueMessage(secondEpochSequenceNumber);
+
+            // The idle cursor should pick up the new message.
+            Assert.True(cache.TryGetNextMessage(cursor, out var container));
+            Assert.Equal(secondEpochSequenceNumber, container.SequenceToken.SequenceNumber);
+
+            void EnqueueMessage(long sequenceNumber)
+            {
+                var now = DateTime.UtcNow;
+                var msg = new TestQueueMessage
+                {
+                    StreamId = stream,
+                    SequenceNumber = sequenceNumber,
+                };
+                cache.Add(new List<CachedMessage>() { converter.ToCachedMessage(msg, now) }, now);
+            }
+        }
+
+        /// <summary>
+        /// A cursor placed at a token that sits after a sequence number jump larger than int.MaxValue
+        /// must start at that token. With an overflowing compare the token looks older than the oldest
+        /// cached message; because purge metadata exists, the cursor is then silently rewound to the
+        /// oldest cached message and the entire cache is re-delivered.
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void CursorNotRewoundToOldestMessageAfterLargeSequenceNumberJump()
+        {
+            var bufferPool = new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(PooledBufferSize));
+            var dataAdapter = new TestCacheDataAdapter();
+            var cache = new PooledQueueCache(dataAdapter, NullLogger.Instance, null, null, TimeSpan.FromSeconds(30));
+            var evictionStrategy = new ChronologicalEvictionStrategy(NullLogger.Instance, new TimePurgePredicate(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1)), null, null);
+            evictionStrategy.PurgeObservable = cache;
+            var converter = new CachedMessageConverter(bufferPool, evictionStrategy);
+
+            var stream = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
+            const long firstEpochSequenceNumber = 1000;
+            // Larger than int.MaxValue, chosen so the truncated 32 bit difference flips sign.
+            const long secondEpochSequenceNumber = firstEpochSequenceNumber + 1 + int.MaxValue + 3L;
+
+            // Add messages from the first epoch.
+            for (var i = 0; i < 5; i++)
+            {
+                EnqueueMessage(firstEpochSequenceNumber + i);
+            }
+
+            // Evict the oldest message so that purge metadata is recorded for the stream.
+            cache.RemoveOldestMessage();
+
+            // The queue grain is reactivated and its numbering jumps far ahead of the previous epoch.
+            EnqueueMessage(secondEpochSequenceNumber);
+
+            // A cursor for the new message must deliver that message only, not the whole cache.
+            var cursor = cache.GetCursor(stream, new EventSequenceTokenV2(secondEpochSequenceNumber));
+            Assert.True(cache.TryGetNextMessage(cursor, out var container));
+            Assert.Equal(secondEpochSequenceNumber, container.SequenceToken.SequenceNumber);
+            Assert.False(cache.TryGetNextMessage(cursor, out _));
+
+            void EnqueueMessage(long sequenceNumber)
+            {
+                var now = DateTime.UtcNow;
+                var msg = new TestQueueMessage
+                {
+                    StreamId = stream,
+                    SequenceNumber = sequenceNumber,
+                };
+                cache.Add(new List<CachedMessage>() { converter.ToCachedMessage(msg, now) }, now);
+            }
+        }
+
         private int RunGoldenPath(PooledQueueCache cache, CachedMessageConverter converter, int startOfCache)
         {
             int sequenceNumber = startOfCache;


### PR DESCRIPTION
Fixes #10246

## Problem

`CachedMessageExtensions.Compare` compares a cached message's sequence number to a token
by casting the 64-bit difference to `int`:

```csharp
? (int)(cachedMessage.SequenceNumber - token.SequenceNumber)
```

For gaps larger than `int.MaxValue` the truncated result has an arbitrary sign (or is `0`
for gaps that are multiples of 2^32), so the comparison silently returns the wrong
ordering.

Such gaps occur in practice with the in-box memory stream provider:
`MemoryStreamQueueGrain` seeds its sequence counter with `DateTime.UtcNow.Ticks` on every
activation, so a queue-grain deactivation/reactivation (silo crash, restart, migration)
moves the numbering forward by far more than 2^31 in a single step (2^31 ticks ≈ 3.6
minutes). When a pulling agent's cache holds messages from both sides of such a jump, the
corrupted comparison produces two failure modes in `PooledQueueCache`:

- **Silent delivery stall.** `SetCursor` treats new (post-jump) messages as older than an
  idle cursor's pre-jump token ("token too new to be in cache") and parks the cursor as
  `Unset`; delivery stops for every live subscriber with no exception and no log line.
- **Full-cache replay.** Placing a cursor at a post-jump token while the oldest cached
  message is pre-jump can take the "token too old" branch; because the purge-metadata gate
  in that branch uses a *correct* long comparison, the post-jump token passes it and the
  cursor is silently rewound to the oldest cached message, re-delivering the entire
  retained cache. Each replay pass then dies at the epoch boundary with a
  `QueueCacheMissException` whose token values are self-contradictory
  (`Low < Requested < High`), and a token-less re-subscribe starts the next pass. In one
  production incident this produced ~1.7M re-deliveries of a ~34.5k-message cache against
  ~7.2k genuine publishes, plus ~5.3k messages that were never delivered to any
  subscriber during the preceding stall.

## Solution

Use `long.CompareTo`, which is overflow-safe, instead of the truncating cast. This matches
the comparison semantics `EventSequenceTokenV2.CompareTo` already implements. Since the
memory provider's epoch bases are wall-clock ticks, they are monotonic across
reactivations, so a correct 64-bit comparison orders cross-epoch tokens properly — fixing
both failure modes. The `EventIndex` tiebreak is left as-is: it is an `int - int` on small
non-negative batch indices and cannot overflow.

Added regression tests to `PooledQueueCacheTests`:

- `CompareHandlesSequenceNumberGapsLargerThanIntMaxValue` — direct `Compare` checks across
  gaps that previously flipped sign (both directions) or collapsed to zero, plus the
  equal-sequence-number event-index tiebreak.
- `IdleCursorContinuesAfterLargeSequenceNumberJump` — an idle cursor must deliver a
  message published after a > int.MaxValue jump (previously: silent stall,
  `TryGetNextMessage` returned `false` forever).
- `CursorNotRewoundToOldestMessageAfterLargeSequenceNumberJump` — a cursor placed at a
  post-jump token must deliver only that message (previously: rewound to the oldest cached
  message and replayed the cache).

All three fail without the one-line fix and pass with it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10245)