### PR TITLE
perf: cache compatible placement silos

### DIFF
--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -149,7 +149,14 @@ namespace Orleans.Runtime.Placement
 
             if (_manifestUpdatesTask is Task manifestUpdatesTask)
             {
-                await manifestUpdatesTask.WaitAsync(cancellationToken).SuppressThrowing();
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    await manifestUpdatesTask.SuppressThrowing();
+                }
+                else
+                {
+                    await manifestUpdatesTask.WaitAsync(cancellationToken).SuppressThrowing();
+                }
             }
 
             _siloStatusOracle.UnSubscribeFromSiloStatusEvents(this);
@@ -247,9 +254,30 @@ namespace Orleans.Runtime.Placement
 
         private SiloAddress[] GetUnfilteredCompatibleSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort interfaceVersion)
         {
-            var generation = Volatile.Read(ref _placementCacheGeneration);
-            var key = new CompatibleSilosCacheKey(grainType, interfaceType, interfaceVersion, generation);
-            return _compatibleSilosCache.GetOrAdd(key, key => ComputeUnfilteredCompatibleSilos(key.GrainType, key.InterfaceType, key.InterfaceVersion));
+            if (interfaceVersion == 0)
+            {
+                interfaceType = default;
+            }
+
+            while (true)
+            {
+                var generation = Volatile.Read(ref _placementCacheGeneration);
+                var key = new CompatibleSilosCacheKey(grainType, interfaceType, interfaceVersion, generation);
+                var result = _compatibleSilosCache.GetOrAdd(
+                    key,
+                    static (key, placementService) => placementService.ComputeUnfilteredCompatibleSilos(
+                        key.GrainType,
+                        key.InterfaceType,
+                        key.InterfaceVersion),
+                    this);
+
+                if (generation == Volatile.Read(ref _placementCacheGeneration))
+                {
+                    return result;
+                }
+
+                _compatibleSilosCache.TryRemove(key, out _);
+            }
         }
 
         private SiloAddress[] ComputeUnfilteredCompatibleSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort interfaceVersion)

--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -21,7 +22,7 @@ namespace Orleans.Runtime.Placement
     /// <summary>
     /// Central point for placement decisions.
     /// </summary>
