### PR TITLE
fix(cosmos): continue reminder queries after empty pages

### DIFF
--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
@@ -79,18 +79,14 @@ internal partial class CosmosReminderTable : IReminderTable
                 var query = self._container.GetItemLinqQueryable<ReminderEntity>(requestOptions: requestOptions).ToFeedIterator();
 
                 var reminders = new List<ReminderEntity>();
-                do
+                while (query.HasMoreResults)
                 {
                     var queryResponse = await query.ReadNextAsync().ConfigureAwait(false);
                     if (queryResponse != null && queryResponse.Count > 0)
                     {
                         reminders.AddRange(queryResponse);
                     }
-                    else
-                    {
-                        break;
-                    }
-                } while (query.HasMoreResults);
+                }
 
                 return reminders;
             },
@@ -122,18 +118,14 @@ internal partial class CosmosReminderTable : IReminderTable
 
                 var iterator = query.ToFeedIterator();
                 var reminders = new List<ReminderEntity>();
-                do
+                while (iterator.HasMoreResults)
                 {
                     var queryResponse = await iterator.ReadNextAsync().ConfigureAwait(false);
                     if (queryResponse != null && queryResponse.Count > 0)
                     {
                         reminders.AddRange(queryResponse);
                     }
-                    else
-                    {
-                        break;
-                    }
-                } while (iterator.HasMoreResults);
+                }
 
                 return reminders;
             },

--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
@@ -77,7 +77,7 @@ internal partial class CosmosReminderTable : IReminderTable
             {
                 var (self, grainId, requestOptions) = args;
                 var iterator = self._container.GetItemLinqQueryable<ReminderEntity>(requestOptions: requestOptions).ToFeedIterator();
-                return iterator.DrainAsync();
+                return iterator.ToListAsync();
             },
             (this, grainId, requestOptions)).ConfigureAwait(false);
 
@@ -105,7 +105,7 @@ internal partial class CosmosReminderTable : IReminderTable
                     ? query.Where(r => r.GrainHash > begin && r.GrainHash <= end)
                     : query.Where(r => r.GrainHash > begin || r.GrainHash <= end);
 
-                return query.ToFeedIterator().DrainAsync();
+                return query.ToFeedIterator().ToListAsync();
             },
             (this, begin, end)).ConfigureAwait(false);
 
@@ -213,7 +213,7 @@ internal partial class CosmosReminderTable : IReminderTable
                 var iterator = self._container.GetItemLinqQueryable<ReminderEntity>()
                     .Where(entity => entity.ServiceId == self._clusterOptions.ServiceId)
                     .ToFeedIterator();
-                return iterator.DrainAsync();
+                return iterator.ToListAsync();
             }, this).ConfigureAwait(false);
 
             var deleteTasks = new List<Task>();

