### PR TITLE
fix(runtime): transition silo status before grain deactivation

### DIFF
--- a/src/Orleans.Core/Lifecycle/ServiceLifecycleStage.cs
+++ b/src/Orleans.Core/Lifecycle/ServiceLifecycleStage.cs
@@ -47,7 +47,17 @@ namespace Orleans
         /// and the gateway, no other component should run
         /// at this stage
         /// </summary>
-        public const int BecomeActive = Active-1;
+        public const int BecomeActive = Active - 1;
+
+        /// <summary>
+        /// Deactivate grain activations during silo shutdown.
+        /// </summary>
+        public const int GrainDeactivation = BecomeActive - 1;
+
+        /// <summary>
+        /// Stop the grain directory after shutdown-triggered grain migrations have completed.
+        /// </summary>
+        public const int GrainDirectoryShutdown = GrainDeactivation - 1;
 
         /// <summary>
         /// Validate connectivity to active cluster members before becoming active.

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -315,8 +315,8 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
 
         observer.Subscribe(nameof(DistributedGrainDirectory), ServiceLifecycleStage.RuntimeInitialize, OnRuntimeInitializeStart, OnRuntimeInitializeStop);
 
-        // Transition into 'ShuttingDown'/'Stopping' stage, removing ourselves from directory membership, but allow some time for hand-off before transitioning to 'Dead'.
-        observer.Subscribe(nameof(DistributedGrainDirectory), ServiceLifecycleStage.BecomeActive - 1, NoOpStart, OnShuttingDown);
+        // Keep the directory available until shutdown-triggered grain migrations have completed.
+        observer.Subscribe(nameof(DistributedGrainDirectory), ServiceLifecycleStage.GrainDirectoryShutdown, NoOpStart, OnShuttingDown);
 
         static Task NoOpStart(CancellationToken _) => Task.CompletedTask;
 

--- a/src/Orleans.Runtime/Silo/Silo.cs
+++ b/src/Orleans.Runtime/Silo/Silo.cs
@@ -468,11 +468,13 @@ namespace Orleans.Runtime
             lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeInitialize, RunOnRuntimeInitializeStart, RunOnRuntimeInitializeStop);
             lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeServices, RunOnRuntimeServicesStart, RunOnRuntimeServicesStop);
             lifecycle.Subscribe<Silo>(ServiceLifecycleStage.RuntimeGrainServices, RunOnRuntimeGrainServicesStart);
-            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.BecomeActive, RunOnBecomeActiveStart, RunOnBecomeActiveStop);
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.BecomeActive, RunOnBecomeActiveStart);
+            lifecycle.Subscribe<Silo>(ServiceLifecycleStage.GrainDeactivation, NoOpStart, RunOnBecomeActiveStop);
             lifecycle.Subscribe<Silo>(ServiceLifecycleStage.Active, RunOnActiveStart, RunOnActiveStop);
 
             // Stage callbacks are dispatched onto the thread pool so that any blocking
             // work in the silo start/stop paths does not stall the lifecycle scheduler.
+            static Task NoOpStart(CancellationToken ct) => Task.CompletedTask;
             Task RunOnRuntimeInitializeStart(CancellationToken ct) => Task.Run(() => OnRuntimeInitializeStart(ct));
             Task RunOnRuntimeInitializeStop(CancellationToken ct) => Task.Run(() => OnRuntimeInitializeStop(ct));
             Task RunOnRuntimeServicesStart(CancellationToken ct) => Task.Run(() => OnRuntimeServicesStart(ct));

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -365,6 +365,8 @@ namespace Orleans
         public const int ApplicationServices = 10000;
         public const int BecomeActive = 19999;
         public const int First = int.MinValue;
+        public const int GrainDeactivation = 19998;
+        public const int GrainDirectoryShutdown = 19997;
         public const int Last = int.MaxValue;
         public const int RuntimeGrainServices = 8000;
         public const int RuntimeInitialize = 2000;

--- a/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs
@@ -155,7 +155,7 @@ namespace NonSilo.Tests.Membership
 
             await StopLifecycle();
 
-            Assert.Equal(SiloStatus.ShuttingDown, levels[ServiceLifecycleStage.BecomeActive - 1]);
+            Assert.Equal(SiloStatus.ShuttingDown, levels[ServiceLifecycleStage.GrainDeactivation]);
             Assert.Equal(SiloStatus.ShuttingDown, levels[ServiceLifecycleStage.ValidateInitialConnectivity - 1]);
             Assert.Equal(SiloStatus.ShuttingDown, levels[ServiceLifecycleStage.AfterRuntimeGrainServices - 1]);
             Assert.Equal(SiloStatus.Dead, levels[ServiceLifecycleStage.RuntimeInitialize - 1]);
