### PR TITLE
fix(serialization): defer interface collection codec dependencies

### DIFF
--- a/src/Orleans.Serialization/Codecs/InterfaceCollectionCodecs.cs
+++ b/src/Orleans.Serialization/Codecs/InterfaceCollectionCodecs.cs
@@ -2,7 +2,6 @@ using System.Buffers;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
-using Orleans.Serialization.GeneratedCodeHelpers;
 using Orleans.Serialization.Serializers;
 using Orleans.Serialization.WireProtocol;
 
@@ -224,7 +223,7 @@ internal abstract class ListInterfaceCodec<TInterface, T> : IFieldCodec<TInterfa
 
     protected ListInterfaceCodec(IFieldCodec<T> elementCodec)
     {
-        _elementCodec = OrleansGeneratedCodeHelper.UnwrapService(this, elementCodec);
+        _elementCodec = elementCodec;
     }
 
     public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TInterface value) where TBufferWriter : IBufferWriter<byte>
@@ -340,8 +339,8 @@ internal abstract class SetInterfaceCodec<TInterface, T> : IFieldCodec<TInterfac
 
     protected SetInterfaceCodec(IFieldCodec<T> elementCodec, IFieldCodec<IEqualityComparer<T>> comparerCodec)
     {
-        _elementCodec = OrleansGeneratedCodeHelper.UnwrapService(this, elementCodec);
-        _comparerCodec = OrleansGeneratedCodeHelper.UnwrapService(this, comparerCodec);
+        _elementCodec = elementCodec;
+        _comparerCodec = comparerCodec;
     }
 
     public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TInterface value) where TBufferWriter : IBufferWriter<byte>
@@ -468,9 +467,9 @@ internal abstract class DictionaryInterfaceCodec<TInterface, TKey, TValue> : IFi
         IFieldCodec<TValue> valueCodec,
         IFieldCodec<IEqualityComparer<TKey>> comparerCodec)
     {
-        _keyCodec = OrleansGeneratedCodeHelper.UnwrapService(this, keyCodec);
-        _valueCodec = OrleansGeneratedCodeHelper.UnwrapService(this, valueCodec);
-        _comparerCodec = OrleansGeneratedCodeHelper.UnwrapService(this, comparerCodec);
+        _keyCodec = keyCodec;
+        _valueCodec = valueCodec;
+        _comparerCodec = comparerCodec;
     }
 
     public void WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, Type expectedType, TInterface value) where TBufferWriter : IBufferWriter<byte>

--- a/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
@@ -271,6 +271,30 @@ public class InterfaceCollectionRegressionTests
     }
 
     [Fact]
+    public void RuntimeConcreteCodecDoesNotRequireFallbackElementCodec()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        Assert.False(serializer.CanSerialize(typeof(UnsupportedElement)));
+        Assert.True(serializer.CanSerialize(typeof(IReadOnlyList<UnsupportedElement>)));
+
+        IReadOnlyList<UnsupportedElement> original = new GeneratedUnsupportedElementReadOnlyList { Marker = "preserved" };
+        var result = serializer.Deserialize<IReadOnlyList<UnsupportedElement>>(
+            serializer.SerializeToArray(original));
+
+        var concrete = Assert.IsType<GeneratedUnsupportedElementReadOnlyList>(result);
+        Assert.Equal("preserved", concrete.Marker);
+    }
+
+    [Fact]
+    public void NullInterfaceFieldDoesNotRequireFallbackElementCodec()
+    {
+        var result = RoundTrip(new UnsupportedElementListContainer());
+
+        Assert.Null(result.Values);
+    }
+
+    [Fact]
     public void RuntimeConcreteSetComparerIsPreservedWhenAvailable()
     {
         var original = new SetContainer
@@ -347,6 +371,19 @@ public class InterfaceCollectionRegressionTests
     }
 
 #if !NETCOREAPP3_1
+    [Fact]
+    public void CanDeserializeLegacyInterfaceCodecPayload()
+    {
+        const string payload = "3001D8283104374C697374496E74657266616365436F64656360315B5B696E745D5D000701050009000DE0";
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer<IList<int>>>();
+
+        var result = serializer.Deserialize(Convert.FromHexString(payload));
+
+        Assert.IsType<List<int>>(result);
+        Assert.Equal(ExpectedArray, result);
+    }
+
     [Fact]
     public Task EnumerableInterfaceFallback_Formatted_MatchesSnapshot()
         => VerifyFallbackBitStream<IEnumerable<int>>(new UnknownList<int>(ExpectedArray), EnumerableCodecAlias);
@@ -505,6 +542,32 @@ public class InterfaceCollectionRegressionTests
         public int this[int index] => Values[index];
 
         public IEnumerator<int> GetEnumerator() => Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public sealed class UnsupportedElement;
+
+    [GenerateSerializer]
+    [Alias("Orleans.Serialization.UnitTests.InterfaceCollectionRegressionTests.UnsupportedElementListContainer")]
+    public sealed class UnsupportedElementListContainer
+    {
+        [Id(0)]
+        public IList<UnsupportedElement> Values { get; set; }
+    }
+
+    [GenerateSerializer]
+    [Alias("Orleans.Serialization.UnitTests.InterfaceCollectionRegressionTests.GeneratedUnsupportedElementReadOnlyList")]
+    public sealed class GeneratedUnsupportedElementReadOnlyList : IReadOnlyList<UnsupportedElement>
+    {
+        [Id(0)]
+        public string Marker { get; set; }
+
+        public int Count => 0;
+
+        public UnsupportedElement this[int index] => throw new ArgumentOutOfRangeException(nameof(index));
+
+        public IEnumerator<UnsupportedElement> GetEnumerator() => Enumerable.Empty<UnsupportedElement>().GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }


### PR DESCRIPTION
Fixes #10300

Orleans 10.2 interface collection codecs eagerly unwrapped their fallback element codecs during construction. A generated type containing an interface collection field could therefore fail while its codec was being constructed—even when the field was null—because the interface codec resolved an unavailable element codec before any runtime collection value existed.

Keep the injected fallback codec holders lazy so concrete runtime codecs are resolved first and null fields require no element codec. Preserve the existing interface codec type as the fallback wire-format identity, and cover both generated null-field and custom concrete-runtime-codec scenarios.