### PR TITLE
fix: fence silos missing from newer membership views

### DIFF
--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -139,16 +139,9 @@ namespace Orleans.Runtime.MembershipService
 
             LogInformationReceivedClusterMembershipSnapshot(this.log, snapshot);
 
-            if (snapshot.Entries.TryGetValue(this.myAddress, out var localSiloEntry))
-            {
-                if (localSiloEntry.Status == SiloStatus.Dead && this.CurrentStatus != SiloStatus.Dead)
-                {
-                    LogWarningFoundMyselfDeadInRefreshFromSnapshot(this.log, localSiloEntry.ToFullString());
-                    this.KillMyselfLocally($"I should be Dead according to membership table (in RefreshFromSnapshot). Local entry: {(localSiloEntry.ToFullString())}.");
-                }
-            }
-
-            this.updates.TryPublish(MembershipTableSnapshot.Update, snapshot);
+            this.updates.TryPublish(
+                (previous, update) => this.ProcessMembershipUpdate(previous, MembershipTableSnapshot.Update(previous, update.Snapshot), update.Caller),
+                (Snapshot: snapshot, Caller: nameof(RefreshFromSnapshot)));
         }
 
         private async Task<bool> RefreshInternal(bool requireCleanup)
@@ -476,13 +469,45 @@ namespace Orleans.Runtime.MembershipService
             if (table is null) throw new ArgumentNullException(nameof(table));
             LogDebugProcessTableUpdate(this.log, caller, table);
 
-            if (this.updates.TryPublish(MembershipTableSnapshot.Update, table))
+            if (this.updates.TryPublish(
+                (previous, update) => this.ProcessMembershipUpdate(previous, MembershipTableSnapshot.Update(previous, update.Table), update.Caller),
+                (Table: table, Caller: caller)))
             {
                 this.LogMissedIAmAlives(table);
 
                 LogDebugProcessTableUpdateWithTable(this.log, caller, new(table));
                 MembershipEvents.EmitViewChanged(this.snapshot, this.myAddress);
             }
+        }
+
+        private MembershipTableSnapshot ProcessMembershipUpdate(
+            MembershipTableSnapshot previous,
+            MembershipTableSnapshot updated,
+            string caller)
+        {
+            if (this.CurrentStatus == SiloStatus.Dead)
+            {
+                return updated;
+            }
+
+            if (updated.Entries.TryGetValue(this.myAddress, out var localSiloEntry))
+            {
+                if (localSiloEntry.Status == SiloStatus.Dead)
+                {
+                    LogWarningFoundMyselfDeadInMembershipUpdate(this.log, caller, localSiloEntry.ToFullString());
+                    this.KillMyselfLocally($"I should be Dead according to the membership table (in {caller}). Local entry: {localSiloEntry.ToFullString()}.");
+                }
+            }
+            else if (previous.Entries.TryGetValue(this.myAddress, out var previousLocalSiloEntry)
+                && previousLocalSiloEntry.Status != SiloStatus.Created
+                && updated.Version > previous.Version)
+            {
+                LogWarningLocalSiloMissingFromMembershipUpdate(this.log, caller, previous.Version, updated.Version);
+                this.KillMyselfLocally(
+                    $"My entry is missing from a newer membership table view (in {caller}). Previous version: {previous.Version}, updated version: {updated.Version}.");
+            }
+
+            return updated;
         }
 
         private void LogMissedIAmAlives(MembershipTableData table)
@@ -951,9 +976,19 @@ namespace Orleans.Runtime.MembershipService
         [LoggerMessage(
             EventId = (int)ErrorCode.MembershipFoundMyselfDead1,
             Level = LogLevel.Warning,
-            Message = "I should be Dead according to membership table (in RefreshFromSnapshot). Local entry: {Entry}."
+            Message = "I should be Dead according to the membership table (in {Caller}). Local entry: {Entry}."
         )]
