### PR TITLE
fix(runtime): close callback admission during shutdown

### DIFF
--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -8,12 +8,19 @@ namespace Orleans.Runtime
 {
     internal sealed partial class CallbackData
     {
+        private const int CancellationRegistrationNone = 0;
+        private const int CancellationRegistrationPending = 1;
+        private const int CancellationRegistrationPublished = 2;
+        private const int CancellationRegistrationDisposed = 3;
+
         private readonly SharedCallbackData shared;
         private readonly IResponseCompletionSource context;
         private readonly ApplicationRequestInstruments _applicationRequestInstruments;
         private int completed;
+        private int _cancellationRegistrationState;
         private StatusResponse? lastKnownStatus;
         private ValueStopwatch stopwatch;
+        private CancellationToken _cancellationToken;
         private CancellationTokenRegistration _cancellationTokenRegistration;
 
         public CallbackData(
@@ -40,12 +47,29 @@ namespace Orleans.Runtime
                 return;
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
-            _cancellationTokenRegistration = cancellationToken.UnsafeRegister(static arg =>
+            _cancellationToken = cancellationToken;
+            if (Interlocked.CompareExchange(
+                ref _cancellationRegistrationState,
+                CancellationRegistrationPending,
+                CancellationRegistrationNone) != CancellationRegistrationNone)
+            {
+                return;
+            }
+
+            var registration = cancellationToken.UnsafeRegister(static arg =>
             {
                 var callbackData = (CallbackData)arg!;
                 callbackData.OnCancellation();
             }, this);
+
+            _cancellationTokenRegistration = registration;
+            if (Interlocked.CompareExchange(
+                ref _cancellationRegistrationState,
+                CancellationRegistrationPublished,
+                CancellationRegistrationPending) != CancellationRegistrationPending)
+            {
+                registration.Dispose();
+            }
         }
 
         private void SignalCancellation()
@@ -112,8 +136,8 @@ namespace Orleans.Runtime
             _applicationRequestInstruments.OnAppRequestsEnd((long)stopwatch.Elapsed.TotalMilliseconds);
             _applicationRequestInstruments.OnAppRequestsCanceled(GetTargetGrainType());
             OrleansCallBackDataEvent.Instance.OnCanceled(Message);
-            context.Complete(Response.FromException(new OperationCanceledException(_cancellationTokenRegistration.Token)));
-            _cancellationTokenRegistration.Dispose();
+            context.Complete(Response.FromException(new OperationCanceledException(_cancellationToken)));
+            DisposeCancellationRegistration();
         }
 
         public void OnTimeout()
@@ -130,7 +154,7 @@ namespace Orleans.Runtime
             }
 
             this.shared.Unregister(this.Message);
-            _cancellationTokenRegistration.Dispose();
+            DisposeCancellationRegistration();
             _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
             _applicationRequestInstruments.OnAppRequestsTimedOut(GetTargetGrainType());
 
@@ -155,7 +179,7 @@ namespace Orleans.Runtime
 
             this.stopwatch.Stop();
             this.shared.Unregister(this.Message);
-            _cancellationTokenRegistration.Dispose();
+            DisposeCancellationRegistration();
             _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
 
             OrleansCallBackDataEvent.Instance.OnTargetSiloFail(this.Message);
@@ -175,7 +199,7 @@ namespace Orleans.Runtime
 
             this.stopwatch.Stop();
             this.shared.Unregister(this.Message);
-            _cancellationTokenRegistration.Dispose();
+            DisposeCancellationRegistration();
             _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
 
             var msg = this.Message;
@@ -193,11 +217,35 @@ namespace Orleans.Runtime
             OrleansCallBackDataEvent.Instance.DoCallback(this.Message);
 
             this.stopwatch.Stop();
-            _cancellationTokenRegistration.Dispose();
+            DisposeCancellationRegistration();
             _applicationRequestInstruments.OnAppRequestsEnd((long)this.stopwatch.Elapsed.TotalMilliseconds);
 
             // do callback outside the CallbackData lock. Just not a good practice to hold a lock for this unrelated operation.
             ResponseCallback(response, this.context);
+        }
+
+        private void DisposeCancellationRegistration()
+        {
+            // Registration can invoke the cancellation callback synchronously before UnsafeRegister
+            // returns. Transfer the state to Disposed and let the publisher dispose in that case.
+            while (true)
+            {
+                var state = Volatile.Read(ref _cancellationRegistrationState);
+                if (state == CancellationRegistrationDisposed)
+                {
+                    return;
+                }
+
+                if (Interlocked.CompareExchange(ref _cancellationRegistrationState, CancellationRegistrationDisposed, state) == state)
+                {
+                    if (state == CancellationRegistrationPublished)
+                    {
+                        _cancellationTokenRegistration.Dispose();
+                    }
+
+                    return;
+                }
+            }
         }
 
         private static void ResponseCallback(Message message, IResponseCompletionSource context)

