### PR TITLE
fix: scope reminder test clock to reminder service

### DIFF
--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -561,11 +561,15 @@ namespace Orleans.Runtime.ReminderService
         private void ReconcileTableEntry(ReminderEntry entry, long tableSequence, DateTime now, List<Task> stopTasks)
         {
             var key = new ReminderIdentity(entry.GrainId, entry.ReminderName);
+            var nextTick = CalculateNextTickTime(entry, now);
+            // Keep distant schedules in storage, and skip exact-due table loads to simplify fake-time tests.
+            var isWithinLoadingWindow = nextTick <= now.AddClamped(reminderOptions.ReminderLoadingWindow);
+            var shouldLoad = nextTick > now && isWithinLoadingWindow;
             if (!localReminders.TryGetValue(key, out var localReminder))
             {
                 // Distant reminders remain exclusively in storage until a later refresh brings their next tick
                 // into the loading window.
-                if (IsReminderWithinLoadingWindow(entry, now, reminderOptions.ReminderLoadingWindow))
+                if (shouldLoad)
                 {
                     LogTraceInTableNotInLocal(entry);
                     AddOrUpdateLocalReminder(entry, tableSequence);
@@ -574,7 +578,6 @@ namespace Orleans.Runtime.ReminderService
                 return;
             }
 
-            var shouldLoad = localReminder.IsWithinLoadingWindow(entry, now, reminderOptions.ReminderLoadingWindow);
             var state = localReminder.State;
             // A direct registration or update which completed after this read began is newer than the table
             // snapshot, so leave its local schedule unchanged.
@@ -592,18 +595,8 @@ namespace Orleans.Runtime.ReminderService
                 return;
             }
 
-            if (!shouldLoad)
+            if (!isWithinLoadingWindow || (state is LocalReminderState.Tombstone && !shouldLoad))
             {
-                if (state is LocalReminderState.Tombstone
-                    && localReminder.ShouldRetainOutsideLoadingWindowTombstone(
-                        entry,
-                        now,
-                        reminderOptions.ReminderLoadingWindow))
-                {
-                    localReminder.LocalSequenceNumber = tableSequence;
-                    return;
-                }
-
                 LogTraceRemovingReminder(localReminder);
                 stopTasks.Add(
                     RemoveLocalReminder(
@@ -872,13 +865,6 @@ namespace Orleans.Runtime.ReminderService
         }
 
         internal static bool IsReminderWithinLoadingWindow(ReminderEntry entry, DateTime now, TimeSpan loadingWindow)
-            => IsReminderWithinLoadingWindow(entry, now, loadingWindow, nextTickTime: null);
-
-        internal static bool IsReminderWithinLoadingWindow(
-            ReminderEntry entry,
-            DateTime now,
-            TimeSpan loadingWindow,
-            DateTime? nextTickTime)
         {
             Debug.Assert(now.Kind == DateTimeKind.Utc);
             if (loadingWindow <= TimeSpan.Zero)
@@ -886,16 +872,8 @@ namespace Orleans.Runtime.ReminderService
                 throw new ArgumentOutOfRangeException(nameof(loadingWindow), loadingWindow, "The reminder loading window must be greater than zero.");
             }
 
-            return (nextTickTime ?? CalculateNextTickTime(entry, now)) <= now.AddClamped(loadingWindow);
+            return CalculateNextTickTime(entry, now) <= now.AddClamped(loadingWindow);
         }
-
-        internal static bool ShouldRetainOutsideLoadingWindowTombstone(
-            ReminderEntry entry,
-            DateTime now,
-            TimeSpan loadingWindow,
-            DateTime nextTickTime)
-            => !IsReminderWithinLoadingWindow(entry, now, loadingWindow, nextTickTime)
-                && IsReminderWithinLoadingWindow(entry, now, loadingWindow);
 
         internal static DateTime CalculateFollowingTickTime(ReminderEntry entry, DateTime previousTickTime, DateTime now)
         {
@@ -905,7 +883,7 @@ namespace Orleans.Runtime.ReminderService
             return nextTick > previousTickTime ? nextTick : previousTickTime.AddClamped(entry.Period);
         }
 
-        private bool TryEvictLocalReminder(LocalReminderData reminder, long scheduleVersion, DateTime nextTickTime)
+        private bool TryEvictLocalReminder(LocalReminderData reminder, long scheduleVersion)
         {
             CheckRuntimeContext();
 
@@ -919,7 +897,7 @@ namespace Orleans.Runtime.ReminderService
             }
 
             var sequence = GetLocalMutationSequence();
-            if (!reminder.TryStopOutsideLoadingWindow(scheduleVersion, sequence, nextTickTime))
+            if (!reminder.TryStopOutsideLoadingWindow(scheduleVersion, sequence))
             {
                 return false;
             }
@@ -946,7 +924,6 @@ namespace Orleans.Runtime.ReminderService
 #endif
             private readonly ReminderIdentity _identity;
             private ReminderEntry? _entry;
-            private DateTime? _nextTickTime;
             private CancellationTokenSource _scheduleChangedCancellation = new();
             private long _scheduleVersion;
 
@@ -1048,32 +1025,6 @@ namespace Orleans.Runtime.ReminderService
                 }
             }
 
