### PR TITLE
fix(ci): upload CodeQL results together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,7 @@ on:
     - cron: '0 6 * * 1'  # Run weekly on Monday at 6:00 UTC
 
 jobs:
+  # Keep the final job id as "analyze" so CodeQL matches its analysis_key to the configuration on main.
   generate:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ on:
     - cron: '0 6 * * 1'  # Run weekly on Monday at 6:00 UTC
 
 jobs:
-  analyze:
+  generate:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 360
@@ -49,4 +49,38 @@ jobs:
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           category: "/language:${{ matrix.language }}"
-          upload: ${{ github.event_name == 'merge_group' && 'never' || 'always' }}
+          upload: never
+          post-processed-sarif-path: sarif-results
+
+      - name: Stage CodeQL results
+        if: github.event_name != 'merge_group'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: codeql-sarif-${{ matrix.language }}
+          path: sarif-results
+          retention-days: 1
+
+  analyze:
+    name: Upload CodeQL results
+    if: github.event_name != 'merge_group'
+    needs: generate
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Download CodeQL results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: codeql-sarif-*
+          path: sarif-results
+
+      - name: Upload CodeQL results
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        with:
+          sarif_file: sarif-results


### PR DESCRIPTION
CodeQL's language matrix uploads results as each analysis finishes. Fast Actions and JavaScript uploads can trigger GitHub Advanced Security's pull-request evaluation before the slower C# result exists, producing a stale configuration-not-found warning.\n\nStage each language's post-processed SARIF output and upload all results together after every analysis completes. This preserves the existing per-language categories and the no-upload behavior for merge queues while ensuring GitHub evaluates a complete configuration set.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10295)