### PR TITLE
fix(streaming): refresh idle EventHub cursors to avoid QueueCacheMissException

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -398,6 +398,7 @@ namespace Orleans.Streaming.EventHubs
 
             public void Refresh(StreamSequenceToken token)
             {
+                this.cache.Refresh(this.cursor, token);
             }
 
             public void RecordDeliveryFailure()

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -137,6 +137,12 @@ namespace Orleans.Streaming.EventHubs
             return cache.GetCursor(streamId, sequenceToken);
         }
 
+        /// <inheritdoc />
+        public void Refresh(object cursor, StreamSequenceToken sequenceToken)
+        {
+            cache.Refresh(cursor, sequenceToken);
+        }
+
         /// <summary>
         /// Try to get the next message in the cache for the provided cursor.
         /// </summary>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubQueueCache.cs
@@ -26,6 +26,14 @@ namespace Orleans.Streaming.EventHubs
         /// <param name="sequenceToken"></param>
         /// <returns></returns>
         object GetCursor(StreamId streamId, StreamSequenceToken sequenceToken);
+
+        /// <summary>
+        /// Refreshes an inactive cursor at the provided sequence token.
+        /// </summary>
+        /// <param name="cursor">The cursor to refresh.</param>
+        /// <param name="sequenceToken">The sequence token to position the cursor at.</param>
+        void Refresh(object cursor, StreamSequenceToken sequenceToken) { }
+
         /// <summary>
         /// Try to get the next message in the cache for the provided cursor.
         /// </summary>

--- a/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
+++ b/src/Orleans.Streaming/Common/PooledCache/PooledQueueCache.cs
@@ -120,6 +120,40 @@ namespace Orleans.Providers.Streams.Common
             return cursor;
         }
 
+        /// <summary>
+        /// Repositions an idle or unset cursor at the provided sequence token.
+        /// </summary>
+        /// <param name="cursorObj">The cursor to refresh.</param>
+        /// <param name="sequenceToken">The sequence token to position the cursor at.</param>
+        public void Refresh(object cursorObj, StreamSequenceToken sequenceToken)
+        {
+            ArgumentNullException.ThrowIfNull(cursorObj);
+
+            if (cursorObj is not Cursor cursor)
+            {
+                throw new ArgumentOutOfRangeException(nameof(cursorObj), "Cursor is bad");
+            }
+
+            // Only reposition idle or unset cursors. An active (Set) cursor is mid-enumeration and must not be moved.
+            // A null token has no reposition target, so leave the cursor untouched and let the normal idle wake-up
+            // path handle it, rather than repositioning to the newest event (which would skip data).
+            if (sequenceToken is null || cursor.State == CursorStates.Set)
+            {
+                return;
+            }
+
+            // Refresh only ever moves a cursor forward. If the cursor is already positioned at or ahead of the
+            // requested token (for example an unset cursor waiting on a future token), leave it in place so we do
+            // not rewind it and re-deliver events the consumer has already requested to start after.
+            if (cursor.SequenceToken is not null && cursor.SequenceToken.CompareTo(sequenceToken) >= 0)
+            {
+                return;
+            }
+
+            cursor.State = CursorStates.Unset;
+            SetCursor(cursor, sequenceToken);
+        }
+
         private void ReportCacheMessageStatistics()
         {
             if (this.IsEmpty)

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -464,6 +464,8 @@ namespace Orleans.Streaming.EventHubs
 
         public int GetMaxAddCount() { throw null; }
 
+        public void Refresh(object cursor, Streams.StreamSequenceToken sequenceToken) { }
+
         public void SignalPurge() { }
 
         public bool TryGetNextMessage(object cursorObj, out Streams.IBatchContainer message) { throw null; }
@@ -546,6 +548,7 @@ namespace Orleans.Streaming.EventHubs
         System.Collections.Generic.List<Streams.StreamPosition> Add(System.Collections.Generic.List<Azure.Messaging.EventHubs.EventData> message, System.DateTime dequeueTimeUtc);
         void AddCachePressureMonitor(ICachePressureMonitor monitor);
         object GetCursor(Runtime.StreamId streamId, Streams.StreamSequenceToken sequenceToken);
+        void Refresh(object cursor, Streams.StreamSequenceToken sequenceToken);
         void SignalPurge();
         bool TryGetNextMessage(object cursorObj, out Streams.IBatchContainer message);
     }

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -809,6 +809,8 @@ namespace Orleans.Providers.Streams.Common
 
         public object GetCursor(Runtime.StreamId streamId, Orleans.Streams.StreamSequenceToken sequenceToken) { throw null; }
 
