### PR TITLE
fix(streaming): don't recycle in-flight pooled buffers mid-batch

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -209,14 +209,19 @@ namespace Orleans.Streaming.EventHubs
             if (currentBuffer == null || !currentBuffer.TryGetSegment(size, out segment))
             {
                 // no block or block full, get new block and try again
-                currentBuffer = bufferPool.Allocate();
-                //call EvictionStrategy's OnBlockAllocated method
-                this.evictionStrategy.OnBlockAllocated(currentBuffer);
-                // if this fails with clean block, then requested size is too big
-                if (!currentBuffer.TryGetSegment(size, out segment))
+                var newBuffer = bufferPool.Allocate();
+                // if this fails with a clean block, then requested size is too big; return the
+                // unused block to the pool and fail. Registering it with the eviction strategy
+                // before confirming the segment fits would leak it, because a batch that never
+                // commits is never reclaimed by the purge-time logic.
+                if (!newBuffer.TryGetSegment(size, out segment))
                 {
+                    newBuffer.Dispose();
                     throw new ArgumentOutOfRangeException(nameof(size), $"Message size is to big. MessageSize: {size}");
                 }
+                currentBuffer = newBuffer;
+                //call EvictionStrategy's OnBlockAllocated method
+                this.evictionStrategy.OnBlockAllocated(currentBuffer);
             }
             return segment;
         }

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -217,7 +217,7 @@ namespace Orleans.Streaming.EventHubs
                 if (!newBuffer.TryGetSegment(size, out segment))
                 {
                     newBuffer.Dispose();
-                    throw new ArgumentOutOfRangeException(nameof(size), $"Message size is to big. MessageSize: {size}");
+                    throw new ArgumentOutOfRangeException(nameof(size), $"Message size is too big. MessageSize: {size}");
                 }
                 currentBuffer = newBuffer;
                 //call EvictionStrategy's OnBlockAllocated method

--- a/src/Orleans.Streaming/Common/PooledCache/ChronologicalEvictionStrategy.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/ChronologicalEvictionStrategy.cs
@@ -18,7 +18,6 @@ namespace Orleans.Providers.Streams.Common
         /// Protected for test purposes
         /// </summary>
         protected readonly Queue<FixedSizeBuffer> inUseBuffers;
-        private FixedSizeBuffer currentBuffer;
         private readonly ICacheMonitor cacheMonitor;
         private readonly PeriodicAction periodicMonitoring;
         private long cacheSizeInByte;
