### PR TITLE
fix(directory): cancel snapshot pulls from departed silos

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -113,35 +113,35 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         DistributedRemoteGrainDirectory.Create(this, membershipService, shared);
     }
 
-    public async Task<GrainAddress?> Lookup(GrainId grainId) => await LookupAsync(grainId, CancellationToken.None);
+    public async Task<GrainAddress?> Lookup(GrainId grainId) => await LookupAsync(grainId, _stoppedCts.Token);
 
-    public async Task<GrainAddress?> Register(GrainAddress address) => await RegisterAsync(address, null, CancellationToken.None);
+    public async Task<GrainAddress?> Register(GrainAddress address) => await RegisterAsync(address, null, _stoppedCts.Token);
 
     public async Task Unregister(GrainAddress address) => await InvokeAsync(
         address.GrainId,
-        static (partition, version, address, cancellationToken) => partition.DeregisterAsync(version, address),
+        static (partition, version, address, cancellationToken) => partition.DeregisterAsync(version, address, cancellationToken),
         address,
-        CancellationToken.None);
+        _stoppedCts.Token);
 
-    public async Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress) => await RegisterAsync(address, previousAddress, CancellationToken.None);
+    public async Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress) => await RegisterAsync(address, previousAddress, _stoppedCts.Token);
 
     public Task UnregisterSilos(List<SiloAddress> siloAddresses) => Task.CompletedTask;
 
     internal Task<GrainAddress?> LookupAsync(GrainId grainId, CancellationToken cancellationToken) => InvokeAsync(
         grainId,
-        static (partition, version, grainId, cancellationToken) => partition.LookupAsync(version, grainId),
+        static (partition, version, grainId, cancellationToken) => partition.LookupAsync(version, grainId, cancellationToken),
         grainId,
         cancellationToken);
 
     internal async Task<GrainAddress?> RegisterAsync(GrainAddress address, GrainAddress? previousAddress, CancellationToken cancellationToken) => await InvokeAsync(
         address.GrainId,
-        static (partition, version, state, cancellationToken) => partition.RegisterAsync(version, state.Address, state.PreviousAddress),
+        static (partition, version, state, cancellationToken) => partition.RegisterAsync(version, state.Address, state.PreviousAddress, cancellationToken),
         (Address: address, PreviousAddress: previousAddress),
         cancellationToken);
 
     internal Task UnregisterAsync(GrainAddress address, CancellationToken cancellationToken) => InvokeAsync(
         address.GrainId,
-        static (partition, version, address, cancellationToken) => partition.DeregisterAsync(version, address),
+        static (partition, version, address, cancellationToken) => partition.DeregisterAsync(version, address, cancellationToken),
         address,
         cancellationToken);
 
@@ -184,9 +184,15 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
             try
             {
                 RequestContext.Set("gid", partitionReference.GetGrainId());
-                invokeResult = await func(partitionReference, view.Version, state, cancellationToken);
+                using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    GetClusterMemberCancellationToken(owner));
+                invokeResult = await func(partitionReference, view.Version, state, requestCts.Token);
             }
