### PR TITLE
fix(membership): retain recently-declared-dead entries during pruning

### DIFF
--- a/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IMembershipTable.cs
@@ -317,6 +317,35 @@ namespace Orleans
             }
         }
 
+        /// <summary>
+        /// Gets the most recent time at which this entry is known to have been updated. This is the later of
+        /// <see cref="EffectiveIAmAliveTime"/> and the most recent time at which a silo voted to suspect this
+        /// silo (see <see cref="SuspectTimes"/>). Declaring a silo dead records a suspect vote, so this value
+        /// reflects a recent death declaration even when the silo last reported itself alive long ago. It is
+        /// used to retain the most-recently-updated defunct entries when cleaning up the membership table, so
+        /// that recently-declared-dead silos remain visible in membership snapshots.
+        /// </summary>
+        internal DateTime EffectiveUpdateTime
+        {
+            get
+            {
+                var result = EffectiveIAmAliveTime;
+                if (SuspectTimes is { } suspectTimes)
+                {
+                    foreach (var vote in suspectTimes)
+                    {
+                        var voteTimeUtc = DateTime.SpecifyKind(vote.Item2, DateTimeKind.Utc);
+                        if (voteTimeUtc > result)
+                        {
+                            result = voteTimeUtc;
+                        }
+                    }
+                }
+
+                return result;
+            }
+        }
+
         public void AddOrUpdateSuspector(SiloAddress localSilo, DateTime voteTime, int maxVotes)
         {
             var allVotes = SuspectTimes ??= new List<Tuple<SiloAddress, DateTime>>();

--- a/src/Orleans.Runtime/MembershipService/InMemoryMembershipTable.cs
+++ b/src/Orleans.Runtime/MembershipService/InMemoryMembershipTable.cs
@@ -91,7 +91,7 @@ namespace Orleans.Runtime.MembershipService
             foreach (var (key, (value, _)) in siloTable)
             {
                 if (value.Status != SiloStatus.Active
-                    && new DateTime(Math.Max(value.IAmAliveTime.Ticks, value.StartTime.Ticks), DateTimeKind.Utc) < beforeDate)
+                    && value.EffectiveUpdateTime < beforeDate)
                 {
                     removedEntries.Add(key);
                 }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableCleanupAgent.cs
@@ -151,7 +151,7 @@ namespace Orleans.Runtime.MembershipService
                     if (defunctSiloEntryCount > maxDefunctSiloEntries)
                     {
                         var newestEntryToRemove = newestDefunctEntries.Peek();
-                        var excessBeforeDate = GetDefunctSiloCleanupCutoff(newestEntryToRemove.EffectiveIAmAliveTime);
+                        var excessBeforeDate = GetDefunctSiloCleanupCutoff(newestEntryToRemove.EffectiveUpdateTime);
                         if (!beforeDate.HasValue || excessBeforeDate > beforeDate.Value)
                         {
                             beforeDate = excessBeforeDate;
@@ -246,7 +246,7 @@ namespace Orleans.Runtime.MembershipService
 
             private static int Compare(DefunctSiloEntryPriority left, DefunctSiloEntryPriority right)
             {
-                var result = left._entry.EffectiveIAmAliveTime.CompareTo(right._entry.EffectiveIAmAliveTime);
+                var result = left._entry.EffectiveUpdateTime.CompareTo(right._entry.EffectiveUpdateTime);
                 return result != 0 ? result : left._entry.SiloAddress.CompareTo(right._entry.SiloAddress);
             }
         }

--- a/test/Orleans.Core.Tests/Membership/InMemoryMembershipTable.cs
+++ b/test/Orleans.Core.Tests/Membership/InMemoryMembershipTable.cs
@@ -63,7 +63,7 @@ namespace NonSilo.Tests.Membership
                 foreach (var (entry, etag) in this.entries)
                 {
                     if (entry.Status == SiloStatus.Dead
-                        && new DateTime(Math.Max(entry.IAmAliveTime.Ticks, entry.StartTime.Ticks), DateTimeKind.Utc) < beforeDate)
+                        && entry.EffectiveUpdateTime < beforeDate)
                     {
                         continue;
                     }

--- a/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
@@ -112,6 +112,46 @@ namespace NonSilo.Tests.Membership
         }
 
         [Fact]
+        public async Task MembershipTableCleanupAgent_ThresholdCleanup_RetainsRecentlySuspectedEntries()
+        {
+            var now = this.timeProvider.GetUtcNow();
+            var recentlySuspectedSilo = Silo("127.0.0.1:700@100");
+            var options = new ClusterMembershipOptions { DefunctSiloCleanupPeriod = null, MaxDefunctSiloEntries = 1 };
+            var membershipManager = new TestMembershipManager();
+
+            // This entry reported itself alive most recently, but was not suspected recently.
+            var newerAliveEntry = Entry(Silo("127.0.0.1:500@100"), SiloStatus.Dead, now.AddMinutes(-2));
+
+            // This entry last reported itself alive long ago, but was declared dead (suspected) very recently.
+            // It is therefore the most-recently-updated defunct entry and should be retained even though its
+            // IAmAliveTime is the oldest.
+            var recentlySuspectedEntry = Entry(recentlySuspectedSilo, SiloStatus.Dead, now.AddMinutes(-10));
+            recentlySuspectedEntry.AddSuspector(this.localSilo, now.AddMinutes(-1).UtcDateTime);
+
+            var table = new InMemoryMembershipTable(
+                new TableVersion(123, "123"),
+                newerAliveEntry,
+                recentlySuspectedEntry);
+            var cleanupAgent = this.CreateCleanupAgent(options, table, membershipManager);
+            var lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
+            ((ILifecycleParticipant<ISiloLifecycle>)cleanupAgent).Participate(lifecycle);
+
+            await lifecycle.OnStart();
+            membershipManager.Publish(Snapshot(
+                Entry(this.localSilo, SiloStatus.Active, now),
+                Entry(Silo("127.0.0.1:200@200"), SiloStatus.Active, now),
+                newerAliveEntry,
+                recentlySuspectedEntry));
+            await Until(() => table.Calls.Any(call => call.Method == nameof(IMembershipTable.CleanupDefunctSiloEntries)));
+
+            var updatedTable = await table.ReadAll();
+            Assert.Single(updatedTable.Members, member => member.Item1.Status == SiloStatus.Dead);
+            Assert.Contains(updatedTable.Members, member => member.Item1.SiloAddress.Equals(recentlySuspectedSilo));
+
+            await lifecycle.OnStop();
+        }
+
+        [Fact]
         public async Task MembershipTableCleanupAgent_ExpirationCleanup_SkipsUntilExpiredNonActiveEntryOrCleanupPeriodElapsed()
         {
             var options = new ClusterMembershipOptions


### PR DESCRIPTION
## Problem

We recently added `MaxDefunctSiloEntries` to cap the number of non-active (e.g. `Dead`) entries kept in the membership table. When the cap is exceeded, the cleanup agent prunes the oldest defunct entries, keeping the most-recently-updated ones so they still appear in membership snapshots.

Recency was measured by `EffectiveIAmAliveTime` (the later of `StartTime` and `IAmAliveTime`). The problem is that declaring *another* silo dead does not update that silo's `IAmAliveTime` — only a silo's own periodic self-update does. So a silo that was declared `Dead` just now, but last reported itself alive long ago, looks like the *oldest* defunct entry and is pruned immediately, disappearing from snapshots right after it died.

## Solution

Reference the entry's suspect times during pruning instead of bumping `IAmAliveTime` on death. A new internal `MembershipEntry.EffectiveUpdateTime` returns the later of `EffectiveIAmAliveTime` and the most recent `SuspectTimes` vote. Declaring a silo dead records a suspect vote, so a recently-declared-dead entry is now correctly treated as the most-recently-updated defunct entry and is retained.

`EffectiveUpdateTime` is used consistently in:
- the cleanup agent's defunct-entry selection (`DefunctSiloEntryPriority`) and cutoff computation, and
- the in-memory membership providers' removal predicate (used by the default/dev `SystemTarget` clustering).

This keeps the death-declaration timestamp as the source of truth without mutating `IAmAliveTime`.

### Notes / scope
- Cloud/ADO.NET providers are unchanged. The Azure table provider already keys removal off the row write timestamp (which reflects the death write), so recently-dead entries are retained there. The ADO.NET provider keys removal off the `IAmAliveTime` column and cannot see suspect times without a schema change — that remains a pre-existing limitation and is out of scope here.

### Tests
Added `MembershipTableCleanupAgent_ThresholdCleanup_RetainsRecentlySuspectedEntries`, which sets up two `Dead` entries where the one with the oldest `IAmAliveTime` has a very recent suspect vote, and asserts it is the entry that survives pruning. Full membership suite passes (67 tests).