-    internal partial class PlacementService : IPlacementContext, ILifecycleParticipant<ISiloLifecycle>, PlacementService.ITestAccessor
+    internal partial class PlacementService : IPlacementContext, ISiloStatusListener, ILifecycleParticipant<ISiloLifecycle>, PlacementService.ITestAccessor
     {
         private const int PlacementWorkerCount = 16;
         private readonly PlacementStrategyResolver _strategyResolver;
@@ -31,11 +32,15 @@ namespace Orleans.Runtime.Placement
         private readonly GrainVersionManifest _grainInterfaceVersions;
         private readonly CachedVersionSelectorManager _versionSelectorManager;
         private readonly ISiloStatusOracle _siloStatusOracle;
+        private readonly IClusterManifestProvider _clusterManifestProvider;
         private readonly bool _assumeHomogeneousSilosForTesting;
         private readonly PlacementWorker[] _workers;
         private readonly PlacementFilterStrategyResolver _filterStrategyResolver;
         private readonly PlacementFilterDirectorResolver _placementFilterDirectoryResolver;
+        private readonly ConcurrentDictionary<CompatibleSilosCacheKey, SiloAddress[]> _compatibleSilosCache = new();
         private readonly CancellationTokenSource _shutdownCts = new();
+        private long _placementCacheGeneration;
+        private Task? _manifestUpdatesTask;
 
         internal interface ITestAccessor
         {
@@ -55,6 +60,7 @@ namespace Orleans.Runtime.Placement
             GrainLocator grainLocator,
             GrainVersionManifest grainInterfaceVersions,
             CachedVersionSelectorManager versionSelectorManager,
+            IClusterManifestProvider clusterManifestProvider,
             PlacementDirectorResolver directorResolver,
             PlacementStrategyResolver strategyResolver,
             PlacementFilterStrategyResolver filterStrategyResolver,
@@ -70,7 +76,9 @@ namespace Orleans.Runtime.Placement
             _grainInterfaceVersions = grainInterfaceVersions;
             _versionSelectorManager = versionSelectorManager;
             _siloStatusOracle = siloStatusOracle;
+            _clusterManifestProvider = clusterManifestProvider;
             _assumeHomogeneousSilosForTesting = siloMessagingOptions.CurrentValue.AssumeHomogenousSilosForTesting;
+            _siloStatusOracle.SubscribeToSiloStatusEvents(this);
             _workers = new PlacementWorker[PlacementWorkerCount];
             for (var i = 0; i < PlacementWorkerCount; i++)
             {
@@ -102,10 +110,14 @@ namespace Orleans.Runtime.Placement
             lifecycle.Subscribe(
                 nameof(PlacementService),
                 ServiceLifecycleStage.RuntimeInitialize + 1,
-                NoOpStart,
+                StartAsync,
                 StopAsync);
+        }
 
-            static Task NoOpStart(CancellationToken _) => Task.CompletedTask;
+        private Task StartAsync(CancellationToken cancellationToken)
+        {
+            _manifestUpdatesTask = Task.Run(ProcessClusterManifestUpdates);
+            return Task.CompletedTask;
         }
 
         private async Task StopAsync(CancellationToken cancellationToken)
@@ -129,6 +141,13 @@ namespace Orleans.Runtime.Placement
             {
                 await completionTask.WaitAsync(cancellationToken).SuppressThrowing();
             }
+
+            if (_manifestUpdatesTask is Task manifestUpdatesTask)
+            {
+                await manifestUpdatesTask.WaitAsync(cancellationToken).SuppressThrowing();
+            }
+
+            _siloStatusOracle.UnSubscribeFromSiloStatusEvents(this);
         }
 
         /// <summary>
@@ -170,9 +189,7 @@ namespace Orleans.Runtime.Placement
             // with the current silo
             var compatibleSilos = _assumeHomogeneousSilosForTesting
                 ? _siloStatusOracle.GetActiveSilos()
-                : target.InterfaceVersion > 0
-                    ? _versionSelectorManager.GetSuitableSilos(grainType, target.InterfaceType, target.InterfaceVersion).SuitableSilos
-                    : _grainInterfaceVersions.GetSupportedSilos(grainType).Result;
+                : GetUnfilteredCompatibleSilos(grainType, target.InterfaceType, target.InterfaceVersion);
 
             if (!_assumeHomogeneousSilosForTesting)
             {
@@ -222,6 +239,22 @@ namespace Orleans.Runtime.Placement
             return compatibleSilos;
         }
 
+        private SiloAddress[] GetUnfilteredCompatibleSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort interfaceVersion)
+        {
+            var generation = Volatile.Read(ref _placementCacheGeneration);
+            var key = new CompatibleSilosCacheKey(grainType, interfaceType, interfaceVersion, generation);
+            return _compatibleSilosCache.GetOrAdd(key, key => ComputeUnfilteredCompatibleSilos(key.GrainType, key.InterfaceType, key.InterfaceVersion));
+        }
+
+        private SiloAddress[] ComputeUnfilteredCompatibleSilos(GrainType grainType, GrainInterfaceType interfaceType, ushort interfaceVersion)
+        {
+            var silos = interfaceVersion > 0
+                ? _versionSelectorManager.GetSuitableSilos(grainType, interfaceType, interfaceVersion).SuitableSilos
+                : _grainInterfaceVersions.GetSupportedSilos(grainType).Result;
+
+            return silos;
+        }
+
         public IReadOnlyDictionary<ushort, SiloAddress[]> GetCompatibleSilosWithVersions(PlacementTarget target)
         {
             if (target.InterfaceVersion == 0)
@@ -236,6 +269,33 @@ namespace Orleans.Runtime.Placement
                 .SuitableSilosByVersion;
 
             return silos;
+        }
+
+        void ISiloStatusListener.SiloStatusChangeNotification(SiloAddress updatedSilo, SiloStatus status) => InvalidatePlacementCaches();
+
+        private async Task ProcessClusterManifestUpdates()
+        {
+            try
+            {
+                await foreach (var _ in _clusterManifestProvider.Updates.WithCancellation(_shutdownCts.Token))
+                {
+                    InvalidatePlacementCaches();
+                }
+            }
+            catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested)
+            {
+                // Ignore during shutdown.
+            }
+            catch (Exception exception)
+            {
+                LogErrorProcessingClusterManifestUpdates(exception);
+            }
+        }
+
+        private void InvalidatePlacementCaches()
+        {
+            Interlocked.Increment(ref _placementCacheGeneration);
+            _compatibleSilosCache.Clear();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -619,6 +679,12 @@ namespace Orleans.Runtime.Placement
         private partial void LogTraceAddressMessageSelectTarget(Message message);
 
         [LoggerMessage(
+            Level = LogLevel.Error,
+            Message = "Error processing cluster manifest updates."
+        )]
+        private partial void LogErrorProcessingClusterManifestUpdates(Exception exception);
+
+        [LoggerMessage(
             Level = LogLevel.Debug,
             Message = "Invalidating {Count} cached entries for message {Message}"
         )]
@@ -629,5 +695,11 @@ namespace Orleans.Runtime.Placement
             Message = "Error in placement worker."
         )]
         private static partial void LogWarnInPlacementWorker(ILogger logger, Exception exception);
