### PR TITLE
fix(testinghost): dispose stopped in-process silo hosts without leaking or hanging

### DIFF
--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -166,6 +166,23 @@ namespace Orleans.Runtime
             this.context.Complete(Response.FromException(exception));
         }
 
+        public void OnHostShutdown()
+        {
+            if (Interlocked.CompareExchange(ref this.completed, 1, 0) != 0)
+            {
+                return;
+            }
+
+            this.stopwatch.Stop();
+            this.shared.Unregister(this.Message);
+            _cancellationTokenRegistration.Dispose();
+            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+
+            var msg = this.Message;
+            var exception = new SiloUnavailableException($"The local Orleans host is shutting down and can no longer process the request: {msg}.");
+            this.context.Complete(Response.FromException(exception));
+        }
+
         public void DoCallback(Message response)
         {
             if (Interlocked.CompareExchange(ref this.completed, 1, 0) != 0)

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -167,6 +167,11 @@ namespace Orleans
                 await messageCenter.StopAsync(cancellationToken);
             }
 
+            // Once messaging has stopped the client can no longer receive responses, so any requests
+            // which are still outstanding will never complete. Fault them now so that in-flight grain
+            // calls observe a terminal result instead of hanging forever.
+            BreakOutstandingMessages();
+
             if (_manifestProvider is { } provider)
             {
                 await provider.StopAsync(cancellationToken);
@@ -429,6 +434,21 @@ namespace Orleans
                 if (deadSilo.Equals(callback.Value.Message.TargetSilo))
                 {
                     callback.Value.OnTargetSiloFail();
+                }
+            }
+        }
+
+        private void BreakOutstandingMessages()
+        {
+            foreach (var (_, callback) in callbacks)
+            {
+                try
+                {
+                    callback.OnHostShutdown();
+                }
+                catch (Exception exception)
+                {
+                    LogErrorWhileProcessingCallbackExpiry(logger, exception);
                 }
             }
         }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -523,6 +523,27 @@ namespace Orleans.Runtime
             {
                 await task.WaitAsync(tc);
             }
+
+            // Once the silo is shutting down it can no longer receive responses, so any requests which
+            // are still outstanding will never complete. Fault them now so that in-flight grain calls
+            // observe a terminal result instead of hanging forever, which would otherwise deadlock grain
+            // deactivation and host disposal during an ungraceful shutdown.
+            BreakOutstandingMessages();
+        }
+
+        private void BreakOutstandingMessages()
+        {
+            foreach (var (_, callback) in callbacks)
+            {
+                try
+                {
+                    callback.OnHostShutdown();
+                }
+                catch (Exception exception)
+                {
+                    LogWarningWhileProcessingCallbackExpiry(this.logger, exception);
+                }
+            }
         }
 
         private Task OnRuntimeInitializeStart(CancellationToken tc)

