### PR TITLE
fix(directory): support rolling upgrades to distributed directory

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -229,18 +229,29 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
     internal CancellationToken GetClusterMemberCancellationToken(SiloAddress siloAddress) =>
         _clusterMemberCancellationTokens.GetToken(siloAddress);
 
-    public async ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(MembershipVersion membershipVersion, RingRange range, SiloAddress siloAddress, int partitionIndex)
+    public async ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(
+        MembershipVersion membershipVersion,
+        RingRange range,
+        SiloAddress siloAddress,
+        int partitionIndex,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         foreach (var partition in _partitions)
         {
             partition.OnRecoveringPartition(membershipVersion, range, siloAddress, partitionIndex).Ignore();
         }
 
-        return await GetRegisteredActivations(membershipVersion, range, false);
+        return await GetRegisteredActivations(membershipVersion, range, false, cancellationToken);
     }
 
-    public ValueTask<Immutable<List<GrainAddress>>> GetRegisteredActivations(MembershipVersion membershipVersion, RingRange range, bool isValidation)
+    public ValueTask<Immutable<List<GrainAddress>>> GetRegisteredActivations(
+        MembershipVersion membershipVersion,
+        RingRange range,
+        bool isValidation,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (!isValidation)
         {
             LogDebugCollectingRegisteredActivations(_logger, range, membershipVersion);
@@ -259,6 +270,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
 
         foreach (var (grainId, activation) in _localActivations)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var directory = GetGrainDirectory(activation, _grainDirectoryResolver!);
             if (directory == this)
             {

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -63,6 +63,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
     private readonly IServiceProvider _serviceProvider;
     private readonly ImmutableArray<GrainDirectoryPartition> _partitions;
     private readonly CancellationTokenSource _stoppedCts = new();
+    private readonly ClusterMemberCancellationTokens _clusterMemberCancellationTokens;
     private readonly DirectoryInstruments _directoryInstruments;
 
     internal CancellationToken OnStoppedToken => _stoppedCts.Token;
@@ -96,6 +97,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         _membershipService = membershipService;
         _logger = logger;
         _directoryInstruments = directoryInstruments;
+        _clusterMemberCancellationTokens = new(_stoppedCts.Token);
         var partitionsPerSilo = membershipService.PartitionsPerSilo;
         var partitions = ImmutableArray.CreateBuilder<GrainDirectoryPartition>(partitionsPerSilo);
         for (var i = 0; i < partitionsPerSilo; i++)
@@ -224,6 +226,9 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
     internal static bool CanInvokeClusterMember(ClusterMembershipSnapshot snapshot, SiloAddress siloAddress)
         => snapshot.GetSiloStatus(siloAddress) is SiloStatus.Active or SiloStatus.Joining or SiloStatus.ShuttingDown;
 
+    internal CancellationToken GetClusterMemberCancellationToken(SiloAddress siloAddress) =>
+        _clusterMemberCancellationTokens.GetToken(siloAddress);
+
     public async ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(MembershipVersion membershipVersion, RingRange range, SiloAddress siloAddress, int partitionIndex)
     {
         foreach (var partition in _partitions)
@@ -345,7 +350,6 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
             {
                 tasks.Add(partition.OnShuttingDown(token));
             }
-
             await Task.WhenAll(tasks).SuppressThrowing();
         }
     }
@@ -364,6 +368,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
                 await foreach (var update in _membershipService.ViewUpdates.WithCancellation(_stoppedCts.Token))
                 {
                     tasks.RemoveAll(t => t.IsCompleted);
+                    _clusterMemberCancellationTokens.Update(update.ClusterMembershipSnapshot);
                     var changes = update.ClusterMembershipSnapshot.CreateUpdate(previousUpdate);
 
                     foreach (var change in changes.Changes)
@@ -405,6 +410,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         }
 
         await Task.WhenAll(tasks).SuppressThrowing();
+        _clusterMemberCancellationTokens.Dispose();
     }
 
     private async Task ObserveMembershipUpdateTask(Task task)
@@ -487,4 +493,76 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         Message = "Invoking '{Operation}' on '{Owner}' for grain '{GrainId}'."
     )]
     private static partial void LogTraceInvokingOperation(ILogger logger, string operation, SiloAddress owner, GrainId grainId);
+}
+
+internal sealed class ClusterMemberCancellationTokens(CancellationToken shutdownToken) : IDisposable
+{
+    private static readonly CancellationToken CanceledToken = new(canceled: true);
+    private Dictionary<SiloAddress, Entry> _entries = [];
+
+    internal int Count => Volatile.Read(ref _entries).Count;
+
+    public CancellationToken GetToken(SiloAddress siloAddress)
+    {
+        var entries = Volatile.Read(ref _entries);
+        return entries.TryGetValue(siloAddress, out var entry) ? entry.Token : CanceledToken;
+    }
+
+    public void Update(ClusterMembershipSnapshot snapshot)
+    {
+        var previous = Volatile.Read(ref _entries);
+        var updated = new Dictionary<SiloAddress, Entry>(snapshot.Members.Count);
+        foreach (var (siloAddress, _) in snapshot.Members)
+        {
+            if (!DistributedGrainDirectory.CanInvokeClusterMember(snapshot, siloAddress))
+            {
+                continue;
+            }
+
+            updated.Add(
+                siloAddress,
+                previous.TryGetValue(siloAddress, out var entry) ? entry : new Entry(shutdownToken));
+        }
+
+        Volatile.Write(ref _entries, updated);
+        DisposeRemoved(previous, updated);
+    }
+
+    public void Dispose()
+    {
+        var previous = Interlocked.Exchange(ref _entries, []);
+        DisposeRemoved(previous, []);
+    }
+
+    private static void DisposeRemoved(
+        Dictionary<SiloAddress, Entry> previous,
+        Dictionary<SiloAddress, Entry> updated)
+    {
+        foreach (var (siloAddress, entry) in previous)
+        {
+            if (!updated.ContainsKey(siloAddress))
+            {
+                entry.Dispose();
+            }
+        }
+    }
+
+    private sealed class Entry : IDisposable
+    {
+        private readonly CancellationTokenSource _source;
+
+        public Entry(CancellationToken shutdownToken)
+        {
+            _source = CancellationTokenSource.CreateLinkedTokenSource(shutdownToken);
+            Token = _source.Token;
+        }
+
+        public CancellationToken Token { get; }
+
+        public void Dispose()
+        {
+            _source.Cancel();
+            _source.Dispose();
+        }
+    }
 }

--- a/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
@@ -76,7 +76,7 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
         TaskScheduler = TaskScheduler.Current,
     };
 
