### PR TITLE
fix(streaming): avoid LeaseBasedQueueBalancer timer disposal race during shutdown

### DIFF
--- a/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -102,20 +102,21 @@ public partial class LeaseBasedQueueBalancer(
     {
         if (Cancellation.IsCancellationRequested) return;
 
+        // Stop processing membership updates.
+        await base.Shutdown();
+
         // Stop acquiring and renewing leases.
-        _leaseMaintenanceTimer.Dispose();
-        _leaseAcquisitionTimer.Dispose();
         await Task.WhenAll(_leaseMaintenanceTimerTask, _leaseAcquisitionTimerTask);
 
-        // Release all owned leases.
-        var shutdownTask = _executor.AddNext(async () =>
+        // Drain queued operations and release all owned leases.
+        await _executor.AddNext(async () =>
         {
             _responsibility = 0;
-            await ReleaseLeasesToMeetResponsibility();
+            await ReleaseLeasesToMeetResponsibility(isShuttingDown: true);
         });
 
-        // Signal shutdown.
-        await base.Shutdown();
+        _leaseMaintenanceTimer.Dispose();
+        _leaseAcquisitionTimer.Dispose();
     }
 
     /// <inheritdoc/>
@@ -132,7 +133,7 @@ public partial class LeaseBasedQueueBalancer(
     private async Task PeriodicallyMaintainLeases()
     {
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
-        while (await _leaseMaintenanceTimer.WaitForNextTickAsync())
+        while (await WaitForNextTick(_leaseMaintenanceTimer))
         {
             try
             {
@@ -169,7 +170,7 @@ public partial class LeaseBasedQueueBalancer(
     private async Task PeriodicallyAcquireLeasesToMeetResponsibility()
     {
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
-        while (await _leaseAcquisitionTimer.WaitForNextTickAsync())
+        while (await WaitForNextTick(_leaseAcquisitionTimer))
         {
             // Set the period for the next round.
             // It may be mutated by another method, but not concurrently.
@@ -212,9 +213,9 @@ public partial class LeaseBasedQueueBalancer(
         }
     }
 
-    private async Task ReleaseLeasesToMeetResponsibility()
+    private async Task ReleaseLeasesToMeetResponsibility(bool isShuttingDown = false)
     {
-        if (Cancellation.IsCancellationRequested) return;
+        if (Cancellation.IsCancellationRequested && !isShuttingDown) return;
         LogTraceReleaseLeasesToMeetResponsibility(Logger, _myQueues.Count, _responsibility);
 
         var queueCountToRelease = _myQueues.Count - _responsibility;
@@ -396,6 +397,18 @@ public partial class LeaseBasedQueueBalancer(
         }
 
         return Task.CompletedTask;
+    }
+
+    private async ValueTask<bool> WaitForNextTick(PeriodicTimer timer)
+    {
+        try
+        {
+            return await timer.WaitForNextTickAsync(Cancellation);
+        }
+        catch (OperationCanceledException) when (Cancellation.IsCancellationRequested)
+        {
+            return false;
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
+++ b/src/Orleans.Streaming/QueueBalancer/LeaseBasedQueueBalancer.cs
@@ -105,18 +105,24 @@ public partial class LeaseBasedQueueBalancer(
         // Stop processing membership updates.
         await base.Shutdown();
 
-        // Stop acquiring and renewing leases.
-        await Task.WhenAll(_leaseMaintenanceTimerTask, _leaseAcquisitionTimerTask);
-
-        // Drain queued operations and release all owned leases.
-        await _executor.AddNext(async () =>
+        try
         {
-            _responsibility = 0;
-            await ReleaseLeasesToMeetResponsibility(isShuttingDown: true);
-        });
+            // Stop acquiring and renewing leases.
+            await Task.WhenAll(_leaseMaintenanceTimerTask, _leaseAcquisitionTimerTask);
 
-        _leaseMaintenanceTimer.Dispose();
-        _leaseAcquisitionTimer.Dispose();
+            // Drain queued operations and release all owned leases.
+            await _executor.AddNext(async () =>
+            {
+                _responsibility = 0;
+                await ReleaseLeasesToMeetResponsibility(isShuttingDown: true);
+            });
+        }
+        finally
+        {
+            // Ensure the timers are always disposed, even if draining queued operations or releasing leases fails.
+            _leaseMaintenanceTimer.Dispose();
+            _leaseAcquisitionTimer.Dispose();
+        }
     }
 
     /// <inheritdoc/>

--- a/test/Orleans.Streaming.Tests/Orleans.Streaming.Tests.csproj
+++ b/test/Orleans.Streaming.Tests/Orleans.Streaming.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp">

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/LeaseBasedQueueBalancerTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/LeaseBasedQueueBalancerTests.cs
@@ -1,8 +1,9 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Threading.Channels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Orleans.Configuration;
 using Orleans.LeaseProviders;
@@ -46,13 +47,14 @@ public class LeaseBasedQueueBalancerTests
             LeaseLength = TimeSpan.FromDays(2),
             LeaseRenewPeriod = TimeSpan.FromDays(1),
         };
+        var recordingLoggerFactory = new RecordingLoggerFactory();
         var balancer = new TestLeaseBasedQueueBalancer(
             "provider",
             options,
             leaseProvider,
             services,
-            NullLoggerFactory.Instance,
-            TimeProvider.System);
+            recordingLoggerFactory,
+            new FakeTimeProvider());
 
         await balancer.Initialize(queueMapper);
         balancer.NotifyClusterMembershipChange([siloAddress]);
@@ -74,6 +76,12 @@ public class LeaseBasedQueueBalancerTests
         await leaseProvider.Received(1).Release(
             options.LeaseCategory,
             Arg.Is<AcquiredLease[]>(leases => leases.Length == 1 && leases[0] == acquiredLease));
+
+        // The original bug allowed a queued membership update to touch the PeriodicTimer instances after
+        // they were disposed, which logged "Error updating lease responsibilities." with an inner
+        // ObjectDisposedException. Assert that shutdown completed cleanly, with no such error logged.
+        Assert.DoesNotContain(recordingLoggerFactory.Entries, entry => entry.Exception is ObjectDisposedException);
+        Assert.DoesNotContain(recordingLoggerFactory.Entries, entry => entry.Level >= LogLevel.Error);
     }
 
     private sealed class TestLeaseBasedQueueBalancer(
@@ -86,5 +94,35 @@ public class LeaseBasedQueueBalancerTests
         : LeaseBasedQueueBalancer(name, options, leaseProvider, services, loggerFactory, timeProvider)
     {
         public void NotifyClusterMembershipChange(HashSet<SiloAddress> activeSilos) => OnClusterMembershipChange(activeSilos);
+    }
+
+    /// <summary>
+    /// An <see cref="ILoggerFactory"/> that records every log entry so tests can assert on logged
+    /// errors, such as the <see cref="ObjectDisposedException"/> that was previously logged when a
+    /// queued membership update accessed a disposed <see cref="PeriodicTimer"/> during shutdown.
+    /// </summary>
+    private sealed class RecordingLoggerFactory : ILoggerFactory
+    {
+        private readonly ConcurrentQueue<LogEntry> _entries = new();
+
+        public IReadOnlyCollection<LogEntry> Entries => _entries.ToArray();
+
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(categoryName, _entries);
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public void Dispose() { }
+
+        public readonly record struct LogEntry(LogLevel Level, string Category, Exception Exception, string Message);
+
+        private sealed class RecordingLogger(string category, ConcurrentQueue<LogEntry> entries) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                => entries.Enqueue(new LogEntry(logLevel, category, exception, formatter(state, exception)));
+        }
     }
 }

--- a/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/LeaseBasedQueueBalancerTests.cs
+++ b/test/Orleans.Streaming.Tests/OrleansRuntime/Streams/LeaseBasedQueueBalancerTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using System.Threading.Channels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Orleans.Configuration;
+using Orleans.LeaseProviders;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Xunit;
+
+namespace UnitTests.OrleansRuntime.Streams;
+
+public class LeaseBasedQueueBalancerTests
+{
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public async Task Shutdown_DrainsQueuedMembershipUpdatesBeforeDisposingTimers()
+    {
+        var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13000), 1);
+        var membershipUpdates = Channel.CreateUnbounded<ClusterMembershipSnapshot>();
+        var membership = Substitute.For<IClusterMembershipService>();
+        membership.MembershipUpdates.Returns(membershipUpdates.Reader.ReadAllAsync());
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        localSiloDetails.SiloAddress.Returns(siloAddress);
+        using var services = new ServiceCollection()
+            .AddSingleton(membership)
+            .AddSingleton(localSiloDetails)
+            .BuildServiceProvider();
+
+        var queueId = QueueId.GetQueueId("queue", 0, 0);
+        var queueMapper = Substitute.For<IStreamQueueMapper>();
+        queueMapper.GetAllQueues().Returns([queueId]);
+        var acquireStarted = new TaskCompletionSource<LeaseRequest[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var acquireCompleted = new TaskCompletionSource<AcquireLeaseResult[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var leaseProvider = Substitute.For<ILeaseProvider>();
+        leaseProvider.Acquire(Arg.Any<string>(), Arg.Any<LeaseRequest[]>()).Returns(call =>
+        {
+            acquireStarted.TrySetResult(call.Arg<LeaseRequest[]>());
+            return acquireCompleted.Task;
+        });
+        leaseProvider.Release(Arg.Any<string>(), Arg.Any<AcquiredLease[]>()).Returns(Task.CompletedTask);
+        var options = new LeaseBasedQueueBalancerOptions
+        {
+            LeaseAcquisitionPeriod = TimeSpan.FromDays(1),
+            LeaseLength = TimeSpan.FromDays(2),
+            LeaseRenewPeriod = TimeSpan.FromDays(1),
+        };
+        var balancer = new TestLeaseBasedQueueBalancer(
+            "provider",
+            options,
+            leaseProvider,
+            services,
+            NullLoggerFactory.Instance,
+            TimeProvider.System);
+
+        await balancer.Initialize(queueMapper);
+        balancer.NotifyClusterMembershipChange([siloAddress]);
+        var requests = await acquireStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        var shutdownTask = balancer.Shutdown();
+        var acquiredLease = new AcquiredLease(requests[0].ResourceKey, options.LeaseLength, "token", DateTime.UtcNow);
+
+        try
+        {
+            await Assert.ThrowsAsync<TimeoutException>(
+                () => shutdownTask.WaitAsync(TimeSpan.FromMilliseconds(100)));
+        }
+        finally
+        {
+            acquireCompleted.TrySetResult([new AcquireLeaseResult(acquiredLease, ResponseCode.OK, null)]);
+            await shutdownTask;
+        }
+
+        await leaseProvider.Received(1).Release(
+            options.LeaseCategory,
+            Arg.Is<AcquiredLease[]>(leases => leases.Length == 1 && leases[0] == acquiredLease));
+    }
+
+    private sealed class TestLeaseBasedQueueBalancer(
+        string name,
+        LeaseBasedQueueBalancerOptions options,
+        ILeaseProvider leaseProvider,
+        IServiceProvider services,
+        ILoggerFactory loggerFactory,
+        TimeProvider timeProvider)
+        : LeaseBasedQueueBalancer(name, options, leaseProvider, services, loggerFactory, timeProvider)
+    {
+        public void NotifyClusterMembershipChange(HashSet<SiloAddress> activeSilos) => OnClusterMembershipChange(activeSilos);
+    }
+}


### PR DESCRIPTION
Fixes #10280.\n\nShutdown now cancels and joins the lease maintenance loops before draining queued responsibility updates and disposing their timers. The final executor operation still releases owned leases, and its failures are observed.\n\nA deterministic regression test blocks lease acquisition while shutdown begins, verifies that shutdown waits for queued work, and confirms that the acquired lease is released.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10286)