-        private static partial void LogWarningFoundMyselfDeadInRefreshFromSnapshot(ILogger logger, string entry);
+        private static partial void LogWarningFoundMyselfDeadInMembershipUpdate(ILogger logger, string caller, string entry);
+
+        [LoggerMessage(
+            Level = LogLevel.Warning,
+            Message = "The local silo entry is missing from a newer membership table view (in {Caller}). Previous version: {PreviousVersion}, updated version: {UpdatedVersion}."
+        )]
+        private static partial void LogWarningLocalSiloMissingFromMembershipUpdate(
+            ILogger logger,
+            string caller,
+            MembershipVersion previousVersion,
+            MembershipVersion updatedVersion);
 
         [LoggerMessage(
             Level = LogLevel.Warning,

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -139,9 +139,7 @@ namespace Orleans.Runtime.MembershipService
 
             LogInformationReceivedClusterMembershipSnapshot(this.log, snapshot);
 
-            this.updates.TryPublish(
-                (previous, update) => this.ProcessMembershipUpdate(previous, MembershipTableSnapshot.Update(previous, update.Snapshot), update.Caller),
-                (Snapshot: snapshot, Caller: nameof(RefreshFromSnapshot)));
+            this.TryProcessMembershipUpdate(MembershipTableSnapshot.Update, snapshot, nameof(RefreshFromSnapshot));
         }
 
         private async Task<bool> RefreshInternal(bool requireCleanup)
@@ -469,9 +467,7 @@ namespace Orleans.Runtime.MembershipService
             if (table is null) throw new ArgumentNullException(nameof(table));
             LogDebugProcessTableUpdate(this.log, caller, table);
 
-            if (this.updates.TryPublish(
-                (previous, update) => this.ProcessMembershipUpdate(previous, MembershipTableSnapshot.Update(previous, update.Table), update.Caller),
-                (Table: table, Caller: caller)))
+            if (this.TryProcessMembershipUpdate(MembershipTableSnapshot.Update, table, caller))
             {
                 this.LogMissedIAmAlives(table);
 
@@ -480,14 +476,29 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        private MembershipTableSnapshot ProcessMembershipUpdate(
+        private bool TryProcessMembershipUpdate<TState>(
+            Func<MembershipTableSnapshot, TState, MembershipTableSnapshot> updateFunc,
+            TState state,
+            string caller)
+        {
+            var update = new MembershipUpdate<TState>(updateFunc, state);
+            if (!this.updates.TryPublish(static (previous, update) => update.Apply(previous), update))
+            {
+                return false;
+            }
+
+            this.ProcessMembershipUpdate(update.Previous, update.Published, caller);
+            return true;
+        }
+
+        private void ProcessMembershipUpdate(
             MembershipTableSnapshot previous,
             MembershipTableSnapshot updated,
             string caller)
         {
             if (this.CurrentStatus == SiloStatus.Dead)
             {
-                return updated;
+                return;
             }
 
             if (updated.Entries.TryGetValue(this.myAddress, out var localSiloEntry))
@@ -506,8 +517,21 @@ namespace Orleans.Runtime.MembershipService
                 this.KillMyselfLocally(
                     $"My entry is missing from a newer membership table view (in {caller}). Previous version: {previous.Version}, updated version: {updated.Version}.");
             }
+        }
 
-            return updated;
+        private sealed class MembershipUpdate<TState>(
+            Func<MembershipTableSnapshot, TState, MembershipTableSnapshot> updateFunc,
+            TState state)
+        {
+            public MembershipTableSnapshot Previous { get; private set; } = default!;
+
+            public MembershipTableSnapshot Published { get; private set; } = default!;
+
+            public MembershipTableSnapshot Apply(MembershipTableSnapshot previous)
+            {
+                this.Previous = previous;
+                return this.Published = updateFunc(previous, state);
+            }
         }
 
         private void LogMissedIAmAlives(MembershipTableData table)

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -506,14 +507,10 @@ namespace Orleans.Runtime.MembershipService
 
             if (updated.Entries.TryGetValue(this.myAddress, out var localSiloEntry))
             {
-                if (previousLocalSiloEntry.Status != SiloStatus.Dead || localSiloEntry.Status == SiloStatus.Dead)
-                {
-                    return updated;
-                }
-
-                return new MembershipTableSnapshot(
-                    updated.Version,
-                    updated.Entries.SetItem(this.myAddress, localSiloEntry.WithStatus(SiloStatus.Dead)));
+                Debug.Assert(
+                    previousLocalSiloEntry.Status != SiloStatus.Dead || localSiloEntry.Status == SiloStatus.Dead,
+                    "The local silo cannot transition from Dead to another status.");
+                return updated;
             }
 
             // The local silo was present in the previous view but is missing now. Preserve its entry so

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -516,6 +516,9 @@ namespace Orleans.Runtime.MembershipService
                     updated.Entries.SetItem(this.myAddress, localSiloEntry.WithStatus(SiloStatus.Dead)));
             }
 