-    private CancellationTokenSource CreateTimeoutCts() => new(OperationTimeout);
+    private CancellationTokenSource CreateTimeoutCts() => CreateTimeoutCts(CancellationToken.None);
 
     private CancellationTokenSource CreateTimeoutCts(CancellationToken cancellationToken)
     {

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -762,14 +762,34 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         var attempt = 0;
         while (!ShutdownToken.IsCancellationRequested)
         {
-            if (!DistributedGrainDirectory.CanInvokeClusterMember(_owner.LatestClusterMembershipSnapshot, siloAddress))
+            var memberCancellationToken = _owner.GetClusterMemberCancellationToken(siloAddress);
+            if (memberCancellationToken.IsCancellationRequested)
             {
                 break;
             }
 
             try
             {
-                return await func();
+                var operationTask = func();
+                try
+                {
+                    if (operationTask.IsCompleted)
+                    {
+                        return await operationTask;
+                    }
+
+                    return await operationTask.WaitAsync(memberCancellationToken);
+                }
+                catch (OperationCanceledException) when (memberCancellationToken.IsCancellationRequested)
+                {
+                    if (operationTask.IsCompleted)
+                    {
+                        return await operationTask;
+                    }
+
+                    operationTask.Ignore();
+                    break;
+                }
             }
             catch (Exception ex)
             {
@@ -779,7 +799,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                 }
 
                 await _owner.RefreshViewAsync(default, ShutdownToken);
-                if (!DistributedGrainDirectory.CanInvokeClusterMember(_owner.LatestClusterMembershipSnapshot, siloAddress))
+                if (memberCancellationToken.IsCancellationRequested)
                 {
                     break;
                 }

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -128,8 +128,13 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         return null;
     }
 
-    ValueTask<bool> IGrainDirectoryPartition.AcknowledgeSnapshotTransferAsync(SiloAddress silo, int partitionIndex, MembershipVersion rangeVersion)
+    ValueTask<bool> IGrainDirectoryPartition.AcknowledgeSnapshotTransferAsync(
+        SiloAddress silo,
+        int partitionIndex,
+        MembershipVersion rangeVersion,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         RemoveSnapshotTransferPartner(
             (silo, partitionIndex, rangeVersion),
             snapshotFilter: (state, snapshot) => snapshot.DirectoryMembershipVersion == state.rangeVersion,
@@ -583,7 +588,11 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
             // The acknowledgement step lets the previous owner know that the snapshot has been received so that it can proceed.
             InvokeOnClusterMember(
                 previousOwner,
-                async () => await partition.AcknowledgeSnapshotTransferAsync(_id, _partitionIndex, previousVersion),
+                async cancellationToken => await partition.AcknowledgeSnapshotTransferAsync(
+                    _id,
+                    _partitionIndex,
+                    previousVersion,
+                    cancellationToken),
                 false,
                 nameof(IGrainDirectoryPartition.AcknowledgeSnapshotTransferAsync)).Ignore();
 
@@ -666,17 +675,17 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
             var client = _grainFactory.GetSystemTarget<IGrainDirectoryClient>(Constants.GrainDirectoryType, siloAddress);
             var result = await InvokeOnClusterMember(
                 siloAddress,
-                async () =>
+                async cancellationToken =>
                 {
                     var innerSw = ValueStopwatch.StartNew();
                     Immutable<List<GrainAddress>> result = default;
                         if (isValidation)
                         {
-                            result = await client.GetRegisteredActivations(version, range, isValidation: true);
+                            result = await client.GetRegisteredActivations(version, range, isValidation: true, cancellationToken);
                         }
                         else
                         {
-                            result = await client.RecoverRegisteredActivations(version, range, _id, _partitionIndex);
+                            result = await client.RecoverRegisteredActivations(version, range, _id, _partitionIndex, cancellationToken);
                         }
 
                     return result;
@@ -756,40 +765,24 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         }
     }
 
-    private async Task<T> InvokeOnClusterMember<T>(SiloAddress siloAddress, Func<Task<T>> func, T defaultValue, string operationName)
+    private async Task<T> InvokeOnClusterMember<T>(
+        SiloAddress siloAddress,
+        Func<CancellationToken, Task<T>> func,
+        T defaultValue,
+        string operationName)
     {
         GrainRuntime.CheckRuntimeContext(this);
+        var memberCancellationToken = _owner.GetClusterMemberCancellationToken(siloAddress);
         var attempt = 0;
-        while (!ShutdownToken.IsCancellationRequested)
+        while (!memberCancellationToken.IsCancellationRequested)
         {
-            var memberCancellationToken = _owner.GetClusterMemberCancellationToken(siloAddress);
-            if (memberCancellationToken.IsCancellationRequested)
-            {
-                break;
-            }
-
             try
             {
-                var operationTask = func();
-                try
-                {
-                    if (operationTask.IsCompleted)
-                    {
-                        return await operationTask;
-                    }
-
-                    return await operationTask.WaitAsync(memberCancellationToken);
-                }
-                catch (OperationCanceledException) when (memberCancellationToken.IsCancellationRequested)
-                {
-                    if (operationTask.IsCompleted)
-                    {
-                        return await operationTask;
-                    }
-
-                    operationTask.Ignore();
-                    break;
-                }
+                return await func(memberCancellationToken);
+            }
+            catch (OperationCanceledException) when (memberCancellationToken.IsCancellationRequested)
+            {
+                break;
             }
             catch (Exception ex)
             {

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -799,7 +799,8 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                 }
 
                 await _owner.RefreshViewAsync(default, ShutdownToken);
-                if (memberCancellationToken.IsCancellationRequested)
+                if (memberCancellationToken.IsCancellationRequested
+                    || !DistributedGrainDirectory.CanInvokeClusterMember(_owner.LatestClusterMembershipSnapshot, siloAddress))
                 {
                     break;
                 }

--- a/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
 
@@ -20,17 +21,30 @@ internal interface IGrainDirectoryPartition : ISystemTarget
     ValueTask<GrainDirectoryPartitionSnapshot?> GetSnapshotAsync(MembershipVersion version, MembershipVersion rangeVersion, RingRange range);
 
     [Alias("AcknowledgeSnapshotTransferAsync")]
-    ValueTask<bool> AcknowledgeSnapshotTransferAsync(SiloAddress silo, int partitionIndex, MembershipVersion version);
+    ValueTask<bool> AcknowledgeSnapshotTransferAsync(
+        SiloAddress silo,
+        int partitionIndex,
+        MembershipVersion version,
+        CancellationToken cancellationToken = default);
 }
 
 [Alias("IGrainDirectoryClient")]
 internal interface IGrainDirectoryClient : ISystemTarget
 {
     [Alias("GetRegisteredActivations")]
-    ValueTask<Immutable<List<GrainAddress>>> GetRegisteredActivations(MembershipVersion membershipVersion, RingRange range, bool isValidation);
+    ValueTask<Immutable<List<GrainAddress>>> GetRegisteredActivations(
+        MembershipVersion membershipVersion,
+        RingRange range,
+        bool isValidation,
+        CancellationToken cancellationToken = default);
 
     [Alias("RecoverRegisteredActivations")]
-    ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(MembershipVersion membershipVersion, RingRange range, SiloAddress siloAddress, int partitionId);
+    ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(
+        MembershipVersion membershipVersion,
+        RingRange range,
+        SiloAddress siloAddress,
+        int partitionId,
+        CancellationToken cancellationToken = default);
 }
 
 [Alias("IGrainDirectoryTestHooks")]

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Concurrency;
@@ -22,12 +23,18 @@ internal sealed class LocalGrainDirectoryClientCompatibility : SystemTarget, IGr
         shared.ActivationDirectory.RecordNewTarget(this);
     }
 
-    public ValueTask<Immutable<List<GrainAddress>>> GetRegisteredActivations(MembershipVersion membershipVersion, RingRange range, bool isValidation)
+    public ValueTask<Immutable<List<GrainAddress>>> GetRegisteredActivations(
+        MembershipVersion membershipVersion,
+        RingRange range,
+        bool isValidation,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var grainDirectoryResolver = _grainDirectoryResolver ??= ActivationServices.GetRequiredService<GrainDirectoryResolver>();
         List<GrainAddress> result = [];
         foreach (var (_, activation) in _localActivations)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!UsesLocalGrainDirectory(activation, grainDirectoryResolver))
             {
                 continue;
@@ -66,8 +73,13 @@ internal sealed class LocalGrainDirectoryClientCompatibility : SystemTarget, IGr
         return false;
     }
 
-    public ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(MembershipVersion membershipVersion, RingRange range, SiloAddress siloAddress, int partitionId)
-        => GetRegisteredActivations(membershipVersion, range, isValidation: false);
+    public ValueTask<Immutable<List<GrainAddress>>> RecoverRegisteredActivations(
+        MembershipVersion membershipVersion,
+        RingRange range,
+        SiloAddress siloAddress,
+        int partitionId,
+        CancellationToken cancellationToken)
+        => GetRegisteredActivations(membershipVersion, range, isValidation: false, cancellationToken);
 }
 
 internal sealed class LocalGrainDirectoryPartitionCompatibility : SystemTarget, IGrainDirectoryPartition
@@ -106,5 +118,13 @@ internal sealed class LocalGrainDirectoryPartitionCompatibility : SystemTarget, 
         return new((GrainDirectoryPartitionSnapshot?)null);
     }
 
-    public ValueTask<bool> AcknowledgeSnapshotTransferAsync(SiloAddress silo, int partitionIndex, MembershipVersion version) => new(true);
+    public ValueTask<bool> AcknowledgeSnapshotTransferAsync(
+        SiloAddress silo,
+        int partitionIndex,
+        MembershipVersion version,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return new(true);
+    }
 }

--- a/src/Orleans.Runtime/Messaging/MessageCenter.cs
+++ b/src/Orleans.Runtime/Messaging/MessageCenter.cs
@@ -98,8 +98,9 @@ namespace Orleans.Runtime.Messaging
         /// Indicates that application messages should be blocked from being sent or received.
         /// This method is used by the "fast stop" process.
         /// <para>
-        /// Specifically, all outbound application messages are dropped, except for rejections and messages to the membership table grain.
-        /// Inbound application requests are rejected, and other inbound application messages are dropped.
+        /// Specifically, all outbound application requests and one-way messages are rejected or dropped,
+        /// while responses and messages to the membership table grain are allowed to complete.
+        /// Inbound application requests are rejected with cache invalidation, and other inbound application messages are dropped.
         /// </para>
         /// </summary>
         public void BlockApplicationMessages()
@@ -145,10 +146,27 @@ namespace Orleans.Runtime.Messaging
             Debug.Assert(!msg.IsLocalOnly);
 
             // Note that if we identify or add other grains that are required for proper stopping, we will need to treat them as we do the membership table grain here.
-            if (IsBlockingApplicationMessages && !msg.IsSystemMessage && msg.Result is not Message.ResponseTypes.Rejection && !Constants.SystemMembershipTableType.Equals(msg.TargetGrain))
+            var isBlockedApplicationMessage = IsBlockingApplicationMessages
+                && !msg.IsSystemMessage
+                && msg.Direction is not Message.Directions.Response
+                && !Constants.SystemMembershipTableType.Equals(msg.TargetGrain);
+            if (isBlockedApplicationMessage)
             {
-                // Drop the message on the floor if it's an application message that isn't a rejection
-                this.messagingTrace.OnDropBlockedApplicationMessage(msg);
+                if (msg.Direction == Message.Directions.Request)
+                {
+                    ProcessRequestToInvalidActivation(
+                        msg,
+                        new GrainAddress { GrainId = msg.TargetGrain, SiloAddress = msg.TargetSilo },
+                        forwardingAddress: null,
+                        failedOperation: "Silo stopping",
+                        rejectMessages: true);
+                }
+                else
+                {
+                    this.messagingTrace.OnDropBlockedApplicationMessage(msg);
+                }
+
+                return;
             }
             else
             {
@@ -315,7 +333,7 @@ namespace Orleans.Runtime.Messaging
             }
         }
 
