### PR TITLE
fix(streaming): bound Event Hubs shutdown

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -273,9 +273,7 @@ namespace Orleans.Streaming.EventHubs
                 {
                     if (localReceiver != null)
                     {
-                        closeTask = localReceiver is ICancellableEventHubReceiver cancellableReceiver
-                            ? cancellableReceiver.CloseAsync(closeCancellationToken)
-                            : localReceiver.CloseAsync();
+                        closeTask = localReceiver.CloseAsync(closeCancellationToken);
                     }
                 }
                 catch (Exception ex)

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -267,11 +267,15 @@ namespace Orleans.Streaming.EventHubs
 
                 // start closing receiver
                 Task closeTask = Task.CompletedTask;
+                using var closeCancellation = timeout == Timeout.InfiniteTimeSpan ? null : new CancellationTokenSource(timeout);
+                var closeCancellationToken = closeCancellation?.Token ?? CancellationToken.None;
                 try
                 {
                     if (localReceiver != null)
                     {
-                        closeTask = localReceiver.CloseAsync();
+                        closeTask = localReceiver is ICancellableEventHubReceiver cancellableReceiver
+                            ? cancellableReceiver.CloseAsync(closeCancellationToken)
+                            : localReceiver.CloseAsync();
                     }
                 }
                 catch (Exception ex)
@@ -292,7 +296,7 @@ namespace Orleans.Streaming.EventHubs
                 // finish return receiver closing task
                 try
                 {
-                    await closeTask;
+                    await closeTask.WaitAsync(closeCancellationToken);
                 }
                 catch (Exception ex)
                 {

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubReceiver.cs
@@ -4,6 +4,7 @@ using Azure.Messaging.EventHubs.Primitives;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.Streaming.EventHubs
@@ -29,10 +30,15 @@ namespace Orleans.Streaming.EventHubs
         Task CloseAsync();
     }
 
+    internal interface ICancellableEventHubReceiver
+    {
+        Task CloseAsync(CancellationToken cancellationToken);
+    }
+
     /// <summary>
     /// pass through decorator class for EventHubReceiver
     /// </summary>
-    internal partial class EventHubReceiverProxy : IEventHubReceiver
+    internal partial class EventHubReceiverProxy : IEventHubReceiver, ICancellableEventHubReceiver
     {
         private readonly PartitionReceiver client;
 
@@ -81,9 +87,11 @@ namespace Orleans.Streaming.EventHubs
             return await client.ReceiveBatchAsync(maxCount, waitTime);
         }
 
-        public async Task CloseAsync()
+        public Task CloseAsync() => CloseAsync(CancellationToken.None);
+
+        public async Task CloseAsync(CancellationToken cancellationToken)
         {
-            await client.CloseAsync();
+            await client.CloseAsync(cancellationToken);
         }
 
         [LoggerMessage(

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubReceiver.cs
@@ -28,17 +28,19 @@ namespace Orleans.Streaming.EventHubs
         /// </summary>
         /// <returns></returns>
         Task CloseAsync();
-    }
 
-    internal interface ICancellableEventHubReceiver
-    {
-        Task CloseAsync(CancellationToken cancellationToken);
+        /// <summary>
+        /// Sends a cleanup message which can be canceled.
+        /// </summary>
+        /// <param name="cancellationToken">The token used to cancel the operation.</param>
+        /// <returns>A task representing the operation.</returns>
+        Task CloseAsync(CancellationToken cancellationToken) => CloseAsync();
     }
 
     /// <summary>
     /// pass through decorator class for EventHubReceiver
     /// </summary>
-    internal partial class EventHubReceiverProxy : IEventHubReceiver, ICancellableEventHubReceiver
+    internal partial class EventHubReceiverProxy : IEventHubReceiver
     {
         private readonly PartitionReceiver client;
 

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
+using Orleans.Internal;
 using Orleans.Runtime;
 using Orleans.Serialization;
 using Orleans.Streams;
@@ -147,7 +148,16 @@ namespace Orleans.Providers.Streams.Common
             var manager = this.pullingAgentManager;
             if (manager != null)
             {
-                await manager.Stop();
+                var stopTask = manager.Stop();
+                try
+                {
+                    await stopTask.WaitAsync(token);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    // The lifecycle deadline only bounds the observer; manager cleanup continues.
+                    stopTask.Ignore();
+                }
             }
 
             stateManager.CommitState();

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs
@@ -117,14 +117,20 @@ namespace Orleans.Streams
 
         public async Task Stop()
         {
+            var balancer = this.queueBalancer;
+            if (balancer is null)
+            {
+                return;
+            }
+
             await StopAgents();
             if (queuePrintTimer != null)
             {
                 queuePrintTimer.Dispose();
                 this.queuePrintTimer = null;
             }
-            await this.queueBalancer.Shutdown();
             this.queueBalancer = null;
+            await balancer.Shutdown();
         }
 
         public async Task StartAgents()
@@ -373,8 +379,7 @@ namespace Orleans.Streams
 
                 agents.Add(agent);
                 deactivatedAgents[queueId] = agent;
-                var agentGrainRef = agent.AsReference<IPersistentStreamPullingAgent>();
-                var task = OrleansTaskExtentions.SafeExecute(agentGrainRef.Shutdown);
+                var task = OrleansTaskExtentions.SafeExecute(() => agent.RunOrQueueTask(agent.Shutdown));
                 task = task.LogException(logger, ErrorCode.PersistentStreamPullingManager_11,
                     $"PersistentStreamPullingAgent {agent.QueueId} failed to Shutdown.");
                 removeTasks.Add(task);

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -561,6 +561,7 @@ namespace Orleans.Streaming.EventHubs
     public partial interface IEventHubReceiver
     {
         System.Threading.Tasks.Task CloseAsync();
+        System.Threading.Tasks.Task CloseAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData>> ReceiveAsync(int maxCount, System.TimeSpan waitTime);
     }
 

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -109,9 +109,24 @@ public class EventHubCheckpointerTests
         }
     }
 
