### PR TITLE
fix(runtime): stop retrying dead directory members

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -68,6 +68,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
     internal CancellationToken OnStoppedToken => _stoppedCts.Token;
     internal DirectoryInstruments DirectoryInstruments => _directoryInstruments;
     internal ClusterMembershipSnapshot ClusterMembershipSnapshot => _membershipService.CurrentView.ClusterMembershipSnapshot;
+    internal ClusterMembershipSnapshot LatestClusterMembershipSnapshot => _membershipService.ClusterMembershipService.CurrentSnapshot;
 
     // The recovery membership value is used to avoid a race between concurrent registration & recovery operations which could lead to lost registrations.
     // This could occur when a new activation is created and begins registering itself with a host which crashes. Concurrently, the new owner initiates
@@ -187,6 +188,13 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
             {
                 // This likely indicates that the target silo has been declared dead.
                 ++attempts;
+                var latestClusterMembership = LatestClusterMembershipSnapshot;
+                if (!CanInvokeClusterMember(latestClusterMembership, owner))
+                {
+                    view = await _membershipService.RefreshViewAsync(latestClusterMembership.Version, cancellationToken);
+                    continue;
+                }
+
                 await Task.Delay(delay, cancellationToken);
                 delay *= 1.5;
                 continue;
@@ -212,6 +220,9 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
             return result;
         }
     }
+
+    internal static bool CanInvokeClusterMember(ClusterMembershipSnapshot snapshot, SiloAddress siloAddress)
+        => snapshot.GetSiloStatus(siloAddress) is SiloStatus.Active or SiloStatus.Joining or SiloStatus.ShuttingDown;
 
     public async ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(MembershipVersion membershipVersion, RingRange range, SiloAddress siloAddress, int partitionIndex)
     {

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -778,7 +778,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                     LogErrorErrorInvokingOperation(_logger, ex, operationName, siloAddress);
                 }
 
-                await _owner.RefreshViewAsync(default, CancellationToken.None);
+                await _owner.RefreshViewAsync(default, ShutdownToken);
                 if (!DistributedGrainDirectory.CanInvokeClusterMember(_owner.LatestClusterMembershipSnapshot, siloAddress))
                 {
                     break;

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -23,6 +23,10 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 {
     private const float MaxActivationQueryRangePercent = 5f;
     private const int MaxActivationQueryRangeCount = 32;
+    private static readonly IBackoffProvider ClusterMemberRetryBackoff = new ExponentialBackoff(
+        TimeSpan.FromMilliseconds(100),
+        TimeSpan.FromSeconds(5),
+        TimeSpan.FromMilliseconds(100));
 
     internal static SystemTargetGrainId CreateGrainId(SiloAddress siloAddress, int partitionIndex) => SystemTargetGrainId.Create(Constants.GrainDirectoryPartitionType, siloAddress, partitionIndex.ToString(CultureInfo.InvariantCulture));
     private readonly Dictionary<GrainId, GrainAddress> _directory = [];
@@ -755,10 +759,10 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
     private async Task<T> InvokeOnClusterMember<T>(SiloAddress siloAddress, Func<Task<T>> func, T defaultValue, string operationName)
     {
         GrainRuntime.CheckRuntimeContext(this);
-        var clusterMembershipSnapshot = _owner.ClusterMembershipSnapshot;
+        var attempt = 0;
         while (!ShutdownToken.IsCancellationRequested)
         {
-            if (clusterMembershipSnapshot.GetSiloStatus(siloAddress) is not (SiloStatus.Active or SiloStatus.Joining or SiloStatus.ShuttingDown))
+            if (!DistributedGrainDirectory.CanInvokeClusterMember(_owner.LatestClusterMembershipSnapshot, siloAddress))
             {
                 break;
             }
@@ -775,12 +779,12 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                 }
 
                 await _owner.RefreshViewAsync(default, CancellationToken.None);
-                if (_owner.ClusterMembershipSnapshot.Version == clusterMembershipSnapshot.Version)
+                if (!DistributedGrainDirectory.CanInvokeClusterMember(_owner.LatestClusterMembershipSnapshot, siloAddress))
                 {
-                    await Task.Delay(TimeSpan.FromMilliseconds(100));
+                    break;
                 }
 
-                clusterMembershipSnapshot = _owner.ClusterMembershipSnapshot;
+                await Task.Delay(ClusterMemberRetryBackoff.Next(attempt++), ShutdownToken);
             }
         }
 

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Collections.Immutable;
 using System.Linq;
 using Orleans.Runtime.GrainDirectory;
 using TestExtensions;
@@ -9,6 +10,24 @@ namespace UnitTests.GrainDirectory;
 [TestCategory("BVT"), TestCategory("Directory")]
 public sealed class GrainDirectoryPartitionTests
 {
+    private static readonly SiloAddress TestSiloAddress = SiloAddress.FromParsableString("127.0.0.1:11111@123");
+
+    [Theory]
+    [InlineData(SiloStatus.Active, true)]
+    [InlineData(SiloStatus.Joining, true)]
+    [InlineData(SiloStatus.ShuttingDown, true)]
+    [InlineData(SiloStatus.Stopping, false)]
+    [InlineData(SiloStatus.Dead, false)]
+    public void CanInvokeClusterMember_RequiresAvailableStatus(SiloStatus status, bool expected)
+    {
+        var members = ImmutableDictionary<SiloAddress, ClusterMember>.Empty.Add(
+            TestSiloAddress,
+            new ClusterMember(TestSiloAddress, status, "TestSilo"));
+        var snapshot = new ClusterMembershipSnapshot(members, new MembershipVersion(1));
+
+        Assert.Equal(expected, DistributedGrainDirectory.CanInvokeClusterMember(snapshot, TestSiloAddress));
+    }
+
     [Fact]
     public void GetSnapshotTransferRanges_ReturnsOnlyPreviousOwnerIntersections()
     {


### PR DESCRIPTION
Directory recovery could repeatedly send `RecoverRegisteredActivations` requests to a silo which the messaging layer already knew was dead. The recovery loop consulted a lagging directory membership view and retried failures indefinitely at a fixed 100 ms interval, producing sustained message floods.

Use the latest cluster membership snapshot before recovery and snapshot-transfer calls so unavailable targets are abandoned immediately. Transient failures retain retries, but now use randomized exponential backoff capped at five seconds. Regular directory calls also refresh and reroute immediately when their current owner is known unavailable.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10261)