### PR TITLE
fix(runtime): fault outstanding callbacks when a host shuts down

### DIFF
--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -166,6 +166,23 @@ namespace Orleans.Runtime
             this.context.Complete(Response.FromException(exception));
         }
 
+        public void OnHostShutdown()
+        {
+            if (Interlocked.CompareExchange(ref this.completed, 1, 0) != 0)
+            {
+                return;
+            }
+
+            this.stopwatch.Stop();
+            this.shared.Unregister(this.Message);
+            _cancellationTokenRegistration.Dispose();
+            _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
+
+            var msg = this.Message;
+            var exception = new SiloUnavailableException($"The local Orleans host is shutting down and can no longer process the request: {msg}.");
+            this.context.Complete(Response.FromException(exception));
+        }
+
         public void DoCallback(Message response)
         {
             if (Interlocked.CompareExchange(ref this.completed, 1, 0) != 0)

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -167,6 +167,11 @@ namespace Orleans
                 await messageCenter.StopAsync(cancellationToken);
             }
 
+            // Once messaging has stopped the client can no longer receive responses, so any requests
+            // which are still outstanding will never complete. Fault them now so that in-flight grain
+            // calls observe a terminal result instead of hanging forever.
+            BreakOutstandingMessages();
+
             if (_manifestProvider is { } provider)
             {
                 await provider.StopAsync(cancellationToken);
@@ -429,6 +434,21 @@ namespace Orleans
                 if (deadSilo.Equals(callback.Value.Message.TargetSilo))
                 {
                     callback.Value.OnTargetSiloFail();
+                }
+            }
+        }
+
+        private void BreakOutstandingMessages()
+        {
+            foreach (var (_, callback) in callbacks)
+            {
+                try
+                {
+                    callback.OnHostShutdown();
+                }
+                catch (Exception exception)
+                {
+                    LogErrorWhileProcessingCallbackExpiry(logger, exception);
                 }
             }
         }

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -523,6 +523,27 @@ namespace Orleans.Runtime
             {
                 await task.WaitAsync(tc);
             }
