### PR TITLE
feat(serialization): add codecs for FrozenDictionary and FrozenSet

### DIFF
--- a/src/Orleans.Serialization/Codecs/FrozenDictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FrozenDictionaryCodec.cs
@@ -1,0 +1,105 @@
+#if NET8_0_OR_GREATER
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.GeneratedCodeHelpers;
+using Orleans.Serialization.Serializers;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+#nullable disable
+namespace Orleans.Serialization.Codecs
+{
+    /// <summary>
+    /// Serializer for <see cref="FrozenDictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    [RegisterSerializer]
+    public sealed class FrozenDictionaryCodec<TKey, TValue> : GeneralizedReferenceTypeSurrogateCodec<FrozenDictionary<TKey, TValue>, FrozenDictionarySurrogate<TKey, TValue>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FrozenDictionaryCodec{TKey, TValue}"/> class.
+        /// </summary>
+        /// <param name="surrogateSerializer">The surrogate serializer.</param>
+        public FrozenDictionaryCodec(IValueSerializer<FrozenDictionarySurrogate<TKey, TValue>> surrogateSerializer) : base(surrogateSerializer)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override FrozenDictionary<TKey, TValue> ConvertFromSurrogate(ref FrozenDictionarySurrogate<TKey, TValue> surrogate)
+            => surrogate.Values.ToFrozenDictionary(surrogate.KeyComparer);
+
+        /// <inheritdoc/>
+        public override void ConvertToSurrogate(FrozenDictionary<TKey, TValue> value, ref FrozenDictionarySurrogate<TKey, TValue> surrogate)
+        {
+            surrogate.Values = new(value);
+            surrogate.KeyComparer = value.Comparer != EqualityComparer<TKey>.Default ? value.Comparer : null;
+        }
+    }
+
+    /// <summary>
+    /// Surrogate type used by <see cref="FrozenDictionaryCodec{TKey, TValue}"/>.
+    /// </summary>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    [GenerateSerializer]
+    public struct FrozenDictionarySurrogate<TKey, TValue>
+    {
+        /// <summary>
+        /// Gets or sets the values.
+        /// </summary>
+        /// <value>The values.</value>
+        [Id(0)]
+        public List<KeyValuePair<TKey, TValue>> Values;
+
+        /// <summary>
+        /// Gets or sets the key comparer.
+        /// </summary>
+        /// <value>The key comparer.</value>
+        [Id(1)]
+        public IEqualityComparer<TKey> KeyComparer;
+    }
+
+    /// <summary>
+    /// Copier for <see cref="FrozenDictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    [RegisterCopier]
+    public sealed class FrozenDictionaryCopier<TKey, TValue> : IDeepCopier<FrozenDictionary<TKey, TValue>>, IOptionalDeepCopier, IDerivedTypeCopier
+    {
+        private readonly IDeepCopier<TKey> _keyCopier;
+        private readonly IDeepCopier<TValue> _valueCopier;
+
+        public FrozenDictionaryCopier(IDeepCopier<TKey> keyCopier, IDeepCopier<TValue> valueCopier)
+        {
+            _keyCopier = OrleansGeneratedCodeHelper.GetOptionalCopier(keyCopier);
+            _valueCopier = OrleansGeneratedCodeHelper.GetOptionalCopier(valueCopier);
+        }
+
+        public bool IsShallowCopyable() => _keyCopier is null && _valueCopier is null;
+
+        /// <inheritdoc/>
+        public FrozenDictionary<TKey, TValue> DeepCopy(FrozenDictionary<TKey, TValue> input, CopyContext context)
+        {
+            if (context.TryGetCopy<FrozenDictionary<TKey, TValue>>(input, out var result))
+                return result;
+
+            if (input.Count == 0 || _keyCopier is null && _valueCopier is null)
+                return input;
+
+            // There is a possibility for infinite recursion here if any value in the input collection is able to take part in a cyclic reference.
+            // Mitigate that by returning a shallow-copy in such a case.
+            context.RecordCopy(input, input);
+
+            var items = new List<KeyValuePair<TKey, TValue>>(input.Count);
+            foreach (var item in input)
+                items.Add(new(_keyCopier is null ? item.Key : _keyCopier.DeepCopy(item.Key, context),
+                    _valueCopier is null ? item.Value : _valueCopier.DeepCopy(item.Value, context)));
+
+            var res = items.ToFrozenDictionary(input.Comparer);
+            context.RecordCopy(input, res);
+            return res;
+        }
+    }
+}
+#endif

