### PR TITLE
ci: enable GitHub autobaseline for nightly-main pipeline

### DIFF
--- a/.azure/pipelines/nightly-main.yaml
+++ b/.azure/pipelines/nightly-main.yaml
@@ -48,6 +48,8 @@ extends:
     template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     sdl:
+      autobaseline:
+        enableForGitHub: true
       policheck:
         enabled: true
       tsa:


### PR DESCRIPTION
Adds `sdl.autobaseline.enableForGitHub: true` under `extends.parameters` in `.azure/pipelines/nightly-main.yaml`.

The main CI pipeline (`build.yaml`) already has this setting. Without it here too, 1ES SDL baseline updates for the nightly pipeline get raised as unclosable PRs against the ADO mirror instead of against GitHub, the source of truth.

Note: this setting only takes effect if the dnceng pipeline definition for `nightly-main.yaml` is GitHub-backed (i.e. its `self` repository is not the Azure Repos mirror). If it still points at the mirror, it will need to be repointed with help from 1ES PT.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10297)