### PR TITLE
fix(reminders): fix scheduling for long due times

### DIFF
--- a/src/Orleans.Core/Utils/TimeProviderExtensions.cs
+++ b/src/Orleans.Core/Utils/TimeProviderExtensions.cs
@@ -1,0 +1,30 @@
+namespace Orleans.Internal;
+
+internal static class TimeProviderExtensions
+{
+    private static readonly TimeSpan MaximumTimerDelay = TimeSpan.FromMilliseconds(0xfffffffe);
+
+    public static async Task DelayUntilAsync(
+        this TimeProvider timeProvider,
+        DateTimeOffset dueTime,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var remaining = dueTime - timeProvider.GetUtcNow();
+            if (remaining <= TimeSpan.Zero)
+            {
+                return;
+            }
+
+            // Task.Delay cannot represent delays beyond approximately 49.7 days. Waiting in bounded
+            // chunks preserves the absolute deadline without imposing that limit on callers.
+            await Task.Delay(
+                remaining > MaximumTimerDelay ? MaximumTimerDelay : remaining,
+                timeProvider,
+                cancellationToken);
+        }
+    }
+}

--- a/src/Orleans.Core/Utils/TimeProviderExtensions.cs
+++ b/src/Orleans.Core/Utils/TimeProviderExtensions.cs
@@ -4,6 +4,31 @@ internal static class TimeProviderExtensions
 {
     private static readonly TimeSpan MaximumTimerDelay = TimeSpan.FromMilliseconds(0xfffffffe);
 
+    public static async Task DelayAsync(
+        this TimeProvider timeProvider,
+        TimeSpan delay,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentOutOfRangeException.ThrowIfLessThan(delay, TimeSpan.Zero);
+        var startTimestamp = timeProvider.GetTimestamp();
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var elapsed = timeProvider.GetElapsedTime(startTimestamp);
+            if (elapsed >= delay)
+            {
+                return;
+            }
+
+            var remaining = delay - elapsed;
+            await Task.Delay(
+                remaining > MaximumTimerDelay ? MaximumTimerDelay : remaining,
+                timeProvider,
+                cancellationToken);
+        }
+    }
+
     public static async Task DelayUntilAsync(
         this TimeProvider timeProvider,
         DateTimeOffset dueTime,

--- a/src/Orleans.Core/Utils/TimeProviderExtensions.cs
+++ b/src/Orleans.Core/Utils/TimeProviderExtensions.cs
@@ -10,6 +10,12 @@ internal static class TimeProviderExtensions
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
+        if (delay == Timeout.InfiniteTimeSpan)
+        {
+            await Task.Delay(delay, timeProvider, cancellationToken);
+            return;
+        }
+
         ArgumentOutOfRangeException.ThrowIfLessThan(delay, TimeSpan.Zero);
         var startTimestamp = timeProvider.GetTimestamp();
         while (true)

--- a/src/Orleans.Reminders/Diagnostics/ReminderEvents.cs
+++ b/src/Orleans.Reminders/Diagnostics/ReminderEvents.cs
@@ -108,6 +108,11 @@ public static class ReminderEvents
     {
         Unknown = 0,
         Unregistered = 1,
+        /// <summary>
+        /// Unused. Retained for compatibility.
+        /// </summary>
+        [Obsolete("Unused, will be removed in a future version.")]
+        Replaced = 2,
         RemovedFromRange = 3,
         RemovedFromTable = 4,
         ServiceStopped = 5,

--- a/src/Orleans.Reminders/Diagnostics/ReminderEvents.cs
+++ b/src/Orleans.Reminders/Diagnostics/ReminderEvents.cs
@@ -108,7 +108,6 @@ public static class ReminderEvents
     {
         Unknown = 0,
         Unregistered = 1,
-        Replaced = 2,
         RemovedFromRange = 3,
         RemovedFromTable = 4,
         ServiceStopped = 5,

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -763,7 +763,6 @@ namespace Orleans.Runtime.ReminderService
             private readonly object _lock = new();
 #endif
             private ReminderEntry _entry;
-            private CancellationTokenSource _scheduleChangedCancellation = new();
             private bool _isFirstTickPending;
             private long _scheduleVersion;
 
@@ -852,7 +851,6 @@ namespace Orleans.Runtime.ReminderService
                 ArgumentNullException.ThrowIfNull(entry);
 
                 long scheduleVersion;
-                CancellationTokenSource scheduleChangedCancellation;
                 IAsyncTimer timerToDispose;
                 lock (_lock)
                 {
@@ -866,12 +864,9 @@ namespace Orleans.Runtime.ReminderService
                     timerToDispose = _timer;
                     _timer = CreateTimer(entry);
                     scheduleVersion = ++_scheduleVersion;
-                    scheduleChangedCancellation = _scheduleChangedCancellation;
-                    _scheduleChangedCancellation = new();
                 }
 
                 ReminderEvents.EmitLocalReminderScheduleChanged(entry.GrainId, entry.ReminderName, this, scheduleVersion, _shared.Silo);
-                scheduleChangedCancellation.Cancel();
                 timerToDispose.Dispose();
             }
 
@@ -879,7 +874,6 @@ namespace Orleans.Runtime.ReminderService
             {
                 ReminderEntry entry;
                 IAsyncTimer timerToDispose;
-                CancellationTokenSource scheduleChangedCancellation;
                 Task? runTask;
                 lock (_lock)
                 {
@@ -890,12 +884,10 @@ namespace Orleans.Runtime.ReminderService
                     }
 
                     timerToDispose = _timer;
-                    scheduleChangedCancellation = _scheduleChangedCancellation;
                     runTask = _runTask;
                 }
 
                 _shared.LogDebugStoppingReminder(entry, reason);
-                scheduleChangedCancellation.Cancel();
                 timerToDispose.Dispose();
                 return runTask ?? Task.CompletedTask;
             }
@@ -976,9 +968,8 @@ namespace Orleans.Runtime.ReminderService
             {
                 while (true)
                 {
-                    TimeSpan? overrideDelay;
+                    TimeSpan overrideDelay;
                     IAsyncTimer timer;
-                    CancellationToken scheduleChangedToken;
                     GrainId grainId;
                     string reminderName;
                     long scheduleVersion;
@@ -991,27 +982,33 @@ namespace Orleans.Runtime.ReminderService
 
                         _isFirstTickPending = false;
                         overrideDelay = GetInitialDueTime(_entry);
-
                         timer = _timer;
-                        scheduleChangedToken = _scheduleChangedCancellation.Token;
                         grainId = _entry.GrainId;
                         reminderName = _entry.ReminderName;
                         scheduleVersion = _scheduleVersion;
                     }
 
                     var nextTick = timer.NextTick(overrideDelay);
-                    if (!scheduleChangedToken.IsCancellationRequested)
+                    if (IsCurrentSchedule(timer))
                     {
                         ReminderEvents.EmitLocalReminderTickWaitArmed(grainId, reminderName, this, scheduleVersion, _shared.Silo);
                     }
 
                     var result = await nextTick;
-                    if (!result && scheduleChangedToken.IsCancellationRequested)
+                    if (!result && !IsCurrentSchedule(timer))
                     {
                         continue;
                     }
 
                     return result;
+                }
+            }
+
+            private bool IsCurrentSchedule(IAsyncTimer timer)
+            {
+                lock (_lock)
+                {
+                    return _stopReason == (int)ReminderEvents.LocalReminderStopReason.Unknown && ReferenceEquals(timer, _timer);
                 }
             }
 

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -748,6 +748,11 @@ namespace Orleans.Runtime.ReminderService
             return dueTimeSpan;
         }
 