@@ -202,7 +202,7 @@ namespace NonSilo.Tests.Membership
             cancellation.Cancel();
             await StopLifecycle(cancellation.Token);
 
-            Assert.Equal(SiloStatus.Stopping, levels[ServiceLifecycleStage.BecomeActive - 1]);
+            Assert.Equal(SiloStatus.Stopping, levels[ServiceLifecycleStage.GrainDeactivation]);
             Assert.Equal(SiloStatus.Stopping, levels[ServiceLifecycleStage.ValidateInitialConnectivity - 1]);
             Assert.Equal(SiloStatus.Stopping, levels[ServiceLifecycleStage.AfterRuntimeGrainServices - 1]);
             Assert.Equal(SiloStatus.Dead, levels[ServiceLifecycleStage.RuntimeInitialize - 1]);

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
@@ -1,0 +1,249 @@
+#nullable enable
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Hosting;
+using Orleans.Placement;
+using Orleans.Runtime;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.MembershipService;
+using Orleans.Runtime.Placement;
+using Orleans.TestingHost;
+using Xunit;
+
+namespace UnitTests.GrainDirectory;
+
+[TestCategory("BVT"), TestCategory("Directory")]
+public sealed class GrainDirectoryShutdownMigrationTests
+{
+    [Fact]
+    public async Task PreferLocalGrain_MigratesWhenHostingSiloShutsDown()
+    {
+        var builder = new InProcessTestClusterBuilder(2);
+        builder.ConfigureSilo((_, siloBuilder) =>
+        {
+            siloBuilder.Services.AddSingleton<MembershipTableManager>();
+            siloBuilder.Services.AddSingleton<IMembershipManager, DelayedMembershipManager>();
+#pragma warning disable ORLEANSEXP003
+            siloBuilder.AddDistributedGrainDirectory();
+#pragma warning restore ORLEANSEXP003
+        });
+
+        await using var cluster = builder.Build();
+        await cluster.DeployAsync();
+        await cluster.WaitForLivenessToStabilizeAsync();
+        await WaitForDirectoryMembershipAsync(cluster);
+
+        var survivingSilo = cluster.Silos[0];
+        var shuttingDownSilo = cluster.Silos[1];
+        var immediateGrain = cluster.Client.GetGrain<IShutdownMigrationGrain>(Guid.NewGuid());
+        var postHandoffGrain = cluster.Client.GetGrain<IShutdownMigrationGrain>(Guid.NewGuid());
+
+        RequestContext.Set(IPlacementDirector.PlacementHintKey, shuttingDownSilo.SiloAddress);
+        try
+        {
+            await immediateGrain.SetState(42, waitForDirectoryHandoff: false);
+            await postHandoffGrain.SetState(43, waitForDirectoryHandoff: true);
+            Assert.Equal(shuttingDownSilo.SiloAddress, await immediateGrain.GetLocation());
+            Assert.Equal(shuttingDownSilo.SiloAddress, await postHandoffGrain.GetLocation());
+        }
+        finally
+        {
+            RequestContext.Remove(IPlacementDirector.PlacementHintKey);
+        }
+
+        ShutdownMigrationTestCoordinator.Reset();
+        var stopTask = cluster.StopSiloAsync(shuttingDownSilo);
+        try
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await WaitForDirectoryMembershipAsync(
+                survivingSilo.ServiceProvider.GetRequiredService<DirectoryMembershipService>(),
+                [survivingSilo.SiloAddress],
+                timeout.Token);
+        }
+        finally
+        {
+            ShutdownMigrationTestCoordinator.CompleteDirectoryHandoff();
+            await stopTask;
+        }
+
+        await cluster.WaitForLivenessToStabilizeAsync();
+
+        await AssertMigrated(immediateGrain, 42);
+        await AssertMigrated(postHandoffGrain, 43);
+
+        async Task AssertMigrated(IShutdownMigrationGrain grain, int expectedState)
+        {
+            Assert.Equal(survivingSilo.SiloAddress, await grain.GetLocation());
+            Assert.Equal(expectedState, await grain.GetState());
+            Assert.Equal(DeactivationReasonCode.ShuttingDown, await grain.GetPreviousDeactivationReason());
+            Assert.Equal(SiloStatus.ShuttingDown, await grain.GetPreviousSiloStatus());
+        }
+    }
+
+    private static async Task WaitForDirectoryMembershipAsync(InProcessTestCluster cluster)
+    {
+        var expectedMembers = cluster.Silos.Select(static silo => silo.SiloAddress).ToHashSet();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await Task.WhenAll(cluster.Silos.Select(
+            silo => WaitForDirectoryMembershipAsync(
+                silo.ServiceProvider.GetRequiredService<DirectoryMembershipService>(),
+                expectedMembers,
+                timeout.Token)));
+    }
+
+    private static async Task WaitForDirectoryMembershipAsync(
+        DirectoryMembershipService membershipService,
+        HashSet<SiloAddress> expectedMembers,
+        CancellationToken cancellationToken)
+    {
+        if (expectedMembers.SetEquals(membershipService.CurrentView.Members))
+        {
+            return;
+        }
+
+        await foreach (var view in membershipService.ViewUpdates.WithCancellation(cancellationToken))
+        {
+            if (expectedMembers.SetEquals(view.Members))
+            {
+                return;
+            }
+        }
+
+        throw new TimeoutException("Timed out waiting for the distributed grain directory membership to stabilize.");
+    }
+}
+
+public interface IShutdownMigrationGrain : IGrainWithGuidKey
+{
+    ValueTask<SiloAddress> GetLocation();
+
+    ValueTask<int> GetState();
+
+    ValueTask<DeactivationReasonCode> GetPreviousDeactivationReason();
+
+    ValueTask<SiloStatus> GetPreviousSiloStatus();
+
+    ValueTask SetState(int value, bool waitForDirectoryHandoff);
+}
+
+[PreferLocalPlacement]
+public sealed class ShutdownMigrationGrain : Grain, IShutdownMigrationGrain, IGrainMigrationParticipant
+{
+    private readonly ISiloStatusOracle _siloStatusOracle;
+    private int _state;
+    private DeactivationReasonCode _previousDeactivationReason;
+    private SiloStatus _previousSiloStatus;
+    private bool _waitForDirectoryHandoff;
+
+    public ShutdownMigrationGrain(ISiloStatusOracle siloStatusOracle)
+    {
+        _siloStatusOracle = siloStatusOracle;
+    }
+
+    public ValueTask<SiloAddress> GetLocation() => new(GrainContext.Address.SiloAddress!);
+
+    public ValueTask<int> GetState() => new(_state);
+
+    public ValueTask<DeactivationReasonCode> GetPreviousDeactivationReason() => new(_previousDeactivationReason);
+
+    public ValueTask<SiloStatus> GetPreviousSiloStatus() => new(_previousSiloStatus);
+
+    public ValueTask SetState(int value, bool waitForDirectoryHandoff)
+    {
+        _state = value;
+        _waitForDirectoryHandoff = waitForDirectoryHandoff;
+        return default;
+    }
+
+    public override async Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
+    {
+        if (reason.ReasonCode is DeactivationReasonCode.ShuttingDown)
+        {
+            _previousDeactivationReason = reason.ReasonCode;
+            _previousSiloStatus = _siloStatusOracle.CurrentStatus;
+            if (_waitForDirectoryHandoff)
+            {
+                await ShutdownMigrationTestCoordinator.WaitForDirectoryHandoff(cancellationToken);
+            }
+
+            this.MigrateOnIdle();
+        }
+
+        await base.OnDeactivateAsync(reason, cancellationToken);
+    }
+
+    public void OnDehydrate(IDehydrationContext migrationContext)
+    {
+        migrationContext.TryAddValue("state", _state);
+        migrationContext.TryAddValue("deactivation-reason", _previousDeactivationReason);
+        migrationContext.TryAddValue("silo-status", _previousSiloStatus);
+    }
+
+    public void OnRehydrate(IRehydrationContext migrationContext)
+    {
+        migrationContext.TryGetValue("state", out _state);
+        migrationContext.TryGetValue("deactivation-reason", out _previousDeactivationReason);
+        migrationContext.TryGetValue("silo-status", out _previousSiloStatus);
+    }
+}
+
+internal static class ShutdownMigrationTestCoordinator
+{
+    private static TaskCompletionSource<bool> _directoryHandoff = CreateCompletedSource();
+
+    public static void Reset() =>
+        Interlocked.Exchange(ref _directoryHandoff, new(TaskCreationOptions.RunContinuationsAsynchronously));
+
+    public static void CompleteDirectoryHandoff() =>
+        Volatile.Read(ref _directoryHandoff).TrySetResult(true);
+
+    public static Task WaitForDirectoryHandoff(CancellationToken cancellationToken) =>
+        Volatile.Read(ref _directoryHandoff).Task.WaitAsync(cancellationToken);
+
+    private static TaskCompletionSource<bool> CreateCompletedSource()
+    {
+        var result = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        result.SetResult(true);
+        return result;
+    }
+}
+
+internal sealed class DelayedMembershipManager(MembershipTableManager inner) : IMembershipManager
+{
+    public MembershipTableSnapshot CurrentSnapshot => ((IMembershipManager)inner).CurrentSnapshot;
+
+    public IAsyncEnumerable<MembershipTableSnapshot> MembershipUpdates => ((IMembershipManager)inner).MembershipUpdates;
+
+    public SiloStatus LocalSiloStatus => ((IMembershipManager)inner).LocalSiloStatus;
+
+    public bool CheckHealth(DateTime lastCheckTime, out string reason) =>
+        ((IHealthCheckable)inner).CheckHealth(lastCheckTime, out reason);
+
+    public void Participate(ISiloLifecycle lifecycle) => ((ILifecycleParticipant<ISiloLifecycle>)inner).Participate(lifecycle);
+
+    public Task ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) =>
+        ((IMembershipManager)inner).ProcessGossipSnapshot(snapshot, cancellationToken);
+
+    public Task Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken) =>
+        ((IMembershipManager)inner).Refresh(targetVersion, cancellationToken);
+
+    public Task<bool> TryKillSilo(SiloAddress silo, CancellationToken cancellationToken) =>
+        ((IMembershipManager)inner).TryKillSilo(silo, cancellationToken);
+
+    public Task<bool> TrySuspectSilo(SiloAddress silo, SiloAddress? indirectProbingSilo, CancellationToken cancellationToken) =>
+        ((IMembershipManager)inner).TrySuspectSilo(silo, indirectProbingSilo, cancellationToken);
+
+    public Task UpdateIAmAlive(CancellationToken cancellationToken) =>
+        ((IMembershipManager)inner).UpdateIAmAlive(cancellationToken);
+
+    public async Task UpdateLocalStatus(SiloStatus status, CancellationToken cancellationToken)
+    {
+        if (status is SiloStatus.ShuttingDown)
+        {
+            // Model a membership provider which takes long enough to expose concurrent shutdown callbacks.
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+
+        await ((IMembershipManager)inner).UpdateLocalStatus(status, cancellationToken);
+    }
+}

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
@@ -101,12 +101,19 @@ public sealed class GrainDirectoryShutdownMigrationTests
             return;
         }
 