@@ -62,13 +61,7 @@ namespace Orleans.Providers.Streams.Common
         /// <inheritdoc />
         public void OnBlockAllocated(FixedSizeBuffer newBlock)
         {
-            if (this.PurgeObservable.IsEmpty && this.currentBuffer != null
-                && this.inUseBuffers.Contains(this.currentBuffer) && this.inUseBuffers.Count == 1)
-            {
-                this.inUseBuffers.Dequeue().Dispose();
-            }
             this.inUseBuffers.Enqueue(newBlock);
-            this.currentBuffer = newBlock;
             //report metrics
             this.cacheSizeInByte += newBlock.SizeInByte;
             this.cacheMonitor?.TrackMemoryAllocated(newBlock.SizeInByte);

--- a/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
@@ -88,7 +88,7 @@ namespace Orleans.Providers.Streams.Generator
                 if (!newBuffer.TryGetSegment(size, out segment))
                 {
                     newBuffer.Dispose();
-                    string errmsg = $"Message size is to big. MessageSize: {size}";
+                    string errmsg = $"Message size is too big. MessageSize: {size}";
                     throw new ArgumentOutOfRangeException(nameof(queueMessage), errmsg);
                 }
                 currentBuffer = newBuffer;

--- a/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
+++ b/src/Orleans.Streaming/Generator/GeneratorPooledCache.cs
@@ -82,15 +82,18 @@ namespace Orleans.Providers.Streams.Generator
             if (currentBuffer == null || !currentBuffer.TryGetSegment(size, out segment))
             {
                 // no block or block full, get new block and try again
-                currentBuffer = bufferPool.Allocate();
-                //call EvictionStrategy's OnBlockAllocated method
-                this.evictionStrategy.OnBlockAllocated(currentBuffer);
-                // if this fails with clean block, then requested size is too big
-                if (!currentBuffer.TryGetSegment(size, out segment))
+                var newBuffer = bufferPool.Allocate();
+                // if this fails with a clean block, then requested size is too big; return the
+                // unused block to the pool and fail rather than leaking a block that is never committed.
+                if (!newBuffer.TryGetSegment(size, out segment))
                 {
+                    newBuffer.Dispose();
                     string errmsg = $"Message size is to big. MessageSize: {size}";
                     throw new ArgumentOutOfRangeException(nameof(queueMessage), errmsg);
                 }
+                currentBuffer = newBuffer;
+                //call EvictionStrategy's OnBlockAllocated method
+                this.evictionStrategy.OnBlockAllocated(currentBuffer);
             }
 
             // encode namespace, offset, partitionkey, properties and payload into segment

--- a/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
+++ b/src/Orleans.Streaming/MemoryStreams/MemoryPooledCache.cs
@@ -72,16 +72,19 @@ namespace Orleans.Providers
             if (currentBuffer == null || !currentBuffer.TryGetSegment(size, out segment))
             {
                 // no block or block full, get new block and try again
-                currentBuffer = bufferPool.Allocate();
-                //call EvictionStrategy's OnBlockAllocated method
-                this.evictionStrategy.OnBlockAllocated(currentBuffer);
-                // if this fails with clean block, then requested size is too big
-                if (!currentBuffer.TryGetSegment(size, out segment))
+                var newBuffer = bufferPool.Allocate();
+                // if this fails with a clean block, then requested size is too big; return the
+                // unused block to the pool and fail rather than leaking a block that is never committed.
+                if (!newBuffer.TryGetSegment(size, out segment))
                 {
+                    newBuffer.Dispose();
                     string errmsg = string.Format(CultureInfo.InvariantCulture,
                         "Message size is too big. MessageSize: {0}", size);
                     throw new ArgumentOutOfRangeException(nameof(queueMessage), errmsg);
                 }
+                currentBuffer = newBuffer;
+                //call EvictionStrategy's OnBlockAllocated method
+                this.evictionStrategy.OnBlockAllocated(currentBuffer);
             }
             // encode namespace, offset, partitionkey, properties and payload into segment
             int writeOffset = 0;

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -20,7 +20,7 @@ namespace UnitTests.OrleansRuntime.Streams
             private static readonly byte[] FixedMessage = new byte[MessageSize];
             public StreamId StreamId;
             public long SequenceNumber;
-            public readonly byte[] Data = FixedMessage;
+            public byte[] Data = FixedMessage;
             public DateTime EnqueueTimeUtc = DateTime.UtcNow;
         }
 
@@ -113,16 +113,19 @@ namespace UnitTests.OrleansRuntime.Streams
                 if (currentBuffer == null || !currentBuffer.TryGetSegment(size, out segment))
                 {
                     // no block or block full, get new block and try again
-                    currentBuffer = bufferPool.Allocate();
-                    //call EvictionStrategy's OnBlockAllocated method
-                    this.evictionStrategy.OnBlockAllocated(currentBuffer);
-                    // if this fails with clean block, then requested size is too big
-                    if (!currentBuffer.TryGetSegment(size, out segment))
+                    var newBuffer = bufferPool.Allocate();
+                    // if this fails with a clean block, then requested size is too big; return the
+                    // unused block to the pool and fail rather than leaking a block that is never committed.
+                    if (!newBuffer.TryGetSegment(size, out segment))
                     {
+                        newBuffer.Dispose();
                         string errmsg = string.Format(CultureInfo.InvariantCulture,
                             "Message size is too big. MessageSize: {0}", size);
                         throw new ArgumentOutOfRangeException(nameof(queueMessage), errmsg);
                     }
+                    currentBuffer = newBuffer;
+                    //call EvictionStrategy's OnBlockAllocated method
+                    this.evictionStrategy.OnBlockAllocated(currentBuffer);
                 }
                 // encode namespace, offset, partitionkey, properties and payload into segment
                 int writeOffset = 0;