-    private sealed class TestEventHubReceiver : IEventHubReceiver, ICancellableEventHubReceiver
+    private sealed class TestEventHubReceiver : IEventHubReceiver
     {
-        public bool BlockCloseUntilCanceled { get; set; }
+        public int CloseCount { get; private set; }
+
+        public Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime)
+        {
+            return Task.FromResult<IEnumerable<EventData>>([]);
+        }
+
+        public Task CloseAsync()
+        {
+            CloseCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class BlockingEventHubReceiver : IEventHubReceiver
+    {
         public int CloseCount { get; private set; }
 
         public Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime)
@@ -124,9 +139,7 @@ public class EventHubCheckpointerTests
         public Task CloseAsync(CancellationToken cancellationToken)
         {
             CloseCount++;
-            return BlockCloseUntilCanceled
-                ? Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
-                : Task.CompletedTask;
+            return Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
         }
     }
 
@@ -148,7 +161,7 @@ public class EventHubCheckpointerTests
     private static async Task<EventHubAdapterReceiver> CreateReceiver(
         TestCheckpointer checkpointer,
         TestEventHubQueueCache cache = null,
-        TestEventHubReceiver eventHubReceiver = null)
+        IEventHubReceiver eventHubReceiver = null)
     {
         var settings = new EventHubPartitionSettings
         {
@@ -217,7 +230,7 @@ public class EventHubCheckpointerTests
     {
         var checkpointer = new TestCheckpointer();
         var cache = new TestEventHubQueueCache();
-        var eventHubReceiver = new TestEventHubReceiver { BlockCloseUntilCanceled = true };
+        var eventHubReceiver = new BlockingEventHubReceiver();
         var receiver = await CreateReceiver(checkpointer, cache, eventHubReceiver);
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -109,8 +109,9 @@ public class EventHubCheckpointerTests
         }
     }
 
-    private sealed class TestEventHubReceiver : IEventHubReceiver
+    private sealed class TestEventHubReceiver : IEventHubReceiver, ICancellableEventHubReceiver
     {
+        public bool BlockCloseUntilCanceled { get; set; }
         public int CloseCount { get; private set; }
 
         public Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime)
@@ -118,10 +119,14 @@ public class EventHubCheckpointerTests
             return Task.FromResult<IEnumerable<EventData>>([]);
         }
 
-        public Task CloseAsync()
+        public Task CloseAsync() => CloseAsync(CancellationToken.None);
+
+        public Task CloseAsync(CancellationToken cancellationToken)
         {
             CloseCount++;
-            return Task.CompletedTask;
+            return BlockCloseUntilCanceled
+                ? Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+                : Task.CompletedTask;
         }
     }
 
@@ -201,6 +206,22 @@ public class EventHubCheckpointerTests
         var receiver = await CreateReceiver(checkpointer, cache, eventHubReceiver);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => receiver.Shutdown(TimeSpan.FromSeconds(5)));
+
+        Assert.Equal(1, checkpointer.FlushCount);
+        Assert.Equal(1, cache.DisposeCount);
+        Assert.Equal(1, eventHubReceiver.CloseCount);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task Shutdown_CancelsBlockedReceiverClose()
+    {
+        var checkpointer = new TestCheckpointer();
+        var cache = new TestEventHubQueueCache();
+        var eventHubReceiver = new TestEventHubReceiver { BlockCloseUntilCanceled = true };
+        var receiver = await CreateReceiver(checkpointer, cache, eventHubReceiver);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => receiver.Shutdown(TimeSpan.FromMilliseconds(50)).WaitAsync(TimeSpan.FromSeconds(5)));
 
         Assert.Equal(1, checkpointer.FlushCount);
         Assert.Equal(1, cache.DisposeCount);

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -673,6 +673,22 @@ namespace UnitTests.StreamingTests
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+        public async Task Shutdown_IsIdempotent()
+        {
+            var queueId = QueueId.GetQueueId("queue", 0u, 0u);
+            var receiver = Substitute.For<IQueueAdapterReceiver>();
+            receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
+            var agent = CreateAgent(pubSub: null, queueId, receiver);
+            var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
+            await InitializeAgent(agent);
+
+            await testAccessor.Shutdown();
+            await testAccessor.Shutdown();
+
+            await receiver.Received(1).Shutdown(Arg.Any<TimeSpan>());
+        }
+
+        [Fact, TestCategory("BVT"), TestCategory("Streaming")]
         public async Task RunQueuePump_ReadsAfterReinitialize()
         {
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);


### PR DESCRIPTION
Fixes #10283.

Event Hubs receiver shutdown could exceed its configured budget because PartitionReceiver.CloseAsync() was called without cancellation, causing local pulling-agent system-target calls to hit the 30-second response timeout. This change passes the receiver shutdown budget through to the Azure SDK close operation, bounds the provider lifecycle observer while allowing cleanup to continue, and invokes local pulling-agent shutdown without a message round trip.

Manager and agent shutdown paths are also made idempotent, with regression coverage for a blocked receiver close and repeated shutdown.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10288)