+            // The local silo was present in the previous view but is missing now. Preserve its entry so
+            // that non-newer views cannot erase it; a newer view means that it is dead, so publish an
+            // artificial Dead entry for downstream observers before self-terminating.
             return new MembershipTableSnapshot(
                 updated.Version,
                 updated.Entries.SetItem(

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -481,56 +481,59 @@ namespace Orleans.Runtime.MembershipService
             TState state,
             string caller)
         {
-            var update = new MembershipUpdate<TState>(updateFunc, state);
-            if (!this.updates.TryPublish(static (previous, update) => update.Apply(previous), update))
+            if (!this.updates.TryPublish(
+                static (previous, update) => update.Manager.ProcessMembershipUpdate(
+                    previous,
+                    update.UpdateFunc(previous, update.State)),
+                (Manager: this, UpdateFunc: updateFunc, State: state)))
             {
                 return false;
             }
 
-            this.ProcessMembershipUpdate(update.Previous, update.Published, caller);
+            this.CheckIfLocalSiloIsDead(caller);
             return true;
         }
 
-        private void ProcessMembershipUpdate(
+        private MembershipTableSnapshot ProcessMembershipUpdate(
             MembershipTableSnapshot previous,
-            MembershipTableSnapshot updated,
-            string caller)
+            MembershipTableSnapshot updated)
         {
-            if (this.CurrentStatus == SiloStatus.Dead)
+            if (!previous.Entries.TryGetValue(this.myAddress, out var previousLocalSiloEntry)
+                || previousLocalSiloEntry.Status == SiloStatus.Created)
             {
-                return;
+                return updated;
             }
 
             if (updated.Entries.TryGetValue(this.myAddress, out var localSiloEntry))
             {
-                if (localSiloEntry.Status == SiloStatus.Dead)
+                if (previousLocalSiloEntry.Status != SiloStatus.Dead || localSiloEntry.Status == SiloStatus.Dead)
                 {
-                    LogWarningFoundMyselfDeadInMembershipUpdate(this.log, caller, localSiloEntry.ToFullString());
-                    this.KillMyselfLocally($"I should be Dead according to the membership table (in {caller}). Local entry: {localSiloEntry.ToFullString()}.");
+                    return updated;
                 }
+
+                return new MembershipTableSnapshot(
+                    updated.Version,
+                    updated.Entries.SetItem(this.myAddress, localSiloEntry.WithStatus(SiloStatus.Dead)));
             }
-            else if (previous.Entries.TryGetValue(this.myAddress, out var previousLocalSiloEntry)
-                && previousLocalSiloEntry.Status != SiloStatus.Created
-                && updated.Version > previous.Version)
-            {
-                LogWarningLocalSiloMissingFromMembershipUpdate(this.log, caller, previous.Version, updated.Version);
-                this.KillMyselfLocally(
-                    $"My entry is missing from a newer membership table view (in {caller}). Previous version: {previous.Version}, updated version: {updated.Version}.");
-            }
+
+            return new MembershipTableSnapshot(
+                updated.Version,
+                updated.Entries.SetItem(
+                    this.myAddress,
+                    previousLocalSiloEntry.Status == SiloStatus.Dead || updated.Version > previous.Version
+                        ? previousLocalSiloEntry.WithStatus(SiloStatus.Dead)
+                        : previousLocalSiloEntry));
         }
 
-        private sealed class MembershipUpdate<TState>(
-            Func<MembershipTableSnapshot, TState, MembershipTableSnapshot> updateFunc,
-            TState state)
+        private void CheckIfLocalSiloIsDead(string caller)
         {
-            public MembershipTableSnapshot Previous { get; private set; } = default!;
-
-            public MembershipTableSnapshot Published { get; private set; } = default!;
-
-            public MembershipTableSnapshot Apply(MembershipTableSnapshot previous)
+            var current = this.snapshot;
+            if (this.CurrentStatus != SiloStatus.Dead
+                && current.Entries.TryGetValue(this.myAddress, out var localSiloEntry)
+                && localSiloEntry.Status == SiloStatus.Dead)
             {
-                this.Previous = previous;
-                return this.Published = updateFunc(previous, state);
+                LogWarningFoundMyselfDeadInMembershipUpdate(this.log, caller, localSiloEntry.ToFullString());
+                this.KillMyselfLocally($"I should be Dead according to the membership table (in {caller}). Local entry: {localSiloEntry.ToFullString()}.");
             }
         }
 
@@ -1003,16 +1006,6 @@ namespace Orleans.Runtime.MembershipService
             Message = "I should be Dead according to the membership table (in {Caller}). Local entry: {Entry}."
         )]
         private static partial void LogWarningFoundMyselfDeadInMembershipUpdate(ILogger logger, string caller, string entry);
