### PR TITLE
fix(directory): make rolling upgrade handoffs durable

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedRemoteGrainDirectory.cs
@@ -150,19 +150,6 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
         }
     }
 
-    private void DestroyDuplicateActivations(Dictionary<SiloAddress, List<GrainAddress>>? duplicates)
-    {
-        if (duplicates is null || duplicates.Count == 0)
-        {
-            return;
-        }
-
-        EnqueueOperation(
-            nameof(DestroyDuplicateActivations),
-            duplicates,
-            static (self, state) => self.DestroyDuplicateActivationsAsync((Dictionary<SiloAddress, List<GrainAddress>>)state));
-    }
-
     private async Task DestroyDuplicateActivationsAsync(Dictionary<SiloAddress, List<GrainAddress>> duplicates)
     {
         while (duplicates.Count > 0)
@@ -205,7 +192,6 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
             }
         });
 
-        Dictionary<SiloAddress, List<GrainAddress>>? duplicates = null;
         Exception? failure = null;
         for (var i = pendingRegistrations.Count - 1; i >= 0; i--)
         {
@@ -221,10 +207,10 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
             {
                 if (registration.SiloAddress is { } siloAddress)
                 {
-                    if (duplicates is null || !duplicates.TryGetValue(siloAddress, out var activations))
+                    if (!batch.DuplicateActivations.TryGetValue(siloAddress, out var activations))
                     {
                         activations = [];
-                        (duplicates ??= []).Add(siloAddress, activations);
+                        batch.DuplicateActivations.Add(siloAddress, activations);
                     }
 
                     activations.Add(registration);
@@ -234,7 +220,7 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
             pendingRegistrations.RemoveAt(i);
         }
 
-        DestroyDuplicateActivations(duplicates);
+        await DestroyDuplicateActivationsAsync(batch.DuplicateActivations);
 
         if (failure is not null)
         {
@@ -243,6 +229,7 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
         }
 
         LogInformationAcceptSplitPartitionCompleted(_logger, Silo, batch.InitialCount);
+        batch.Completion.TrySetResult();
     }
 
     public async Task<AddressAndTag> RegisterAsync(GrainAddress address, int hopCount)
@@ -337,15 +324,29 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
     public Task AcceptSplitPartition(List<GrainAddress> singleActivations)
     {
         LogInformationAcceptSplitPartitionStarted(_logger, Silo, singleActivations.Count);
-        if (singleActivations.Count > 0)
+        if (singleActivations.Count == 0)
         {
-            EnqueueOperation(
-                nameof(AcceptSplitPartition),
-                new SplitPartitionRegistrationBatch([.. singleActivations]),
-                static (self, state) => self.ProcessSplitPartitionRegistrationsAsync((SplitPartitionRegistrationBatch)state));
+            return Task.CompletedTask;
         }
 
-        return Task.CompletedTask;
+        lock (_pendingOperations)
+        {
+            foreach (var operation in _pendingOperations)
+            {
+                if (operation.State is SplitPartitionRegistrationBatch existingBatch
+                    && existingBatch.Matches(singleActivations))
+                {
+                    return existingBatch.Completion.Task.WaitAsync(_directory.OnStoppedToken);
+                }
+            }
+
+            var batch = new SplitPartitionRegistrationBatch(singleActivations);
+            EnqueueOperation(
+                nameof(AcceptSplitPartition),
+                batch,
+                static (self, state) => self.ProcessSplitPartitionRegistrationsAsync((SplitPartitionRegistrationBatch)state));
+            return batch.Completion.Task.WaitAsync(_directory.OnStoppedToken);
+        }
     }
 
     [LoggerMessage(
@@ -378,9 +379,15 @@ internal sealed partial class DistributedRemoteGrainDirectory : SystemTarget, IR
     )]
     private static partial void LogWarningOperationFailedRetry(ILogger logger, Exception exception, string operation);
 
-    private sealed class SplitPartitionRegistrationBatch(List<GrainAddress> pendingRegistrations)
+    private sealed class SplitPartitionRegistrationBatch(List<GrainAddress> registrations)
     {
-        public int InitialCount { get; } = pendingRegistrations.Count;
-        public List<GrainAddress> PendingRegistrations { get; } = pendingRegistrations;
+        private readonly List<GrainAddress> _registrations = [.. registrations];
+
+        public int InitialCount => _registrations.Count;
+        public List<GrainAddress> PendingRegistrations { get; } = [.. registrations];
+        public Dictionary<SiloAddress, List<GrainAddress>> DuplicateActivations { get; } = [];
+        public TaskCompletionSource Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool Matches(List<GrainAddress> registrations) => _registrations.SequenceEqual(registrations);
     }
 }

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -883,6 +883,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     staleCacheEvidence);
             }
 
