### PR TITLE
fix: eliminate rebalancer waiter timeout race

### DIFF
--- a/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
+++ b/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
@@ -112,7 +112,7 @@ public class DiagnosticInfrastructureRegressionTests
         using var observer = RebalancerDiagnosticObserver.Create();
         var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 12002), 3);
 
-        await Assert.ThrowsAsync<TimeoutException>(() => observer.WaitForSessionStopAsync(TimeSpan.FromMilliseconds(100)));
+        await Assert.ThrowsAsync<TimeoutException>(() => observer.WaitForSessionStopAsync(TimeSpan.Zero));
 
         var waitTask = observer.WaitForSessionStopAsync();
         ActivationRebalancerEvents.EmitSessionStop(siloAddress, "latest", 1);

--- a/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
+++ b/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
@@ -76,8 +76,11 @@ public class DiagnosticInfrastructureRegressionTests
 
         ActivationRebalancerEvents.EmitCycleStop(siloAddress, 1, 1, 0.1, TimeSpan.FromMilliseconds(1), false);
 
-        var waitTask = observer.WaitForCycleAsync(TimeSpan.FromSeconds(1));
+        var waitTask = observer.WaitForCycleAsync();
+        Assert.False(waitTask.IsCompleted);
+
         ActivationRebalancerEvents.EmitCycleStop(siloAddress, 2, 2, 0.2, TimeSpan.FromMilliseconds(1), false);
+        Assert.True(waitTask.IsCompletedSuccessfully);
 
         var result = await waitTask;
         Assert.Equal(2, result.CycleNumber);
@@ -92,12 +95,31 @@ public class DiagnosticInfrastructureRegressionTests
 
         ActivationRebalancerEvents.EmitSessionStop(siloAddress, "existing", 1);
 
-        var waitTask = observer.WaitForSessionStopAsync(TimeSpan.FromSeconds(1));
+        var waitTask = observer.WaitForSessionStopAsync();
+        Assert.False(waitTask.IsCompleted);
+
         ActivationRebalancerEvents.EmitSessionStop(siloAddress, "latest", 2);
+        Assert.True(waitTask.IsCompletedSuccessfully);
 
         var result = await waitTask;
         Assert.Equal("latest", result.Reason);
         Assert.Equal(2, result.TotalCycles);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task RebalancerDiagnosticObserver_WaitAfterTimeout_CanObserveLaterEvent()
+    {
+        using var observer = RebalancerDiagnosticObserver.Create();
+        var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 12002), 3);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => observer.WaitForSessionStopAsync(TimeSpan.FromMilliseconds(100)));
+
+        var waitTask = observer.WaitForSessionStopAsync();
+        ActivationRebalancerEvents.EmitSessionStop(siloAddress, "latest", 1);
+        Assert.True(waitTask.IsCompletedSuccessfully);
+
+        var result = await waitTask;
+        Assert.Equal("latest", result.Reason);
     }
 
     [Fact, TestCategory("BVT")]

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/RebalancerDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/RebalancerDiagnosticObserver.cs
@@ -20,7 +20,7 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     private readonly ConcurrentQueue<ActivationRebalancerEvents.SessionStart> _sessionStartEvents = new();
     private readonly ConcurrentQueue<ActivationRebalancerEvents.SessionStop> _sessionStopEvents = new();
     private readonly object _waitersLock = new();
-    private readonly List<IWaiter> _waiters = [];
+    private readonly List<Waiter> _waiters = [];
     private IDisposable? _subscription;
 
     /// <summary>
@@ -236,7 +236,8 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
 
             var waiter = new ConditionWaiter(predicate);
             _waiters.Add(waiter);
-            return WaitWithTimeoutAsync(waiter, timeout, timeoutMessage);
+            waiter.StartTimeout(timeout, () => TimeoutWaiter(waiter, timeoutMessage));
+            return waiter.Task;
         }
     }
 
@@ -250,55 +251,35 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
         {
             var waiter = new EventWaiter<TEvent>(predicate);
             _waiters.Add(waiter);
-            return WaitWithTimeoutAsync(waiter, timeout, timeoutMessage);
+            waiter.StartTimeout(timeout, () => TimeoutWaiter(waiter, timeoutMessage));
+            return waiter.Task;
         }
     }
 