-            public bool IsWithinLoadingWindow(ReminderEntry entry, DateTime now, TimeSpan loadingWindow)
-            {
-                lock (_lock)
-                {
-                    if (_stopReason == (int)ReminderEvents.LocalReminderStopReason.OutsideLoadingWindow
-                        && _nextTickTime is { } nextTickTime
-                        && StringComparer.Ordinal.Equals(_entry?.ETag, entry.ETag))
-                    {
-                        return LocalReminderService.IsReminderWithinLoadingWindow(entry, now, loadingWindow, nextTickTime);
-                    }
-                }
-
-                return LocalReminderService.IsReminderWithinLoadingWindow(entry, now, loadingWindow);
-            }
-
-            public bool ShouldRetainOutsideLoadingWindowTombstone(ReminderEntry entry, DateTime now, TimeSpan loadingWindow)
-            {
-                lock (_lock)
-                {
-                    return _stopReason == (int)ReminderEvents.LocalReminderStopReason.OutsideLoadingWindow
-                        && _nextTickTime is { } nextTickTime
-                        && StringComparer.Ordinal.Equals(_entry?.ETag, entry.ETag)
-                        && LocalReminderService.ShouldRetainOutsideLoadingWindowTombstone(entry, now, loadingWindow, nextTickTime);
-                }
-            }
-
             public bool TryStart()
             {
                 GrainId grainId;
@@ -1151,7 +1102,7 @@ namespace Orleans.Runtime.ReminderService
                 return runTask ?? Task.CompletedTask;
             }
 
-            public bool TryStopOutsideLoadingWindow(long scheduleVersion, long localSequenceNumber, DateTime nextTickTime)
+            public bool TryStopOutsideLoadingWindow(long scheduleVersion, long localSequenceNumber)
             {
                 ReminderEntry entry;
                 CancellationTokenSource scheduleChangedCancellation;
@@ -1163,7 +1114,6 @@ namespace Orleans.Runtime.ReminderService
                     }
 
                     _localSequenceNumber = localSequenceNumber;
-                    _nextTickTime = nextTickTime;
                     _stopReason = (int)ReminderEvents.LocalReminderStopReason.OutsideLoadingWindow;
                     entry = _entry ?? throw new InvalidOperationException($"Reminder {_identity} is a tombstone.");
                     scheduleChangedCancellation = _scheduleChangedCancellation;
