### PR TITLE
fix(runtime): avoid service resolution after silo shutdown

### DIFF
--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -47,7 +47,7 @@ namespace Orleans.Runtime
         private IGrainCallCancellationManager _cancellationManager;
         private HostedClient hostedClient;
 
-        private HostedClient HostedClient => this.hostedClient ??= this.ServiceProvider.GetRequiredService<HostedClient>();
+        private HostedClient HostedClient => this.hostedClient;
         private readonly MessageFactory messageFactory;
         private IGrainReferenceRuntime grainReferenceRuntime;
         private Task callbackTimerTask;
@@ -113,15 +113,25 @@ namespace Orleans.Runtime
 
         public GrainFactory ConcreteGrainFactory { get; }
 
-        private GrainLocator GrainLocator
-            => this.grainLocator ?? (this.grainLocator = this.ServiceProvider.GetRequiredService<GrainLocator>());
+        private GrainLocator GrainLocator => this.grainLocator;
 
-        private List<IIncomingGrainCallFilter> GrainCallFilters
-            => this.grainCallFilters ??= new List<IIncomingGrainCallFilter>(this.ServiceProvider.GetServices<IIncomingGrainCallFilter>());
+        private List<IIncomingGrainCallFilter> GrainCallFilters => this.grainCallFilters;
 
-        private MessageCenter MessageCenter => this.messageCenter ?? (this.messageCenter = this.ServiceProvider.GetRequiredService<MessageCenter>());
+        private MessageCenter MessageCenter => this.messageCenter;
 