+
+            // Once the silo is shutting down it can no longer receive responses, so any requests which
+            // are still outstanding will never complete. Fault them now so that in-flight grain calls
+            // observe a terminal result instead of hanging forever, which would otherwise deadlock grain
+            // deactivation and host disposal during an ungraceful shutdown.
+            BreakOutstandingMessages();
+        }
+
+        private void BreakOutstandingMessages()
+        {
+            foreach (var (_, callback) in callbacks)
+            {
+                try
+                {
+                    callback.OnHostShutdown();
+                }
+                catch (Exception exception)
+                {
+                    LogWarningWhileProcessingCallbackExpiry(this.logger, exception);
+                }
+            }
         }
 
         private Task OnRuntimeInitializeStart(CancellationToken tc)

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/Grains/BlockingCallGrains.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/Grains/BlockingCallGrains.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Concurrency;
+using Orleans.Runtime;
+
+namespace Orleans.TestingHost.Tests.Grains
+{
+    public interface IRemoteBlockerGrain : IGrainWithGuidKey
+    {
+        Task<string> GetSiloIdentity();
+        Task BlockUntilReleased();
+    }
+
+    public interface ILocalWorkerGrain : IGrainWithGuidKey
+    {
+        Task CallRemote(IRemoteBlockerGrain remote);
+    }
+
+    public interface ILauncherGrain : IGrainWithGuidKey
+    {
+        Task<string> GetSiloIdentity();
+        Task StartBlockingCall(ILocalWorkerGrain worker, IRemoteBlockerGrain remote);
+    }
+
+    /// <summary>
+    /// A regular grain which blocks until the test releases it, holding the response to a call open so
+    /// the caller stays in-flight. State is keyed by the grain's primary key so each test is isolated
+    /// from the process-wide statics used by the others.
+    /// </summary>
+    public class RemoteBlockerGrain : Grain, IRemoteBlockerGrain
+    {
+        private sealed record BlockState(TaskCompletionSource Release, SemaphoreSlim Entered);
+
+        private static readonly ConcurrentDictionary<Guid, BlockState> States = new();
+
+        private static BlockState GetState(Guid key) =>
+            States.GetOrAdd(key, _ => new BlockState(new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), new SemaphoreSlim(0)));
+
+        public static void Release(Guid key) => GetState(key).Release.TrySetResult();
+
+        public static Task<bool> WaitForEntered(Guid key, TimeSpan timeout) => GetState(key).Entered.WaitAsync(timeout);
+
+        public Task<string> GetSiloIdentity() =>
+            Task.FromResult(this.ServiceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress.ToString());
+
+        public Task BlockUntilReleased()
+        {
+            var state = GetState(this.GetPrimaryKey());
+            state.Entered.Release();
+            return state.Release.Task;
+        }
+    }
+
+    /// <summary>
+    /// A stateless worker (placed local to its caller) which makes an outbound call and awaits the
+    /// response. When its silo is killed while this call is in-flight, the grain context disposal
+    /// awaits deactivation of this worker, which cannot complete until the response arrives - which it
+    /// never will. That reproduces the shutdown deadlock unless outstanding callbacks are faulted.
+    /// </summary>
+    [StatelessWorker(1)]
+    public class LocalWorkerGrain : Grain, ILocalWorkerGrain
+    {
+        public Task CallRemote(IRemoteBlockerGrain remote) => remote.BlockUntilReleased();
+    }
+
+    /// <summary>
+    /// A regular (identity-placed) grain used to trigger the stateless worker call so the worker is
+    /// co-located on this grain's silo, giving the test a deterministic silo to kill.
+    /// </summary>
+    public class LauncherGrain : Grain, ILauncherGrain
+    {
+        public Task<string> GetSiloIdentity() =>
+            Task.FromResult(this.ServiceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress.ToString());
+
+        public Task StartBlockingCall(ILocalWorkerGrain worker, IRemoteBlockerGrain remote)
+        {
+            // Fire-and-forget so this grain does not itself block. The stateless worker is placed on
+            // this silo and will block awaiting the remote response.
+            _ = worker.CallRemote(remote);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/HostShutdownCallbackTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/HostShutdownCallbackTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+using Orleans.TestingHost.Tests.Grains;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.TestingHost.Tests
+{
+    /// <summary>
+    /// Tests that an Orleans host (silo or client) faults its outstanding grain-call callbacks when it
+    /// shuts down, so in-flight calls observe a terminal result instead of hanging forever once the
+    /// host can no longer receive responses.
+    /// </summary>
+    [TestCategory("Functional")]
+    public class HostShutdownCallbackTests
+    {
+        [Fact]
+        public async Task StoppedClient_WithInFlightCall_FaultsInsteadOfHanging()
+        {
+            // A client that is stopped while it has an in-flight grain call must fault the outstanding
+            // request rather than leave the caller hanging forever. During client shutdown the callback
+            // expiry timer is disposed, so unless outstanding callbacks are explicitly faulted the
+            // awaiting task never completes.
+            var builder = new InProcessTestClusterBuilder(1);
+            builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
+            await using var cluster = builder.Build();
+            await cluster.DeployAsync();
+
+            var key = Guid.NewGuid();
+            var blocker = cluster.Client.GetGrain<IRemoteBlockerGrain>(key);
+
+            // Start (but do not await) a call to a grain that blocks and never responds.
+            var pending = blocker.BlockUntilReleased();
+            Assert.True(await RemoteBlockerGrain.WaitForEntered(key, TimeSpan.FromSeconds(30)), "The blocking call was never entered.");
+
+            // Stop the client while the call is in-flight.
+            await cluster.StopClusterClientAsync();
+
+            // The pending call must fault promptly instead of hanging.
+            var faulted = await Task.WhenAny(pending, Task.Delay(TimeSpan.FromSeconds(30)));
+            Assert.True(faulted == pending, "Stopping the client should fault in-flight calls instead of hanging.");
+            await Assert.ThrowsAnyAsync<Exception>(async () => await pending);
+
+            RemoteBlockerGrain.Release(key);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When an Orleans host (silo or client) shuts down, it can no longer receive responses to grain calls. Any requests still outstanding at that point never complete, so the awaiting caller hangs forever.

This is especially damaging during an *ungraceful* silo shutdown. If an activation is awaiting an outbound response, it cannot be deactivated, which blocks disposal of its grain context and, in turn, blocks disposal of the host itself. This manifests as a hang during host/`ServiceProvider` disposal (observed while stopping in-process test clusters, and surfaced by the leak fix in #10272).

Regular activations only *cancel* their pending operations during disposal, but a `[StatelessWorker]` grain context awaits `worker.Deactivated`, which cannot complete while the worker is blocked on an in-flight outbound call whose callback will never be signalled.

## Solution

Fault all outstanding grain-call callbacks during host shutdown so in-flight calls observe a terminal `SiloUnavailableException` instead of hanging:

- `CallbackData.OnHostShutdown()` completes the callback with a terminal exception, guarding against double-completion with the same interlocked compare-exchange used by `OnTimeout`/`OnTargetSiloFail`.
- `InsideRuntimeClient` breaks its outstanding callbacks at the `RuntimeInitialize` lifecycle stop stage, which runs **last** (after messaging has stopped), so faulting is always safe. Graceful shutdowns have already drained their grains, so it is effectively a no-op there; only ungraceful shutdowns leave residual callbacks.
- `OutsideRuntimeClient` breaks its outstanding callbacks in `StopAsync` once messaging has stopped, mirroring the silo path so clients no longer hang on in-flight calls at shutdown.

Includes a deterministic client regression test (`HostShutdownCallbackTests`) that hangs without the fix and passes with it.

This is the base change; the in-process test cluster disposal/leak fix (#10272) builds on top of it.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10275)