### PR TITLE
perf: add span formatting for membership snapshots

### DIFF
--- a/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
+++ b/src/Orleans.Core.Abstractions/IDs/SiloAddress.cs
@@ -238,7 +238,7 @@ namespace Orleans.Runtime
         /// <returns>String representation of this SiloAddress.</returns>
         public override string ToString() => $"{this}";
 
-        string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => ToString();
+        string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => format == "H" ? ToStringWithHashCode() : ToString();
 
         bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
         {
@@ -248,7 +248,10 @@ namespace Orleans.Runtime
             if (format.Length == 1 && format[0] == 'H')
             {
                 if (!destination[charsWritten..].TryWrite($"/x{GetConsistentHashCode():X8}", out var len))
+                {
+                    charsWritten = 0;
                     return false;
+                }
 
                 charsWritten += len;
             }

--- a/src/Orleans.Core.Abstractions/Runtime/MembershipVersion.cs
+++ b/src/Orleans.Core.Abstractions/Runtime/MembershipVersion.cs
@@ -9,7 +9,7 @@ namespace Orleans.Runtime
     /// </summary>
     [Serializable, GenerateSerializer, Immutable]
     [JsonConverter(typeof(MembershipVersionConverter))]
-    public readonly struct MembershipVersion : IComparable<MembershipVersion>, IEquatable<MembershipVersion>
+    public readonly struct MembershipVersion : IComparable<MembershipVersion>, IEquatable<MembershipVersion>, ISpanFormattable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MembershipVersion"/> struct.
@@ -44,7 +44,29 @@ namespace Orleans.Runtime
         public override int GetHashCode() => this.Value.GetHashCode();
 
         /// <inheritdoc/>
-        public override string ToString() => Value != MinValue.Value ? $"{Value}" : "default";
+        public override string ToString() => Value != MinValue.Value ? Value.ToString() : "default";
+
+        /// <inheritdoc/>
+        string IFormattable.ToString(string? format, IFormatProvider? formatProvider)
+            => Value != MinValue.Value ? Value.ToString(format, formatProvider) : "default";
+
+        /// <inheritdoc/>
+        bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+        {
+            if (Value != MinValue.Value)
+            {
+                return Value.TryFormat(destination, out charsWritten, format, provider);
+            }
+
+            if ("default".AsSpan().TryCopyTo(destination))
+            {
+                charsWritten = "default".Length;
+                return true;
+            }
+
+            charsWritten = 0;
+            return false;
+        }
 
         /// <summary>
         /// Compares the provided operands for equality.

--- a/src/Orleans.Core/Runtime/MembershipTableSnapshot.cs
+++ b/src/Orleans.Core/Runtime/MembershipTableSnapshot.cs
@@ -10,7 +10,7 @@ namespace Orleans.Runtime
     /// Represents an immutable snapshot of cluster membership state.
     /// </summary>
     [GenerateSerializer, Immutable]
-    internal sealed class MembershipTableSnapshot
+    internal sealed class MembershipTableSnapshot : ISpanFormattable
     {
         private static readonly MembershipTableSnapshot InitialValue = new(MembershipVersion.MinValue, ImmutableDictionary<SiloAddress, MembershipEntry>.Empty);
 
@@ -198,6 +198,59 @@ namespace Orleans.Runtime
             foreach (var entry in this.Entries) sb.Append($", {entry.Value}");
             sb.Append(']');
             return sb.ToString();
+        }
+
+        string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => ToString();
+
+        bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+        {
+            var written = 0;
+
+            if (!destination.TryWrite($"[Version: {this.Version}, {this.Entries.Count} silos", out var length))
+            {
+                goto fail;
+            }
+
+            Advance(ref destination, ref written, length);
+
+            foreach (var entry in this.Entries)
+            {
+                if (!destination.TryWrite($", {entry.Value}", out length))
+                {
+                    goto fail;
+                }
+
+                Advance(ref destination, ref written, length);
+            }
+
+            if (!Append(ref destination, ref written, "]"))
+            {
+                goto fail;
+            }
+
+            charsWritten = written;
+            return true;
+
+        fail:
+            charsWritten = 0;
+            return false;
+
+            static bool Append(ref Span<char> destination, ref int written, ReadOnlySpan<char> value)
+            {
+                if (!value.TryCopyTo(destination))
+                {
+                    return false;
+                }
+
+                Advance(ref destination, ref written, value.Length);
+                return true;
+            }
+
+            static void Advance(ref Span<char> destination, ref int written, int length)
+            {
+                destination = destination[length..];
+                written += length;
+            }
         }
     }
 }