@@ -167,6 +170,109 @@ namespace UnitTests.OrleansRuntime.Streams
             int startSequenceNuber = 222;
             startSequenceNuber = RunGoldenPath(cache, converter, startSequenceNuber);
             RunGoldenPath(cache, converter, startSequenceNuber);
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/dotnet/orleans/issues/10263.
+        /// A batch is encoded into pooled buffers before it is committed to the cache. When such a
+        /// batch spans more than one <see cref="FixedSizeBuffer"/> while the cache is empty, the
+        /// eviction strategy must not recycle a buffer that still holds in-flight (uncommitted)
+        /// segments from that same batch. Previously it did: the buffer was returned to the LIFO
+        /// pool, the next allocation in the same batch popped it straight back and overwrote the
+        /// earlier messages from offset 0, silently corrupting their payloads (surfacing later as an
+        /// ArgumentOutOfRangeException while decoding). This test writes distinct payloads and
+        /// asserts every one survives a multi-buffer batch added to an empty cache.
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void MultiBufferBatchFromEmptyCacheKeepsPayloadsIntact()
+        {
+            var bufferPool = new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(PooledBufferSize));
+            var dataAdapter = new TestCacheDataAdapter();
+            var cache = new PooledQueueCache(dataAdapter, NullLogger.Instance, null, null);
+            var evictionStrategy = new ChronologicalEvictionStrategy(NullLogger.Instance, new TimePurgePredicate(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(10)), null, null);
+            evictionStrategy.PurgeObservable = cache;
+            var converter = new CachedMessageConverter(bufferPool, evictionStrategy);
+
+            const int startSequenceNumber = 42;
+            // Enough messages to span several buffers within a single batch.
+            const int messageCount = MessagesPerBuffer * 5;
+            var stream = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
+
+            var messages = Enumerable.Range(0, messageCount)
+                .Select(i => new TestQueueMessage
+                {
+                    StreamId = stream,
+                    SequenceNumber = startSequenceNumber + i,
+                    Data = CreatePayload(i),
+                })
+                .ToList();
+
+            // Encode the whole batch into pooled buffers first, then commit - the same order the real
+            // EventHub/Memory/Generator caches use, and the order that triggers the corruption.
+            var utcNow = DateTime.UtcNow;
+            var cachedMessages = messages.Select(m => converter.ToCachedMessage(m, utcNow)).ToList();
+            cache.Add(cachedMessages, utcNow);
+
+            // Read every message back and assert its payload is exactly what we wrote.
+            var cursor = cache.GetCursor(stream, new EventSequenceTokenV2(startSequenceNumber));
+            for (int i = 0; i < messageCount; i++)
+            {
+                Assert.True(cache.TryGetNextMessage(cursor, out var batch), $"Missing message at index {i}");
+                var container = Assert.IsType<TestBatchContainer>(batch);
+                Assert.Equal(startSequenceNumber + i, container.SequenceToken.SequenceNumber);
+                Assert.Equal(CreatePayload(i), container.Data);
+            }
+            Assert.False(cache.TryGetNextMessage(cursor, out _));
+
+            static byte[] CreatePayload(int index)
+            {
+                var payload = new byte[MessageSize];
+                // Distinct, index-dependent pattern so any cross-message overwrite is detectable.
+                for (int j = 0; j < payload.Length; j++)
+                {
+                    payload[j] = (byte)((index + j) & 0xFF);
+                }
+                return payload;
+            }
+        }
+
+        /// <summary>
+        /// A message too large to ever fit in a pooled buffer must fail without leaking buffers. The
+        /// failed allocation must return its block to the pool so repeated oversized (poison)
+        /// messages reuse a single block instead of growing the retained set without bound.
+        /// </summary>
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void OversizedMessageDoesNotLeakBuffers()
+        {
+            int buffersCreated = 0;
+            var bufferPool = new ObjectPool<FixedSizeBuffer>(() =>
+            {
+                buffersCreated++;
+                return new FixedSizeBuffer(PooledBufferSize);
+            });
+            var dataAdapter = new TestCacheDataAdapter();
+            var cache = new PooledQueueCache(dataAdapter, NullLogger.Instance, null, null);
+            var evictionStrategy = new ChronologicalEvictionStrategy(NullLogger.Instance, new TimePurgePredicate(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(10)), null, null);
+            evictionStrategy.PurgeObservable = cache;
+            var converter = new CachedMessageConverter(bufferPool, evictionStrategy);
+
+            var stream = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
+            // A payload larger than a whole buffer can never be encoded into a single segment.
+            var oversized = new TestQueueMessage
+            {
+                StreamId = stream,
+                SequenceNumber = 1,
+                Data = new byte[PooledBufferSize * 2],
+            };
+
+            for (int i = 0; i < 5; i++)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => converter.ToCachedMessage(oversized, DateTime.UtcNow));
+            }
+
+            // Every failed attempt returns its block to the pool, so only a single block is ever
+            // created and then reused. Before the fix each attempt leaked a block (buffersCreated == 5).
+            Assert.Equal(1, buffersCreated);
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -20,7 +20,7 @@ namespace UnitTests.OrleansRuntime.Streams
             private static readonly byte[] FixedMessage = new byte[MessageSize];
             public StreamId StreamId;
             public long SequenceNumber;
