### PR TITLE
feat(streaming): make SequentialItem serializable

### DIFF
--- a/src/Orleans.Streaming/Core/IAsyncBatchObserver.cs
+++ b/src/Orleans.Streaming/Core/IAsyncBatchObserver.cs
@@ -8,6 +8,7 @@ namespace Orleans.Streams
     /// Represents a stream item within a sequence.
     /// </summary>
     /// <typeparam name="T">The item type.</typeparam>
+    [GenerateSerializer]
     public class SequentialItem<T>
     {
         /// <summary>
@@ -25,12 +26,14 @@ namespace Orleans.Streams
         /// Gets the item.
         /// </summary>
         /// <value>The item.</value>
+        [Id(0)]
         public T Item { get; }
 
         /// <summary>
         /// Gets the token.
         /// </summary>
         /// <value>The token.</value>
+        [Id(1)]
         public StreamSequenceToken Token { get; }
     }
 

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1799,12 +1799,15 @@ namespace Orleans.Streams
         public bool IsMatch(string streamNameSpace) { throw null; }
     }
 
+    [GenerateSerializer]
     public partial class SequentialItem<T>
     {
         public SequentialItem(T item, StreamSequenceToken token) { }
 
+        [Id(0)]
         public T Item { get { throw null; } }
 
+        [Id(1)]
         public StreamSequenceToken Token { get { throw null; } }
     }
 

--- a/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
+++ b/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
@@ -44,6 +44,7 @@
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.TestKit\Orleans.Serialization.TestKit.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.FSharp\Orleans.Serialization.FSharp.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization\Orleans.Serialization.csproj" />
+    <ProjectReference Include="$(SourceRoot)src\Orleans.Streaming\Orleans.Streaming.csproj" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.SystemTextJson\Orleans.Serialization.SystemTextJson.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.NewtonsoftJson\Orleans.Serialization.NewtonsoftJson.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.MessagePack\Orleans.Serialization.MessagePack.csproj" />

--- a/test/Orleans.Serialization.UnitTests/SequentialItemSerializationTests.cs
+++ b/test/Orleans.Serialization.UnitTests/SequentialItemSerializationTests.cs
@@ -1,0 +1,118 @@
+#if NET6_0_OR_GREATER
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Providers.Streams.Common;
+using Orleans.Serialization;
+using Orleans.Serialization.Cloning;
+using Orleans.Serialization.Codecs;
+using Orleans.Serialization.Serializers;
+using Orleans.Streams;
+using UnitTests.SerializerExternalModels;
+using Xunit;
+
+namespace Orleans.Serialization.UnitTests;
+
+[Trait("Category", "BVT")]
+public sealed class SequentialItemSerializationTests : IDisposable
+{
+    private readonly ServiceProvider _serviceProvider;
+    private readonly CodecProvider _codecProvider;
+    private readonly Serializer _serializer;
+    private readonly DeepCopier _deepCopier;
+
+    public SequentialItemSerializationTests()
+    {
+        _serviceProvider = new ServiceCollection()
+            .AddSerializer()
+            .BuildServiceProvider();
+        _codecProvider = _serviceProvider.GetRequiredService<CodecProvider>();
+        _serializer = _serviceProvider.GetRequiredService<Serializer>();
+        _deepCopier = _serviceProvider.GetRequiredService<DeepCopier>();
+    }
+
+    [Fact]
+    public void GeneratedOpenGenericCodecAndCopierResolveForConstructedSequentialItem()
+    {
+        var codec = _codecProvider.GetCodec<SequentialItem<Person2External>>();
+        var copier = _codecProvider.GetDeepCopier<SequentialItem<Person2External>>();
+
+        AssertGeneratedOpenGeneric(
+            codec.GetType(),
+            "Codec_SequentialItem`1",
+            typeof(IFieldCodec<>));
+        AssertGeneratedOpenGeneric(
+            copier.GetType(),
+            "Copier_SequentialItem`1",
+            typeof(IDeepCopier<>));
+    }
+
+    [Fact]
+    public void ConstructedSequentialItemSerializesAndDeserializes()
+    {
+        var original = CreateSequentialItem();
+
+        var serialized = _serializer.SerializeToArray(original);
+        var result = _serializer.Deserialize<SequentialItem<Person2External>>(serialized);
+
+        Assert.NotEmpty(serialized);
+        Assert.NotSame(original, result);
+        AssertSequentialItem(original, result);
+        Assert.NotSame(original.Item, result.Item);
+        Assert.NotSame(original.Token, result.Token);
+    }
+
+    [Fact]
+    public void ConstructedSequentialItemIsDeepCopied()
+    {
+        var original = CreateSequentialItem();
+
+        var result = _deepCopier.Copy(original);
+
+        Assert.NotSame(original, result);
+        AssertSequentialItem(original, result);
+        Assert.NotSame(original.Item, result.Item);
+        Assert.NotSame(original.Token, result.Token);
+    }
+
+    public void Dispose() => _serviceProvider.Dispose();
+
+    private static SequentialItem<Person2External> CreateSequentialItem() =>
+        new(
+            new Person2External(42, "Douglas")
+            {
+                FavouriteColor = "blue",
+                StarSign = "Betelgeuse",
+            },
+            new EventSequenceTokenV2(123, 7));
+
+    private static void AssertGeneratedOpenGeneric(Type resolvedType, string expectedName, Type serviceType)
+    {
+        Assert.True(resolvedType.IsConstructedGenericType);
+        var genericType = resolvedType.GetGenericTypeDefinition();
+        Assert.Equal(expectedName, genericType.Name);
+        Assert.Equal("OrleansCodeGen.Orleans.Streams", genericType.Namespace);
+        Assert.Equal(typeof(Person2External), Assert.Single(resolvedType.GenericTypeArguments));
+
+        var implementedService = Assert.Single(
+            resolvedType.GetInterfaces(),
+            type => type.IsGenericType && type.GetGenericTypeDefinition() == serviceType);
+        Assert.Equal(typeof(SequentialItem<Person2External>), implementedService.GenericTypeArguments[0]);
+    }
+
+    private static void AssertSequentialItem(
+        SequentialItem<Person2External> expected,
+        SequentialItem<Person2External> actual)
+    {
+        Assert.Equal(42, actual.Item.Age);
+        Assert.Equal("Douglas", actual.Item.Name);
+        Assert.Equal("blue", actual.Item.FavouriteColor);
+        Assert.Equal("Betelgeuse", actual.Item.StarSign);
+        Assert.Equal(expected.Item, actual.Item);
+
+        var token = Assert.IsType<EventSequenceTokenV2>(actual.Token);
+        Assert.Equal(123, token.SequenceNumber);
+        Assert.Equal(7, token.EventIndex);
+        Assert.Equal(expected.Token, token);
+    }
+}
+#endif


### PR DESCRIPTION
SequentialItem<T> is a public streaming data container, but it did not have generated serialization support.

This adds stable generated serialization metadata for its item and token members, together with focused coverage for codec and copier resolution, serialization round-tripping, and deep copying.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10302)