+        public void Refresh(object cursorObj, Orleans.Streams.StreamSequenceToken sequenceToken) { }
+
         public void RemoveOldestMessage() { }
 
         public bool TryGetNextMessage(object cursorObj, out Orleans.Streams.IBatchContainer message) { throw null; }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -69,12 +69,21 @@ public class EventHubCheckpointerTests
 
         public int DisposeCount { get; private set; }
         public string PurgeOffsetToReport { get; set; }
+        public object Cursor { get; } = new();
+        public object RefreshedCursor { get; private set; }
+        public StreamSequenceToken RefreshToken { get; private set; }
 
         public int GetMaxAddCount() => 1_000;
 
         public List<StreamPosition> Add(List<EventData> message, DateTime dequeueTimeUtc) => [];
 
-        public object GetCursor(StreamId streamId, StreamSequenceToken sequenceToken) => new();
+        public object GetCursor(StreamId streamId, StreamSequenceToken sequenceToken) => Cursor;
+
+        public void Refresh(object cursor, StreamSequenceToken sequenceToken)
+        {
+            RefreshedCursor = cursor;
+            RefreshToken = sequenceToken;
+        }
 
         public bool TryGetNextMessage(object cursorObj, out IBatchContainer message)
         {
@@ -167,6 +176,20 @@ public class EventHubCheckpointerTests
         await receiver.Initialize(TimeSpan.FromSeconds(5));
 
         return receiver;
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task CursorRefresh_DelegatesToEventHubCache()
+    {
+        var cache = new TestEventHubQueueCache();
+        var receiver = await CreateReceiver(new TestCheckpointer(), cache);
+        var cursor = receiver.GetCacheCursor(StreamId.Create("namespace", Guid.NewGuid()), MakeToken(1));
+        var refreshToken = MakeToken(2);
+
+        cursor.Refresh(refreshToken);
+
+        Assert.Same(cache.Cursor, cache.RefreshedCursor);
+        Assert.Same(refreshToken, cache.RefreshToken);
     }
 
     [Fact, TestCategory("BVT")]

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/PooledQueueCacheTests.cs
@@ -182,6 +182,111 @@ namespace UnitTests.OrleansRuntime.Streams
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void RefreshIdleCursorStartsAtProvidedTokenAfterPurge()
+        {
+            var bufferPool = new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(PooledBufferSize));
+            var dataAdapter = new TestCacheDataAdapter();
+            // Disable purge metadata to reproduce a cursor outliving both cached data and its token metadata.
+            var cache = new PooledQueueCache(dataAdapter, NullLogger.Instance, null, null);
+            var evictionStrategy = new ChronologicalEvictionStrategy(NullLogger.Instance, new TimePurgePredicate(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(10)), null, null);
+            evictionStrategy.PurgeObservable = cache;
+            var converter = new CachedMessageConverter(bufferPool, evictionStrategy);
+            var stream = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
+
+            AddMessage(1);
+            var cursor = cache.GetCursor(stream, new EventSequenceTokenV2(1));
+            Assert.True(cache.TryGetNextMessage(cursor, out _));
+            Assert.False(cache.TryGetNextMessage(cursor, out _));
+
+            cache.RemoveOldestMessage();
+            AddMessage(2);
+            var newEventToken = new EventSequenceTokenV2(2);
+
+            cache.Refresh(cursor, newEventToken);
+
+            Assert.True(cache.TryGetNextMessage(cursor, out var message));
+            Assert.Equal(newEventToken, message.SequenceToken);
+            Assert.False(cache.TryGetNextMessage(cursor, out _));
+
+            void AddMessage(long sequenceNumber)
+            {
+                var now = DateTime.UtcNow;
+                var message = new TestQueueMessage
+                {
+                    StreamId = stream,
+                    SequenceNumber = sequenceNumber,
+                };
+                cache.Add([converter.ToCachedMessage(message, now)], now);
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void RefreshDoesNotRepositionActiveCursor()
+        {
+            var bufferPool = new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(PooledBufferSize));
+            var dataAdapter = new TestCacheDataAdapter();
+            var cache = new PooledQueueCache(dataAdapter, NullLogger.Instance, null, null);
+            var evictionStrategy = new ChronologicalEvictionStrategy(NullLogger.Instance, new TimePurgePredicate(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(10)), null, null);
+            evictionStrategy.PurgeObservable = cache;
+            var converter = new CachedMessageConverter(bufferPool, evictionStrategy);
+            var stream = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
+            var now = DateTime.UtcNow;
+            cache.Add(
+            [
+                converter.ToCachedMessage(new TestQueueMessage { StreamId = stream, SequenceNumber = 1 }, now),
+                converter.ToCachedMessage(new TestQueueMessage { StreamId = stream, SequenceNumber = 2 }, now),
+            ], now);
+            var cursor = cache.GetCursor(stream, new EventSequenceTokenV2(1));
+
+            cache.Refresh(cursor, new EventSequenceTokenV2(2));
+
+            Assert.True(cache.TryGetNextMessage(cursor, out var firstMessage));
+            Assert.Equal(1, firstMessage.SequenceToken.SequenceNumber);
+            Assert.True(cache.TryGetNextMessage(cursor, out var secondMessage));
+            Assert.Equal(2, secondMessage.SequenceToken.SequenceNumber);
+            Assert.False(cache.TryGetNextMessage(cursor, out _));
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public void RefreshDoesNotRewindCursorHoldingFutureToken()
+        {
+            var bufferPool = new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(PooledBufferSize));
+            var dataAdapter = new TestCacheDataAdapter();
+            var cache = new PooledQueueCache(dataAdapter, NullLogger.Instance, null, null);
+            var evictionStrategy = new ChronologicalEvictionStrategy(NullLogger.Instance, new TimePurgePredicate(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(10)), null, null);
+            evictionStrategy.PurgeObservable = cache;
+            var converter = new CachedMessageConverter(bufferPool, evictionStrategy);
+            var stream = StreamId.Create(TestStreamNamespace, Guid.NewGuid());
+
+            // Position an unset cursor on a token that is still in the future relative to the cache.
+            AddMessage(1);
+            var cursor = cache.GetCursor(stream, new EventSequenceTokenV2(5));
+
+            // A refresh with an older token must not rewind the cursor behind its requested start.
+            cache.Refresh(cursor, new EventSequenceTokenV2(2));
+
+            AddMessage(2);
+            AddMessage(3);
+            AddMessage(4);
+            AddMessage(5);
+
+            Assert.True(cache.TryGetNextMessage(cursor, out var message));
+            Assert.Equal(5, message.SequenceToken.SequenceNumber);
+            Assert.False(cache.TryGetNextMessage(cursor, out _));
+
+            void AddMessage(long sequenceNumber)
+            {
+                var now = DateTime.UtcNow;
+                var message = new TestQueueMessage
+                {
+                    StreamId = stream,
+                    SequenceNumber = sequenceNumber,
+                };
+                cache.Add([converter.ToCachedMessage(message, now)], now);
+            }
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public void AvoidCacheMissMultipleStreamsActive()
         {
             var bufferPool = new ObjectPool<FixedSizeBuffer>(() => new FixedSizeBuffer(PooledBufferSize));

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -313,12 +313,119 @@ namespace UnitTests.StreamingTests
             }
         }
 
+        private sealed class PurgeablePooledQueueCache : IQueueCache
+        {
+            private readonly PooledQueueCache cache = new(new CacheDataAdapter(), NullLogger.Instance, null, null);
+
+            public int GetMaxAddCount() => 1000;
+
+            public void AddToCache(IList<IBatchContainer> messages)
+            {
+                var now = DateTime.UtcNow;
+                cache.Add(
+                    messages.Select(message => new CachedMessage
+                    {
+                        StreamId = message.StreamId,
+                        SequenceNumber = message.SequenceToken.SequenceNumber,
+                        EventIndex = message.SequenceToken.EventIndex,
+                        EnqueueTimeUtc = now,
+                        DequeueTimeUtc = now,
+                    }).ToList(),
+                    now);
+            }
+
+            public bool TryPurgeFromCache(out IList<IBatchContainer> purgedItems)
+            {
+                purgedItems = null;
+                return false;
+            }
+
+            public IQueueCacheCursor GetCacheCursor(StreamId streamId, StreamSequenceToken token)
+                => new Cursor(cache, cache.GetCursor(streamId, token));
+
+            public bool IsUnderPressure() => false;
+
+            public void UpdateDeliveryProgress(StreamSequenceToken earliestSubscriptionToken, DateTime utcNow)
+            {
+            }
+
+            public void Purge()
+            {
+                while (!cache.IsEmpty)
+                {
+                    cache.RemoveOldestMessage();
+                }
+            }
+
+            private sealed class CacheDataAdapter : ICacheDataAdapter
+            {
+                public IBatchContainer GetBatchContainer(ref CachedMessage cachedMessage)
+                    => new TestBatchContainer(cachedMessage.StreamId, GetSequenceToken(ref cachedMessage));
+
+                public StreamSequenceToken GetSequenceToken(ref CachedMessage cachedMessage)
+                    => new EventSequenceTokenV2(cachedMessage.SequenceNumber, cachedMessage.EventIndex);
+            }
+
+            private sealed class Cursor(PooledQueueCache cache, object cursor) : IQueueCacheCursor
+            {
+                private IBatchContainer current;
+
+                public void Dispose()
+                {
+                }
+
+                public IBatchContainer GetCurrent(out Exception exception)
+                {
+                    exception = null;
+                    return current;
+                }
+
+                public bool MoveNext() => cache.TryGetNextMessage(cursor, out current);
+
+                public void Refresh(StreamSequenceToken token) => cache.Refresh(cursor, token);
+
+                public void RecordDeliveryFailure()
+                {
+                }
+            }
+        }
+
         private sealed class TestBatchContainer(StreamId streamId, StreamSequenceToken token) : IBatchContainer
         {
             public StreamId StreamId { get; } = streamId;
             public StreamSequenceToken SequenceToken { get; } = token;
             public IEnumerable<Tuple<T, StreamSequenceToken>> GetEvents<T>() => [];
             public bool ImportRequestContext() => false;
+        }
+
+        private sealed class RecordingConsumer : IStreamConsumerExtension
+        {
+            private readonly TaskCompletionSource<bool> releaseDelivery = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public TaskCompletionSource<bool> Delivered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            public List<StreamSequenceToken> DeliveredTokens { get; } = new();
+
+            public Task<StreamHandshakeToken> DeliverImmutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken)
+                => throw new NotSupportedException();
+
+            public Task<StreamHandshakeToken> DeliverMutable(GuidId subscriptionId, QualifiedStreamId streamId, object item, StreamSequenceToken currentToken, StreamHandshakeToken handshakeToken)
+                => throw new NotSupportedException();
+
+            public async Task<StreamHandshakeToken> DeliverBatch(GuidId subscriptionId, QualifiedStreamId streamId, IBatchContainer item, StreamHandshakeToken handshakeToken)
+            {
+                DeliveredTokens.Add(item.SequenceToken);
+                Delivered.TrySetResult(true);
+                await releaseDelivery.Task;
+                return null;
+            }
+
+            public Task CompleteStream(GuidId subscriptionId) => Task.CompletedTask;
+
+            public Task ErrorInStream(GuidId subscriptionId, Exception exc) => Task.CompletedTask;
+
+            public Task<StreamHandshakeToken> GetSequenceToken(GuidId subscriptionId) => Task.FromResult<StreamHandshakeToken>(null);
+
+            public void ReleaseDelivery() => releaseDelivery.TrySetResult(true);
         }
 
         private sealed class RewindConsumer(StreamHandshakeToken rewindToken) : IStreamConsumerExtension
