### PR TITLE
fix: use explicit address equality

### DIFF
--- a/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
+++ b/src/Orleans.Core/Networking/Shared/SocketConnectionListener.cs
@@ -62,7 +62,7 @@ namespace Orleans.Networking.Shared
             listenSocket.EnableFastPath();
 
             // Kestrel expects IPv6Any to bind to both IPv6 and IPv4
-            if (EndPoint is IPEndPoint ip && ip.Address == IPAddress.IPv6Any)
+            if (EndPoint is IPEndPoint ip && Equals(ip.Address, IPAddress.IPv6Any))
             {
                 listenSocket.DualMode = true;
             }

--- a/src/Orleans.Core/Placement/Repartitioning/IActivationRepartitionerSystemTarget.cs
+++ b/src/Orleans.Core/Placement/Repartitioning/IActivationRepartitionerSystemTarget.cs
@@ -97,7 +97,7 @@ public readonly struct EdgeVertex(
     public static bool operator !=(EdgeVertex left, EdgeVertex right) => !left.Equals(right);
 
     public override bool Equals([NotNullWhen(true)] object obj) => obj is EdgeVertex other && Equals(other);
-    public bool Equals(EdgeVertex other) => Id == other.Id && Silo == other.Silo && IsMigratable == other.IsMigratable;
+    public bool Equals(EdgeVertex other) => Id == other.Id && Silo.Equals(other.Silo) && IsMigratable == other.IsMigratable;
 
     public override int GetHashCode() => HashCode.Combine(Id, Silo, IsMigratable);
 

--- a/src/Orleans.Runtime/Diagnostics/DeploymentLoadPublisherEvents.cs
+++ b/src/Orleans.Runtime/Diagnostics/DeploymentLoadPublisherEvents.cs
@@ -158,7 +158,7 @@ public static class DeploymentLoadPublisherEvents
 
     internal static void EmitReceived(SiloAddress sourceSiloAddress, SiloAddress observerSiloAddress, SiloRuntimeStatistics statistics)
     {
-        if (sourceSiloAddress == observerSiloAddress
+        if (sourceSiloAddress.Equals(observerSiloAddress)
             || !Listener.IsEnabled(nameof(Received)))
         {
             return;

--- a/src/Orleans.Runtime/Hosting/EndpointOptions.cs
+++ b/src/Orleans.Runtime/Hosting/EndpointOptions.cs
@@ -28,10 +28,10 @@ namespace Orleans.Configuration
                         + $"to configure endpoints and ensure that {nameof(AdvertisedIPAddress)} is set.");
                 }
 
-                if (value == IPAddress.Any
-                    || value == IPAddress.IPv6Any
-                    || value == IPAddress.None
-                    || value == IPAddress.IPv6None)
+                if (Equals(value, IPAddress.Any)
+                    || Equals(value, IPAddress.IPv6Any)
+                    || Equals(value, IPAddress.None)
+                    || Equals(value, IPAddress.IPv6None))
                 {
                     throw new OrleansConfigurationException(
                         $"Invalid value specified for {nameof(AdvertisedIPAddress)}. The value was {value}");
@@ -76,13 +76,13 @@ namespace Orleans.Configuration
         public const int DEFAULT_GATEWAY_PORT = 30000;
 
         /// <summary>
-        /// Gets or sets the endpoint used to listen for silo to silo communication. 
+        /// Gets or sets the endpoint used to listen for silo to silo communication.
         /// If not set will default to <see cref="AdvertisedIPAddress"/> + <see cref="SiloPort"/>
         /// </summary>
         public IPEndPoint SiloListeningEndpoint { get; set; }
 
         /// <summary>
-        /// Gets or sets the endpoint used to listen for client to silo communication. 
+        /// Gets or sets the endpoint used to listen for client to silo communication.
         /// If not set will default to <see cref="AdvertisedIPAddress"/> + <see cref="GatewayPort"/>
         /// </summary>
         public IPEndPoint GatewayListeningEndpoint { get; set; }

--- a/src/Orleans.Runtime/Networking/SiloConnectionMaintainer.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnectionMaintainer.cs
@@ -43,7 +43,7 @@ namespace Orleans.Runtime.Messaging
 
         public void SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status)
         {
-            if (status == SiloStatus.Dead && updatedSilo != siloStatusOracle.SiloAddress)
+            if (status == SiloStatus.Dead && !updatedSilo.Equals(siloStatusOracle.SiloAddress))
             {
                 this.runtimeClient.BreakOutstandingMessagesToSilo(updatedSilo);
                 _ = Task.Run(() => this.CloseConnectionAsync(updatedSilo));

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -114,7 +114,7 @@ namespace Orleans.Runtime
                 foreach (var siloAddress in members)
                 {
                     // No need to make a grain call to ourselves.
-                    if (siloAddress == _siloDetails.SiloAddress)
+                    if (siloAddress.Equals(_siloDetails.SiloAddress))
                     {
                         continue;
                     }

--- a/src/Orleans.Runtime/Placement/Rebalancing/ActivationRebalancerMonitor.cs
+++ b/src/Orleans.Runtime/Placement/Rebalancing/ActivationRebalancerMonitor.cs
@@ -74,7 +74,7 @@ internal sealed partial class ActivationRebalancerMonitor : SystemTarget, IActiv
             _monitorTimer = RegisterGrainTimer(async ct =>
             {
                 var elapsedSinceHeartbeat = _timeProvider.GetElapsedTime(_lastHeartbeatTimestamp);
-                var shouldFetchReport = _latestReport.Host == SiloAddress.Zero ||
+                var shouldFetchReport = SiloAddress.Zero.Equals(_latestReport.Host) ||
                     elapsedSinceHeartbeat >= IActivationRebalancerMonitor.WorkerReportPeriod;
 
                 if (shouldFetchReport)

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/PlacementDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/PlacementDiagnosticObserver.cs
@@ -76,7 +76,7 @@ public sealed class PlacementDiagnosticObserver : IDisposable, IObserver<Deploym
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
         using var cts = new CancellationTokenSource(effectiveTimeout);
 
-        var existingMatch = _publishedEvents.FirstOrDefault(e => e.SiloAddress == siloAddress);
+        var existingMatch = _publishedEvents.FirstOrDefault(e => e.SiloAddress.Equals(siloAddress));
         if (existingMatch is not null)
         {
             return existingMatch;
@@ -93,7 +93,7 @@ public sealed class PlacementDiagnosticObserver : IDisposable, IObserver<Deploym
                 break;
             }
 
-            var match = _publishedEvents.FirstOrDefault(e => e.SiloAddress == siloAddress);
+            var match = _publishedEvents.FirstOrDefault(e => e.SiloAddress.Equals(siloAddress));
             if (match is not null)
             {
                 return match;
@@ -114,7 +114,7 @@ public sealed class PlacementDiagnosticObserver : IDisposable, IObserver<Deploym
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
         using var cts = new CancellationTokenSource(effectiveTimeout);
 
-        var existingMatch = _clusterRefreshedEvents.FirstOrDefault(e => e.SiloAddress == siloAddress);
+        var existingMatch = _clusterRefreshedEvents.FirstOrDefault(e => e.SiloAddress.Equals(siloAddress));
         if (existingMatch is not null)
         {
             return existingMatch;
@@ -131,7 +131,7 @@ public sealed class PlacementDiagnosticObserver : IDisposable, IObserver<Deploym
                 break;
             }
 
-            var match = _clusterRefreshedEvents.FirstOrDefault(e => e.SiloAddress == siloAddress);
+            var match = _clusterRefreshedEvents.FirstOrDefault(e => e.SiloAddress.Equals(siloAddress));
             if (match is not null)
             {
                 return match;
@@ -189,7 +189,7 @@ public sealed class PlacementDiagnosticObserver : IDisposable, IObserver<Deploym
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
         using var cts = new CancellationTokenSource(effectiveTimeout);
 
-        var existingMatch = _receivedEvents.FirstOrDefault(e => e.FromSilo == fromSilo && e.ReceiverSilo == receiverSilo);
+        var existingMatch = _receivedEvents.FirstOrDefault(e => e.FromSilo.Equals(fromSilo) && e.ReceiverSilo.Equals(receiverSilo));
         if (existingMatch is not null)
         {
             return existingMatch;
@@ -206,7 +206,7 @@ public sealed class PlacementDiagnosticObserver : IDisposable, IObserver<Deploym
                 break;
             }
 
-            var match = _receivedEvents.FirstOrDefault(e => e.FromSilo == fromSilo && e.ReceiverSilo == receiverSilo);
+            var match = _receivedEvents.FirstOrDefault(e => e.FromSilo.Equals(fromSilo) && e.ReceiverSilo.Equals(receiverSilo));
             if (match is not null)
             {
                 return match;
@@ -295,7 +295,7 @@ public sealed class PlacementDiagnosticObserver : IDisposable, IObserver<Deploym
     /// <returns>The count of refresh events.</returns>
     public int GetClusterRefreshCount(SiloAddress siloAddress)
     {
-        return _clusterRefreshedEvents.Count(e => e.SiloAddress == siloAddress);
+        return _clusterRefreshedEvents.Count(e => e.SiloAddress.Equals(siloAddress));
     }
 
     /// <summary>


### PR DESCRIPTION
Some address comparisons can bind to an unintended equality overload when written with == or !=. Use explicit Equals calls for IPAddress and SiloAddress comparisons across networking, placement, and diagnostics.

This PR is stacked on https://github.com/dotnet/orleans/pull/10256 so the commits appear in the same order as the dissemination branch; merge the parsing PR first.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10257)