-            catch (OrleansMessageRejectionException) when (attempts < MaxAttempts && !cancellationToken.IsCancellationRequested)
+            catch (Exception exception) when (
+                exception is OrleansMessageRejectionException or OperationCanceledException
+                && attempts < MaxAttempts
+                && !cancellationToken.IsCancellationRequested)
             {
                 // This likely indicates that the target silo has been declared dead.
                 ++attempts;
@@ -448,7 +454,7 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         var view = _membershipService.CurrentView;
         if (view.TryGetOwner(grainId, out var owner, out var partitionReference) && Silo.Equals(owner))
         {
-            var result = await partitionReference.LookupAsync(view.Version, grainId);
+            var result = await partitionReference.LookupAsync(view.Version, grainId, _stoppedCts.Token);
             if (result.TryGetResult(view.Version, out var address))
             {
                 return address;

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.Interface.cs
@@ -8,12 +8,17 @@ namespace Orleans.Runtime.GrainDirectory;
 
 internal sealed partial class GrainDirectoryPartition
 {
-    async ValueTask<DirectoryResult<GrainAddress>> IGrainDirectoryPartition.RegisterAsync(MembershipVersion version, GrainAddress address, GrainAddress? currentRegistration)
+    async ValueTask<DirectoryResult<GrainAddress>> IGrainDirectoryPartition.RegisterAsync(
+        MembershipVersion version,
+        GrainAddress address,
+        GrainAddress? currentRegistration,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         ArgumentNullException.ThrowIfNull(address);
         LogRegisterAsync(version, address, currentRegistration);
 
-        var currentView = await WaitForOwnershipViewAsync(address.GrainId, version);
+        var currentView = await WaitForOwnershipViewAsync(address.GrainId, version, cancellationToken);
         if (!IsOwner(currentView, address.GrainId))
         {
             return DirectoryResult.RefreshRequired<GrainAddress>(currentView.Version);
@@ -23,11 +28,15 @@ internal sealed partial class GrainDirectoryPartition
         return DirectoryResult.FromResult(RegisterCore(address, currentRegistration, currentView.Version), version);
     }
 
-    async ValueTask<DirectoryResult<GrainAddress?>> IGrainDirectoryPartition.LookupAsync(MembershipVersion version, GrainId grainId)
+    async ValueTask<DirectoryResult<GrainAddress?>> IGrainDirectoryPartition.LookupAsync(
+        MembershipVersion version,
+        GrainId grainId,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         LogLookupAsync(version, grainId);
 
-        var currentView = await WaitForOwnershipViewAsync(grainId, version);
+        var currentView = await WaitForOwnershipViewAsync(grainId, version, cancellationToken);
         if (!IsOwner(currentView, grainId))
         {
             return DirectoryResult.RefreshRequired<GrainAddress?>(currentView.Version);
@@ -36,12 +45,16 @@ internal sealed partial class GrainDirectoryPartition
         return DirectoryResult.FromResult(LookupCore(grainId), version);
     }
 
-    async ValueTask<DirectoryResult<bool>> IGrainDirectoryPartition.DeregisterAsync(MembershipVersion version, GrainAddress address)
+    async ValueTask<DirectoryResult<bool>> IGrainDirectoryPartition.DeregisterAsync(
+        MembershipVersion version,
+        GrainAddress address,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         ArgumentNullException.ThrowIfNull(address);
         LogDeregisterAsync(version, address);
 
-        var currentView = await WaitForOwnershipViewAsync(address.GrainId, version);
+        var currentView = await WaitForOwnershipViewAsync(address.GrainId, version, cancellationToken);
         if (!IsOwner(currentView, address.GrainId))
         {
             return DirectoryResult.RefreshRequired<bool>(currentView.Version);
@@ -71,15 +84,20 @@ internal sealed partial class GrainDirectoryPartition
         return null;
     }
 
-    private async ValueTask<DirectoryMembershipSnapshot> WaitForOwnershipViewAsync(GrainId grainId, MembershipVersion version)
+    private async ValueTask<DirectoryMembershipSnapshot> WaitForOwnershipViewAsync(
+        GrainId grainId,
+        MembershipVersion version,
+        CancellationToken cancellationToken)
     {
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ShutdownToken);
         while (true)
         {
             // Requests which arrive with a stale membership version must still wait for any in-flight ownership
             // transition in the current view before deciding whether this partition can serve them.
             var currentView = CurrentView;
             var waitVersion = currentView.Version > version ? currentView.Version : version;
-            await WaitForRange(grainId, waitVersion);
+            await WaitForRange(grainId, waitVersion, linkedCts.Token);
+            linkedCts.Token.ThrowIfCancellationRequested();
             if (ReferenceEquals(currentView, CurrentView))
             {
                 return currentView;

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -93,12 +93,18 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         return CurrentView;
     }
 
-    async ValueTask<GrainDirectoryPartitionSnapshot?> IGrainDirectoryPartition.GetSnapshotAsync(MembershipVersion version, MembershipVersion rangeVersion, RingRange range)
+    async ValueTask<GrainDirectoryPartitionSnapshot?> IGrainDirectoryPartition.GetSnapshotAsync(
+        MembershipVersion version,
+        MembershipVersion rangeVersion,
+        RingRange range,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         LogTraceGetSnapshotAsync(_logger, version, rangeVersion, range);
 
         // Wait for the range to be unlocked.
-        await WaitForRange(range, version);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ShutdownToken);
+        await WaitForRange(range, version, linkedCts.Token);
 
         ShutdownToken.ThrowIfCancellationRequested();
         List<GrainAddress> partitionAddresses = [];
@@ -194,15 +200,19 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
     private bool IsOwner(DirectoryMembershipSnapshot view, GrainId grainId) => view.TryGetOwner(grainId, out _, out var partitionReference) && GrainId.Equals(partitionReference.GetGrainId());
 
-    private ValueTask WaitForRange(GrainId grainId, MembershipVersion version) => WaitForRange(RingRange.FromPoint(grainId.GetUniformHashCode()), version);
+    private ValueTask WaitForRange(GrainId grainId, MembershipVersion version) =>
+        WaitForRange(RingRange.FromPoint(grainId.GetUniformHashCode()), version);
 
-    private ValueTask WaitForRange(RingRange range, MembershipVersion version)
+    private ValueTask WaitForRange(RingRange range, MembershipVersion version) =>
+        WaitForRange(range, version, ShutdownToken);
+
+    private ValueTask WaitForRange(RingRange range, MembershipVersion version, CancellationToken cancellationToken)
     {
         GrainRuntime.CheckRuntimeContext(this);
         Task? completion = null;
         if (CurrentView.Version < version || TryGetIntersectingLock(range, version, out completion))
         {
-            return WaitForRangeCore(range, version, completion);
+            return WaitForRangeCore(range, version, completion, cancellationToken);
         }
 
         return ValueTask.CompletedTask;
@@ -222,21 +232,25 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
             return false;
         }
 
-        async ValueTask WaitForRangeCore(RingRange range, MembershipVersion version, Task? task)
+        async ValueTask WaitForRangeCore(
+            RingRange range,
+            MembershipVersion version,
+            Task? task,
+            CancellationToken cancellationToken)
         {
             if (task is not null)
             {
-                await task;
+                await task.WaitAsync(cancellationToken);
             }
 
             if (CurrentView.Version < version)
             {
-                await RefreshViewAsync(version, ShutdownToken);
+                await RefreshViewAsync(version, cancellationToken);
             }
 
             while (TryGetIntersectingLock(range, version, out var completion))
             {
-                await completion.WaitAsync(ShutdownToken);
+                await completion.WaitAsync(cancellationToken);
             }
         }
     }
@@ -554,11 +568,27 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                 }
 
                 // Alternatively, the previous owner could push the snapshot. The pull-based approach is used here because it is simpler.
-                var snapshot = await partition.GetSnapshotAsync(current.Version, previousVersion, queryRange).AsTask().WaitAsync(ShutdownToken);
+                var snapshot = await InvokeOnClusterMember(
+                    previousOwner,
+                    cancellationToken => partition.GetSnapshotAsync(
+                        current.Version,
+                        previousVersion,
+                        queryRange,
+                        cancellationToken).AsTask(),
+                    default(GrainDirectoryPartitionSnapshot?),
+                    nameof(IGrainDirectoryPartition.GetSnapshotAsync));
 
                 if (snapshot is null)
                 {
-                    LogWarningExpectedValidSnapshot(_logger, previousOwner, queryRange);
+                    if (_owner.GetClusterMemberCancellationToken(previousOwner).IsCancellationRequested)
+                    {
+                        LogWarningRemoteHostUnavailable(_logger, queryRange);
+                    }
+                    else
+                    {
+                        LogWarningExpectedValidSnapshot(_logger, previousOwner, queryRange);
+                    }
+
                     return false;
                 }
 

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -106,7 +106,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ShutdownToken);
         await WaitForRange(range, version, linkedCts.Token);
 
-        ShutdownToken.ThrowIfCancellationRequested();
+        linkedCts.Token.ThrowIfCancellationRequested();
         List<GrainAddress> partitionAddresses = [];
         foreach (var partitionSnapshot in _partitionSnapshots)
         {

--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -203,6 +203,9 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
     private ValueTask WaitForRange(GrainId grainId, MembershipVersion version) =>
         WaitForRange(RingRange.FromPoint(grainId.GetUniformHashCode()), version);
 
+    private ValueTask WaitForRange(GrainId grainId, MembershipVersion version, CancellationToken cancellationToken) =>
+        WaitForRange(RingRange.FromPoint(grainId.GetUniformHashCode()), version, cancellationToken);
+
     private ValueTask WaitForRange(RingRange range, MembershipVersion version) =>
         WaitForRange(range, version, ShutdownToken);
 

--- a/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
@@ -18,7 +18,11 @@ internal interface IGrainDirectoryPartition : ISystemTarget
     ValueTask<DirectoryResult<bool>> DeregisterAsync(MembershipVersion version, GrainAddress address);
 
     [Alias("GetSnapshotAsync")]
-    ValueTask<GrainDirectoryPartitionSnapshot?> GetSnapshotAsync(MembershipVersion version, MembershipVersion rangeVersion, RingRange range);
+    ValueTask<GrainDirectoryPartitionSnapshot?> GetSnapshotAsync(
+        MembershipVersion version,
+        MembershipVersion rangeVersion,
+        RingRange range,
+        CancellationToken cancellationToken = default);
 
     [Alias("AcknowledgeSnapshotTransferAsync")]
     ValueTask<bool> AcknowledgeSnapshotTransferAsync(

--- a/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/IGrainDirectoryPartition.cs
@@ -9,13 +9,23 @@ namespace Orleans.Runtime.GrainDirectory;
 internal interface IGrainDirectoryPartition : ISystemTarget
 {
     [Alias("RegisterAsync")]
-    ValueTask<DirectoryResult<GrainAddress>> RegisterAsync(MembershipVersion version, GrainAddress address, GrainAddress? currentRegistration);
+    ValueTask<DirectoryResult<GrainAddress>> RegisterAsync(
+        MembershipVersion version,
+        GrainAddress address,
+        GrainAddress? currentRegistration,
+        CancellationToken cancellationToken = default);
 
     [Alias("LookupAsync")]
-    ValueTask<DirectoryResult<GrainAddress?>> LookupAsync(MembershipVersion version, GrainId grainId);
+    ValueTask<DirectoryResult<GrainAddress?>> LookupAsync(
+        MembershipVersion version,
+        GrainId grainId,
+        CancellationToken cancellationToken = default);
 
     [Alias("DeregisterAsync")]
-    ValueTask<DirectoryResult<bool>> DeregisterAsync(MembershipVersion version, GrainAddress address);
+    ValueTask<DirectoryResult<bool>> DeregisterAsync(
+        MembershipVersion version,
+        GrainAddress address,
+        CancellationToken cancellationToken = default);
 
     [Alias("GetSnapshotAsync")]
     ValueTask<GrainDirectoryPartitionSnapshot?> GetSnapshotAsync(

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
@@ -111,8 +111,14 @@ internal sealed class LocalGrainDirectoryPartitionCompatibility : SystemTarget, 
         return new(DirectoryResult.FromResult(true, version));
     }
 
-    public ValueTask<GrainDirectoryPartitionSnapshot?> GetSnapshotAsync(MembershipVersion version, MembershipVersion rangeVersion, RingRange range)
+    public ValueTask<GrainDirectoryPartitionSnapshot?> GetSnapshotAsync(
+        MembershipVersion version,
+        MembershipVersion rangeVersion,
+        RingRange range,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         // LocalGrainDirectory stores entries using the legacy single-ring ownership scheme, so this local
         // partition cannot produce a complete snapshot for a distributed virtual partition range.
         return new((GrainDirectoryPartitionSnapshot?)null);

--- a/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
+++ b/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryCompatibility.cs
@@ -93,20 +93,33 @@ internal sealed class LocalGrainDirectoryPartitionCompatibility : SystemTarget, 
         shared.ActivationDirectory.RecordNewTarget(this);
     }
 
-    public ValueTask<DirectoryResult<GrainAddress>> RegisterAsync(MembershipVersion version, GrainAddress address, GrainAddress? currentRegistration)
+    public ValueTask<DirectoryResult<GrainAddress>> RegisterAsync(
+        MembershipVersion version,
+        GrainAddress address,
+        GrainAddress? currentRegistration,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var result = _directory.DirectoryPartition.AddSingleActivation(address, currentRegistration);
         return new(DirectoryResult.FromResult(result.Address!, version));
     }
 
-    public ValueTask<DirectoryResult<GrainAddress?>> LookupAsync(MembershipVersion version, GrainId grainId)
+    public ValueTask<DirectoryResult<GrainAddress?>> LookupAsync(
+        MembershipVersion version,
+        GrainId grainId,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var result = _directory.DirectoryPartition.LookUpActivation(grainId);
         return new(DirectoryResult.FromResult<GrainAddress?>(result.Address, version));
     }
 
-    public ValueTask<DirectoryResult<bool>> DeregisterAsync(MembershipVersion version, GrainAddress address)
+    public ValueTask<DirectoryResult<bool>> DeregisterAsync(
+        MembershipVersion version,
+        GrainAddress address,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         _directory.DirectoryPartition.RemoveActivation(address.GrainId, address.ActivationId, UnregistrationCause.Force);
         return new(DirectoryResult.FromResult(true, version));
     }


### PR DESCRIPTION
During an in-place rolling upgrade, a distributed directory partition could begin pulling a snapshot from the retiring owner while that silo transitioned from ShuttingDown to Dead. Snapshot pulls were the one per-member directory operation not bound to the membership-driven cancellation token, so the acquisition range lock remained held until the 30-second messaging timeout. Local lookups for that range queued behind the lock and timed out as a result.

This change plumbs the shared member cancellation token through GetSnapshotAsync and range waits. When the previous owner departs, the snapshot pull now stops immediately and the existing recovery path takes over. Callee shutdown remains linked into the wait, and diagnostics distinguish an unavailable owner from an invalid snapshot.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10318)