@@ -346,6 +453,60 @@ namespace UnitTests.StreamingTests
             public Task ErrorInStream(GuidId subscriptionId, Exception exc) => Task.CompletedTask;
 
             public Task<StreamHandshakeToken> GetSequenceToken(GuidId subscriptionId) => Task.FromResult(rewindToken);
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task ReadFromQueue_RefreshesIdleCursorAfterItsTokenMetadataIsPurged()
+        {
+            var pubSub = Substitute.For<IStreamPubSub>();
+            pubSub.RegisterProducer(default, default)
+                .ReturnsForAnyArgs(Task.FromResult<ISet<PubSubSubscriptionState>>(new HashSet<PubSubSubscriptionState>()));
+
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var streamId = StreamId.Create("namespace", Guid.NewGuid());
+            var qualifiedStreamId = new QualifiedStreamId("provider", streamId);
+            var oldToken = new EventSequenceTokenV2(1);
+            var newToken = new EventSequenceTokenV2(2);
+            var queueCache = new PurgeablePooledQueueCache();
+            queueCache.AddToCache([new TestBatchContainer(streamId, oldToken)]);
+            var cursor = queueCache.GetCacheCursor(streamId, oldToken);
+            Assert.True(cursor.MoveNext());
+            Assert.False(cursor.MoveNext());
+
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+                .Returns(Task.FromResult<IList<IBatchContainer>>([new TestBatchContainer(streamId, newToken)]));
+            var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
+            queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
+            var agent = CreateAgent(pubSub, queueId, receiver, queueAdapterCache);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+            await testAccessor.RegisterStream(qualifiedStreamId, oldToken, DateTime.UtcNow);
+
+            var streamData = (await testAccessor.GetPubSubCache()).Single().Value;
+            var consumer = new RecordingConsumer();
+            var consumerData = streamData.AddConsumer(
+                GuidId.GetGuidId(Guid.NewGuid()),
+                qualifiedStreamId,
+                consumer,
+                filterData: null,
+                now: DateTime.UtcNow);
+            consumerData.IsRegistered = true;
+            consumerData.Cursor = cursor;
+            queueCache.Purge();
+
+            Assert.True(await testAccessor.ReadFromQueue(queueId, receiver, 1));
+            await consumer.Delivered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            consumer.ReleaseDelivery();
+
+            var timeout = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+            while (consumerData.State != StreamConsumerDataState.Inactive && DateTime.UtcNow < timeout)
+            {
+                await Task.Delay(10);
+            }
+
+            Assert.Equal(StreamConsumerDataState.Inactive, consumerData.State);
+            Assert.Equal(newToken, Assert.Single(consumer.DeliveredTokens));
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]