--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
@@ -249,7 +249,7 @@ namespace Orleans
 
     [GenerateSerializer]
     [Serializable]
-    public sealed class MembershipEntry
+    public sealed class MembershipEntry : ISpanFormattable
     {
         /// <summary>
         /// The silo unique identity (ip:port:epoch). Used mainly by the Membership Protocol.
@@ -427,6 +427,11 @@ namespace Orleans
         }
 
         public override string ToString() => $"SiloAddress={SiloAddress} SiloName={SiloName} Status={Status}";
+
+        string IFormattable.ToString(string format, IFormatProvider formatProvider) => ToString();
+
+        bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider)
+            => destination.TryWrite($"SiloAddress={SiloAddress} SiloName={SiloName} Status={Status}", out charsWritten);
 
         public string ToFullString()
         {

--- a/src/Orleans.Runtime/MembershipService/ClusterMember.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMember.cs
@@ -7,7 +7,7 @@ namespace Orleans.Runtime
     /// Represents a cluster member.
     /// </summary>
     [Serializable, GenerateSerializer, Immutable]
-    public sealed class ClusterMember : IEquatable<ClusterMember>
+    public sealed class ClusterMember : IEquatable<ClusterMember>, ISpanFormattable
     {                
         /// <summary>
         /// Initializes a new instance of the <see cref="ClusterMember"/> class.
@@ -63,5 +63,10 @@ namespace Orleans.Runtime
 
         /// <inheritdoc/>
         public override string ToString() => $"{this.SiloAddress}/{this.Name}/{this.Status}";
+
+        string IFormattable.ToString(string format, IFormatProvider formatProvider) => ToString();
+
+        bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider)
+            => destination.TryWrite($"{this.SiloAddress}/{this.Name}/{this.Status}", out charsWritten);
     }
 }

--- a/src/Orleans.Runtime/MembershipService/ClusterMembershipSnapshot.cs
+++ b/src/Orleans.Runtime/MembershipService/ClusterMembershipSnapshot.cs
@@ -9,7 +9,7 @@ namespace Orleans.Runtime
     /// Represents a snapshot of cluster membership.
     /// </summary>
     [Serializable, GenerateSerializer, Immutable]
-    public sealed class ClusterMembershipSnapshot
+    public sealed class ClusterMembershipSnapshot : ISpanFormattable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClusterMembershipSnapshot"/> class.
@@ -135,11 +135,74 @@ namespace Orleans.Runtime
                     sb.Append(", ");
                 }
 
-                sb.Append(member.Value);
+                sb.Append($"{member.Value}");
             }
 
             sb.Append("] }}");
             return sb.ToString();
+        }
+
+        string IFormattable.ToString(string format, IFormatProvider formatProvider) => ToString();
+
+        bool ISpanFormattable.TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider)
+        {
+            var written = 0;
+
+            if (!destination.TryWrite($"ClusterMembershipSnapshot {{ Version = {this.Version}, Members.Count = {this.Members.Count}, Members = [", out var length))
+            {
+                goto fail;
+            }
+
+            Advance(ref destination, ref written, length);
+
+            var first = true;
+            foreach (var member in this.Members)
+            {
+                if (first)
+                {
+                    first = false;
+                }
+                else if (!Append(ref destination, ref written, ", "))
+                {
+                    goto fail;
+                }
+
+                if (!destination.TryWrite($"{member.Value}", out length))
+                {
+                    goto fail;
+                }
+
+                Advance(ref destination, ref written, length);
+            }
+
+            if (!Append(ref destination, ref written, "] }}"))
+            {
+                goto fail;
+            }
+
+            charsWritten = written;
+            return true;
+
+        fail:
+            charsWritten = 0;
+            return false;
+
+            static bool Append(ref Span<char> destination, ref int written, ReadOnlySpan<char> value)
+            {
+                if (!value.TryCopyTo(destination))
+                {
+                    return false;
+                }
+
+                Advance(ref destination, ref written, value.Length);
+                return true;
+            }
+
+            static void Advance(ref Span<char> destination, ref int written, int length)
+            {
+                destination = destination[length..];
+                written += length;
+            }
         }
     }
 }