+        internal static DateTime CalculateNextDueTime(DateTime now, TimeSpan period)
+        {
+            return period <= DateTime.MaxValue - now ? now.Add(period) : DateTime.MaxValue;
+        }
+
         private sealed class LocalReminderData
         {
             private readonly LocalReminderService _shared;
@@ -931,7 +936,7 @@ namespace Orleans.Runtime.ReminderService
                                 {
                                     var after = _shared._timeProvider.GetUtcNow().UtcDateTime;
                                     var elapsed = after - before;
-                                    LogTraceTickTriggered(_shared.logger, this, elapsed.TotalSeconds, after + entry.Period);
+                                    LogTraceTickTriggered(_shared.logger, this, elapsed.TotalSeconds, CalculateNextDueTime(after, entry.Period));
                                 }
 
                                 ReminderEvents.EmitTickCompleted(entry.GrainId, entry.ReminderName, status, _shared.Silo);
@@ -940,7 +945,7 @@ namespace Orleans.Runtime.ReminderService
                             catch (Exception exc)
                             {
                                 var after = _shared._timeProvider.GetUtcNow().UtcDateTime;
-                                LogErrorDeliveringReminderTick(_shared.logger, this, after + entry.Period, exc);
+                                LogErrorDeliveringReminderTick(_shared.logger, this, CalculateNextDueTime(after, entry.Period), exc);
                                 ReminderEvents.EmitTickFailed(entry.GrainId, entry.ReminderName, status, exc, _shared.Silo);
 
                                 // What to do with repeated failures to deliver a reminder's ticks?
@@ -984,15 +989,8 @@ namespace Orleans.Runtime.ReminderService
                             return false;
                         }
 
-                        if (_isFirstTickPending)
-                        {
-                            _isFirstTickPending = false;
-                            overrideDelay = GetInitialDueTime(_entry);
-                        }
-                        else
-                        {
-                            overrideDelay = null;
-                        }
+                        _isFirstTickPending = false;
+                        overrideDelay = GetInitialDueTime(_entry);
 
                         timer = _timer;
                         scheduleChangedToken = _scheduleChangedCancellation.Token;

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -1008,7 +1008,9 @@ namespace Orleans.Runtime.ReminderService
                     {
                         if (initialDueTime is { } delay)
                         {
-                            var delayTask = Task.Delay(delay, _shared._timeProvider, waitCancellation.Token);
+                            var delayTask = _shared._timeProvider.DelayUntilAsync(
+                                _shared._timeProvider.GetUtcNow() + delay,
+                                waitCancellation.Token);
                             if (!scheduleChangedToken.IsCancellationRequested && !_stopCancellation.IsCancellationRequested)
                             {
                                 ReminderEvents.EmitLocalReminderTickWaitArmed(grainId, reminderName, this, scheduleVersion, _shared.Silo);

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -739,7 +739,7 @@ namespace Orleans.Runtime.ReminderService
                 dueTimeSpan = TimeSpan.FromTicks(dueTimeSpan.Ticks % entry.Period.Ticks);
             }
 
-            // PeriodicTimer requires a positive period, so clamp immediate ticks to a small positive delay.
+            // AsyncTimer requires a positive delay, so clamp immediate ticks to a small positive delay.
             if (dueTimeSpan < MinimumReminderDueTime)
             {
                 dueTimeSpan = MinimumReminderDueTime;
@@ -751,8 +751,7 @@ namespace Orleans.Runtime.ReminderService
         private sealed class LocalReminderData
         {
             private readonly LocalReminderService _shared;
-            private PeriodicTimer? _timer;
-            private readonly CancellationTokenSource _stopCancellation = new();
+            private IAsyncTimer _timer;
 #if NET10_0_OR_GREATER
             private readonly System.Threading.Lock _lock = new();
 #else
@@ -773,6 +772,7 @@ namespace Orleans.Runtime.ReminderService
                 _entry = entry;
                 _localSequenceNumber = -1;
                 _isFirstTickPending = true;
+                _timer = CreateTimer(entry);
             }
 
             public ReminderEntry Entry
@@ -848,7 +848,7 @@ namespace Orleans.Runtime.ReminderService
 
                 long scheduleVersion;
                 CancellationTokenSource scheduleChangedCancellation;
-                PeriodicTimer? timerToDispose;
+                IAsyncTimer timerToDispose;
                 lock (_lock)
                 {
                     if (_entry.GrainId != entry.GrainId || !StringComparer.Ordinal.Equals(_entry.ReminderName, entry.ReminderName))
@@ -859,7 +859,7 @@ namespace Orleans.Runtime.ReminderService
                     _entry = entry;
                     _isFirstTickPending = true;
                     timerToDispose = _timer;
-                    _timer = null;
+                    _timer = CreateTimer(entry);
                     scheduleVersion = ++_scheduleVersion;
                     scheduleChangedCancellation = _scheduleChangedCancellation;
                     _scheduleChangedCancellation = new();
@@ -867,13 +867,13 @@ namespace Orleans.Runtime.ReminderService
 
                 ReminderEvents.EmitLocalReminderScheduleChanged(entry.GrainId, entry.ReminderName, this, scheduleVersion, _shared.Silo);
                 scheduleChangedCancellation.Cancel();
-                timerToDispose?.Dispose();
+                timerToDispose.Dispose();
             }
 
             public Task StopAsync(ReminderEvents.LocalReminderStopReason reason)
             {
                 ReminderEntry entry;
-                PeriodicTimer? timerToDispose;
+                IAsyncTimer timerToDispose;
                 CancellationTokenSource scheduleChangedCancellation;
                 Task? runTask;
                 lock (_lock)
@@ -890,9 +890,8 @@ namespace Orleans.Runtime.ReminderService
                 }
 
                 _shared.LogDebugStoppingReminder(entry, reason);
-                _stopCancellation.Cancel();
                 scheduleChangedCancellation.Cancel();
-                timerToDispose?.Dispose();
+                timerToDispose.Dispose();
                 return runTask ?? Task.CompletedTask;
             }
 
@@ -972,8 +971,8 @@ namespace Orleans.Runtime.ReminderService
             {
                 while (true)
                 {
-                    TimeSpan? initialDueTime;
-                    PeriodicTimer? periodicTimer;
+                    TimeSpan? overrideDelay;
+                    IAsyncTimer timer;
                     CancellationToken scheduleChangedToken;
                     GrainId grainId;
                     string reminderName;
@@ -988,84 +987,33 @@ namespace Orleans.Runtime.ReminderService
                         if (_isFirstTickPending)
                         {
                             _isFirstTickPending = false;
-                            initialDueTime = GetInitialDueTime(_entry);
+                            overrideDelay = GetInitialDueTime(_entry);
                         }
                         else
                         {
-                            initialDueTime = null;
-                            _timer ??= new(_entry.Period, _shared._timeProvider);
+                            overrideDelay = null;
                         }
 
-                        periodicTimer = _timer;
+                        timer = _timer;
                         scheduleChangedToken = _scheduleChangedCancellation.Token;
                         grainId = _entry.GrainId;
                         reminderName = _entry.ReminderName;
                         scheduleVersion = _scheduleVersion;
                     }
 
-                    using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(_stopCancellation.Token, scheduleChangedToken);
-                    try
+                    var nextTick = timer.NextTick(overrideDelay);
+                    if (!scheduleChangedToken.IsCancellationRequested)
                     {
-                        if (initialDueTime is { } delay)
-                        {
-                            var delayTask = _shared._timeProvider.DelayUntilAsync(
-                                _shared._timeProvider.GetUtcNow() + delay,
-                                waitCancellation.Token);
-                            if (!scheduleChangedToken.IsCancellationRequested && !_stopCancellation.IsCancellationRequested)
-                            {
-                                ReminderEvents.EmitLocalReminderTickWaitArmed(grainId, reminderName, this, scheduleVersion, _shared.Silo);
-                            }
-
-                            await delayTask;
-                            if (!TryStartPeriodicTimer(scheduleChangedToken))
-                            {
-                                if (_stopCancellation.IsCancellationRequested)
-                                {
-                                    return false;
-                                }
-
-                                continue;
-                            }
-
-                            return true;
-                        }
-
-                        var nextTick = periodicTimer!.WaitForNextTickAsync(waitCancellation.Token);
-                        if (!scheduleChangedToken.IsCancellationRequested && !_stopCancellation.IsCancellationRequested)
-                        {
-                            ReminderEvents.EmitLocalReminderTickWaitArmed(grainId, reminderName, this, scheduleVersion, _shared.Silo);
-                        }
-
-                        var result = await nextTick;
-                        if (!result && scheduleChangedToken.IsCancellationRequested)
-                        {
-                            continue;
-                        }
-
-                        return result;
+                        ReminderEvents.EmitLocalReminderTickWaitArmed(grainId, reminderName, this, scheduleVersion, _shared.Silo);
                     }
-                    catch (OperationCanceledException) when (_stopCancellation.IsCancellationRequested)
-                    {
-                        return false;
-                    }
-                    catch (OperationCanceledException) when (scheduleChangedToken.IsCancellationRequested)
+
+                    var result = await nextTick;
+                    if (!result && scheduleChangedToken.IsCancellationRequested)
                     {
                         continue;
                     }
-                }
-            }
 
-            private bool TryStartPeriodicTimer(CancellationToken scheduleChangedToken)
-            {
-                lock (_lock)
-                {
-                    if (_stopReason != (int)ReminderEvents.LocalReminderStopReason.Unknown || scheduleChangedToken.IsCancellationRequested || _isFirstTickPending)
-                    {
-                        return false;
-                    }
-
-                    _timer ??= new(_entry.Period, _shared._timeProvider);
-                    return true;
+                    return result;
                 }
             }
 
@@ -1085,6 +1033,11 @@ namespace Orleans.Runtime.ReminderService
 
                     return _entry;
                 }
+            }
+
+            private IAsyncTimer CreateTimer(ReminderEntry entry)
+            {
+                return _shared.asyncTimerFactory.Create(entry.Period, "ReminderService.LocalReminder");
             }
 
             private TimeSpan GetInitialDueTime(ReminderEntry entry)