--- a/src/Orleans.Serialization/Codecs/FrozenSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/FrozenSetCodec.cs
@@ -1,0 +1,96 @@
+#if NET8_0_OR_GREATER
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.GeneratedCodeHelpers;
+using Orleans.Serialization.Serializers;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+#nullable disable
+namespace Orleans.Serialization.Codecs
+{
+    /// <summary>
+    /// Serializer for <see cref="FrozenSet{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    [RegisterSerializer]
+    public sealed class FrozenSetCodec<T> : GeneralizedReferenceTypeSurrogateCodec<FrozenSet<T>, FrozenSetSurrogate<T>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FrozenSetCodec{T}"/> class.
+        /// </summary>
+        /// <param name="surrogateSerializer">The surrogate serializer.</param>
+        public FrozenSetCodec(IValueSerializer<FrozenSetSurrogate<T>> surrogateSerializer) : base(surrogateSerializer)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override FrozenSet<T> ConvertFromSurrogate(ref FrozenSetSurrogate<T> surrogate)
+            => surrogate.Values.ToFrozenSet(surrogate.KeyComparer);
+
+        /// <inheritdoc/>
+        public override void ConvertToSurrogate(FrozenSet<T> value, ref FrozenSetSurrogate<T> surrogate)
+        {
+            surrogate.Values = new(value);
+            surrogate.KeyComparer = value.Comparer != EqualityComparer<T>.Default ? value.Comparer : null;
+        }
+    }
+
+    /// <summary>
+    /// Surrogate type used by <see cref="FrozenSetCodec{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    [GenerateSerializer]
+    public struct FrozenSetSurrogate<T>
+    {
+        /// <summary>
+        /// Gets or sets the values.
+        /// </summary>
+        /// <value>The values.</value>
+        [Id(0)]
+        public List<T> Values;
+
+        /// <summary>
+        /// Gets or sets the key comparer.
+        /// </summary>
+        /// <value>The key comparer.</value>
+        [Id(1)]
+        public IEqualityComparer<T> KeyComparer;
+    }
+
+    /// <summary>
+    /// Copier for <see cref="FrozenSet{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    [RegisterCopier]
+    public sealed class FrozenSetCopier<T> : IDeepCopier<FrozenSet<T>>, IOptionalDeepCopier, IDerivedTypeCopier
+    {
+        private readonly IDeepCopier<T> _copier;
+
+        public FrozenSetCopier(IDeepCopier<T> copier) => _copier = OrleansGeneratedCodeHelper.GetOptionalCopier(copier);
+
+        public bool IsShallowCopyable() => _copier is null;
+
+        /// <inheritdoc/>
+        public FrozenSet<T> DeepCopy(FrozenSet<T> input, CopyContext context)
+        {
+            if (context.TryGetCopy<FrozenSet<T>>(input, out var result))
+                return result;
+
+            if (input.Count == 0 || _copier is null)
+                return input;
+
+            // There is a possibility for infinite recursion here if any value in the input collection is able to take part in a cyclic reference.
+            // Mitigate that by returning a shallow-copy in such a case.
+            context.RecordCopy(input, input);
+
+            var items = new List<T>(input.Count);
+            foreach (var item in input)
+                items.Add(_copier.DeepCopy(item, context));
+
+            var res = items.ToFrozenSet(input.Comparer);
+            context.RecordCopy(input, res);
+            return res;
+        }
+    }
+}
+#endif