+
+        private readonly record struct CompatibleSilosCacheKey(
+            GrainType GrainType,
+            GrainInterfaceType InterfaceType,
+            ushort InterfaceVersion,
+            long CacheGeneration);
     }
 }

--- a/src/Orleans.Runtime/Placement/PlacementService.cs
+++ b/src/Orleans.Runtime/Placement/PlacementService.cs
@@ -46,6 +46,8 @@ namespace Orleans.Runtime.Placement
         {
             Task[] WorkerTasks { get; }
 
+            int CompatibleSilosCacheCount { get; }
+
             Task<SiloAddress> GetOrPlaceActivationAsync(Message message);
         }
 
@@ -79,6 +81,7 @@ namespace Orleans.Runtime.Placement
             _clusterManifestProvider = clusterManifestProvider;
             _assumeHomogeneousSilosForTesting = siloMessagingOptions.CurrentValue.AssumeHomogenousSilosForTesting;
             _siloStatusOracle.SubscribeToSiloStatusEvents(this);
+            _versionSelectorManager.CacheInvalidated += InvalidatePlacementCaches;
             _workers = new PlacementWorker[PlacementWorkerCount];
             for (var i = 0; i < PlacementWorkerCount; i++)
             {
@@ -91,6 +94,8 @@ namespace Orleans.Runtime.Placement
         public SiloStatus LocalSiloStatus => _siloStatusOracle.CurrentStatus;
 
         Task[] ITestAccessor.WorkerTasks => _workers.Select(static worker => worker.CompletionTask).ToArray();
+
+        int ITestAccessor.CompatibleSilosCacheCount => _compatibleSilosCache.Count;
 
         Task<SiloAddress> ITestAccessor.GetOrPlaceActivationAsync(Message message)
         {
@@ -148,6 +153,7 @@ namespace Orleans.Runtime.Placement
             }
 
             _siloStatusOracle.UnSubscribeFromSiloStatusEvents(this);
+            _versionSelectorManager.CacheInvalidated -= InvalidatePlacementCaches;
         }
 
         /// <summary>

--- a/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
+++ b/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs
@@ -25,6 +25,8 @@ namespace Orleans.Runtime.Versions
 
         public CompatibilityDirectorManager CompatibilityDirectorManager { get; }
 
+        public event Action? CacheInvalidated;
+
         public CachedEntry GetSuitableSilos(GrainType grainType, GrainInterfaceType interfaceId, ushort requestedVersion)
         {
             var key = ValueTuple.Create(grainType, interfaceId, requestedVersion);
@@ -39,6 +41,7 @@ namespace Orleans.Runtime.Versions
         public void ResetCache()
         {
             this.suitableSilosCache.Clear();
+            CacheInvalidated?.Invoke();
         }
 
         private CachedEntry GetSuitableSilosImpl((GrainType Type, GrainInterfaceType Interface, ushort Version) key)

--- a/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
@@ -132,6 +132,23 @@ namespace UnitTests.Runtime
         }
 
         [Fact]