--- a/src/Orleans.TestingHost/InProcessSiloHandle.cs
+++ b/src/Orleans.TestingHost/InProcessSiloHandle.cs
@@ -15,6 +15,7 @@ namespace Orleans.TestingHost
     public class InProcessSiloHandle : SiloHandle
     {
         private bool isActive = true;
+        private int disposed;
         
         /// <summary>Gets a reference to the silo host.</summary>
         public IHost SiloHost { get; init; }
@@ -92,9 +93,17 @@ namespace Orleans.TestingHost
         /// <inheritdoc />
         protected override void Dispose(bool disposing)
         {
-            if (!this.IsActive) return;
+            if (!disposing)
+            {
+                return;
+            }
 
-            if (disposing)
+            if (Interlocked.Exchange(ref this.disposed, 1) != 0)
+            {
+                return;
+            }
+
+            if (this.IsActive)
             {
                 try
                 {
@@ -103,25 +112,35 @@ namespace Orleans.TestingHost
                 catch
                 {
                 }
-
-                this.SiloHost?.Dispose();
             }
+
+            this.SiloHost?.Dispose();
         }
 
         /// <inheritdoc />
         public override async ValueTask DisposeAsync()
         {
-            if (!this.IsActive) return;
+            if (Interlocked.Exchange(ref this.disposed, 1) != 0)
+            {
+                return;
+            }
 
             try
             {
-                await StopSiloAsync(true).ConfigureAwait(false);
+                if (this.IsActive)
+                {
+                    await StopSiloAsync(true).ConfigureAwait(false);
+                }
             }
             finally
             {
                 if (this.SiloHost is IAsyncDisposable asyncDisposable)
                 {
                     await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    this.SiloHost?.Dispose();
                 }
             }
         }

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/Grains/BlockingCallGrains.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/Grains/BlockingCallGrains.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Concurrency;
+using Orleans.Runtime;
+
+namespace Orleans.TestingHost.Tests.Grains
+{
+    public interface IRemoteBlockerGrain : IGrainWithGuidKey
+    {
+        Task<string> GetSiloIdentity();
+        Task BlockUntilReleased();
+    }
+
+    public interface ILocalWorkerGrain : IGrainWithGuidKey
+    {
+        Task CallRemote(IRemoteBlockerGrain remote);
+    }
+
+    public interface ILauncherGrain : IGrainWithGuidKey
+    {
+        Task<string> GetSiloIdentity();
+        Task StartBlockingCall(ILocalWorkerGrain worker, IRemoteBlockerGrain remote);
+    }
+
+    /// <summary>
+    /// A regular grain which blocks until the test releases it, holding the response to a call open so
+    /// the caller stays in-flight. State is keyed by the grain's primary key so each test is isolated
+    /// from the process-wide statics used by the others.
+    /// </summary>
+    public class RemoteBlockerGrain : Grain, IRemoteBlockerGrain
+    {
+        private sealed record BlockState(TaskCompletionSource Release, SemaphoreSlim Entered);
+
+        private static readonly ConcurrentDictionary<Guid, BlockState> States = new();
+
+        private static BlockState GetState(Guid key) =>
+            States.GetOrAdd(key, _ => new BlockState(new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), new SemaphoreSlim(0)));
+
+        public static void Release(Guid key) => GetState(key).Release.TrySetResult();
+
+        public static Task<bool> WaitForEntered(Guid key, TimeSpan timeout) => GetState(key).Entered.WaitAsync(timeout);
+
+        public Task<string> GetSiloIdentity() =>
+            Task.FromResult(this.ServiceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress.ToString());
+
+        public Task BlockUntilReleased()
+        {
+            var state = GetState(this.GetPrimaryKey());
+            state.Entered.Release();
+            return state.Release.Task;
+        }
+    }
+
+    /// <summary>
+    /// A stateless worker (placed local to its caller) which makes an outbound call and awaits the
+    /// response. When its silo is killed while this call is in-flight, the grain context disposal
+    /// awaits deactivation of this worker, which cannot complete until the response arrives - which it
+    /// never will. That reproduces the shutdown deadlock unless outstanding callbacks are faulted.
+    /// </summary>
+    [StatelessWorker(1)]
+    public class LocalWorkerGrain : Grain, ILocalWorkerGrain
+    {
+        public Task CallRemote(IRemoteBlockerGrain remote) => remote.BlockUntilReleased();
+    }
+
+    /// <summary>
+    /// A regular (identity-placed) grain used to trigger the stateless worker call so the worker is
+    /// co-located on this grain's silo, giving the test a deterministic silo to kill.
+    /// </summary>
+    public class LauncherGrain : Grain, ILauncherGrain
+    {
+        public Task<string> GetSiloIdentity() =>
+            Task.FromResult(this.ServiceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress.ToString());
+
+        public Task StartBlockingCall(ILocalWorkerGrain worker, IRemoteBlockerGrain remote)
+        {
+            // Fire-and-forget so this grain does not itself block. The stateless worker is placed on
+            // this silo and will block awaiting the remote response.
+            _ = worker.CallRemote(remote);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/HostShutdownCallbackTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/HostShutdownCallbackTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+using Orleans.TestingHost.Tests.Grains;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.TestingHost.Tests
+{
+    /// <summary>
+    /// Tests that an Orleans host (silo or client) faults its outstanding grain-call callbacks when it
+    /// shuts down, so in-flight calls observe a terminal result instead of hanging forever once the
+    /// host can no longer receive responses.
+    /// </summary>
+    [TestCategory("Functional")]
+    public class HostShutdownCallbackTests
+    {
+        [Fact]
+        public async Task StoppedClient_WithInFlightCall_FaultsInsteadOfHanging()
+        {
+            // A client that is stopped while it has an in-flight grain call must fault the outstanding
+            // request rather than leave the caller hanging forever. During client shutdown the callback
+            // expiry timer is disposed, so unless outstanding callbacks are explicitly faulted the
+            // awaiting task never completes.
+            var builder = new InProcessTestClusterBuilder(1);
+            builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
+            await using var cluster = builder.Build();
+            await cluster.DeployAsync();
+
+            var key = Guid.NewGuid();
+            var blocker = cluster.Client.GetGrain<IRemoteBlockerGrain>(key);
+
+            // Start (but do not await) a call to a grain that blocks and never responds.
+            var pending = blocker.BlockUntilReleased();
+            Assert.True(await RemoteBlockerGrain.WaitForEntered(key, TimeSpan.FromSeconds(30)), "The blocking call was never entered.");
+
+            // Stop the client while the call is in-flight.
+            await cluster.StopClusterClientAsync();
+
+            // The pending call must fault promptly instead of hanging.
+            var faulted = await Task.WhenAny(pending, Task.Delay(TimeSpan.FromSeconds(30)));
+            Assert.True(faulted == pending, "Stopping the client should fault in-flight calls instead of hanging.");
+            await Assert.ThrowsAnyAsync<Exception>(async () => await pending);
+
+            RemoteBlockerGrain.Release(key);
+        }
+    }
+}

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/SiloDisposalLeakTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/SiloDisposalLeakTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+using Orleans.TestingHost.Tests.Grains;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.TestingHost.Tests
+{
+    /// <summary>
+    /// Regression tests for https://github.com/dotnet/orleans/issues/10258.
+    ///
+    /// Stopping an in-process silo (e.g. via <see cref="InProcessTestCluster.StopAllSilosAsync"/>)
+    /// before disposing the cluster must still dispose the underlying <c>SiloHost</c>. If it does not,
+    /// the host's <see cref="IServiceProvider"/> and its background threads (such as the Watchdog) are
+    /// never released, leaking the entire silo for the lifetime of the process.
+    /// </summary>
+    [TestCategory("Functional")]
+    public class SiloDisposalLeakTests
+    {
+        [Fact]
+        public async Task StoppedSilo_AfterClusterDispose_HostIsDisposed()
+        {
+            var builder = new InProcessTestClusterBuilder(1);
+            builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
+            var cluster = builder.Build();
+            await cluster.DeployAsync();
+
+            var serviceProvider = cluster.Silos[0].ServiceProvider;
+
+            // Sanity check: the service provider is usable while the silo is running.
+            Assert.NotNull(serviceProvider.GetService<ILocalSiloDetails>());
+
+            // The pattern from the issue: stop the silos first, then dispose the cluster.
+            await cluster.StopAllSilosAsync();
+            await cluster.DisposeAsync();
+
+            // If the host was disposed, its service provider is disposed too and resolving throws.
+            // Prior to the fix the host was never disposed when the silo had already been stopped, so
+            // this resolution would succeed and the silo (including its Watchdog threads) would be retained.
+            Assert.Throws<ObjectDisposedException>(() => serviceProvider.GetService<ILocalSiloDetails>());
+        }
+
+        [Fact]
+        public async Task StoppedSilo_AfterHandleDispose_HostIsDisposed()
+        {
+            var builder = new InProcessTestClusterBuilder(1);
+            builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
+            var cluster = builder.Build();
+            await cluster.DeployAsync();
+
+            var handle = cluster.Silos[0];
+            var serviceProvider = handle.ServiceProvider;
+
+            // Stop the silo, then dispose the handle directly. Disposal must dispose the host even
+            // though the handle is no longer active.
+            await handle.StopSiloAsync(stopGracefully: true);
+            await handle.DisposeAsync();
+
+            Assert.Throws<ObjectDisposedException>(() => serviceProvider.GetService<ILocalSiloDetails>());
+
+            await cluster.DisposeAsync();
+        }
+
+        [Fact]
+        public void StoppedSilo_AfterClusterDispose_ServiceProviderIsCollected()
+        {
+            // Deploy, stop, and dispose entirely within a non-inlined synchronous helper that returns
+            // only a WeakReference. This keeps the cluster and every intermediate local out of this
+            // frame so that, once the helper returns, nothing roots the silo's service provider except
+            // (before the fix) the still-running host and its background threads.
+            var weakRef = DeployStopAndDispose();
+
+            AssertCollected(weakRef);
+        }
+
+        [Fact]
+        public void KilledSilo_AfterClusterDispose_ServiceProviderIsCollected()
+        {
+            var weakRef = DeployKillAndDispose();
+
+            AssertCollected(weakRef);
+        }
+
+        [Fact]
+        public async Task KilledSilo_WithInFlightOutboundCall_DisposesPromptly()
+        {
+            // Regression test for the deadlock that surfaced in CI: killing a silo whose stateless
+            // worker is awaiting an outbound call (whose response can never arrive once the silo stops)
+            // must not hang while disposing the silo host. A stateless worker's grain context disposal
+            // awaits the worker's deactivation, which cannot complete until the outbound call does; the
+            // runtime faults outstanding callbacks during shutdown so that deactivation can complete.
+            var builder = new InProcessTestClusterBuilder(2);
+            builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
+            await using var cluster = builder.Build();
+            await cluster.DeployAsync();
+
+            var client = cluster.Client;
+
+            // The launcher is an identity-placed grain: it gives us a deterministic silo to kill, and
+            // the stateless worker it invokes is placed on that same silo.
+            var launcher = client.GetGrain<ILauncherGrain>(Guid.NewGuid());
+            var launcherSilo = await launcher.GetSiloIdentity();
+
+            // The remote blocker must live on a different silo so the worker's call is a genuine
+            // outbound request whose response is severed when the launcher's silo is killed.
+            IRemoteBlockerGrain remote = null;
+            var remoteKey = Guid.Empty;
+            for (var i = 0; i < 200 && remote is null; i++)
+            {
+                var key = Guid.NewGuid();
+                var candidate = client.GetGrain<IRemoteBlockerGrain>(key);
+                var silo = await candidate.GetSiloIdentity();
+                if (silo != launcherSilo)
+                {
+                    remote = candidate;
+                    remoteKey = key;
+                }
+            }
+
+            Assert.NotNull(remote);
+
+            var worker = client.GetGrain<ILocalWorkerGrain>(Guid.NewGuid());
+
+            // Trigger the outbound call from a stateless worker co-located on the launcher's silo.
+            await launcher.StartBlockingCall(worker, remote);
+            Assert.True(await RemoteBlockerGrain.WaitForEntered(remoteKey, TimeSpan.FromSeconds(30)), "The blocking call was never entered.");
+
+            var launcherHandle = cluster.Silos.Single(s => s.SiloAddress.ToString() == launcherSilo);
+
+            // Kill the launcher's silo (ungraceful) and dispose its host. Prior to the fix this hangs.
+            var killAndDispose = cluster.KillSiloAsync(launcherHandle);
+            var completed = await Task.WhenAny(killAndDispose, Task.Delay(TimeSpan.FromSeconds(60)));
+            Assert.True(completed == killAndDispose, "Killing a silo with an in-flight outbound call should not hang host disposal.");
+            await killAndDispose;
+
+            // Allow the surviving silo to shut down cleanly.
+            RemoteBlockerGrain.Release(remoteKey);
+        }
+
+        private static void AssertCollected(WeakReference weakRef)
+        {
+            // Background threads (e.g. the Watchdog) can briefly keep the provider rooted on their stack
+            // while they wind down, so retry with a bounded timeout rather than asserting after a single GC.
+            for (var attempt = 0; attempt < 20 && weakRef.IsAlive; attempt++)
+            {
+                GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+                GC.WaitForPendingFinalizers();
+                GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+                if (weakRef.IsAlive)
+                {
+                    System.Threading.Thread.Sleep(100);
+                }
+            }
+
+            Assert.False(weakRef.IsAlive, "The stopped silo's service provider should be collectible after the cluster is disposed.");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static WeakReference DeployStopAndDispose()
+        {
+            var cluster = BuildCluster();
+            cluster.DeployAsync().GetAwaiter().GetResult();
+            var weakRef = new WeakReference(cluster.Silos[0].ServiceProvider);
+            cluster.StopAllSilosAsync().GetAwaiter().GetResult();
+            cluster.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            return weakRef;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static WeakReference DeployKillAndDispose()
+        {
+            var cluster = BuildCluster();
+            cluster.DeployAsync().GetAwaiter().GetResult();
+            var weakRef = new WeakReference(cluster.Silos[0].ServiceProvider);
+            cluster.KillSiloAsync(cluster.Silos[0]).GetAwaiter().GetResult();
+            cluster.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            return weakRef;
+        }
+
+        private static InProcessTestCluster BuildCluster()
+        {
+            var builder = new InProcessTestClusterBuilder(1);
+            builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
+            return builder.Build();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`InProcessTestClusterBuilder`/`InProcessTestCluster` leaks memory: stopped silos are never fully released (#10258). `InProcessSiloHandle.Dispose`/`DisposeAsync` began with `if (!IsActive) return;`, and stopping a silo sets `IsActive` to `false`, so a stopped silo's `SiloHost` was never disposed. That left the entire silo object graph (the `IHost`, its `ServiceProvider`, watchdog threads, and everything they root) alive for the lifetime of the test process. Building many in-process clusters in a single run accumulated stopped silo graphs and leaked memory.

## Solution

Decouple disposal from `IsActive` using a one-shot interlocked guard, so the `SiloHost` is disposed exactly once regardless of the silo's active state, and await async disposal directly.

Adds regression tests that assert a stopped/killed silo's host is disposed and its `ServiceProvider` is collectible by the GC, plus a repro that kills a silo with an in-flight outbound call and asserts host disposal completes promptly instead of hanging.

## Stacked on #10275

This PR is stacked on top of **#10275** (fault outstanding callbacks when a host shuts down). That base change is what allows an ungracefully-killed silo with an in-flight outbound call to dispose without hanging. Until #10275 merges, this PR's diff will also show those runtime changes; once it merges, this branch will show only the in-process test cluster disposal/leak fix.