-    private async Task WaitWithTimeoutAsync(ConditionWaiter waiter, TimeSpan timeout, Func<string> timeoutMessage)
-    {
-        try
-        {
-            await waiter.Task.WaitAsync(timeout);
-        }
-        catch (TimeoutException)
-        {
-            RemoveWaiter(waiter);
-            throw new TimeoutException(timeoutMessage());
-        }
-    }
-
-    private async Task<TEvent> WaitWithTimeoutAsync<TEvent>(
-        EventWaiter<TEvent> waiter,
-        TimeSpan timeout,
-        Func<string> timeoutMessage)
-        where TEvent : ActivationRebalancerEvents.RebalancerEvent
-    {
-        try
-        {
-            return await waiter.Task.WaitAsync(timeout);
-        }
-        catch (TimeoutException)
-        {
-            RemoveWaiter(waiter);
-            throw new TimeoutException(timeoutMessage());
-        }
-    }
-
-    private void RemoveWaiter(IWaiter waiter)
+    private void TimeoutWaiter(Waiter waiter, Func<string> timeoutMessage)
     {
         lock (_waitersLock)
         {
-            _waiters.Remove(waiter);
+            if (!_waiters.Remove(waiter))
+            {
+                return;
+            }
+
+            waiter.TrySetException(new TimeoutException(timeoutMessage()));
         }
+
+        waiter.StopTimeout();
     }
 
     private void SignalWaiters(ActivationRebalancerEvents.RebalancerEvent value)
     {
         for (var i = _waiters.Count - 1; i >= 0; i--)
         {
-            if (_waiters[i].TryComplete(value))
+            var waiter = _waiters[i];
+            if (waiter.TryComplete(value))
             {
                 _waiters.RemoveAt(i);
+                waiter.StopTimeout();
             }
         }
     }
@@ -340,18 +321,36 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
         _subscription?.Dispose();
     }
 
-    private interface IWaiter
+    private abstract class Waiter
     {
-        bool TryComplete(ActivationRebalancerEvents.RebalancerEvent value);
+        private System.Threading.Timer? _timeoutTimer;
+
+        public abstract bool TryComplete(ActivationRebalancerEvents.RebalancerEvent value);
+
+        public abstract bool TrySetException(Exception exception);
+
+        public void StartTimeout(TimeSpan timeout, Action callback)
+        {
+            _timeoutTimer = new System.Threading.Timer(
+                static state => ((Action)state!).Invoke(),
+                callback,
+                timeout,
+                System.Threading.Timeout.InfiniteTimeSpan);
+        }
+
+        public void StopTimeout()
+        {
+            Interlocked.Exchange(ref _timeoutTimer, null)?.Dispose();
+        }
     }
 
-    private sealed class ConditionWaiter(Func<bool> predicate) : IWaiter
+    private sealed class ConditionWaiter(Func<bool> predicate) : Waiter
     {
         private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public Task Task => _completion.Task;
 
-        public bool TryComplete(ActivationRebalancerEvents.RebalancerEvent value)
+        public override bool TryComplete(ActivationRebalancerEvents.RebalancerEvent value)
         {
             if (!predicate())
             {
@@ -360,16 +359,18 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
 
             return _completion.TrySetResult();
         }
+
+        public override bool TrySetException(Exception exception) => _completion.TrySetException(exception);
     }
 
-    private sealed class EventWaiter<TEvent>(Func<TEvent, bool> predicate) : IWaiter
+    private sealed class EventWaiter<TEvent>(Func<TEvent, bool> predicate) : Waiter
         where TEvent : ActivationRebalancerEvents.RebalancerEvent
     {
         private readonly TaskCompletionSource<TEvent> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public Task<TEvent> Task => _completion.Task;
 
-        public bool TryComplete(ActivationRebalancerEvents.RebalancerEvent value)
+        public override bool TryComplete(ActivationRebalancerEvents.RebalancerEvent value)
         {
             if (value is not TEvent evt || !predicate(evt))
             {
@@ -378,5 +379,7 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
 
             return _completion.TrySetResult(evt);
         }
+
+        public override bool TrySetException(Exception exception) => _completion.TrySetException(exception);
     }
 }

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/RebalancerDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/RebalancerDiagnosticObserver.cs
@@ -331,11 +331,13 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
 
         public void StartTimeout(TimeSpan timeout, Action callback)
         {
-            _timeoutTimer = new System.Threading.Timer(
+            var timer = new System.Threading.Timer(
                 static state => ((Action)state!).Invoke(),
                 callback,
-                timeout,
+                System.Threading.Timeout.InfiniteTimeSpan,
                 System.Threading.Timeout.InfiniteTimeSpan);
+            Interlocked.Exchange(ref _timeoutTimer, timer)?.Dispose();
+            timer.Change(timeout, System.Threading.Timeout.InfiniteTimeSpan);
         }
 
         public void StopTimeout()


### PR DESCRIPTION
The rebalancer diagnostic regression test could time out under macOS CI load even though the awaited event was emitted synchronously. The observer completed an inner task, but returned an async `WaitAsync` wrapper whose continuation could lose to the timeout timer when the thread pool was delayed.

Complete event waiters directly while holding the observer's waiter lock, and serialize timeout removal through that same lock. This makes event delivery and timeout completion atomic without increasing timeout values. The regression coverage now verifies that prior events do not satisfy new waiters, new emissions complete waiters synchronously, and a timed-out waiter does not interfere with subsequent events.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10311)