-        private void ProcessRequestToInvalidActivation(
+        internal void ProcessRequestToInvalidActivation(
             Message message,
             GrainAddress? oldAddress,
             SiloAddress? forwardingAddress,
@@ -334,6 +352,11 @@ namespace Orleans.Runtime.Messaging
             // IMPORTANT: do not do anything on activation context anymore, since this activation is invalid already.
             if (rejectMessages)
             {
+                if (oldAddress != null)
+                {
+                    message.AddToCacheInvalidationHeader(oldAddress, validAddress: null);
+                }
+
                 this.RejectMessage(message, Message.RejectionTypes.Transient, exc, failedOperation);
             }
             else

--- a/src/Orleans.Runtime/Networking/SiloConnection.cs
+++ b/src/Orleans.Runtime/Networking/SiloConnection.cs
@@ -84,20 +84,23 @@ namespace Orleans.Runtime.Messaging
                 return;
             }
 
-            // If we've stopped application message processing, then filter those out now
+            // If we've stopped application message processing, then reject requests and filter out other messages.
             // Note that if we identify or add other grains that are required for proper stopping, we will need to treat them as we do the membership table grain here.
             if (messageCenter.IsBlockingApplicationMessages && !msg.IsSystemMessage)
             {
-                // We reject new requests, and drop all other messages
+                // We reject new requests with targeted cache invalidation and drop all other messages.
                 if (msg.Direction != Message.Directions.Request)
                 {
                     this.MessagingTrace.OnDropBlockedApplicationMessage(msg);
                     return;
                 }
 
-                MessagingInstrumentation.OnRejectedMessage(msg);
-                var rejection = this.MessageFactory.CreateRejectionResponse(msg, Message.RejectionTypes.Unrecoverable, "Silo stopping", new SiloUnavailableException());
-                this.Send(rejection);
+                messageCenter.ProcessRequestToInvalidActivation(
+                    msg,
+                    new GrainAddress { GrainId = msg.TargetGrain, SiloAddress = msg.TargetSilo },
+                    forwardingAddress: null,
+                    failedOperation: "Silo stopping",
+                    rejectMessages: true);
                 return;
             }
 

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryPartitionTests.cs
@@ -11,6 +11,7 @@ namespace UnitTests.GrainDirectory;
 public sealed class GrainDirectoryPartitionTests
 {
     private static readonly SiloAddress TestSiloAddress = SiloAddress.FromParsableString("127.0.0.1:11111@123");
+    private static readonly SiloAddress ReplacementSiloAddress = SiloAddress.FromParsableString("127.0.0.1:11111@124");
 
     [Theory]
     [InlineData(SiloStatus.Active, true)]
@@ -26,6 +27,119 @@ public sealed class GrainDirectoryPartitionTests
         var snapshot = new ClusterMembershipSnapshot(members, new MembershipVersion(1));
 
         Assert.Equal(expected, DistributedGrainDirectory.CanInvokeClusterMember(snapshot, TestSiloAddress));
+    }
+
+    [Fact]
+    public void ClusterMemberCancellationTokens_ReusesTokenUntilMemberStops()
+    {
+        using var shutdown = new CancellationTokenSource();
+        using var tokens = new ClusterMemberCancellationTokens(shutdown.Token);
+        tokens.Update(CreateSnapshot(1, (TestSiloAddress, SiloStatus.Active)));
+        var token = tokens.GetToken(TestSiloAddress);
+
+        tokens.Update(CreateSnapshot(2, (TestSiloAddress, SiloStatus.ShuttingDown)));
+
+        Assert.Equal(token, tokens.GetToken(TestSiloAddress));
+        Assert.False(token.IsCancellationRequested);
+        Assert.Equal(1, tokens.Count);
+
+        tokens.Update(CreateSnapshot(3, (TestSiloAddress, SiloStatus.Stopping)));
+
+        Assert.True(token.IsCancellationRequested);
+        Assert.True(tokens.GetToken(TestSiloAddress).IsCancellationRequested);
+        Assert.Equal(0, tokens.Count);
+    }
+
+    [Theory]
+    [InlineData(SiloStatus.Stopping)]
+    [InlineData(SiloStatus.Dead)]
+    [InlineData(SiloStatus.None)]
+    public void ClusterMemberCancellationTokens_CancelsUnavailableMember(SiloStatus status)
+    {
+        using var shutdown = new CancellationTokenSource();
+        using var tokens = new ClusterMemberCancellationTokens(shutdown.Token);
+        tokens.Update(CreateSnapshot(1, (TestSiloAddress, SiloStatus.Active)));
+        var token = tokens.GetToken(TestSiloAddress);
+
+        tokens.Update(
+            status == SiloStatus.None
+                ? CreateSnapshot(2)
+                : CreateSnapshot(2, (TestSiloAddress, status)));
+
+        Assert.True(token.IsCancellationRequested);
+        Assert.True(tokens.GetToken(TestSiloAddress).IsCancellationRequested);
+        Assert.Equal(0, tokens.Count);
+    }
+
+    [Fact]
+    public void ClusterMemberCancellationTokens_ReplacesTokenForNewGeneration()
+    {
+        using var shutdown = new CancellationTokenSource();
+        using var tokens = new ClusterMemberCancellationTokens(shutdown.Token);
+        tokens.Update(CreateSnapshot(1, (TestSiloAddress, SiloStatus.Active)));
+        var originalToken = tokens.GetToken(TestSiloAddress);
+
+        tokens.Update(CreateSnapshot(
+            2,
+            (TestSiloAddress, SiloStatus.Dead),
+            (ReplacementSiloAddress, SiloStatus.Joining)));
+        var replacementToken = tokens.GetToken(ReplacementSiloAddress);
+
+        Assert.True(originalToken.IsCancellationRequested);
+        Assert.False(replacementToken.IsCancellationRequested);
+        Assert.NotEqual(originalToken, replacementToken);
+        Assert.Equal(1, tokens.Count);
+    }
+
+    [Fact]
+    public void ClusterMemberCancellationTokens_PublishesRemovalBeforeCancelingToken()
+    {
+        using var shutdown = new CancellationTokenSource();
+        using var tokens = new ClusterMemberCancellationTokens(shutdown.Token);
+        tokens.Update(CreateSnapshot(1, (TestSiloAddress, SiloStatus.Active)));
+        var token = tokens.GetToken(TestSiloAddress);
+        var tokenObservedDuringCancellation = default(CancellationToken);
+        using var registration = token.Register(
+            () => tokenObservedDuringCancellation = tokens.GetToken(TestSiloAddress));
+
+        tokens.Update(CreateSnapshot(2, (TestSiloAddress, SiloStatus.Dead)));
+
+        Assert.True(tokenObservedDuringCancellation.IsCancellationRequested);
+        Assert.NotEqual(token, tokenObservedDuringCancellation);
+    }
+
+    [Fact]
+    public void ClusterMemberCancellationTokens_ShutdownCancelsAllTokens()
+    {
+        using var shutdown = new CancellationTokenSource();
+        using var tokens = new ClusterMemberCancellationTokens(shutdown.Token);
+        tokens.Update(CreateSnapshot(
+            1,
+            (TestSiloAddress, SiloStatus.Active),
+            (ReplacementSiloAddress, SiloStatus.Active)));
+        var firstToken = tokens.GetToken(TestSiloAddress);
+        var secondToken = tokens.GetToken(ReplacementSiloAddress);
+
+        shutdown.Cancel();
+
+        Assert.True(firstToken.IsCancellationRequested);
+        Assert.True(secondToken.IsCancellationRequested);
+        Assert.True(tokens.GetToken(SiloAddress.Zero).IsCancellationRequested);
+    }
+
+    [Fact]
+    public void ClusterMemberCancellationTokens_DisposeCancelsAndRemovesAllTokens()
+    {
+        using var shutdown = new CancellationTokenSource();
+        using var tokens = new ClusterMemberCancellationTokens(shutdown.Token);
+        tokens.Update(CreateSnapshot(1, (TestSiloAddress, SiloStatus.Active)));
+        var token = tokens.GetToken(TestSiloAddress);
+
+        tokens.Dispose();
+
+        Assert.True(token.IsCancellationRequested);
+        Assert.True(tokens.GetToken(TestSiloAddress).IsCancellationRequested);
+        Assert.Equal(0, tokens.Count);
     }
 
     [Fact]
@@ -62,5 +176,18 @@ public sealed class GrainDirectoryPartitionTests
         var actual = GrainDirectoryPartition.GetSnapshotTransferRanges(previousOwnerRange, addedRange).ToArray();
 
         Assert.Equal(expected, actual);
+    }
+
+    private static ClusterMembershipSnapshot CreateSnapshot(
+        long version,
+        params (SiloAddress SiloAddress, SiloStatus Status)[] members)
+    {
+        var builder = ImmutableDictionary.CreateBuilder<SiloAddress, ClusterMember>();
+        foreach (var (siloAddress, status) in members)
+        {
+            builder.Add(siloAddress, new ClusterMember(siloAddress, status, $"Silo-{siloAddress.Generation}"));
+        }
+
+        return new ClusterMembershipSnapshot(builder.ToImmutable(), new MembershipVersion(version));
     }
 }

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -1318,10 +1318,16 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             return true;
         }
 