--- a/src/Orleans.Core/Runtime/CallbackData.cs
+++ b/src/Orleans.Core/Runtime/CallbackData.cs
@@ -8,19 +8,17 @@ namespace Orleans.Runtime
 {
     internal sealed partial class CallbackData
     {
-        private const int CancellationRegistrationNone = 0;
-        private const int CancellationRegistrationPending = 1;
-        private const int CancellationRegistrationPublished = 2;
-        private const int CancellationRegistrationDisposed = 3;
+        private const int StateNone = 0;
+        private const int StateCompleted = 1;
+        private const int StateCancellationRegistrationPending = 2;
+        private const int StateCancellationRegistrationPublished = 4;
 
         private readonly SharedCallbackData shared;
         private readonly IResponseCompletionSource context;
         private readonly ApplicationRequestInstruments _applicationRequestInstruments;
-        private int completed;
-        private int _cancellationRegistrationState;
+        private int _state;
         private StatusResponse? lastKnownStatus;
         private ValueStopwatch stopwatch;
-        private CancellationToken _cancellationToken;
         private CancellationTokenRegistration _cancellationTokenRegistration;
 
         public CallbackData(
@@ -38,7 +36,7 @@ namespace Orleans.Runtime
 
         public Message Message { get; } // might hold metadata used by response pipeline
 
-        public bool IsCompleted => this.completed == 1;
+        public bool IsCompleted => (Volatile.Read(ref _state) & StateCompleted) != 0;
 
         public void SubscribeForCancellation(CancellationToken cancellationToken)
         {
@@ -47,26 +45,25 @@ namespace Orleans.Runtime
                 return;
             }
 
-            _cancellationToken = cancellationToken;
             if (Interlocked.CompareExchange(
-                ref _cancellationRegistrationState,
-                CancellationRegistrationPending,
-                CancellationRegistrationNone) != CancellationRegistrationNone)
+                ref _state,
+                StateCancellationRegistrationPending,
+                StateNone) != StateNone)
             {
                 return;
             }
 
-            var registration = cancellationToken.UnsafeRegister(static arg =>
+            var registration = cancellationToken.UnsafeRegister(static (arg, token) =>
             {
                 var callbackData = (CallbackData)arg!;
-                callbackData.OnCancellation();
+                callbackData.OnCancellation(token);
             }, this);
 
             _cancellationTokenRegistration = registration;
             if (Interlocked.CompareExchange(
-                ref _cancellationRegistrationState,
-                CancellationRegistrationPublished,
-                CancellationRegistrationPending) != CancellationRegistrationPending)
+                ref _state,
+                StateCancellationRegistrationPublished,
+                StateCancellationRegistrationPending) != StateCancellationRegistrationPending)
             {
                 registration.Dispose();
             }
@@ -113,7 +110,7 @@ namespace Orleans.Runtime
             return type.IsDefault ? "unknown" : type.ToString()!;
         }
 