### PR DESCRIPTION
## Problem

Orleans retains inactive stream cursors longer than the EventHub cache retains data and token metadata. When new data wakes an inactive consumer, `PersistentStreamPullingAgent.StartInactiveCursors` calls `cursor.Refresh(startToken)` — but EventHub's `Cursor.Refresh` was an empty no-op. The stale cursor then requested an already-evicted token and threw `QueueCacheMissException`.

## Solution

Add real refresh support to the shared `PooledQueueCache`:

- An **idle or unset** cursor is repositioned to the supplied non-null `startToken` (the first newly available event) **without skipping it**. The cursor is reset to `Unset` before `SetCursor` so it lands exactly at the token rather than being advanced past it by the idle-skip path.
- An **active (`Set`)** cursor that is mid-enumeration is left untouched.
- Refresh only ever moves a cursor **forward**: a cursor already positioned at or ahead of the requested token is left in place rather than rewound, matching `SimpleQueueCache`'s conservatism.
- A `null` token is a no-op, preserving the previous behavior on the delivery hot path.

`EventHubQueueCache` and the EventHub cursor now delegate to `PooledQueueCache.Refresh`. `IEventHubQueueCache.Refresh` is added as a default-implemented no-op so external cache implementations of this documented extension point keep compiling.

## Tests

- Cache-level: refreshing an idle cursor after its event and token metadata are purged delivers the new event exactly once without `QueueCacheMissException`; refresh does not reposition an active cursor; refresh does not rewind a cursor already holding a future token.
- EventHub: the cursor's `Refresh` delegates to the underlying cache.
- Pulling agent: integration test covering the idle -> purge -> new-event wake-up sequence.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10266)