-        return string.Equals(entry.Category, "Orleans.Messaging", StringComparison.Ordinal)
-            && entry.Message.StartsWith("Failed to address message", StringComparison.Ordinal)
-            && entry.Message.Contains("IGrainDirectoryPartition.", StringComparison.Ordinal)
-            && entry.Message.Contains("not active on this silo", StringComparison.Ordinal);
+        if (!string.Equals(entry.Category, "Orleans.Messaging", StringComparison.Ordinal)
+            || !entry.Message.StartsWith("Failed to address message", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return (entry.Message.Contains("IGrainDirectoryPartition.", StringComparison.Ordinal)
+                && entry.Message.Contains("not active on this silo", StringComparison.Ordinal))
+            || (string.Equals(entry.ExceptionType, typeof(SiloUnavailableException).FullName, StringComparison.Ordinal)
+                && entry.ExceptionMessage?.Contains("is shutting down", StringComparison.Ordinal) == true);
     }
 
     private void WriteInPlacePhaseReport(
@@ -1902,7 +1908,7 @@ internal sealed class RollingUpgradeIdentityGrain : Grain, IRollingUpgradeIdenti
 internal sealed class TrackingGrainDirectoryCache : IGrainDirectoryCache
 {
     private readonly IGrainDirectoryCache _inner = new LruGrainDirectoryCache(
-        maxCacheSize: 1_000_000,
+        maxCacheSize: 4_096,
         maxCacheTTL: TimeSpan.FromMinutes(10),
         timeProvider: TimeProvider.System);
     private int _clearCount;

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Orleans;
 using Orleans.Concurrency;
+using Orleans.Configuration;
 using Orleans.GrainDirectory;
 using Orleans.Hosting;
 using Orleans.Runtime;
@@ -644,4 +645,1284 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
 
         public static void Remove(string clusterId) => DiagnosticsByCluster.TryRemove(clusterId, out _);
     }
+
+    [Fact]
+    public async Task RollingUpgrade_RestartInPlace_PreservesTrafficAndDirectoryIntegrity()
+    {
+        const int SiloCount = 3;
+        var operationTimeout = TimeSpan.FromSeconds(45);
+        var cleanupTimeout = TimeSpan.FromSeconds(30);
+        var upgradedSiloNames = new ConcurrentDictionary<string, byte>(StringComparer.Ordinal);
+        var phase = new RollingUpgradePhase("deploy-local", output);
+        var logs = new PhaseAwareLogCapture(phase);
+        var staleCacheEvidence = new StaleCacheEvidenceCapture();
+        var retiredAddresses = new HashSet<SiloAddress>();
+        var trackedGrainKeys = Enumerable.Range(1, 12).Select(static value => -(long)value).ToList();
+        var restartPhases = new List<string>(SiloCount);
+        var verificationPhases = new List<string>(SiloCount);
+        var nextVerificationGrainKey = 2_000_000L;
+
+        var builder = new InProcessTestClusterBuilder(SiloCount);
+        builder.Options.UseTestClusterGrainDirectory = false;
+        builder.ConfigureSilo((siloOptions, siloBuilder) =>
+        {
+            if (!upgradedSiloNames.ContainsKey(siloOptions.SiloName))
+            {
+                return;
+            }
+
+#pragma warning disable ORLEANSEXP003
+            siloBuilder.AddDistributedGrainDirectory();
+#pragma warning restore ORLEANSEXP003
+        });
+        builder.ConfigureSiloHost((siloOptions, hostBuilder) =>
+        {
+            hostBuilder.Services.Configure<GrainDirectoryOptions>(
+                static options => options.CachingStrategy = GrainDirectoryOptions.CachingStrategyType.Custom);
+            hostBuilder.Services.AddSingleton<TrackingGrainDirectoryCache>();
+            hostBuilder.Services.AddSingleton<IGrainDirectoryCache>(
+                static services => services.GetRequiredService<TrackingGrainDirectoryCache>());
+            hostBuilder.Logging.AddFilter(typeof(DistributedRemoteGrainDirectory).FullName, LogLevel.Information);
+            hostBuilder.Logging.AddFilter(typeof(GrainDirectoryHandoffManager).FullName, LogLevel.Information);
+            hostBuilder.Logging.AddFilter("Orleans.Messaging", LogLevel.Warning);
+            hostBuilder.Services.AddSingleton<ILoggerProvider>(
+                new PhaseAwareLoggerProvider(siloOptions.SiloName, logs));
+        });
+
+        var cluster = builder.Build();
+        SustainedRollingUpgradeTraffic? traffic = null;
+        var deployed = false;
+        try
+        {
+            await cluster.DeployAsync().WaitAsync(operationTimeout);
+            deployed = true;
+
+            var originalClient = cluster.Client;
+            Assert.Equal(SiloCount, cluster.Silos.Count);
+            Assert.Equal(SiloCount, cluster.Silos.Select(static silo => silo.Name).Distinct(StringComparer.Ordinal).Count());
+            Assert.All(cluster.Silos, static silo => Assert.Null(silo.ServiceProvider.GetService<DirectoryMembershipService>()));
+            Assert.Empty(upgradedSiloNames);
+
+            output.WriteLine(
+                $"Phase '{phase.Current}': {SiloCount} LocalGrainDirectory silos: "
+                + string.Join(", ", cluster.Silos.Select(static silo => $"{silo.Name}={silo.SiloAddress}")));
+
+            var initialObservations = await CallIdentityGrainsAsync(originalClient, trackedGrainKeys, operationTimeout);
+            var repeatedInitialObservations = await CallIdentityGrainsAsync(originalClient, trackedGrainKeys, operationTimeout);
+            AssertStableActivationProgress(initialObservations, repeatedInitialObservations, "initial LocalGrainDirectory phase");
+            await ValidateTrackedDirectoryCheckpointAsync(
+                cluster,
+                repeatedInitialObservations,
+                cluster.Silos.Select(static silo => silo.SiloAddress).ToHashSet(),
+                retiredAddresses,
+                "initial LocalGrainDirectory phase",
+                staleCacheEvidence);
+
+            traffic = new SustainedRollingUpgradeTraffic(
+                originalClient,
+                cluster,
+                phase,
+                trackedGrainKeys.ToArray(),
+                expectedMaximumSilos: SiloCount,
+                callTimeout: TimeSpan.FromSeconds(10));
+            traffic.Start(workerCount: 3);
+            var initialWorkerProgress = traffic.GetWorkerProgress();
+            await traffic.WaitForPhaseSuccessesAsync(phase.Current, minimumSuccesses: 12, operationTimeout);
+            await traffic.WaitForAllWorkersProgressAsync(
+                initialWorkerProgress,
+                "initial LocalGrainDirectory traffic",
+                operationTimeout);
+            AssertNoTrafficFailures(traffic, phase.Current);
+            AssertTransientTrafficFailuresWithinLimit(traffic, 0, phase.Current);
+
+            var restartOrder = cluster.Silos
+                .OrderBy(static silo => silo.InstanceNumber == 0)
+                .ThenBy(static silo => silo.InstanceNumber)
+                .ToArray();
+            Assert.Equal(SiloCount, restartOrder.Length);
+            Assert.All(restartOrder[..^1], static silo => Assert.NotEqual(0, silo.InstanceNumber));
+            Assert.Equal(0, restartOrder[^1].InstanceNumber);
+
+            for (var restartIndex = 0; restartIndex < restartOrder.Length; restartIndex++)
+            {
+                var oldSilo = restartOrder[restartIndex];
+                var restartPhase = $"restart-{restartIndex + 1}-{oldSilo.Name}";
+                restartPhases.Add(restartPhase);
+                phase.Set(restartPhase);
+                Assert.True(
+                    upgradedSiloNames.TryAdd(oldSilo.Name, 0),
+                    $"Stable silo name '{oldSilo.Name}' was marked as upgraded more than once.");
+                Assert.Equal(SiloCount, cluster.Silos.Count);
+                Assert.Same(originalClient, cluster.Client);
+
+                await traffic.WaitForPhaseSuccessesAsync(restartPhase, minimumSuccesses: 4, operationTimeout);
+                var oldAddress = oldSilo.SiloAddress;
+                output.WriteLine(
+                    $"Phase '{restartPhase}': restarting {oldSilo.Name} ({oldAddress}) in place; "
+                    + $"upgraded names=[{string.Join(", ", upgradedSiloNames.Keys.Order())}].");
+                var cacheSentinelSilos = cluster.Silos
+                    .Where(silo => !ReferenceEquals(silo, oldSilo))
+                    .ToArray();
+                var cacheClearBaselines = cacheSentinelSilos.ToDictionary(
+                    static silo => silo,
+                    static silo => silo.ServiceProvider.GetRequiredService<TrackingGrainDirectoryCache>().ClearCount);
+
+                var restartTask = cluster.RestartSiloAsync(oldSilo);
+                var restartStartedAt = DateTimeOffset.UtcNow;
+                var workerProgressBeforeRestart = traffic.GetWorkerProgress();
+                var successCountBeforeRestart = traffic.SuccessfulCalls;
+                using var progressRaceCancellation = new CancellationTokenSource();
+                var progressDuringRestartTask = traffic.WaitForTotalProgressAsync(
+                    successCountBeforeRestart + 1,
+                    progressRaceCancellation.Token);
+                var restartRaceWinner = await Task.WhenAny(restartTask, progressDuringRestartTask);
+                if (ReferenceEquals(restartRaceWinner, progressDuringRestartTask))
+                {
+                    await progressDuringRestartTask;
+                    Assert.True(
+                        traffic.SuccessfulCalls > successCountBeforeRestart,
+                        $"The progress task completed without recording a successful call during '{restartPhase}'.");
+                    output.WriteLine(
+                        $"  Workload progress won the restart race after {DateTimeOffset.UtcNow - restartStartedAt}: "
+                        + $"{successCountBeforeRestart}->{traffic.SuccessfulCalls} successful calls; "
+                        + traffic.FormatWorkerProgress(workerProgressBeforeRestart));
+                }
+                else
+                {
+                    output.WriteLine(
+                        $"  Restart completed before the next post-start workload success after "
+                        + $"{DateTimeOffset.UtcNow - restartStartedAt}; "
+                        + traffic.FormatWorkerProgress(workerProgressBeforeRestart));
+                }
+
+                progressRaceCancellation.Cancel();
+                try
+                {
+                    await progressDuringRestartTask;
+                }
+                catch (OperationCanceledException) when (progressRaceCancellation.IsCancellationRequested)
+                {
+                }
+
+                var replacement = await restartTask.WaitAsync(operationTimeout);
+                Assert.NotNull(replacement);
+                Assert.Equal(oldSilo.Name, replacement.Name);
+                Assert.Equal(oldSilo.InstanceNumber, replacement.InstanceNumber);
+                Assert.NotEqual(oldAddress, replacement.SiloAddress);
+                Assert.Contains(replacement, cluster.Silos);
+                Assert.Equal(SiloCount, cluster.Silos.Count);
+                Assert.True(cluster.Silos.Count <= SiloCount, "An in-place restart grew the live cluster beyond three silos.");
+                Assert.Same(originalClient, cluster.Client);
+                Assert.NotNull(replacement.ServiceProvider.GetService<DirectoryMembershipService>());
+                Assert.True(retiredAddresses.Add(oldAddress), $"Silo address '{oldAddress}' was retired twice.");
+                var retiredAt = DateTimeOffset.UtcNow;
+                var workerProgressAfterRetirement = traffic.GetWorkerProgress();
+
+                var expectedDistributedSilos = restartIndex + 1;
+                var distributedSilos = cluster.Silos.Count(
+                    static silo => silo.ServiceProvider.GetService<DirectoryMembershipService>() is not null);
+                Assert.Equal(expectedDistributedSilos, distributedSilos);
+                Assert.Equal(SiloCount - expectedDistributedSilos, cluster.Silos.Count - distributedSilos);
+                if (expectedDistributedSilos == 2)
+                {
+                    Assert.Equal(1, cluster.Silos.Count(
+                        static silo => silo.ServiceProvider.GetService<DirectoryMembershipService>() is null));
+                    Assert.Equal(2, distributedSilos);
+                }
+
+                await cluster.WaitForLivenessToStabilizeAsync().WaitAsync(operationTimeout);
+                await WaitForClusterMembershipConvergenceAsync(cluster, retiredAddresses, restartPhase, operationTimeout);
+                await WaitForDirectoryConvergenceAsync(cluster, $"during {restartPhase}");
+                AssertCachesWereNotCleared(cacheClearBaselines, restartPhase);
+                await traffic.WaitForAllWorkersProgressAsync(
+                    workerProgressAfterRetirement,
+                    $"post-retirement portion of restart phase '{restartPhase}'",
+                    operationTimeout);
+                AssertNoTrafficFailures(traffic, restartPhase);
+                AssertTransientTrafficFailuresWithinLimit(traffic, SiloCount, restartPhase);
+                var liveAddresses = cluster.Silos.Select(static silo => silo.SiloAddress).ToHashSet();
+                AssertTrafficUsesOnlyLiveAddresses(
+                    traffic,
+                    restartPhase,
+                    liveAddresses,
+                    retiredAddresses,
+                    completedAtOrAfter: retiredAt);
+
+                var verificationPhase = $"{restartPhase}-post-convergence";
+                verificationPhases.Add(verificationPhase);
+                phase.Set(verificationPhase);
+                await traffic.WaitForPhaseSuccessesAsync(verificationPhase, minimumSuccesses: 12, operationTimeout);
+                AssertTrafficUsesOnlyLiveAddresses(traffic, verificationPhase, liveAddresses, retiredAddresses);
+
+                var freshKeys = Enumerable.Range(0, 4)
+                    .Select(_ => Interlocked.Increment(ref nextVerificationGrainKey))
+                    .ToArray();
+                trackedGrainKeys.AddRange(freshKeys);
+                var observations = await CallIdentityGrainsAsync(originalClient, freshKeys, operationTimeout);
+                var repeatedObservations = await CallIdentityGrainsAsync(originalClient, freshKeys, operationTimeout);
+                AssertStableActivationProgress(observations, repeatedObservations, verificationPhase);
+                await ValidateTrackedDirectoryCheckpointAsync(
+                    cluster,
+                    repeatedObservations,
+                    liveAddresses,
+                    retiredAddresses,
+                    verificationPhase,
+                    staleCacheEvidence);
+                AssertNoTrafficFailures(traffic, restartPhase, verificationPhase);
+                AssertTransientTrafficFailuresWithinLimit(traffic, SiloCount, restartPhase);
+                AssertTransientTrafficFailuresWithinLimit(traffic, 0, verificationPhase);
+                AssertNoImpactfulErrors(logs);
+                WriteInPlacePhaseReport(
+                    verificationPhase,
+                    cluster,
+                    upgradedSiloNames,
+                    retiredAddresses,
+                    traffic,
+                    logs,
+                    staleCacheEvidence);
+            }
+
+            var finalWorkerProgress = traffic.GetWorkerProgress();
+            phase.Set("all-distributed-final");
+            Assert.Equal(SiloCount, cluster.Silos.Count);
+            Assert.Equal(SiloCount, upgradedSiloNames.Count);
+            Assert.All(
+                cluster.Silos,
+                static silo => Assert.NotNull(silo.ServiceProvider.GetService<DirectoryMembershipService>()));
+            Assert.Same(originalClient, cluster.Client);
+
+            await traffic.WaitForPhaseSuccessesAsync(phase.Current, minimumSuccesses: 20, operationTimeout);
+            await traffic.WaitForAllWorkersProgressAsync(
+                finalWorkerProgress,
+                "final all-DistributedGrainDirectory phase",
+                operationTimeout);
+            var finalLiveAddresses = cluster.Silos.Select(static silo => silo.SiloAddress).ToHashSet();
+            AssertTrafficUsesOnlyLiveAddresses(traffic, phase.Current, finalLiveAddresses, retiredAddresses);
+            await traffic.StopSchedulingAndDrainAsync(operationTimeout);
+            foreach (var restartPhase in restartPhases)
+            {
+                AssertTransientTrafficFailuresWithinLimit(traffic, SiloCount, restartPhase);
+            }
+
+            foreach (var verificationPhase in verificationPhases)
+            {
+                AssertTransientTrafficFailuresWithinLimit(traffic, 0, verificationPhase);
+            }
+
+            var finalObservations = await CallIdentityGrainsAsync(originalClient, trackedGrainKeys, operationTimeout);
+            var repeatedFinalObservations = await CallIdentityGrainsAsync(originalClient, trackedGrainKeys, operationTimeout);
+            AssertStableActivationProgress(finalObservations, repeatedFinalObservations, phase.Current);
+            await ValidateTrackedDirectoryCheckpointAsync(
+                cluster,
+                repeatedFinalObservations,
+                finalLiveAddresses,
+                retiredAddresses,
+                phase.Current,
+                staleCacheEvidence);
+            await WaitForClusterMembershipConvergenceAsync(cluster, retiredAddresses, phase.Current, operationTimeout);
+            await WaitForDirectoryConvergenceAsync(cluster, "in the final all-DistributedGrainDirectory phase");
+
+            Assert.Equal(SiloCount, traffic.MaximumObservedSiloCount);
+            Assert.True(traffic.MaximumObservedSiloCount <= SiloCount);
+            AssertNoTrafficFailures(traffic);
+            AssertTransientTrafficFailuresWithinLimit(traffic, 0, phase.Current);
+            AssertNoImpactfulErrors(logs);
+            WriteInPlacePhaseReport(
+                phase.Current,
+                cluster,
+                upgradedSiloNames,
+                retiredAddresses,
+                traffic,
+                logs,
+                staleCacheEvidence);
+        }
+        catch
+        {
+            if (deployed)
+            {
+                await DumpInPlaceFailureDiagnosticsAsync(
+                    cluster,
+                    phase,
+                    upgradedSiloNames,
+                    retiredAddresses,
+                    trackedGrainKeys,
+                    traffic,
+                    logs,
+                    staleCacheEvidence);
+            }
+
+            throw;
+        }
+        finally
+        {
+            phase.Set("cleanup");
+            try
+            {
+                if (traffic is not null)
+                {
+                    await traffic.CancelAsync(cleanupTimeout);
+                }
+            }
+            finally
+            {
+                try
+                {
+                    if (deployed)
+                    {
+                        await cluster.StopAllSilosAsync().WaitAsync(cleanupTimeout);
+                    }
+                }
+                finally
+                {
+                    await cluster.DisposeAsync().AsTask().WaitAsync(cleanupTimeout);
+                }
+            }
+        }
+    }
+
+    private static async Task<Dictionary<long, RollingUpgradeGrainObservation>> CallIdentityGrainsAsync(
+        IGrainFactory client,
+        IEnumerable<long> grainKeys,
+        TimeSpan timeout)
+    {
+        var calls = grainKeys.Distinct().Select(async grainKey =>
+        {
+            var grain = client.GetGrain<IRollingUpgradeIdentityGrain>(grainKey);
+            var observation = await grain.Observe().AsTask().WaitAsync(timeout);
+            Assert.Equal(grain.GetGrainId(), observation.Address.GrainId);
+            Assert.NotNull(observation.Address.SiloAddress);
+            Assert.False(observation.Address.ActivationId.IsDefault);
+            Assert.True(observation.CallCount > 0);
+            return (GrainKey: grainKey, Observation: observation);
+        }).ToArray();
+
+        return (await Task.WhenAll(calls)).ToDictionary(static result => result.GrainKey, static result => result.Observation);
+    }
+
+    private static void AssertCachesWereNotCleared(
+        Dictionary<InProcessSiloHandle, int> baselines,
+        string stage)
+    {
+        foreach (var (silo, baseline) in baselines)
+        {
+            var cache = silo.ServiceProvider.GetRequiredService<TrackingGrainDirectoryCache>();
+            Assert.Equal(baseline, cache.ClearCount);
+        }
+    }
+
+    private static void AssertStableActivationProgress(
+        Dictionary<long, RollingUpgradeGrainObservation> first,
+        Dictionary<long, RollingUpgradeGrainObservation> second,
+        string stage)
+    {
+        Assert.Equal(first.Keys.Order(), second.Keys.Order());
+        foreach (var (grainKey, firstObservation) in first)
+        {
+            var secondObservation = second[grainKey];
+            Assert.Equal(
+                firstObservation.Address.ActivationId,
+                secondObservation.Address.ActivationId);
+            Assert.Equal(
+                firstObservation.Address.SiloAddress,
+                secondObservation.Address.SiloAddress);
+            Assert.True(
+                secondObservation.CallCount > firstObservation.CallCount,
+                $"Grain {grainKey} did not make call-count progress during '{stage}': "
+                + $"{firstObservation.CallCount} -> {secondObservation.CallCount}.");
+        }
+    }
+
+    private async Task ValidateTrackedDirectoryCheckpointAsync(
+        InProcessTestCluster cluster,
+        Dictionary<long, RollingUpgradeGrainObservation> observations,
+        HashSet<SiloAddress> liveAddresses,
+        HashSet<SiloAddress> retiredAddresses,
+        string stage,
+        StaleCacheEvidenceCapture staleCacheEvidence)
+    {
+        var distributedPartitions = new List<IGrainDirectoryTestHooks>();
+        foreach (var silo in cluster.Silos)
+        {
+            if (silo.ServiceProvider.GetService<DirectoryMembershipService>() is not { } membershipService)
+            {
+                continue;
+            }
+
+            for (var partitionIndex = 0; partitionIndex < membershipService.PartitionsPerSilo; partitionIndex++)
+            {
+                distributedPartitions.Add(
+                    cluster.InternalClient.GetSystemTarget<IGrainDirectoryTestHooks>(
+                        GrainDirectoryPartition.CreateGrainId(silo.SiloAddress, partitionIndex).GrainId));
+            }
+        }
+
+        // Validate the observable directory state before invoking recovery so that recovery cannot
+        // repair a lost registration and mask a rolling-upgrade regression.
+        await ValidateObservedAddressesAsync(
+            cluster,
+            observations,
+            liveAddresses,
+            retiredAddresses,
+            stage,
+            staleCacheEvidence);
+
+        var integrityChecks = distributedPartitions
+            .Select(static partition => partition.RecoverAndCheckIntegrityAsync().AsTask())
+            .ToArray();
+        await Task.WhenAll(integrityChecks);
+        output.WriteLine(
+            $"  Validated {observations.Count} bounded tracked grains and "
+            + $"{distributedPartitions.Count} DistributedGrainDirectory partitions during '{stage}'.");
+    }
+
+    private static async Task ValidateObservedAddressesAsync(
+        InProcessTestCluster cluster,
+        Dictionary<long, RollingUpgradeGrainObservation> observations,
+        HashSet<SiloAddress> liveAddresses,
+        HashSet<SiloAddress> retiredAddresses,
+        string stage,
+        StaleCacheEvidenceCapture staleCacheEvidence)
+    {
+        var activations = GetDirectoryActivations(cluster);
+        foreach (var (grainKey, observation) in observations)
+        {
+            var observedAddress = observation.Address;
+            Assert.Contains(observedAddress.SiloAddress!, liveAddresses);
+            Assert.DoesNotContain(observedAddress.SiloAddress!, retiredAddresses);
+
+            var activationMatches = activations
+                .Where(activation => activation.Address.GrainId.Equals(observedAddress.GrainId))
+                .ToArray();
+            var activation = Assert.Single(activationMatches);
+            Assert.Equal(observedAddress.SiloAddress, activation.Address.SiloAddress);
+            Assert.Equal(observedAddress.ActivationId, activation.Address.ActivationId);
+
+            foreach (var silo in cluster.Silos)
+            {
+                var grainLocator = silo.ServiceProvider.GetRequiredService<GrainLocator>();
+                if (grainLocator.TryLookupInCache(observedAddress.GrainId, out var cachedAddress))
+                {
+                    Assert.Equal(observedAddress.GrainId, cachedAddress.GrainId);
+                    if (!CacheHintMatchesObservation(cachedAddress, observedAddress))
+                    {
+                        staleCacheEvidence.Add(stage, silo, grainKey, cachedAddress, observedAddress, retiredAddresses);
+                    }
+                }
+
+                grainLocator.InvalidateCache(observedAddress.GrainId);
+                var resolvedAddress = await grainLocator.Lookup(observedAddress.GrainId);
+                Assert.NotNull(resolvedAddress);
+                AssertAddressMatchesObservation(
+                    resolvedAddress,
+                    observedAddress,
+                    liveAddresses,
+                    retiredAddresses,
+                    silo,
+                    grainKey,
+                    stage,
+                    "authoritative directory lookup",
+                    requireActivationIdentity: true);
+
+                Assert.True(
+                    grainLocator.TryLookupInCache(observedAddress.GrainId, out var repopulatedAddress),
+                    $"Authoritative lookup on '{silo.Name}' did not repopulate the cache for grain {grainKey} during '{stage}'.");
+                AssertAddressMatchesObservation(
+                    repopulatedAddress,
+                    observedAddress,
+                    liveAddresses,
+                    retiredAddresses,
+                    silo,
+                    grainKey,
+                    stage,
+                    "repopulated cache",
+                    requireActivationIdentity: true);
+            }
+        }
+    }
+
+    private static bool CacheHintMatchesObservation(GrainAddress cachedAddress, GrainAddress observedAddress) =>
+        cachedAddress.GrainId.Equals(observedAddress.GrainId)
+        && Equals(cachedAddress.SiloAddress, observedAddress.SiloAddress)
+        && (cachedAddress.ActivationId.IsDefault || cachedAddress.ActivationId.Equals(observedAddress.ActivationId));
+
+    private static void AssertAddressMatchesObservation(
+        GrainAddress resolvedAddress,
+        GrainAddress observedAddress,
+        HashSet<SiloAddress> liveAddresses,
+        HashSet<SiloAddress> retiredAddresses,
+        InProcessSiloHandle resolvingSilo,
+        long grainKey,
+        string stage,
+        string source,
+        bool requireActivationIdentity)
+    {
+        Assert.Equal(observedAddress.GrainId, resolvedAddress.GrainId);
+        Assert.NotNull(resolvedAddress.SiloAddress);
+        Assert.Contains(resolvedAddress.SiloAddress, liveAddresses);
+        Assert.DoesNotContain(resolvedAddress.SiloAddress!, retiredAddresses);
+        Assert.Equal(
+            observedAddress.SiloAddress,
+            resolvedAddress.SiloAddress);
+        if (requireActivationIdentity || !resolvedAddress.ActivationId.IsDefault)
+        {
+            Assert.Equal(
+                observedAddress.ActivationId,
+                resolvedAddress.ActivationId);
+            Assert.True(
+                observedAddress.Matches(resolvedAddress),
+                $"{source} on '{resolvingSilo.Name}' returned '{resolvedAddress.ToFullString()}' for grain {grainKey} "
+                + $"during '{stage}', but the grain reported '{observedAddress.ToFullString()}'.");
+        }
+    }
+
+    private async Task WaitForClusterMembershipConvergenceAsync(
+        InProcessTestCluster cluster,
+        HashSet<SiloAddress> retiredAddresses,
+        string stage,
+        TimeSpan timeout)
+    {
+        output.WriteLine($"  Waiting for cluster membership convergence during '{stage}'...");
+        using var cancellation = new CancellationTokenSource(timeout);
+        try
+        {
+            while (true)
+            {
+                var silos = cluster.Silos;
+                var liveAddresses = silos.Select(static silo => silo.SiloAddress).ToHashSet();
+                var membershipServices = silos
+                    .Select(static silo => silo.ServiceProvider.GetRequiredService<ClusterMembershipService>())
+                    .ToArray();
+                var targetVersion = new MembershipVersion(
+                    membershipServices.Max(static service => service.CurrentSnapshot.Version.Value));
+                await Task.WhenAll(
+                    membershipServices.Select(service => service.Refresh(targetVersion, cancellation.Token).AsTask()));
+
+                if (membershipServices.All(service =>
+                        liveAddresses.All(address => service.CurrentSnapshot.GetSiloStatus(address) == SiloStatus.Active)
+                        && retiredAddresses.All(address => service.CurrentSnapshot.GetSiloStatus(address) == SiloStatus.Dead)))
+                {
+                    output.WriteLine(
+                        $"  Cluster membership converged at version {targetVersion} during '{stage}': "
+                        + $"live={liveAddresses.Count}, retired={retiredAddresses.Count}.");
+                    return;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(50), cancellation.Token);
+            }
+        }
+        catch (OperationCanceledException exception) when (cancellation.IsCancellationRequested)
+        {
+            var statusReport = string.Join(
+                Environment.NewLine,
+                cluster.Silos.Select(silo =>
+                {
+                    var snapshot = silo.ServiceProvider.GetRequiredService<ClusterMembershipService>().CurrentSnapshot;
+                    return $"{silo.Name} ({silo.SiloAddress}) version={snapshot.Version}: "
+                        + string.Join(", ", snapshot.Members.Select(static member => $"{member.Key}={member.Value.Status}"));
+                }));
+            throw new TimeoutException(
+                $"Timed out waiting for cluster membership convergence during '{stage}' after {timeout}."
+                + Environment.NewLine
+                + statusReport,
+                exception);
+        }
+    }
+
+    private void AssertNoTrafficFailures(SustainedRollingUpgradeTraffic traffic, params string[] phases)
+    {
+        var failures = traffic.Failures
+            .Where(failure => phases.Length == 0 || phases.Contains(failure.Phase, StringComparer.Ordinal))
+            .ToArray();
+        foreach (var failure in failures.Take(20))
+        {
+            output.WriteLine(
+                $"CALLER FAILURE phase='{failure.Phase}' worker={failure.Worker} grain={failure.GrainKey}: "
+                + $"{failure.Exception.GetType().Name}: {failure.Exception.Message}");
+        }
+
+        Assert.Empty(failures);
+    }
+
+    private void AssertTransientTrafficFailuresWithinLimit(
+        SustainedRollingUpgradeTraffic traffic,
+        int maximumFailures,
+        params string[] phases)
+    {
+        var failures = traffic.TransientFailures
+            .Where(failure => phases.Contains(failure.Phase, StringComparer.Ordinal))
+            .ToArray();
+        foreach (var failure in failures.Take(20))
+        {
+            output.WriteLine(
+                $"RETRIED TRANSIENT CALL phase='{failure.Phase}' worker={failure.Worker} grain={failure.GrainKey}: "
+                + $"{failure.Exception.GetType().Name}: {failure.Exception.Message}");
+        }
+
+        Assert.True(
+            failures.Length <= maximumFailures,
+            $"Observed {failures.Length} retried transient calls in [{string.Join(", ", phases)}]; "
+            + $"the maximum is {maximumFailures}.");
+    }
+
+    private static void AssertTrafficUsesOnlyLiveAddresses(
+        SustainedRollingUpgradeTraffic traffic,
+        string phase,
+        HashSet<SiloAddress> liveAddresses,
+        HashSet<SiloAddress> retiredAddresses,
+        DateTimeOffset? completedAtOrAfter = null)
+    {
+        var observations = traffic.GetObservations(phase);
+        if (completedAtOrAfter is { } lowerBound)
+        {
+            observations = observations
+                .Where(observation => observation.CompletedAt >= lowerBound)
+                .ToArray();
+        }
+
+        Assert.NotEmpty(observations);
+        foreach (var observation in observations)
+        {
+            var address = observation.Observation.Address;
+            Assert.Contains(address.SiloAddress!, liveAddresses);
+            Assert.DoesNotContain(address.SiloAddress!, retiredAddresses);
+            Assert.False(address.ActivationId.IsDefault);
+            Assert.True(observation.Observation.CallCount > 0);
+        }
+    }
+
+    private void AssertNoImpactfulErrors(PhaseAwareLogCapture logs)
+    {
+        var errors = logs.ToArray()
+            .Where(static entry => entry.Level >= LogLevel.Error)
+            .Where(static entry => !IsExpectedIntentionalRestartLog(entry))
+            .ToArray();
+        foreach (var error in errors.Take(20))
+        {
+            output.WriteLine($"IMPACTFUL ERROR {error}");
+        }
+
+        Assert.Empty(errors);
+    }
+
+    private static bool IsExpectedIntentionalRestartLog(PhaseAwareLogEntry entry)
+    {
+        if (!entry.Phase.StartsWith("restart-", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (string.Equals(entry.Category, "Orleans.Runtime.GrainDirectory.ClientDirectory", StringComparison.Ordinal)
+            && entry.Message.StartsWith("Exception publishing client routing table", StringComparison.Ordinal)
+            && string.Equals(entry.ExceptionType, typeof(TaskCanceledException).FullName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return string.Equals(entry.Category, "Orleans.Messaging", StringComparison.Ordinal)
+            && entry.Message.StartsWith("Failed to address message", StringComparison.Ordinal)
+            && entry.Message.Contains("IGrainDirectoryPartition.", StringComparison.Ordinal)
+            && entry.Message.Contains("not active on this silo", StringComparison.Ordinal);
+    }
+
+    private void WriteInPlacePhaseReport(
+        string stage,
+        InProcessTestCluster cluster,
+        ConcurrentDictionary<string, byte> upgradedSiloNames,
+        HashSet<SiloAddress> retiredAddresses,
+        SustainedRollingUpgradeTraffic traffic,
+        PhaseAwareLogCapture logs,
+        StaleCacheEvidenceCapture staleCacheEvidence)
+    {
+        var distributedCount = cluster.Silos.Count(
+            static silo => silo.ServiceProvider.GetService<DirectoryMembershipService>() is not null);
+        var stageLogs = logs.ToArray().Where(entry => string.Equals(entry.Phase, stage, StringComparison.Ordinal)).ToArray();
+        var stageStaleCacheEvidence = staleCacheEvidence
+            .ToArray()
+            .Where(entry => string.Equals(entry.Phase, stage, StringComparison.Ordinal))
+            .ToArray();
+        output.WriteLine(
+            $"PHASE REPORT '{stage}': live={cluster.Silos.Count}, Local={cluster.Silos.Count - distributedCount}, "
+            + $"DGD={distributedCount}, upgradedNames={upgradedSiloNames.Count}, retiredAddresses={retiredAddresses.Count}, "
+            + $"trafficSuccesses={traffic.SuccessfulCalls}, callerFailures={traffic.Failures.Length}, "
+            + $"retriedTransientCalls={traffic.TransientFailures.Length}, "
+            + $"maxObservedLiveSilos={traffic.MaximumObservedSiloCount}, phaseLogs={stageLogs.Length}, "
+            + $"staleCacheHints={stageStaleCacheEvidence.Length}.");
+        output.WriteLine(
+            "  Live silos: "
+            + string.Join(", ", cluster.Silos.Select(static silo => $"{silo.Name}={silo.SiloAddress}")));
+        foreach (var entry in stageStaleCacheEvidence.Take(20))
+        {
+            output.WriteLine($"  STALE CACHE HINT {entry}");
+        }
+
+        foreach (var entry in stageLogs.Take(20))
+        {
+            output.WriteLine($"  {entry}");
+        }
+    }
+
+    private async Task DumpInPlaceFailureDiagnosticsAsync(
+        InProcessTestCluster cluster,
+        RollingUpgradePhase phase,
+        ConcurrentDictionary<string, byte> upgradedSiloNames,
+        HashSet<SiloAddress> retiredAddresses,
+        List<long> trackedGrainKeys,
+        SustainedRollingUpgradeTraffic? traffic,
+        PhaseAwareLogCapture logs,
+        StaleCacheEvidenceCapture staleCacheEvidence)
+    {
+        output.WriteLine($"ROLLING UPGRADE FAILURE in phase '{phase.Current}'.");
+        output.WriteLine($"Upgraded stable silo names: [{string.Join(", ", upgradedSiloNames.Keys.Order())}]");
+        output.WriteLine($"Retired silo addresses: [{string.Join(", ", retiredAddresses)}]");
+        output.WriteLine(
+            "Live silo handles: "
+            + string.Join(", ", cluster.Silos.Select(static silo => $"{silo.Name}={silo.SiloAddress} active={silo.IsActive}")));
+
+        if (traffic is not null)
+        {
+            output.WriteLine(
+                $"Traffic: successes={traffic.SuccessfulCalls}, failures={traffic.Failures.Length}, "
+                + $"retriedTransientCalls={traffic.TransientFailures.Length}, "
+                + $"maxObservedLiveSilos={traffic.MaximumObservedSiloCount}.");
+            foreach (var failure in traffic.Failures.Take(50))
+            {
+                output.WriteLine(
+                    $"  CALLER FAILURE phase='{failure.Phase}' worker={failure.Worker} "
+                    + $"grain={failure.GrainKey}: {failure.Exception}");
+            }
+
+            foreach (var failure in traffic.TransientFailures.TakeLast(50))
+            {
+                output.WriteLine(
+                    $"  RETRIED TRANSIENT CALL phase='{failure.Phase}' worker={failure.Worker} "
+                    + $"grain={failure.GrainKey}: {failure.Exception}");
+            }
+        }
+
+        foreach (var entry in logs.ToArray().TakeLast(200))
+        {
+            output.WriteLine($"  CAPTURED LOG {entry}");
+        }
+
+        foreach (var entry in staleCacheEvidence.ToArray().TakeLast(200))
+        {
+            output.WriteLine($"  STALE CACHE HINT {entry}");
+        }
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        foreach (var grainKey in trackedGrainKeys.Take(6))
+        {
+            var grainId = cluster.Client.GetGrain<IRollingUpgradeIdentityGrain>(grainKey).GetGrainId();
+            output.WriteLine($"DETAILED GRAIN REPORTS for grain {grainKey} ({grainId}):");
+            foreach (var silo in cluster.Silos)
+            {
+                try
+                {
+                    var siloControl = cluster.InternalClient.GetSystemTarget<ISiloControl>(
+                        Constants.SiloControlType,
+                        silo.SiloAddress);
+                    var report = await siloControl.GetDetailedGrainReport(grainId).WaitAsync(cancellation.Token);
+                    output.WriteLine(report.ToString());
+                }
+                catch (Exception exception)
+                {
+                    output.WriteLine(
+                        $"  Failed to get report from {silo.Name} ({silo.SiloAddress}): "
+                        + $"{exception.GetType().Name}: {exception.Message}");
+                }
+            }
+        }
+    }
+
+    private sealed class RollingUpgradePhase(string initialPhase, ITestOutputHelper testOutput)
+    {
+        private string _current = initialPhase;
+
+        public string Current => Volatile.Read(ref _current);
+
+        public void Set(string value)
+        {
+            Volatile.Write(ref _current, value);
+            testOutput.WriteLine($"BEGIN PHASE '{value}'");
+        }
+    }
+
+    private sealed class SustainedRollingUpgradeTraffic(
+        IGrainFactory client,
+        InProcessTestCluster cluster,
+        RollingUpgradePhase phase,
+        long[] hotGrainKeys,
+        int expectedMaximumSilos,
+        TimeSpan callTimeout)
+    {
+        private readonly CancellationTokenSource _shutdown = new();
+        private readonly ConcurrentDictionary<string, long> _phaseSuccesses = new(StringComparer.Ordinal);
+        private readonly ConcurrentQueue<RollingUpgradeTrafficFailure> _failures = new();
+        private readonly ConcurrentQueue<RollingUpgradeTrafficFailure> _transientFailures = new();
+        private readonly ConcurrentQueue<RollingUpgradeTrafficObservation> _observations = new();
+        private TaskCompletionSource<bool> _progressSignal = CreateProgressSignal();
+        private Task _runTask = Task.CompletedTask;
+        private long[] _workerSuccesses = [];
+        private long _successfulCalls;
+        private long _nextFreshGrainKey = 1_000_000;
+        private int _maximumObservedSiloCount;
+        private int _observationCount;
+        private int _stopScheduling;
+
+        public long SuccessfulCalls => Interlocked.Read(ref _successfulCalls);
+
+        public int MaximumObservedSiloCount => Volatile.Read(ref _maximumObservedSiloCount);
+
+        public RollingUpgradeTrafficFailure[] Failures => _failures.ToArray();
+
+        public RollingUpgradeTrafficFailure[] TransientFailures => _transientFailures.ToArray();
+
+        public void Start(int workerCount)
+        {
+            Assert.True(_runTask.IsCompleted);
+            Assert.True(workerCount > 0);
+            _workerSuccesses = new long[workerCount];
+            ObserveSiloCount();
+            _runTask = Task.WhenAll(Enumerable.Range(0, workerCount).Select(worker => RunWorkerAsync(worker, _shutdown.Token)));
+        }
+
+        public long[] GetWorkerProgress()
+        {
+            var result = new long[_workerSuccesses.Length];
+            for (var i = 0; i < result.Length; i++)
+            {
+                result[i] = Interlocked.Read(ref _workerSuccesses[i]);
+            }
+
+            return result;
+        }
+
+        public string FormatWorkerProgress(long[] baseline)
+        {
+            var current = GetWorkerProgress();
+            Assert.Equal(baseline.Length, current.Length);
+            return "worker progress=["
+                + string.Join(", ", current.Select((value, worker) => $"{worker}:{baseline[worker]}->{value}"))
+                + "]";
+        }
+
+        public RollingUpgradeTrafficObservation[] GetObservations(string targetPhase) =>
+            _observations
+                .ToArray()
+                .Where(observation => string.Equals(observation.Phase, targetPhase, StringComparison.Ordinal))
+                .ToArray();
+
+        public async Task WaitForPhaseSuccessesAsync(string targetPhase, long minimumSuccesses, TimeSpan timeout)
+        {
+            using var cancellation = new CancellationTokenSource(timeout);
+            try
+            {
+                while (GetPhaseSuccesses(targetPhase) < minimumSuccesses)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(20), cancellation.Token);
+                }
+            }
+            catch (OperationCanceledException exception) when (cancellation.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"Traffic made {GetPhaseSuccesses(targetPhase)}/{minimumSuccesses} successful calls "
+                    + $"during phase '{targetPhase}' after {timeout}.",
+                    exception);
+            }
+        }
+
+        public async Task WaitForAllWorkersProgressAsync(long[] baseline, string stage, TimeSpan timeout)
+        {
+            Assert.Equal(_workerSuccesses.Length, baseline.Length);
+            using var cancellation = new CancellationTokenSource(timeout);
+            try
+            {
+                while (true)
+                {
+                    var progressSignal = Volatile.Read(ref _progressSignal);
+                    var current = GetWorkerProgress();
+                    if (current.Select((value, worker) => value > baseline[worker]).All(static value => value))
+                    {
+                        return;
+                    }
+
+                    await progressSignal.Task.WaitAsync(cancellation.Token);
+                }
+            }
+            catch (OperationCanceledException exception) when (cancellation.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"Not every traffic worker made progress during {stage} after {timeout}: "
+                    + FormatWorkerProgress(baseline)
+                    + $", caller failures={Failures.Length}.",
+                    exception);
+            }
+        }
+
+        public async Task WaitForTotalProgressAsync(long target, CancellationToken cancellationToken)
+        {
+            while (SuccessfulCalls < target)
+            {
+                var progressSignal = Volatile.Read(ref _progressSignal);
+                if (SuccessfulCalls >= target)
+                {
+                    return;
+                }
+
+                await progressSignal.Task.WaitAsync(cancellationToken);
+            }
+        }
+
+        public async Task StopSchedulingAndDrainAsync(TimeSpan timeout)
+        {
+            Volatile.Write(ref _stopScheduling, 1);
+            try
+            {
+                await _runTask.WaitAsync(timeout);
+            }
+            catch (TimeoutException exception)
+            {
+                throw new TimeoutException(
+                    $"Timed out after {timeout} while draining in-flight traffic calls: "
+                    + FormatWorkerProgress(new long[_workerSuccesses.Length])
+                    + $", caller failures={Failures.Length}.",
+                    exception);
+            }
+        }
+
+        public async Task CancelAsync(TimeSpan timeout)
+        {
+            Volatile.Write(ref _stopScheduling, 1);
+            _shutdown.Cancel();
+            await _runTask.WaitAsync(timeout);
+            _shutdown.Dispose();
+        }
+
+        private long GetPhaseSuccesses(string targetPhase) =>
+            _phaseSuccesses.TryGetValue(targetPhase, out var value) ? value : 0;
+
+        private async Task RunWorkerAsync(int worker, CancellationToken cancellationToken)
+        {
+            var iteration = 0;
+            while (!cancellationToken.IsCancellationRequested && Volatile.Read(ref _stopScheduling) == 0)
+            {
+                ObserveSiloCount();
+                var hotKey = hotGrainKeys[(worker + iteration) % hotGrainKeys.Length];
+                await CallOnceAsync(worker, hotKey, cancellationToken);
+                if (iteration % 5 == 0
+                    && !cancellationToken.IsCancellationRequested
+                    && Volatile.Read(ref _stopScheduling) == 0)
+                {
+                    await CallOnceAsync(worker, Interlocked.Increment(ref _nextFreshGrainKey), cancellationToken);
+                }
+
+                iteration++;
+                if (Volatile.Read(ref _stopScheduling) != 0)
+                {
+                    return;
+                }
+
+                try
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(25), cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+            }
+        }
+
+        private async Task CallOnceAsync(int worker, long grainKey, CancellationToken cancellationToken)
+        {
+            var callPhase = phase.Current;
+            try
+            {
+                var grain = client.GetGrain<IRollingUpgradeIdentityGrain>(grainKey);
+                var observation = await ObserveWithRetryAsync(grain, callPhase, worker, grainKey, cancellationToken);
+                if (!grain.GetGrainId().Equals(observation.Address.GrainId)
+                    || observation.Address.SiloAddress is null
+                    || observation.Address.ActivationId.IsDefault
+                    || observation.CallCount <= 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Grain {grainKey} returned an invalid activation observation '{observation}'.");
+                }
+
+                _phaseSuccesses.AddOrUpdate(callPhase, 1, static (_, current) => current + 1);
+                _observations.Enqueue(new(callPhase, worker, grainKey, observation, DateTimeOffset.UtcNow));
+                if (Interlocked.Increment(ref _observationCount) > 4_096
+                    && _observations.TryDequeue(out _))
+                {
+                    Interlocked.Decrement(ref _observationCount);
+                }
+
+                Interlocked.Increment(ref _workerSuccesses[worker]);
+                Interlocked.Increment(ref _successfulCalls);
+                SignalProgress();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (Exception exception)
+            {
+                _failures.Enqueue(new(callPhase, worker, grainKey, exception, DateTimeOffset.UtcNow));
+            }
+        }
+
+        private async Task<RollingUpgradeGrainObservation> ObserveWithRetryAsync(
+            IRollingUpgradeIdentityGrain grain,
+            string callPhase,
+            int worker,
+            long grainKey,
+            CancellationToken cancellationToken)
+        {
+            const int MaxAttempts = 2;
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    return await grain.Observe().AsTask().WaitAsync(callTimeout, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception exception) when (attempt < MaxAttempts && IsTransientUpgradeFailure(exception))
+                {
+                    _transientFailures.Enqueue(new(callPhase, worker, grainKey, exception, DateTimeOffset.UtcNow));
+                    await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+                }
+            }
+        }
+
+        private static bool IsTransientUpgradeFailure(Exception exception) =>
+            exception.GetBaseException() is TimeoutException
+                or SiloUnavailableException
+                or OrleansMessageRejectionException;
+
+        private void SignalProgress()
+        {
+            var nextSignal = CreateProgressSignal();
+            Interlocked.Exchange(ref _progressSignal, nextSignal).TrySetResult(true);
+        }
+
+        private static TaskCompletionSource<bool> CreateProgressSignal() =>
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private void ObserveSiloCount()
+        {
+            var count = cluster.Silos.Count;
+            var currentMaximum = Volatile.Read(ref _maximumObservedSiloCount);
+            while (count > currentMaximum)
+            {
+                var observed = Interlocked.CompareExchange(ref _maximumObservedSiloCount, count, currentMaximum);
+                if (observed == currentMaximum)
+                {
+                    break;
+                }
+
+                currentMaximum = observed;
+            }
+
+            if (count > expectedMaximumSilos)
+            {
+                _failures.Enqueue(
+                    new(
+                        phase.Current,
+                        null,
+                        null,
+                        new InvalidOperationException(
+                            $"Observed {count} live silo handles; the maximum is {expectedMaximumSilos}."),
+                        DateTimeOffset.UtcNow));
+            }
+        }
+    }
+
+    private sealed record RollingUpgradeTrafficObservation(
+        string Phase,
+        int Worker,
+        long GrainKey,
+        RollingUpgradeGrainObservation Observation,
+        DateTimeOffset CompletedAt);
+
+    private sealed record RollingUpgradeTrafficFailure(
+        string Phase,
+        int? Worker,
+        long? GrainKey,
+        Exception Exception,
+        DateTimeOffset Timestamp);
+
+    private sealed class StaleCacheEvidenceCapture
+    {
+        private readonly ConcurrentQueue<StaleCacheEvidence> _entries = new();
+
+        public void Add(
+            string phase,
+            InProcessSiloHandle resolvingSilo,
+            long grainKey,
+            GrainAddress cachedAddress,
+            GrainAddress observedAddress,
+            HashSet<SiloAddress> retiredAddresses)
+        {
+            _entries.Enqueue(
+                new(
+                    DateTimeOffset.UtcNow,
+                    phase,
+                    resolvingSilo.Name,
+                    resolvingSilo.SiloAddress,
+                    grainKey,
+                    cachedAddress,
+                    observedAddress,
+                    cachedAddress.SiloAddress is { } cachedSilo && retiredAddresses.Contains(cachedSilo)));
+        }
+
+        public StaleCacheEvidence[] ToArray() => _entries.ToArray();
+    }
+
+    private sealed record StaleCacheEvidence(
+        DateTimeOffset Timestamp,
+        string Phase,
+        string ResolvingSiloName,
+        SiloAddress ResolvingSiloAddress,
+        long GrainKey,
+        GrainAddress CachedAddress,
+        GrainAddress ObservedAddress,
+        bool ReferencedRetiredSilo)
+    {
+        public override string ToString() =>
+            $"{Timestamp:O} phase='{Phase}' resolvingSilo='{ResolvingSiloName}' ({ResolvingSiloAddress}) "
+            + $"grain={GrainKey} retired={ReferencedRetiredSilo} cached='{CachedAddress.ToFullString()}' "
+            + $"observed='{ObservedAddress.ToFullString()}'";
+    }
+
+    private sealed class PhaseAwareLoggerProvider(string siloName, PhaseAwareLogCapture capture) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new PhaseAwareLogger(siloName, categoryName, capture);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class PhaseAwareLogger(
+            string siloName,
+            string category,
+            PhaseAwareLogCapture capture) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) =>
+                logLevel >= LogLevel.Error
+                || (logLevel >= LogLevel.Information
+                    && (string.Equals(category, typeof(DistributedRemoteGrainDirectory).FullName, StringComparison.Ordinal)
+                        || string.Equals(category, typeof(GrainDirectoryHandoffManager).FullName, StringComparison.Ordinal)))
+                || (logLevel >= LogLevel.Warning
+                    && string.Equals(category, "Orleans.Messaging", StringComparison.Ordinal));
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (IsEnabled(logLevel))
+                {
+                    capture.Add(siloName, category, logLevel, eventId, formatter(state, exception), exception);
+                }
+            }
+        }
+    }
+
+    private sealed class PhaseAwareLogCapture(RollingUpgradePhase phase)
+    {
+        private readonly ConcurrentQueue<PhaseAwareLogEntry> _entries = new();
+
+        public void Add(
+            string siloName,
+            string category,
+            LogLevel level,
+            EventId eventId,
+            string message,
+            Exception? exception)
+        {
+            var baseException = exception?.GetBaseException();
+            _entries.Enqueue(
+                new(
+                    DateTimeOffset.UtcNow,
+                    phase.Current,
+                    siloName,
+                    category,
+                    level,
+                    eventId,
+                    message,
+                    baseException?.GetType().FullName,
+                    baseException?.Message));
+        }
+
+        public PhaseAwareLogEntry[] ToArray() => _entries.ToArray();
+    }
+
+    private sealed record PhaseAwareLogEntry(
+        DateTimeOffset Timestamp,
+        string Phase,
+        string SiloName,
+        string Category,
+        LogLevel Level,
+        EventId EventId,
+        string Message,
+        string? ExceptionType,
+        string? ExceptionMessage)
+    {
+        public override string ToString() =>
+            $"{Timestamp:O} phase='{Phase}' silo='{SiloName}' [{Level}] [{Category}] ({EventId.Id}:{EventId.Name}) "
+            + $"{Message}"
+            + (ExceptionType is null ? string.Empty : $" | {ExceptionType}: {ExceptionMessage}");
+    }
+}
+
+internal interface IRollingUpgradeIdentityGrain : IGrainWithIntegerKey
+{
+    ValueTask<RollingUpgradeGrainObservation> Observe();
+}
+
+[GenerateSerializer, Immutable]
+internal sealed record RollingUpgradeGrainObservation(
+    [property: Id(0)] GrainAddress Address,
+    [property: Id(1)] long CallCount);
+
+internal sealed class RollingUpgradeIdentityGrain : Grain, IRollingUpgradeIdentityGrain
+{
+    private long _callCount;
+
+    public ValueTask<RollingUpgradeGrainObservation> Observe() =>
+        new(new RollingUpgradeGrainObservation(GrainContext.Address, ++_callCount));
+}
+
+internal sealed class TrackingGrainDirectoryCache : IGrainDirectoryCache
+{
+    private readonly IGrainDirectoryCache _inner = new LruGrainDirectoryCache(
+        maxCacheSize: 1_000_000,
+        maxCacheTTL: TimeSpan.FromMinutes(10),
+        timeProvider: TimeProvider.System);
+    private int _clearCount;
+
+    public int ClearCount => Volatile.Read(ref _clearCount);
+
+    public IEnumerable<(GrainAddress ActivationAddress, int Version)> KeyValues => _inner.KeyValues;
+
+    public void AddOrUpdate(GrainAddress value, int version) => _inner.AddOrUpdate(value, version);
+
+    public bool Remove(GrainId key) => _inner.Remove(key);
+
+    public bool Remove(GrainAddress key) => _inner.Remove(key);
+
+    public void Clear()
+    {
+        Interlocked.Increment(ref _clearCount);
+        _inner.Clear();
+    }
+
+    public bool LookUp(GrainId key, out GrainAddress result, out int version) =>
+        _inner.LookUp(key, out result, out version);
 }

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -1318,6 +1318,13 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             return true;
         }
 
