### PR TITLE
refactor(streaming): remove unused implicit subscriber grain factory

### DIFF
--- a/src/Orleans.Streaming/Providers/ClientStreamingProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/ClientStreamingProviderRuntime.cs
@@ -31,7 +31,7 @@ namespace Orleans.Providers
             this.clientContext = clientContext;
             this.runtimeClient = serviceProvider.GetService<IRuntimeClient>()!; // Registered by DefaultClientServices.
             grainBasedPubSub = new GrainBasedPubSubRuntime(GrainFactory);
-            var tmp = new ImplicitStreamPubSub(this.grainFactory, this.implicitSubscriberTable);
+            var tmp = new ImplicitStreamPubSub(this.implicitSubscriberTable);
             implicitPubSub = tmp;
             combinedGrainBasedAndImplicitPubSub = new StreamPubSubImpl(grainBasedPubSub, tmp);
             streamDirectory = new StreamDirectory();

--- a/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
+++ b/src/Orleans.Streaming/Providers/SiloStreamProviderRuntime.cs
@@ -41,7 +41,7 @@ namespace Orleans.Runtime.Providers
             this.runtimeClient = runtimeClient;
             this.logger = this.loggerFactory.CreateLogger<SiloProviderRuntime>();
             this.grainBasedPubSub = new GrainBasedPubSubRuntime(this.GrainFactory);
-            var tmp = new ImplicitStreamPubSub(this.runtimeClient.InternalGrainFactory, implicitStreamSubscriberTable);
+            var tmp = new ImplicitStreamPubSub(implicitStreamSubscriberTable);
             this.implictPubSub = tmp;
             this.combinedGrainBasedAndImplicitPubSub = new StreamPubSubImpl(this.grainBasedPubSub, tmp);
         }

--- a/src/Orleans.Streaming/PubSub/ImplicitStreamPubSub.cs
+++ b/src/Orleans.Streaming/PubSub/ImplicitStreamPubSub.cs
@@ -9,17 +9,15 @@ namespace Orleans.Streams
 {
     internal class ImplicitStreamPubSub : IStreamPubSub
     {
-        private readonly IInternalGrainFactory grainFactory;
         private readonly ImplicitStreamSubscriberTable implicitTable;
 
-        public ImplicitStreamPubSub(IInternalGrainFactory grainFactory, ImplicitStreamSubscriberTable implicitPubSubTable)
+        public ImplicitStreamPubSub(ImplicitStreamSubscriberTable implicitPubSubTable)
         {
             if (implicitPubSubTable == null)
             {
                 throw new ArgumentNullException(nameof(implicitPubSubTable));
             }
 
-            this.grainFactory = grainFactory;
             this.implicitTable = implicitPubSubTable;
         }
 
@@ -28,7 +26,7 @@ namespace Orleans.Streams
             ISet<PubSubSubscriptionState> result = new HashSet<PubSubSubscriptionState>();
             if (!ImplicitStreamSubscriberTable.IsImplicitSubscribeEligibleNameSpace(streamId.GetNamespace())) return Task.FromResult(result);
 
-            IDictionary<Guid, GrainId> implicitSubscriptions = implicitTable.GetImplicitSubscribers(streamId, this.grainFactory);
+            IDictionary<Guid, GrainId> implicitSubscriptions = implicitTable.GetImplicitSubscribers(streamId);
             foreach (var kvp in implicitSubscriptions)
             {
                 GuidId subscriptionId = GuidId.GetGuidId(kvp.Key);
@@ -84,7 +82,7 @@ namespace Orleans.Streams
             }
             else
             {
-                var implicitConsumers = this.implicitTable.GetImplicitSubscribers(streamId, grainFactory);
+                var implicitConsumers = this.implicitTable.GetImplicitSubscribers(streamId);
                 var subscriptions = implicitConsumers.Select(consumer =>
                 {
                     var grainId = consumer.Value;

--- a/src/Orleans.Streaming/PubSub/ImplicitStreamPubSub.cs
+++ b/src/Orleans.Streaming/PubSub/ImplicitStreamPubSub.cs
@@ -11,14 +11,14 @@ namespace Orleans.Streams
     {
         private readonly ImplicitStreamSubscriberTable implicitTable;
 
-        public ImplicitStreamPubSub(ImplicitStreamSubscriberTable implicitPubSubTable)
+        public ImplicitStreamPubSub(ImplicitStreamSubscriberTable implicitSubscriberTable)
         {
-            if (implicitPubSubTable == null)
+            if (implicitSubscriberTable == null)
             {
-                throw new ArgumentNullException(nameof(implicitPubSubTable));
+                throw new ArgumentNullException(nameof(implicitSubscriberTable));
             }
 
-            this.implicitTable = implicitPubSubTable;
+            this.implicitTable = implicitSubscriberTable;
         }
 
         public Task<ISet<PubSubSubscriptionState>> RegisterProducer(QualifiedStreamId streamId, GrainId streamProducer)

--- a/src/Orleans.Streaming/PubSub/ImplicitStreamSubscriberTable.cs
+++ b/src/Orleans.Streaming/PubSub/ImplicitStreamSubscriberTable.cs
@@ -107,10 +107,10 @@ namespace Orleans.Streams
         }
 
         /// <summary>
-        /// Retrieve a map of implicit subscriptionsIds to implicit subscribers, given a stream ID. This method throws an exception if there's no namespace associated with the stream ID.
+        /// Retrieves a map of implicit subscription IDs to implicit subscriber grain IDs for the specified stream.
         /// </summary>
         /// <param name="streamId">A stream ID.</param>
-        /// <returns>A set of GrainId that are implicitly subscribed grains. They are expected to support the streaming consumer extension.</returns>
+        /// <returns>A dictionary mapping subscription IDs to implicitly subscribed grain IDs. The grains are expected to support the streaming consumer extension.</returns>
         /// <exception cref="System.ArgumentException">The stream ID doesn't have an associated namespace.</exception>
         /// <exception cref="System.InvalidOperationException">Internal invariant violation.</exception>
         internal Dictionary<Guid, GrainId> GetImplicitSubscribers(QualifiedStreamId streamId)

--- a/src/Orleans.Streaming/PubSub/ImplicitStreamSubscriberTable.cs
+++ b/src/Orleans.Streaming/PubSub/ImplicitStreamSubscriberTable.cs
@@ -110,11 +110,10 @@ namespace Orleans.Streams
         /// Retrieve a map of implicit subscriptionsIds to implicit subscribers, given a stream ID. This method throws an exception if there's no namespace associated with the stream ID.
         /// </summary>
         /// <param name="streamId">A stream ID.</param>
-        /// <param name="grainFactory">The grain factory used to get consumer references.</param>
         /// <returns>A set of GrainId that are implicitly subscribed grains. They are expected to support the streaming consumer extension.</returns>
         /// <exception cref="System.ArgumentException">The stream ID doesn't have an associated namespace.</exception>
         /// <exception cref="System.InvalidOperationException">Internal invariant violation.</exception>
-        internal Dictionary<Guid, GrainId> GetImplicitSubscribers(QualifiedStreamId streamId, IInternalGrainFactory grainFactory) 
+        internal Dictionary<Guid, GrainId> GetImplicitSubscribers(QualifiedStreamId streamId)
         {
             var streamNamespace = streamId.GetNamespace();
             if (!IsImplicitSubscribeEligibleNameSpace(streamNamespace))


### PR DESCRIPTION
Removes the unused internal grain factory parameter from implicit stream subscriber lookup and its callers. The lookup already returns grain IDs directly, so retaining and threading the factory adds unnecessary coupling.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10322)