### PR TITLE
ci: enable GitHub autobaseline for 3.x build pipeline

### DIFF
--- a/.azure/pipelines/build.yaml
+++ b/.azure/pipelines/build.yaml
@@ -73,6 +73,9 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
+    sdl:
+      autobaseline:
+        enableForGitHub: true
     pool:
       name: $(pool_name)
       image: $(pool_image)


### PR DESCRIPTION
Adds `sdl.autobaseline.enableForGitHub: true` under `extends.parameters` in `.azure/pipelines/build.yaml` on the `3.x` branch.

The `main` branch's `build.yaml` already has this setting. Without it here too, 1ES SDL baseline updates for the 3.x pipeline get raised as unclosable PRs against the ADO mirror instead of against GitHub, the source of truth.

Note: this setting only takes effect if the dnceng pipeline definition for this file on `3.x` is GitHub-backed (i.e. its `self` repository is not the Azure Repos mirror). If it still points at the mirror, it will need to be repointed with help from 1ES PT.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10298)