### PR TITLE
docs: require conventional commit format for PR titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - Push feature branches to your personal fork, which is configured as `origin`.
 - Create PRs using `dotnet/orleans` as the base repository and `origin`/personal fork branches as the head.
 - Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages from now on.
-- PR titles must also follow Conventional Commits naming conventions because squash-and-rebase merges use the PR title as the resulting commit message.
+- PR titles must also follow Conventional Commits naming conventions because squash merges use the PR title as the resulting commit message.
 - When creating PRs, keep the PR description simple: explain the problem it addresses and the solution it implements, including the rationale where helpful. Do not include a section describing what commands to run to test the PR.
 
 Example:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Push feature branches to your personal fork, which is configured as `origin`.
 - Create PRs using `dotnet/orleans` as the base repository and `origin`/personal fork branches as the head.
 - Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages from now on.
+- PR titles must also follow Conventional Commits naming conventions because squash-and-rebase merges use the PR title as the resulting commit message.
 - When creating PRs, keep the PR description simple: explain the problem it addresses and the solution it implements, including the rationale where helpful. Do not include a section describing what commands to run to test the PR.
 
 Example:


### PR DESCRIPTION
PR titles become the final commit messages when changes are squash-and-rebase merged, so they need to follow Conventional Commits naming conventions. This updates the repository workflow guidance to state that requirement and explain why it applies.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10310)