+        public async Task GetCompatibleSilos_WithoutInterfaceVersion_ReusesCacheAcrossInterfaces()
+        {
+            var silos = CreateSilos(2);
+            var fixture = new PlacementServiceFixture(activeSilos: silos, manifestSilos: silos);
+            var firstTarget = CreatePlacementTarget(interfaceType: GrainInterfaceType.Create("test.interface.one"));
+            var secondTarget = CreatePlacementTarget(interfaceType: GrainInterfaceType.Create("test.interface.two"));
+
+            var first = fixture.Target.GetCompatibleSilos(firstTarget);
+            var second = fixture.Target.GetCompatibleSilos(secondTarget);
+
+            Assert.Same(first, second);
+            Assert.Equal(1, GetTestAccessor(fixture.Target).CompatibleSilosCacheCount);
+
+            await StopAsync(fixture.Target);
+        }
+
+        [Fact]
         public async Task GetCompatibleSilos_MembershipChange_InvalidatesCachedResult()
         {
             var silos = CreateSilos(2);
@@ -213,8 +230,14 @@ namespace UnitTests.Runtime
             return new PlacementServiceFixture().Target;
         }
 
-        private static PlacementTarget CreatePlacementTarget(Dictionary<string, object>? requestContextData = null) =>
-            new(GrainId.Create(TestGrainType, "grain-1"), requestContextData ?? new Dictionary<string, object>(), TestInterfaceType, 0);
+        private static PlacementTarget CreatePlacementTarget(
+            Dictionary<string, object>? requestContextData = null,
+            GrainInterfaceType? interfaceType = null) =>
+            new(
+                GrainId.Create(TestGrainType, "grain-1"),
+                requestContextData ?? new Dictionary<string, object>(),
+                interfaceType ?? TestInterfaceType,
+                0);
 
         private static PlacementService CreateTarget(
             IOptionsMonitor<SiloMessagingOptions> optionsMonitor,

--- a/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
@@ -151,6 +151,25 @@ namespace UnitTests.Runtime
         }
 
         [Fact]
+        public async Task GetCompatibleSilos_VersionSelectorCacheReset_InvalidatesCachedResult()
+        {
+            var silos = CreateSilos(2);
+            var fixture = new PlacementServiceFixture(activeSilos: silos, manifestSilos: silos);
+            var placementTarget = CreatePlacementTarget();
+
+            fixture.Target.GetCompatibleSilos(placementTarget);
+            Assert.Equal(1, GetTestAccessor(fixture.Target).CompatibleSilosCacheCount);
+
+            fixture.VersionSelectorManager.ResetCache();
+
+            Assert.Equal(0, GetTestAccessor(fixture.Target).CompatibleSilosCacheCount);
+            fixture.Target.GetCompatibleSilos(placementTarget);
+            Assert.Equal(1, GetTestAccessor(fixture.Target).CompatibleSilosCacheCount);
+
+            await StopAsync(fixture.Target);
+        }
+
+        [Fact]
         public async Task GetCompatibleSilos_ManifestUpdate_InvalidatesCachedResult()
         {
             var silos = CreateSilos(2);
@@ -202,7 +221,8 @@ namespace UnitTests.Runtime
             ILocalSiloDetails localSiloDetails,
             ISiloStatusOracle siloStatusOracle,
             TestClusterManifestProvider clusterManifestProvider,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            CachedVersionSelectorManager versionSelectorManager)
         {
             var grainVersionManifest = new GrainVersionManifest(clusterManifestProvider);
             var filterStrategyResolver = new PlacementFilterStrategyResolver(serviceProvider, new GrainPropertiesResolver(clusterManifestProvider));
@@ -215,7 +235,7 @@ namespace UnitTests.Runtime
                 NullLoggerFactory.Instance.CreateLogger<PlacementService>(),
                 grainLocator: null!,
                 grainInterfaceVersions: grainVersionManifest,
-                versionSelectorManager: null!,
+                versionSelectorManager,
                 clusterManifestProvider,
                 directorResolver: null!,
                 strategyResolver: null!,
@@ -342,6 +362,7 @@ namespace UnitTests.Runtime
                 SetActiveSilos(activeSilos);
 
                 ClusterManifestProvider = manifestProvider ?? new TestClusterManifestProvider(CreateClusterManifest(manifestSilos, useFilter));
+                VersionSelectorManager = new CachedVersionSelectorManager(new GrainVersionManifest(ClusterManifestProvider), null!, null!);
                 FilterDirector = useFilter ? new TestPlacementFilterDirector() : null;
                 ServiceProvider = CreateServiceProvider(FilterDirector);
 
@@ -357,7 +378,7 @@ namespace UnitTests.Runtime
                 SiloStatusOracle.SubscribeToSiloStatusEvents(Arg.Do<ISiloStatusListener>(listener => StatusListener = listener)).Returns(true);
                 SiloStatusOracle.UnSubscribeFromSiloStatusEvents(Arg.Any<ISiloStatusListener>()).Returns(true);
 
-                Target = CreateTarget(optionsMonitor, localSiloDetails, SiloStatusOracle, ClusterManifestProvider, ServiceProvider);
+                Target = CreateTarget(optionsMonitor, localSiloDetails, SiloStatusOracle, ClusterManifestProvider, ServiceProvider, VersionSelectorManager);
             }
 
             public PlacementService Target { get; }