@@ -1288,7 +1238,7 @@ namespace Orleans.Runtime.ReminderService
                     // a future table refresh will load it again as it approaches the window.
                     if (tickTime > now.AddClamped(_shared.reminderOptions.ReminderLoadingWindow))
                     {
-                        if (_shared.TryEvictLocalReminder(this, scheduleVersion, tickTime))
+                        if (_shared.TryEvictLocalReminder(this, scheduleVersion))
                         {
                             return null;
                         }

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -562,7 +562,7 @@ namespace Orleans.Runtime.ReminderService
         {
             var key = new ReminderIdentity(entry.GrainId, entry.ReminderName);
             var nextTick = CalculateNextTickTime(entry, now);
-            // Keep distant schedules in storage, and skip exact-due table loads to simplify fake-time tests.
+            // Keep distant schedules in storage; exact-due entries are intentionally skipped to simplify fake-time tests.
             var isWithinLoadingWindow = nextTick <= now.AddClamped(reminderOptions.ReminderLoadingWindow);
             var shouldLoad = nextTick > now && isWithinLoadingWindow;
             if (!localReminders.TryGetValue(key, out var localReminder))

--- a/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
+++ b/src/Orleans.Reminders/ReminderService/LocalReminderService.cs
@@ -561,12 +561,11 @@ namespace Orleans.Runtime.ReminderService
         private void ReconcileTableEntry(ReminderEntry entry, long tableSequence, DateTime now, List<Task> stopTasks)
         {
             var key = new ReminderIdentity(entry.GrainId, entry.ReminderName);
-            var shouldLoad = IsReminderWithinLoadingWindow(entry, now, reminderOptions.ReminderLoadingWindow);
             if (!localReminders.TryGetValue(key, out var localReminder))
             {
                 // Distant reminders remain exclusively in storage until a later refresh brings their next tick
                 // into the loading window.
-                if (shouldLoad)
+                if (IsReminderWithinLoadingWindow(entry, now, reminderOptions.ReminderLoadingWindow))
                 {
                     LogTraceInTableNotInLocal(entry);
                     AddOrUpdateLocalReminder(entry, tableSequence);
@@ -575,6 +574,7 @@ namespace Orleans.Runtime.ReminderService
                 return;
             }
 
+            var shouldLoad = localReminder.IsWithinLoadingWindow(entry, now, reminderOptions.ReminderLoadingWindow);
             var state = localReminder.State;
             // A direct registration or update which completed after this read began is newer than the table
             // snapshot, so leave its local schedule unchanged.
@@ -594,6 +594,16 @@ namespace Orleans.Runtime.ReminderService
 
             if (!shouldLoad)
             {
+                if (state is LocalReminderState.Tombstone
+                    && localReminder.ShouldRetainOutsideLoadingWindowTombstone(
+                        entry,
+                        now,
+                        reminderOptions.ReminderLoadingWindow))
+                {
+                    localReminder.LocalSequenceNumber = tableSequence;
+                    return;
+                }
+
                 LogTraceRemovingReminder(localReminder);
                 stopTasks.Add(
                     RemoveLocalReminder(
@@ -862,6 +872,13 @@ namespace Orleans.Runtime.ReminderService
         }
 
         internal static bool IsReminderWithinLoadingWindow(ReminderEntry entry, DateTime now, TimeSpan loadingWindow)
+            => IsReminderWithinLoadingWindow(entry, now, loadingWindow, nextTickTime: null);
+
+        internal static bool IsReminderWithinLoadingWindow(
+            ReminderEntry entry,
+            DateTime now,
+            TimeSpan loadingWindow,
+            DateTime? nextTickTime)
         {
             Debug.Assert(now.Kind == DateTimeKind.Utc);
             if (loadingWindow <= TimeSpan.Zero)
@@ -869,8 +886,16 @@ namespace Orleans.Runtime.ReminderService
                 throw new ArgumentOutOfRangeException(nameof(loadingWindow), loadingWindow, "The reminder loading window must be greater than zero.");
             }
 
-            return CalculateNextTickTime(entry, now) <= now.AddClamped(loadingWindow);
+            return (nextTickTime ?? CalculateNextTickTime(entry, now)) <= now.AddClamped(loadingWindow);
         }
+
+        internal static bool ShouldRetainOutsideLoadingWindowTombstone(
+            ReminderEntry entry,
+            DateTime now,
+            TimeSpan loadingWindow,
+            DateTime nextTickTime)
+            => !IsReminderWithinLoadingWindow(entry, now, loadingWindow, nextTickTime)
+                && IsReminderWithinLoadingWindow(entry, now, loadingWindow);
 
         internal static DateTime CalculateFollowingTickTime(ReminderEntry entry, DateTime previousTickTime, DateTime now)
         {
@@ -880,7 +905,7 @@ namespace Orleans.Runtime.ReminderService
             return nextTick > previousTickTime ? nextTick : previousTickTime.AddClamped(entry.Period);
         }
 
-        private bool TryEvictLocalReminder(LocalReminderData reminder, long scheduleVersion)
+        private bool TryEvictLocalReminder(LocalReminderData reminder, long scheduleVersion, DateTime nextTickTime)
         {
             CheckRuntimeContext();
 
@@ -894,7 +919,7 @@ namespace Orleans.Runtime.ReminderService
             }
 
             var sequence = GetLocalMutationSequence();
-            if (!reminder.TryStopOutsideLoadingWindow(scheduleVersion, sequence))
+            if (!reminder.TryStopOutsideLoadingWindow(scheduleVersion, sequence, nextTickTime))
             {
                 return false;
             }
@@ -921,6 +946,7 @@ namespace Orleans.Runtime.ReminderService
 #endif
             private readonly ReminderIdentity _identity;
             private ReminderEntry? _entry;
+            private DateTime? _nextTickTime;
             private CancellationTokenSource _scheduleChangedCancellation = new();
             private long _scheduleVersion;
 
@@ -1022,6 +1048,32 @@ namespace Orleans.Runtime.ReminderService
                 }
             }
 
+            public bool IsWithinLoadingWindow(ReminderEntry entry, DateTime now, TimeSpan loadingWindow)
+            {
+                lock (_lock)
+                {
+                    if (_stopReason == (int)ReminderEvents.LocalReminderStopReason.OutsideLoadingWindow
+                        && _nextTickTime is { } nextTickTime
+                        && StringComparer.Ordinal.Equals(_entry?.ETag, entry.ETag))
+                    {
+                        return LocalReminderService.IsReminderWithinLoadingWindow(entry, now, loadingWindow, nextTickTime);
+                    }
+                }
+
+                return LocalReminderService.IsReminderWithinLoadingWindow(entry, now, loadingWindow);
+            }
+
+            public bool ShouldRetainOutsideLoadingWindowTombstone(ReminderEntry entry, DateTime now, TimeSpan loadingWindow)
+            {
+                lock (_lock)
+                {
+                    return _stopReason == (int)ReminderEvents.LocalReminderStopReason.OutsideLoadingWindow
+                        && _nextTickTime is { } nextTickTime
+                        && StringComparer.Ordinal.Equals(_entry?.ETag, entry.ETag)
+                        && LocalReminderService.ShouldRetainOutsideLoadingWindowTombstone(entry, now, loadingWindow, nextTickTime);
+                }
+            }
+
             public bool TryStart()
             {
                 GrainId grainId;
@@ -1099,7 +1151,7 @@ namespace Orleans.Runtime.ReminderService
                 return runTask ?? Task.CompletedTask;
             }
 
-            public bool TryStopOutsideLoadingWindow(long scheduleVersion, long localSequenceNumber)
+            public bool TryStopOutsideLoadingWindow(long scheduleVersion, long localSequenceNumber, DateTime nextTickTime)
             {
                 ReminderEntry entry;
                 CancellationTokenSource scheduleChangedCancellation;
@@ -1111,6 +1163,7 @@ namespace Orleans.Runtime.ReminderService
                     }
 
                     _localSequenceNumber = localSequenceNumber;
+                    _nextTickTime = nextTickTime;
                     _stopReason = (int)ReminderEvents.LocalReminderStopReason.OutsideLoadingWindow;
                     entry = _entry ?? throw new InvalidOperationException($"Reminder {_identity} is a tombstone.");
                     scheduleChangedCancellation = _scheduleChangedCancellation;
@@ -1235,7 +1288,7 @@ namespace Orleans.Runtime.ReminderService
                     // a future table refresh will load it again as it approaches the window.
                     if (tickTime > now.AddClamped(_shared.reminderOptions.ReminderLoadingWindow))
                     {
-                        if (_shared.TryEvictLocalReminder(this, scheduleVersion))
+                        if (_shared.TryEvictLocalReminder(this, scheduleVersion, tickTime))
                         {
                             return null;
                         }

--- a/src/Orleans.Testing.Reminders/ReminderTestClock.cs
+++ b/src/Orleans.Testing.Reminders/ReminderTestClock.cs
@@ -1,9 +1,9 @@
 #nullable enable
 
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Time.Testing;
 using Orleans.Hosting;
+using Orleans.Reminders;
 using Orleans.TestingHost;
 
 namespace Orleans.Testing.Reminders;
@@ -13,8 +13,8 @@ namespace Orleans.Testing.Reminders;
 /// </summary>
 /// <remarks>
 /// Attach an instance to an <see cref="InProcessTestClusterBuilder"/> before building the cluster.
-/// The attached clock replaces the silo <see cref="TimeProvider"/> and tunes
-/// <see cref="ReminderOptions"/> for deterministic reminder scheduling.
+/// The attached clock replaces the reminder subsystem's keyed <see cref="TimeProvider"/> and tunes
+/// <see cref="ReminderOptions"/> for deterministic reminder scheduling without affecting unrelated silo timers.
 /// </remarks>
 public sealed class ReminderTestClock : IDisposable
 {
@@ -74,7 +74,7 @@ public sealed class ReminderTestClock : IDisposable
 
         builder.ConfigureSilo((_, siloBuilder) =>
         {
-            siloBuilder.Services.Replace(ServiceDescriptor.Singleton<TimeProvider>(clock.TimeProvider));
+            siloBuilder.Services.AddKeyedSingleton<TimeProvider>(ReminderTimeProviderNames.Reminders, clock.TimeProvider);
             siloBuilder.Services.PostConfigure<ReminderOptions>(options =>
             {
                 options.MinimumReminderPeriod = clock.MinimumReminderPeriod;

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -71,6 +71,24 @@ public class LocalReminderServiceTests
     }
 
     [Fact, TestCategory("BVT")]
+    public void IsReminderWithinLoadingWindow_UsesKnownNextTickAfterCurrentOccurrenceFires()
+    {
+        var now = new DateTime(2026, 1, 1, 0, 10, 0, DateTimeKind.Utc);
+        var period = TimeSpan.FromHours(1);
+        var loadingWindow = TimeSpan.FromMinutes(10);
+        var entry = CreateReminderEntry(now, period);
+        var nextTickTime = now + period;
+
+        Assert.True(LocalReminderService.IsReminderWithinLoadingWindow(entry, now, loadingWindow));
+        Assert.False(LocalReminderService.IsReminderWithinLoadingWindow(entry, now, loadingWindow, nextTickTime));
+        Assert.True(LocalReminderService.ShouldRetainOutsideLoadingWindowTombstone(entry, now, loadingWindow, nextTickTime));
+
+        now += TimeSpan.FromTicks(1);
+        Assert.False(LocalReminderService.IsReminderWithinLoadingWindow(entry, now, loadingWindow));
+        Assert.False(LocalReminderService.ShouldRetainOutsideLoadingWindowTombstone(entry, now, loadingWindow, nextTickTime));
+    }
+
+    [Fact, TestCategory("BVT")]
     public void ReminderOptions_DefaultLoadingWindowIsTwiceDefaultRefreshPeriod()
     {
         var options = new ReminderOptions();

--- a/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/LocalReminderServiceTests.cs
@@ -71,24 +71,6 @@ public class LocalReminderServiceTests
     }
 
     [Fact, TestCategory("BVT")]
-    public void IsReminderWithinLoadingWindow_UsesKnownNextTickAfterCurrentOccurrenceFires()
-    {
-        var now = new DateTime(2026, 1, 1, 0, 10, 0, DateTimeKind.Utc);
-        var period = TimeSpan.FromHours(1);
-        var loadingWindow = TimeSpan.FromMinutes(10);
-        var entry = CreateReminderEntry(now, period);
-        var nextTickTime = now + period;
-
-        Assert.True(LocalReminderService.IsReminderWithinLoadingWindow(entry, now, loadingWindow));
-        Assert.False(LocalReminderService.IsReminderWithinLoadingWindow(entry, now, loadingWindow, nextTickTime));
-        Assert.True(LocalReminderService.ShouldRetainOutsideLoadingWindowTombstone(entry, now, loadingWindow, nextTickTime));
-
-        now += TimeSpan.FromTicks(1);
-        Assert.False(LocalReminderService.IsReminderWithinLoadingWindow(entry, now, loadingWindow));
-        Assert.False(LocalReminderService.ShouldRetainOutsideLoadingWindowTombstone(entry, now, loadingWindow, nextTickTime));
-    }
-
-    [Fact, TestCategory("BVT")]
     public void ReminderOptions_DefaultLoadingWindowIsTwiceDefaultRefreshPeriod()
     {
         var options = new ReminderOptions();

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -37,6 +37,9 @@ namespace UnitTests.TimerTests
 
             protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
             {
+                // These tests advance reminder time in large jumps and assert exact local lifecycle state.
+                // Use one owner so a second silo's queued refresh cannot span two clock advances.
+                builder.Options.InitialSilosCount = 1;
                 _reminderClock = builder.AddReminderTestClock();
                 builder.ConfigureSilo((_, siloBuilder) =>
                 {

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Internal;
+using Orleans.Reminders;
 using Orleans.Testing.Reminders;
 using Orleans.TestingHost;
 using TestExtensions;
@@ -77,6 +78,19 @@ namespace UnitTests.TimerTests
         private readonly ReminderTableReadController _readController;
 
         // Basic tests
+
+        [Fact]
+        public void ReminderTestClock_IsScopedToReminderService()
+        {
+            foreach (var silo in HostedCluster.Silos)
+            {
+                var unkeyedProvider = silo.ServiceProvider.GetRequiredService<TimeProvider>();
+                var reminderProvider = silo.ServiceProvider.GetRequiredKeyedService<TimeProvider>(ReminderTimeProviderNames.Reminders);
+
+                Assert.Same(TimeProvider.System, unkeyedProvider);
+                Assert.NotSame(unkeyedProvider, reminderProvider);
+            }
+        }
 
         /// <summary>
         /// Tests basic reminder operations including stopping reminders by reference.

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -37,6 +37,8 @@ namespace UnitTests.TimerTests
 
             protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
             {
+                // The controlled-read tests validate ordering within one reminder owner.
+                builder.Options.InitialSilosCount = 1;
                 _reminderClock = builder.AddReminderTestClock();
                 builder.ConfigureSilo((_, siloBuilder) =>
                 {

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -37,9 +37,6 @@ namespace UnitTests.TimerTests
 
             protected override void ConfigureTestCluster(InProcessTestClusterBuilder builder)
             {
-                // These tests advance reminder time in large jumps and assert exact local lifecycle state.
-                // Use one owner so a second silo's queued refresh cannot span two clock advances.
-                builder.Options.InitialSilosCount = 1;
                 _reminderClock = builder.AddReminderTestClock();
                 builder.ConfigureSilo((_, siloBuilder) =>
                 {


### PR DESCRIPTION
ReminderTestClock replaced the unkeyed TimeProvider, so Orleans' keyed fallback routed unrelated silo background timers through FakeTimeProvider. Advancing reminder time could therefore synchronously execute membership, health, and other timer callbacks and hang functional reminder tests.

Register the fake provider specifically for ReminderTimeProviderNames.Reminders and verify that unkeyed silo time remains TimeProvider.System.

The scoped clock also makes table refreshes deterministic at exact reminder cadence boundaries. Load table entries only when their next tick is in the future and within the loading window, deliberately skipping an exact-due table load instead of reloading an occurrence which just fired. The controlled stale-read tests use one reminder owner so their blocked table read and direct local mutation share the sequence whose ordering they validate.