--- a/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/CosmosReminderTable.cs
@@ -73,22 +73,11 @@ internal partial class CosmosReminderTable : IReminderTable
         {
             var pk = new PartitionKey(ReminderEntity.ConstructPartitionKey(_clusterOptions.ServiceId, grainId));
             var requestOptions = new QueryRequestOptions { PartitionKey = pk };
-            var response = await _executor.ExecuteOperation(static async args =>
+            var response = await _executor.ExecuteOperation(static args =>
             {
                 var (self, grainId, requestOptions) = args;
-                var query = self._container.GetItemLinqQueryable<ReminderEntity>(requestOptions: requestOptions).ToFeedIterator();
-
-                var reminders = new List<ReminderEntity>();
-                while (query.HasMoreResults)
-                {
-                    var queryResponse = await query.ReadNextAsync().ConfigureAwait(false);
-                    if (queryResponse != null && queryResponse.Count > 0)
-                    {
-                        reminders.AddRange(queryResponse);
-                    }
-                }
-
-                return reminders;
+                var iterator = self._container.GetItemLinqQueryable<ReminderEntity>(requestOptions: requestOptions).ToFeedIterator();
+                return iterator.DrainAsync();
             },
             (this, grainId, requestOptions)).ConfigureAwait(false);
 
@@ -106,7 +95,7 @@ internal partial class CosmosReminderTable : IReminderTable
     {
         try
         {
-            var response = await _executor.ExecuteOperation(static async args =>
+            var response = await _executor.ExecuteOperation(static args =>
             {
                 var (self, begin, end) = args;
                 var query = self._container.GetItemLinqQueryable<ReminderEntity>()
@@ -116,18 +105,7 @@ internal partial class CosmosReminderTable : IReminderTable
                     ? query.Where(r => r.GrainHash > begin && r.GrainHash <= end)
                     : query.Where(r => r.GrainHash > begin || r.GrainHash <= end);
 
-                var iterator = query.ToFeedIterator();
-                var reminders = new List<ReminderEntity>();
-                while (iterator.HasMoreResults)
-                {
-                    var queryResponse = await iterator.ReadNextAsync().ConfigureAwait(false);
-                    if (queryResponse != null && queryResponse.Count > 0)
-                    {
-                        reminders.AddRange(queryResponse);
-                    }
-                }
-
-                return reminders;
+                return query.ToFeedIterator().DrainAsync();
             },
             (this, begin, end)).ConfigureAwait(false);
 
@@ -230,26 +208,12 @@ internal partial class CosmosReminderTable : IReminderTable
     {
         try
         {
-            var entities = await _executor.ExecuteOperation(static async self =>
+            var entities = await _executor.ExecuteOperation(static self =>
             {
-                var query = self._container.GetItemLinqQueryable<ReminderEntity>()
+                var iterator = self._container.GetItemLinqQueryable<ReminderEntity>()
                     .Where(entity => entity.ServiceId == self._clusterOptions.ServiceId)
                     .ToFeedIterator();
-                var reminders = new List<ReminderEntity>();
-                do
-                {
-                    var queryResponse = await query.ReadNextAsync().ConfigureAwait(false);
-                    if (queryResponse != null && queryResponse.Count > 0)
-                    {
-                        reminders.AddRange(queryResponse);
-                    }
-                    else
-                    {
-                        break;
-                    }
-                } while (query.HasMoreResults);
-
-                return reminders;
+                return iterator.DrainAsync();
             }, this).ConfigureAwait(false);
 
             var deleteTasks = new List<Task>();

--- a/src/Azure/Orleans.Reminders.Cosmos/FeedIteratorExtensions.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/FeedIteratorExtensions.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+
+namespace Orleans.Reminders.Cosmos;
+
+internal static class FeedIteratorExtensions
+{
+    /// <summary>
+    /// Fully drains a Cosmos DB <see cref="FeedIterator{T}"/>, collecting every item across
+    /// all pages. Empty pages are skipped but do not terminate iteration: <see
+    /// cref="FeedIterator.HasMoreResults"/> may remain <c>true</c> after an empty
+    /// <see cref="FeedIterator{T}.ReadNextAsync(System.Threading.CancellationToken)"/>
+    /// result (for example when the previous page consumed the RU budget while scanning a
+    /// partition with no matching items), so iteration must continue until
+    /// <c>HasMoreResults</c> is <c>false</c>.
+    /// </summary>
+    public static async Task<List<T>> DrainAsync<T>(
+        this FeedIterator<T> iterator,
+        CancellationToken cancellationToken = default)
+    {
+        var items = new List<T>();
+        while (iterator.HasMoreResults)
+        {
+            var page = await iterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
+            if (page is { Count: > 0 })
+            {
+                items.AddRange(page);
+            }
+        }
+
+        return items;
+    }
+}

--- a/src/Azure/Orleans.Reminders.Cosmos/FeedIteratorExtensions.cs
+++ b/src/Azure/Orleans.Reminders.Cosmos/FeedIteratorExtensions.cs
@@ -13,7 +13,7 @@ internal static class FeedIteratorExtensions
     /// partition with no matching items), so iteration must continue until
     /// <c>HasMoreResults</c> is <c>false</c>.
     /// </summary>
-    public static async Task<List<T>> DrainAsync<T>(
+    public static async Task<List<T>> ToListAsync<T>(
         this FeedIterator<T> iterator,
         CancellationToken cancellationToken = default)
     {

--- a/test/Extensions/Orleans.Cosmos.Tests/FeedIteratorExtensionsTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/FeedIteratorExtensionsTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace Tester.Cosmos.Reminders;
 
 /// <summary>
-/// Unit tests for <see cref="FeedIteratorExtensions.DrainAsync{T}"/>. These validate the
+/// Unit tests for <see cref="FeedIteratorExtensions.ToListAsync{T}"/>. These validate the
 /// specific pagination invariant that once tripped a real production bug in
 /// <c>CosmosReminderTable.ReadRows</c>: a <see cref="FeedIterator{T}"/> can return an
 /// empty page while <see cref="FeedIterator.HasMoreResults"/> remains <c>true</c>
@@ -27,7 +27,7 @@ namespace Tester.Cosmos.Reminders;
 public class FeedIteratorExtensionsTests
 {
     [Fact]
-    public async Task DrainAsync_EmptyPageInMiddle_ContinuesIterating()
+    public async Task ToListAsync_EmptyPageInMiddle_ContinuesIterating()
     {
         // Simulates the pathological page layout the fix guards against: results,
         // then an empty page while HasMoreResults is still true, then more results.
@@ -37,13 +37,13 @@ public class FeedIteratorExtensionsTests
             Array.Empty<int>(),
             new[] { 4, 5 });
 
-        var drained = await iterator.DrainAsync();
+        var drained = await iterator.ToListAsync();
 
         Assert.Equal(new[] { 1, 2, 3, 4, 5 }, drained);
     }
 
     [Fact]
-    public async Task DrainAsync_LeadingEmptyPage_ContinuesIterating()
+    public async Task ToListAsync_LeadingEmptyPage_ContinuesIterating()
     {
         // First page empty while HasMoreResults is still true. A break-on-empty
         // implementation would return zero rows even though matches exist further on.
@@ -51,42 +51,42 @@ public class FeedIteratorExtensionsTests
             Array.Empty<int>(),
             new[] { 1, 2, 3 });
 
-        var drained = await iterator.DrainAsync();
+        var drained = await iterator.ToListAsync();
 
         Assert.Equal(new[] { 1, 2, 3 }, drained);
     }
 
     [Fact]
-    public async Task DrainAsync_AllEmptyPages_ReturnsEmpty()
+    public async Task ToListAsync_AllEmptyPages_ReturnsEmpty()
     {
         var iterator = new FakeFeedIterator<int>(
             Array.Empty<int>(),
             Array.Empty<int>(),
             Array.Empty<int>());
 
-        var drained = await iterator.DrainAsync();
+        var drained = await iterator.ToListAsync();
 
         Assert.Empty(drained);
     }
 
     [Fact]
-    public async Task DrainAsync_SinglePage_ReturnsAllItems()
+    public async Task ToListAsync_SinglePage_ReturnsAllItems()
     {
         var iterator = new FakeFeedIterator<int>(new[] { 1, 2, 3, 4, 5 });
 
-        var drained = await iterator.DrainAsync();
+        var drained = await iterator.ToListAsync();
 
         Assert.Equal(new[] { 1, 2, 3, 4, 5 }, drained);
     }
 
     [Fact]
-    public async Task DrainAsync_TrailingEmptyPage_ReturnsAllItems()
+    public async Task ToListAsync_TrailingEmptyPage_ReturnsAllItems()
     {
         var iterator = new FakeFeedIterator<int>(
             new[] { 1, 2 },
             Array.Empty<int>());
 
-        var drained = await iterator.DrainAsync();
+        var drained = await iterator.ToListAsync();
 
         Assert.Equal(new[] { 1, 2 }, drained);
     }

--- a/test/Extensions/Orleans.Cosmos.Tests/FeedIteratorExtensionsTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/FeedIteratorExtensionsTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Orleans.Reminders.Cosmos;
+using Xunit;
+
+namespace Tester.Cosmos.Reminders;
+
+/// <summary>
+/// Unit tests for <see cref="FeedIteratorExtensions.DrainAsync{T}"/>. These validate the
+/// specific pagination invariant that once tripped a real production bug in
+/// <c>CosmosReminderTable.ReadRows</c>: a <see cref="FeedIterator{T}"/> can return an
+/// empty page while <see cref="FeedIterator.HasMoreResults"/> remains <c>true</c>
+/// (e.g. when the previous page exhausted the RU budget while scanning a partition
+/// with no matches). The drain helper must keep iterating past empty pages.
+///
+/// A live Cosmos DB (or emulator) cannot reliably reproduce this pattern in a
+/// deterministic way, so these tests drive the helper with an in-memory
+/// <see cref="FeedIterator{T}"/> subclass that plays back a scripted sequence of
+/// pages including empty ones.
+/// </summary>
+public class FeedIteratorExtensionsTests
+{
+    [Fact]
+    public async Task DrainAsync_EmptyPageInMiddle_ContinuesIterating()
+    {
+        // Simulates the pathological page layout the fix guards against: results,
+        // then an empty page while HasMoreResults is still true, then more results.
+        // A "break on first empty page" drain would drop the trailing rows.
+        var iterator = new FakeFeedIterator<int>(
+            new[] { 1, 2, 3 },
+            Array.Empty<int>(),
+            new[] { 4, 5 });
+
+        var drained = await iterator.DrainAsync();
+
+        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, drained);
+    }
+
+    [Fact]
+    public async Task DrainAsync_LeadingEmptyPage_ContinuesIterating()
+    {
+        // First page empty while HasMoreResults is still true. A break-on-empty
+        // implementation would return zero rows even though matches exist further on.
+        var iterator = new FakeFeedIterator<int>(
+            Array.Empty<int>(),
+            new[] { 1, 2, 3 });
+
+        var drained = await iterator.DrainAsync();
+
+        Assert.Equal(new[] { 1, 2, 3 }, drained);
+    }
+
+    [Fact]
+    public async Task DrainAsync_AllEmptyPages_ReturnsEmpty()
+    {
+        var iterator = new FakeFeedIterator<int>(
+            Array.Empty<int>(),
+            Array.Empty<int>(),
+            Array.Empty<int>());
+
+        var drained = await iterator.DrainAsync();
+
+        Assert.Empty(drained);
+    }
+
+    [Fact]
+    public async Task DrainAsync_SinglePage_ReturnsAllItems()
+    {
+        var iterator = new FakeFeedIterator<int>(new[] { 1, 2, 3, 4, 5 });
+
+        var drained = await iterator.DrainAsync();
+
+        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, drained);
+    }
+
+    [Fact]
+    public async Task DrainAsync_TrailingEmptyPage_ReturnsAllItems()
+    {
+        var iterator = new FakeFeedIterator<int>(
+            new[] { 1, 2 },
+            Array.Empty<int>());
+
+        var drained = await iterator.DrainAsync();
+
+        Assert.Equal(new[] { 1, 2 }, drained);
+    }
+
+    /// <summary>
+    /// A <see cref="FeedIterator{T}"/> that plays back a scripted list of pages.
+    /// <see cref="HasMoreResults"/> stays <c>true</c> until every scripted page has
+    /// been consumed via <see cref="ReadNextAsync(CancellationToken)"/>, so an empty
+    /// page never terminates iteration on its own.
+    /// </summary>
+    private sealed class FakeFeedIterator<T> : FeedIterator<T>
+    {
+        private readonly Queue<IReadOnlyList<T>> _pages;
+
+        public FakeFeedIterator(params IReadOnlyList<T>[] pages)
+        {
+            _pages = new Queue<IReadOnlyList<T>>(pages);
+        }
+
+        public override bool HasMoreResults => _pages.Count > 0;
+
+        public override Task<FeedResponse<T>> ReadNextAsync(CancellationToken cancellationToken = default)
+        {
+            if (_pages.Count == 0)
+            {
+                throw new InvalidOperationException("ReadNextAsync called after all pages consumed.");
+            }
+
+            return Task.FromResult<FeedResponse<T>>(new FakeFeedResponse<T>(_pages.Dequeue()));
+        }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="FeedResponse{T}"/> stub exposing the members the drain
+    /// helper actually reads (<see cref="Count"/> and the enumerator). Everything
+    /// else returns a safe default so nothing throws on unrelated access.
+    /// </summary>
+    private sealed class FakeFeedResponse<T> : FeedResponse<T>
+    {
+        private readonly IReadOnlyList<T> _items;
+
+        public FakeFeedResponse(IReadOnlyList<T> items) => _items = items;
+
+        public override int Count => _items.Count;
+        public override string ContinuationToken => null!;
+        public override string IndexMetrics => null!;
+        public override Headers Headers => null!;
+        public override IEnumerable<T> Resource => _items;
+        public override HttpStatusCode StatusCode => HttpStatusCode.OK;
+        public override double RequestCharge => 0;
+        public override string ActivityId => string.Empty;
+        public override string ETag => null!;
+        public override CosmosDiagnostics Diagnostics => null!;
+
+        public override IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+    }
+}


### PR DESCRIPTION
This pull request improves the reliability and maintainability of Cosmos DB reminder table operations by introducing a robust helper for draining paginated query results and refactoring the codebase to use it. The most important changes are summarized below:

**Core reliability fix:**

* Added a new `DrainAsync` extension method in `FeedIteratorExtensions.cs` that fully drains a `FeedIterator<T>`, ensuring all items are collected across all pages, even if empty pages appear before the end. This addresses a subtle bug where iteration could previously terminate early if an empty page was encountered while more results remained.

**Refactoring to use the new helper:**

* Refactored `CosmosReminderTable.cs` methods (`ReadRows(GrainId)`, `ReadRows(uint, uint)`, and `TestOnlyClearTable`) to use the new `DrainAsync` helper instead of duplicating page-draining logic. This reduces code duplication and ensures robust iteration in all cases. [[1]](diffhunk://#diff-5f6cbbc2b37db7439b94bb7e80023e5448ec42cbcf4a76d39b09301c0042c170L76-R80) [[2]](diffhunk://#diff-5f6cbbc2b37db7439b94bb7e80023e5448ec42cbcf4a76d39b09301c0042c170L113-R98) [[3]](diffhunk://#diff-5f6cbbc2b37db7439b94bb7e80023e5448ec42cbcf4a76d39b09301c0042c170L123-R108) [[4]](diffhunk://#diff-5f6cbbc2b37db7439b94bb7e80023e5448ec42cbcf4a76d39b09301c0042c170L241-R216)

**Testing and validation:**

* Added comprehensive unit tests in `FeedIteratorExtensionsTests.cs` to verify that `DrainAsync` correctly handles various pagination scenarios, including empty pages in the middle, at the start, or at the end of the sequence. These tests use a custom in-memory `FeedIterator` to simulate edge cases that can occur in production.

Fixes #10273

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10276)