-
-        [LoggerMessage(
-            Level = LogLevel.Warning,
-            Message = "The local silo entry is missing from a newer membership table view (in {Caller}). Previous version: {PreviousVersion}, updated version: {UpdatedVersion}."
-        )]
-        private static partial void LogWarningLocalSiloMissingFromMembershipUpdate(
-            ILogger logger,
-            string caller,
-            MembershipVersion previousVersion,
-            MembershipVersion updatedVersion);
 
         [LoggerMessage(
             Level = LogLevel.Warning,

--- a/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
@@ -453,7 +453,11 @@ namespace NonSilo.Tests.Membership
         [Fact]
         public async Task MembershipTableManager_MissingLocalEntry_OnlyNewerSnapshotAfterJoiningTerminates()
         {
-            var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
+            var now = DateTimeOffset.UtcNow;
+            var otherSilo = Silo("127.0.0.1:200@100");
+            var membershipTable = new InMemoryMembershipTable(
+                new TableVersion(123, "123"),
+                Entry(otherSilo, SiloStatus.Active, now));
             var manager = this.CreateMembershipTableManager(membershipTable);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
 
@@ -465,11 +469,28 @@ namespace NonSilo.Tests.Membership
             var currentVersion = manager.MembershipTableSnapshot.Version;
 
             await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(currentVersion.Value - 1)));
-            await manager.RefreshFromSnapshot(Snapshot(currentVersion));
+            await manager.RefreshFromSnapshot(Snapshot(
+                currentVersion,
+                Entry(otherSilo, SiloStatus.Active, now.AddMinutes(1))));
+            Assert.Equal(SiloStatus.Joining, manager.MembershipTableSnapshot.Entries[this.localSilo].Status);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
 
-            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(currentVersion.Value + 1)));
+            await using var membershipUpdates = manager.MembershipTableUpdates.GetAsyncEnumerator();
+            Assert.True(await membershipUpdates.MoveNextAsync());
+
+            await manager.RefreshFromSnapshot(Snapshot(
+                new MembershipVersion(currentVersion.Value + 1),
+                Entry(otherSilo, SiloStatus.Active, now.AddMinutes(1))));
+            Assert.True(await membershipUpdates.MoveNextAsync());
+            Assert.Equal(SiloStatus.Dead, membershipUpdates.Current.Entries[this.localSilo].Status);
+            Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.Entries[this.localSilo].Status);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
+
+            await manager.RefreshFromSnapshot(Snapshot(
+                new MembershipVersion(currentVersion.Value + 2),
+                Entry(this.localSilo, SiloStatus.Active, DateTimeOffset.UtcNow)));
+            Assert.True(await membershipUpdates.MoveNextAsync());
+            Assert.Equal(SiloStatus.Dead, membershipUpdates.Current.Entries[this.localSilo].Status);
 
             await this.lifecycle.OnStop();
         }