--- a/src/Orleans.Runtime/Timers/AsyncTimer.cs
+++ b/src/Orleans.Runtime/Timers/AsyncTimer.cs
@@ -45,18 +45,27 @@ namespace Orleans.Runtime
             {
                 { } value => value,
                 _ when lastFired == DateTime.MinValue => period,
-                _ => lastFired.Add(period).Subtract(start)
+                _ when start - lastFired < period => period - (start - lastFired),
+                _ => TimeSpan.Zero,
             };
 
             if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
 
-            var dueTime = start.Add(delay);
+            var hasAbsoluteDueTime = delay <= DateTime.MaxValue - start;
+            var dueTime = hasAbsoluteDueTime ? start.Add(delay) : DateTime.MaxValue;
             this.expected = dueTime;
             if (delay > TimeSpan.Zero)
             {
                 try
                 {
-                    await _timeProvider.DelayUntilAsync(new DateTimeOffset(dueTime), cancellation.Token).ConfigureAwait(false);
+                    if (hasAbsoluteDueTime)
+                    {
+                        await _timeProvider.DelayUntilAsync(new DateTimeOffset(dueTime), cancellation.Token).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await _timeProvider.DelayAsync(delay, cancellation.Token).ConfigureAwait(false);
+                    }
                 }
                 catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
                 {

--- a/src/Orleans.Runtime/Timers/AsyncTimer.cs
+++ b/src/Orleans.Runtime/Timers/AsyncTimer.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Orleans.Internal;
 
 #nullable disable
 namespace Orleans.Runtime
@@ -53,22 +54,11 @@ namespace Orleans.Runtime
             this.expected = dueTime;
             if (delay > TimeSpan.Zero)
             {
-                // for backwards compatibility, support timers with periods up to ReminderRegistry.MaxSupportedTimeout
-                var maxDelay = TimeSpan.FromMilliseconds(int.MaxValue);
-                while (delay > maxDelay)
+                try
                 {
-                    delay -= maxDelay;
-                    var task2 = await Task.WhenAny(Task.Delay(maxDelay, _timeProvider, cancellation.Token)).ConfigureAwait(false);
-                    if (task2.IsCanceled)
-                    {
-                        await Task.Yield();
-                        expected = default;
-                        return false;
-                    }
+                    await _timeProvider.DelayUntilAsync(new DateTimeOffset(dueTime), cancellation.Token).ConfigureAwait(false);
                 }
-
-                var task = await Task.WhenAny(Task.Delay(delay, _timeProvider, cancellation.Token)).ConfigureAwait(false);
-                if (task.IsCanceled)
+                catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
                 {
                     await Task.Yield();
                     expected = default;

--- a/src/Orleans.Runtime/Timers/AsyncTimer.cs
+++ b/src/Orleans.Runtime/Timers/AsyncTimer.cs
@@ -45,16 +45,18 @@ namespace Orleans.Runtime
             {
                 { } value => value,
                 _ when lastFired == DateTime.MinValue => period,
+                _ when period == Timeout.InfiniteTimeSpan => period,
                 _ when start - lastFired < period => period - (start - lastFired),
                 _ => TimeSpan.Zero,
             };
 
-            if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+            var isInfinite = delay == Timeout.InfiniteTimeSpan;
+            if (delay < TimeSpan.Zero && !isInfinite) delay = TimeSpan.Zero;
 
-            var hasAbsoluteDueTime = delay <= DateTime.MaxValue - start;
+            var hasAbsoluteDueTime = !isInfinite && delay <= DateTime.MaxValue - start;
             var dueTime = hasAbsoluteDueTime ? start.Add(delay) : DateTime.MaxValue;
             this.expected = dueTime;
-            if (delay > TimeSpan.Zero)
+            if (delay > TimeSpan.Zero || isInfinite)
             {
                 try
                 {

--- a/src/api/Orleans.Reminders/Orleans.Reminders.cs
+++ b/src/api/Orleans.Reminders/Orleans.Reminders.cs
@@ -192,6 +192,8 @@ namespace Orleans.Reminders.Diagnostics
         {
             Unknown = 0,
             Unregistered = 1,
+            [System.Obsolete("Unused, will be removed in a future version.")]
+            Replaced = 2,
             RemovedFromRange = 3,
             RemovedFromTable = 4,
             ServiceStopped = 5

--- a/src/api/Orleans.Reminders/Orleans.Reminders.cs
+++ b/src/api/Orleans.Reminders/Orleans.Reminders.cs
@@ -192,7 +192,6 @@ namespace Orleans.Reminders.Diagnostics
         {
             Unknown = 0,
             Unregistered = 1,
-            Replaced = 2,
             RemovedFromRange = 3,
             RemovedFromTable = 4,
             ServiceStopped = 5

--- a/test/Grains/TestGrainInterfaces/IReminderTestGrain2.cs
+++ b/test/Grains/TestGrainInterfaces/IReminderTestGrain2.cs
@@ -14,6 +14,7 @@ namespace UnitTests.GrainInterfaces
     public interface IReminderTestGrain2 : IGrainWithGuidKey
     {
         Task<IGrainReminder> StartReminder(string reminderName, TimeSpan? period = null, bool validate = false);
+        Task<IGrainReminder> StartReminder(string reminderName, TimeSpan dueTime, TimeSpan period);
 
         Task StopReminder(string reminderName);
         Task StopReminder(IGrainReminder reminder);
@@ -46,4 +47,3 @@ namespace UnitTests.GrainInterfaces
         Task<bool> StartReminder(string reminderName);
     }
 }
-

--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -60,17 +60,25 @@ namespace UnitTests.Grains
         public async Task<IGrainReminder> StartReminder(string reminderName, TimeSpan? p = null, bool validate = false)
         {
             TimeSpan usePeriod = p ?? this.period;
-            this.logger.LogInformation("Starting reminder {ReminderName}.", reminderName);
             TimeSpan dueTime;
             if (reminderOptions.Value.MinimumReminderPeriod < TimeSpan.FromSeconds(2))
                 dueTime = TimeSpan.FromSeconds(2) - reminderOptions.Value.MinimumReminderPeriod;
             else dueTime = usePeriod - TimeSpan.FromSeconds(2);
 
+            return await StartReminder(reminderName, dueTime, usePeriod, validate);
+        }
+
+        public Task<IGrainReminder> StartReminder(string reminderName, TimeSpan dueTime, TimeSpan period)
+            => StartReminder(reminderName, dueTime, period, validate: false);
+
+        private async Task<IGrainReminder> StartReminder(string reminderName, TimeSpan dueTime, TimeSpan period, bool validate)
+        {
+            this.logger.LogInformation("Starting reminder {ReminderName}.", reminderName);
             IGrainReminder r;
             if (validate)
-                r = await this.RegisterOrUpdateReminder(reminderName, dueTime, usePeriod);
+                r = await this.RegisterOrUpdateReminder(reminderName, dueTime, period);
             else
-                r = await this.unvalidatedReminderRegistry.RegisterOrUpdateReminder(GrainId, reminderName, dueTime, usePeriod);
+                r = await this.unvalidatedReminderRegistry.RegisterOrUpdateReminder(GrainId, reminderName, dueTime, period);
 
             this.allReminders[reminderName] = new(r);
             this.sequence[reminderName] = 0;

--- a/test/Orleans.Core.Tests/Runtime/AsyncTimerTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/AsyncTimerTests.cs
@@ -7,6 +7,93 @@ namespace NonSilo.Tests.Runtime;
 
 public class AsyncTimerTests
 {
+    [Theory, TestCategory("BVT")]
+    [InlineData(0)]
+    [InlineData(-2)]
+    [InlineData(-1000)]
+    public async Task NextTick_TreatsNonInfiniteNonPositivePeriodAsImmediate(int milliseconds)
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var timer = new AsyncTimer(TimeSpan.FromMilliseconds(milliseconds), "test", NullLogger.Instance, timeProvider);
+
+        var task = timer.NextTick();
+
+        Assert.True(task.IsCompletedSuccessfully);
+        Assert.True(await task);
+    }
+
+    [Theory, TestCategory("BVT")]
+    [InlineData(0)]
+    [InlineData(-2)]
+    [InlineData(-1000)]
+    public async Task NextTick_TreatsNonInfiniteNonPositiveOverrideAsImmediate(int milliseconds)
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var timer = new AsyncTimer(TimeSpan.FromDays(1), "test", NullLogger.Instance, timeProvider);
+
+        var task = timer.NextTick(TimeSpan.FromMilliseconds(milliseconds));
+
+        Assert.True(task.IsCompletedSuccessfully);
+        Assert.True(await task);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task NextTick_SupportsInfinitePeriod()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var timer = new AsyncTimer(Timeout.InfiniteTimeSpan, "test", NullLogger.Instance, timeProvider);
+
+        Assert.True(await timer.NextTick(TimeSpan.Zero));
+        var task = timer.NextTick();
+
+        timeProvider.Advance(TimeSpan.FromDays(60));
+        Assert.False(task.IsCompleted);
+        timer.Dispose();
+        Assert.False(await task);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task NextTick_SupportsInfiniteOverride()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var timer = new AsyncTimer(TimeSpan.FromDays(1), "test", NullLogger.Instance, timeProvider);
+
+        var task = timer.NextTick(Timeout.InfiniteTimeSpan);
+
+        timeProvider.Advance(TimeSpan.FromDays(60));
+        Assert.False(task.IsCompleted);
+        timer.Dispose();
+        Assert.False(await task);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task NextTick_SupportsPeriodsBeyondMaximumTimerDelay()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var timer = new AsyncTimer(TimeSpan.FromDays(60), "test", NullLogger.Instance, timeProvider);
+
+        var task = timer.NextTick();
+
+        timeProvider.Advance(TimeSpan.FromDays(50));
+        Assert.False(task.IsCompleted);
+        timeProvider.Advance(TimeSpan.FromDays(10));
+        Assert.True(await task);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task NextTick_SupportsOverridesBeyondMaximumTimerDelay()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var timer = new AsyncTimer(TimeSpan.FromDays(1), "test", NullLogger.Instance, timeProvider);
+
+        var task = timer.NextTick(TimeSpan.FromDays(60));
+
+        timeProvider.Advance(TimeSpan.FromDays(50));
+        Assert.False(task.IsCompleted);
+        timeProvider.Advance(TimeSpan.FromDays(10));
+        Assert.True(await task);
+    }
+
     [Fact, TestCategory("BVT")]
     public async Task NextTick_SupportsMaximumPeriod()
     {

--- a/test/Orleans.Core.Tests/Runtime/AsyncTimerTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/AsyncTimerTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Orleans.Runtime;
+using Xunit;
+
+namespace NonSilo.Tests.Runtime;
+
+public class AsyncTimerTests
+{
+    [Fact, TestCategory("BVT")]
+    public async Task NextTick_SupportsMaximumPeriod()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var timer = new AsyncTimer(TimeSpan.MaxValue, "test", NullLogger.Instance, timeProvider);
+
+        var task = timer.NextTick();
+
+        Assert.False(task.IsCompleted);
+        timer.Dispose();
+        Assert.False(await task);
+    }
+}

--- a/test/Orleans.Core.Tests/Utils/TimeProviderExtensionsTests.cs
+++ b/test/Orleans.Core.Tests/Utils/TimeProviderExtensionsTests.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Time.Testing;
+using Orleans.Internal;
+using Xunit;
+
+namespace NonSilo.Tests.Utils;
+
+public class TimeProviderExtensionsTests
+{
+    [Fact, TestCategory("BVT")]
+    public async Task DelayUntilAsync_SupportsDelaysBeyondMaximumTimerDelay()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var delay = TimeSpan.FromDays(60);
+
+        var task = timeProvider.DelayUntilAsync(timeProvider.GetUtcNow() + delay);
+
+        Assert.False(task.IsCompleted);
+        timeProvider.Advance(delay);
+        await task;
+    }
+}

--- a/test/Orleans.Core.Tests/Utils/TimeProviderExtensionsTests.cs
+++ b/test/Orleans.Core.Tests/Utils/TimeProviderExtensionsTests.cs
@@ -7,15 +7,31 @@ namespace NonSilo.Tests.Utils;
 public class TimeProviderExtensionsTests
 {
     [Fact, TestCategory("BVT")]
-    public async Task DelayUntilAsync_SupportsDelaysBeyondMaximumTimerDelay()
+    public async Task DelayAsync_SupportsDelaysBeyondMaximumTimerDelay()
     {
         var timeProvider = new FakeTimeProvider();
         var delay = TimeSpan.FromDays(60);
 
+        var task = timeProvider.DelayAsync(delay);
+
+        Assert.False(task.IsCompleted);
+        timeProvider.Advance(TimeSpan.FromDays(50));
+        Assert.False(task.IsCompleted);
+        timeProvider.Advance(TimeSpan.FromDays(10));
+        await task;
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task DelayUntilAsync_SupportsDelaysBeyondMaximumTimerDelay()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var delay = TimeSpan.FromDays(60);
         var task = timeProvider.DelayUntilAsync(timeProvider.GetUtcNow() + delay);
 
         Assert.False(task.IsCompleted);
-        timeProvider.Advance(delay);
+        timeProvider.Advance(TimeSpan.FromDays(50));
+        Assert.False(task.IsCompleted);
+        timeProvider.Advance(TimeSpan.FromDays(10));
         await task;
     }
 }

--- a/test/Orleans.Core.Tests/Utils/TimeProviderExtensionsTests.cs
+++ b/test/Orleans.Core.Tests/Utils/TimeProviderExtensionsTests.cs
@@ -7,6 +7,42 @@ namespace NonSilo.Tests.Utils;
 public class TimeProviderExtensionsTests
 {
     [Fact, TestCategory("BVT")]
+    public async Task DelayAsync_CompletesImmediatelyForZeroDelay()
+    {
+        var timeProvider = new FakeTimeProvider();
+
+        var task = timeProvider.DelayAsync(TimeSpan.Zero);
+
+        Assert.True(task.IsCompletedSuccessfully);
+        await task;
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task DelayAsync_SupportsInfiniteDelay()
+    {
+        var timeProvider = new FakeTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+
+        var task = timeProvider.DelayAsync(Timeout.InfiniteTimeSpan, cancellation.Token);
+
+        timeProvider.Advance(TimeSpan.FromDays(60));
+        Assert.False(task.IsCompleted);
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+    }
+
+    [Theory, TestCategory("BVT")]
+    [InlineData(-2)]
+    [InlineData(-1000)]
+    public async Task DelayAsync_RejectsInvalidNegativeDelays(int milliseconds)
+    {
+        var timeProvider = new FakeTimeProvider();
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => timeProvider.DelayAsync(TimeSpan.FromMilliseconds(milliseconds)));
+    }
+
+    [Fact, TestCategory("BVT")]
     public async Task DelayAsync_SupportsDelaysBeyondMaximumTimerDelay()
     {
         var timeProvider = new FakeTimeProvider();
@@ -18,6 +54,21 @@ public class TimeProviderExtensionsTests
         timeProvider.Advance(TimeSpan.FromDays(50));
         Assert.False(task.IsCompleted);
         timeProvider.Advance(TimeSpan.FromDays(10));
+        await task;
+    }
+
+    [Theory, TestCategory("BVT")]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-1000)]
+    public async Task DelayUntilAsync_CompletesImmediatelyForCurrentOrPastDueTime(int milliseconds)
+    {
+        var timeProvider = new FakeTimeProvider();
+        var dueTime = timeProvider.GetUtcNow() + TimeSpan.FromMilliseconds(milliseconds);
+
+        var task = timeProvider.DelayUntilAsync(dueTime);
+
+        Assert.True(task.IsCompletedSuccessfully);
         await task;
     }
 

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -58,6 +58,16 @@ public class LocalReminderServiceTests
         Assert.Equal(TimeSpan.FromSeconds(9), dueTime);
     }
 
+    [Fact, TestCategory("BVT")]
+    public void CalculateNextDueTime_ClampsOverflow()
+    {
+        var now = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var dueTime = LocalReminderService.CalculateNextDueTime(now, TimeSpan.MaxValue);
+
+        Assert.Equal(DateTime.MaxValue, dueTime);
+    }
+
     private static ReminderEntry CreateReminderEntry(DateTime startAt, TimeSpan period)
     {
         return new ReminderEntry

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -125,6 +125,24 @@ namespace UnitTests.TimerTests
             await thirdTick;
         }
 
+        [Fact]
+        public async Task Rem_Grain_LongDueTime()
+        {
+            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            var grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+            const string reminderName = "LONG_DUE_TIME";
+            var grainId = grain.GetGrainId();
+
+            await grain.StartReminder(reminderName, TimeSpan.FromDays(60), TimeSpan.FromDays(1));
+            await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cts.Token);
+
+            var firstTick = observer.WaitForTickCountAsync(grainId, 1, cts.Token, reminderName);
+            await AdvanceReminderTimeAsync(TimeSpan.FromDays(50), cts.Token);
+            Assert.Equal(0, observer.GetTickCount(grainId, reminderName));
+            await AdvanceReminderTimeAsync(TimeSpan.FromDays(10), cts.Token);
+            await firstTick;
+        }
+
         // Single join tests ... multi grain, multi reminders
 
         /// <summary>

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -107,13 +107,22 @@ namespace UnitTests.TimerTests
             await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cts.Token);
 
             var firstTick = observer.WaitForTickCountAsync(grainId, 1, cts.Token, reminderName);
-            await AdvanceReminderTimeAsync(period, cts.Token);
+            await AdvanceReminderTimeAsync(TimeSpan.FromDays(50), cts.Token);
+            Assert.Equal(0, observer.GetTickCount(grainId, reminderName));
+            await AdvanceReminderTimeAsync(TimeSpan.FromDays(10), cts.Token);
             await firstTick;
             await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cts.Token);
 
             var secondTick = observer.WaitForTickCountAsync(grainId, 2, cts.Token, reminderName);
-            await AdvanceReminderTimeAsync(period, cts.Token);
+            await AdvanceReminderTimeAsync(TimeSpan.FromDays(90), cts.Token);
             await secondTick;
+            await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cts.Token);
+
+            var thirdTick = observer.WaitForTickCountAsync(grainId, 3, cts.Token, reminderName);
+            await AdvanceReminderTimeAsync(TimeSpan.FromDays(29), cts.Token);
+            Assert.Equal(2, observer.GetTickCount(grainId, reminderName));
+            await AdvanceReminderTimeAsync(TimeSpan.FromDays(1), cts.Token);
+            await thirdTick;
         }
 
         // Single join tests ... multi grain, multi reminders

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -94,6 +94,28 @@ namespace UnitTests.TimerTests
             await Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder();
         }
 