@@ -367,6 +388,8 @@ namespace UnitTests.Runtime
             public TestClusterManifestProvider ClusterManifestProvider { get; }
 
             public ServiceProvider ServiceProvider { get; }
+
+            public CachedVersionSelectorManager VersionSelectorManager { get; }
 
             public TestPlacementFilterDirector? FilterDirector { get; }
 

--- a/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/PlacementServiceTests.cs
@@ -1,15 +1,23 @@
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Channels;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Orleans.Configuration;
+using Orleans.Metadata;
+using Orleans.Placement;
 using Orleans.Runtime;
 using Orleans.Runtime.Diagnostics;
 using Orleans.Runtime.Placement;
+using Orleans.Runtime.Placement.Filtering;
+using Orleans.Runtime.Versions;
 using Orleans.TestingHost.Diagnostics;
 using TestExtensions;
 using Xunit;
@@ -19,6 +27,8 @@ namespace UnitTests.Runtime
     [TestCategory("BVT"), TestCategory("Placement")]
     public class PlacementServiceTests
     {
+        private static readonly GrainType TestGrainType = GrainType.Create("test");
+        private static readonly GrainInterfaceType TestInterfaceType = GrainInterfaceType.Create("test.interface");
         private static int _siloGeneration;
 
         [Fact]
@@ -105,18 +115,98 @@ namespace UnitTests.Runtime
             Assert.Throws<SiloUnavailableException>(() => target.GetCompatibleSilosWithVersions(placementTarget));
         }
 
+        [Fact]
+        public async Task GetCompatibleSilos_WithoutFilters_UsesCachedResult()
+        {
+            var silos = CreateSilos(2);
+            var fixture = new PlacementServiceFixture(activeSilos: silos, manifestSilos: silos);
+            var placementTarget = CreatePlacementTarget();
+
+            var first = fixture.Target.GetCompatibleSilos(placementTarget);
+            var second = fixture.Target.GetCompatibleSilos(placementTarget);
+
+            Assert.Same(first, second);
+            Assert.True(silos.ToHashSet().SetEquals(first));
+
+            await StopAsync(fixture.Target);
+        }
+
+        [Fact]
+        public async Task GetCompatibleSilos_MembershipChange_InvalidatesCachedResult()
+        {
+            var silos = CreateSilos(2);
+            var fixture = new PlacementServiceFixture(activeSilos: silos, manifestSilos: silos);
+            var placementTarget = CreatePlacementTarget();
+
+            var first = fixture.Target.GetCompatibleSilos(placementTarget);
+
+            fixture.ClusterManifestProvider.SetCurrent(CreateClusterManifest(new[] { silos[1] }, version: new MajorMinorVersion(1, 0)));
+            fixture.NotifyMembershipChanged(silos[1]);
+            var second = fixture.Target.GetCompatibleSilos(placementTarget);
+
+            Assert.NotSame(first, second);
+            Assert.Equal(new[] { silos[1] }, second);
+
+            await StopAsync(fixture.Target);
+        }
+
+        [Fact]
+        public async Task GetCompatibleSilos_ManifestUpdate_InvalidatesCachedResult()
+        {
+            var silos = CreateSilos(2);
+            var manifestProvider = new TestClusterManifestProvider(CreateClusterManifest(new[] { silos[0] }));
+            var fixture = new PlacementServiceFixture(activeSilos: silos, manifestSilos: new[] { silos[0] }, manifestProvider: manifestProvider);
+            var placementTarget = CreatePlacementTarget();
+            var lifecycle = await StartAsync(fixture.Target);
+
+            var first = fixture.Target.GetCompatibleSilos(placementTarget);
+            Assert.Equal(new[] { silos[0] }, first);
+
+            manifestProvider.Publish(CreateClusterManifest(new[] { silos[1] }, version: new MajorMinorVersion(1, 0)));
+
+            await Until(() => fixture.Target.GetCompatibleSilos(placementTarget).SequenceEqual(new[] { silos[1] }));
+            var second = fixture.Target.GetCompatibleSilos(placementTarget);
+
+            Assert.NotSame(first, second);
+            Assert.Equal(new[] { silos[1] }, second);
+
+            await lifecycle.OnStop();
+        }
+
+        [Fact]
+        public async Task GetCompatibleSilos_WithFilters_RunsFiltersPerRequest()
+        {
+            var silos = CreateSilos(2);
+            var fixture = new PlacementServiceFixture(activeSilos: silos, manifestSilos: silos, useFilter: true);
+
+            var first = fixture.Target.GetCompatibleSilos(CreatePlacementTarget(new Dictionary<string, object> { ["target-silo"] = silos[0] }));
+            var second = fixture.Target.GetCompatibleSilos(CreatePlacementTarget(new Dictionary<string, object> { ["target-silo"] = silos[1] }));
+
+            Assert.Equal(new[] { silos[0] }, first);
+            Assert.Equal(new[] { silos[1] }, second);
+            Assert.Equal(2, fixture.FilterDirector!.CallCount);
+
+            await StopAsync(fixture.Target);
+        }
+
         private static PlacementService CreateTarget()
         {
-            var optionsMonitor = Substitute.For<IOptionsMonitor<SiloMessagingOptions>>();
-            optionsMonitor.CurrentValue.Returns(new SiloMessagingOptions());
+            return new PlacementServiceFixture().Target;
+        }
 