--- a/src/Orleans.Serialization/Serializers/CodecProvider.cs
+++ b/src/Orleans.Serialization/Serializers/CodecProvider.cs
@@ -651,19 +651,19 @@ namespace Orleans.Serialization.Serializers
             {
                 copierType = surrogateCodecType;
             }
-            else if (searchType.BaseType is { } baseType)
+            else if (searchType.BaseType is { } baseType
+                && CreateCopierInstance(
+                    fieldType.BaseType,
+                    baseType switch
+                    {
+                        { IsConstructedGenericType: true } => baseType.GetGenericTypeDefinition(),
+                        _ => baseType
+                    }) is IDerivedTypeCopier derivedTypeCopier)
             {
-                // Find copiers which generalize over all subtypes.
-                if (CreateCopierInstance(fieldType, baseType) is IDerivedTypeCopier baseCopier)
-                {
-                    return baseCopier;
-                }
-                else if (baseType.IsGenericType
-                    && baseType.IsConstructedGenericType
-                    && CreateCopierInstance(fieldType, baseType.GetGenericTypeDefinition()) is IDerivedTypeCopier genericBaseCopier)
-                {
-                    return genericBaseCopier;
-                }
+                // Find copiers which generalize over all subtypes. The field type and search type are advanced in
+                // lockstep so that the generic arguments used to construct the copier always match the arity of the
+                // copier's declared type, even when a subtype changes arity (e.g. the internal frozen collection types).
+                return derivedTypeCopier;
             }
 
             return copierType != null ? (IDeepCopier)GetServiceOrCreateInstance(copierType, constructorArguments) : null;

--- a/src/api/Orleans.Serialization/Orleans.Serialization.cs
+++ b/src/api/Orleans.Serialization/Orleans.Serialization.cs
@@ -1824,6 +1824,64 @@ namespace Orleans.Serialization.Codecs
             where TBufferWriter : System.Buffers.IBufferWriter<byte> { }
     }
 