--- a/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
+++ b/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
@@ -2737,7 +2737,7 @@ namespace Orleans.Runtime
     [GenerateSerializer]
     [Immutable]
     [System.Text.Json.Serialization.JsonConverter(typeof(MembershipVersionConverter))]
-    public readonly partial struct MembershipVersion : System.IComparable<MembershipVersion>, System.IEquatable<MembershipVersion>
+    public readonly partial struct MembershipVersion : System.IComparable<MembershipVersion>, System.IEquatable<MembershipVersion>, System.ISpanFormattable, System.IFormattable
     {
         private readonly int _dummyPrimitive;
         public MembershipVersion(long version) { }
@@ -2766,6 +2766,10 @@ namespace Orleans.Runtime
         public static bool operator <(MembershipVersion left, MembershipVersion right) { throw null; }
 
         public static bool operator <=(MembershipVersion left, MembershipVersion right) { throw null; }
+
+        string System.IFormattable.ToString(string? format, System.IFormatProvider? formatProvider) { throw null; }
+
+        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider? provider) { throw null; }
 
         public override readonly string ToString() { throw null; }
     }

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -245,7 +245,7 @@ namespace Orleans
     }
 
     [GenerateSerializer]
-    public sealed partial class MembershipEntry
+    public sealed partial class MembershipEntry : System.ISpanFormattable, System.IFormattable
     {
         [Id(8)]
         public int FaultZone { get { throw null; } set { } }
@@ -283,6 +283,10 @@ namespace Orleans
         public void AddOrUpdateSuspector(Runtime.SiloAddress localSilo, System.DateTime voteTime, int maxVotes) { }
 
         public void AddSuspector(Runtime.SiloAddress suspectingSilo, System.DateTime suspectingTime) { }
+
+        string System.IFormattable.ToString(string format, System.IFormatProvider formatProvider) { throw null; }
+
+        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider provider) { throw null; }
 
         public string ToFullString() { throw null; }
 

--- a/src/api/Orleans.Runtime/Orleans.Runtime.cs
+++ b/src/api/Orleans.Runtime/Orleans.Runtime.cs
@@ -506,7 +506,7 @@ namespace Orleans.Runtime
 {
     [GenerateSerializer]
     [Immutable]
-    public sealed partial class ClusterMember : System.IEquatable<ClusterMember>
+    public sealed partial class ClusterMember : System.IEquatable<ClusterMember>, System.ISpanFormattable, System.IFormattable
     {
         public ClusterMember(SiloAddress siloAddress, SiloStatus status, string name) { }
 
@@ -525,12 +525,16 @@ namespace Orleans.Runtime
 
         public override int GetHashCode() { throw null; }
 
+        string System.IFormattable.ToString(string format, System.IFormatProvider formatProvider) { throw null; }
+
+        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider provider) { throw null; }
+
         public override string ToString() { throw null; }
     }
 
     [GenerateSerializer]
     [Immutable]
-    public sealed partial class ClusterMembershipSnapshot
+    public sealed partial class ClusterMembershipSnapshot : System.ISpanFormattable, System.IFormattable
     {
         public ClusterMembershipSnapshot(System.Collections.Immutable.ImmutableDictionary<SiloAddress, ClusterMember> members, MembershipVersion version) { }
 
@@ -547,6 +551,10 @@ namespace Orleans.Runtime
         public SiloStatus GetSiloStatus(SiloAddress silo, MembershipVersion seenAtVersion) { throw null; }
 
         public SiloStatus GetSiloStatus(SiloAddress silo) { throw null; }
+
+        string System.IFormattable.ToString(string format, System.IFormatProvider formatProvider) { throw null; }
+
+        bool System.ISpanFormattable.TryFormat(System.Span<char> destination, out int charsWritten, System.ReadOnlySpan<char> format, System.IFormatProvider provider) { throw null; }
 
         public override string ToString() { throw null; }
     }

--- a/test/Orleans.Core.Tests/Membership/MembershipTableSnapshotTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableSnapshotTests.cs
@@ -96,6 +96,20 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(SiloStatus.Dead, snapshot.GetSiloStatus(unknownSilo));
         }
 