-            public byte[] Data = FixedMessage;
+            public byte[] Data { get; init; } = FixedMessage;
             public DateTime EnqueueTimeUtc = DateTime.UtcNow;
         }
 


### PR DESCRIPTION
## Problem

Fixes #10263.

Pooled stream caches (EventHub, Memory, Generator) can silently corrupt message payloads, which later surfaces as an `ArgumentOutOfRangeException` in `SegmentBuilder.ReadNextString`.

`ChronologicalEvictionStrategy.OnBlockAllocated` eagerly freed the previous pooled buffer whenever the cache reported empty (`PurgeObservable.IsEmpty`). That was safe when the strategy was written, but callers now encode an *entire batch* into pooled buffers **before** committing it to the cache. During that encode `IsEmpty` stays `true`, so the buffer being freed can still hold in-flight, uncommitted segments for the current batch. The freed buffer is returned to the (LIFO) object pool, and the very next allocation in the same batch pops it straight back and overwrites the earlier segments from offset 0 — corrupting those messages. The three pooled caches all share this eviction strategy, so all of them are affected, not just EventHub.

## Solution

Remove the eager-free branch in `OnBlockAllocated`. In-use buffers are already reclaimed correctly at purge time by `FreePurgedBuffers`, which only releases buffers once their segments are no longer referenced by committed messages.

Removing the eager-free would, on its own, expose a pre-existing buffer leak: for a message too large to ever fit in a pooled buffer, the eager-free was the only thing that reclaimed the freshly allocated (and never-committed) block. To close that, the EventHub, Memory and Generator caches now dispose the freshly allocated block back to the pool and throw **before** registering it with the eviction strategy, so repeated oversized (poison) messages reuse a single block instead of growing the retained set without bound.

Adds regression tests for multi-buffer batch payload integrity from an empty cache and for the oversized-message no-leak behavior. Both fail without the fix and pass with it.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10264)