### PR TITLE
fix: clean up rebalancer diagnostic waiters

### DIFF
--- a/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
+++ b/test/Orleans.Core.Tests/Diagnostics/DiagnosticInfrastructureRegressionTests.cs
@@ -112,7 +112,13 @@ public class DiagnosticInfrastructureRegressionTests
         using var observer = RebalancerDiagnosticObserver.Create();
         var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 12002), 3);
 
-        await Assert.ThrowsAsync<TimeoutException>(() => observer.WaitForSessionStopAsync(TimeSpan.Zero));
+        var timedOutWaitTask = observer.WaitForSessionStopAsync(TimeSpan.Zero);
+        Assert.True(timedOutWaitTask.IsCompleted);
+        await Assert.ThrowsAsync<TimeoutException>(() => timedOutWaitTask);
+
+        var timedOutCountWaitTask = observer.WaitForSessionStopCountAsync(1, TimeSpan.Zero);
+        Assert.True(timedOutCountWaitTask.IsCompleted);
+        await Assert.ThrowsAsync<TimeoutException>(() => timedOutCountWaitTask);
 
         var waitTask = observer.WaitForSessionStopAsync();
         ActivationRebalancerEvents.EmitSessionStop(siloAddress, "latest", 1);
@@ -120,6 +126,18 @@ public class DiagnosticInfrastructureRegressionTests
 
         var result = await waitTask;
         Assert.Equal("latest", result.Reason);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task RebalancerDiagnosticObserver_Dispose_CompletesOutstandingWaiters()
+    {
+        var observer = RebalancerDiagnosticObserver.Create();
+        var waitTask = observer.WaitForSessionStopAsync();
+
+        observer.Dispose();
+
+        Assert.True(waitTask.IsCompleted);
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => waitTask);
     }
 
     [Fact, TestCategory("BVT")]

--- a/test/TestInfrastructure/TestExtensions/Diagnostics/RebalancerDiagnosticObserver.cs
+++ b/test/TestInfrastructure/TestExtensions/Diagnostics/RebalancerDiagnosticObserver.cs
@@ -21,6 +21,7 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     private readonly object _waitersLock = new();
     private readonly List<Waiter> _waiters = [];
     private IDisposable? _subscription;
+    private bool _disposed;
 
     /// <summary>
     /// Gets all captured cycle start events.
@@ -228,14 +229,21 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     {
         lock (_waitersLock)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
             if (predicate())
             {
                 return Task.CompletedTask;
             }
 
+            if (timeout == TimeSpan.Zero)
+            {
+                return Task.FromException(new TimeoutException(timeoutMessage()));
+            }
+
             var waiter = new ConditionWaiter(predicate);
-            _waiters.Add(waiter);
             waiter.StartTimeout(timeout, () => TimeoutWaiter(waiter, timeoutMessage));
+            _waiters.Add(waiter);
             return waiter.Task;
         }
     }
@@ -248,9 +256,16 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
     {
         lock (_waitersLock)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (timeout == TimeSpan.Zero)
+            {
+                return Task.FromException<TEvent>(new TimeoutException(timeoutMessage()));
+            }
+
             var waiter = new EventWaiter<TEvent>(predicate);
-            _waiters.Add(waiter);
             waiter.StartTimeout(timeout, () => TimeoutWaiter(waiter, timeoutMessage));
+            _waiters.Add(waiter);
             return waiter.Task;
         }
     }
@@ -317,7 +332,24 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
 
     public void Dispose()
     {
-        _subscription?.Dispose();
+        Interlocked.Exchange(ref _subscription, null)?.Dispose();
+
+        lock (_waitersLock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            foreach (var waiter in _waiters)
+            {
+                waiter.TrySetException(new ObjectDisposedException(nameof(RebalancerDiagnosticObserver)));
+                waiter.StopTimeout();
+            }
+
+            _waiters.Clear();
+        }
     }
 
     private abstract class Waiter
@@ -330,13 +362,26 @@ public sealed class RebalancerDiagnosticObserver : IDisposable, IObserver<Activa
 
         public void StartTimeout(TimeSpan timeout, Action callback)
         {
-            var timer = new System.Threading.Timer(
+            if (timeout == System.Threading.Timeout.InfiniteTimeSpan)
+            {
+                return;
+            }
+
+            _timeoutTimer = new System.Threading.Timer(
                 static state => ((Action)state!).Invoke(),
                 callback,
                 System.Threading.Timeout.InfiniteTimeSpan,
                 System.Threading.Timeout.InfiniteTimeSpan);
-            Interlocked.Exchange(ref _timeoutTimer, timer)?.Dispose();
-            timer.Change(timeout, System.Threading.Timeout.InfiniteTimeSpan);
+
+            try
+            {
+                _timeoutTimer.Change(timeout, System.Threading.Timeout.InfiniteTimeSpan);
+            }
+            catch
+            {
+                StopTimeout();
+                throw;
+            }
         }
 
         public void StopTimeout()


### PR DESCRIPTION
Follow-up to #10311 addressing valid post-merge review findings in the rebalancer diagnostic test observer.

Zero-duration waits now fault synchronously instead of depending on a thread-pool timer callback. Disposing an observer faults outstanding waiters and stops their timers so callbacks cannot outlive the observer. Timer ownership is kept directly on each waiter, with cleanup if scheduling fails.

The existing 30/60-second default waits remain unchanged and continue to rely on the test runner timeout for hangs.