+        [Fact]
+        public async Task Rem_Grain_LongPeriod()
+        {
+            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            var grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+            const string reminderName = "LONG_PERIOD";
+            var period = TimeSpan.FromDays(60);
+            var grainId = grain.GetGrainId();
+
+            await grain.StartReminder(reminderName, period);
+            await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cts.Token);
+
+            var firstTick = observer.WaitForTickCountAsync(grainId, 1, cts.Token, reminderName);
+            await AdvanceReminderTimeAsync(period, cts.Token);
+            await firstTick;
+            await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cts.Token);
+
+            var secondTick = observer.WaitForTickCountAsync(grainId, 2, cts.Token, reminderName);
+            await AdvanceReminderTimeAsync(period, cts.Token);
+            await secondTick;
+        }
+
         // Single join tests ... multi grain, multi reminders
 
         /// <summary>


### PR DESCRIPTION
Fixes #10249.

Add internal `TimeProvider` extensions which wait in timer-safe chunks. Absolute deadlines are recomputed after each chunk, and relative delays use provider timestamps so delays up to `TimeSpan.MaxValue` remain cancellable without overflowing `DateTime`.

Use `AsyncTimer` for local reminders and recalculate each wait from the reminder's `StartAt` and `Period`. This supports both long initial delays and long periods while preserving cadence after late delivery, schedule updates, and shutdown cancellation.

Add fake-time regression coverage for the native timer boundary, 60-day reminder periods, overdue cadence, and overflow limits.