+            AssertSplitPartitionHandoffsAreDurable(logs);
             var finalWorkerProgress = traffic.GetWorkerProgress();
             phase.Set("all-distributed-final");
             Assert.Equal(SiloCount, cluster.Silos.Count);
@@ -1303,6 +1304,46 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         }
 
         Assert.Empty(errors);
+    }
+
+    private static void AssertSplitPartitionHandoffsAreDurable(PhaseAwareLogCapture logs)
+    {
+        var completedHandoffs = new Dictionary<(string Silo, int Count), int>();
+        var removedHandoffs = 0;
+        foreach (var entry in logs.ToArray())
+        {
+            var isCompleted = string.Equals(
+                entry.EventId.Name,
+                "LogInformationAcceptSplitPartitionCompleted",
+                StringComparison.Ordinal);
+            var isRemoved = string.Equals(
+                entry.EventId.Name,
+                "LogInformationRemovedTransferredEntries",
+                StringComparison.Ordinal);
+            if (!isCompleted && !isRemoved)
+            {
+                continue;
+            }
+
+            Assert.False(string.IsNullOrEmpty(entry.HandoffSilo));
+            Assert.True(entry.HandoffCount.HasValue);
+            var handoff = (entry.HandoffSilo!, entry.HandoffCount.Value);
+            completedHandoffs.TryGetValue(handoff, out var count);
+            if (isCompleted)
+            {
+                completedHandoffs[handoff] = count + 1;
+            }
+            else
+            {
+                removedHandoffs++;
+                Assert.True(
+                    count > 0,
+                    $"Sender-side registrations were removed before the recipient completed the handoff: {entry}");
+                completedHandoffs[handoff] = count - 1;
+            }
+        }
+
+        Assert.True(removedHandoffs > 0, "The rolling upgrade did not exercise a non-empty split-partition handoff.");
     }
 
     private static bool IsExpectedIntentionalRestartLog(PhaseAwareLogEntry entry)
@@ -1842,8 +1883,41 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             {
                 if (IsEnabled(logLevel))
                 {
-                    capture.Add(siloName, category, logLevel, eventId, formatter(state, exception), exception);
+                    var (handoffSilo, handoffCount) = GetHandoffIdentity(state);
+                    capture.Add(
+                        siloName,
+                        category,
+                        logLevel,
+                        eventId,
+                        formatter(state, exception),
+                        exception,
+                        handoffSilo,
+                        handoffCount);
                 }
+            }
+
+            private static (string? Silo, int? Count) GetHandoffIdentity<TState>(TState state)
+            {
+                if (state is not IEnumerable<KeyValuePair<string, object?>> properties)
+                {
+                    return default;
+                }
+
+                string? silo = null;
+                int? count = null;
+                foreach (var property in properties)
+                {
+                    if (property.Key is "Silo" or "AddedSilo")
+                    {
+                        silo = property.Value?.ToString();
+                    }
+                    else if (property.Key == "Count" && property.Value is int value)
+                    {
+                        count = value;
+                    }
+                }
+
+                return (silo, count);
             }
         }
     }
@@ -1858,7 +1932,9 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             LogLevel level,
             EventId eventId,
             string message,
-            Exception? exception)
+            Exception? exception,
+            string? handoffSilo,
+            int? handoffCount)
         {
             var baseException = exception?.GetBaseException();
             _entries.Enqueue(
@@ -1871,7 +1947,9 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     eventId,
                     message,
                     baseException?.GetType().FullName,
-                    baseException?.Message));
+                    baseException?.Message,
+                    handoffSilo,
+                    handoffCount));
         }
 
         public PhaseAwareLogEntry[] ToArray() => _entries.ToArray();
@@ -1886,7 +1964,9 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         EventId EventId,
         string Message,
         string? ExceptionType,
-        string? ExceptionMessage)
+        string? ExceptionMessage,
+        string? HandoffSilo,
+        int? HandoffCount)
     {
         public override string ToString() =>
             $"{Timestamp:O} phase='{Phase}' silo='{SiloName}' [{Level}] [{Category}] ({EventId.Id}:{EventId.Name}) "


### PR DESCRIPTION
During LocalGrainDirectory to DistributedGrainDirectory rolling upgrades, split-partition handoffs acknowledged queued registration work before it completed. The legacy owner could remove its entries first, briefly leaving no authoritative registration and allowing a duplicate activation to be created.

This change makes the handoff acknowledgment complete only after the distributed directory has installed the registrations and cleaned up losing activations. Repeated sender retries coalesce onto the existing transfer, and the rolling-upgrade test now verifies from structured diagnostics that recipient completion precedes sender removal and that a non-empty handoff was exercised.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10323)