-        await foreach (var view in membershipService.ViewUpdates.WithCancellation(cancellationToken))
+        try
         {
-            if (expectedMembers.SetEquals(view.Members))
+            await foreach (var view in membershipService.ViewUpdates.WithCancellation(cancellationToken))
             {
-                return;
+                if (expectedMembers.SetEquals(view.Members))
+                {
+                    return;
+                }
             }
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException("Timed out waiting for the distributed grain directory membership to stabilize.", exception);
         }
 
         throw new TimeoutException("Timed out waiting for the distributed grain directory membership to stabilize.");
@@ -241,7 +248,14 @@ internal sealed class DelayedMembershipManager(MembershipTableManager inner) : I
         if (status is SiloStatus.ShuttingDown)
         {
             // Model a membership provider which takes long enough to expose concurrent shutdown callbacks.
-            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // End the artificial delay promptly, but let the real manager publish the requested status.
+            }
         }
 
         await ((IMembershipManager)inner).UpdateLocalStatus(status, cancellationToken);

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
@@ -241,7 +241,7 @@ internal sealed class DelayedMembershipManager(MembershipTableManager inner) : I
         if (status is SiloStatus.ShuttingDown)
         {
             // Model a membership provider which takes long enough to expose concurrent shutdown callbacks.
-            await Task.Delay(TimeSpan.FromSeconds(1));
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
         }
 
         await ((IMembershipManager)inner).UpdateLocalStatus(status, cancellationToken);


### PR DESCRIPTION
Grains using `PreferLocalPlacement` could select the shutting-down silo when `MigrateOnIdle()` was called from `OnDeactivateAsync`, because membership status publication and grain deactivation ran concurrently.

This changes the shutdown lifecycle ordering so the silo publishes `ShuttingDown` before grain deactivation begins, then keeps the distributed grain directory available until shutdown-triggered migrations complete. It also adds a two-silo regression test which covers migrations both before and during asynchronous directory ownership handoff.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10294)