-        private void OnCancellation()
+        private void OnCancellation(CancellationToken cancellationToken)
         {
             // If waiting for acknowledgement is enabled, simply signal to the remote grain that cancellation
             // is requested and return.
@@ -125,7 +122,7 @@ namespace Orleans.Runtime
 
             // Otherwise, cancel the request immediately, without waiting for the callee to acknowledge the
             // cancellation request. The callee will still be signaled.
-            if (Interlocked.CompareExchange(ref completed, 1, 0) != 0)
+            if (!TryComplete())
             {
                 return;
             }
@@ -136,13 +133,13 @@ namespace Orleans.Runtime
             _applicationRequestInstruments.OnAppRequestsEnd((long)stopwatch.Elapsed.TotalMilliseconds);
             _applicationRequestInstruments.OnAppRequestsCanceled(GetTargetGrainType());
             OrleansCallBackDataEvent.Instance.OnCanceled(Message);
-            context.Complete(Response.FromException(new OperationCanceledException(_cancellationToken)));
+            context.Complete(Response.FromException(new OperationCanceledException(cancellationToken)));
             DisposeCancellationRegistration();
         }
 
         public void OnTimeout()
         {
-            if (Interlocked.CompareExchange(ref completed, 1, 0) != 0)
+            if (!TryComplete())
             {
                 return;
             }
@@ -172,7 +169,7 @@ namespace Orleans.Runtime
 
         public void OnTargetSiloFail()
         {
-            if (Interlocked.CompareExchange(ref this.completed, 1, 0) != 0)
+            if (!TryComplete())
             {
                 return;
             }
@@ -192,7 +189,7 @@ namespace Orleans.Runtime
 
         public void OnHostShutdown()
         {
-            if (Interlocked.CompareExchange(ref this.completed, 1, 0) != 0)
+            if (!TryComplete())
             {
                 return;
             }
@@ -209,7 +206,7 @@ namespace Orleans.Runtime
 
         public void DoCallback(Message response)
         {
-            if (Interlocked.CompareExchange(ref this.completed, 1, 0) != 0)
+            if (!TryComplete())
             {
                 return;
             }
@@ -224,27 +221,14 @@ namespace Orleans.Runtime
             ResponseCallback(response, this.context);
         }
 
+        private bool TryComplete() => (Interlocked.Or(ref _state, StateCompleted) & StateCompleted) == 0;
+
         private void DisposeCancellationRegistration()
         {
-            // Registration can invoke the cancellation callback synchronously before UnsafeRegister
-            // returns. Transfer the state to Disposed and let the publisher dispose in that case.
-            while (true)
+            // If registration is still pending, its publisher observes completion and disposes it.
+            if ((Volatile.Read(ref _state) & StateCancellationRegistrationPublished) != 0)
             {
-                var state = Volatile.Read(ref _cancellationRegistrationState);
-                if (state == CancellationRegistrationDisposed)
-                {
-                    return;
-                }
-
-                if (Interlocked.CompareExchange(ref _cancellationRegistrationState, CancellationRegistrationDisposed, state) == state)
-                {
-                    if (state == CancellationRegistrationPublished)
-                    {
-                        _cancellationTokenRegistration.Dispose();
-                    }
-
-                    return;
-                }
+                _cancellationTokenRegistration.Dispose();
             }
         }
 

--- a/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
+++ b/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs
@@ -28,6 +28,7 @@ namespace Orleans
 
         private readonly ConcurrentDictionary<CorrelationId, CallbackData> callbacks;
         private InvokableObjectManager localObjects;
+        private int _isStopping;
         private bool disposing;
         private bool disposed;
 
@@ -155,7 +156,12 @@ namespace Orleans
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
+            Volatile.Write(ref _isStopping, 1);
             this.callbackTimer.Dispose();
+
+            // Fault callbacks before any cancellation-sensitive waits. Completing them can resume code
+            // which issues follow-up calls, so request admission must already be closed.
+            BreakOutstandingMessages();
 
             if (this.callbackTimerTask is { } task)
             {
@@ -166,11 +172,6 @@ namespace Orleans
             {
                 await messageCenter.StopAsync(cancellationToken);
             }
-
-            // Once messaging has stopped the client can no longer receive responses, so any requests
-            // which are still outstanding will never complete. Fault them now so that in-flight grain
-            // calls observe a terminal result instead of hanging forever.
-            BreakOutstandingMessages();
 
             if (_manifestProvider is { } provider)
             {
@@ -291,12 +292,28 @@ namespace Orleans
             if (!oneWay)
             {
                 var callbackData = new CallbackData(this.sharedCallbackData, context, message, _applicationRequestInstruments);
-                callbackData.SubscribeForCancellation(cancellationToken);
+                if (Volatile.Read(ref _isStopping) != 0)
+                {
+                    callbackData.OnHostShutdown();
+                    return;
+                }
+
                 callbacks.TryAdd(message.Id, callbackData);
+                callbackData.SubscribeForCancellation(cancellationToken);
+
+                if (Volatile.Read(ref _isStopping) != 0)
+                {
+                    callbackData.OnHostShutdown();
+                    return;
+                }
             }
             else
             {
                 context?.Complete();
+                if (Volatile.Read(ref _isStopping) != 0)
+                {
+                    return;
+                }
             }
 
             LogSendingMessage(logger, message);
@@ -418,8 +435,10 @@ namespace Orleans
         {
             if (this.disposing) return;
             this.disposing = true;
+            Volatile.Write(ref _isStopping, 1);
 
             Utils.SafeExecute(() => this.callbackTimer.Dispose());
+            BreakOutstandingMessages();
 
             Utils.SafeExecute(() => MessageCenter?.Dispose());
 

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -519,16 +519,17 @@ namespace Orleans.Runtime
         private async Task OnRuntimeInitializeStop(CancellationToken tc)
         {
             this.callbackTimer.Dispose();
+            // Once the silo is shutting down it can no longer receive responses, so any requests which
+            // are still outstanding will never complete. Fault them now so that in-flight grain calls
+            // observe a terminal result instead of hanging forever, which would otherwise deadlock grain
+            // deactivation and host disposal during an ungraceful shutdown. This must happen before
+            // waiting for the timer task since that wait observes the shutdown cancellation token.
+            BreakOutstandingMessages();
+
             if (this.callbackTimerTask is { } task)
             {
                 await task.WaitAsync(tc);
             }
-
-            // Once the silo is shutting down it can no longer receive responses, so any requests which
-            // are still outstanding will never complete. Fault them now so that in-flight grain calls
-            // observe a terminal result instead of hanging forever, which would otherwise deadlock grain
-            // deactivation and host disposal during an ungraceful shutdown.
-            BreakOutstandingMessages();
         }
 
         private void BreakOutstandingMessages()

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -37,7 +37,7 @@ namespace Orleans.Runtime
         private readonly SharedCallbackData sharedCallbackData;
         private readonly SharedCallbackData systemSharedCallbackData;
         private readonly PeriodicTimer callbackTimer;
-        private int isStopping;
+        private int _isStopping;
 
         private GrainLocator grainLocator;
         private MessageCenter messageCenter;
@@ -180,17 +180,27 @@ namespace Orleans.Runtime
 
                 // Register a callback for the request.
                 callbackData = new CallbackData(sharedData, context, message, _applicationRequestInstruments);
+                if (Volatile.Read(ref _isStopping) != 0)
+                {
+                    callbackData.OnHostShutdown();
+                    return;
+                }
+
                 callbacks.TryAdd((message.SendingGrain, message.Id), callbackData);
                 callbackData.SubscribeForCancellation(cancellationToken);
             }
             else
             {
                 context?.Complete();
+                if (Volatile.Read(ref _isStopping) != 0)
+                {
+                    return;
+                }
             }
 
             // Completing callbacks during shutdown can resume application code which issues follow-up
             // calls. Reject those calls so that they cannot outlive the shutdown callback sweep.
-            if (Volatile.Read(ref this.isStopping) != 0)
+            if (Volatile.Read(ref _isStopping) != 0)
             {
                 callbackData?.OnHostShutdown();
                 return;
@@ -528,7 +538,7 @@ namespace Orleans.Runtime
 
         private async Task OnRuntimeInitializeStop(CancellationToken tc)
         {
-            Volatile.Write(ref this.isStopping, 1);
+            Volatile.Write(ref _isStopping, 1);
             this.callbackTimer.Dispose();
             // Once the silo is shutting down it can no longer receive responses, so any requests which
             // are still outstanding will never complete. Fault them now so that in-flight grain calls

--- a/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
+++ b/src/Orleans.Runtime/Core/InsideRuntimeClient.cs
@@ -37,6 +37,7 @@ namespace Orleans.Runtime
         private readonly SharedCallbackData sharedCallbackData;
         private readonly SharedCallbackData systemSharedCallbackData;
         private readonly PeriodicTimer callbackTimer;
+        private int isStopping;
 
         private GrainLocator grainLocator;
         private MessageCenter messageCenter;
@@ -172,18 +173,27 @@ namespace Orleans.Runtime
             }
 
             var oneWay = (options & InvokeMethodOptions.OneWay) != 0;
+            CallbackData callbackData = null;
             if (!oneWay)
             {
                 Debug.Assert(context is not null);
 
                 // Register a callback for the request.
-                var callbackData = new CallbackData(sharedData, context, message, _applicationRequestInstruments);
+                callbackData = new CallbackData(sharedData, context, message, _applicationRequestInstruments);
                 callbacks.TryAdd((message.SendingGrain, message.Id), callbackData);
                 callbackData.SubscribeForCancellation(cancellationToken);
             }
             else
             {
                 context?.Complete();
+            }
+
+            // Completing callbacks during shutdown can resume application code which issues follow-up
+            // calls. Reject those calls so that they cannot outlive the shutdown callback sweep.
+            if (Volatile.Read(ref this.isStopping) != 0)
+            {
+                callbackData?.OnHostShutdown();
+                return;
             }
 
             this.messagingTrace.OnSendRequest(message);
@@ -518,6 +528,7 @@ namespace Orleans.Runtime
 
         private async Task OnRuntimeInitializeStop(CancellationToken tc)
         {
+            Volatile.Write(ref this.isStopping, 1);
             this.callbackTimer.Dispose();
             // Once the silo is shutting down it can no longer receive responses, so any requests which
             // are still outstanding will never complete. Fault them now so that in-flight grain calls

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.Runtime;
+using Orleans.Serialization.Invocation;
+using Xunit;
+
+namespace Tester;
+
+public class CallbackDataTests
+{
+    [Fact, TestCategory("BVT")]
+    public void AlreadyCanceledTokenCompletesCallback()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var completion = new TestResponseCompletionSource();
+        var unregisterCount = 0;
+        var callback = CreateCallback(
+            completion,
+            _ => Interlocked.Increment(ref unregisterCount),
+            CreateInstruments(serviceProvider));
+
+        callback.SubscribeForCancellation(cancellation.Token);
+
+        Assert.True(callback.IsCompleted);
+        Assert.Equal(1, unregisterCount);
+        var exception = Assert.IsType<OperationCanceledException>(completion.Response.Exception);
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public void CancellationRegistrationAddedAfterCompletionIsDisposed()
+    {
+        using var serviceProvider = CreateServiceProvider();
+        using var cancellation = new CancellationTokenSource();
+
+        var callbackReference = CreateCompletedCallback(cancellation.Token, CreateInstruments(serviceProvider));
+
+        for (var attempt = 0; attempt < 10 && callbackReference.IsAlive; attempt++)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+        }
+
+        Assert.False(callbackReference.IsAlive);
+        GC.KeepAlive(cancellation);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateCompletedCallback(CancellationToken cancellationToken, ApplicationRequestInstruments instruments)
+    {
+        var callback = CreateCallback(new TestResponseCompletionSource(), _ => { }, instruments);
+
+        callback.OnHostShutdown();
+        callback.SubscribeForCancellation(cancellationToken);
+
+        return new WeakReference(callback);
+    }
+
+    private static CallbackData CreateCallback(
+        IResponseCompletionSource completion,
+        Action<Message> unregister,
+        ApplicationRequestInstruments instruments)
+    {
+        var shared = new SharedCallbackData(
+            unregister,
+            logger: NullLogger<CallbackData>.Instance,
+            responseTimeout: TimeSpan.FromMinutes(1),
+            cancelOnTimeout: false,
+            waitForCancellationAcknowledgement: false,
+            cancellationManager: null);
+        return new CallbackData(shared, completion, new Message(), instruments);
+    }
+
+    private static ServiceProvider CreateServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        return services.BuildServiceProvider();
+    }
+
+    private static ApplicationRequestInstruments CreateInstruments(IServiceProvider serviceProvider) =>
+        new(new OrleansInstruments(serviceProvider.GetRequiredService<IMeterFactory>()));
+
+    private sealed class TestResponseCompletionSource : IResponseCompletionSource
+    {
+        public Response Response { get; private set; }
+
+        public void Complete(Response value) => Response = value;
+
+        public void Complete() => Response = Orleans.Serialization.Invocation.Response.Completed;
+    }
+}

--- a/test/Orleans.Runtime.Tests/CallbackDataTests.cs
+++ b/test/Orleans.Runtime.Tests/CallbackDataTests.cs
@@ -34,7 +34,7 @@ public class CallbackDataTests
     }
 
     [Fact, TestCategory("BVT")]
-    public void CancellationRegistrationAddedAfterCompletionIsDisposed()
+    public void CancellationSubscriptionAfterCompletionDoesNotRetainCallback()
     {
         using var serviceProvider = CreateServiceProvider();
         using var cancellation = new CancellationTokenSource();

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/Grains/BlockingCallGrains.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/Grains/BlockingCallGrains.cs
@@ -57,13 +57,23 @@ namespace Orleans.TestingHost.Tests.Grains
     /// <summary>
     /// A stateless worker (placed local to its caller) which makes an outbound call and awaits the
     /// response. When its silo is killed while this call is in-flight, the grain context disposal
-    /// awaits deactivation of this worker, which cannot complete until the response arrives - which it
-    /// never will. That reproduces the shutdown deadlock unless outstanding callbacks are faulted.
+    /// awaits deactivation of this worker. If the first call faults during shutdown, the worker retries
+    /// to verify that no new callback can be registered after the shutdown callback sweep.
     /// </summary>
     [StatelessWorker(1)]
     public class LocalWorkerGrain : Grain, ILocalWorkerGrain
     {
-        public Task CallRemote(IRemoteBlockerGrain remote) => remote.BlockUntilReleased();
+        public async Task CallRemote(IRemoteBlockerGrain remote)
+        {
+            try
+            {
+                await remote.BlockUntilReleased();
+            }
+            catch (SiloUnavailableException)
+            {
+                await remote.BlockUntilReleased();
+            }
+        }
     }
 
     /// <summary>

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/HostShutdownCallbackTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/HostShutdownCallbackTests.cs
@@ -31,6 +31,7 @@ namespace Orleans.TestingHost.Tests
 
             // Start (but do not await) a call to a grain that blocks and never responds.
             var pending = blocker.BlockUntilReleased();
+            var followUp = RetryAfterFailure(pending, blocker);
             Assert.True(await RemoteBlockerGrain.WaitForEntered(key, TimeSpan.FromSeconds(30)), "The blocking call was never entered.");
 
             // Stop the client while the call is in-flight.
@@ -41,7 +42,23 @@ namespace Orleans.TestingHost.Tests
             Assert.True(faulted == pending, "Stopping the client should fault in-flight calls instead of hanging.");
             await Assert.ThrowsAnyAsync<Exception>(async () => await pending);
 
+            var followUpFaulted = await Task.WhenAny(followUp, Task.Delay(TimeSpan.FromSeconds(30)));
+            Assert.True(followUpFaulted == followUp, "Calls issued after client shutdown begins should fault instead of hanging.");
+            await Assert.ThrowsAnyAsync<Exception>(async () => await followUp);
+
             RemoteBlockerGrain.Release(key);
+        }
+
+        private static async Task RetryAfterFailure(Task pending, IRemoteBlockerGrain blocker)
+        {
+            try
+            {
+                await pending;
+            }
+            catch
+            {
+                await blocker.BlockUntilReleased();
+            }
         }
     }
 }

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/SiloDisposalLeakTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/SiloDisposalLeakTests.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
+using Orleans.Runtime.Placement;
 using Orleans.TestingHost.Tests.Grains;
 using TestExtensions;
 using Xunit;
@@ -102,32 +102,39 @@ namespace Orleans.TestingHost.Tests
             await cluster.DeployAsync();
 
             var client = cluster.Client;
+            var launcherHandle = cluster.Silos[0];
+            var remoteHandle = cluster.Silos[1];
 
-            // The launcher is an identity-placed grain: it gives us a deterministic silo to kill, and
-            // the stateless worker it invokes is placed on that same silo.
+            // Place the launcher on the silo which will be killed. The stateless workers it invokes are
+            // placed on that same silo.
+            RequestContext.Set(IPlacementDirector.PlacementHintKey, launcherHandle.SiloAddress);
             var launcher = client.GetGrain<ILauncherGrain>(Guid.NewGuid());
-            var launcherSilo = await launcher.GetSiloIdentity();
+            try
+            {
+                Assert.Equal(launcherHandle.SiloAddress.ToString(), await launcher.GetSiloIdentity());
+            }
+            finally
+            {
+                RequestContext.Remove(IPlacementDirector.PlacementHintKey);
+            }
 
             var remoteKeys = new List<Guid>(PendingCallCount);
             for (var call = 0; call < PendingCallCount; call++)
             {
-                // Each remote blocker must live on a different silo so the worker's call is a genuine
-                // outbound request whose response is severed when the launcher's silo is killed.
-                IRemoteBlockerGrain remote = null;
-                var remoteKey = Guid.Empty;
-                for (var attempt = 0; attempt < 200 && remote is null; attempt++)
+                // Place each blocker on the surviving silo so the worker's call is a genuine outbound
+                // request whose response is severed when the launcher's silo is killed.
+                var remoteKey = Guid.NewGuid();
+                RequestContext.Set(IPlacementDirector.PlacementHintKey, remoteHandle.SiloAddress);
+                var remote = client.GetGrain<IRemoteBlockerGrain>(remoteKey);
+                try
                 {
-                    var key = Guid.NewGuid();
-                    var candidate = client.GetGrain<IRemoteBlockerGrain>(key);
-                    var silo = await candidate.GetSiloIdentity();
-                    if (silo != launcherSilo)
-                    {
-                        remote = candidate;
-                        remoteKey = key;
-                    }
+                    Assert.Equal(remoteHandle.SiloAddress.ToString(), await remote.GetSiloIdentity());
+                }
+                finally
+                {
+                    RequestContext.Remove(IPlacementDirector.PlacementHintKey);
                 }
 
-                Assert.NotNull(remote);
                 remoteKeys.Add(remoteKey);
 
                 // Trigger the outbound call from a stateless worker co-located on the launcher's silo.
@@ -135,8 +142,6 @@ namespace Orleans.TestingHost.Tests
                 await launcher.StartBlockingCall(worker, remote);
                 Assert.True(await RemoteBlockerGrain.WaitForEntered(remoteKey, TimeSpan.FromSeconds(30)), "The blocking call was never entered.");
             }
-
-            var launcherHandle = cluster.Silos.Single(s => s.SiloAddress.ToString() == launcherSilo);
 
             // Kill the launcher's silo (ungraceful) and dispose its host. Prior to the fix this can hang
             // if cancellation interrupts callback timer shutdown before the callbacks are faulted.

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/SiloDisposalLeakTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/SiloDisposalLeakTests.cs
@@ -94,8 +94,8 @@ namespace Orleans.TestingHost.Tests
             // Regression test for the deadlock that surfaced in CI: killing a silo whose stateless
             // workers are awaiting outbound calls (whose responses can never arrive once the silo stops)
             // must not hang while disposing the silo host. A stateless worker's grain context disposal
-            // awaits each worker's deactivation, which cannot complete until the outbound calls do; the
-            // runtime faults outstanding callbacks during shutdown so that deactivation can complete.
+            // awaits each worker's deactivation. Faulting those calls resumes the workers, which retry
+            // and would register new callbacks after the shutdown sweep unless registration is closed.
             var builder = new InProcessTestClusterBuilder(2);
             builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
             await using var cluster = builder.Build();

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/SiloDisposalLeakTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/SiloDisposalLeakTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -88,10 +89,12 @@ namespace Orleans.TestingHost.Tests
         [Fact]
         public async Task KilledSilo_WithInFlightOutboundCall_DisposesPromptly()
         {
+            const int PendingCallCount = 8;
+
             // Regression test for the deadlock that surfaced in CI: killing a silo whose stateless
-            // worker is awaiting an outbound call (whose response can never arrive once the silo stops)
+            // workers are awaiting outbound calls (whose responses can never arrive once the silo stops)
             // must not hang while disposing the silo host. A stateless worker's grain context disposal
-            // awaits the worker's deactivation, which cannot complete until the outbound call does; the
+            // awaits each worker's deactivation, which cannot complete until the outbound calls do; the
             // runtime faults outstanding callbacks during shutdown so that deactivation can complete.
             var builder = new InProcessTestClusterBuilder(2);
             builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
@@ -105,40 +108,48 @@ namespace Orleans.TestingHost.Tests
             var launcher = client.GetGrain<ILauncherGrain>(Guid.NewGuid());
             var launcherSilo = await launcher.GetSiloIdentity();
 
-            // The remote blocker must live on a different silo so the worker's call is a genuine
-            // outbound request whose response is severed when the launcher's silo is killed.
-            IRemoteBlockerGrain remote = null;
-            var remoteKey = Guid.Empty;
-            for (var i = 0; i < 200 && remote is null; i++)
+            var remoteKeys = new List<Guid>(PendingCallCount);
+            for (var call = 0; call < PendingCallCount; call++)
             {
-                var key = Guid.NewGuid();
-                var candidate = client.GetGrain<IRemoteBlockerGrain>(key);
-                var silo = await candidate.GetSiloIdentity();
-                if (silo != launcherSilo)
+                // Each remote blocker must live on a different silo so the worker's call is a genuine
+                // outbound request whose response is severed when the launcher's silo is killed.
+                IRemoteBlockerGrain remote = null;
+                var remoteKey = Guid.Empty;
+                for (var attempt = 0; attempt < 200 && remote is null; attempt++)
                 {
-                    remote = candidate;
-                    remoteKey = key;
+                    var key = Guid.NewGuid();
+                    var candidate = client.GetGrain<IRemoteBlockerGrain>(key);
+                    var silo = await candidate.GetSiloIdentity();
+                    if (silo != launcherSilo)
+                    {
+                        remote = candidate;
+                        remoteKey = key;
+                    }
                 }
+
+                Assert.NotNull(remote);
+                remoteKeys.Add(remoteKey);
+
+                // Trigger the outbound call from a stateless worker co-located on the launcher's silo.
+                var worker = client.GetGrain<ILocalWorkerGrain>(Guid.NewGuid());
+                await launcher.StartBlockingCall(worker, remote);
+                Assert.True(await RemoteBlockerGrain.WaitForEntered(remoteKey, TimeSpan.FromSeconds(30)), "The blocking call was never entered.");
             }
-
-            Assert.NotNull(remote);
-
-            var worker = client.GetGrain<ILocalWorkerGrain>(Guid.NewGuid());
-
-            // Trigger the outbound call from a stateless worker co-located on the launcher's silo.
-            await launcher.StartBlockingCall(worker, remote);
-            Assert.True(await RemoteBlockerGrain.WaitForEntered(remoteKey, TimeSpan.FromSeconds(30)), "The blocking call was never entered.");
 
             var launcherHandle = cluster.Silos.Single(s => s.SiloAddress.ToString() == launcherSilo);
 
-            // Kill the launcher's silo (ungraceful) and dispose its host. Prior to the fix this hangs.
+            // Kill the launcher's silo (ungraceful) and dispose its host. Prior to the fix this can hang
+            // if cancellation interrupts callback timer shutdown before the callbacks are faulted.
             var killAndDispose = cluster.KillSiloAsync(launcherHandle);
             var completed = await Task.WhenAny(killAndDispose, Task.Delay(TimeSpan.FromSeconds(60)));
             Assert.True(completed == killAndDispose, "Killing a silo with an in-flight outbound call should not hang host disposal.");
             await killAndDispose;
 
             // Allow the surviving silo to shut down cleanly.
-            RemoteBlockerGrain.Release(remoteKey);
+            foreach (var remoteKey in remoteKeys)
+            {
+                RemoteBlockerGrain.Release(remoteKey);
+            }
         }
 
         private static void AssertCollected(WeakReference weakRef)


### PR DESCRIPTION
Hard-killing an in-process silo can deadlock host disposal when stateless workers have transaction calls in flight.

The CI dumps show host disposal waiting on `StatelessWorkerGrainContext.DisposeAsyncInternal`. Faulting the original callbacks resumes transaction cleanup, which can issue follow-up requests after the shutdown sweep and register callbacks that can never receive responses.

Close callback admission before draining outstanding calls in both silo and client runtimes. Requests check the stopping state before insertion and again afterward, ensuring each callback is completed by either the shutdown sweep or the admitting thread. Callback cancellation registration now uses a nonblocking publication/disposal handshake so synchronous cancellation or concurrent completion cannot leak a registration.

The regression coverage includes multiple blocked silo workers which retry after shutdown, a client call which retries after shutdown, cancellation during registration, and registration attempted after callback completion.