+        if (string.Equals(entry.Category, typeof(GrainCallCancellationManager).FullName, StringComparison.Ordinal)
+            && entry.Message.StartsWith("Error while cancelling", StringComparison.Ordinal)
+            && string.Equals(entry.ExceptionType, typeof(SiloUnavailableException).FullName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
         if (!string.Equals(entry.Category, "Orleans.Messaging", StringComparison.Ordinal)
             || !entry.Message.StartsWith("Failed to address message", StringComparison.Ordinal))
         {


### PR DESCRIPTION
Live clusters need to migrate from `LocalGrainDirectory` to `DistributedGrainDirectory` without directory stalls, stale routing, or disruptive cache resets during a rolling deployment.

This change adds a realistic three-silo rolling-upgrade suite which keeps sustained hot and fresh grain traffic running while silos are restarted one at a time. It captures phase-aware membership, directory handoff, activation, cache, caller, and error diagnostics, and verifies mixed-mode convergence, unique activations, targeted invalidation, and the absence of whole-cache clears.

The runtime changes:
- reject requests arriving at a stopping silo with targeted cache invalidation while allowing already-produced responses to complete
- bound recovery calls to departing members using one shared shutdown-linked cancellation token per silo
- publish member-token snapshots from the existing membership loop so the invocation hot path avoids per-call cancellation sources, membership observers, and `Task.WhenAny`
- preserve `ShuttingDown` as callable and cancel member operations only at `Stopping`, `Dead`, or removal

A bounded retry is used only for the unavoidable in-flight disruption when the client's gateway itself restarts. Persistent failures and all post-convergence failures remain test failures.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10309)