### PR TITLE
test: wait for grain call before checking cancellation

### DIFF
--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -189,6 +189,11 @@ namespace UnitTests.GrainInterfaces
         Task ScheduleDelayedPingToSelfAndDeactivate(IGenericPingSelf<T> target, T t, TimeSpan delay);
     }
 
+    public interface ILongRunningTaskObserver : IGrainObserver
+    {
+        void OnCallStarted(Guid callId);
+    }
+
     public interface ILongRunningTaskGrain<T> : IGrainWithGuidKey
     {
         Task<string> GetRuntimeInstanceId();
@@ -201,6 +206,7 @@ namespace UnitTests.GrainInterfaces
         [AlwaysInterleave]
         Task LongWaitGrainCancellationInterleaving(GrainCancellationToken tc, TimeSpan delay, Guid callId);
         Task LongWait(CancellationToken tc, TimeSpan delay, Guid callId);
+        Task LongWaitWithStartNotification(TimeSpan delay, Guid callId, ILongRunningTaskObserver observer, CancellationToken cancellationToken);
         [AlwaysInterleave]
         Task LongWaitInterleaving(CancellationToken tc, TimeSpan delay, Guid callId);
         Task CallOtherLongRunningTask(ILongRunningTaskGrain<T> target, CancellationToken tc, TimeSpan delay, Guid callId);

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -785,6 +785,13 @@ namespace UnitTests.Grains
         }
 
         public Task LongWaitInterleaving(CancellationToken ct, TimeSpan delay, Guid callId) => LongWait(ct, delay, callId);
+
+        public Task LongWaitWithStartNotification(TimeSpan delay, Guid callId, ILongRunningTaskObserver observer, CancellationToken cancellationToken)
+        {
+            observer.OnCallStarted(callId);
+            return LongWait(cancellationToken, delay, callId);
+        }
+
         public async Task LongWait(CancellationToken ct, TimeSpan delay, Guid callId)
         {
             try

--- a/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
+++ b/test/Orleans.Runtime.Tests/CancellationTests/CancellationTokenTests.cs
@@ -67,14 +67,29 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
     public async Task GrainTaskCancellation(int delay)
     {
         var grain = fixture.GrainFactory.GetGrain<ILongRunningTaskGrain<bool>>(Guid.NewGuid());
-        using var cts = new CancellationTokenSource();
-        var callId = Guid.NewGuid();
-        var grainTask = grain.LongWait(cts.Token, TimeSpan.FromSeconds(10), callId);
-        cts.CancelAfter(delay);
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
-        if (delay > 0)
+        var observer = new LongRunningTaskObserver();
+        var observerReference = fixture.GrainFactory.CreateObjectReference<ILongRunningTaskObserver>(observer);
+        try
         {
-            await WaitForCallCancellation(grain, callId);
+            using var cts = new CancellationTokenSource();
+            var callId = Guid.NewGuid();
+            var grainTask = grain.LongWaitWithStartNotification(TimeSpan.FromSeconds(10), callId, observerReference, cts.Token);
+            if (delay > 0)
+            {
+                // A timer does not guarantee that a new activation has begun executing the request.
+                await observer.WaitForCallToStart(callId);
+            }
+
+            cts.CancelAfter(delay);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => grainTask);
+            if (delay > 0)
+            {
+                await WaitForCallCancellation(grain, callId);
+            }
+        }
+        finally
+        {
+            fixture.GrainFactory.DeleteObjectReference<ILongRunningTaskObserver>(observerReference);
         }
     }
 
@@ -351,6 +366,19 @@ public abstract class CancellationTokenTests(CancellationTokenTests.FixtureBase 
         }
 
         Assert.Fail("Did not encounter the expected call id");
+    }
+
+    private sealed class LongRunningTaskObserver : ILongRunningTaskObserver
+    {
+        private readonly TaskCompletionSource<Guid> _callStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void OnCallStarted(Guid callId) => _callStarted.TrySetResult(callId);
+
+        public async Task WaitForCallToStart(Guid expectedCallId)
+        {
+            var callId = await _callStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            Assert.Equal(expectedCallId, callId);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
The delayed grain cancellation test assumed that a positive timer meant the grain method had started. On slower activation paths, cancellation can remove the request from the activation's waiting queue and return `OperationCanceledException` without invoking the method, leaving the test waiting for a cancellation record which can never be written.

Add a test observer handshake emitted from inside the grain method and wait for it before scheduling delayed cancellation. This preserves immediate-cancellation coverage while making the delayed cases deterministically exercise cancellation of a running call. No runtime product behavior is changed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10319)