-            var localSiloDetails = Substitute.For<ILocalSiloDetails>();
-            var localSilo = SiloAddress.New(IPAddress.Loopback, 11111, Interlocked.Increment(ref _siloGeneration));
-            localSiloDetails.SiloAddress.Returns(localSilo);
+        private static PlacementTarget CreatePlacementTarget(Dictionary<string, object>? requestContextData = null) =>
+            new(GrainId.Create(TestGrainType, "grain-1"), requestContextData ?? new Dictionary<string, object>(), TestInterfaceType, 0);
 
-            var siloStatusOracle = Substitute.For<ISiloStatusOracle>();
-            siloStatusOracle.CurrentStatus.Returns(SiloStatus.Active);
-            siloStatusOracle.GetActiveSilos().Returns(new[] { localSilo });
+        private static PlacementService CreateTarget(
+            IOptionsMonitor<SiloMessagingOptions> optionsMonitor,
+            ILocalSiloDetails localSiloDetails,
+            ISiloStatusOracle siloStatusOracle,
+            TestClusterManifestProvider clusterManifestProvider,
+            IServiceProvider serviceProvider)
+        {
+            var grainVersionManifest = new GrainVersionManifest(clusterManifestProvider);
+            var filterStrategyResolver = new PlacementFilterStrategyResolver(serviceProvider, new GrainPropertiesResolver(clusterManifestProvider));
+            var placementFilterDirectorResolver = new PlacementFilterDirectorResolver(serviceProvider);
 
             return new PlacementService(
                 optionsMonitor,
@@ -124,19 +214,83 @@ namespace UnitTests.Runtime
                 siloStatusOracle,
                 NullLoggerFactory.Instance.CreateLogger<PlacementService>(),
                 grainLocator: null!,
-                grainInterfaceVersions: null!,
+                grainInterfaceVersions: grainVersionManifest,
                 versionSelectorManager: null!,
+                clusterManifestProvider,
                 directorResolver: null!,
                 strategyResolver: null!,
-                filterStrategyResolver: null!,
-                placementFilterDirectoryResolver: null!);
+                filterStrategyResolver,
+                placementFilterDirectorResolver);
         }
 