+        [Fact]
+        public void MembershipTableSnapshot_TryFormat_MatchesToString()
+        {
+            var silo = Silo("127.0.0.1:100@1");
+            var snapshot = MembershipTableSnapshot.Create(Table(Entry(silo, SiloStatus.Active)));
+
+            AssertSpanFormattable(snapshot);
+            AssertSpanFormattable(snapshot.Version);
+            AssertSpanFormattable(snapshot.Entries[silo]);
+            AssertSpanFormattable(silo);
+            AssertSpanFormattable(silo, "H");
+            AssertSpanFormattable(MembershipVersion.MinValue);
+        }
+
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
 
         private static MembershipEntry Entry(SiloAddress address, SiloStatus status, DateTimeOffset iAmAliveTime = default)
@@ -125,6 +139,24 @@ namespace NonSilo.Tests.Membership
             }
 
             return new MembershipTableSnapshot(table.Version, entries.ToImmutable());
+        }
+
+        private static void AssertSpanFormattable(ISpanFormattable value, string format = null)
+        {
+            var expected = value.ToString(format, null);
+            var formatSpan = format is null ? default : format.AsSpan();
+            Span<char> destination = stackalloc char[expected.Length];
+
+            Assert.True(value.TryFormat(destination, out var charsWritten, formatSpan, null));
+            Assert.Equal(expected.Length, charsWritten);
+            Assert.Equal(expected, destination[..charsWritten].ToString());
+
+            if (expected.Length > 0)
+            {
+                Span<char> tooSmall = stackalloc char[expected.Length - 1];
+                Assert.False(value.TryFormat(tooSmall, out charsWritten, formatSpan, null));
+                Assert.Equal(0, charsWritten);
+            }
         }
 
     }

--- a/test/Orleans.Runtime.Internal.Tests/ClusterMembershipSnapshotTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ClusterMembershipSnapshotTests.cs
@@ -40,9 +40,38 @@ public class ClusterMembershipSnapshotTests
         Assert.Equal(SiloStatus.Dead, snapshot.GetSiloStatus(silo, new MembershipVersion(2)));
     }
 
+    [Fact]
+    public void ClusterMembershipSnapshot_TryFormat_MatchesToString()
+    {
+        var member = new ClusterMember(CreateSiloAddress(1), SiloStatus.Active, "silo");
+        var snapshot = CreateSnapshot(member, version: 2);
+
+        AssertSpanFormattable(snapshot);
+        AssertSpanFormattable(snapshot.Version);
+        AssertSpanFormattable(member);
+        AssertSpanFormattable(member.SiloAddress);
+    }
+
     private static ClusterMembershipSnapshot CreateSnapshot(ClusterMember member, long version)
         => new(ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(member.SiloAddress, member), new MembershipVersion(version));
 
     private static SiloAddress CreateSiloAddress(int generation, int port = 11111)
         => SiloAddress.New(new IPEndPoint(IPAddress.Loopback, port), generation);
+
+    private static void AssertSpanFormattable(ISpanFormattable value)
+    {
+        var expected = value.ToString(null, null);
+        Span<char> destination = stackalloc char[expected.Length];
+
+        Assert.True(value.TryFormat(destination, out var charsWritten, default, null));
+        Assert.Equal(expected.Length, charsWritten);
+        Assert.Equal(expected, destination[..charsWritten].ToString());
+
+        if (expected.Length > 0)
+        {
+            Span<char> tooSmall = stackalloc char[expected.Length - 1];
+            Assert.False(value.TryFormat(tooSmall, out charsWritten, default, null));
+            Assert.Equal(0, charsWritten);
+        }
+    }
 }


### PR DESCRIPTION
Membership snapshots are rendered in diagnostic and logging paths, but the existing formatting relied on string-building and interpolation through nested member values. This adds span-based formatting so callers can format snapshots and their member/version values without unnecessary intermediate strings.

This change implements `ISpanFormattable`/`IFormattable` for `MembershipTableSnapshot`, `ClusterMembershipSnapshot`, `MembershipEntry`, `ClusterMember`, and `MembershipVersion`, while preserving the existing string output. It also tightens `SiloAddress` formatting so the existing `H` format is honored through `IFormattable` and failed span writes report zero characters written.

The public API baselines and targeted coverage were updated to match the new interfaces and verify span formatting remains equivalent to `ToString()`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10248)