### PR TITLE
test: fix grain directory nullability diagnostics

### DIFF
--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -1051,7 +1052,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             for (var partitionIndex = 0; partitionIndex < membershipService.PartitionsPerSilo; partitionIndex++)
             {
                 distributedPartitions.Add(
-                    cluster.InternalClient.GetSystemTarget<IGrainDirectoryTestHooks>(
+                    cluster.InternalClient!.GetSystemTarget<IGrainDirectoryTestHooks>(
                         GrainDirectoryPartition.CreateGrainId(silo.SiloAddress, partitionIndex).GrainId));
             }
         }
@@ -1431,7 +1432,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             {
                 try
                 {
-                    var siloControl = cluster.InternalClient.GetSystemTarget<ISiloControl>(
+                    var siloControl = cluster.InternalClient!.GetSystemTarget<ISiloControl>(
                         Constants.SiloControlType,
                         silo.SiloAddress);
                     var report = await siloControl.GetDetailedGrainReport(grainId).WaitAsync(cancellation.Token);
@@ -1936,6 +1937,6 @@ internal sealed class TrackingGrainDirectoryCache : IGrainDirectoryCache
         _inner.Clear();
     }
 
-    public bool LookUp(GrainId key, out GrainAddress result, out int version) =>
+    public bool LookUp(GrainId key, [NotNullWhen(true)] out GrainAddress? result, out int version) =>
         _inner.LookUp(key, out result, out version);
 }


### PR DESCRIPTION
The solution build was failing because rolling-upgrade test helpers did not satisfy current nullable-reference contracts.

Mark the initialized internal test client at its system-target call sites and align the tracking cache wrapper with `IGrainDirectoryCache.LookUp`, including its `NotNullWhen(true)` annotation. This restores a clean build with zero warnings and errors.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10315)