-        private static async Task StopAsync(PlacementService target, CancellationToken cancellationToken = default)
+        private static SiloAddress[] CreateSilos(int count)
+        {
+            var result = new SiloAddress[count];
+            for (var i = 0; i < count; i++)
+            {
+                result[i] = SiloAddress.New(IPAddress.Loopback, 11111, Interlocked.Increment(ref _siloGeneration));
+            }
+
+            return result;
+        }
+
+        private static ClusterManifest CreateClusterManifest(SiloAddress[] silos, bool useFilter = false, MajorMinorVersion? version = null)
+        {
+            var manifest = CreateGrainManifest(useFilter);
+            var manifests = silos.ToImmutableDictionary(silo => silo, _ => manifest);
+            return new ClusterManifest(version ?? MajorMinorVersion.Zero, manifests);
+        }
+
+        private static GrainManifest CreateGrainManifest(bool useFilter)
+        {
+            var grainProperties = ImmutableDictionary.Create<string, string>(StringComparer.Ordinal);
+            if (useFilter)
+            {
+                var filterName = typeof(TestPlacementFilterStrategy).Name;
+                grainProperties = grainProperties
+                    .Add(WellKnownGrainTypeProperties.PlacementFilter, filterName)
+                    .Add($"{WellKnownGrainTypeProperties.PlacementFilter}.{filterName}.order", "0");
+            }
+
+            return new GrainManifest(
+                ImmutableDictionary.CreateRange(new[] { new KeyValuePair<GrainType, GrainProperties>(TestGrainType, new GrainProperties(grainProperties)) }),
+                ImmutableDictionary.CreateRange(new[]
+                {
+                    new KeyValuePair<GrainInterfaceType, GrainInterfaceProperties>(
+                        TestInterfaceType,
+                        new GrainInterfaceProperties(
+                            ImmutableDictionary.Create<string, string>(StringComparer.Ordinal)
+                                .Add(WellKnownGrainInterfaceProperties.Version, "0")))
+                }));
+        }
+
+        private static ServiceProvider CreateServiceProvider(TestPlacementFilterDirector? filterDirector = null)
+        {
+            IServiceCollection services = new ServiceCollection();
+            if (filterDirector is not null)
+            {
+                services.Add(ServiceDescriptor.DescribeKeyed(
+                    typeof(PlacementFilterStrategy),
+                    typeof(TestPlacementFilterStrategy).Name,
+                    typeof(TestPlacementFilterStrategy),
+                    ServiceLifetime.Transient));
+                services.AddKeyedSingleton<IPlacementFilterDirector>(typeof(TestPlacementFilterStrategy), filterDirector);
+            }
+
+            return services.BuildServiceProvider();
+        }
+
+        private static async Task<SiloLifecycleSubject> StartAsync(PlacementService target)
         {
             var lifecycle = new SiloLifecycleSubject(NullLoggerFactory.Instance.CreateLogger<SiloLifecycleSubject>());
             ((ILifecycleParticipant<ISiloLifecycle>)target).Participate(lifecycle);
             await lifecycle.OnStart();
+            return lifecycle;
+        }
+
+        private static async Task StopAsync(PlacementService target, CancellationToken cancellationToken = default)
+        {
+            var lifecycle = await StartAsync(target);
             await lifecycle.OnStop(cancellationToken);
         }
 
@@ -162,5 +316,131 @@ namespace UnitTests.Runtime
             Assert.Equal(workerCount, stoppedEvents.Count);
         }
 