-        public IGrainReferenceRuntime GrainReferenceRuntime => this.grainReferenceRuntime ?? (this.grainReferenceRuntime = this.ServiceProvider.GetRequiredService<IGrainReferenceRuntime>());
+        public IGrainReferenceRuntime GrainReferenceRuntime => this.grainReferenceRuntime;
+
+        internal void ConsumeServices()
+        {
+            this.grainLocator = this.ServiceProvider.GetRequiredService<GrainLocator>();
+            this.grainCallFilters = new List<IIncomingGrainCallFilter>(this.ServiceProvider.GetServices<IIncomingGrainCallFilter>());
+            this.messageCenter = this.ServiceProvider.GetRequiredService<MessageCenter>();
+            this.grainReferenceRuntime = this.ServiceProvider.GetRequiredService<IGrainReferenceRuntime>();
+            this.hostedClient = this.ServiceProvider.GetRequiredService<HostedClient>();
+            _cancellationManager = this.ServiceProvider.GetRequiredService<IGrainCallCancellationManager>();
+            sharedCallbackData.CancellationManager = _cancellationManager;
+            systemSharedCallbackData.CancellationManager = _cancellationManager;
+        }
 
         public void SendRequest(
             GrainReference target,
@@ -234,14 +244,9 @@ namespace Orleans.Runtime
 
         public void SniffIncomingMessage(Message message)
         {
-            if (Volatile.Read(ref _isStopping) != 0)
-            {
-                return;
-            }
-
             try
             {
-                if (message.CacheInvalidationHeader is { } cacheUpdates)
+                if (message.CacheInvalidationHeader is { } cacheUpdates && Volatile.Read(ref _isStopping) == 0)
                 {
                     lock (cacheUpdates)
                     {
@@ -410,16 +415,16 @@ namespace Orleans.Runtime
         {
             OrleansInsideRuntimeClientEvent.Instance.ReceiveResponse(message);
 
-            if (Volatile.Read(ref _isStopping) != 0)
-            {
-                ProcessResponseCallback(message, hostShutdown: message.Result is Message.ResponseTypes.Status);
-                return;
-            }
-
             var result = message.Result;
             if (result != Message.ResponseTypes.Rejection && result != Message.ResponseTypes.Status)
             {
                 ProcessResponseCallback(message);
+                return;
+            }
+
+            if (Volatile.Read(ref _isStopping) != 0)
+            {
+                ProcessResponseCallback(message, hostShutdown: result is Message.ResponseTypes.Status);
                 return;
             }
 
@@ -618,9 +623,6 @@ namespace Orleans.Runtime
 
         public void Participate(ISiloLifecycle lifecycle)
         {
-            _cancellationManager = this.ServiceProvider.GetRequiredService<IGrainCallCancellationManager>();
-            sharedCallbackData.CancellationManager = _cancellationManager;
-            systemSharedCallbackData.CancellationManager = _cancellationManager;
             lifecycle.Subscribe<InsideRuntimeClient>(ServiceLifecycleStage.RuntimeInitialize, OnRuntimeInitializeStart, OnRuntimeInitializeStop);
         }
 

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -623,6 +623,7 @@ namespace Orleans.Runtime
 
         public void Participate(ISiloLifecycle lifecycle)
         {
+            ConsumeServices();
             lifecycle.Subscribe<InsideRuntimeClient>(ServiceLifecycleStage.RuntimeInitialize, OnRuntimeInitializeStart, OnRuntimeInitializeStop);
         }
 

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -246,7 +246,7 @@ namespace Orleans.Runtime
         {
             try
             {
-                if (message.CacheInvalidationHeader is { } cacheUpdates && Volatile.Read(ref _isStopping) == 0)
+                if (message.CacheInvalidationHeader is { } cacheUpdates)
                 {
                     lock (cacheUpdates)
                     {
@@ -422,12 +422,6 @@ namespace Orleans.Runtime
                 return;
             }
 
-            if (Volatile.Read(ref _isStopping) != 0)
-            {
-                ProcessResponseCallback(message, hostShutdown: result is Message.ResponseTypes.Status);
-                return;
-            }
-
             if (result is Message.ResponseTypes.Rejection)
             {
                 if (!message.TargetSilo.Matches(this.MySilo))
@@ -471,20 +465,13 @@ namespace Orleans.Runtime
             }
         }
 
-        private void ProcessResponseCallback(Message message, bool hostShutdown = false)
+        private void ProcessResponseCallback(Message message)
         {
             if (callbacks.TryRemove((message.TargetGrain, message.Id), out var callbackData))
             {
                 // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
                 // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
-                if (hostShutdown)
-                {
-                    callbackData.OnHostShutdown();
-                }
-                else
-                {
-                    callbackData.DoCallback(message);
-                }
+                callbackData.DoCallback(message);
             }
             else
             {

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -234,6 +234,11 @@ namespace Orleans.Runtime
 
         public void SniffIncomingMessage(Message message)
         {
+            if (Volatile.Read(ref _isStopping) != 0)
+            {
+                return;
+            }
+
             try
             {
                 if (message.CacheInvalidationHeader is { } cacheUpdates)
@@ -405,6 +410,12 @@ namespace Orleans.Runtime
         {
             OrleansInsideRuntimeClientEvent.Instance.ReceiveResponse(message);
 
+            if (Volatile.Read(ref _isStopping) != 0)
+            {
+                ProcessResponseCallback(message, hostShutdown: message.Result is Message.ResponseTypes.Status);
+                return;
+            }
+
             var result = message.Result;
             if (result != Message.ResponseTypes.Rejection && result != Message.ResponseTypes.Status)
             {
@@ -455,13 +466,20 @@ namespace Orleans.Runtime
             }
         }
 
-        private void ProcessResponseCallback(Message message)
+        private void ProcessResponseCallback(Message message, bool hostShutdown = false)
         {
             if (callbacks.TryRemove((message.TargetGrain, message.Id), out var callbackData))
             {
                 // IMPORTANT: we do not schedule the response callback via the scheduler, since the only thing it does
                 // is to resolve/break the resolver. The continuations/waits that are based on this resolution will be scheduled as work items.
-                callbackData.DoCallback(message);
+                if (hostShutdown)
+                {
+                    callbackData.OnHostShutdown();
+                }
+                else
+                {
+                    callbackData.DoCallback(message);
+                }
             }
             else
             {

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -120,7 +120,6 @@ namespace Orleans.Runtime
 
             // Initialize the message center
             messageCenter = Services.GetRequiredService<MessageCenter>();
-            runtimeClient.ConsumeServices();
             messageCenter.SniffIncomingMessage = runtimeClient.SniffIncomingMessage;
 
             this.SystemStatus = SystemStatus.Created;

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -120,6 +120,7 @@ namespace Orleans.Runtime
 
             // Initialize the message center
             messageCenter = Services.GetRequiredService<MessageCenter>();
+            runtimeClient.ConsumeServices();
             messageCenter.SniffIncomingMessage = runtimeClient.SniffIncomingMessage;
 
             this.SystemStatus = SystemStatus.Created;

--- a/test/Orleans.Runtime.Tests/InsideRuntimeClientTests.cs
+++ b/test/Orleans.Runtime.Tests/InsideRuntimeClientTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+using Orleans.TestingHost;
+using TestExtensions;
+using Xunit;
+
+namespace Tester;
+
+[TestCategory("BVT")]
+public class InsideRuntimeClientTests
+{
+    [Fact]
+    public async Task LateRejectionAfterSiloDisposalDoesNotResolveServices()
+    {
+        var builder = new InProcessTestClusterBuilder(1);
+        builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
+        await using var cluster = builder.Build();
+        await cluster.DeployAsync();
+
+        var silo = cluster.Silos[0];
+        var runtimeClient = silo.ServiceProvider.GetRequiredService<InsideRuntimeClient>();
+        var rejection = new Message
+        {
+            Direction = Message.Directions.Response,
+            Result = Message.ResponseTypes.Rejection,
+            TargetSilo = silo.SiloAddress,
+            TargetGrain = GrainId.Create("caller", Guid.NewGuid().ToString()),
+            SendingGrain = GrainId.Create("target", Guid.NewGuid().ToString()),
+            BodyObject = new RejectionResponse
+            {
+                RejectionType = Message.RejectionTypes.Unrecoverable,
+                RejectionInfo = "The outbound queue is stopped",
+            },
+        };
+
+        await silo.StopSiloAsync(stopGracefully: false);
+        await silo.DisposeAsync();
+
+        Assert.Null(Record.Exception(() => runtimeClient.ReceiveResponse(rejection)));
+    }
+}


### PR DESCRIPTION
#10290 closes callback admission and establishes `_isStopping` before the shutdown callback sweep, but `InsideRuntimeClient` still lazily resolves several dependencies from runtime paths. A late rejection can therefore reach `ReceiveResponse` after the silo service provider has been disposed and throw `ObjectDisposedException` while resolving `GrainLocator`.

This follow-up mirrors `OutsideRuntimeClient.ConsumeServices`: `InsideRuntimeClient` eagerly consumes its dependencies when it participates in the silo lifecycle, after construction but before lifecycle startup. This avoids constructor cycles and eliminates lazy DI resolution from runtime paths without adding shutdown-state reads to hot paths.

Regression coverage delivers an unrecoverable rejection after ungraceful silo shutdown and provider disposal.

Fixes #10282