+    [RegisterSerializer]
+    public sealed partial class FrozenDictionaryCodec<TKey, TValue> : GeneralizedReferenceTypeSurrogateCodec<System.Collections.Frozen.FrozenDictionary<TKey, TValue>, FrozenDictionarySurrogate<TKey, TValue>>
+    {
+        public FrozenDictionaryCodec(Serializers.IValueSerializer<FrozenDictionarySurrogate<TKey, TValue>> surrogateSerializer) : base(default!) { }
+
+        public override System.Collections.Frozen.FrozenDictionary<TKey, TValue> ConvertFromSurrogate(ref FrozenDictionarySurrogate<TKey, TValue> surrogate) { throw null; }
+
+        public override void ConvertToSurrogate(System.Collections.Frozen.FrozenDictionary<TKey, TValue> value, ref FrozenDictionarySurrogate<TKey, TValue> surrogate) { }
+    }
+
+    [RegisterCopier]
+    public sealed partial class FrozenDictionaryCopier<TKey, TValue> : Cloning.IDeepCopier<System.Collections.Frozen.FrozenDictionary<TKey, TValue>>, Cloning.IDeepCopier, Cloning.IOptionalDeepCopier, Cloning.IDerivedTypeCopier
+    {
+        public FrozenDictionaryCopier(Cloning.IDeepCopier<TKey> keyCopier, Cloning.IDeepCopier<TValue> valueCopier) { }
+
+        public System.Collections.Frozen.FrozenDictionary<TKey, TValue> DeepCopy(System.Collections.Frozen.FrozenDictionary<TKey, TValue> input, Cloning.CopyContext context) { throw null; }
+
+        public bool IsShallowCopyable() { throw null; }
+    }
+
+    [GenerateSerializer]
+    public partial struct FrozenDictionarySurrogate<TKey, TValue>
+    {
+        [Id(1)]
+        public System.Collections.Generic.IEqualityComparer<TKey> KeyComparer;
+        [Id(0)]
+        public System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<TKey, TValue>> Values;
+    }
+
+    [RegisterSerializer]
+    public sealed partial class FrozenSetCodec<T> : GeneralizedReferenceTypeSurrogateCodec<System.Collections.Frozen.FrozenSet<T>, FrozenSetSurrogate<T>>
+    {
+        public FrozenSetCodec(Serializers.IValueSerializer<FrozenSetSurrogate<T>> surrogateSerializer) : base(default!) { }
+
+        public override System.Collections.Frozen.FrozenSet<T> ConvertFromSurrogate(ref FrozenSetSurrogate<T> surrogate) { throw null; }
+
+        public override void ConvertToSurrogate(System.Collections.Frozen.FrozenSet<T> value, ref FrozenSetSurrogate<T> surrogate) { }
+    }
+
+    [RegisterCopier]
+    public sealed partial class FrozenSetCopier<T> : Cloning.IDeepCopier<System.Collections.Frozen.FrozenSet<T>>, Cloning.IDeepCopier, Cloning.IOptionalDeepCopier, Cloning.IDerivedTypeCopier
+    {
+        public FrozenSetCopier(Cloning.IDeepCopier<T> copier) { }
+
+        public System.Collections.Frozen.FrozenSet<T> DeepCopy(System.Collections.Frozen.FrozenSet<T> input, Cloning.CopyContext context) { throw null; }
+
+        public bool IsShallowCopyable() { throw null; }
+    }
+
+    [GenerateSerializer]
+    public partial struct FrozenSetSurrogate<T>
+    {
+        [Id(1)]
+        public System.Collections.Generic.IEqualityComparer<T> KeyComparer;
+        [Id(0)]
+        public System.Collections.Generic.List<T> Values;
+    }
+
     public abstract partial class GeneralizedReferenceTypeSurrogateCodec<TField, TSurrogate> : IFieldCodec<TField>, IFieldCodec, IDerivedTypeCodec where TField : class where TSurrogate : struct
     {
         protected GeneralizedReferenceTypeSurrogateCodec(Serializers.IValueSerializer<TSurrogate> surrogateSerializer) { }
@@ -4761,6 +4819,42 @@ namespace OrleansCodeGen.Orleans.Serialization.Codecs
     [System.CodeDom.Compiler.GeneratedCode("OrleansCodeGen", "10.0.0.0")]
     [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public sealed partial class Codec_FrozenDictionarySurrogate<TKey, TValue> : global::Orleans.Serialization.Codecs.IFieldCodec<global::Orleans.Serialization.Codecs.FrozenDictionarySurrogate<TKey, TValue>>, global::Orleans.Serialization.Codecs.IFieldCodec, global::Orleans.Serialization.Serializers.IValueSerializer<global::Orleans.Serialization.Codecs.FrozenDictionarySurrogate<TKey, TValue>>, global::Orleans.Serialization.Serializers.IValueSerializer
+    {
+        public Codec_FrozenDictionarySurrogate(global::Orleans.Serialization.Serializers.ICodecProvider codecProvider) { }
+
+        public void Deserialize<TReaderInput>(ref global::Orleans.Serialization.Buffers.Reader<TReaderInput> reader, scoped ref global::Orleans.Serialization.Codecs.FrozenDictionarySurrogate<TKey, TValue> instance) { }
+
+        public global::Orleans.Serialization.Codecs.FrozenDictionarySurrogate<TKey, TValue> ReadValue<TReaderInput>(ref global::Orleans.Serialization.Buffers.Reader<TReaderInput> reader, global::Orleans.Serialization.WireProtocol.Field field) { throw null; }
+
+        public void Serialize<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, scoped ref global::Orleans.Serialization.Codecs.FrozenDictionarySurrogate<TKey, TValue> instance)
+            where TBufferWriter : System.Buffers.IBufferWriter<byte> { }
+
+        public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, System.Type expectedType, global::Orleans.Serialization.Codecs.FrozenDictionarySurrogate<TKey, TValue> value)
+            where TBufferWriter : System.Buffers.IBufferWriter<byte> { }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("OrleansCodeGen", "10.0.0.0")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public sealed partial class Codec_FrozenSetSurrogate<T> : global::Orleans.Serialization.Codecs.IFieldCodec<global::Orleans.Serialization.Codecs.FrozenSetSurrogate<T>>, global::Orleans.Serialization.Codecs.IFieldCodec, global::Orleans.Serialization.Serializers.IValueSerializer<global::Orleans.Serialization.Codecs.FrozenSetSurrogate<T>>, global::Orleans.Serialization.Serializers.IValueSerializer
+    {
+        public Codec_FrozenSetSurrogate(global::Orleans.Serialization.Serializers.ICodecProvider codecProvider) { }
+
+        public void Deserialize<TReaderInput>(ref global::Orleans.Serialization.Buffers.Reader<TReaderInput> reader, scoped ref global::Orleans.Serialization.Codecs.FrozenSetSurrogate<T> instance) { }
+
+        public global::Orleans.Serialization.Codecs.FrozenSetSurrogate<T> ReadValue<TReaderInput>(ref global::Orleans.Serialization.Buffers.Reader<TReaderInput> reader, global::Orleans.Serialization.WireProtocol.Field field) { throw null; }
+
+        public void Serialize<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, scoped ref global::Orleans.Serialization.Codecs.FrozenSetSurrogate<T> instance)
+            where TBufferWriter : System.Buffers.IBufferWriter<byte> { }
+
+        public void WriteField<TBufferWriter>(ref global::Orleans.Serialization.Buffers.Writer<TBufferWriter> writer, uint fieldIdDelta, System.Type expectedType, global::Orleans.Serialization.Codecs.FrozenSetSurrogate<T> value)
+            where TBufferWriter : System.Buffers.IBufferWriter<byte> { }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("OrleansCodeGen", "10.0.0.0")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public sealed partial class Codec_ImmutableArraySurrogate<T> : global::Orleans.Serialization.Codecs.IFieldCodec<global::Orleans.Serialization.Codecs.ImmutableArraySurrogate<T>>, global::Orleans.Serialization.Codecs.IFieldCodec, global::Orleans.Serialization.Serializers.IValueSerializer<global::Orleans.Serialization.Codecs.ImmutableArraySurrogate<T>>, global::Orleans.Serialization.Serializers.IValueSerializer
     {
         public Codec_ImmutableArraySurrogate(global::Orleans.Serialization.Serializers.ICodecProvider codecProvider) { }
@@ -5054,6 +5148,26 @@ namespace OrleansCodeGen.Orleans.Serialization.Codecs
         public Copier_ConcurrentQueueSurrogate(global::Orleans.Serialization.Serializers.ICodecProvider codecProvider) { }
 
         public global::Orleans.Serialization.Codecs.ConcurrentQueueSurrogate<T> DeepCopy(global::Orleans.Serialization.Codecs.ConcurrentQueueSurrogate<T> result, global::Orleans.Serialization.Cloning.CopyContext context) { throw null; }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("OrleansCodeGen", "10.0.0.0")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public sealed partial class Copier_FrozenDictionarySurrogate<TKey, TValue> : global::Orleans.Serialization.Cloning.IDeepCopier<global::Orleans.Serialization.Codecs.FrozenDictionarySurrogate<TKey, TValue>>, global::Orleans.Serialization.Cloning.IDeepCopier
+    {
+        public Copier_FrozenDictionarySurrogate(global::Orleans.Serialization.Serializers.ICodecProvider codecProvider) { }
+
+        public global::Orleans.Serialization.Codecs.FrozenDictionarySurrogate<TKey, TValue> DeepCopy(global::Orleans.Serialization.Codecs.FrozenDictionarySurrogate<TKey, TValue> result, global::Orleans.Serialization.Cloning.CopyContext context) { throw null; }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("OrleansCodeGen", "10.0.0.0")]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public sealed partial class Copier_FrozenSetSurrogate<T> : global::Orleans.Serialization.Cloning.IDeepCopier<global::Orleans.Serialization.Codecs.FrozenSetSurrogate<T>>, global::Orleans.Serialization.Cloning.IDeepCopier
+    {
+        public Copier_FrozenSetSurrogate(global::Orleans.Serialization.Serializers.ICodecProvider codecProvider) { }
+
+        public global::Orleans.Serialization.Codecs.FrozenSetSurrogate<T> DeepCopy(global::Orleans.Serialization.Codecs.FrozenSetSurrogate<T> result, global::Orleans.Serialization.Cloning.CopyContext context) { throw null; }
     }
 
     [System.CodeDom.Compiler.GeneratedCode("OrleansCodeGen", "10.0.0.0")]

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Net;
 using System.Numerics;
 #if NET8_0_OR_GREATER
+using System.Collections.Frozen;
 using System.Xml.Linq;
 using Orleans.Runtime;
 using Orleans.Runtime.Serialization;
@@ -3411,6 +3412,131 @@ namespace Orleans.Serialization.UnitTests
 
         protected override bool IsImmutable => false;
     }
+
+#if NET8_0_OR_GREATER
+    public class FrozenDictionaryCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FrozenDictionary<string, int>, FrozenDictionaryCodec<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
+    {
+        protected override FrozenDictionary<string, int> CreateValue()
+        {
+            var result = new Dictionary<string, int>();
+            var len = Random.Next(17);
+            for (var i = 0; i < len + 5; i++)
+            {
+                result[Random.Next().ToString()] = Random.Next();
+            }
+
+            return result.ToFrozenDictionary();
+        }
+
+        protected override FrozenDictionary<string, int>[] TestValues => [null, FrozenDictionary<string, int>.Empty, CreateValue(), CreateValue(), CreateValue()];
+        protected override bool Equals(FrozenDictionary<string, int> left, FrozenDictionary<string, int> right) => ReferenceEquals(left, right) || left is not null && right is not null && left.Count == right.Count && left.All(kv => right.TryGetValue(kv.Key, out var value) && value == kv.Value);
+
+        [Fact]
+        public void PreservesKeyComparer()
+        {
+            var original = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["one"] = 1
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+            var result = RoundTripThroughCodec(original);
+
+            Assert.Same(StringComparer.OrdinalIgnoreCase, result.Comparer);
+            Assert.Equal(1, result["ONE"]);
+        }
+    }
+
+    public class FrozenDictionaryCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FrozenDictionary<string, int>, FrozenDictionaryCopier<string, int>>(output, fixture), IClassFixture<SerializationTesterFixture>
+    {
+        protected override bool IsImmutable => true;
+        protected override FrozenDictionary<string, int> CreateValue()
+        {
+            var result = new Dictionary<string, int>();
+            var len = Random.Next(17);
+            for (var i = 0; i < len + 5; i++)
+            {
+                result[Random.Next().ToString()] = Random.Next();
+            }
+
+            return result.ToFrozenDictionary();
+        }
+
+        protected override FrozenDictionary<string, int>[] TestValues => [null, FrozenDictionary<string, int>.Empty, CreateValue(), CreateValue(), CreateValue()];
+        protected override bool Equals(FrozenDictionary<string, int> left, FrozenDictionary<string, int> right) => ReferenceEquals(left, right) || left is not null && right is not null && left.Count == right.Count && left.All(kv => right.TryGetValue(kv.Key, out var value) && value == kv.Value);
+    }
+
+    public class FrozenSetCodecTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<FrozenSet<string>, FrozenSetCodec<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
+    {
+        protected override FrozenSet<string> CreateValue()
+        {
+            var hashSet = new HashSet<string>();
+            var len = Random.Next(17);
+            for (var i = 0; i < len + 5; i++)
+            {
+                _ = hashSet.Add(Random.Next().ToString());
+            }
+
+            return hashSet.ToFrozenSet();
+        }
+
+        protected override FrozenSet<string>[] TestValues => [null, FrozenSet<string>.Empty, CreateValue(), CreateValue(), CreateValue()];
+
+        protected override bool Equals(FrozenSet<string> left, FrozenSet<string> right) => ReferenceEquals(left, right) || left.SetEquals(right);
+
+        [Fact]
+        public void PreservesKeyComparer()
+        {
+            var original = new[] { "one" }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+            var result = RoundTripThroughCodec(original);
+
+            Assert.Same(StringComparer.OrdinalIgnoreCase, result.Comparer);
+            Assert.Contains("ONE", (IReadOnlySet<string>)result);
+        }
+    }
+
+    public class FrozenSetCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FrozenSet<string>, FrozenSetCopier<string>>(output, fixture), IClassFixture<SerializationTesterFixture>
+    {
+        protected override FrozenSet<string> CreateValue()
+        {
+            var hashSet = new HashSet<string>();
+            var len = Random.Next(17);
+            for (var i = 0; i < len + 5; i++)
+            {
+                _ = hashSet.Add(Random.Next().ToString());
+            }
+
+            return hashSet.ToFrozenSet();
+        }
+
+        protected override FrozenSet<string>[] TestValues => [null, FrozenSet<string>.Empty, CreateValue(), CreateValue(), CreateValue()];
+
+        protected override bool Equals(FrozenSet<string> left, FrozenSet<string> right) => ReferenceEquals(left, right) || left.SetEquals(right);
+
+        protected override bool IsImmutable => true;
+    }
+
+    public sealed class FrozenSetMutableCopierTests(ITestOutputHelper output, SerializationTesterFixture fixture) : CopierTester<FrozenSet<object>, FrozenSetCopier<object>>(output, fixture), IClassFixture<SerializationTesterFixture>
+    {
+        protected override FrozenSet<object> CreateValue()
+        {
+            var hashSet = new HashSet<object>();
+            var len = Random.Next(17);
+            for (var i = 0; i < len + 5; i++)
+            {
+                _ = hashSet.Add(Random.Next());
+            }
+
+            return hashSet.ToFrozenSet();
+        }
+
+        protected override FrozenSet<object>[] TestValues => [null, FrozenSet<object>.Empty, CreateValue(), CreateValue(), CreateValue()];
+
+        protected override bool Equals(FrozenSet<object> left, FrozenSet<object> right) => ReferenceEquals(left, right) || left.SetEquals(right);
+
+        protected override bool IsImmutable => false;
+    }
+#endif
 
     public class UriTests(ITestOutputHelper output, SerializationTesterFixture fixture) : FieldCodecTester<Uri, UriCodec>(output, fixture), IClassFixture<SerializationTesterFixture>
     {


### PR DESCRIPTION
## Problem

Orleans had no serialization support for the frozen collection types introduced in .NET 8 (`FrozenDictionary<TKey, TValue>` and `FrozenSet<T>`). Attempting to serialize a grain call, storage payload, or stream event containing one of these types would fail.

## Solution

Add serialization codecs and copiers for `FrozenDictionary<TKey, TValue>` and `FrozenSet<T>`, modeled on the existing immutable-collection codecs. They are guarded by `#if NET8_0_OR_GREATER` so they only compile on platforms that ship the frozen collections (the netstandard2.1 target excludes them).

Notable details:

- **Surrogates** carry the entries as a `List<>` plus the collection's comparer (stored only when non-default). Reading entries straight out of the source collection avoids re-hashing keys when constructing the surrogate.
- **Copiers** deep-copy their contents in the same manner as the immutable-collection copiers, short-circuiting to a shallow copy when the element copiers are shallow-copyable.
- Frozen collection types are **abstract** base types whose runtime instances are internal subtypes, potentially of a different generic arity. The copiers therefore implement `IDerivedTypeCopier`, and `CodecProvider.CreateCopierInstance` now advances the field type and search type in lockstep when resolving derived-type copiers, mirroring the existing codec-side logic. Without this, resolving a copier for a subtype with mismatched arity threw an `ArgumentException` from `MakeGenericType`.

Tests cover round-tripping through the codec, copier behavior (including mutable element types), and comparer preservation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10270)