+        private static async Task Until(Func<bool> condition)
+        {
+            var maxTimeout = 10_000;
+            while (!condition() && (maxTimeout -= 10) > 0)
+            {
+                await Task.Delay(10);
+            }
+
+            Assert.True(maxTimeout > 0);
+        }
+
+        private sealed class PlacementServiceFixture
+        {
+            private Dictionary<SiloAddress, SiloStatus> _siloStatuses = new();
+
+            public PlacementServiceFixture(
+                SiloAddress[]? activeSilos = null,
+                SiloAddress[]? manifestSilos = null,
+                TestClusterManifestProvider? manifestProvider = null,
+                bool useFilter = false)
+            {
+                activeSilos ??= CreateSilos(1);
+                manifestSilos ??= activeSilos;
+                SetActiveSilos(activeSilos);
+
+                ClusterManifestProvider = manifestProvider ?? new TestClusterManifestProvider(CreateClusterManifest(manifestSilos, useFilter));
+                FilterDirector = useFilter ? new TestPlacementFilterDirector() : null;
+                ServiceProvider = CreateServiceProvider(FilterDirector);
+
+                var optionsMonitor = Substitute.For<IOptionsMonitor<SiloMessagingOptions>>();
+                optionsMonitor.CurrentValue.Returns(new SiloMessagingOptions());
+
+                var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+                localSiloDetails.SiloAddress.Returns(activeSilos[0]);
+
+                SiloStatusOracle = Substitute.For<ISiloStatusOracle>();
+                SiloStatusOracle.CurrentStatus.Returns(SiloStatus.Active);
+                SiloStatusOracle.GetActiveSilos().Returns(_ => _siloStatuses.Keys.ToArray());
+                SiloStatusOracle.SubscribeToSiloStatusEvents(Arg.Do<ISiloStatusListener>(listener => StatusListener = listener)).Returns(true);
+                SiloStatusOracle.UnSubscribeFromSiloStatusEvents(Arg.Any<ISiloStatusListener>()).Returns(true);
+
+                Target = CreateTarget(optionsMonitor, localSiloDetails, SiloStatusOracle, ClusterManifestProvider, ServiceProvider);
+            }
+
+            public PlacementService Target { get; }
+
+            public ISiloStatusOracle SiloStatusOracle { get; }
+
+            public TestClusterManifestProvider ClusterManifestProvider { get; }
+
+            public ServiceProvider ServiceProvider { get; }
+
+            public TestPlacementFilterDirector? FilterDirector { get; }
+
+            private ISiloStatusListener StatusListener { get; set; } = null!;
+
+            public void SetActiveSilos(params SiloAddress[] silos)
+            {
+                _siloStatuses = silos.ToDictionary(silo => silo, _ => SiloStatus.Active);
+            }
+
+            public void NotifyMembershipChanged(SiloAddress silo)
+            {
+                StatusListener.SiloStatusChangeNotification(silo, SiloStatus.Active);
+            }
+        }
+
+        private sealed class TestClusterManifestProvider : IClusterManifestProvider
+        {
+            private readonly Channel<ClusterManifest> _updates = Channel.CreateUnbounded<ClusterManifest>();
+            private ClusterManifest _current;
+
+            public TestClusterManifestProvider(ClusterManifest current)
+            {
+                _current = current;
+                LocalGrainManifest = current.AllGrainManifests.FirstOrDefault() ?? CreateGrainManifest(useFilter: false);
+            }
+
+            public ClusterManifest Current => Volatile.Read(ref _current);
+
+            public IAsyncEnumerable<ClusterManifest> Updates => ReadUpdates();
+
+            public GrainManifest LocalGrainManifest { get; }
+
+            public void Publish(ClusterManifest manifest)
+            {
+                SetCurrent(manifest);
+                Assert.True(_updates.Writer.TryWrite(manifest));
+            }
+
+            public void SetCurrent(ClusterManifest manifest) => Volatile.Write(ref _current, manifest);
+
+            private async IAsyncEnumerable<ClusterManifest> ReadUpdates([EnumeratorCancellation] CancellationToken cancellationToken = default)
+            {
+                yield return Current;
+
+                await foreach (var manifest in _updates.Reader.ReadAllAsync(cancellationToken))
+                {
+                    yield return manifest;
+                }
+            }
+        }
+
+        private sealed class TestPlacementFilterStrategy : PlacementFilterStrategy
+        {
+            public TestPlacementFilterStrategy()
+                : base(0)
+            {
+            }
+        }
+
+        private sealed class TestPlacementFilterDirector : IPlacementFilterDirector
+        {
+            public int CallCount { get; private set; }
+
+            public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target, IEnumerable<SiloAddress> silos)
+            {
+                CallCount++;
+                if (target.RequestContextData.TryGetValue("target-silo", out var value) && value is SiloAddress requestedSilo)
+                {
+                    return silos.Where(silo => silo.Equals(requestedSilo));
+                }
+
+                return silos;
+            }
+        }
     }
 }


### PR DESCRIPTION
`PlacementService` repeatedly recomputes manifest-compatible silo candidates for placement requests, even though the inputs change only when cluster membership or the cluster manifest changes.

This change caches the unfiltered compatible silo results by grain type, interface type, and interface version. The cache is invalidated when silo status changes or a new cluster manifest is observed. Placement filter results remain uncached because filters can inspect per-request `RequestContext` data; filtered requests reuse only the cached intermediate candidate set.

The focused tests cover cache reuse, membership and manifest invalidation, per-request filter execution, and lifecycle shutdown behavior.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10314)