@@ -517,6 +538,7 @@ namespace NonSilo.Tests.Membership
             Assert.DoesNotContain(prunedTable.Members, row => row.Item1.SiloAddress.Equals(this.localSilo));
 
             await manager.Refresh();
+            Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.Entries[this.localSilo].Status);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
 
             await this.lifecycle.OnStop();

--- a/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
@@ -441,7 +441,11 @@ namespace NonSilo.Tests.Membership
             await manager.RefreshFromSnapshot(Snapshot(
                 new MembershipVersion(version.Value - 1),
                 Entry(this.localSilo, SiloStatus.Dead, DateTimeOffset.UtcNow)));
+            this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
 
+            await manager.RefreshFromSnapshot(Snapshot(
+                new MembershipVersion(version.Value + 1),
+                Entry(this.localSilo, SiloStatus.Dead, DateTimeOffset.UtcNow)));
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
             await this.lifecycle.OnStop();
         }

--- a/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NonSilo.Tests.Utilities;
@@ -427,6 +428,96 @@ namespace NonSilo.Tests.Membership
             await this.lifecycle.OnStop();
         }
 
+        [Fact]
+        public async Task MembershipTableManager_ExplicitDeadSnapshot_Terminates()
+        {
+            var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
+            var manager = this.CreateMembershipTableManager(membershipTable);
+            ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
+            await this.lifecycle.OnStart();
+            await manager.UpdateStatus(SiloStatus.Joining);
+
+            var version = manager.MembershipTableSnapshot.Version;
+            await manager.RefreshFromSnapshot(Snapshot(
+                new MembershipVersion(version.Value - 1),
+                Entry(this.localSilo, SiloStatus.Dead, DateTimeOffset.UtcNow)));
+
+            this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
+            await this.lifecycle.OnStop();
+        }
+
+        [Fact]
+        public async Task MembershipTableManager_MissingLocalEntry_OnlyNewerSnapshotAfterJoiningTerminates()
+        {
+            var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
+            var manager = this.CreateMembershipTableManager(membershipTable);
+            ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
+
+            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(1)));
+            this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
+
+            await this.lifecycle.OnStart();
+            await manager.UpdateStatus(SiloStatus.Joining);
+            var currentVersion = manager.MembershipTableSnapshot.Version;
+
+            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(currentVersion.Value - 1)));
+            await manager.RefreshFromSnapshot(Snapshot(currentVersion));
+            this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
+
+            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(currentVersion.Value + 1)));
+            this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
+
+            await this.lifecycle.OnStop();
+        }
+
+        [Fact]
+        public async Task MembershipTableManager_MissingLocalEntry_WhenJoinSnapshotWasNotPublished_DoesNotTerminate()
+        {
+            var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
+            var manager = this.CreateMembershipTableManager(membershipTable);
+            ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
+            await this.lifecycle.OnStart();
+
+            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(125)));
+            await manager.UpdateStatus(SiloStatus.Joining);
+            Assert.Equal(SiloStatus.Joining, manager.CurrentStatus);
+            Assert.DoesNotContain(this.localSilo, manager.MembershipTableSnapshot.Entries.Keys);
+
+            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(126)));
+            this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
+
+            await this.lifecycle.OnStop();
+        }
+
+        [Fact]
+        public async Task MembershipTableManager_DeclaredDeadThenPrunedBeforeRefresh_Terminates()
+        {
+            var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
+            var manager = this.CreateMembershipTableManager(membershipTable);
+            ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
+            await this.lifecycle.OnStart();
+            await manager.UpdateStatus(SiloStatus.Joining);
+
+            while (true)
+            {
+                var table = await membershipTable.ReadAll();
+                var row = table.Members.Single(e => e.Item1.SiloAddress.Equals(this.localSilo));
+                if (await membershipTable.UpdateRow(row.Item1.WithStatus(SiloStatus.Dead), row.Item2, table.Version.Next()))
+                {
+                    break;
+                }
+            }
+
+            await membershipTable.CleanupDefunctSiloEntries(DateTimeOffset.UtcNow.AddMinutes(1));
+            var prunedTable = await membershipTable.ReadAll();
+            Assert.DoesNotContain(prunedTable.Members, row => row.Item1.SiloAddress.Equals(this.localSilo));
+
+            await manager.Refresh();
+            this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
+
+            await this.lifecycle.OnStop();
+        }
+
         /// <summary>
         /// Try to suspect another silo of failing but discover that this silo has failed.
         /// </summary>
