### PR TITLE
fix(serialization)!: enforce type allow-list in default JSON storage serializer

### DIFF
--- a/src/Orleans.Core/Serialization/OrleansJsonSerializationBinder.cs
+++ b/src/Orleans.Core/Serialization/OrleansJsonSerializationBinder.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Orleans.Serialization.TypeSystem;
 
@@ -6,28 +7,87 @@ using Orleans.Serialization.TypeSystem;
 namespace Orleans.Serialization
 {
     /// <summary>
-    /// Implementation of <see cref="ISerializationBinder"/> which resolves types using a <see cref="TypeResolver"/>.
+    /// Implementation of <see cref="ISerializationBinder"/> which resolves types using a <see cref="TypeConverter"/>
+    /// and enforces the configured Orleans type allow-list, preventing arbitrary types from being constructed
+    /// during deserialization.
     /// </summary>
     public class OrleansJsonSerializationBinder : DefaultSerializationBinder
     {
-        private readonly TypeResolver typeResolver;
+        private readonly TypeResolver _typeResolver;
+        private readonly TypeConverter _typeConverter;
+        private readonly bool _allowAllTypes;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OrleansJsonSerializationBinder"/> class.
         /// </summary>
         /// <param name="typeResolver">The type resolver.</param>
+        /// <remarks>
+        /// This constructor does not enforce the Orleans type allow-list: any resolvable type may be constructed
+        /// during deserialization. It is retained for backwards compatibility. Prefer the constructor which accepts
+        /// a <see cref="TypeConverter"/> so that the type allow-list is enforced.
+        /// </remarks>
         public OrleansJsonSerializationBinder(TypeResolver typeResolver)
         {
-            this.typeResolver = typeResolver;
+            _typeResolver = typeResolver;
+            _allowAllTypes = true;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrleansJsonSerializationBinder"/> class which enforces the
+        /// Orleans type allow-list.
+        /// </summary>
+        /// <param name="typeConverter">The type converter used to resolve and validate types against the allow-list.</param>
+        /// <param name="typeResolver">The type resolver used to resolve types when the allow-list is disabled.</param>
+        /// <param name="allowAllTypes">
+        /// When <see langword="true"/>, restores the legacy behavior of allowing any resolvable type to be constructed
+        /// during deserialization, bypassing the type allow-list. This is insecure and is not recommended.
+        /// </param>
+        public OrleansJsonSerializationBinder(TypeConverter typeConverter, TypeResolver typeResolver, bool allowAllTypes = false)
+        {
+            _typeConverter = typeConverter;
+            _typeResolver = typeResolver;
+            _allowAllTypes = allowAllTypes;
         }
 
         /// <inheritdoc />
         public override Type BindToType(string assemblyName, string typeName)
         {
             var fullName = !string.IsNullOrWhiteSpace(assemblyName) ? typeName + ',' + assemblyName : typeName;
-            if (typeResolver.TryResolveType(fullName, out var type)) return type;
 
-            return base.BindToType(assemblyName, typeName);
+            if (_allowAllTypes || _typeConverter is null)
+            {
+                // Legacy, permissive behavior: resolve any type without consulting the allow-list.
+                if (_typeResolver is not null && _typeResolver.TryResolveType(fullName, out var resolvedType))
+                {
+                    return resolvedType;
+                }
+
+                return base.BindToType(assemblyName, typeName);
+            }
+
+            // Enforce the Orleans type allow-list. TypeConverter.TryParse throws for types which are explicitly
+            // disallowed and only resolves types which are permitted by the configured filters and allowed-type
+            // configuration.
+            try
+            {
+                if (_typeConverter.TryParse(fullName, out var type))
+                {
+                    return type;
+                }
+            }
+            catch (InvalidOperationException exception)
+            {
+                // TypeConverter throws InvalidOperationException when the type is resolvable but not permitted by
+                // the allow-list. Surface a JSON-specific error which also mentions the opt-out.
+                throw new JsonSerializationException(BuildNotAllowedMessage(fullName), exception);
+            }
+
+            throw new JsonSerializationException(BuildNotAllowedMessage(fullName));
         }
+
+        private static string BuildNotAllowedMessage(string fullName) =>
+            $"Unable to resolve type \"{fullName}\". The type could not be found or is not permitted by the configured type allow-list. " +
+            $"To allow it, mark the type with [GenerateSerializer], add it to {nameof(Configuration.TypeManifestOptions)}.{nameof(Configuration.TypeManifestOptions.AllowedTypes)}, " +
+            $"register an {nameof(ITypeNameFilter)} or {nameof(ITypeFilter)} which allows it, or set {nameof(OrleansJsonSerializerOptions)}.{nameof(OrleansJsonSerializerOptions.AllowAllTypes)} to true to restore the previous behavior.";
     }
 }

--- a/src/Orleans.Core/Serialization/OrleansJsonSerializerOptions.cs
+++ b/src/Orleans.Core/Serialization/OrleansJsonSerializerOptions.cs
@@ -9,6 +9,29 @@ namespace Orleans.Serialization
     {
         public JsonSerializerSettings JsonSerializerSettings { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether any resolvable type may be constructed during
+        /// deserialization, including types named in the serialized payload via
+        /// <see cref="Newtonsoft.Json.TypeNameHandling"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The default value is <see langword="false"/>. When <see langword="false"/>, only types permitted
+        /// by the Orleans type allow-list may be constructed during deserialization &#8212; for example,
+        /// types marked with <c>[GenerateSerializer]</c>, types added to
+        /// <see cref="Orleans.Serialization.Configuration.TypeManifestOptions.AllowedTypes"/>, or types
+        /// allowed by a registered <see cref="ITypeNameFilter"/> or <see cref="ITypeFilter"/>. This prevents
+        /// arbitrary, potentially dangerous types from being instantiated when deserializing untrusted
+        /// persisted or streamed state.
+        /// </para>
+        /// <para>
+        /// Setting this to <see langword="true"/> restores the previous behavior of allowing any loadable
+        /// type to be constructed during deserialization. This is <b>insecure</b> and is not recommended;
+        /// prefer allow-listing individual types instead.
+        /// </para>
+        /// </remarks>
+        public bool AllowAllTypes { get; set; }
+
         public OrleansJsonSerializerOptions()
         {
             JsonSerializerSettings = OrleansJsonSerializerSettings.GetDefaultSerializerSettings();
@@ -26,7 +49,7 @@ namespace Orleans.Serialization
 
         public void PostConfigure(string name, OrleansJsonSerializerOptions options)
         {
-            OrleansJsonSerializerSettings.Configure(_serviceProvider, options.JsonSerializerSettings);
+            OrleansJsonSerializerSettings.Configure(_serviceProvider, options.JsonSerializerSettings, options.AllowAllTypes);
         }
     }
 }

--- a/src/Orleans.Core/Serialization/OrleansJsonSerializerSettings.cs
+++ b/src/Orleans.Core/Serialization/OrleansJsonSerializerSettings.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Orleans.GrainReferences;
 using Orleans.Serialization.TypeSystem;
@@ -35,16 +36,18 @@ namespace Orleans.Serialization
         public static JsonSerializerSettings GetDefaultSerializerSettings(IServiceProvider services)
         {
             var settings = GetDefaultSerializerSettings();
-            Configure(services, settings);
+            var allowAllTypes = services.GetService<IOptions<OrleansJsonSerializerOptions>>()?.Value.AllowAllTypes ?? false;
+            Configure(services, settings, allowAllTypes);
             return settings;
         }
 
-        internal static void Configure(IServiceProvider services, JsonSerializerSettings jsonSerializerSettings)
+        internal static void Configure(IServiceProvider services, JsonSerializerSettings jsonSerializerSettings, bool allowAllTypes = false)
         {
             if (jsonSerializerSettings.SerializationBinder == null)
             {
                 var typeResolver = services.GetRequiredService<TypeResolver>();
-                jsonSerializerSettings.SerializationBinder = new OrleansJsonSerializationBinder(typeResolver);
+                var typeConverter = services.GetRequiredService<TypeConverter>();
+                jsonSerializerSettings.SerializationBinder = new OrleansJsonSerializationBinder(typeConverter, typeResolver, allowAllTypes);
             }
 
             jsonSerializerSettings.Converters.Add(new IPAddressConverter());

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -1744,6 +1744,8 @@ namespace Orleans.Serialization
 
     public partial class OrleansJsonSerializationBinder : Newtonsoft.Json.Serialization.DefaultSerializationBinder
     {
+        public OrleansJsonSerializationBinder(TypeSystem.TypeConverter typeConverter, TypeSystem.TypeResolver typeResolver, bool allowAllTypes = false) { }
+
         public OrleansJsonSerializationBinder(TypeSystem.TypeResolver typeResolver) { }
 
         public override System.Type BindToType(string assemblyName, string typeName) { throw null; }
@@ -1767,6 +1769,8 @@ namespace Orleans.Serialization
 
     public partial class OrleansJsonSerializerOptions
     {
+        public bool AllowAllTypes { get { throw null; } set { } }
+
         public Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { throw null; } set { } }
     }
 

--- a/test/Orleans.Core.Tests/Serialization/OrleansJsonSerializationBinderTests.cs
+++ b/test/Orleans.Core.Tests/Serialization/OrleansJsonSerializationBinderTests.cs
@@ -1,0 +1,166 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Orleans;
+using Orleans.Serialization;
+using Orleans.Serialization.TypeSystem;
+using Xunit;
+
+namespace NonSilo.Tests.Serialization;
+
+/// <summary>
+/// Tests for <see cref="OrleansJsonSerializationBinder"/>, which enforces the Orleans type allow-list when
+/// resolving types named in a JSON payload via <see cref="TypeNameHandling"/>. This prevents arbitrary CLR
+/// types from being constructed during deserialization of persisted or streamed grain state.
+/// </summary>
+[TestCategory("BVT"), TestCategory("Serialization")]
+public class OrleansJsonSerializationBinderTests
+{
+    private static ServiceProvider BuildServiceProvider(params Type[] allowedTypes)
+    {
+        var services = new ServiceCollection();
+        services.AddSerializer(builder => builder.Configure(options =>
+        {
+            foreach (var type in allowedTypes)
+            {
+                options.AllowedTypes.Add(type.FullName);
+            }
+        }));
+
+        return services.BuildServiceProvider();
+    }
+
+    private static OrleansJsonSerializationBinder CreateStrictBinder(IServiceProvider services, bool allowAllTypes = false)
+        => new OrleansJsonSerializationBinder(
+            services.GetRequiredService<TypeConverter>(),
+            services.GetRequiredService<TypeResolver>(),
+            allowAllTypes);
+
+    private static JsonSerializerSettings CreateSettings(ISerializationBinder binder) => new JsonSerializerSettings
+    {
+        TypeNameHandling = TypeNameHandling.All,
+        TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
+        SerializationBinder = binder,
+    };
+
+    [Fact]
+    public void BindToType_AllowedByConfiguration_ResolvesType()
+    {
+        using var services = BuildServiceProvider(typeof(AllowedState));
+        var binder = CreateStrictBinder(services);
+
+        var type = binder.BindToType(typeof(AllowedState).Assembly.GetName().Name, typeof(AllowedState).FullName);
+
+        Assert.Equal(typeof(AllowedState), type);
+    }
+
+    [Fact]
+    public void BindToType_NotAllowed_Throws()
+    {
+        using var services = BuildServiceProvider(typeof(AllowedState));
+        var binder = CreateStrictBinder(services);
+
+        var exception = Assert.Throws<JsonSerializationException>(() =>
+            binder.BindToType(typeof(DisallowedState).Assembly.GetName().Name, typeof(DisallowedState).FullName));
+
+        Assert.Contains(nameof(OrleansJsonSerializerOptions.AllowAllTypes), exception.Message);
+    }
+
+    [Fact]
+    public void BindToType_NotAllowed_WithAllowAllTypes_ResolvesType()
+    {
+        using var services = BuildServiceProvider(typeof(AllowedState));
+        var binder = CreateStrictBinder(services, allowAllTypes: true);
+
+        var type = binder.BindToType(typeof(DisallowedState).Assembly.GetName().Name, typeof(DisallowedState).FullName);
+
+        Assert.Equal(typeof(DisallowedState), type);
+    }
+
+    [Fact]
+    public void BindToType_LegacyConstructor_ResolvesAnyType()
+    {
+        using var services = BuildServiceProvider(typeof(AllowedState));
+        var binder = new OrleansJsonSerializationBinder(services.GetRequiredService<TypeResolver>());
+
+        var type = binder.BindToType(typeof(DisallowedState).Assembly.GetName().Name, typeof(DisallowedState).FullName);
+
+        Assert.Equal(typeof(DisallowedState), type);
+    }
+
+    [Fact]
+    public void BindToType_GenerateSerializerType_IsAllowedWithoutConfiguration()
+    {
+        var services = new ServiceCollection();
+        services.AddSerializer(builder => builder.AddAssembly(typeof(GeneratedState).Assembly));
+        using var provider = services.BuildServiceProvider();
+        var binder = CreateStrictBinder(provider);
+
+        var type = binder.BindToType(typeof(GeneratedState).Assembly.GetName().Name, typeof(GeneratedState).FullName);
+
+        Assert.Equal(typeof(GeneratedState), type);
+    }
+
+    [Fact]
+    public void Deserialize_AllowedType_RoundTrips()
+    {
+        using var services = BuildServiceProvider(typeof(AllowedState));
+        var settings = CreateSettings(CreateStrictBinder(services));
+        var payload = new AllowedState { Name = "orleans", Value = 42 };
+
+        var json = JsonConvert.SerializeObject(payload, settings);
+        var result = (AllowedState)JsonConvert.DeserializeObject(json, typeof(object), settings);
+
+        Assert.Equal(payload.Name, result.Name);
+        Assert.Equal(payload.Value, result.Value);
+    }
+
+    [Fact]
+    public void Deserialize_DisallowedType_Throws()
+    {
+        using var services = BuildServiceProvider(typeof(AllowedState));
+        var settings = CreateSettings(CreateStrictBinder(services));
+        var json = CreateDisallowedPayload();
+
+        Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject(json, typeof(object), settings));
+    }
+
+    [Fact]
+    public void Deserialize_DisallowedType_WithAllowAllTypes_Succeeds()
+    {
+        using var services = BuildServiceProvider(typeof(AllowedState));
+        var settings = CreateSettings(CreateStrictBinder(services, allowAllTypes: true));
+        var json = CreateDisallowedPayload();
+
+        var result = JsonConvert.DeserializeObject(json, typeof(object), settings);
+
+        var state = Assert.IsType<DisallowedState>(result);
+        Assert.Equal("gadget", state.Name);
+    }
+
+    private static string CreateDisallowedPayload()
+    {
+        var assemblyName = typeof(DisallowedState).Assembly.GetName().Name;
+        return $"{{\"$type\":\"{typeof(DisallowedState).FullName}, {assemblyName}\",\"Name\":\"gadget\",\"Value\":1}}";
+    }
+}
+
+public sealed class AllowedState
+{
+    public string Name { get; set; }
+    public int Value { get; set; }
+}
+
+public sealed class DisallowedState
+{
+    public string Name { get; set; }
+    public int Value { get; set; }
+}
+
+[GenerateSerializer]
+public sealed class GeneratedState
+{
+    [Id(0)] public string Name { get; set; }
+    [Id(1)] public int Value { get; set; }
+}


### PR DESCRIPTION
## Problem

Orleans'' default grain-storage serializer (`JsonGrainStorageSerializer` → `OrleansJsonSerializer`) is configured with `TypeNameHandling.All`, so every serialized object embeds a `$type` token that is honored on read. The `OrleansJsonSerializationBinder` resolved that `$type` via `CachedTypeResolver` and, on failure, fell back to Newtonsoft''s permissive `DefaultSerializationBinder` — **neither consults any allow-list**. An attacker able to influence persisted, streamed, or transactional state could therefore cause **arbitrary CLR types to be constructed during deserialization** — the classic `TypeNameHandling.All` gadget-chain vulnerability. The same shared settings feed grain storage, JSON streaming, and (Azure) transactional state, so all three were affected.

## Solution

Make the binder enforce Orleans'' **existing** type allow-list rather than introduce a parallel Newtonsoft-specific system. `OrleansJsonSerializationBinder.BindToType` now resolves `$type` through `TypeConverter`, which only constructs types that are permitted by the configured `ITypeNameFilter` / `ITypeFilter` / `TypeManifestOptions.AllowedTypes` (or auto-allow-listed via `[GenerateSerializer]`). Disallowed types throw an actionable `JsonSerializationException` that lists every remediation option.

This is **secure by default with an opt-out**:

- Well-behaved apps keep working unchanged: `[GenerateSerializer]` state types are already auto-allow-listed, and `DefaultTypeFilter` still permits BCL collections/primitives. `TypeNameHandling.All` is retained so **existing persisted state stays readable** — security comes from the binder, not from changing the wire format.
- A new, dedicated `OrleansJsonSerializerOptions.AllowAllTypes` (default `false`) restores the previous permissive behavior for the JSON storage/streaming/transaction path only, without weakening the native serializer''s global type filtering. Narrower opt-ins (`AllowedTypes`, `ITypeNameFilter`) are preferred and are surfaced in the exception message.
- The legacy `OrleansJsonSerializationBinder(TypeResolver)` constructor is kept (permissive) for API compatibility; a new constructor takes the `TypeConverter` + opt-out flag.

### Compatibility

Breaking for apps that persist `$type` entries for types that are neither `[GenerateSerializer]`-registered nor covered by a filter — these now throw on read. The thrown exception explains the four ways to resolve it: mark the type `[GenerateSerializer]`, add it to `TypeManifestOptions.AllowedTypes`, register an `ITypeNameFilter`/`ITypeFilter`, or set `OrleansJsonSerializerOptions.AllowAllTypes = true` to restore the old behavior.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10268)