@@ -767,6 +858,24 @@ namespace NonSilo.Tests.Membership
         }
 
         private static SiloAddress Silo(string value) => SiloAddress.FromParsableString(value);
+
+        private MembershipTableManager CreateMembershipTableManager(IMembershipTable membershipTable)
+        {
+            return new MembershipTableManager(
+                localSiloDetails: this.localSiloDetails,
+                clusterMembershipOptions: Options.Create(new ClusterMembershipOptions()),
+                membershipTable: membershipTable,
+                fatalErrorHandler: this.fatalErrorHandler,
+                gossiper: this.membershipGossiper,
+                log: this.loggerFactory.CreateLogger<MembershipTableManager>(),
+                timerFactory: new AsyncTimerFactory(this.loggerFactory, TimeProvider.System),
+                siloLifecycle: this.lifecycle);
+        }
+
+        private static MembershipTableSnapshot Snapshot(MembershipVersion version, params MembershipEntry[] entries)
+        {
+            return new MembershipTableSnapshot(version, entries.ToImmutableDictionary(entry => entry.SiloAddress));
+        }
 
         private static async Task<MembershipEvents.SuspectOrKillRequestCompleted> WaitForSuspectOrKillCompletion(DiagnosticEventCollector membershipEvents, SiloAddress silo)
         {

--- a/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
@@ -486,12 +486,6 @@ namespace NonSilo.Tests.Membership
             Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.Entries[this.localSilo].Status);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
 
-            await manager.RefreshFromSnapshot(Snapshot(
-                new MembershipVersion(currentVersion.Value + 2),
-                Entry(this.localSilo, SiloStatus.Active, DateTimeOffset.UtcNow)));
-            Assert.True(await membershipUpdates.MoveNextAsync());
-            Assert.Equal(SiloStatus.Dead, membershipUpdates.Current.Entries[this.localSilo].Status);
-
             await this.lifecycle.OnStop();
         }
 


### PR DESCRIPTION
Membership self-fencing currently depends on the local Dead tombstone remaining in the membership table. If cleanup removes that row before the silo refreshes, it can continue running while heartbeat updates retry indefinitely.

This change fences an already-joined silo when a strictly newer authoritative membership view omits its local entry. It preserves explicit Dead handling and ignores missing entries in startup, stale, equal, or unpublished-join views. Regression coverage includes the dead-row cleanup race.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10262)