### PR TITLE
feat(runtime): add efficient runtime state dissemination

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -145,7 +145,6 @@
     <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageVersion Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
     <PackageVersion Update="Microsoft.CodeAnalysis" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.Accordant" Version="0.1.6" />
     <PackageVersion Update="Azure.Core" Version="1.51.1" />
     <PackageVersion Update="Azure.Identity" Version="1.18.0" />
     <PackageVersion Update="Azure.Security.KeyVault.Secrets" Version="4.8.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,6 @@
     <PackageVersion Include="CassandraCSharpDriver" Version="3.22.0" />
     <PackageVersion Include="Consul" Version="1.7.14.10" />
     <PackageVersion Include="CsCheck" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.Accordant" Version="0.1.6" />
     <PackageVersion Include="FSharp.Core" Version="9.0.303" />
     <PackageVersion Include="Google.Cloud.Firestore" Version="4.3.0" />
     <PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.36.0" />
@@ -146,6 +145,7 @@
     <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageVersion Update="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
     <PackageVersion Update="Microsoft.CodeAnalysis" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.Accordant" Version="0.1.6" />
     <PackageVersion Update="Azure.Core" Version="1.51.1" />
     <PackageVersion Update="Azure.Identity" Version="1.18.0" />
     <PackageVersion Update="Azure.Security.KeyVault.Secrets" Version="4.8.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="CassandraCSharpDriver" Version="3.22.0" />
     <PackageVersion Include="Consul" Version="1.7.14.10" />
     <PackageVersion Include="CsCheck" Version="4.5.0" />
+    <PackageVersion Include="Microsoft.Accordant" Version="0.1.6" />
     <PackageVersion Include="FSharp.Core" Version="9.0.303" />
     <PackageVersion Include="Google.Cloud.Firestore" Version="4.3.0" />
     <PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.36.0" />

--- a/dissemination.md
+++ b/dissemination.md
@@ -259,14 +259,15 @@ internal interface IDisseminationTopic
 
     DisseminationTopicOptions Options { get; }
 
-    IReadOnlyList<DisseminationDigest> GetDigests();
+    IReadOnlyList<DisseminationTopicDigest> GetDigests();
 
-    int CompareVersion(DisseminationDigest left, DisseminationDigest right);
+    int CompareVersion(DisseminationTopicDigest left, DisseminationTopicDigest right);
 
-    bool IsObsolete(DisseminationDigest digest);
+    bool IsObsolete(DisseminationTopicDigest digest);
 
     ValueTask<DisseminationValue?> GetValue(
-        DisseminationDigest digest,
+        DisseminationTopicDigest digest,
+        DisseminationTopicDigest? peerDigest,
         CancellationToken cancellationToken);
 
     ValueTask<DisseminationApplyResult> ApplyValue(
@@ -274,8 +275,8 @@ internal interface IDisseminationTopic
         CancellationToken cancellationToken);
 
     ValueTask OnFallbackRequired(
-        SiloAddress peer,
-        DisseminationDigest digest,
+        SiloAddress? peer,
+        DisseminationTopicDigest digest,
         CancellationToken cancellationToken);
 }
 ```
@@ -283,33 +284,31 @@ internal interface IDisseminationTopic
 Digest and value shapes:
 
 ```csharp
-internal readonly record struct DisseminationDigest(
-    string Topic,
+internal readonly record struct DisseminationTopicDigest(
     string Key,
     long Version);
 
 internal sealed class DisseminationValue
 {
-    public DisseminationDigest Digest { get; init; }
+    public DisseminationTopicDigest Digest { get; init; }
     public SiloAddress Root { get; init; }
     public DateTimeOffset ExpiresAt { get; init; }
-    public byte[] Payload { get; init; }
+    public ReadOnlyMemory<byte> Payload { get; init; }
 }
 ```
 
-`DisseminationDigest` is the payload-free summary exchanged during anti-entropy. It identifies one version of one logical value:
+`DisseminationTopicDigest` is the topic-local payload-free summary exchanged during anti-entropy. It identifies one version of one logical value within the enclosing topic:
 
 | Property | Meaning |
 |---|---|
-| `Topic` | Logical namespace and semantic owner, such as `load` or `membership`. |
 | `Key` | Topic-local string key. Membership uses `"cluster"`; load statistics use the source silo's `SiloAddress.ToParsableString()` value. |
-| `Version` | Monotonic version for this `(Topic, Key)` stream. Higher versions supersede lower versions according to topic comparison rules. |
+| `Version` | Monotonic version for this topic/key stream. Higher versions supersede lower versions according to topic comparison rules. |
 
-`DisseminationValue` carries a digest plus routing and payload data:
+`DisseminationValue` carries a topic-local digest plus routing and payload data. Gossip and repair responses group values by topic, so the topic is not repeated on each value:
 
 | Property | Meaning |
 |---|---|
-| `Digest` | The `DisseminationDigest` for the value being sent. |
+| `Digest` | The `DisseminationTopicDigest` for the value being sent. |
 | `Root` | Silo which rooted this tree broadcast. This is routing metadata and is not necessarily the same as the value key. |
 | `ExpiresAt` | Time after which the value should not be applied or forwarded. |
 | `Payload` | Serialized topic-specific value. The topic owns deserialization, validation, version comparison, and application. |

--- a/dissemination.md
+++ b/dissemination.md
@@ -59,11 +59,11 @@ Current load publication is the clearest high-rate scalability pressure. Each si
 
 Design:
 
-- Disseminate load updates as latest-wins topic items.
-- Item id: `(topic = load, origin silo, statistics DateTime ticks)`.
+- Disseminate load updates as latest-wins topic values.
+- Digest: `(topic = load, key = origin silo address string, version = statistics DateTime ticks, payload kind = SiloRuntimeStatistics)`.
 - Coalesce pending load updates by origin silo.
 - Keep only the latest statistics per origin while sends are in flight.
-- Apply each item independently: newer timestamps replace older timestamps; equal timestamps are duplicates.
+- Apply each value independently: newer timestamps replace older timestamps; equal timestamps are duplicates.
 - Keep direct stale-stat repair as a correctness backstop for active silos.
 
 Backstop:
@@ -98,7 +98,7 @@ Design:
 - The external membership table remains canonical.
 - Receivers merge only through existing membership-table snapshot processing.
 - Use full snapshots first; do not require deltas for correctness.
-- Item id: `(topic = membership, origin silo, membership table version)`.
+- Digest: `(topic = membership, key = "cluster", version = membership table version, payload kind = MembershipSnapshot)`.
 - Older, equal, duplicated, and reordered snapshots are harmless because the membership manager already merges by version.
 
 Backstop:
@@ -132,7 +132,7 @@ Design:
 
 - Disseminate manifest hash summaries or hints only.
 - Use content-addressed storage: `ManifestHash -> GrainManifest`.
-- Item id: `(topic = manifest, origin silo, manifest version or hash)`.
+- Digest or hash hint: `(topic = manifest, key = silo address string, version = manifest version, payload kind = ManifestHash)`.
 - Pull missing manifests by hash from peers.
 - Preserve current fully materialized client/gateway manifest APIs.
 - Do not push full manifests via eager gossip.
@@ -217,10 +217,8 @@ Coalescers
 
 Shared dissemination substrate
   Topic registry
-  Shared overlay
-  Per-item seen/cache state
-  Eager/lazy edge state
-  Prune/graft repair
+  Deterministic spanning tree
+  Digest anti-entropy repair
   Capability and fallback
   Batch construction
 
@@ -229,28 +227,26 @@ Transport
   Legacy topic-specific fallback calls
 ```
 
-### Shared overlay
+### Deterministic spanning trees
 
-The overlay owns peer relationships:
+The dissemination substrate maintains two rooted k-ary trees from cluster membership:
 
-- Eager peers receive full payload batches.
-- Lazy peers receive advertisement batches.
-- Capability state determines which peers can receive new control operations.
-- Failure/backoff state prevents error storms.
-- Membership updates remove inactive peers and add replacement candidates.
+- `AllMembers`: silos in `Joining`, `Active`, `ShuttingDown`, or `Stopping`.
+- `ActiveMembers`: silos in `Active`.
 
-Initial peer sets should use an expander-style construction similar to `ClusterHealthMonitor`:
+Both tree inputs are immutable arrays sorted by the natural deterministic `SiloAddress` sort order, not by an additional hash. When cluster membership changes, both cached topologies are rebuilt from the latest member arrays. Each topic declares which membership scope it uses:
 
-- Use multiple salted hash rings over active silos.
-- Exclude self.
-- Select low-overlap neighbors.
-- Use the result only to seed/replenish eager/lazy peer sets.
+- Membership snapshots use `AllMembers`, matching existing membership gossip eligibility.
+- Deployment load statistics use `ActiveMembers`, matching existing load publisher behavior.
+- Manifest exchange remains active-only and pull-based.
 
-Do not recompute eager peers on every tick. Steady-state adaptation belongs to prune/graft edge state.
+For a broadcast rooted at `root`, treat `root` as logical tree index `0` by rotating the selected sorted array during child lookup. For fanout `k`, the node at tree index `i` owns child tree indexes `k * i + 1` through `k * i + k`.
+
+The all-members tree can include silos which are not reachable yet or are leaving. Active participants still need to be known dissemination-capable before a publish uses the tree. Transient unavailability for `Joining`, `ShuttingDown`, or `Stopping` participants does not fail publication: missed subtrees are repaired by anti-entropy or removed by cluster membership.
 
 ### Topic API
 
-A topic driver supplies item semantics. The substrate supplies transport, batching, deduplication, and repair.
+A topic driver supplies value semantics. The substrate supplies transport, batching, duplicate suppression, and repair.
 
 Example shape:
 
@@ -259,49 +255,66 @@ internal interface IDisseminationTopic
 {
     string Name { get; }
 
+    DisseminationMembershipScope MembershipScope { get; }
+
     DisseminationTopicOptions Options { get; }
 
-    ValueTask<IReadOnlyList<DisseminationItem>> DrainPendingItems(
-        int maxItems,
-        int maxBytes,
+    IReadOnlyList<DisseminationDigest> GetDigests();
+
+    int CompareVersion(DisseminationDigest left, DisseminationDigest right);
+
+    bool IsObsolete(DisseminationDigest digest);
+
+    ValueTask<DisseminationValue?> GetValue(
+        DisseminationDigest digest,
         CancellationToken cancellationToken);
 
-    bool IsObsolete(DisseminationItemId id);
-
-    ValueTask<DisseminationApplyResult> ApplyItem(
-        DisseminationItem item,
+    ValueTask<DisseminationApplyResult> ApplyValue(
+        DisseminationValue value,
         CancellationToken cancellationToken);
 
     ValueTask OnFallbackRequired(
         SiloAddress peer,
-        DisseminationItemId id,
+        DisseminationDigest digest,
         CancellationToken cancellationToken);
 }
 ```
 
-Item and advertisement shapes:
+Digest and value shapes:
 
 ```csharp
-internal readonly record struct DisseminationItemId(
+internal readonly record struct DisseminationDigest(
     string Topic,
-    SiloAddress Origin,
-    long Sequence,
+    string Key,
+    long Version,
     string PayloadKind);
 
-internal sealed class DisseminationItem
+internal sealed class DisseminationValue
 {
-    public DisseminationItemId Id { get; init; }
-    public uint Round { get; init; }
+    public DisseminationDigest Digest { get; init; }
+    public SiloAddress Root { get; init; }
     public DateTimeOffset ExpiresAt { get; init; }
     public byte[] Payload { get; init; }
 }
-
-internal sealed class DisseminationAdvertisement
-{
-    public DisseminationItemId Id { get; init; }
-    public uint Round { get; init; }
-}
 ```
+
+`DisseminationDigest` is the payload-free summary exchanged during anti-entropy. It identifies one version of one logical value:
+
+| Property | Meaning |
+|---|---|
+| `Topic` | Logical namespace and semantic owner, such as `load` or `membership`. |
+| `Key` | Topic-local string key. Membership uses `"cluster"`; load statistics use the source silo's `SiloAddress.ToParsableString()` value. |
+| `Version` | Monotonic version for this `(Topic, Key, PayloadKind)` stream. Higher versions supersede lower versions according to topic comparison rules. |
+| `PayloadKind` | Concrete payload shape within the topic, allowing one topic to support multiple wire formats or value types. |
+
+`DisseminationValue` carries a digest plus routing and payload data:
+
+| Property | Meaning |
+|---|---|
+| `Digest` | The `DisseminationDigest` for the value being sent. |
+| `Root` | Silo which rooted this tree broadcast. This is routing metadata and is not necessarily the same as the value key. |
+| `ExpiresAt` | Time after which the value should not be applied or forwarded. |
+| `Payload` | Serialized topic-specific value. The topic owns deserialization, validation, version comparison, and application. |
 
 Apply result:
 
@@ -536,9 +549,12 @@ Recommended instruments:
 |---|---|---|---|
 | `orleans.dissemination.gossip.sent` | Counter | messages | `topic`, `kind` |
 | `orleans.dissemination.gossip.received` | Counter | messages | `topic`, `kind` |
-| `orleans.dissemination.items.sent` | Counter | items | `topic`, `kind` |
-| `orleans.dissemination.items.applied` | Counter | items | `topic`, `result` |
+| `orleans.dissemination.values.sent` | Counter | values | `topic`, `kind` |
+| `orleans.dissemination.values.applied` | Counter | values | `topic`, `result` |
 | `orleans.dissemination.bytes.sent` | Counter | bytes | `topic`, `kind` |
+| `orleans.dissemination.anti_entropy.exchanges` | Counter | operations | `direction`, `truncated` |
+| `orleans.dissemination.anti_entropy.digests` | Counter | digests | `direction` |
+| `orleans.dissemination.anti_entropy.values` | Counter | values | `direction` |
 | `orleans.dissemination.prunes.sent` | Counter | messages | `topic` |
 | `orleans.dissemination.grafts.sent` | Counter | items | `topic` |
 | `orleans.dissemination.grafts.served` | Counter | items | `topic`, `result` |
@@ -547,7 +563,7 @@ Recommended instruments:
 | `orleans.dissemination.send.duration` | Histogram | milliseconds | `topic`, `kind` |
 | `orleans.dissemination.convergence.latency` | Histogram | milliseconds | `topic` |
 | `orleans.dissemination.fallbacks` | Counter | operations | `topic`, `reason` |
-| `orleans.dissemination.payload.dropped` | Counter | items | `topic`, `reason` |
+| `orleans.dissemination.payload.dropped` | Counter | values | `topic`, `reason` |
 
 Avoid unbounded metric cardinality:
 
@@ -574,28 +590,28 @@ Recommended events:
 | `Dissemination.AdvertiseReceive` | Lazy advertisement batch received. |
 | `Dissemination.PruneSend` | Edge demotion requested. |
 | `Dissemination.PruneReceive` | Edge demotion processed. |
-| `Dissemination.GraftSend` | Missing item repair requested. |
+| `Dissemination.GraftSend` | Missing value repair requested. |
 | `Dissemination.GraftReceive` | Repair request received. |
 | `Dissemination.GraftServe` | Cached payload served or unavailable. |
-| `Dissemination.ItemApply` | Topic item applied/duplicate/obsolete/rejected. |
-| `Dissemination.ItemCoalesce` | Pending item replaced or batched. |
+| `Dissemination.ValueApply` | Topic value applied/duplicate/obsolete/rejected. |
+| `Dissemination.ValueCoalesce` | Pending value replaced or batched. |
 | `Dissemination.CacheEvict` | Payload evicted. |
 | `Dissemination.CapabilityProbe` | Peer capability result. |
 | `Dissemination.Fallback` | Topic fallback used. |
 | `Dissemination.PayloadDrop` | Oversize or invalid payload dropped. |
 
-Event payloads may include peer and item identity because `DiagnosticListener` is opt-in and diagnostic, but payloads must not include sensitive data beyond internal runtime identifiers.
+Event payloads may include peer and value identity because `DiagnosticListener` is opt-in and diagnostic, but payloads must not include sensitive data beyond internal runtime identifiers.
 
 Example event payload:
 
 ```csharp
-internal sealed class DisseminationItemEvent
+internal sealed class DisseminationValueEvent
 {
     public string Topic { get; init; }
     public SiloAddress LocalSilo { get; init; }
     public SiloAddress? Peer { get; init; }
-    public SiloAddress Origin { get; init; }
-    public long Sequence { get; init; }
+    public string Key { get; init; }
+    public long Version { get; init; }
     public string PayloadKind { get; init; }
     public string Result { get; init; }
     public int PayloadBytes { get; init; }

--- a/dissemination.md
+++ b/dissemination.md
@@ -380,7 +380,7 @@ Batching is orthogonal to Plumtree. A batch is a transport envelope; correctness
 ```text
 DisseminationGossipBatch
   Sender
-  Items[]
+  ValuesByTopic[topic][]
 
 DisseminationAdvertisementBatch
   Sender

--- a/dissemination.md
+++ b/dissemination.md
@@ -765,8 +765,8 @@ Compatibility:
 Suggested commands:
 
 ```powershell
-dotnet test .\test\Orleans.Runtime.Internal.Tests\Orleans.Runtime.Internal.Tests.csproj --framework net8.0 --filter "Category=Dissemination" -- -parallel none -noshadow
-dotnet test .\test\Orleans.Runtime.Internal.Tests\Orleans.Runtime.Internal.Tests.csproj --framework net10.0 --filter "Category=Dissemination" -- -parallel none -noshadow
+dotnet test --project test\Orleans.Runtime.Internal.Tests\Orleans.Runtime.Internal.Tests.csproj --framework net8.0 --filter-trait "Category=Dissemination" --minimum-expected-tests 1 --max-parallel-test-modules 1
+dotnet test --project test\Orleans.Runtime.Internal.Tests\Orleans.Runtime.Internal.Tests.csproj --framework net10.0 --filter-trait "Category=Dissemination" --minimum-expected-tests 1 --max-parallel-test-modules 1
 dotnet build .\Orleans.slnx -bl
 ```
 

--- a/dissemination.md
+++ b/dissemination.md
@@ -286,8 +286,7 @@ Digest and value shapes:
 internal readonly record struct DisseminationDigest(
     string Topic,
     string Key,
-    long Version,
-    string PayloadKind);
+    long Version);
 
 internal sealed class DisseminationValue
 {
@@ -304,8 +303,7 @@ internal sealed class DisseminationValue
 |---|---|
 | `Topic` | Logical namespace and semantic owner, such as `load` or `membership`. |
 | `Key` | Topic-local string key. Membership uses `"cluster"`; load statistics use the source silo's `SiloAddress.ToParsableString()` value. |
-| `Version` | Monotonic version for this `(Topic, Key, PayloadKind)` stream. Higher versions supersede lower versions according to topic comparison rules. |
-| `PayloadKind` | Concrete payload shape within the topic, allowing one topic to support multiple wire formats or value types. |
+| `Version` | Monotonic version for this `(Topic, Key)` stream. Higher versions supersede lower versions according to topic comparison rules. |
 
 `DisseminationValue` carries a digest plus routing and payload data:
 
@@ -612,7 +610,6 @@ internal sealed class DisseminationValueEvent
     public SiloAddress? Peer { get; init; }
     public string Key { get; init; }
     public long Version { get; init; }
-    public string PayloadKind { get; init; }
     public string Result { get; init; }
     public int PayloadBytes { get; init; }
     public DateTimeOffset Timestamp { get; init; }

--- a/dissemination.md
+++ b/dissemination.md
@@ -13,13 +13,13 @@ This document describes a design for an internal Orleans dissemination subsystem
 - Make batching a transport optimization which is orthogonal to Plumtree tree maintenance.
 - Provide first-class observability through logs, metrics, and `DiagnosticListener` events.
 
-## Non-goals
+## Scope boundaries
 
-- This is not a general application pub/sub system.
-- This is not reliable ordered delivery.
-- This is not a replacement for the membership table.
-- This is not a large-payload broadcast channel.
-- This should not introduce new sockets or a separate networking stack.
+- The subsystem carries bounded, monotonic Orleans runtime state between silos.
+- Delivery is best-effort and converges through topic-specific anti-entropy and authoritative refresh paths.
+- The membership table remains the liveness authority.
+- Payload size limits keep gossip traffic bounded.
+- Orleans system-target messaging provides the transport.
 
 ## References
 
@@ -327,32 +327,28 @@ internal enum DisseminationApplyResult
 
 ### Transport API
 
-Use distinct control operations instead of overloading one generic one-way payload. This prevents old silos from misinterpreting control messages as full data payloads.
+Use distinct gossip and anti-entropy operations so payload delivery and repair remain independently bounded.
 
 ```csharp
 internal interface IDisseminationSystemTarget : ISystemTarget
 {
-    Task<DisseminationCapabilityResponse> GetCapabilities(
-        DisseminationCapabilityRequest request);
+    Task PushGossip(
+        DisseminationGossipBatch batch,
+        CancellationToken cancellationToken);
 
-    Task PushGossip(DisseminationGossipBatch batch);
-
-    Task PushAdvertise(DisseminationAdvertisementBatch batch);
-
-    Task Graft(DisseminationGraftBatch request);
-
-    Task Prune(DisseminationPruneMessage message);
+    Task<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(
+        DisseminationAntiEntropyRequest request,
+        CancellationToken cancellationToken);
 }
 ```
 
-Capabilities must be topic-aware. A peer is only capable for a topic if:
+Topic support is learned from inbound gossip and the `SupportedTopics` advertised by successful anti-entropy responses. A peer is confirmed for a topic when:
 
 - The dissemination system target exists.
 - The topic is registered.
 - The topic is enabled.
-- The peer supports the requested protocol version and payload kinds.
 
-Unknown peers must use legacy topic-specific fallbacks or existing direct repair paths.
+Legacy topic-specific publication remains active for each unconfirmed peer. Confirmation is tracked per topic, expires after a bounded interval, is replaced by authoritative anti-entropy responses, and is removed when the peer leaves membership.
 
 ### Time and scheduling
 
@@ -453,26 +449,19 @@ If the implementation keeps independent per-topic loops initially, document that
 
 ## Reliability and rolling upgrades
 
-### Capability probing
+### Topic support discovery
 
-Before sending Plumtree control operations to a peer:
-
-1. Probe capabilities using an explicit request/response operation.
-2. Include topic name and protocol version in the probe.
-3. Cache capability with TTL.
-4. Re-probe on membership changes, transient failures, and cache expiry.
-
-Do not cache "unsupported" forever. A peer can upgrade during a rolling deployment, and a transient failure should not permanently downgrade it.
+Anti-entropy responses advertise enabled topics, and inbound gossip demonstrates support for the topics in that batch. The sender continues legacy topic-specific publication to each unconfirmed peer. Confirmations expire, later anti-entropy responses replace earlier topic sets, and membership changes prune confirmation state, so runtime option changes and restarted silo generations re-establish the correct delivery path.
 
 ### Fallbacks
 
-Fallback must be topic-specific:
+Fallback is topic-specific:
 
 - Load metrics fallback uses the existing deployment load publisher system target or direct stale-stat refresh.
 - Membership fallback uses existing membership notification/table refresh.
 - Manifest fallback uses direct manifest fetch or fetch-by-hash.
 
-Do not route fallback through a new dissemination system target that older silos do not have.
+Fallback uses established system targets which remain available during rolling upgrades.
 
 ### Oversize payloads
 
@@ -491,7 +480,6 @@ Global options:
 
 - Enable/disable dissemination subsystem.
 - Max concurrent sends.
-- Capability cache TTL.
 - Failure backoff.
 - Max batch bytes.
 - Max batch items.

--- a/dissemination.md
+++ b/dissemination.md
@@ -1,0 +1,818 @@
+# Topic-Based Dissemination for Orleans
+
+This document describes a design for an internal Orleans dissemination subsystem. It distills lessons from exploring anti-entropy, epidemic gossip, content-addressed manifests, and Plumtree-style broadcast trees. It is intended as the basis for a fresh implementation, not a description of any prototype branch.
+
+## Goals
+
+- Provide one internal topic-based dissemination subsystem for silo-to-silo runtime state.
+- Reduce all-to-all communication for high-rate state such as deployment load statistics.
+- Preserve correctness backstops for liveness and placement.
+- Keep the implementation deterministic and highly testable.
+- Keep public behavior default-safe and opt-in during rollout.
+- Support rolling upgrades and mixed-version clusters without payload misinterpretation.
+- Make batching a transport optimization which is orthogonal to Plumtree tree maintenance.
+- Provide first-class observability through logs, metrics, and `DiagnosticListener` events.
+
+## Non-goals
+
+- This is not a general application pub/sub system.
+- This is not reliable ordered delivery.
+- This is not a replacement for the membership table.
+- This is not a large-payload broadcast channel.
+- This should not introduce new sockets or a separate networking stack.
+
+## References
+
+- Plumtree overview: https://www.bartoszsypytkowski.com/plumtree/
+- F# HyParView/Plumtree gist: https://gist.github.com/Horusiath/84fac596101b197da0546d1697580d99
+
+## Plumtree primer
+
+Plumtree is a hybrid broadcast protocol. It combines tree-like efficient eager delivery with epidemic-style lazy repair.
+
+| Concept | Meaning |
+|---|---|
+| Eager peer | Receives full payloads immediately. |
+| Lazy peer | Receives `Advertise` announcements instead of full payloads. |
+| Message id | Stable identity for an item, such as `(topic, origin silo, sequence)`. |
+| `Advertise` | Lazy advertisement: "I have item X." |
+| `Graft` | Repair request: "I missed item X; send it to me." |
+| `Prune` | Eager-edge demotion: "This eager edge is redundant; make it lazy." |
+| Payload cache | Short-lived cache used to serve grafts. |
+
+Canonical Plumtree forms a broadcast tree per source/root over an underlying peer graph. In Orleans, every silo can be the root for its own updates. For example, a load-stat update from silo `S42` is rooted at `S42`, and its item id could be `(load, S42, statsTimestampTicks)`.
+
+For this design, we intentionally generalize the model:
+
+- Maintain one shared dissemination overlay per cluster, or per compatibility domain.
+- Use topics and per-item ids to separate semantics.
+- Let every topic reuse the same eager/lazy peer state.
+- Keep per-topic merge and obsolescence logic outside the overlay.
+
+This differs from pure per-source Plumtree. A shared overlay is simpler and lets membership, load, and manifest hints reuse the same efficient tree. The tradeoff is that edge adaptation is shared: a prune decision affects future traffic for more than one source/topic. Therefore pruning must be based on edge usefulness over a moving window, not on one duplicate item.
+
+## Scenarios
+
+### Deployment load statistics
+
+Current load publication is the clearest high-rate scalability pressure. Each silo periodically publishes its own `SiloRuntimeStatistics` for placement and load balancing.
+
+Design:
+
+- Disseminate load updates as latest-wins topic items.
+- Item id: `(topic = load, origin silo, statistics DateTime ticks)`.
+- Coalesce pending load updates by origin silo.
+- Keep only the latest statistics per origin while sends are in flight.
+- Apply each item independently: newer timestamps replace older timestamps; equal timestamps are duplicates.
+- Keep direct stale-stat repair as a correctness backstop for active silos.
+
+Backstop:
+
+- If an active silo has no stats or stale stats beyond the configured threshold, directly refresh that silo using the existing runtime statistics path.
+- Do not remove active-silo stats solely because gossip missed an update. Membership status remains authoritative for removal.
+
+Relevant existing locations:
+
+- `src\Orleans.Runtime\Placement\DeploymentLoadPublisher.cs`
+- `src\Orleans.Core\SystemTargetInterfaces\IDeploymentLoadPublisher.cs`
+- `src\Orleans.Core\Statistics\SiloRuntimeStatistics.cs`
+- `src\Orleans.Runtime\Placement\ISiloStatisticsChangeListener.cs`
+- `src\Orleans.Runtime\Placement\ResourceOptimizedPlacementDirector.cs`
+- `src\Orleans.Runtime\Configuration\Options\DeploymentLoadPublisherOptions.cs`
+
+Expected edits:
+
+- Add a load topic driver under `src\Orleans.Runtime\Dissemination`.
+- Add load-topic options to `DeploymentLoadPublisherOptions`.
+- Update `DeploymentLoadPublisher` to publish through the dissemination topic when enabled.
+- Preserve the existing all-to-all path when dissemination is disabled.
+- Preserve direct refresh and status-change removal semantics.
+
+### Cluster membership updates
+
+Membership dissemination is liveness-adjacent and must remain table-authoritative.
+
+Design:
+
+- Treat Plumtree dissemination as a best-effort accelerator for membership snapshots.
+- The external membership table remains canonical.
+- Receivers merge only through existing membership-table snapshot processing.
+- Use full snapshots first; do not require deltas for correctness.
+- Item id: `(topic = membership, origin silo, membership table version)`.
+- Older, equal, duplicated, and reordered snapshots are harmless because the membership manager already merges by version.
+
+Backstop:
+
+- Periodic table refresh remains the recovery path.
+- Unsupported or failed dissemination should trigger or rely on table refresh.
+
+Relevant existing locations:
+
+- `src\Orleans.Runtime\MembershipService\MembershipTableManager.cs`
+- `src\Orleans.Runtime\MembershipService\MembershipGossiper.cs`
+- `src\Orleans.Runtime\MembershipService\MembershipSystemTarget.cs`
+- `src\Orleans.Runtime\MembershipService\ClusterMembershipSnapshot.cs`
+- `src\Orleans.Runtime\MembershipService\ClusterMembershipUpdate.cs`
+- `src\Orleans.Core\SystemTargetInterfaces\IMembershipService.cs`
+- `src\Orleans.Core\Configuration\Options\ClusterMembershipOptions.cs`
+
+Expected edits:
+
+- Add a membership topic driver under `src\Orleans.Runtime\Dissemination`.
+- Add membership-topic options to `ClusterMembershipOptions`.
+- Update `MembershipGossiper` to use the dissemination topic when enabled.
+- Preserve existing `UseLivenessGossip` and table-refresh semantics.
+- Preserve direct membership system-target notification as mixed-version fallback.
+
+### Cluster manifest dissemination
+
+Cluster manifests are different from load and membership. They are larger, less frequent, and naturally content-addressed. They should not be full-payload Plumtree broadcasts.
+
+Design:
+
+- Disseminate manifest hash summaries or hints only.
+- Use content-addressed storage: `ManifestHash -> GrainManifest`.
+- Item id: `(topic = manifest, origin silo, manifest version or hash)`.
+- Pull missing manifests by hash from peers.
+- Preserve current fully materialized client/gateway manifest APIs.
+- Do not push full manifests via eager gossip.
+
+Invariant:
+
+- Full manifest payloads are fetched using bounded request/response APIs, preferably by hash, with payload-size and paging support if needed.
+- Full manifest gossip should be prohibited because manifests can exceed normal gossip payload limits.
+
+Backstop:
+
+- Existing direct manifest fetch remains the correctness path.
+- If a hash cannot be resolved, fall back to direct `GetSiloManifest`.
+
+Relevant existing locations:
+
+- `src\Orleans.Runtime\Manifest\SiloManifestProvider.cs`
+- `src\Orleans.Runtime\Manifest\ClusterManifestProvider.cs`
+- `src\Orleans.Runtime\GrainTypeManager\ClusterManifestSystemTarget.cs`
+- `src\Orleans.Core\Manifest\IClusterManifestProvider.cs`
+- `src\Orleans.Core\Manifest\IClusterManifestSystemTarget.cs`
+- `src\Orleans.Core.Abstractions\Manifest\ClusterManifest.cs`
+- `src\Orleans.Core.Abstractions\Manifest\GrainManifest.cs`
+
+Expected edits:
+
+- Add manifest hash/CAS support under `src\Orleans.Runtime\Dissemination`.
+- Add additive internal manifest system-target methods for hash summary and fetch-by-hash.
+- Update `ClusterManifestProvider` to use hash summaries before direct fetch.
+- Preserve existing client-facing manifest update APIs.
+
+## Files and project locations
+
+Core contracts and public options:
+
+- `src\Orleans.Core\SystemTargetInterfaces\IDisseminationSystemTarget.cs`
+- `src\Orleans.Core\SystemTargetInterfaces\IDeploymentLoadPublisher.cs`
+- `src\Orleans.Core\SystemTargetInterfaces\IMembershipService.cs`
+- `src\Orleans.Core\Manifest\IClusterManifestSystemTarget.cs`
+- `src\Orleans.Core\Runtime\Constants.cs`
+- `src\Orleans.Core\Configuration\Options\ClusterMembershipOptions.cs`
+- `src\api\Orleans.Core\Orleans.Core.cs`
+
+Runtime implementation:
+
+- `src\Orleans.Runtime\Dissemination\*.cs`
+- `src\Orleans.Runtime\Hosting\DefaultSiloServices.cs`
+- `src\Orleans.Runtime\Placement\DeploymentLoadPublisher.cs`
+- `src\Orleans.Runtime\MembershipService\MembershipGossiper.cs`
+- `src\Orleans.Runtime\GrainTypeManager\ClusterManifestSystemTarget.cs`
+- `src\Orleans.Runtime\Manifest\ClusterManifestProvider.cs`
+- `src\Orleans.Runtime\Configuration\Options\DeploymentLoadPublisherOptions.cs`
+- `src\api\Orleans.Runtime\Orleans.Runtime.cs`
+
+Tests:
+
+- `test\Orleans.Runtime.Internal.Tests\Dissemination\*.cs`
+- Functional tests near existing membership, manifest, and placement/load test suites.
+- CsCheck is already available through `Directory.Packages.props`.
+
+Serialization/API constraints:
+
+- All cross-silo DTOs need `[GenerateSerializer]` and stable `[Id(n)]` values.
+- Never renumber existing serialization ids.
+- Public option changes require `src\api` baseline updates.
+- Prefer additive wire changes for rolling upgrades.
+
+## Architecture
+
+### Layering
+
+```text
+Topic API
+  Load topic
+  Membership topic
+  Manifest topic
+
+Coalescers
+  Latest load per silo
+  Latest membership snapshot/version
+  Manifest hash hints
+
+Shared dissemination substrate
+  Topic registry
+  Shared overlay
+  Per-item seen/cache state
+  Eager/lazy edge state
+  Prune/graft repair
+  Capability and fallback
+  Batch construction
+
+Transport
+  Orleans system-target calls
+  Legacy topic-specific fallback calls
+```
+
+### Shared overlay
+
+The overlay owns peer relationships:
+
+- Eager peers receive full payload batches.
+- Lazy peers receive advertisement batches.
+- Capability state determines which peers can receive new control operations.
+- Failure/backoff state prevents error storms.
+- Membership updates remove inactive peers and add replacement candidates.
+
+Initial peer sets should use an expander-style construction similar to `ClusterHealthMonitor`:
+
+- Use multiple salted hash rings over active silos.
+- Exclude self.
+- Select low-overlap neighbors.
+- Use the result only to seed/replenish eager/lazy peer sets.
+
+Do not recompute eager peers on every tick. Steady-state adaptation belongs to prune/graft edge state.
+
+### Topic API
+
+A topic driver supplies item semantics. The substrate supplies transport, batching, deduplication, and repair.
+
+Example shape:
+
+```csharp
+internal interface IDisseminationTopic
+{
+    string Name { get; }
+
+    DisseminationTopicOptions Options { get; }
+
+    ValueTask<IReadOnlyList<DisseminationItem>> DrainPendingItems(
+        int maxItems,
+        int maxBytes,
+        CancellationToken cancellationToken);
+
+    bool IsObsolete(DisseminationItemId id);
+
+    ValueTask<DisseminationApplyResult> ApplyItem(
+        DisseminationItem item,
+        CancellationToken cancellationToken);
+
+    ValueTask OnFallbackRequired(
+        SiloAddress peer,
+        DisseminationItemId id,
+        CancellationToken cancellationToken);
+}
+```
+
+Item and advertisement shapes:
+
+```csharp
+internal readonly record struct DisseminationItemId(
+    string Topic,
+    SiloAddress Origin,
+    long Sequence,
+    string PayloadKind);
+
+internal sealed class DisseminationItem
+{
+    public DisseminationItemId Id { get; init; }
+    public uint Round { get; init; }
+    public DateTimeOffset ExpiresAt { get; init; }
+    public byte[] Payload { get; init; }
+}
+
+internal sealed class DisseminationAdvertisement
+{
+    public DisseminationItemId Id { get; init; }
+    public uint Round { get; init; }
+}
+```
+
+Apply result:
+
+```csharp
+internal enum DisseminationApplyResult
+{
+    Applied,
+    Duplicate,
+    Obsolete,
+    Rejected,
+}
+```
+
+### Transport API
+
+Use distinct control operations instead of overloading one generic one-way payload. This prevents old silos from misinterpreting control messages as full data payloads.
+
+```csharp
+internal interface IDisseminationSystemTarget : ISystemTarget
+{
+    Task<DisseminationCapabilityResponse> GetCapabilities(
+        DisseminationCapabilityRequest request);
+
+    Task PushGossip(DisseminationGossipBatch batch);
+
+    Task PushAdvertise(DisseminationAdvertisementBatch batch);
+
+    Task Graft(DisseminationGraftBatch request);
+
+    Task Prune(DisseminationPruneMessage message);
+}
+```
+
+Capabilities must be topic-aware. A peer is only capable for a topic if:
+
+- The dissemination system target exists.
+- The topic is registered.
+- The topic is enabled.
+- The peer supports the requested protocol version and payload kinds.
+
+Unknown peers must use legacy topic-specific fallbacks or existing direct repair paths.
+
+### Time and scheduling
+
+All time-dependent behavior must use injected time:
+
+- Inject `TimeProvider` into the substrate.
+- Use `TimeProvider.GetUtcNow()` for cache expiry, graft due times, failure backoff, and stale checks.
+- Use `TimeProvider.CreateTimer(...)` or a small Orleans timer abstraction backed by `TimeProvider`.
+- Tests should use `FakeTimeProvider` to advance time deterministically.
+
+Do not use `DateTime.UtcNow` directly in protocol state.
+
+State mutation must be serialized:
+
+- Route system-target inbound operations, timer ticks, graft timeouts, cache pruning, and membership-change events through one serialized queue per overlay.
+- Avoid mutating protocol state concurrently from thread-pool timer callbacks and system-target turns.
+
+## Batching
+
+Batching is orthogonal to Plumtree. A batch is a transport envelope; correctness remains per item.
+
+### Batch wire shape
+
+```text
+DisseminationGossipBatch
+  Sender
+  Items[]
+
+DisseminationAdvertisementBatch
+  Sender
+  Advertisements[]
+
+DisseminationGraftBatch
+  Sender
+  ItemIds[]
+```
+
+Each item, advertisement, and graft request carries its topic and id. The batch has no independent delivery semantics.
+
+### Per-item rules
+
+- Deduplicate per item id.
+- Cache payloads per item id.
+- Apply topic merge rules per item.
+- Send lazy advertisements per item.
+- Graft missing payloads per item.
+- Retry unavailable grafts per item.
+
+### Prune rules with batches
+
+`Prune` is edge-level, so it must not fire because one item in a batch was duplicate.
+
+Use edge usefulness over a moving window:
+
+- If a peer sends a batch with at least one new, non-obsolete item, keep the edge eager.
+- If a peer repeatedly sends batches with zero useful items, demote that edge to lazy.
+- Use thresholds such as duplicate-only batch count, duplicate ratio, and minimum observation window.
+- Do not let one partially duplicate multi-topic batch prune an edge needed by other topics.
+
+This is the key rule which keeps batching orthogonal to Plumtree.
+
+### Topic coalescers
+
+Each topic may coalesce before items enter the shared overlay.
+
+Load metrics:
+
+- Pending map: `SiloAddress -> latest SiloRuntimeStatistics`.
+- Keep only the newest timestamp per silo.
+- Flush on max delay, max item count, or max bytes.
+
+Membership:
+
+- Pending snapshot by latest membership version.
+- Full snapshots first.
+- Table refresh remains authority.
+
+Manifest:
+
+- Pending hash hints by silo/version/hash.
+- No full manifest payloads in gossip batches.
+- Fetch missing full payloads by hash.
+
+### Fairness and backpressure
+
+The batcher should enforce:
+
+- Max items per batch.
+- Max serialized bytes per batch.
+- Max per-peer queued advertisements.
+- Max per-topic queued items.
+- Max flush delay.
+- Max concurrent sends.
+
+If batching across topics, construct batches using weighted round-robin or another fair scheduler so high-rate load statistics cannot starve membership or manifest hints.
+
+If the implementation keeps independent per-topic loops initially, document that cross-topic fairness is not guaranteed and add a follow-up task before enabling cross-topic batches.
+
+## Reliability and rolling upgrades
+
+### Capability probing
+
+Before sending Plumtree control operations to a peer:
+
+1. Probe capabilities using an explicit request/response operation.
+2. Include topic name and protocol version in the probe.
+3. Cache capability with TTL.
+4. Re-probe on membership changes, transient failures, and cache expiry.
+
+Do not cache "unsupported" forever. A peer can upgrade during a rolling deployment, and a transient failure should not permanently downgrade it.
+
+### Fallbacks
+
+Fallback must be topic-specific:
+
+- Load metrics fallback uses the existing deployment load publisher system target or direct stale-stat refresh.
+- Membership fallback uses existing membership notification/table refresh.
+- Manifest fallback uses direct manifest fetch or fetch-by-hash.
+
+Do not route fallback through a new dissemination system target that older silos do not have.
+
+### Oversize payloads
+
+Oversize full payloads should be explicit failures:
+
+- Emit a diagnostic event.
+- Increment a metric.
+- Trigger topic fallback if available.
+- Never silently claim dissemination success.
+
+Manifest full payloads should not be sent through gossip at all.
+
+## Options
+
+Global options:
+
+- Enable/disable dissemination subsystem.
+- Max concurrent sends.
+- Capability cache TTL.
+- Failure backoff.
+- Max batch bytes.
+- Max batch items.
+
+Overlay options:
+
+- Eager peer count.
+- Lazy peer count.
+- Initial jitter.
+- Lazy advertise interval.
+- Graft delay.
+- Prune duplicate-only threshold.
+- Prune observation window.
+- Payload cache TTL.
+- Max cached payload count/bytes.
+
+Topic options:
+
+- Enable topic.
+- Max pending item count.
+- Max coalescing delay.
+- Stale item TTL.
+- Topic fallback enabled.
+- Topic-specific payload limit.
+
+Validation:
+
+- `PayloadCacheTtl > LazyAdvertiseInterval + GraftDelay + RequestTimeout`.
+- Peer counts are positive when topic is enabled.
+- Batch size limits are positive.
+- Stale TTL is greater than publish/coalescing interval for latest-wins topics.
+
+## Metrics and observability
+
+Use three observability surfaces:
+
+- Structured logs for warnings and unusual failures.
+- `System.Diagnostics.Metrics` for low-cardinality counters and histograms.
+- `DiagnosticListener` for detailed per-event diagnostics.
+
+### Metrics
+
+Meter name:
+
+```text
+Microsoft.Orleans.Dissemination
+```
+
+Recommended instruments:
+
+| Instrument | Type | Unit | Tags |
+|---|---|---|---|
+| `orleans.dissemination.gossip.sent` | Counter | messages | `topic`, `kind` |
+| `orleans.dissemination.gossip.received` | Counter | messages | `topic`, `kind` |
+| `orleans.dissemination.items.sent` | Counter | items | `topic`, `kind` |
+| `orleans.dissemination.items.applied` | Counter | items | `topic`, `result` |
+| `orleans.dissemination.bytes.sent` | Counter | bytes | `topic`, `kind` |
+| `orleans.dissemination.prunes.sent` | Counter | messages | `topic` |
+| `orleans.dissemination.grafts.sent` | Counter | items | `topic` |
+| `orleans.dissemination.grafts.served` | Counter | items | `topic`, `result` |
+| `orleans.dissemination.cache.entries` | ObservableGauge | entries | `topic` |
+| `orleans.dissemination.queue.depth` | ObservableGauge | items | `topic`, `queue` |
+| `orleans.dissemination.send.duration` | Histogram | milliseconds | `topic`, `kind` |
+| `orleans.dissemination.convergence.latency` | Histogram | milliseconds | `topic` |
+| `orleans.dissemination.fallbacks` | Counter | operations | `topic`, `reason` |
+| `orleans.dissemination.payload.dropped` | Counter | items | `topic`, `reason` |
+
+Avoid unbounded metric cardinality:
+
+- Do not tag metrics with `SiloAddress`.
+- Do not tag metrics with message ids.
+- Use `topic`, `kind`, and coarse `result`/`reason` tags only.
+- Put peer and message details in diagnostic events instead.
+
+### DiagnosticListener events
+
+Listener name:
+
+```text
+Microsoft.Orleans.Dissemination
+```
+
+Recommended events:
+
+| Event | Purpose |
+|---|---|
+| `Dissemination.GossipSend` | Full payload batch sent. |
+| `Dissemination.GossipReceive` | Full payload batch received. |
+| `Dissemination.AdvertiseSend` | Lazy advertisement batch sent. |
+| `Dissemination.AdvertiseReceive` | Lazy advertisement batch received. |
+| `Dissemination.PruneSend` | Edge demotion requested. |
+| `Dissemination.PruneReceive` | Edge demotion processed. |
+| `Dissemination.GraftSend` | Missing item repair requested. |
+| `Dissemination.GraftReceive` | Repair request received. |
+| `Dissemination.GraftServe` | Cached payload served or unavailable. |
+| `Dissemination.ItemApply` | Topic item applied/duplicate/obsolete/rejected. |
+| `Dissemination.ItemCoalesce` | Pending item replaced or batched. |
+| `Dissemination.CacheEvict` | Payload evicted. |
+| `Dissemination.CapabilityProbe` | Peer capability result. |
+| `Dissemination.Fallback` | Topic fallback used. |
+| `Dissemination.PayloadDrop` | Oversize or invalid payload dropped. |
+
+Event payloads may include peer and item identity because `DiagnosticListener` is opt-in and diagnostic, but payloads must not include sensitive data beyond internal runtime identifiers.
+
+Example event payload:
+
+```csharp
+internal sealed class DisseminationItemEvent
+{
+    public string Topic { get; init; }
+    public SiloAddress LocalSilo { get; init; }
+    public SiloAddress? Peer { get; init; }
+    public SiloAddress Origin { get; init; }
+    public long Sequence { get; init; }
+    public string PayloadKind { get; init; }
+    public string Result { get; init; }
+    public int PayloadBytes { get; init; }
+    public DateTimeOffset Timestamp { get; init; }
+}
+```
+
+## Testing approach
+
+Testing should exercise the protocol core separately from Orleans networking, then verify Orleans integration with small clusters.
+
+### Unit tests
+
+Protocol state machine:
+
+- First full gossip caches payload and forwards to eager peers.
+- Duplicate full gossip does not reapply and contributes to edge-prune scoring.
+- A partially useful batch does not prune an edge.
+- Repeated all-duplicate batches demote an edge to lazy.
+- Lazy `Advertise` for an unseen item schedules delayed graft.
+- Lazy `Advertise` for an obsolete item is ignored.
+- `Graft` promotes a lazy edge to eager and serves cached payload.
+- Graft retry tries alternate announcers.
+- Cache expiry prevents serving expired payloads and triggers fallback/diagnostics.
+- Oversize payloads emit events and use fallback.
+- Capability cache expires and re-probes.
+
+Overlay:
+
+- Expander seed selection excludes self.
+- Only active silos are selected.
+- Peer sets are bounded.
+- Ring selection is deterministic.
+- Peer replacement occurs after membership changes.
+- Prune/graft state is not overwritten by periodic reseeding.
+
+Topic drivers:
+
+- Load latest-wins semantics reject older and equal timestamps.
+- Load coalescer keeps latest stats per silo.
+- Membership snapshots merge only through membership manager.
+- Manifest hash determinism is stable across dictionary ordering.
+- Manifest fetch-by-hash validates expected hash.
+
+Options:
+
+- Invalid peer counts fail validation.
+- Invalid TTL/delay combinations fail validation.
+- Batch limits must be positive.
+- Topic-specific stale TTLs are consistent with publish intervals.
+
+Time:
+
+- Use `FakeTimeProvider` to advance graft delay, lazy dispatch, cache expiry, failure backoff, capability TTL, and stale repair deterministically.
+
+### Property-based tests with CsCheck
+
+Use CsCheck to generate event schedules, overlays, failures, and item streams.
+
+Core properties:
+
+- At-most-once apply per item id.
+- Newer load stats are never overwritten by older stats.
+- Equal load stat timestamps do not reapply.
+- Every non-obsolete item reaches every non-failed node eventually when the overlay remains connected and loss is eventually repaired.
+- No item remains permanently pending when at least one announcer has a cached payload.
+- No infinite prune/graft oscillation under stable membership and bounded loss.
+- Capability fallback never sends control operations to peers known unsupported.
+- Cache size remains bounded under arbitrary duplicate/rejected item streams.
+- Batching preserves per-item semantics: applying items individually or in batches yields equivalent final topic state.
+
+Generators:
+
+- Cluster size: 1 to several hundred for regular property runs.
+- Eager/lazy degree.
+- Message origins and sequences.
+- Topic mix.
+- Duplicate, reorder, and loss rates.
+- Peer failure/recovery schedules.
+- Payload sizes near batch boundaries.
+- Time advancement steps using `FakeTimeProvider`.
+
+Longer-running property tests can run outside BVT if they are too expensive for the default test path.
+
+### Deterministic simulations
+
+Add in-memory simulations which drive the real protocol core:
+
+- 2,000 logical nodes.
+- Multiple origins publishing load stats.
+- Mixed load, membership, and manifest-hint topics.
+- Random eager send loss.
+- Random lazy advertisement loss.
+- Peer churn.
+- Mixed capability peers.
+
+Assertions:
+
+- Full payload sends are near `O(N)` for each item, not `O(N * fanout)`.
+- Advertise/graft traffic remains bounded.
+- Convergence latency stays within expected repair intervals.
+- Prune/graft stabilizes under fixed membership.
+- Batching reduces network messages without changing final state.
+
+### Functional and integration tests
+
+Use `TestClusterBuilder` and existing Orleans test infrastructure.
+
+Load statistics:
+
+- Multi-silo cluster converges on active-silo load stats.
+- Placement listeners still receive updates.
+- A silo join is discovered and repaired.
+- A stopped silo is removed only through status changes.
+- Stale stats trigger direct refresh.
+
+Membership:
+
+- A silo missing intermediate versions catches up through disseminated snapshot or table refresh.
+- Older/equal snapshots are ignored.
+- Unsupported dissemination peer falls back to membership notification/table refresh.
+- Dissemination disabled still converges through existing table refresh.
+
+Manifest:
+
+- Identical manifests produce identical hashes.
+- Dictionary ordering does not affect hashes.
+- Unknown hash resolution fetches payload once and reuses CAS.
+- Client/gateway manifest APIs still return materialized manifests.
+- Mixed-version peers fall back to direct manifest fetch.
+
+Batching:
+
+- Cross-topic batch applies items according to each topic's semantics.
+- High-rate load updates do not starve membership updates.
+- Batch size limits split batches safely.
+- A partially duplicate batch does not prune a useful edge.
+
+Compatibility:
+
+- New peer to old peer: no control envelopes are sent before capability is known.
+- Old peer fallback uses existing topic-specific APIs.
+- Capability cache expiration allows upgraded peers to become Plumtree-capable.
+
+### Test plan
+
+1. Unit-test DTO validation, option validation, coalescers, overlay selection, and protocol state transitions.
+2. Add CsCheck property tests for core invariants and batch equivalence.
+3. Add deterministic simulations for 2,000 logical nodes and mixed-topic traffic.
+4. Add focused functional tests for load, membership, and manifest scenarios.
+5. Add mixed-version/fallback simulations using fake transports.
+6. Run focused tests on `net8.0` and `net10.0`.
+7. Run full `dotnet build Orleans.slnx -bl`.
+
+Suggested commands:
+
+```powershell
+dotnet test .\test\Orleans.Runtime.Internal.Tests\Orleans.Runtime.Internal.Tests.csproj --framework net8.0 --filter "Category=Dissemination" -- -parallel none -noshadow
+dotnet test .\test\Orleans.Runtime.Internal.Tests\Orleans.Runtime.Internal.Tests.csproj --framework net10.0 --filter "Category=Dissemination" -- -parallel none -noshadow
+dotnet build .\Orleans.slnx -bl
+```
+
+## Area-by-area design critique and mitigations
+
+### Plumtree model
+
+Critique: Pure Plumtree is per-source. A shared overlay can couple prune/graft decisions across topics and sources.
+
+Mitigation: Document the shared-overlay choice explicitly. Use edge usefulness thresholds rather than single-message prune. Keep per-item dedup and merge semantics separate from edge adaptation.
+
+### Time and determinism
+
+Critique: Wall-clock time makes graft, cache, backoff, and stale repair tests flaky.
+
+Mitigation: Require injected `TimeProvider` and `FakeTimeProvider` tests. No protocol state should call `DateTime.UtcNow` directly.
+
+### Batching
+
+Critique: Per-item repair and link-level prune can conflict.
+
+Mitigation: Treat batches as envelopes only. Keep item-level ids, caches, grafts, and merge results. Prune only after an edge-level duplicate/obsolete threshold over a window.
+
+### Manifest dissemination
+
+Critique: Full manifests can exceed gossip payload limits.
+
+Mitigation: Disseminate only hash hints/summaries. Fetch full manifests by hash through bounded request/response APIs and preserve direct fetch fallback.
+
+### Rolling upgrade
+
+Critique: Overloaded control messages can be misread by older silos.
+
+Mitigation: Use distinct system-target methods and topic-aware capability probing. Use legacy topic-specific fallback until capability is known.
+
+### Metrics
+
+Critique: Per-peer metric tags would explode cardinality.
+
+Mitigation: Keep metrics low-cardinality with topic/kind/result tags. Put peer and item details in `DiagnosticListener` events.
+
+### Load latest-wins semantics
+
+Critique: Lazy repair can request obsolete load items.
+
+Mitigation: Topic driver checks obsolescence before grafting and before applying. Direct stale-stat repair handles missed active-silo data.
+
+### Membership authority
+
+Critique: Gossip must not become the liveness authority.
+
+Mitigation: Dissemination is only an accelerator. The membership table and existing snapshot merge logic remain authoritative.
+
+## Rollout
+
+1. Implement substrate disabled by default.
+2. Enable load statistics dissemination in targeted performance tests.
+3. Add manifest hash/CAS optimization.
+4. Enable membership snapshot dissemination only after mixed-version and failure tests pass.
+5. Measure message counts, convergence latency, stale repair rates, and placement behavior at scale.
+6. Revisit defaults after production-like performance and reliability data.

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -35,7 +35,7 @@ Scope: this design covers Orleans internal runtime replication for bounded, mono
 
 The key distinguishing factors are value cardinality, update rate, payload size, diffability, and correctness authority. Load has many small latest-wins values. Membership has one correctness-sensitive stream which can potentially be represented as diffs. Manifests are large, mostly identical across hosts, and better handled by content-addressed pull with direct fallback.
 
-Deployment load mutations use one status-and-version boundary shared by direct publication, refresh, dissemination, and terminal membership removal. Active status is checked before version comparison, newer timestamps supersede older timestamps, and terminal removal is ordered with updates so a late value cannot resurrect a removed silo.
+Deployment load mutations use one status-and-version boundary shared by direct publication, refresh, dissemination, and terminal membership removal. Active status is checked before version comparison, newer timestamps supersede older timestamps, and terminal removal records a tombstone and removes cached state atomically so a late value cannot resurrect a removed silo. Subscriber callbacks and diagnostic events run after the committed mutation releases that boundary.
 
 ## Value model
 

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -165,7 +165,7 @@ Current branch behavior:
 3. Send `DisseminationAntiEntropyRequest` containing a per-topic map of stale local digests. If no stale digests remain for a peer, skip that peer for the round.
 4. The receiver maps remote digests by key within each requested topic.
 5. For each requested local digest key, if local state is newer than the requester digest, materialize a value.
-6. Return values up to `MaxBatchItems` and `MaxBatchBytes`, where `MaxBatchBytes` is the sum of payload byte lengths rather than exact serialized envelope size, setting `Truncated` if more values remain.
+6. Return topic-grouped values up to `MaxBatchItems` and `MaxBatchBytes`, where `MaxBatchBytes` is the sum of payload byte lengths rather than exact serialized envelope size, setting `Truncated` if more values remain.
 7. The requester applies returned values locally.
 
 Each topic has an `ExpectedUpdateCadence` used to decide when a `(topic, key)` stream is stale enough to probe. Deployment load statistics default to 2 seconds and membership snapshots default to 10 seconds. Recent tree or repair updates suppress digest probes for that stream until the cadence elapses. Omitted digests mean "not probing this stream in this round" rather than "missing this stream", which keeps anti-entropy from returning values for streams that are already receiving regular fast-path updates. When a topic knows that a stream should exist but has no local value, it can send an explicit low-watermark digest for that key; deployment load does this for active silos with missing local statistics.

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -16,7 +16,7 @@ The goal is to reduce routine fanout while preserving correctness backstops. The
 |---|---|
 | Relevant silos can address each other directly | Dissemination can build trees from cluster membership. |
 | Membership and fault detection are authoritative | Dissemination uses membership to choose peers and relies on existing liveness logic to remove failed silos. |
-| Values are monotonic per `(topic, key, payloadKind)` | Topic version comparison provides duplicate suppression. |
+| Values are monotonic per `(topic, key)` | Topic version comparison provides duplicate suppression. |
 | Topics own value semantics | The protocol handles routing, validation, and batching. Topics compare versions, materialize values, apply values, and perform fallback. |
 | Rolling upgrades are best-effort | New dissemination messages are attempted directly. Peers which cannot process them fail or reject them, and anti-entropy plus existing authoritative refresh paths repair after the temporary mismatch clears. |
 | Payloads are bounded | Oversize payloads are rejected and topic fallback is used during publication. Gossip and anti-entropy batches are bounded by item count and total payload bytes. |
@@ -37,17 +37,16 @@ The key distinguishing factors are value cardinality, update rate, payload size,
 
 ## Value model
 
-Each disseminated value is summarized by a payload-free `DisseminationDigest`:
+Each disseminated value is summarized by a payload-free `DisseminationTopicDigest`. The topic comes from the enclosing grouped batch or topic API:
 
 ```text
-(topic, key, version, payloadKind)
+(key, version)
 ```
 
-`DisseminationDigest` properties:
+`DisseminationTopicDigest` properties:
 
 | Property | Meaning |
 |---|---|
-| `Topic` | Logical dissemination topic, such as membership or deployment load. |
 | `Key` | Topic-defined string identifying one monotonic value stream within the topic. Examples: `"cluster"` for membership and `SiloAddress.ToParsableString()` for load statistics. |
 | `Version` | Topic-defined monotonic version. The protocol treats it as opaque except for sorting; topics decide whether one digest is newer than another. |
 
@@ -195,7 +194,7 @@ Implemented repair design:
 
 - Anti-entropy pull can exchange diffs when a topic can produce and apply them.
 - The source of truth for a topic should be able to accept a peer digest and produce the smallest useful payload for that peer.
-- `DisseminationDigest.Version` remains the target value version after the payload is applied.
+- `DisseminationTopicDigest.Version` remains the target value version after the payload is applied.
 - Membership diff and snapshot payloads are self-describing, so receivers can validate and reject unsupported payloads without widening the digest identity.
 - A diff payload must include enough topic-specific base information for the receiver to decide whether it can apply the diff. If the receiver's local base is too old, too new, or missing, the topic rejects the diff and relies on anti-entropy or fallback to obtain a full value.
 
@@ -240,11 +239,11 @@ Important structures:
 
 | Structure | Purpose |
 |---|---|
-| `DisseminationDigest` | Payload-free summary used for identity, version comparison, receiver validation, and anti-entropy. |
+| `DisseminationTopicDigest` | Topic-local payload-free summary used for key identity, version comparison, receiver validation, and anti-entropy. |
 | `DisseminationValue` | Payload envelope used by tree gossip and anti-entropy responses. |
 | `DisseminationMembership` | Transport snapshot containing ordered `AllMembers` and `ActiveMembers`. |
 | `ParticipantTopology` | Cached ordered participants, index map, and participant set for one membership scope. |
-| `DigestKey` | Protocol comparison key `(topic, key, payloadKind)` used to compare versions for the same value stream. |
+| `DigestKey` | Protocol comparison key `(topic, key)` used to compare versions for the same value stream. |
 | `AntiEntropyState` | Per-round local topics, digests, and selected peers grouped by topic. |
 | `_failureBackoffUntil` | Short backoff for failed sends and anti-entropy requests. |
 
@@ -329,7 +328,7 @@ Integration points:
 
 7. Per-peer outbound gossip coalescing.
    - Queue tree sends per peer before transport.
-   - Coalesce pending values by `(topic, key, payloadKind)` and keep the newest version.
+   - Coalesce pending values by `(topic, key)` and keep the newest version.
    - Flush by earliest topic coalescing delay, batch item/byte limits, or per-topic pending item limits.
 
 ## Future work, shortcomings, and trade-offs

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-This document describes the current efficient-broadcast branch and the next design changes discussed for it. The branch already implements deterministic tree broadcast, digest-based anti-entropy repair, value-oriented wire contracts, natural `SiloAddress` ordering, and per-topic membership scopes. Five items are accepted as design direction and still need implementation work: status-and-age-prioritized topology ordering, dynamic fanout, fixed-tree fast-path forwarding, level-aware randomized anti-entropy peer selection, and diff-capable value exchange for topics which can produce diffs.
+This document describes the current efficient-broadcast branch. The branch implements deterministic fixed-tree broadcast, digest-based anti-entropy repair, value-oriented wire contracts, status-and-age-prioritized topology ordering, dynamic fanout, per-topic membership scopes, level-aware randomized repair peer selection, membership snapshot diffs, manifest peer-fill, stale-only anti-entropy probes, and per-peer outbound gossip coalescing.
 
 ## Problem statement
 
@@ -59,7 +59,7 @@ The payload envelope is `DisseminationValue`:
 | `Digest` | The resulting value identity/version represented by the payload. |
 | `Root` | The silo which originated the update and acts as the temporary virtual root for fast-path forwarding. The value key lives in `Digest.Key`. |
 | `ExpiresAt` | A topic TTL after which the value is no longer useful and is dropped as stale. |
-| `Payload` | Serialized topic payload. Today this is a full value for implemented topics. Future diff-capable topics can encode a delta payload while keeping `Digest.Version` as the post-apply version. |
+| `Payload` | Serialized topic payload. Deployment load uses full values. Membership can use either a full snapshot or a diff payload while keeping `Digest.Version` as the post-apply version. |
 
 Using a plain string key keeps the common wire model simple and topic-neutral. Topic implementations validate and parse their own keys at the boundary.
 
@@ -115,9 +115,11 @@ originatorTargets = topLevel + children(index(root))
 
 This gives every participant the same fixed topology when their membership view agrees. The originator sends to at most `2 * fanout` distinct peers, and every other forwarding participant sends to at most `fanout` peers.
 
+Outbound tree sends are queued per peer before transport. The queue coalesces values by `(topic, key, payloadKind)` and keeps only the newest version for each stream, then flushes when the earliest topic `MaxCoalescingDelay` expires or when batch/item limits are reached. This preserves monotonic latest-wins semantics while allowing different originators' values to share the same `DisseminationGossipBatch` on relay nodes.
+
 ### Critique of the fixed-tree fast path
 
-The fixed-tree design improves the common deployment-load case. Since each silo periodically originates its own load value, rotating the tree around each originator spreads every originator's direct sends across the whole cluster over time. A fixed forest keeps each originator's direct fast-path target set bounded and stable while preserving deterministic reachability.
+The fixed-tree design improves the common deployment-load case. Each silo periodically originates its own load value, so a fixed forest keeps every originator's direct fast-path target set bounded and stable while preserving deterministic reachability.
 
 The subtle correctness requirement is that the fixed topology must behave like a forest under a temporary virtual root. If the design used a single fixed root and the originator only sent to that root's children, the fixed root itself would miss updates originated by other silos. Defining the first `fanout` ordered participants as top-level virtual-root children gives complete coverage: the top-level nodes cover the fixed forest, while the originator also sends to its own children to cover the subtree below the originator when its parent excludes it.
 
@@ -159,20 +161,22 @@ Anti-entropy periodically compares local digests with selected peers and transfe
 
 Current branch behavior:
 
-1. Enumerate enabled topics and their local `DisseminationDigest` values.
+1. Enumerate enabled topics and their local `DisseminationDigest` values whose `(topic, key)` streams have not received a recent update.
 2. Select repair peers per topic using that topic's membership scope.
 3. Capability-probe selected peers for topic protocol version and payload kinds.
-4. Send `DisseminationAntiEntropyRequest` containing requested topics and local digests.
+4. Send `DisseminationAntiEntropyRequest` containing requested topics and stale local digests. If no stale digests remain for a peer after capability filtering, skip that peer for the round.
 5. The receiver maps remote digests by `(topic, key, payloadKind)`.
-6. For each local digest, if local state is newer than the requester digest or the requester has no digest, materialize a value.
+6. For each requested local digest key, if local state is newer than the requester digest, materialize a value.
 7. Return values up to `MaxBatchItems` and `MaxBatchBytes`, setting `Truncated` if more values remain.
 8. The requester applies returned values locally.
 
-Sorted digest iteration makes truncation deterministic, so repeated repair rounds converge over time.
+Each topic has an `ExpectedUpdateCadence` used to decide when a `(topic, key)` stream is stale enough to probe. Deployment load statistics default to 2 seconds and membership snapshots default to 10 seconds. Recent tree or repair updates suppress digest probes for that stream until the cadence elapses. Omitted digests mean "not probing this stream in this round" rather than "missing this stream", which keeps anti-entropy from returning values for streams that are already receiving regular fast-path updates. When a topic knows that a stream should exist but has no local value, it can send an explicit low-watermark digest for that key; deployment load does this for active silos with missing local statistics.
 
-### Accepted change: level-aware randomized repair peer selection
+Sorted digest iteration makes truncation deterministic, so repeated stale repair rounds converge over time.
 
-The intended repair-peer selection is level-aware and randomized, using the same fixed topic topology and evaluated fanout factor.
+### Level-aware randomized repair peer selection
+
+Repair-peer selection is level-aware and randomized, using the same fixed topic topology and evaluated fanout factor.
 
 For each topic repair round:
 
@@ -187,11 +191,11 @@ This keeps repair traffic bounded, sends repair probes against or sideways to th
 
 ## Diff-capable value exchange
 
-The current implemented topics materialize full values. Diffable topics, especially membership snapshots, can reduce bytes using topic-specific diffs.
+Deployment load statistics materialize full latest-wins values. Membership snapshots reduce anti-entropy repair bytes using topic-specific diffs when the peer's digest is within retained history, and fall back to full snapshots otherwise.
 
-Accepted design direction:
+Implemented repair design:
 
-- Both push and pull should exchange diffs when a topic can produce and apply them.
+- Anti-entropy pull can exchange diffs when a topic can produce and apply them.
 - The source of truth for a topic should be able to accept a peer digest and produce the smallest useful payload for that peer.
 - `DisseminationDigest.Version` remains the target value version after the payload is applied.
 - `PayloadKind` distinguishes full snapshots from diff payloads, so capability probing can negotiate support and mixed-version peers can fall back to full values.
@@ -288,9 +292,9 @@ Integration points:
 - `src\Orleans.Runtime\Manifest\ClusterManifestProvider.cs` and `src\Orleans.Runtime\GrainTypeManager\ClusterManifestSystemTarget.cs`: fetch manifest hashes first, reuse cached manifests by hash, validate hashes, and fall back to direct manifest fetch.
 - `src\Orleans.Runtime\Hosting\DefaultSiloServices.cs`: registers dissemination service, transport, system target, and topics.
 
-## Implementation plan for accepted follow-up decisions
+## Implemented follow-up decisions
 
-1. Implement fixed-tree fast-path forwarding.
+1. Fixed-tree fast-path forwarding.
    - Order participants by status rank, age, and `SiloAddress`.
    - Use status rank `Active`, `Joining`, `ShuttingDown`, `Stopping` for `AllMembers`; `ActiveMembers` has a constant status component.
    - Preserve the supplied topology order when building `ParticipantTopology`.
@@ -300,28 +304,39 @@ Integration points:
    - De-duplicate sends and exclude the originator from outbound target sets.
    - Add tests for top-level originators, deep originators, the first ordered participant, small clusters, all-member status/age ordering, dynamic fanout, and complete reachability.
 
-2. Implement level-aware randomized anti-entropy peer selection.
+2. Level-aware randomized anti-entropy peer selection.
    - Use the fixed forest levels from the topic's membership scope.
    - Add a testable repair-round salt source or derive one from time/round number.
    - Add helpers to compute k-ary tree level ranges and previous-level candidate windows.
    - Preserve per-topic membership scope selection.
    - Add tests for root, first-level, deeper-level, small-cluster, and bounded peer-count cases.
 
-3. Extend topic materialization for peer-aware payload selection.
+3. Peer-aware repair payload selection.
    - Add a topic API which accepts the peer digest when available and returns the best payload kind: diff if useful, full value otherwise.
    - Keep current full-value behavior as the default implementation path.
-   - Ensure anti-entropy requests and future peer-aware pushes can ask for a payload relative to a remote digest.
+   - Ensure anti-entropy requests can ask for a payload relative to a remote digest.
 
-4. Add membership diff support.
+4. Membership diff support.
    - Retain a bounded history of membership changes by membership version.
    - Add a membership diff payload kind and advertise it through capability probing.
    - Apply diffs only when the local base version matches the payload requirements.
    - Fall back to full snapshots when history is missing, truncated, or incompatible.
 
-5. Improve manifest convergence by fetching from peer cluster manifests.
+5. Manifest convergence from peer cluster manifests.
    - When several active members are missing, query one or more active peers for their cluster manifest or hash summary.
    - Fill and validate all manifests available from that response.
    - Fall back to direct per-silo fetch for the remaining missing entries.
+
+6. Stale-only anti-entropy.
+   - Add per-topic `ExpectedUpdateCadence`.
+   - Track recent `(topic, key)` updates and omit fresh streams from anti-entropy requests.
+   - Treat omitted digests as unprobed streams rather than missing streams.
+   - Let topics emit low-watermark digests for known missing streams which still need repair.
+
+7. Per-peer outbound gossip coalescing.
+   - Queue tree sends per peer before transport.
+   - Coalesce pending values by `(topic, key, payloadKind)` and keep the newest version.
+   - Flush by earliest topic coalescing delay, batch item/byte limits, or per-topic pending item limits.
 
 ## Future work, shortcomings, and trade-offs
 
@@ -329,7 +344,7 @@ The main trade-off is that the tree fast path reduces sends and relies on anti-e
 
 Other trade-offs and improvement areas:
 
-- Level-aware randomized anti-entropy should improve convergence under skew and correlated failures, but it is still probabilistic and needs careful tests for small clusters and first-level/root behavior.
+- Level-aware randomized anti-entropy improves convergence under skew and correlated failures, but it is still probabilistic and should be monitored under real cluster churn.
 - Fixed-tree forwarding bounds each originator's direct send set, while top-level and high-level participants carry more relay traffic than leaves.
 - Status-and-age-prioritized ordering improves expected interior-node availability and value hit-rate while keeping ordering deterministic.
 - Dynamic fanout trades direct send count for tree depth: a 2-hop target gives faster convergence with larger fanout; a 3-hop target lowers per-node sends and adds one relay hop.
@@ -338,5 +353,5 @@ Other trade-offs and improvement areas:
 - Deterministic trees require silos to mostly agree on membership. Anti-entropy repairs short-lived skew, but the fast path can duplicate or miss during disagreement.
 - The protocol scope is monotonic versioned values. Ordered event streams would need separate sequencing, retention, and acknowledgment semantics.
 - Manifest whole-cluster fetch can reduce request count but can also transfer more bytes than per-silo fetch in highly divergent clusters. Hash validation and fallback keep it safe.
-- Tree sends are still simple and per-value. A future batcher could coalesce cross-topic work, respect `MaxConcurrentSends`, and enforce fair scheduling.
+- Tree sends are coalesced per peer before transport. Future scheduling work could respect `MaxConcurrentSends` across flushes and enforce cross-topic fairness under sustained overload.
 - Once the protocol ships, wire-shape or payload-kind changes should become additive and versioned. The current branch keeps protocol version `2` while the contract is branch-local.

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-This document describes the current efficient-broadcast branch. The branch implements deterministic fixed-tree broadcast, digest-based anti-entropy repair, value-oriented wire contracts, status-and-age-prioritized topology ordering, dynamic fanout, per-topic membership scopes, level-aware randomized repair peer selection, membership snapshot diffs, manifest peer-fill, stale-only anti-entropy probes, and per-peer outbound gossip coalescing.
+This document describes the current efficient-broadcast branch. The branch implements deterministic fixed-tree broadcast, digest-based anti-entropy repair, value-oriented wire contracts, status-and-age-prioritized topology ordering, dynamic fanout, per-topic membership scopes, level-aware randomized repair peer selection, membership snapshot diffs, manifest peer-fill, stale-only anti-entropy probes, and per-peer outbound gossip coalescing. Dissemination is currently opt-in: the global `DisseminationOptions.Enabled` flag and each topic's `DisseminationTopicOptions.Enabled` flag default to `false`, so existing direct publication/gossip paths remain the default unless dissemination is explicitly enabled.
 
 ## Problem statement
 
@@ -18,8 +18,8 @@ The goal is to reduce routine fanout while preserving correctness backstops. The
 | Membership and fault detection are authoritative | Dissemination uses membership to choose peers and relies on existing liveness logic to remove failed silos. |
 | Values are monotonic per `(topic, key, payloadKind)` | Topic version comparison provides duplicate suppression. |
 | Topics own value semantics | The protocol handles routing, validation, and batching. Topics compare versions, materialize values, apply values, and perform fallback. |
-| Rolling upgrades are best-effort | New dissemination messages are attempted directly. Peers which cannot process them fail or reject them, and anti-entropy plus existing fallback paths repair after the temporary mismatch clears. |
-| Payloads are bounded | Oversize payloads are rejected and topic fallback is used. Batch responses are bounded by item count and bytes. |
+| Rolling upgrades are best-effort | New dissemination messages are attempted directly. Peers which cannot process them fail or reject them, and anti-entropy plus existing authoritative refresh paths repair after the temporary mismatch clears. |
+| Payloads are bounded | Oversize payloads are rejected and topic fallback is used during publication. Gossip and anti-entropy batches are bounded by item count and total payload bytes. |
 | Delivery is best-effort | Tree send failures are repaired by anti-entropy on its periodic cadence. |
 | Different runtime systems have different membership eligibility | The protocol maintains both active-only and all-member topologies and lets each topic choose. |
 
@@ -166,7 +166,7 @@ Current branch behavior:
 3. Send `DisseminationAntiEntropyRequest` containing requested topic names and stale local digests. If no stale digests remain for a peer, skip that peer for the round.
 4. The receiver maps remote digests by `(topic, key, payloadKind)`.
 5. For each requested local digest key, if local state is newer than the requester digest, materialize a value.
-6. Return values up to `MaxBatchItems` and `MaxBatchBytes`, setting `Truncated` if more values remain.
+6. Return values up to `MaxBatchItems` and `MaxBatchBytes`, where `MaxBatchBytes` is the sum of payload byte lengths rather than exact serialized envelope size, setting `Truncated` if more values remain.
 7. The requester applies returned values locally.
 
 Each topic has an `ExpectedUpdateCadence` used to decide when a `(topic, key)` stream is stale enough to probe. Deployment load statistics default to 2 seconds and membership snapshots default to 10 seconds. Recent tree or repair updates suppress digest probes for that stream until the cadence elapses. Omitted digests mean "not probing this stream in this round" rather than "missing this stream", which keeps anti-entropy from returning values for streams that are already receiving regular fast-path updates. When a topic knows that a stream should exist but has no local value, it can send an explicit low-watermark digest for that key; deployment load does this for active silos with missing local statistics.
@@ -180,7 +180,7 @@ Repair-peer selection is level-aware and randomized, using the same fixed topic 
 For each topic repair round:
 
 1. Build the same participant topology used by that topic.
-2. Derive a per-topic, per-round pseudo-random salt using lightweight randomness with enough variation to spread contacts over time.
+2. Derive a per-topic, per-round pseudo-random salt using lightweight deterministic hashing with enough variation to spread contacts over time.
 3. Map the local silo into the fixed forest's level-order indexes.
 4. Prefer candidates from the previous tree level, meaning one level closer to the virtual root. To keep fanout bounded, sample from a fanout-sized window in that previous level near the local node's parent group.
 5. If the local silo is in the top level, sample from the same top level excluding itself, so top-level nodes cross-check each other.
@@ -200,7 +200,7 @@ Implemented repair design:
 - `PayloadKind` distinguishes full snapshots from diff payloads, so receivers can validate and reject unsupported payloads.
 - A diff payload must include enough topic-specific base information for the receiver to decide whether it can apply the diff. If the receiver's local base is too old, too new, or missing, the topic rejects the diff and relies on anti-entropy or fallback to obtain a full value.
 
-Membership is the primary diff candidate. To support membership diffs effectively, the membership source should retain a bounded change history keyed by membership version. When a peer digest is within the retained range, the responder can send the changes from the peer's version to the current version. If the peer is too far behind or the change history has been truncated, the responder sends a full `MembershipTableSnapshot`.
+Membership is the primary diff candidate. The current implementation retains up to 32 membership snapshots keyed by membership version. When a peer digest is within the retained range, the responder sends the changes from the peer's version to the current version. If the peer is too far behind or the change history has been truncated, the responder sends a full `MembershipTableSnapshot`.
 
 Deployment load statistics already use small latest-wins full payloads. Cluster manifests use content-addressed pull and can fetch a whole cluster manifest from a peer when that is cheaper than many per-silo fetches.
 
@@ -232,8 +232,8 @@ Failure behavior:
 - Send and anti-entropy request failures back off the peer temporarily using `FailureBackoff`.
 - Publication queues tree sends without capability probing. If a peer cannot process a batch, the send fails or the receiver rejects unsupported values.
 - Non-active participants in the all-member tree can be unavailable while publication proceeds.
-- If dissemination is disabled, payloads are oversize, or topic fallback is required, the producer uses the existing topic-specific safety path.
-- Anti-entropy repairs missed values after transient send failures, temporary mixed-version mismatches, or short-lived membership skew.
+- If dissemination is disabled, publish-time validation fails, payloads are oversize, or topic fallback is required before queueing, the producer uses the existing topic-specific safety path.
+- After publication has queued successfully, tree-send failures, unsupported receivers, temporary mixed-version mismatches, or short-lived membership skew are repaired by anti-entropy and existing authoritative refresh paths rather than by immediate legacy send fallback.
 
 ## Algorithms and data structures
 

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -50,7 +50,6 @@ Each disseminated value is summarized by a payload-free `DisseminationDigest`:
 | `Topic` | Logical dissemination topic, such as membership or deployment load. |
 | `Key` | Topic-defined string identifying one monotonic value stream within the topic. Examples: `"cluster"` for membership and `SiloAddress.ToParsableString()` for load statistics. |
 | `Version` | Topic-defined monotonic version. The protocol treats it as opaque except for sorting; topics decide whether one digest is newer than another. |
-| `PayloadKind` | Concrete payload shape or encoding for this topic. It is included in digest comparison keys and receiver-side validation. Diff payloads use separate payload kinds. |
 
 The payload envelope is `DisseminationValue`:
 
@@ -197,7 +196,7 @@ Implemented repair design:
 - Anti-entropy pull can exchange diffs when a topic can produce and apply them.
 - The source of truth for a topic should be able to accept a peer digest and produce the smallest useful payload for that peer.
 - `DisseminationDigest.Version` remains the target value version after the payload is applied.
-- `PayloadKind` distinguishes full snapshots from diff payloads, so receivers can validate and reject unsupported payloads.
+- Membership diff and snapshot payloads are self-describing, so receivers can validate and reject unsupported payloads without widening the digest identity.
 - A diff payload must include enough topic-specific base information for the receiver to decide whether it can apply the diff. If the receiver's local base is too old, too new, or missing, the topic rejects the diff and relies on anti-entropy or fallback to obtain a full value.
 
 Membership is the primary diff candidate. The current implementation retains up to 32 membership snapshots keyed by membership version. When a peer digest is within the retained range, the responder sends the changes from the peer's version to the current version. If the peer is too far behind or the change history has been truncated, the responder sends a full `MembershipTableSnapshot`.
@@ -343,10 +342,10 @@ Other trade-offs and improvement areas:
 - Fixed-tree forwarding bounds each originator's direct send set, while top-level and high-level participants carry more relay traffic than leaves.
 - Status-and-age-prioritized ordering improves expected interior-node availability and value hit-rate while keeping ordering deterministic.
 - Dynamic fanout trades direct send count for tree depth: a 2-hop target gives faster convergence with larger fanout; a 3-hop target lowers per-node sends and adds one relay hop.
-- Diff repair reduces bytes for membership but adds history retention, new payload kinds, base-version validation, and fallback paths.
+- Diff repair reduces bytes for membership but adds history retention, self-describing payloads, base-version validation, and fallback paths.
 - Removing capability probing keeps the fast path cheap but means unsupported or temporarily mismatched peers discover incompatibility by rejecting or failing actual dissemination messages.
 - Deterministic trees require silos to mostly agree on membership. Anti-entropy repairs short-lived skew, but the fast path can duplicate or miss during disagreement.
 - The protocol scope is monotonic versioned values. Ordered event streams would need separate sequencing, retention, and acknowledgment semantics.
 - Manifest whole-cluster fetch can reduce request count but can also transfer more bytes than per-silo fetch in highly divergent clusters. Hash validation and fallback keep it safe.
 - Tree sends are coalesced per peer before transport. Future scheduling work could respect `MaxConcurrentSends` across flushes and enforce cross-topic fairness under sustained overload.
-- Once the protocol ships, wire-shape or payload-kind changes should become additive and versioned.
+- Once the protocol ships, wire-shape changes should become additive and versioned.

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -114,7 +114,7 @@ originatorTargets = topLevel + children(index(root))
 
 This gives every participant the same fixed topology when their membership view agrees. The originator sends to at most `2 * fanout` distinct peers, and every other forwarding participant sends to at most `fanout` peers.
 
-Outbound tree sends are queued per peer before transport. The queue coalesces values by `(topic, key, payloadKind)` and keeps only the newest version for each stream, then flushes when the earliest topic `MaxCoalescingDelay` expires or when batch/item limits are reached. This preserves monotonic latest-wins semantics while allowing different originators' values to share the same `DisseminationGossipBatch` on relay nodes.
+Outbound tree sends are queued per peer before transport. The queue coalesces values by `(topic, key)` and keeps only the newest version for each stream, then flushes when the earliest topic `MaxCoalescingDelay` expires or when batch/item limits are reached. This preserves monotonic latest-wins semantics while allowing different originators' values to share the same topic-grouped `DisseminationGossipBatch` on relay nodes.
 
 ### Critique of the fixed-tree fast path
 

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -160,10 +160,10 @@ Anti-entropy periodically compares local digests with selected peers and transfe
 
 Current branch behavior:
 
-1. Enumerate enabled topics and their local `DisseminationDigest` values whose `(topic, key)` streams have not received a recent update.
+1. Enumerate enabled topics and their local `DisseminationTopicDigest` values whose `(topic, key)` streams have not received a recent update.
 2. Select repair peers per topic using that topic's membership scope.
-3. Send `DisseminationAntiEntropyRequest` containing requested topic names and stale local digests. If no stale digests remain for a peer, skip that peer for the round.
-4. The receiver maps remote digests by `(topic, key, payloadKind)`.
+3. Send `DisseminationAntiEntropyRequest` containing a per-topic map of stale local digests. If no stale digests remain for a peer, skip that peer for the round.
+4. The receiver maps remote digests by key within each requested topic.
 5. For each requested local digest key, if local state is newer than the requester digest, materialize a value.
 6. Return values up to `MaxBatchItems` and `MaxBatchBytes`, where `MaxBatchBytes` is the sum of payload byte lengths rather than exact serialized envelope size, setting `Truncated` if more values remain.
 7. The requester applies returned values locally.

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -17,8 +17,8 @@ The goal is to reduce routine fanout while preserving correctness backstops. The
 | Relevant silos can address each other directly | Dissemination can build trees from cluster membership. |
 | Membership and fault detection are authoritative | Dissemination uses membership to choose peers and relies on existing liveness logic to remove failed silos. |
 | Values are monotonic per `(topic, key, payloadKind)` | Topic version comparison provides duplicate suppression. |
-| Topics own value semantics | The protocol handles routing, validation, capability, and batching. Topics compare versions, materialize values, apply values, and perform fallback. |
-| Rolling upgrades are supported | Peers are capability-probed by topic, protocol version, and payload kind before new messages are sent. This branch keeps protocol version `2` while the contract is branch-local. |
+| Topics own value semantics | The protocol handles routing, validation, and batching. Topics compare versions, materialize values, apply values, and perform fallback. |
+| Rolling upgrades are best-effort | New dissemination messages are attempted directly. Peers which cannot process them fail or reject them, and anti-entropy plus existing fallback paths repair after the temporary mismatch clears. |
 | Payloads are bounded | Oversize payloads are rejected and topic fallback is used. Batch responses are bounded by item count and bytes. |
 | Delivery is best-effort | Tree send failures are repaired by anti-entropy on its periodic cadence. |
 | Different runtime systems have different membership eligibility | The protocol maintains both active-only and all-member topologies and lets each topic choose. |
@@ -50,7 +50,7 @@ Each disseminated value is summarized by a payload-free `DisseminationDigest`:
 | `Topic` | Logical dissemination topic, such as membership or deployment load. |
 | `Key` | Topic-defined string identifying one monotonic value stream within the topic. Examples: `"cluster"` for membership and `SiloAddress.ToParsableString()` for load statistics. |
 | `Version` | Topic-defined monotonic version. The protocol treats it as opaque except for sorting; topics decide whether one digest is newer than another. |
-| `PayloadKind` | Concrete payload shape or encoding for this topic. It is included in capability checks and digest comparison keys. Future diff payloads can use separate payload kinds. |
+| `PayloadKind` | Concrete payload shape or encoding for this topic. It is included in digest comparison keys and receiver-side validation. Diff payloads use separate payload kinds. |
 
 The payload envelope is `DisseminationValue`:
 
@@ -88,7 +88,7 @@ Each topic declares a `DisseminationMembershipScope`:
 - Deployment load statistics use `ActiveMembers`, matching existing load publishing behavior.
 - Manifest exchange remains active-only and pull-based today.
 
-The all-member tree can include silos which are joining or leaving. Active participants must be known dissemination-capable before publication succeeds. Transient probe or send failure for non-active participants in the all-member tree allows publication to proceed; missed values are repaired by anti-entropy or made irrelevant by membership changes.
+The all-member tree can include silos which are joining or leaving. Publication does not preflight peers. Transient send failures, temporary version mismatches, and membership skew are repaired by anti-entropy or made irrelevant by membership changes.
 
 ## Fast-path algorithm: fixed deterministic tree broadcast
 
@@ -163,12 +163,11 @@ Current branch behavior:
 
 1. Enumerate enabled topics and their local `DisseminationDigest` values whose `(topic, key)` streams have not received a recent update.
 2. Select repair peers per topic using that topic's membership scope.
-3. Capability-probe selected peers for topic protocol version and payload kinds.
-4. Send `DisseminationAntiEntropyRequest` containing requested topics and stale local digests. If no stale digests remain for a peer after capability filtering, skip that peer for the round.
-5. The receiver maps remote digests by `(topic, key, payloadKind)`.
-6. For each requested local digest key, if local state is newer than the requester digest, materialize a value.
-7. Return values up to `MaxBatchItems` and `MaxBatchBytes`, setting `Truncated` if more values remain.
-8. The requester applies returned values locally.
+3. Send `DisseminationAntiEntropyRequest` containing requested topic names and stale local digests. If no stale digests remain for a peer, skip that peer for the round.
+4. The receiver maps remote digests by `(topic, key, payloadKind)`.
+5. For each requested local digest key, if local state is newer than the requester digest, materialize a value.
+6. Return values up to `MaxBatchItems` and `MaxBatchBytes`, setting `Truncated` if more values remain.
+7. The requester applies returned values locally.
 
 Each topic has an `ExpectedUpdateCadence` used to decide when a `(topic, key)` stream is stale enough to probe. Deployment load statistics default to 2 seconds and membership snapshots default to 10 seconds. Recent tree or repair updates suppress digest probes for that stream until the cadence elapses. Omitted digests mean "not probing this stream in this round" rather than "missing this stream", which keeps anti-entropy from returning values for streams that are already receiving regular fast-path updates. When a topic knows that a stream should exist but has no local value, it can send an explicit low-watermark digest for that key; deployment load does this for active silos with missing local statistics.
 
@@ -198,7 +197,7 @@ Implemented repair design:
 - Anti-entropy pull can exchange diffs when a topic can produce and apply them.
 - The source of truth for a topic should be able to accept a peer digest and produce the smallest useful payload for that peer.
 - `DisseminationDigest.Version` remains the target value version after the payload is applied.
-- `PayloadKind` distinguishes full snapshots from diff payloads, so capability probing can negotiate support and mixed-version peers can fall back to full values.
+- `PayloadKind` distinguishes full snapshots from diff payloads, so receivers can validate and reject unsupported payloads.
 - A diff payload must include enough topic-specific base information for the receiver to decide whether it can apply the diff. If the receiver's local base is too old, too new, or missing, the topic rejects the diff and relies on anti-entropy or fallback to obtain a full value.
 
 Membership is the primary diff candidate. To support membership diffs effectively, the membership source should retain a bounded change history keyed by membership version. When a peer digest is within the retained range, the responder can send the changes from the peer's version to the current version. If the peer is too far behind or the change history has been truncated, the responder sends a full `MembershipTableSnapshot`.
@@ -226,17 +225,15 @@ Accepted improvement:
 
 This keeps manifests pull-based while reducing the number of direct per-member requests during convergence.
 
-## Capability, failure handling, and fallback
-
-Capability probing is per `(peer, topic)`. A capability request includes the topic protocol version and supported payload kinds. Results are cached for `CapabilityCacheTtl`.
+## Failure handling and fallback
 
 Failure behavior:
 
-- Transient capability probe failures use short backoff and leave capability support undecided.
 - Send and anti-entropy request failures back off the peer temporarily using `FailureBackoff`.
-- Publication requires active participants in the selected tree to support the topic and payload kind. This prevents a missing active internal tree node from silently stranding active descendants.
+- Publication queues tree sends without capability probing. If a peer cannot process a batch, the send fails or the receiver rejects unsupported values.
 - Non-active participants in the all-member tree can be unavailable while publication proceeds.
-- If dissemination is disabled, payloads are oversize, peers are incompatible, or topic fallback is required, the producer uses the existing topic-specific safety path.
+- If dissemination is disabled, payloads are oversize, or topic fallback is required, the producer uses the existing topic-specific safety path.
+- Anti-entropy repairs missed values after transient send failures, temporary mixed-version mismatches, or short-lived membership skew.
 
 ## Algorithms and data structures
 
@@ -244,14 +241,12 @@ Important structures:
 
 | Structure | Purpose |
 |---|---|
-| `DisseminationDigest` | Payload-free summary used for identity, version comparison, capability filtering, and anti-entropy. |
+| `DisseminationDigest` | Payload-free summary used for identity, version comparison, receiver validation, and anti-entropy. |
 | `DisseminationValue` | Payload envelope used by tree gossip and anti-entropy responses. |
 | `DisseminationMembership` | Transport snapshot containing ordered `AllMembers` and `ActiveMembers`. |
 | `ParticipantTopology` | Cached ordered participants, index map, and participant set for one membership scope. |
 | `DigestKey` | Protocol comparison key `(topic, key, payloadKind)` used to compare versions for the same value stream. |
 | `AntiEntropyState` | Per-round local topics, digests, and selected peers grouped by topic. |
-| `_capabilityCache` | Cached peer topic capabilities and supported payload kinds. |
-| `_capabilityProbeBackoffUntil` | Short backoff for failed capability probes. |
 | `_failureBackoffUntil` | Short backoff for failed sends and anti-entropy requests. |
 
 Important ordering rules:
@@ -273,7 +268,7 @@ Core contracts:
 
 Runtime implementation:
 
-- `src\Orleans.Runtime\Dissemination\DisseminationProtocol.cs`: tree broadcast, anti-entropy, capability cache, topology cache, validation, and failure backoff.
+- `src\Orleans.Runtime\Dissemination\DisseminationProtocol.cs`: tree broadcast, anti-entropy, topology cache, validation, and failure backoff.
 - `src\Orleans.Runtime\Dissemination\DisseminationService.cs`: serialized protocol execution and anti-entropy lifecycle loop.
 - `src\Orleans.Runtime\Dissemination\DisseminationSystemTarget.cs`: Orleans system target endpoint.
 - `src\Orleans.Runtime\Dissemination\OrleansDisseminationTransport.cs`: system-target transport adapter and membership-scope construction.
@@ -318,7 +313,7 @@ Integration points:
 
 4. Membership diff support.
    - Retain a bounded history of membership changes by membership version.
-   - Add a membership diff payload kind and advertise it through capability probing.
+   - Add a membership diff payload kind and validate it at the receiver.
    - Apply diffs only when the local base version matches the payload requirements.
    - Fall back to full snapshots when history is missing, truncated, or incompatible.
 
@@ -340,7 +335,7 @@ Integration points:
 
 ## Future work, shortcomings, and trade-offs
 
-The main trade-off is that the tree fast path reduces sends and relies on anti-entropy for repair. A capable child send failure can leave that child's subtree stale until anti-entropy repairs it. Convergence latency is bounded by anti-entropy cadence.
+The main trade-off is that the tree fast path reduces sends and relies on anti-entropy for repair. A child send failure can leave that child's subtree stale until anti-entropy repairs it. Convergence latency is bounded by anti-entropy cadence.
 
 Other trade-offs and improvement areas:
 
@@ -349,9 +344,9 @@ Other trade-offs and improvement areas:
 - Status-and-age-prioritized ordering improves expected interior-node availability and value hit-rate while keeping ordering deterministic.
 - Dynamic fanout trades direct send count for tree depth: a 2-hop target gives faster convergence with larger fanout; a 3-hop target lowers per-node sends and adds one relay hop.
 - Diff repair reduces bytes for membership but adds history retention, new payload kinds, base-version validation, and fallback paths.
-- Capability probing can be `O(N)` on first publication after cache expiry because active tree participants must be known capable.
+- Removing capability probing keeps the fast path cheap but means unsupported or temporarily mismatched peers discover incompatibility by rejecting or failing actual dissemination messages.
 - Deterministic trees require silos to mostly agree on membership. Anti-entropy repairs short-lived skew, but the fast path can duplicate or miss during disagreement.
 - The protocol scope is monotonic versioned values. Ordered event streams would need separate sequencing, retention, and acknowledgment semantics.
 - Manifest whole-cluster fetch can reduce request count but can also transfer more bytes than per-silo fetch in highly divergent clusters. Hash validation and fallback keep it safe.
 - Tree sends are coalesced per peer before transport. Future scheduling work could respect `MaxConcurrentSends` across flushes and enforce cross-topic fairness under sustained overload.
-- Once the protocol ships, wire-shape or payload-kind changes should become additive and versioned. The current branch keeps protocol version `2` while the contract is branch-local.
+- Once the protocol ships, wire-shape or payload-kind changes should become additive and versioned.

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-This document describes the current efficient-broadcast branch. The branch implements deterministic fixed-tree broadcast, digest-based anti-entropy repair, value-oriented wire contracts, status-and-age-prioritized topology ordering, dynamic fanout, per-topic membership scopes, level-aware randomized repair peer selection, membership snapshot diffs, manifest peer-fill, stale-only anti-entropy probes, and per-peer outbound gossip coalescing. Dissemination is currently opt-in: the global `DisseminationOptions.Enabled` flag and each topic's `DisseminationTopicOptions.Enabled` flag default to `false`, so existing direct publication/gossip paths remain the default unless dissemination is explicitly enabled.
+This document describes the current efficient-broadcast branch. The branch implements deterministic fixed-tree broadcast, digest-based anti-entropy repair, value-oriented wire contracts, status-and-age-prioritized topology ordering, dynamic fanout, per-topic membership scopes, level-aware randomized repair peer selection, membership snapshot diffs, manifest peer-fill, stale-only anti-entropy probes, per-peer outbound gossip coalescing, and topic-aware rolling-upgrade fallback. Dissemination is currently opt-in: the global `DisseminationOptions.Enabled` flag and each topic's `DisseminationTopicOptions.Enabled` flag default to `false`, so existing direct publication/gossip paths remain the default unless dissemination is explicitly enabled.
 
 ## Problem statement
 
@@ -18,7 +18,7 @@ The goal is to reduce routine fanout while preserving correctness backstops. The
 | Membership and fault detection are authoritative | Dissemination uses membership to choose peers and relies on existing liveness logic to remove failed silos. |
 | Values are monotonic per `(topic, key)` | Topic version comparison provides duplicate suppression. |
 | Topics own value semantics | The protocol handles routing, validation, and batching. Topics compare versions, materialize values, apply values, and perform fallback. |
-| Rolling upgrades are best-effort | New dissemination messages are attempted directly. Peers which cannot process them fail or reject them, and anti-entropy plus existing authoritative refresh paths repair after the temporary mismatch clears. |
+| Rolling upgrades preserve updates | A peer receives the legacy topic-specific publication path until it confirms support for that enabled dissemination topic through gossip or anti-entropy. |
 | Payloads are bounded | Oversize payloads are rejected and topic fallback is used during publication. Gossip and anti-entropy batches are bounded by item count and total payload bytes. |
 | Delivery is best-effort | Tree send failures are repaired by anti-entropy on its periodic cadence. |
 | Different runtime systems have different membership eligibility | The protocol maintains both active-only and all-member topologies and lets each topic choose. |
@@ -86,7 +86,7 @@ Each topic declares a `DisseminationMembershipScope`:
 - Deployment load statistics use `ActiveMembers`, matching existing load publishing behavior.
 - Manifest exchange remains active-only and pull-based today.
 
-The all-member tree can include silos which are joining or leaving. Publication does not preflight peers. Transient send failures, temporary version mismatches, and membership skew are repaired by anti-entropy or made irrelevant by membership changes.
+The all-member tree can include silos which are joining or leaving. Topic-aware support confirmation keeps legacy publication active for unconfirmed peers, while transient send failures and membership skew are repaired by anti-entropy or made irrelevant by membership changes.
 
 ## Fast-path algorithm: fixed deterministic tree broadcast
 
@@ -161,7 +161,7 @@ Current branch behavior:
 
 1. Enumerate enabled topics and their local `DisseminationTopicDigest` values whose `(topic, key)` streams have not received a recent update.
 2. Select repair peers per topic using that topic's membership scope.
-3. Send `DisseminationAntiEntropyRequest` containing a per-topic map of stale local digests. If no stale digests remain for a peer, skip that peer for the round.
+3. Send one or more bounded `DisseminationAntiEntropyRequest` messages containing per-topic maps of stale local digests. Requests honor the configured item and byte limits. If no stale digests remain for a peer, skip that peer for the round.
 4. The receiver maps remote digests by key within each requested topic.
 5. For each requested local digest key, if local state is newer than the requester digest, materialize a value.
 6. Return topic-grouped values up to `MaxBatchItems` and `MaxBatchBytes`, where `MaxBatchBytes` is the sum of payload byte lengths rather than exact serialized envelope size, setting `Truncated` if more values remain.
@@ -228,10 +228,15 @@ This keeps manifests pull-based while reducing the number of direct per-member r
 Failure behavior:
 
 - Send and anti-entropy request failures back off the peer temporarily using `FailureBackoff`.
-- Publication queues tree sends without capability probing. If a peer cannot process a batch, the send fails or the receiver rejects unsupported values.
+- Gossip and anti-entropy exchanges confirm support per peer and topic.
+- Membership and deployment-load publishers continue the legacy direct path for each peer until that peer confirms support for the enabled topic.
+- Topic confirmations expire after a bounded interval and authoritative anti-entropy responses replace prior confirmation state, so runtime option changes restore legacy delivery promptly.
 - Non-active participants in the all-member tree can be unavailable while publication proceeds.
 - If dissemination is disabled, publish-time validation fails, payloads are oversize, or topic fallback is required before queueing, the producer uses the existing topic-specific safety path.
-- After publication has queued successfully, tree-send failures, unsupported receivers, temporary mixed-version mismatches, or short-lived membership skew are repaired by anti-entropy and existing authoritative refresh paths rather than by immediate legacy send fallback.
+- Tree-send failures and short-lived membership skew are repaired by anti-entropy and existing authoritative refresh paths.
+- Pending gossip queues enforce per-topic item limits and global batch item/byte limits. Values which expire or become obsolete while queued are discarded before transport.
+- Anti-entropy bounds each request, each response, and the total retained repair data for a round.
+- Shutdown stops new scheduling, waits for active flush work, flushes remaining queued values, and cancels background work before returning.
 
 ## Algorithms and data structures
 
@@ -246,6 +251,7 @@ Important structures:
 | `DigestKey` | Protocol comparison key `(topic, key)` used to compare versions for the same value stream. |
 | `AntiEntropyState` | Per-round local topics, digests, and selected peers grouped by topic. |
 | `_failureBackoffUntil` | Short backoff for failed sends and anti-entropy requests. |
+| `_confirmedPeerTopics` | Expiring per-peer topic support learned from successful anti-entropy responses and inbound dissemination traffic. |
 
 Important ordering rules:
 
@@ -330,6 +336,9 @@ Integration points:
    - Queue tree sends per peer before transport.
    - Coalesce pending values by `(topic, key)` and keep the newest version.
    - Flush by earliest topic coalescing delay, batch item/byte limits, or per-topic pending item limits.
+   - Enforce hard queue bounds while a previous flush is in flight.
+   - Revalidate expiry and obsolescence immediately before transport.
+   - Serialize flushes so `MaxConcurrentSends` is a process-wide dissemination limit.
 
 ## Future work, shortcomings, and trade-offs
 
@@ -342,9 +351,9 @@ Other trade-offs and improvement areas:
 - Status-and-age-prioritized ordering improves expected interior-node availability and value hit-rate while keeping ordering deterministic.
 - Dynamic fanout trades direct send count for tree depth: a 2-hop target gives faster convergence with larger fanout; a 3-hop target lowers per-node sends and adds one relay hop.
 - Diff repair reduces bytes for membership but adds history retention, self-describing payloads, base-version validation, and fallback paths.
-- Removing capability probing keeps the fast path cheap but means unsupported or temporarily mismatched peers discover incompatibility by rejecting or failing actual dissemination messages.
+- Topic support is learned from normal gossip and anti-entropy traffic. Legacy direct publication continues for an unconfirmed peer and stops independently for each topic after confirmation. Confirmations expire and are replaced by later authoritative anti-entropy responses.
 - Deterministic trees require silos to mostly agree on membership. Anti-entropy repairs short-lived skew, but the fast path can duplicate or miss during disagreement.
 - The protocol scope is monotonic versioned values. Ordered event streams would need separate sequencing, retention, and acknowledgment semantics.
 - Manifest whole-cluster fetch can reduce request count but can also transfer more bytes than per-silo fetch in highly divergent clusters. Hash validation and fallback keep it safe.
-- Tree sends are coalesced per peer before transport. Future scheduling work could respect `MaxConcurrentSends` across flushes and enforce cross-topic fairness under sustained overload.
+- Tree sends are coalesced per peer before transport. The scheduler serializes flushes and enforces `MaxConcurrentSends`; cross-topic ordering follows deterministic topic grouping within each bounded peer queue.
 - Once the protocol ships, wire-shape changes should become additive and versioned.

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -35,6 +35,8 @@ Scope: this design covers Orleans internal runtime replication for bounded, mono
 
 The key distinguishing factors are value cardinality, update rate, payload size, diffability, and correctness authority. Load has many small latest-wins values. Membership has one correctness-sensitive stream which can potentially be represented as diffs. Manifests are large, mostly identical across hosts, and better handled by content-addressed pull with direct fallback.
 
+Deployment load mutations use one status-and-version boundary shared by direct publication, refresh, dissemination, and terminal membership removal. Active status is checked before version comparison, newer timestamps supersede older timestamps, and terminal removal is ordered with updates so a late value cannot resurrect a removed silo.
+
 ## Value model
 
 Each disseminated value is summarized by a payload-free `DisseminationTopicDigest`. The topic comes from the enclosing grouped batch or topic API:
@@ -214,6 +216,8 @@ Current branch behavior:
 - When a silo manifest is missing, the provider asks the target silo for its manifest hash, reuses a cached manifest when possible, fetches by hash otherwise, validates the hash before accepting the payload, and falls back to direct manifest fetch if the hash path fails.
 - The provider removes non-active silos from the cluster manifest and only fetches manifests for active silos.
 
+The canonical hash input is a versioned, domain-separated structural encoding. Manifest, collection, entry, field, property, count, raw type-byte, and UTF-16 code-unit boundaries are explicit. Type identifiers are ordered by their raw bytes and property dictionaries are ordered ordinally before encoding. Hashes are transient runtime cache/exchange identifiers rather than persisted manifest identities. If peers use different encoding versions during an upgrade, validation declines cache reuse and the existing direct manifest fetch path supplies the manifest.
+
 Accepted improvement:
 
 - When many active manifests are missing, fetch a peer's whole cluster manifest or hash summary first.
@@ -234,6 +238,7 @@ Failure behavior:
 - Non-active participants in the all-member tree can be unavailable while publication proceeds.
 - If dissemination is disabled, publish-time validation fails, payloads are oversize, or topic fallback is required before queueing, the producer uses the existing topic-specific safety path.
 - Tree-send failures and short-lived membership skew are repaired by anti-entropy and existing authoritative refresh paths.
+- Each received gossip value is processed independently. An apply or forwarding failure is logged and diagnosed for that value, later values in the one-way batch continue, and anti-entropy repairs the missed subtree. Caller cancellation still stops batch processing.
 - Pending gossip queues enforce per-topic item limits and global batch item/byte limits. Values which expire or become obsolete while queued are discarded before transport.
 - Anti-entropy bounds each request, each response, and the total retained repair data for a round.
 - Shutdown stops new scheduling, waits for active flush work, flushes remaining queued values, and cancels background work before returning.
@@ -277,6 +282,8 @@ Runtime implementation:
 - `src\Orleans.Runtime\Dissemination\DisseminationSystemTarget.cs`: Orleans system target endpoint.
 - `src\Orleans.Runtime\Dissemination\OrleansDisseminationTransport.cs`: system-target transport adapter and membership-scope construction.
 - `src\Orleans.Runtime\Dissemination\DisseminationInstruments.cs` and `DisseminationEvents.cs`: metrics and diagnostic events.
+
+Forwarding failures increment `orleans.dissemination.forward.failures` with topic and bounded reason tags (`exception` or `queue-capacity`) and emit `Dissemination.ForwardFailure` diagnostic events containing the topic, key, version, reason, payload size, and the failed peer when a target is known.
 
 Topic implementations:
 

--- a/efficient-broadcast.md
+++ b/efficient-broadcast.md
@@ -1,0 +1,342 @@
+# Efficient Broadcast for Orleans Runtime State
+
+## Status
+
+This document describes the current efficient-broadcast branch and the next design changes discussed for it. The branch already implements deterministic tree broadcast, digest-based anti-entropy repair, value-oriented wire contracts, natural `SiloAddress` ordering, and per-topic membership scopes. Five items are accepted as design direction and still need implementation work: status-and-age-prioritized topology ordering, dynamic fanout, fixed-tree fast-path forwarding, level-aware randomized anti-entropy peer selection, and diff-capable value exchange for topics which can produce diffs.
+
+## Problem statement
+
+Orleans has several pieces of silo-to-silo runtime state which need to spread quickly through the cluster: deployment load statistics, membership snapshots, and manifest-related metadata. Some of this state is high-rate, especially load statistics, and all-to-all publication scales poorly as cluster size grows.
+
+The goal is to reduce routine fanout while preserving correctness backstops. These payloads are monotonically versioned values. A receiver can decide whether an incoming value is newer, duplicate, obsolete, or invalid using topic-specific semantics. Deterministic broadcast plus periodic anti-entropy fits that value model well.
+
+## Challenges and constraints
+
+| Constraint | Implication |
+|---|---|
+| Relevant silos can address each other directly | Dissemination can build trees from cluster membership. |
+| Membership and fault detection are authoritative | Dissemination uses membership to choose peers and relies on existing liveness logic to remove failed silos. |
+| Values are monotonic per `(topic, key, payloadKind)` | Topic version comparison provides duplicate suppression. |
+| Topics own value semantics | The protocol handles routing, validation, capability, and batching. Topics compare versions, materialize values, apply values, and perform fallback. |
+| Rolling upgrades are supported | Peers are capability-probed by topic, protocol version, and payload kind before new messages are sent. This branch keeps protocol version `2` while the contract is branch-local. |
+| Payloads are bounded | Oversize payloads are rejected and topic fallback is used. Batch responses are bounded by item count and bytes. |
+| Delivery is best-effort | Tree send failures are repaired by anti-entropy on its periodic cadence. |
+| Different runtime systems have different membership eligibility | The protocol maintains both active-only and all-member topologies and lets each topic choose. |
+
+Scope: this design covers Orleans internal runtime replication for bounded, monotonic values with existing correctness backstops.
+
+## Usage scenarios
+
+| Scenario | Shape | Membership scope | Authority | Why it is distinct |
+|---|---|---|---|---|
+| Deployment load statistics | One latest-wins value per silo. Key is the source `SiloAddress.ToParsableString()`. Version is `SiloRuntimeStatistics.DateTime.Ticks`. | `ActiveMembers` | Existing placement/load publisher state. | High-rate, small payloads, many independent keys. The main scalability win is bounded routine refresh fanout. |
+| Membership snapshots | One singleton cluster value. Key is `"cluster"`. Version is `MembershipTableSnapshot.Version.Value`. | `AllMembers` | Membership table and membership manager remain authoritative. | Liveness-adjacent, so dissemination is only an accelerator. Existing table refresh/gossip fallback remains the safety path. |
+| Cluster manifests | Content-addressed metadata. Hash identifies a `GrainManifest`; the cluster manifest is a map of active silos to manifests. | Active-only pull today | Existing manifest provider remains authoritative. | Larger and less frequent than load/membership. The current design optimizes fetch-by-hash and cache reuse. |
+
+The key distinguishing factors are value cardinality, update rate, payload size, diffability, and correctness authority. Load has many small latest-wins values. Membership has one correctness-sensitive stream which can potentially be represented as diffs. Manifests are large, mostly identical across hosts, and better handled by content-addressed pull with direct fallback.
+
+## Value model
+
+Each disseminated value is summarized by a payload-free `DisseminationDigest`:
+
+```text
+(topic, key, version, payloadKind)
+```
+
+`DisseminationDigest` properties:
+
+| Property | Meaning |
+|---|---|
+| `Topic` | Logical dissemination topic, such as membership or deployment load. |
+| `Key` | Topic-defined string identifying one monotonic value stream within the topic. Examples: `"cluster"` for membership and `SiloAddress.ToParsableString()` for load statistics. |
+| `Version` | Topic-defined monotonic version. The protocol treats it as opaque except for sorting; topics decide whether one digest is newer than another. |
+| `PayloadKind` | Concrete payload shape or encoding for this topic. It is included in capability checks and digest comparison keys. Future diff payloads can use separate payload kinds. |
+
+The payload envelope is `DisseminationValue`:
+
+| Property | Meaning |
+|---|---|
+| `Digest` | The resulting value identity/version represented by the payload. |
+| `Root` | The silo which originated the update and acts as the temporary virtual root for fast-path forwarding. The value key lives in `Digest.Key`. |
+| `ExpiresAt` | A topic TTL after which the value is no longer useful and is dropped as stale. |
+| `Payload` | Serialized topic payload. Today this is a full value for implemented topics. Future diff-capable topics can encode a delta payload while keeping `Digest.Version` as the post-apply version. |
+
+Using a plain string key keeps the common wire model simple and topic-neutral. Topic implementations validate and parse their own keys at the boundary.
+
+## Membership scopes and topology
+
+The transport returns a `DisseminationMembership` containing two immutable, deterministically ordered arrays:
+
+- `AllMembers`: silos in `Joining`, `Active`, `ShuttingDown`, or `Stopping`.
+- `ActiveMembers`: silos in `Active`.
+
+Topologies order participants by status, age, and address:
+
+```text
+Status: Active > Joining > ShuttingDown > Stopping
+Age: oldest first
+Tie-breaker: SiloAddress.CompareTo
+```
+
+For `ActiveMembers`, the status component is constant, so the order is oldest active silos first followed by `SiloAddress`. For `AllMembers`, status rank keeps active silos near the top of all-member trees and pushes joining or leaving silos toward leaf positions. Age ordering then places longer-lived silos nearer the top, improving the probability that interior forwarding nodes are both available and likely to have the requested values. Age should use the membership entry's `StartTime` when the ordered membership snapshot includes it. `SiloAddress.Generation` is the deterministic age proxy available from the address itself and is already the first component of `SiloAddress.CompareTo`.
+
+`DisseminationProtocol` caches one `ParticipantTopology` per scope and rebuilds a topology when its participant set or order changes. Each topology represents a fixed k-ary forest over the ordered array. A broadcast originator acts as a temporary virtual root above that forest.
+
+Each topic declares a `DisseminationMembershipScope`:
+
+- Membership snapshots use `AllMembers`, matching existing membership gossip eligibility.
+- Deployment load statistics use `ActiveMembers`, matching existing load publishing behavior.
+- Manifest exchange remains active-only and pull-based today.
+
+The all-member tree can include silos which are joining or leaving. Active participants must be known dissemination-capable before publication succeeds. Transient probe or send failure for non-active participants in the all-member tree allows publication to proceed; missed values are repaired by anti-entropy or made irrelevant by membership changes.
+
+## Fast-path algorithm: fixed deterministic tree broadcast
+
+For a topic value:
+
+1. Choose the topic's membership scope and load the corresponding ordered topology.
+2. Ensure the publishing `Root` is present in the participant set.
+3. Use the ordered array directly as a fixed k-ary forest. The first `k` participants are the top-level nodes beneath a virtual root.
+4. Evaluate the fanout factor `k` from the current participant count.
+5. The participant at fixed index `i` owns children at indexes `k * (i + 1)` through `k * (i + 1) + k - 1`.
+6. The originator sends to the top-level nodes and to its own fixed children, de-duplicating targets and excluding itself.
+7. Each receiver validates topic, payload kind, payload size, TTL, and obsolescence.
+8. The topic applies the value using its own version semantics.
+9. A receiver forwards to its own fixed children when the value was newly applied, excluding the originator if it appears in that child set. Duplicate, obsolete, invalid, or expired values terminate at the receiver.
+
+The child calculation is:
+
+```text
+topLevel = indexes 0 ... fanout - 1
+firstChild(index) = fanout * (index + 1)
+children(index) = firstChild(index) ... firstChild(index) + fanout - 1
+originatorTargets = topLevel + children(index(root))
+```
+
+This gives every participant the same fixed topology when their membership view agrees. The originator sends to at most `2 * fanout` distinct peers, and every other forwarding participant sends to at most `fanout` peers.
+
+### Critique of the fixed-tree fast path
+
+The fixed-tree design improves the common deployment-load case. Since each silo periodically originates its own load value, rotating the tree around each originator spreads every originator's direct sends across the whole cluster over time. A fixed forest keeps each originator's direct fast-path target set bounded and stable while preserving deterministic reachability.
+
+The subtle correctness requirement is that the fixed topology must behave like a forest under a temporary virtual root. If the design used a single fixed root and the originator only sent to that root's children, the fixed root itself would miss updates originated by other silos. Defining the first `fanout` ordered participants as top-level virtual-root children gives complete coverage: the top-level nodes cover the fixed forest, while the originator also sends to its own children to cover the subtree below the originator when its parent excludes it.
+
+The trade-off is relay concentration. Top-level and high-level participants forward more updates than leaves because every originator uses the same fixed forest. That concentration is predictable, bounded by fanout per update, and balanced by anti-entropy for repair. If it becomes a hotspot in practice, future variants can rotate the virtual top-level window on a slow cadence or per topic while keeping per-originator direct send sets bounded.
+
+### Dynamic fanout factor
+
+The fanout factor should scale with participant count. The overlay option can expose a code-configured selector:
+
+```csharp
+public Func<int, int> FanOutFactor { get; set; }
+```
+
+The function receives the current participant count for the selected topology and returns the k-ary forest fanout. A fixed fanout is still expressible as `static _ => 3`.
+
+For a virtual-root k-ary forest, the number of participants covered within `h` hops is:
+
+```text
+capacity(h, k) = k + k^2 + ... + k^h
+```
+
+Therefore, using `sqrt(n)` for a 2-hop target and `cbrt(n)` for a 3-hop target is sound and slightly conservative because the lower-order terms add extra capacity. Example bounded selectors:
+
+```csharp
+// Approximately targets 2 hops, bounded to [4, 32].
+static count => (int)Math.Ceiling(Math.Max(4, Math.Min(Math.Sqrt(count), 32)));
+
+// Approximately targets 3 hops, bounded to [4, 32].
+static count => (int)Math.Ceiling(Math.Max(4, Math.Min(Math.Cbrt(count), 32)));
+```
+
+With a maximum fanout of 32, the 2-hop target covers up to `32 + 32^2 = 1,056` participants and the 3-hop target covers up to `32 + 32^2 + 32^3 = 33,824` participants. Larger trees continue to work with additional hops. The evaluated value should be clamped to a positive value and target enumeration should still cap sends by participant count.
+
+A `Func<int, int>` option is appropriate for code-based configuration. Configuration-file scenarios should also have a bindable preset or numeric fallback, such as a `TargetHopCount` plus `MinFanOutFactor` and `MaxFanOutFactor`, which can build the function during options post-configuration.
+
+## Repair algorithm: anti-entropy
+
+Anti-entropy periodically compares local digests with selected peers and transfers newer values from the receiver to the requester.
+
+Current branch behavior:
+
+1. Enumerate enabled topics and their local `DisseminationDigest` values.
+2. Select repair peers per topic using that topic's membership scope.
+3. Capability-probe selected peers for topic protocol version and payload kinds.
+4. Send `DisseminationAntiEntropyRequest` containing requested topics and local digests.
+5. The receiver maps remote digests by `(topic, key, payloadKind)`.
+6. For each local digest, if local state is newer than the requester digest or the requester has no digest, materialize a value.
+7. Return values up to `MaxBatchItems` and `MaxBatchBytes`, setting `Truncated` if more values remain.
+8. The requester applies returned values locally.
+
+Sorted digest iteration makes truncation deterministic, so repeated repair rounds converge over time.
+
+### Accepted change: level-aware randomized repair peer selection
+
+The intended repair-peer selection is level-aware and randomized, using the same fixed topic topology and evaluated fanout factor.
+
+For each topic repair round:
+
+1. Build the same participant topology used by that topic.
+2. Derive a per-topic, per-round pseudo-random salt using lightweight randomness with enough variation to spread contacts over time.
+3. Map the local silo into the fixed forest's level-order indexes.
+4. Prefer candidates from the previous tree level, meaning one level closer to the virtual root. To keep fanout bounded, sample from a fanout-sized window in that previous level near the local node's parent group.
+5. If the local silo is in the top level, sample from the same top level excluding itself, so top-level nodes cross-check each other.
+6. Select up to `AntiEntropyPeerCount` unique peers.
+
+This keeps repair traffic bounded, sends repair probes against or sideways to the broadcast direction, and distributes repair contacts over time. It should remain testable by injecting or deriving the round salt.
+
+## Diff-capable value exchange
+
+The current implemented topics materialize full values. Diffable topics, especially membership snapshots, can reduce bytes using topic-specific diffs.
+
+Accepted design direction:
+
+- Both push and pull should exchange diffs when a topic can produce and apply them.
+- The source of truth for a topic should be able to accept a peer digest and produce the smallest useful payload for that peer.
+- `DisseminationDigest.Version` remains the target value version after the payload is applied.
+- `PayloadKind` distinguishes full snapshots from diff payloads, so capability probing can negotiate support and mixed-version peers can fall back to full values.
+- A diff payload must include enough topic-specific base information for the receiver to decide whether it can apply the diff. If the receiver's local base is too old, too new, or missing, the topic rejects the diff and relies on anti-entropy or fallback to obtain a full value.
+
+Membership is the primary diff candidate. To support membership diffs effectively, the membership source should retain a bounded change history keyed by membership version. When a peer digest is within the retained range, the responder can send the changes from the peer's version to the current version. If the peer is too far behind or the change history has been truncated, the responder sends a full `MembershipTableSnapshot`.
+
+Deployment load statistics already use small latest-wins full payloads. Cluster manifests use content-addressed pull and can fetch a whole cluster manifest from a peer when that is cheaper than many per-silo fetches.
+
+## Manifest handling
+
+Cluster manifests are deliberately different from load and membership. Full manifests can be larger than normal dissemination payloads and are already content-addressable.
+
+Current branch behavior:
+
+- `ManifestHashCalculator` computes a canonical SHA-256 hash for each `GrainManifest`.
+- `ClusterManifestSystemTarget` exposes hash-oriented methods such as `GetSiloManifestHash`, `GetSiloManifestByHash`, and `GetClusterManifestHashSummary`.
+- `ClusterManifestProvider` caches `ManifestHash -> GrainManifest`.
+- When a silo manifest is missing, the provider asks the target silo for its manifest hash, reuses a cached manifest when possible, fetches by hash otherwise, validates the hash before accepting the payload, and falls back to direct manifest fetch if the hash path fails.
+- The provider removes non-active silos from the cluster manifest and only fetches manifests for active silos.
+
+Accepted improvement:
+
+- When many active manifests are missing, fetch a peer's whole cluster manifest or hash summary first.
+- Because most hosts are expected to have the same cluster manifest, one active peer can often provide most missing manifests in one request.
+- Validate each included `GrainManifest` by hash before caching or accepting it.
+- Fall back to direct per-silo fetch only for members which are still missing, stale, invalid, or absent from the peer's cluster manifest.
+
+This keeps manifests pull-based while reducing the number of direct per-member requests during convergence.
+
+## Capability, failure handling, and fallback
+
+Capability probing is per `(peer, topic)`. A capability request includes the topic protocol version and supported payload kinds. Results are cached for `CapabilityCacheTtl`.
+
+Failure behavior:
+
+- Transient capability probe failures use short backoff and leave capability support undecided.
+- Send and anti-entropy request failures back off the peer temporarily using `FailureBackoff`.
+- Publication requires active participants in the selected tree to support the topic and payload kind. This prevents a missing active internal tree node from silently stranding active descendants.
+- Non-active participants in the all-member tree can be unavailable while publication proceeds.
+- If dissemination is disabled, payloads are oversize, peers are incompatible, or topic fallback is required, the producer uses the existing topic-specific safety path.
+
+## Algorithms and data structures
+
+Important structures:
+
+| Structure | Purpose |
+|---|---|
+| `DisseminationDigest` | Payload-free summary used for identity, version comparison, capability filtering, and anti-entropy. |
+| `DisseminationValue` | Payload envelope used by tree gossip and anti-entropy responses. |
+| `DisseminationMembership` | Transport snapshot containing ordered `AllMembers` and `ActiveMembers`. |
+| `ParticipantTopology` | Cached ordered participants, index map, and participant set for one membership scope. |
+| `DigestKey` | Protocol comparison key `(topic, key, payloadKind)` used to compare versions for the same value stream. |
+| `AntiEntropyState` | Per-round local topics, digests, and selected peers grouped by topic. |
+| `_capabilityCache` | Cached peer topic capabilities and supported payload kinds. |
+| `_capabilityProbeBackoffUntil` | Short backoff for failed capability probes. |
+| `_failureBackoffUntil` | Short backoff for failed sends and anti-entropy requests. |
+
+Important ordering rules:
+
+- Participants are sorted by status rank, age, and `SiloAddress.CompareTo`.
+- `ActiveMembers` has a constant status component, so older active silos appear before younger active silos.
+- `AllMembers` uses status rank `Active`, `Joining`, `ShuttingDown`, `Stopping`, then age, then `SiloAddress.CompareTo`.
+- Digests are sorted by topic, payload kind, key, and version for deterministic anti-entropy truncation.
+- Topic key parsing is topic-owned. Invalid keys are rejected or treated as obsolete by the topic.
+
+## Implementation overview
+
+Core contracts:
+
+- `src\Orleans.Core\SystemTargetInterfaces\IDisseminationSystemTarget.cs`: wire DTOs and system target API.
+- `src\Orleans.Runtime\Dissemination\IDisseminationTopic.cs`: topic abstraction for digests, version comparison, materialization, apply, fallback, and membership scope.
+- `src\Orleans.Runtime\Dissemination\IDisseminationTransport.cs`: runtime transport abstraction and `DisseminationMembership`.
+- `src\Orleans.Core\Configuration\Options\DisseminationOptions.cs`: global, overlay, and per-topic options.
+
+Runtime implementation:
+
+- `src\Orleans.Runtime\Dissemination\DisseminationProtocol.cs`: tree broadcast, anti-entropy, capability cache, topology cache, validation, and failure backoff.
+- `src\Orleans.Runtime\Dissemination\DisseminationService.cs`: serialized protocol execution and anti-entropy lifecycle loop.
+- `src\Orleans.Runtime\Dissemination\DisseminationSystemTarget.cs`: Orleans system target endpoint.
+- `src\Orleans.Runtime\Dissemination\OrleansDisseminationTransport.cs`: system-target transport adapter and membership-scope construction.
+- `src\Orleans.Runtime\Dissemination\DisseminationInstruments.cs` and `DisseminationEvents.cs`: metrics and diagnostic events.
+
+Topic implementations:
+
+- `src\Orleans.Runtime\Dissemination\DeploymentLoadStatisticsDisseminationTopic.cs`: latest-wins per-silo runtime statistics using active-member topology.
+- `src\Orleans.Runtime\Dissemination\MembershipDisseminationTopic.cs`: singleton membership snapshot stream using all-member topology.
+- `src\Orleans.Runtime\Dissemination\ManifestHashCalculator.cs`: canonical hash support for manifest pull/cache reuse.
+
+Integration points:
+
+- `src\Orleans.Runtime\Placement\DeploymentLoadPublisher.cs`: tries dissemination first, then falls back to direct stats update/refresh.
+- `src\Orleans.Runtime\MembershipService\MembershipGossiper.cs`: tries dissemination first, then falls back to legacy membership gossip.
+- `src\Orleans.Runtime\Manifest\ClusterManifestProvider.cs` and `src\Orleans.Runtime\GrainTypeManager\ClusterManifestSystemTarget.cs`: fetch manifest hashes first, reuse cached manifests by hash, validate hashes, and fall back to direct manifest fetch.
+- `src\Orleans.Runtime\Hosting\DefaultSiloServices.cs`: registers dissemination service, transport, system target, and topics.
+
+## Implementation plan for accepted follow-up decisions
+
+1. Implement fixed-tree fast-path forwarding.
+   - Order participants by status rank, age, and `SiloAddress`.
+   - Use status rank `Active`, `Joining`, `ShuttingDown`, `Stopping` for `AllMembers`; `ActiveMembers` has a constant status component.
+   - Preserve the supplied topology order when building `ParticipantTopology`.
+   - Add a dynamic `FanOutFactor` selector and compute fanout from participant count.
+   - Change tree child selection from root-rotated indexes to fixed forest indexes.
+   - Build originator target sets from top-level nodes plus the originator's own children.
+   - De-duplicate sends and exclude the originator from outbound target sets.
+   - Add tests for top-level originators, deep originators, the first ordered participant, small clusters, all-member status/age ordering, dynamic fanout, and complete reachability.
+
+2. Implement level-aware randomized anti-entropy peer selection.
+   - Use the fixed forest levels from the topic's membership scope.
+   - Add a testable repair-round salt source or derive one from time/round number.
+   - Add helpers to compute k-ary tree level ranges and previous-level candidate windows.
+   - Preserve per-topic membership scope selection.
+   - Add tests for root, first-level, deeper-level, small-cluster, and bounded peer-count cases.
+
+3. Extend topic materialization for peer-aware payload selection.
+   - Add a topic API which accepts the peer digest when available and returns the best payload kind: diff if useful, full value otherwise.
+   - Keep current full-value behavior as the default implementation path.
+   - Ensure anti-entropy requests and future peer-aware pushes can ask for a payload relative to a remote digest.
+
+4. Add membership diff support.
+   - Retain a bounded history of membership changes by membership version.
+   - Add a membership diff payload kind and advertise it through capability probing.
+   - Apply diffs only when the local base version matches the payload requirements.
+   - Fall back to full snapshots when history is missing, truncated, or incompatible.
+
+5. Improve manifest convergence by fetching from peer cluster manifests.
+   - When several active members are missing, query one or more active peers for their cluster manifest or hash summary.
+   - Fill and validate all manifests available from that response.
+   - Fall back to direct per-silo fetch for the remaining missing entries.
+
+## Future work, shortcomings, and trade-offs
+
+The main trade-off is that the tree fast path reduces sends and relies on anti-entropy for repair. A capable child send failure can leave that child's subtree stale until anti-entropy repairs it. Convergence latency is bounded by anti-entropy cadence.
+
+Other trade-offs and improvement areas:
+
+- Level-aware randomized anti-entropy should improve convergence under skew and correlated failures, but it is still probabilistic and needs careful tests for small clusters and first-level/root behavior.
+- Fixed-tree forwarding bounds each originator's direct send set, while top-level and high-level participants carry more relay traffic than leaves.
+- Status-and-age-prioritized ordering improves expected interior-node availability and value hit-rate while keeping ordering deterministic.
+- Dynamic fanout trades direct send count for tree depth: a 2-hop target gives faster convergence with larger fanout; a 3-hop target lowers per-node sends and adds one relay hop.
+- Diff repair reduces bytes for membership but adds history retention, new payload kinds, base-version validation, and fallback paths.
+- Capability probing can be `O(N)` on first publication after cache expiry because active tree participants must be known capable.
+- Deterministic trees require silos to mostly agree on membership. Anti-entropy repairs short-lived skew, but the fast path can duplicate or miss during disagreement.
+- The protocol scope is monotonic versioned values. Ordered event streams would need separate sequencing, retention, and acknowledgment semantics.
+- Manifest whole-cluster fetch can reduce request count but can also transfer more bytes than per-silo fetch in highly divergent clusters. Hash validation and fallback keep it safe.
+- Tree sends are still simple and per-value. A future batcher could coalesce cross-topic work, respect `MaxConcurrentSends`, and enforce fair scheduling.
+- Once the protocol ships, wire-shape or payload-kind changes should become additive and versioned. The current branch keeps protocol version `2` while the contract is branch-local.

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -96,7 +96,7 @@ namespace Orleans.Configuration
         /// <summary>
         /// Gets or sets dissemination options for membership updates.
         /// </summary>
-        public DisseminationTopicOptions Dissemination { get; set; } = new();
+        public DisseminationTopicOptions Dissemination { get; set; } = new() { ExpectedUpdateCadence = TimeSpan.FromSeconds(10) };
 
         /// <summary>
         /// Gets or sets the number of silos each silo probes for liveness.

--- a/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs
@@ -94,6 +94,11 @@ namespace Orleans.Configuration
         public bool UseLivenessGossip { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets dissemination options for membership updates.
+        /// </summary>
+        public DisseminationTopicOptions Dissemination { get; set; } = new();
+
+        /// <summary>
         /// Gets or sets the number of silos each silo probes for liveness.
         /// </summary>
         /// <remarks>

--- a/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
@@ -25,12 +25,12 @@ public sealed class DisseminationOptions
     /// <summary>
     /// Gets or sets the maximum total payload bytes in one dissemination batch.
     /// </summary>
-    public int MaxBatchBytes { get; set; } = 64 * 1024;
+    public int MaxBatchBytes { get; set; } = 1024 * 1024;
 
     /// <summary>
     /// Gets or sets the maximum number of items in one dissemination batch.
     /// </summary>
-    public int MaxBatchItems { get; set; } = 64;
+    public int MaxBatchItems { get; set; } = 8 * 1024;
 
     /// <summary>
     /// Gets or sets overlay-specific dissemination options.
@@ -120,5 +120,5 @@ public sealed class DisseminationTopicOptions
     /// <summary>
     /// Gets or sets the maximum serialized payload size for this topic.
     /// </summary>
-    public int MaxPayloadBytes { get; set; } = 64 * 1024;
+    public int MaxPayloadBytes { get; set; } = 1024 * 1024;
 }

--- a/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
@@ -18,11 +18,6 @@ public sealed class DisseminationOptions
     public int MaxConcurrentSends { get; set; } = 32;
 
     /// <summary>
-    /// Gets or sets how long peer capability probe results are cached.
-    /// </summary>
-    public TimeSpan CapabilityCacheTtl { get; set; } = TimeSpan.FromMinutes(5);
-
-    /// <summary>
     /// Gets or sets how long failed peers are backed off before retrying.
     /// </summary>
     public TimeSpan FailureBackoff { get; set; } = TimeSpan.FromSeconds(5);

--- a/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
@@ -23,7 +23,7 @@ public sealed class DisseminationOptions
     public TimeSpan FailureBackoff { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
-    /// Gets or sets the maximum serialized bytes in one dissemination batch.
+    /// Gets or sets the maximum total payload bytes in one dissemination batch.
     /// </summary>
     public int MaxBatchBytes { get; set; } = 64 * 1024;
 

--- a/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
@@ -110,6 +110,14 @@ public sealed class DisseminationTopicOptions
     public TimeSpan StaleItemTtl { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
+    /// Gets or sets the expected cadence for updates in this topic.
+    /// </summary>
+    /// <remarks>
+    /// Anti-entropy requests omit digests for topic keys which have received an update within this interval.
+    /// </remarks>
+    public TimeSpan ExpectedUpdateCadence { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
     /// Gets or sets a value indicating whether topic-specific fallback is enabled.
     /// </summary>
     public bool FallbackEnabled { get; set; } = true;

--- a/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
@@ -1,0 +1,101 @@
+using System;
+
+namespace Orleans.Configuration;
+
+/// <summary>
+/// Options for configuring internal silo-to-silo dissemination.
+/// </summary>
+public sealed class DisseminationOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the dissemination subsystem is enabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent dissemination sends.
+    /// </summary>
+    public int MaxConcurrentSends { get; set; } = 32;
+
+    /// <summary>
+    /// Gets or sets how long peer capability probe results are cached.
+    /// </summary>
+    public TimeSpan CapabilityCacheTtl { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Gets or sets how long failed peers are backed off before retrying.
+    /// </summary>
+    public TimeSpan FailureBackoff { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets or sets the maximum serialized bytes in one dissemination batch.
+    /// </summary>
+    public int MaxBatchBytes { get; set; } = 64 * 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum number of items in one dissemination batch.
+    /// </summary>
+    public int MaxBatchItems { get; set; } = 64;
+
+    /// <summary>
+    /// Gets or sets overlay-specific dissemination options.
+    /// </summary>
+    public DisseminationOverlayOptions Overlay { get; set; } = new();
+}
+
+/// <summary>
+/// Options for the dissemination overlay.
+/// </summary>
+public sealed class DisseminationOverlayOptions
+{
+    /// <summary>
+    /// Gets or sets the deterministic spanning tree fanout.
+    /// </summary>
+    public int TreeFanout { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets the interval between anti-entropy repair rounds.
+    /// </summary>
+    public TimeSpan AntiEntropyInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets or sets the number of peers contacted during each anti-entropy repair round.
+    /// </summary>
+    public int AntiEntropyPeerCount { get; set; } = 3;
+}
+
+/// <summary>
+/// Options for a dissemination topic.
+/// </summary>
+public sealed class DisseminationTopicOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether this topic is enabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of pending topic items.
+    /// </summary>
+    public int MaxPendingItemCount { get; set; } = 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum delay for topic coalescing.
+    /// </summary>
+    public TimeSpan MaxCoalescingDelay { get; set; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Gets or sets how long a topic item remains useful.
+    /// </summary>
+    public TimeSpan StaleItemTtl { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether topic-specific fallback is enabled.
+    /// </summary>
+    public bool FallbackEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum serialized payload size for this topic.
+    /// </summary>
+    public int MaxPayloadBytes { get; set; } = 64 * 1024;
+}

--- a/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
@@ -49,9 +49,29 @@ public sealed class DisseminationOptions
 public sealed class DisseminationOverlayOptions
 {
     /// <summary>
-    /// Gets or sets the deterministic spanning tree fanout.
+    /// Gets or sets the code-configured fanout selector.
     /// </summary>
-    public int TreeFanout { get; set; } = 3;
+    /// <remarks>
+    /// The argument is the current participant count for the selected dissemination topology.
+    /// When this value is <see langword="null"/>, <see cref="TargetHopCount"/>, <see cref="MinFanOutFactor"/>,
+    /// and <see cref="MaxFanOutFactor"/> are used to derive a fanout factor.
+    /// </remarks>
+    public Func<int, int>? FanOutFactor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the target number of tree hops used by the bindable fanout selector.
+    /// </summary>
+    public int TargetHopCount { get; set; } = 2;
+
+    /// <summary>
+    /// Gets or sets the minimum fanout factor used by the bindable fanout selector.
+    /// </summary>
+    public int MinFanOutFactor { get; set; } = 4;
+
+    /// <summary>
+    /// Gets or sets the maximum fanout factor used by the bindable fanout selector.
+    /// </summary>
+    public int MaxFanOutFactor { get; set; } = 32;
 
     /// <summary>
     /// Gets or sets the interval between anti-entropy repair rounds.

--- a/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
+++ b/src/Orleans.Core/Configuration/Options/DisseminationOptions.cs
@@ -71,6 +71,9 @@ public sealed class DisseminationOverlayOptions
     /// <summary>
     /// Gets or sets the interval between anti-entropy repair rounds.
     /// </summary>
+    /// <remarks>
+    /// The value must fit within the platform timer range (at most 4,294,967,294 milliseconds).
+    /// </remarks>
     public TimeSpan AntiEntropyInterval { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
@@ -97,6 +100,9 @@ public sealed class DisseminationTopicOptions
     /// <summary>
     /// Gets or sets the maximum delay for topic coalescing.
     /// </summary>
+    /// <remarks>
+    /// The value must fit within the platform timer range (at most 4,294,967,294 milliseconds).
+    /// </remarks>
     public TimeSpan MaxCoalescingDelay { get; set; } = TimeSpan.FromMilliseconds(100);
 
     /// <summary>

--- a/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
+++ b/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
@@ -42,8 +42,12 @@ namespace Orleans.Runtime
     }
 
     /// <summary>
-    /// Identifies a manifest by its canonical content hash.
+    /// Identifies a manifest by its canonical runtime protocol content hash.
     /// </summary>
+    /// <remarks>
+    /// This value is a transient cache and exchange identifier. It is not a persistent manifest identity,
+    /// and its structural encoding can change between Orleans versions.
+    /// </remarks>
     [GenerateSerializer, Immutable]
     internal readonly struct ManifestHash : System.IEquatable<ManifestHash>
     {

--- a/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
+++ b/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
@@ -20,6 +20,79 @@ namespace Orleans.Runtime
         /// </summary>
         /// <returns>The current cluster manifest, or <see langword="null"/> if it is not newer than the provided version.</returns>
         ValueTask<ClusterManifestUpdate?> GetClusterManifestUpdate(MajorMinorVersion previousVersion);
+
+        /// <summary>
+        /// Gets a hash summary for the current cluster manifest.
+        /// </summary>
+        /// <returns>The current cluster manifest hash summary.</returns>
+        ValueTask<ClusterManifestHashSummary> GetClusterManifestHashSummary();
+
+        /// <summary>
+        /// Gets the hash of the local silo manifest.
+        /// </summary>
+        /// <returns>The hash of the local silo manifest.</returns>
+        ValueTask<ManifestHash> GetSiloManifestHash();
+
+        /// <summary>
+        /// Gets the local silo manifest if the provided hash matches it.
+        /// </summary>
+        /// <param name="hash">The expected manifest hash.</param>
+        /// <returns>The local silo manifest, or <see langword="null"/> if the hash does not match.</returns>
+        ValueTask<GrainManifest?> GetSiloManifestByHash(ManifestHash hash);
+    }
+
+    /// <summary>
+    /// Identifies a manifest by its canonical content hash.
+    /// </summary>
+    [GenerateSerializer, Immutable]
+    internal readonly struct ManifestHash : System.IEquatable<ManifestHash>
+    {
+        public ManifestHash(string value)
+        {
+            Value = value;
+        }
+
+        [Id(0)]
+        public string Value { get; }
+
+        public bool Equals(ManifestHash other) => string.Equals(Value, other.Value, System.StringComparison.Ordinal);
+
+        public override bool Equals(object? obj) => obj is ManifestHash other && Equals(other);
+
+        public override int GetHashCode() => System.StringComparer.Ordinal.GetHashCode(Value ?? string.Empty);
+
+        public override string ToString() => Value ?? string.Empty;
+
+        public static bool operator ==(ManifestHash left, ManifestHash right) => left.Equals(right);
+
+        public static bool operator !=(ManifestHash left, ManifestHash right) => !left.Equals(right);
+    }
+
+    /// <summary>
+    /// Represents a hash summary for a cluster manifest.
+    /// </summary>
+    [GenerateSerializer, Immutable]
+    internal sealed class ClusterManifestHashSummary
+    {
+        public ClusterManifestHashSummary(
+            MajorMinorVersion version,
+            ImmutableDictionary<SiloAddress, ManifestHash> siloManifestHashes)
+        {
+            Version = version;
+            SiloManifestHashes = siloManifestHashes;
+        }
+
+        /// <summary>
+        /// Gets the cluster manifest version.
+        /// </summary>
+        [Id(0)]
+        public MajorMinorVersion Version { get; }
+
+        /// <summary>
+        /// Gets the manifest hash for each silo.
+        /// </summary>
+        [Id(1)]
+        public ImmutableDictionary<SiloAddress, ManifestHash> SiloManifestHashes { get; }
     }
 
     /// <summary>

--- a/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
+++ b/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Orleans.Metadata;
@@ -76,7 +77,7 @@ namespace Orleans.Runtime
     {
         public ClusterManifestHashSummary(
             MajorMinorVersion version,
-            ImmutableDictionary<SiloAddress, ManifestHash> siloManifestHashes)
+            FrozenDictionary<SiloAddress, ManifestHash> siloManifestHashes)
         {
             Version = version;
             SiloManifestHashes = siloManifestHashes;
@@ -92,7 +93,7 @@ namespace Orleans.Runtime
         /// Gets the manifest hash for each silo.
         /// </summary>
         [Id(1)]
-        public ImmutableDictionary<SiloAddress, ManifestHash> SiloManifestHashes { get; }
+        public FrozenDictionary<SiloAddress, ManifestHash> SiloManifestHashes { get; }
     }
 
     /// <summary>

--- a/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
+++ b/src/Orleans.Core/Manifest/IClusterManifestSystemTarget.cs
@@ -1,4 +1,3 @@
-using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Orleans.Metadata;
@@ -77,7 +76,7 @@ namespace Orleans.Runtime
     {
         public ClusterManifestHashSummary(
             MajorMinorVersion version,
-            FrozenDictionary<SiloAddress, ManifestHash> siloManifestHashes)
+            ImmutableDictionary<SiloAddress, ManifestHash> siloManifestHashes)
         {
             Version = version;
             SiloManifestHashes = siloManifestHashes;
@@ -93,7 +92,7 @@ namespace Orleans.Runtime
         /// Gets the manifest hash for each silo.
         /// </summary>
         [Id(1)]
-        public FrozenDictionary<SiloAddress, ManifestHash> SiloManifestHashes { get; }
+        public ImmutableDictionary<SiloAddress, ManifestHash> SiloManifestHashes { get; }
     }
 
     /// <summary>

--- a/src/Orleans.Core/OrleansContracts.txt
+++ b/src/Orleans.Core/OrleansContracts.txt
@@ -50,6 +50,13 @@ interface [GrainInterfaceType("Orleans.Placement.Repartitioning.IActivationRepar
 interface [GrainInterfaceType("Orleans.Runtime.IClusterManifestSystemTarget")] Orleans.Runtime.IClusterManifestSystemTarget [Version(0)]
   40D39F85: GetClusterManifest() -> ValueTask<Orleans.Metadata.ClusterManifest>
   4EFCA109: GetClusterManifestUpdate(Orleans.Metadata.MajorMinorVersion) -> ValueTask<Orleans.Runtime.ClusterManifestUpdate?>
+  GetClusterManifestHashSummary() -> ValueTask<Orleans.Runtime.ClusterManifestHashSummary>
+  GetSiloManifestByHash(Orleans.Runtime.ManifestHash) -> ValueTask<Orleans.Metadata.GrainManifest?>
+  GetSiloManifestHash() -> ValueTask<Orleans.Runtime.ManifestHash>
+
+interface Orleans.Runtime.IDisseminationSystemTarget [Version(0)]
+  ExchangeAntiEntropy(Orleans.Runtime.DisseminationAntiEntropyRequest, System.Threading.CancellationToken) -> Task<Orleans.Runtime.DisseminationAntiEntropyResponse>
+  PushGossip(Orleans.Runtime.DisseminationGossipBatch, System.Threading.CancellationToken) -> Task
 
 interface [GrainInterfaceType("Orleans.Runtime.IDeploymentLoadPublisher")] Orleans.Runtime.IDeploymentLoadPublisher [Version(0)]
   C5255F0C: UpdateRuntimeStatistics(Orleans.Runtime.SiloAddress, Orleans.Runtime.SiloRuntimeStatistics) -> Task

--- a/src/Orleans.Core/OrleansContracts.txt
+++ b/src/Orleans.Core/OrleansContracts.txt
@@ -49,14 +49,14 @@ interface [GrainInterfaceType("Orleans.Placement.Repartitioning.IActivationRepar
 
 interface [GrainInterfaceType("Orleans.Runtime.IClusterManifestSystemTarget")] Orleans.Runtime.IClusterManifestSystemTarget [Version(0)]
   40D39F85: GetClusterManifest() -> ValueTask<Orleans.Metadata.ClusterManifest>
+  25AE6E4A: GetClusterManifestHashSummary() -> ValueTask<Orleans.Runtime.ClusterManifestHashSummary>
   4EFCA109: GetClusterManifestUpdate(Orleans.Metadata.MajorMinorVersion) -> ValueTask<Orleans.Runtime.ClusterManifestUpdate?>
-  GetClusterManifestHashSummary() -> ValueTask<Orleans.Runtime.ClusterManifestHashSummary>
-  GetSiloManifestByHash(Orleans.Runtime.ManifestHash) -> ValueTask<Orleans.Metadata.GrainManifest?>
-  GetSiloManifestHash() -> ValueTask<Orleans.Runtime.ManifestHash>
+  93B8854F: GetSiloManifestByHash(Orleans.Runtime.ManifestHash) -> ValueTask<Orleans.Metadata.GrainManifest?>
+  3D9B7FE6: GetSiloManifestHash() -> ValueTask<Orleans.Runtime.ManifestHash>
 
 interface Orleans.Runtime.IDisseminationSystemTarget [Version(0)]
-  ExchangeAntiEntropy(Orleans.Runtime.DisseminationAntiEntropyRequest, System.Threading.CancellationToken) -> Task<Orleans.Runtime.DisseminationAntiEntropyResponse>
-  PushGossip(Orleans.Runtime.DisseminationGossipBatch, System.Threading.CancellationToken) -> Task
+  EF58CB3D: ExchangeAntiEntropy(Orleans.Runtime.DisseminationAntiEntropyRequest, System.Threading.CancellationToken) -> Task<Orleans.Runtime.DisseminationAntiEntropyResponse>
+  EAB5953F: PushGossip(Orleans.Runtime.DisseminationGossipBatch, System.Threading.CancellationToken) -> Task
 
 interface [GrainInterfaceType("Orleans.Runtime.IDeploymentLoadPublisher")] Orleans.Runtime.IDeploymentLoadPublisher [Version(0)]
   C5255F0C: UpdateRuntimeStatistics(Orleans.Runtime.SiloAddress, Orleans.Runtime.SiloRuntimeStatistics) -> Task

--- a/src/Orleans.Core/Runtime/Constants.cs
+++ b/src/Orleans.Core/Runtime/Constants.cs
@@ -17,6 +17,7 @@ namespace Orleans.Runtime
         public static readonly GrainType MembershipServiceType = SystemTargetGrainId.CreateGrainType("clustering");
         public static readonly GrainType SystemMembershipTableType = SystemTargetGrainId.CreateGrainType("clustering.dev");
         public static readonly GrainType DeploymentLoadPublisherSystemTargetType = SystemTargetGrainId.CreateGrainType("load-publisher");
+        public static readonly GrainType DisseminationSystemTargetType = SystemTargetGrainId.CreateGrainType("dissemination");
         public static readonly GrainType TestHooksSystemTargetType = SystemTargetGrainId.CreateGrainType("test.hooks");
         public static readonly GrainType TransactionAgentSystemTargetType = SystemTargetGrainId.CreateGrainType("txn.agent");
         public static readonly GrainType StreamProviderManagerAgentSystemTargetType = SystemTargetGrainId.CreateGrainType("stream.provider-manager");
@@ -46,6 +47,7 @@ namespace Orleans.Runtime
             {CatalogType,"Catalog"},
             {MembershipServiceType,"MembershipService"},
             {DeploymentLoadPublisherSystemTargetType, "DeploymentLoadPublisherSystemTarget"},
+            {DisseminationSystemTargetType, "DisseminationSystemTarget"},
             {StreamProviderManagerAgentSystemTargetType,"StreamProviderManagerAgent"},
             {TestHooksSystemTargetType,"TestHooksSystemTargetType"},
             {TransactionAgentSystemTargetType,"TransactionAgentSystemTarget"},

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using System.Collections.Immutable;
+using System.Threading;
 using Orleans.Concurrency;
 
 namespace Orleans.Runtime;
@@ -7,9 +8,9 @@ namespace Orleans.Runtime;
 internal interface IDisseminationSystemTarget : ISystemTarget
 {
     [OneWay]
-    Task PushGossip(DisseminationGossipBatch batch);
+    Task PushGossip(DisseminationGossipBatch batch, CancellationToken cancellationToken);
 
-    Task<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(DisseminationAntiEntropyRequest request);
+    Task<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(DisseminationAntiEntropyRequest request, CancellationToken cancellationToken);
 }
 
 [GenerateSerializer, Immutable]

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -14,44 +14,6 @@ internal interface IDisseminationSystemTarget : ISystemTarget
 }
 
 [GenerateSerializer, Immutable]
-internal readonly struct DisseminationDigest : IEquatable<DisseminationDigest>
-{
-    public DisseminationDigest(string topic, string key, long version)
-    {
-        Topic = topic ?? string.Empty;
-        Key = key ?? string.Empty;
-        Version = version;
-    }
-
-    [Id(0)]
-    public string Topic { get; }
-
-    [Id(1)]
-    public string Key { get; }
-
-    [Id(2)]
-    public long Version { get; }
-
-    public bool Equals(DisseminationDigest other) =>
-        string.Equals(Topic, other.Topic, StringComparison.Ordinal)
-        && string.Equals(Key, other.Key, StringComparison.Ordinal)
-        && Version == other.Version;
-
-    public override bool Equals(object? obj) => obj is DisseminationDigest other && Equals(other);
-
-    public override int GetHashCode() => HashCode.Combine(
-        StringComparer.Ordinal.GetHashCode(Topic ?? string.Empty),
-        StringComparer.Ordinal.GetHashCode(Key ?? string.Empty),
-        Version);
-
-    public override string ToString() => $"{Topic}/{Key}/{Version}";
-
-    public static bool operator ==(DisseminationDigest left, DisseminationDigest right) => left.Equals(right);
-
-    public static bool operator !=(DisseminationDigest left, DisseminationDigest right) => !left.Equals(right);
-}
-
-[GenerateSerializer, Immutable]
 internal readonly struct DisseminationTopicDigest : IEquatable<DisseminationTopicDigest>
 {
     public DisseminationTopicDigest(string key, long version)
@@ -87,7 +49,7 @@ internal readonly struct DisseminationTopicDigest : IEquatable<DisseminationTopi
 internal sealed class DisseminationValue
 {
     [Id(0)]
-    public DisseminationDigest Digest { get; init; }
+    public DisseminationTopicDigest Digest { get; init; }
 
     [Id(1)]
     public required SiloAddress Root { get; init; }

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -1,4 +1,3 @@
-using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Threading;
 using Orleans.Concurrency;
@@ -68,8 +67,8 @@ internal sealed class DisseminationGossipBatch
     public required SiloAddress Sender { get; init; }
 
     [Id(1)]
-    public FrozenDictionary<string, ImmutableArray<DisseminationValue>> ValuesByTopic { get; init; } =
-        FrozenDictionary<string, ImmutableArray<DisseminationValue>>.Empty;
+    public ImmutableDictionary<string, ImmutableArray<DisseminationValue>> ValuesByTopic { get; init; } =
+        ImmutableDictionary<string, ImmutableArray<DisseminationValue>>.Empty;
 }
 
 [GenerateSerializer, Immutable]
@@ -79,8 +78,8 @@ internal sealed class DisseminationAntiEntropyRequest
     public required SiloAddress Sender { get; init; }
 
     [Id(1)]
-    public FrozenDictionary<string, ImmutableArray<DisseminationTopicDigest>> DigestsByTopic { get; init; } =
-        FrozenDictionary<string, ImmutableArray<DisseminationTopicDigest>>.Empty;
+    public ImmutableDictionary<string, ImmutableArray<DisseminationTopicDigest>> DigestsByTopic { get; init; } =
+        ImmutableDictionary<string, ImmutableArray<DisseminationTopicDigest>>.Empty;
 }
 
 [GenerateSerializer, Immutable]
@@ -90,8 +89,8 @@ internal sealed class DisseminationAntiEntropyResponse
     public required SiloAddress Sender { get; init; }
 
     [Id(1)]
-    public FrozenDictionary<string, ImmutableArray<DisseminationValue>> ValuesByTopic { get; init; } =
-        FrozenDictionary<string, ImmutableArray<DisseminationValue>>.Empty;
+    public ImmutableDictionary<string, ImmutableArray<DisseminationValue>> ValuesByTopic { get; init; } =
+        ImmutableDictionary<string, ImmutableArray<DisseminationValue>>.Empty;
 
     [Id(2)]
     public bool Truncated { get; init; }

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Immutable;
-using System.Threading.Tasks;
 using Orleans.Concurrency;
 
 namespace Orleans.Runtime;
@@ -16,12 +14,11 @@ internal interface IDisseminationSystemTarget : ISystemTarget
 [GenerateSerializer, Immutable]
 internal readonly struct DisseminationDigest : IEquatable<DisseminationDigest>
 {
-    public DisseminationDigest(string topic, string key, long version, string payloadKind)
+    public DisseminationDigest(string topic, string key, long version)
     {
         Topic = topic ?? string.Empty;
         Key = key ?? string.Empty;
         Version = version;
-        PayloadKind = payloadKind ?? string.Empty;
     }
 
     [Id(0)]
@@ -33,24 +30,19 @@ internal readonly struct DisseminationDigest : IEquatable<DisseminationDigest>
     [Id(2)]
     public long Version { get; }
 
-    [Id(3)]
-    public string PayloadKind { get; }
-
     public bool Equals(DisseminationDigest other) =>
         string.Equals(Topic, other.Topic, StringComparison.Ordinal)
         && string.Equals(Key, other.Key, StringComparison.Ordinal)
-        && Version == other.Version
-        && string.Equals(PayloadKind, other.PayloadKind, StringComparison.Ordinal);
+        && Version == other.Version;
 
     public override bool Equals(object? obj) => obj is DisseminationDigest other && Equals(other);
 
     public override int GetHashCode() => HashCode.Combine(
         StringComparer.Ordinal.GetHashCode(Topic ?? string.Empty),
         StringComparer.Ordinal.GetHashCode(Key ?? string.Empty),
-        Version,
-        StringComparer.Ordinal.GetHashCode(PayloadKind ?? string.Empty));
+        Version);
 
-    public override string ToString() => $"{Topic}/{Key}/{Version}/{PayloadKind}";
+    public override string ToString() => $"{Topic}/{Key}/{Version}";
 
     public static bool operator ==(DisseminationDigest left, DisseminationDigest right) => left.Equals(right);
 
@@ -64,7 +56,7 @@ internal sealed class DisseminationValue
     public DisseminationDigest Digest { get; init; }
 
     [Id(1)]
-    public SiloAddress Root { get; init; } = default!;
+    public required SiloAddress Root { get; init; }
 
     [Id(2)]
     public DateTimeOffset ExpiresAt { get; init; }
@@ -77,7 +69,7 @@ internal sealed class DisseminationValue
 internal sealed class DisseminationGossipBatch
 {
     [Id(0)]
-    public SiloAddress Sender { get; init; } = default!;
+    public required SiloAddress Sender { get; init; }
 
     [Id(1)]
     public ImmutableArray<DisseminationValue> Values { get; init; } = [];
@@ -87,7 +79,7 @@ internal sealed class DisseminationGossipBatch
 internal sealed class DisseminationAntiEntropyRequest
 {
     [Id(0)]
-    public SiloAddress Sender { get; init; } = default!;
+    public required SiloAddress Sender { get; init; }
 
     [Id(1)]
     public ImmutableArray<string> Topics { get; init; } = [];
@@ -100,7 +92,7 @@ internal sealed class DisseminationAntiEntropyRequest
 internal sealed class DisseminationAntiEntropyResponse
 {
     [Id(0)]
-    public SiloAddress Sender { get; init; } = default!;
+    public required SiloAddress Sender { get; init; }
 
     [Id(1)]
     public ImmutableArray<DisseminationValue> Values { get; init; } = [];

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -44,58 +44,21 @@ internal sealed class DisseminationCapabilityResponse
 }
 
 [GenerateSerializer, Immutable]
-internal readonly struct DisseminationValueKey : IEquatable<DisseminationValueKey>
+internal readonly struct DisseminationDigest : IEquatable<DisseminationDigest>
 {
-    public DisseminationValueKey(string value, SiloAddress? siloAddress = null)
+    public DisseminationDigest(string topic, string key, long version, string payloadKind)
     {
-        Value = value ?? string.Empty;
-        SiloAddress = siloAddress;
-    }
-
-    [Id(0)]
-    public string Value { get; }
-
-    [Id(1)]
-    public SiloAddress? SiloAddress { get; }
-
-    public static DisseminationValueKey FromString(string value) => new(value);
-
-    public static DisseminationValueKey FromSiloAddress(SiloAddress siloAddress) =>
-        new(siloAddress?.ToParsableString() ?? string.Empty, siloAddress);
-
-    public bool Equals(DisseminationValueKey other) =>
-        string.Equals(Value, other.Value, StringComparison.Ordinal)
-        && Equals(SiloAddress, other.SiloAddress);
-
-    public override bool Equals(object? obj) => obj is DisseminationValueKey other && Equals(other);
-
-    public override int GetHashCode() => HashCode.Combine(
-        StringComparer.Ordinal.GetHashCode(Value ?? string.Empty),
-        SiloAddress);
-
-    public override string ToString() => SiloAddress?.ToParsableString() ?? Value ?? string.Empty;
-
-    public static bool operator ==(DisseminationValueKey left, DisseminationValueKey right) => left.Equals(right);
-
-    public static bool operator !=(DisseminationValueKey left, DisseminationValueKey right) => !left.Equals(right);
-}
-
-[GenerateSerializer, Immutable]
-internal readonly struct DisseminationItemId : IEquatable<DisseminationItemId>
-{
-    public DisseminationItemId(string topic, DisseminationValueKey key, long version, string payloadKind)
-    {
-        Topic = topic;
-        Key = key;
+        Topic = topic ?? string.Empty;
+        Key = key ?? string.Empty;
         Version = version;
-        PayloadKind = payloadKind;
+        PayloadKind = payloadKind ?? string.Empty;
     }
 
     [Id(0)]
     public string Topic { get; }
 
     [Id(1)]
-    public DisseminationValueKey Key { get; }
+    public string Key { get; }
 
     [Id(2)]
     public long Version { get; }
@@ -103,32 +66,32 @@ internal readonly struct DisseminationItemId : IEquatable<DisseminationItemId>
     [Id(3)]
     public string PayloadKind { get; }
 
-    public bool Equals(DisseminationItemId other) =>
+    public bool Equals(DisseminationDigest other) =>
         string.Equals(Topic, other.Topic, StringComparison.Ordinal)
-        && Key.Equals(other.Key)
+        && string.Equals(Key, other.Key, StringComparison.Ordinal)
         && Version == other.Version
         && string.Equals(PayloadKind, other.PayloadKind, StringComparison.Ordinal);
 
-    public override bool Equals(object? obj) => obj is DisseminationItemId other && Equals(other);
+    public override bool Equals(object? obj) => obj is DisseminationDigest other && Equals(other);
 
     public override int GetHashCode() => HashCode.Combine(
         StringComparer.Ordinal.GetHashCode(Topic ?? string.Empty),
-        Key,
+        StringComparer.Ordinal.GetHashCode(Key ?? string.Empty),
         Version,
         StringComparer.Ordinal.GetHashCode(PayloadKind ?? string.Empty));
 
     public override string ToString() => $"{Topic}/{Key}/{Version}/{PayloadKind}";
 
-    public static bool operator ==(DisseminationItemId left, DisseminationItemId right) => left.Equals(right);
+    public static bool operator ==(DisseminationDigest left, DisseminationDigest right) => left.Equals(right);
 
-    public static bool operator !=(DisseminationItemId left, DisseminationItemId right) => !left.Equals(right);
+    public static bool operator !=(DisseminationDigest left, DisseminationDigest right) => !left.Equals(right);
 }
 
 [GenerateSerializer]
-internal sealed class DisseminationItem
+internal sealed class DisseminationValue
 {
     [Id(0)]
-    public DisseminationItemId Id { get; init; }
+    public DisseminationDigest Digest { get; init; }
 
     [Id(1)]
     public SiloAddress Root { get; init; } = default!;
@@ -147,7 +110,7 @@ internal sealed class DisseminationGossipBatch
     public SiloAddress Sender { get; init; } = default!;
 
     [Id(1)]
-    public DisseminationItem[] Items { get; init; } = Array.Empty<DisseminationItem>();
+    public DisseminationValue[] Values { get; init; } = Array.Empty<DisseminationValue>();
 }
 
 [GenerateSerializer]
@@ -160,7 +123,7 @@ internal sealed class DisseminationAntiEntropyRequest
     public DisseminationCapabilityRequest[] Topics { get; init; } = Array.Empty<DisseminationCapabilityRequest>();
 
     [Id(2)]
-    public DisseminationItemId[] Digests { get; init; } = Array.Empty<DisseminationItemId>();
+    public DisseminationDigest[] Digests { get; init; } = Array.Empty<DisseminationDigest>();
 }
 
 [GenerateSerializer]
@@ -170,7 +133,7 @@ internal sealed class DisseminationAntiEntropyResponse
     public SiloAddress Sender { get; init; } = default!;
 
     [Id(1)]
-    public DisseminationItem[] Items { get; init; } = Array.Empty<DisseminationItem>();
+    public DisseminationValue[] Values { get; init; } = Array.Empty<DisseminationValue>();
 
     [Id(2)]
     public bool Truncated { get; init; }

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -106,7 +106,8 @@ internal sealed class DisseminationGossipBatch
     public required SiloAddress Sender { get; init; }
 
     [Id(1)]
-    public ImmutableArray<DisseminationValue> Values { get; init; } = [];
+    public FrozenDictionary<string, ImmutableArray<DisseminationValue>> ValuesByTopic { get; init; } =
+        FrozenDictionary<string, ImmutableArray<DisseminationValue>>.Empty;
 }
 
 [GenerateSerializer, Immutable]

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -6,41 +6,10 @@ namespace Orleans.Runtime;
 
 internal interface IDisseminationSystemTarget : ISystemTarget
 {
-    Task<DisseminationCapabilityResponse> GetCapabilities(DisseminationCapabilityRequest request);
-
     [OneWay]
     Task PushGossip(DisseminationGossipBatch batch);
 
     Task<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(DisseminationAntiEntropyRequest request);
-}
-
-[GenerateSerializer]
-internal sealed class DisseminationCapabilityRequest
-{
-    [Id(0)]
-    public string Topic { get; init; } = string.Empty;
-
-    [Id(1)]
-    public int ProtocolVersion { get; init; }
-
-    [Id(2)]
-    public string[] PayloadKinds { get; init; } = Array.Empty<string>();
-}
-
-[GenerateSerializer]
-internal sealed class DisseminationCapabilityResponse
-{
-    [Id(0)]
-    public string Topic { get; init; } = string.Empty;
-
-    [Id(1)]
-    public int ProtocolVersion { get; init; }
-
-    [Id(2)]
-    public bool Supported { get; init; }
-
-    [Id(3)]
-    public string[] PayloadKinds { get; init; } = Array.Empty<string>();
 }
 
 [GenerateSerializer, Immutable]
@@ -120,7 +89,7 @@ internal sealed class DisseminationAntiEntropyRequest
     public SiloAddress Sender { get; init; } = default!;
 
     [Id(1)]
-    public DisseminationCapabilityRequest[] Topics { get; init; } = Array.Empty<DisseminationCapabilityRequest>();
+    public string[] Topics { get; init; } = Array.Empty<string>();
 
     [Id(2)]
     public DisseminationDigest[] Digests { get; init; } = Array.Empty<DisseminationDigest>();

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Collections.Immutable;
 using Orleans.Concurrency;
 
@@ -50,6 +51,38 @@ internal readonly struct DisseminationDigest : IEquatable<DisseminationDigest>
 }
 
 [GenerateSerializer, Immutable]
+internal readonly struct DisseminationTopicDigest : IEquatable<DisseminationTopicDigest>
+{
+    public DisseminationTopicDigest(string key, long version)
+    {
+        Key = key ?? string.Empty;
+        Version = version;
+    }
+
+    [Id(0)]
+    public string Key { get; }
+
+    [Id(1)]
+    public long Version { get; }
+
+    public bool Equals(DisseminationTopicDigest other) =>
+        string.Equals(Key, other.Key, StringComparison.Ordinal)
+        && Version == other.Version;
+
+    public override bool Equals(object? obj) => obj is DisseminationTopicDigest other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(
+        StringComparer.Ordinal.GetHashCode(Key ?? string.Empty),
+        Version);
+
+    public override string ToString() => $"{Key}/{Version}";
+
+    public static bool operator ==(DisseminationTopicDigest left, DisseminationTopicDigest right) => left.Equals(right);
+
+    public static bool operator !=(DisseminationTopicDigest left, DisseminationTopicDigest right) => !left.Equals(right);
+}
+
+[GenerateSerializer, Immutable]
 internal sealed class DisseminationValue
 {
     [Id(0)]
@@ -82,10 +115,8 @@ internal sealed class DisseminationAntiEntropyRequest
     public required SiloAddress Sender { get; init; }
 
     [Id(1)]
-    public ImmutableArray<string> Topics { get; init; } = [];
-
-    [Id(2)]
-    public ImmutableArray<DisseminationDigest> Digests { get; init; } = [];
+    public FrozenDictionary<string, ImmutableArray<DisseminationTopicDigest>> DigestsByTopic { get; init; } =
+        FrozenDictionary<string, ImmutableArray<DisseminationTopicDigest>>.Empty;
 }
 
 [GenerateSerializer, Immutable]

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Threading.Tasks;
+using Orleans.Concurrency;
+
+namespace Orleans.Runtime;
+
+internal interface IDisseminationSystemTarget : ISystemTarget
+{
+    Task<DisseminationCapabilityResponse> GetCapabilities(DisseminationCapabilityRequest request);
+
+    [OneWay]
+    Task PushGossip(DisseminationGossipBatch batch);
+
+    Task<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(DisseminationAntiEntropyRequest request);
+}
+
+[GenerateSerializer]
+internal sealed class DisseminationCapabilityRequest
+{
+    [Id(0)]
+    public string Topic { get; init; } = string.Empty;
+
+    [Id(1)]
+    public int ProtocolVersion { get; init; }
+
+    [Id(2)]
+    public string[] PayloadKinds { get; init; } = Array.Empty<string>();
+}
+
+[GenerateSerializer]
+internal sealed class DisseminationCapabilityResponse
+{
+    [Id(0)]
+    public string Topic { get; init; } = string.Empty;
+
+    [Id(1)]
+    public int ProtocolVersion { get; init; }
+
+    [Id(2)]
+    public bool Supported { get; init; }
+
+    [Id(3)]
+    public string[] PayloadKinds { get; init; } = Array.Empty<string>();
+}
+
+[GenerateSerializer, Immutable]
+internal readonly struct DisseminationValueKey : IEquatable<DisseminationValueKey>
+{
+    public DisseminationValueKey(string value, SiloAddress? siloAddress = null)
+    {
+        Value = value ?? string.Empty;
+        SiloAddress = siloAddress;
+    }
+
+    [Id(0)]
+    public string Value { get; }
+
+    [Id(1)]
+    public SiloAddress? SiloAddress { get; }
+
+    public static DisseminationValueKey FromString(string value) => new(value);
+
+    public static DisseminationValueKey FromSiloAddress(SiloAddress siloAddress) =>
+        new(siloAddress?.ToParsableString() ?? string.Empty, siloAddress);
+
+    public bool Equals(DisseminationValueKey other) =>
+        string.Equals(Value, other.Value, StringComparison.Ordinal)
+        && Equals(SiloAddress, other.SiloAddress);
+
+    public override bool Equals(object? obj) => obj is DisseminationValueKey other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(
+        StringComparer.Ordinal.GetHashCode(Value ?? string.Empty),
+        SiloAddress);
+
+    public override string ToString() => SiloAddress?.ToParsableString() ?? Value ?? string.Empty;
+
+    public static bool operator ==(DisseminationValueKey left, DisseminationValueKey right) => left.Equals(right);
+
+    public static bool operator !=(DisseminationValueKey left, DisseminationValueKey right) => !left.Equals(right);
+}
+
+[GenerateSerializer, Immutable]
+internal readonly struct DisseminationItemId : IEquatable<DisseminationItemId>
+{
+    public DisseminationItemId(string topic, DisseminationValueKey key, long version, string payloadKind)
+    {
+        Topic = topic;
+        Key = key;
+        Version = version;
+        PayloadKind = payloadKind;
+    }
+
+    [Id(0)]
+    public string Topic { get; }
+
+    [Id(1)]
+    public DisseminationValueKey Key { get; }
+
+    [Id(2)]
+    public long Version { get; }
+
+    [Id(3)]
+    public string PayloadKind { get; }
+
+    public bool Equals(DisseminationItemId other) =>
+        string.Equals(Topic, other.Topic, StringComparison.Ordinal)
+        && Key.Equals(other.Key)
+        && Version == other.Version
+        && string.Equals(PayloadKind, other.PayloadKind, StringComparison.Ordinal);
+
+    public override bool Equals(object? obj) => obj is DisseminationItemId other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(
+        StringComparer.Ordinal.GetHashCode(Topic ?? string.Empty),
+        Key,
+        Version,
+        StringComparer.Ordinal.GetHashCode(PayloadKind ?? string.Empty));
+
+    public override string ToString() => $"{Topic}/{Key}/{Version}/{PayloadKind}";
+
+    public static bool operator ==(DisseminationItemId left, DisseminationItemId right) => left.Equals(right);
+
+    public static bool operator !=(DisseminationItemId left, DisseminationItemId right) => !left.Equals(right);
+}
+
+[GenerateSerializer]
+internal sealed class DisseminationItem
+{
+    [Id(0)]
+    public DisseminationItemId Id { get; init; }
+
+    [Id(1)]
+    public SiloAddress Root { get; init; } = default!;
+
+    [Id(2)]
+    public DateTimeOffset ExpiresAt { get; init; }
+
+    [Id(3)]
+    public byte[] Payload { get; init; } = Array.Empty<byte>();
+}
+
+[GenerateSerializer]
+internal sealed class DisseminationGossipBatch
+{
+    [Id(0)]
+    public SiloAddress Sender { get; init; } = default!;
+
+    [Id(1)]
+    public DisseminationItem[] Items { get; init; } = Array.Empty<DisseminationItem>();
+}
+
+[GenerateSerializer]
+internal sealed class DisseminationAntiEntropyRequest
+{
+    [Id(0)]
+    public SiloAddress Sender { get; init; } = default!;
+
+    [Id(1)]
+    public DisseminationCapabilityRequest[] Topics { get; init; } = Array.Empty<DisseminationCapabilityRequest>();
+
+    [Id(2)]
+    public DisseminationItemId[] Digests { get; init; } = Array.Empty<DisseminationItemId>();
+}
+
+[GenerateSerializer]
+internal sealed class DisseminationAntiEntropyResponse
+{
+    [Id(0)]
+    public SiloAddress Sender { get; init; } = default!;
+
+    [Id(1)]
+    public DisseminationItem[] Items { get; init; } = Array.Empty<DisseminationItem>();
+
+    [Id(2)]
+    public bool Truncated { get; init; }
+}

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -128,7 +128,8 @@ internal sealed class DisseminationAntiEntropyResponse
     public required SiloAddress Sender { get; init; }
 
     [Id(1)]
-    public ImmutableArray<DisseminationValue> Values { get; init; } = [];
+    public FrozenDictionary<string, ImmutableArray<DisseminationValue>> ValuesByTopic { get; init; } =
+        FrozenDictionary<string, ImmutableArray<DisseminationValue>>.Empty;
 
     [Id(2)]
     public bool Truncated { get; init; }

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -96,4 +96,7 @@ internal sealed class DisseminationAntiEntropyResponse
 
     [Id(2)]
     public bool Truncated { get; init; }
+
+    [Id(3)]
+    public ImmutableArray<string> SupportedTopics { get; init; } = [];
 }

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Immutable;
 using System.Threading;
+using System.Threading.Tasks;
 using Orleans.Concurrency;
 
 namespace Orleans.Runtime;

--- a/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
+++ b/src/Orleans.Core/SystemTargetInterfaces/IDisseminationSystemTarget.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Orleans.Concurrency;
 
@@ -56,7 +57,7 @@ internal readonly struct DisseminationDigest : IEquatable<DisseminationDigest>
     public static bool operator !=(DisseminationDigest left, DisseminationDigest right) => !left.Equals(right);
 }
 
-[GenerateSerializer]
+[GenerateSerializer, Immutable]
 internal sealed class DisseminationValue
 {
     [Id(0)]
@@ -69,40 +70,40 @@ internal sealed class DisseminationValue
     public DateTimeOffset ExpiresAt { get; init; }
 
     [Id(3)]
-    public byte[] Payload { get; init; } = Array.Empty<byte>();
+    public ReadOnlyMemory<byte> Payload { get; init; } = Array.Empty<byte>();
 }
 
-[GenerateSerializer]
+[GenerateSerializer, Immutable]
 internal sealed class DisseminationGossipBatch
 {
     [Id(0)]
     public SiloAddress Sender { get; init; } = default!;
 
     [Id(1)]
-    public DisseminationValue[] Values { get; init; } = Array.Empty<DisseminationValue>();
+    public ImmutableArray<DisseminationValue> Values { get; init; } = [];
 }
 
-[GenerateSerializer]
+[GenerateSerializer, Immutable]
 internal sealed class DisseminationAntiEntropyRequest
 {
     [Id(0)]
     public SiloAddress Sender { get; init; } = default!;
 
     [Id(1)]
-    public string[] Topics { get; init; } = Array.Empty<string>();
+    public ImmutableArray<string> Topics { get; init; } = [];
 
     [Id(2)]
-    public DisseminationDigest[] Digests { get; init; } = Array.Empty<DisseminationDigest>();
+    public ImmutableArray<DisseminationDigest> Digests { get; init; } = [];
 }
 
-[GenerateSerializer]
+[GenerateSerializer, Immutable]
 internal sealed class DisseminationAntiEntropyResponse
 {
     [Id(0)]
     public SiloAddress Sender { get; init; } = default!;
 
     [Id(1)]
-    public DisseminationValue[] Values { get; init; } = Array.Empty<DisseminationValue>();
+    public ImmutableArray<DisseminationValue> Values { get; init; } = [];
 
     [Id(2)]
     public bool Truncated { get; init; }

--- a/src/Orleans.Runtime/Configuration/Options/DeploymentLoadPublisherOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/DeploymentLoadPublisherOptions.cs
@@ -12,5 +12,10 @@ namespace Orleans.Configuration
         /// </summary>
         public TimeSpan DeploymentLoadPublisherRefreshTime { get; set; } = DEFAULT_DEPLOYMENT_LOAD_PUBLISHER_REFRESH_TIME;
         public static readonly TimeSpan DEFAULT_DEPLOYMENT_LOAD_PUBLISHER_REFRESH_TIME = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// Gets or sets dissemination options for deployment load statistics.
+        /// </summary>
+        public DisseminationTopicOptions Dissemination { get; set; } = new();
     }
 }

--- a/src/Orleans.Runtime/Configuration/Options/DeploymentLoadPublisherOptions.cs
+++ b/src/Orleans.Runtime/Configuration/Options/DeploymentLoadPublisherOptions.cs
@@ -16,6 +16,6 @@ namespace Orleans.Configuration
         /// <summary>
         /// Gets or sets dissemination options for deployment load statistics.
         /// </summary>
-        public DisseminationTopicOptions Dissemination { get; set; } = new();
+        public DisseminationTopicOptions Dissemination { get; set; } = new() { ExpectedUpdateCadence = TimeSpan.FromSeconds(2) };
     }
 }

--- a/src/Orleans.Runtime/Configuration/Options/DisseminationOptionsValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Options/DisseminationOptionsValidator.cs
@@ -81,6 +81,11 @@ internal sealed class DisseminationTopicOptionsValidator
             return ValidateOptionsResult.Fail($"{owner}.{nameof(DisseminationTopicOptions.StaleItemTtl)} must be greater than {nameof(DisseminationTopicOptions.MaxCoalescingDelay)}.");
         }
 
+        if (options.ExpectedUpdateCadence <= TimeSpan.Zero)
+        {
+            return ValidateOptionsResult.Fail($"{owner}.{nameof(DisseminationTopicOptions.ExpectedUpdateCadence)} must be greater than 0.");
+        }
+
         if (options.MaxPayloadBytes <= 0)
         {
             return ValidateOptionsResult.Fail($"{owner}.{nameof(DisseminationTopicOptions.MaxPayloadBytes)} must be greater than 0.");

--- a/src/Orleans.Runtime/Configuration/Options/DisseminationOptionsValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Options/DisseminationOptionsValidator.cs
@@ -5,6 +5,8 @@ namespace Orleans.Configuration;
 
 internal sealed class DisseminationOptionsValidator : IValidateOptions<DisseminationOptions>
 {
+    private static readonly TimeSpan MaximumTimerDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
+
     public ValidateOptionsResult Validate(string? name, DisseminationOptions options)
     {
         if (options.MaxConcurrentSends <= 0)
@@ -48,6 +50,11 @@ internal sealed class DisseminationOptionsValidator : IValidateOptions<Dissemina
             return ValidateOptionsResult.Fail($"{nameof(DisseminationOverlayOptions.AntiEntropyInterval)} must be greater than 0.");
         }
 
+        if (overlay.AntiEntropyInterval > MaximumTimerDelay)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOverlayOptions.AntiEntropyInterval)} must not exceed {MaximumTimerDelay}.");
+        }
+
         if (overlay.AntiEntropyPeerCount <= 0)
         {
             return ValidateOptionsResult.Fail($"{nameof(DisseminationOverlayOptions.AntiEntropyPeerCount)} must be greater than 0.");
@@ -59,6 +66,8 @@ internal sealed class DisseminationOptionsValidator : IValidateOptions<Dissemina
 
 internal sealed class DisseminationTopicOptionsValidator
 {
+    private static readonly TimeSpan MaximumTimerDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
+
     public static ValidateOptionsResult Validate(string owner, DisseminationTopicOptions options)
     {
         if (options.MaxPendingItemCount <= 0)
@@ -69,6 +78,11 @@ internal sealed class DisseminationTopicOptionsValidator
         if (options.MaxCoalescingDelay <= TimeSpan.Zero)
         {
             return ValidateOptionsResult.Fail($"{owner}.{nameof(DisseminationTopicOptions.MaxCoalescingDelay)} must be greater than 0.");
+        }
+
+        if (options.MaxCoalescingDelay > MaximumTimerDelay)
+        {
+            return ValidateOptionsResult.Fail($"{owner}.{nameof(DisseminationTopicOptions.MaxCoalescingDelay)} must not exceed {MaximumTimerDelay}.");
         }
 
         if (options.StaleItemTtl <= options.MaxCoalescingDelay)

--- a/src/Orleans.Runtime/Configuration/Options/DisseminationOptionsValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Options/DisseminationOptionsValidator.cs
@@ -33,9 +33,19 @@ internal sealed class DisseminationOptionsValidator : IValidateOptions<Dissemina
         }
 
         var overlay = options.Overlay;
-        if (overlay.TreeFanout <= 0)
+        if (overlay.TargetHopCount <= 0)
         {
-            return ValidateOptionsResult.Fail($"{nameof(DisseminationOverlayOptions.TreeFanout)} must be greater than 0.");
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOverlayOptions.TargetHopCount)} must be greater than 0.");
+        }
+
+        if (overlay.MinFanOutFactor <= 0)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOverlayOptions.MinFanOutFactor)} must be greater than 0.");
+        }
+
+        if (overlay.MaxFanOutFactor < overlay.MinFanOutFactor)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOverlayOptions.MaxFanOutFactor)} must be greater than or equal to {nameof(DisseminationOverlayOptions.MinFanOutFactor)}.");
         }
 
         if (overlay.AntiEntropyInterval <= TimeSpan.Zero)

--- a/src/Orleans.Runtime/Configuration/Options/DisseminationOptionsValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Options/DisseminationOptionsValidator.cs
@@ -12,11 +12,6 @@ internal sealed class DisseminationOptionsValidator : IValidateOptions<Dissemina
             return ValidateOptionsResult.Fail($"{nameof(DisseminationOptions.MaxConcurrentSends)} must be greater than 0.");
         }
 
-        if (options.CapabilityCacheTtl <= TimeSpan.Zero)
-        {
-            return ValidateOptionsResult.Fail($"{nameof(DisseminationOptions.CapabilityCacheTtl)} must be greater than 0.");
-        }
-
         if (options.FailureBackoff <= TimeSpan.Zero)
         {
             return ValidateOptionsResult.Fail($"{nameof(DisseminationOptions.FailureBackoff)} must be greater than 0.");

--- a/src/Orleans.Runtime/Configuration/Options/DisseminationOptionsValidator.cs
+++ b/src/Orleans.Runtime/Configuration/Options/DisseminationOptionsValidator.cs
@@ -1,0 +1,93 @@
+using System;
+using Microsoft.Extensions.Options;
+
+namespace Orleans.Configuration;
+
+internal sealed class DisseminationOptionsValidator : IValidateOptions<DisseminationOptions>
+{
+    public ValidateOptionsResult Validate(string? name, DisseminationOptions options)
+    {
+        if (options.MaxConcurrentSends <= 0)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOptions.MaxConcurrentSends)} must be greater than 0.");
+        }
+
+        if (options.CapabilityCacheTtl <= TimeSpan.Zero)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOptions.CapabilityCacheTtl)} must be greater than 0.");
+        }
+
+        if (options.FailureBackoff <= TimeSpan.Zero)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOptions.FailureBackoff)} must be greater than 0.");
+        }
+
+        if (options.MaxBatchBytes <= 0)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOptions.MaxBatchBytes)} must be greater than 0.");
+        }
+
+        if (options.MaxBatchItems <= 0)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOptions.MaxBatchItems)} must be greater than 0.");
+        }
+
+        var overlay = options.Overlay;
+        if (overlay.TreeFanout <= 0)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOverlayOptions.TreeFanout)} must be greater than 0.");
+        }
+
+        if (overlay.AntiEntropyInterval <= TimeSpan.Zero)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOverlayOptions.AntiEntropyInterval)} must be greater than 0.");
+        }
+
+        if (overlay.AntiEntropyPeerCount <= 0)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(DisseminationOverlayOptions.AntiEntropyPeerCount)} must be greater than 0.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}
+
+internal sealed class DisseminationTopicOptionsValidator
+{
+    public static ValidateOptionsResult Validate(string owner, DisseminationTopicOptions options)
+    {
+        if (options.MaxPendingItemCount <= 0)
+        {
+            return ValidateOptionsResult.Fail($"{owner}.{nameof(DisseminationTopicOptions.MaxPendingItemCount)} must be greater than 0.");
+        }
+
+        if (options.MaxCoalescingDelay <= TimeSpan.Zero)
+        {
+            return ValidateOptionsResult.Fail($"{owner}.{nameof(DisseminationTopicOptions.MaxCoalescingDelay)} must be greater than 0.");
+        }
+
+        if (options.StaleItemTtl <= options.MaxCoalescingDelay)
+        {
+            return ValidateOptionsResult.Fail($"{owner}.{nameof(DisseminationTopicOptions.StaleItemTtl)} must be greater than {nameof(DisseminationTopicOptions.MaxCoalescingDelay)}.");
+        }
+
+        if (options.MaxPayloadBytes <= 0)
+        {
+            return ValidateOptionsResult.Fail($"{owner}.{nameof(DisseminationTopicOptions.MaxPayloadBytes)} must be greater than 0.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}
+
+internal sealed class DeploymentLoadPublisherOptionsValidator : IValidateOptions<DeploymentLoadPublisherOptions>
+{
+    public ValidateOptionsResult Validate(string? name, DeploymentLoadPublisherOptions options) =>
+        DisseminationTopicOptionsValidator.Validate(nameof(DeploymentLoadPublisherOptions.Dissemination), options.Dissemination);
+}
+
+internal sealed class ClusterMembershipOptionsDisseminationValidator : IValidateOptions<ClusterMembershipOptions>
+{
+    public ValidateOptionsResult Validate(string? name, ClusterMembershipOptions options) =>
+        DisseminationTopicOptionsValidator.Validate(nameof(ClusterMembershipOptions.Dissemination), options.Dissemination);
+}

--- a/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
@@ -27,7 +27,7 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
         var payload = serializer.SerializeToArray(statistics);
         return new DisseminationValue
         {
-            Digest = new DisseminationDigest(Name, origin.ToParsableString(), statistics.DateTime.Ticks),
+            Digest = new DisseminationTopicDigest(origin.ToParsableString(), statistics.DateTime.Ticks),
             Root = origin,
             ExpiresAt = timeProvider.GetUtcNow() + Options.StaleItemTtl,
             Payload = payload,
@@ -52,15 +52,15 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
         return digests;
     }
 
-    public int CompareVersion(DisseminationDigest left, DisseminationDigest right) => left.Version.CompareTo(right.Version);
+    public int CompareVersion(DisseminationTopicDigest left, DisseminationTopicDigest right) => left.Version.CompareTo(right.Version);
 
-    public bool IsObsolete(DisseminationDigest digest) =>
+    public bool IsObsolete(DisseminationTopicDigest digest) =>
         !TryGetSiloAddress(digest.Key, out var siloAddress)
         || deploymentLoadPublisher.IsRuntimeStatisticsObsolete(siloAddress, digest.Version);
 
     public ValueTask<DisseminationValue?> GetValue(
-        DisseminationDigest digest,
-        DisseminationDigest? peerDigest,
+        DisseminationTopicDigest digest,
+        DisseminationTopicDigest? peerDigest,
         CancellationToken cancellationToken)
     {
         if (!TryGetSiloAddress(digest.Key, out var siloAddress)
@@ -84,7 +84,7 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
         return ValueTask.FromResult(deploymentLoadPublisher.ApplyDisseminatedRuntimeStatistics(siloAddress, statistics));
     }
 
-    public async ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationDigest digest, CancellationToken cancellationToken)
+    public async ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationTopicDigest digest, CancellationToken cancellationToken)
     {
         if (Options.FallbackEnabled && TryGetSiloAddress(digest.Key, out var siloAddress))
         {

--- a/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
@@ -23,80 +23,101 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
 
     public int ProtocolVersion => 2;
 
+    public DisseminationMembershipScope MembershipScope => DisseminationMembershipScope.ActiveMembers;
+
     public DisseminationTopicOptions Options => options.CurrentValue.Dissemination;
 
     public IReadOnlySet<string> PayloadKinds => SupportedPayloadKinds;
 
     public bool IsEnabled => Options.Enabled;
 
-    public DisseminationItem CreateItem(SiloAddress origin, SiloRuntimeStatistics statistics)
+    public DisseminationValue CreateItem(SiloAddress origin, SiloRuntimeStatistics statistics)
     {
         var payload = serializer.SerializeToArray(statistics);
-        return new DisseminationItem
+        return new DisseminationValue
         {
-            Id = new DisseminationItemId(Name, DisseminationValueKey.FromSiloAddress(origin), statistics.DateTime.Ticks, DisseminationTopicNames.SiloRuntimeStatistics),
+            Digest = new DisseminationDigest(Name, origin.ToParsableString(), statistics.DateTime.Ticks, DisseminationTopicNames.SiloRuntimeStatistics),
             Root = origin,
             ExpiresAt = timeProvider.GetUtcNow() + Options.StaleItemTtl,
             Payload = payload,
         };
     }
 
-    public IReadOnlyList<DisseminationItemId> GetDigests()
+    public IReadOnlyList<DisseminationDigest> GetDigests()
     {
-        var digests = new List<DisseminationItemId>();
+        var digests = new List<DisseminationDigest>();
         foreach (var entry in deploymentLoadPublisher.PeriodicStatistics)
         {
             if (!deploymentLoadPublisher.IsRuntimeStatisticsObsolete(entry.Key, entry.Value.DateTime.Ticks))
             {
-                digests.Add(new DisseminationItemId(
+                digests.Add(new DisseminationDigest(
                     Name,
-                    DisseminationValueKey.FromSiloAddress(entry.Key),
+                    entry.Key.ToParsableString(),
                     entry.Value.DateTime.Ticks,
                     DisseminationTopicNames.SiloRuntimeStatistics));
             }
         }
 
-        digests.Sort(static (left, right) => string.CompareOrdinal(left.Key.ToString(), right.Key.ToString()));
+        digests.Sort(static (left, right) => string.CompareOrdinal(left.Key, right.Key));
         return digests;
     }
 
-    public int CompareVersion(DisseminationItemId left, DisseminationItemId right) => left.Version.CompareTo(right.Version);
+    public int CompareVersion(DisseminationDigest left, DisseminationDigest right) => left.Version.CompareTo(right.Version);
 
-    public bool IsObsolete(DisseminationItemId id) =>
-        !string.Equals(id.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
-        || id.Key.SiloAddress is null
-        || deploymentLoadPublisher.IsRuntimeStatisticsObsolete(id.Key.SiloAddress, id.Version);
+    public bool IsObsolete(DisseminationDigest digest) =>
+        !string.Equals(digest.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
+        || !TryGetSiloAddress(digest.Key, out var siloAddress)
+        || deploymentLoadPublisher.IsRuntimeStatisticsObsolete(siloAddress, digest.Version);
 
-    public ValueTask<DisseminationItem?> GetItem(DisseminationItemId id, CancellationToken cancellationToken)
+    public ValueTask<DisseminationValue?> GetValue(DisseminationDigest digest, CancellationToken cancellationToken)
     {
-        if (!string.Equals(id.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
-            || id.Key.SiloAddress is null
-            || !deploymentLoadPublisher.PeriodicStatistics.TryGetValue(id.Key.SiloAddress, out var statistics)
-            || statistics.DateTime.Ticks < id.Version)
+        if (!string.Equals(digest.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
+            || !TryGetSiloAddress(digest.Key, out var siloAddress)
+            || !deploymentLoadPublisher.PeriodicStatistics.TryGetValue(siloAddress, out var statistics)
+            || statistics.DateTime.Ticks < digest.Version)
         {
-            return ValueTask.FromResult<DisseminationItem?>(null);
+            return ValueTask.FromResult<DisseminationValue?>(null);
         }
 
-        return ValueTask.FromResult<DisseminationItem?>(CreateItem(id.Key.SiloAddress, statistics));
+        return ValueTask.FromResult<DisseminationValue?>(CreateItem(siloAddress, statistics));
     }
 
-    public ValueTask<DisseminationApplyResult> ApplyItem(DisseminationItem item, CancellationToken cancellationToken)
+    public ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken)
     {
-        if (!string.Equals(item.Id.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
-            || item.Id.Key.SiloAddress is null)
+        if (!string.Equals(value.Digest.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
+            || !TryGetSiloAddress(value.Digest.Key, out var siloAddress))
         {
             return ValueTask.FromResult(DisseminationApplyResult.Rejected);
         }
 
-        var statistics = serializer.Deserialize<SiloRuntimeStatistics>(item.Payload);
-        return ValueTask.FromResult(deploymentLoadPublisher.ApplyDisseminatedRuntimeStatistics(item.Id.Key.SiloAddress, statistics));
+        var statistics = serializer.Deserialize<SiloRuntimeStatistics>(value.Payload);
+        return ValueTask.FromResult(deploymentLoadPublisher.ApplyDisseminatedRuntimeStatistics(siloAddress, statistics));
     }
 
-    public async ValueTask OnFallbackRequired(SiloAddress peer, DisseminationItemId id, CancellationToken cancellationToken)
+    public async ValueTask OnFallbackRequired(SiloAddress peer, DisseminationDigest digest, CancellationToken cancellationToken)
     {
-        if (Options.FallbackEnabled && id.Key.SiloAddress is not null)
+        if (Options.FallbackEnabled && TryGetSiloAddress(digest.Key, out var siloAddress))
         {
-            await deploymentLoadPublisher.RefreshSiloStatisticsForDissemination(id.Key.SiloAddress);
+            await deploymentLoadPublisher.RefreshSiloStatisticsForDissemination(siloAddress);
+        }
+    }
+
+    private static bool TryGetSiloAddress(string key, out SiloAddress siloAddress)
+    {
+        try
+        {
+            siloAddress = SiloAddress.FromParsableString(key);
+            return true;
+        }
+        catch (FormatException)
+        {
+            siloAddress = default!;
+            return false;
+        }
+        catch (OverflowException)
+        {
+            siloAddress = default!;
+            return false;
         }
     }
 }

--- a/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
@@ -81,7 +81,9 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
         }
 
         var statistics = serializer.Deserialize<SiloRuntimeStatistics>(value.Payload);
-        if (statistics is null)
+        if (statistics is null
+            || !value.Root.Equals(siloAddress)
+            || statistics.DateTime.Ticks != value.Digest.Version)
         {
             return ValueTask.FromResult(DisseminationApplyResult.Rejected);
         }

--- a/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
@@ -81,6 +81,11 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
         }
 
         var statistics = serializer.Deserialize<SiloRuntimeStatistics>(value.Payload);
+        if (statistics is null)
+        {
+            return ValueTask.FromResult(DisseminationApplyResult.Rejected);
+        }
+
         return ValueTask.FromResult(deploymentLoadPublisher.ApplyDisseminatedRuntimeStatistics(siloAddress, statistics));
     }
 

--- a/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
@@ -34,17 +34,16 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
         };
     }
 
-    public IReadOnlyList<DisseminationDigest> GetDigests()
+    public IReadOnlyList<DisseminationTopicDigest> GetDigests()
     {
-        var digests = new List<DisseminationDigest>();
+        var digests = new List<DisseminationTopicDigest>();
         foreach (var siloAddress in deploymentLoadPublisher.GetActiveSilosForDissemination())
         {
             var version = deploymentLoadPublisher.PeriodicStatistics.TryGetValue(siloAddress, out var statistics)
                 && !deploymentLoadPublisher.IsRuntimeStatisticsObsolete(siloAddress, statistics.DateTime.Ticks)
                     ? statistics.DateTime.Ticks
                     : long.MinValue;
-            digests.Add(new DisseminationDigest(
-                Name,
+            digests.Add(new DisseminationTopicDigest(
                 siloAddress.ToParsableString(),
                 version));
         }

--- a/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
@@ -14,18 +14,11 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
     Serializer serializer,
     TimeProvider timeProvider) : IDisseminationTopic
 {
-    private static readonly HashSet<string> SupportedPayloadKinds = new(StringComparer.Ordinal)
-    {
-        DisseminationTopicNames.SiloRuntimeStatistics,
-    };
-
     public string Name => DisseminationTopicNames.DeploymentLoad;
 
     public DisseminationMembershipScope MembershipScope => DisseminationMembershipScope.ActiveMembers;
 
     public DisseminationTopicOptions Options => options.CurrentValue.Dissemination;
-
-    public IReadOnlySet<string> PayloadKinds => SupportedPayloadKinds;
 
     public bool IsEnabled => Options.Enabled;
 
@@ -34,7 +27,7 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
         var payload = serializer.SerializeToArray(statistics);
         return new DisseminationValue
         {
-            Digest = new DisseminationDigest(Name, origin.ToParsableString(), statistics.DateTime.Ticks, DisseminationTopicNames.SiloRuntimeStatistics),
+            Digest = new DisseminationDigest(Name, origin.ToParsableString(), statistics.DateTime.Ticks),
             Root = origin,
             ExpiresAt = timeProvider.GetUtcNow() + Options.StaleItemTtl,
             Payload = payload,
@@ -53,8 +46,7 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
             digests.Add(new DisseminationDigest(
                 Name,
                 siloAddress.ToParsableString(),
-                version,
-                DisseminationTopicNames.SiloRuntimeStatistics));
+                version));
         }
 
         digests.Sort(static (left, right) => string.CompareOrdinal(left.Key, right.Key));
@@ -64,8 +56,7 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
     public int CompareVersion(DisseminationDigest left, DisseminationDigest right) => left.Version.CompareTo(right.Version);
 
     public bool IsObsolete(DisseminationDigest digest) =>
-        !string.Equals(digest.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
-        || !TryGetSiloAddress(digest.Key, out var siloAddress)
+        !TryGetSiloAddress(digest.Key, out var siloAddress)
         || deploymentLoadPublisher.IsRuntimeStatisticsObsolete(siloAddress, digest.Version);
 
     public ValueTask<DisseminationValue?> GetValue(
@@ -73,8 +64,7 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
         DisseminationDigest? peerDigest,
         CancellationToken cancellationToken)
     {
-        if (!string.Equals(digest.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
-            || !TryGetSiloAddress(digest.Key, out var siloAddress)
+        if (!TryGetSiloAddress(digest.Key, out var siloAddress)
             || !deploymentLoadPublisher.PeriodicStatistics.TryGetValue(siloAddress, out var statistics)
             || statistics.DateTime.Ticks < digest.Version)
         {
@@ -86,8 +76,7 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
 
     public ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken)
     {
-        if (!string.Equals(value.Digest.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
-            || !TryGetSiloAddress(value.Digest.Key, out var siloAddress))
+        if (!TryGetSiloAddress(value.Digest.Key, out var siloAddress))
         {
             return ValueTask.FromResult(DisseminationApplyResult.Rejected);
         }
@@ -96,7 +85,7 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
         return ValueTask.FromResult(deploymentLoadPublisher.ApplyDisseminatedRuntimeStatistics(siloAddress, statistics));
     }
 
-    public async ValueTask OnFallbackRequired(SiloAddress peer, DisseminationDigest digest, CancellationToken cancellationToken)
+    public async ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationDigest digest, CancellationToken cancellationToken)
     {
         if (Options.FallbackEnabled && TryGetSiloAddress(digest.Key, out var siloAddress))
         {

--- a/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Serialization;
+
+namespace Orleans.Runtime.Dissemination;
+
+internal sealed class DeploymentLoadStatisticsDisseminationTopic(
+    DeploymentLoadPublisher deploymentLoadPublisher,
+    IOptionsMonitor<DeploymentLoadPublisherOptions> options,
+    Serializer serializer,
+    TimeProvider timeProvider) : IDisseminationTopic
+{
+    private static readonly HashSet<string> SupportedPayloadKinds = new(StringComparer.Ordinal)
+    {
+        DisseminationTopicNames.SiloRuntimeStatistics,
+    };
+
+    public string Name => DisseminationTopicNames.DeploymentLoad;
+
+    public int ProtocolVersion => 2;
+
+    public DisseminationTopicOptions Options => options.CurrentValue.Dissemination;
+
+    public IReadOnlySet<string> PayloadKinds => SupportedPayloadKinds;
+
+    public bool IsEnabled => Options.Enabled;
+
+    public DisseminationItem CreateItem(SiloAddress origin, SiloRuntimeStatistics statistics)
+    {
+        var payload = serializer.SerializeToArray(statistics);
+        return new DisseminationItem
+        {
+            Id = new DisseminationItemId(Name, DisseminationValueKey.FromSiloAddress(origin), statistics.DateTime.Ticks, DisseminationTopicNames.SiloRuntimeStatistics),
+            Root = origin,
+            ExpiresAt = timeProvider.GetUtcNow() + Options.StaleItemTtl,
+            Payload = payload,
+        };
+    }
+
+    public IReadOnlyList<DisseminationItemId> GetDigests()
+    {
+        var digests = new List<DisseminationItemId>();
+        foreach (var entry in deploymentLoadPublisher.PeriodicStatistics)
+        {
+            if (!deploymentLoadPublisher.IsRuntimeStatisticsObsolete(entry.Key, entry.Value.DateTime.Ticks))
+            {
+                digests.Add(new DisseminationItemId(
+                    Name,
+                    DisseminationValueKey.FromSiloAddress(entry.Key),
+                    entry.Value.DateTime.Ticks,
+                    DisseminationTopicNames.SiloRuntimeStatistics));
+            }
+        }
+
+        digests.Sort(static (left, right) => string.CompareOrdinal(left.Key.ToString(), right.Key.ToString()));
+        return digests;
+    }
+
+    public int CompareVersion(DisseminationItemId left, DisseminationItemId right) => left.Version.CompareTo(right.Version);
+
+    public bool IsObsolete(DisseminationItemId id) =>
+        !string.Equals(id.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
+        || id.Key.SiloAddress is null
+        || deploymentLoadPublisher.IsRuntimeStatisticsObsolete(id.Key.SiloAddress, id.Version);
+
+    public ValueTask<DisseminationItem?> GetItem(DisseminationItemId id, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(id.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
+            || id.Key.SiloAddress is null
+            || !deploymentLoadPublisher.PeriodicStatistics.TryGetValue(id.Key.SiloAddress, out var statistics)
+            || statistics.DateTime.Ticks < id.Version)
+        {
+            return ValueTask.FromResult<DisseminationItem?>(null);
+        }
+
+        return ValueTask.FromResult<DisseminationItem?>(CreateItem(id.Key.SiloAddress, statistics));
+    }
+
+    public ValueTask<DisseminationApplyResult> ApplyItem(DisseminationItem item, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(item.Id.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
+            || item.Id.Key.SiloAddress is null)
+        {
+            return ValueTask.FromResult(DisseminationApplyResult.Rejected);
+        }
+
+        var statistics = serializer.Deserialize<SiloRuntimeStatistics>(item.Payload);
+        return ValueTask.FromResult(deploymentLoadPublisher.ApplyDisseminatedRuntimeStatistics(item.Id.Key.SiloAddress, statistics));
+    }
+
+    public async ValueTask OnFallbackRequired(SiloAddress peer, DisseminationItemId id, CancellationToken cancellationToken)
+    {
+        if (Options.FallbackEnabled && id.Key.SiloAddress is not null)
+        {
+            await deploymentLoadPublisher.RefreshSiloStatisticsForDissemination(id.Key.SiloAddress);
+        }
+    }
+}

--- a/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
@@ -21,8 +21,6 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
 
     public string Name => DisseminationTopicNames.DeploymentLoad;
 
-    public int ProtocolVersion => 2;
-
     public DisseminationMembershipScope MembershipScope => DisseminationMembershipScope.ActiveMembers;
 
     public DisseminationTopicOptions Options => options.CurrentValue.Dissemination;
@@ -73,11 +71,9 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
     public ValueTask<DisseminationValue?> GetValue(
         DisseminationDigest digest,
         DisseminationDigest? peerDigest,
-        IReadOnlySet<string> peerPayloadKinds,
         CancellationToken cancellationToken)
     {
         if (!string.Equals(digest.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
-            || !peerPayloadKinds.Contains(DisseminationTopicNames.SiloRuntimeStatistics)
             || !TryGetSiloAddress(digest.Key, out var siloAddress)
             || !deploymentLoadPublisher.PeriodicStatistics.TryGetValue(siloAddress, out var statistics)
             || statistics.DateTime.Ticks < digest.Version)

--- a/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
@@ -69,9 +69,14 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
         || !TryGetSiloAddress(digest.Key, out var siloAddress)
         || deploymentLoadPublisher.IsRuntimeStatisticsObsolete(siloAddress, digest.Version);
 
-    public ValueTask<DisseminationValue?> GetValue(DisseminationDigest digest, CancellationToken cancellationToken)
+    public ValueTask<DisseminationValue?> GetValue(
+        DisseminationDigest digest,
+        DisseminationDigest? peerDigest,
+        IReadOnlySet<string> peerPayloadKinds,
+        CancellationToken cancellationToken)
     {
         if (!string.Equals(digest.PayloadKind, DisseminationTopicNames.SiloRuntimeStatistics, StringComparison.Ordinal)
+            || !peerPayloadKinds.Contains(DisseminationTopicNames.SiloRuntimeStatistics)
             || !TryGetSiloAddress(digest.Key, out var siloAddress)
             || !deploymentLoadPublisher.PeriodicStatistics.TryGetValue(siloAddress, out var statistics)
             || statistics.DateTime.Ticks < digest.Version)

--- a/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/DeploymentLoadStatisticsDisseminationTopic.cs
@@ -46,16 +46,17 @@ internal sealed class DeploymentLoadStatisticsDisseminationTopic(
     public IReadOnlyList<DisseminationDigest> GetDigests()
     {
         var digests = new List<DisseminationDigest>();
-        foreach (var entry in deploymentLoadPublisher.PeriodicStatistics)
+        foreach (var siloAddress in deploymentLoadPublisher.GetActiveSilosForDissemination())
         {
-            if (!deploymentLoadPublisher.IsRuntimeStatisticsObsolete(entry.Key, entry.Value.DateTime.Ticks))
-            {
-                digests.Add(new DisseminationDigest(
-                    Name,
-                    entry.Key.ToParsableString(),
-                    entry.Value.DateTime.Ticks,
-                    DisseminationTopicNames.SiloRuntimeStatistics));
-            }
+            var version = deploymentLoadPublisher.PeriodicStatistics.TryGetValue(siloAddress, out var statistics)
+                && !deploymentLoadPublisher.IsRuntimeStatisticsObsolete(siloAddress, statistics.DateTime.Ticks)
+                    ? statistics.DateTime.Ticks
+                    : long.MinValue;
+            digests.Add(new DisseminationDigest(
+                Name,
+                siloAddress.ToParsableString(),
+                version,
+                DisseminationTopicNames.SiloRuntimeStatistics));
         }
 
         digests.Sort(static (left, right) => string.CompareOrdinal(left.Key, right.Key));

--- a/src/Orleans.Runtime/Dissemination/DisseminationApplyResult.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationApplyResult.cs
@@ -1,0 +1,9 @@
+namespace Orleans.Runtime.Dissemination;
+
+internal enum DisseminationApplyResult
+{
+    Applied,
+    Duplicate,
+    Obsolete,
+    Rejected,
+}

--- a/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
@@ -9,7 +9,7 @@ internal static class DisseminationEvents
     public const string ListenerName = "Microsoft.Orleans.Dissemination";
     public static readonly DiagnosticListener Listener = new(ListenerName);
 
-    public static void EmitValue(DisseminationDigest digest, SiloAddress localSilo, SiloAddress? peer, string result, int payloadBytes)
+    public static void EmitValue(DisseminationDigest digest, SiloAddress localSilo, SiloAddress? peer, DisseminationApplyResult result, int payloadBytes)
     {
         if (Listener.IsEnabled("Dissemination.ValueApply"))
         {
@@ -21,7 +21,7 @@ internal static class DisseminationEvents
                 Key = digest.Key,
                 Version = digest.Version,
                 PayloadKind = digest.PayloadKind,
-                Result = result,
+                Result = result.ToString(),
                 PayloadBytes = payloadBytes,
                 Timestamp = DateTimeOffset.UtcNow,
             });

--- a/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
@@ -19,7 +19,6 @@ internal static class DisseminationEvents
                 Peer = peer,
                 Key = digest.Key,
                 Version = digest.Version,
-                PayloadKind = digest.PayloadKind,
                 Result = result.ToString(),
                 PayloadBytes = payloadBytes,
                 Timestamp = DateTimeOffset.UtcNow,
@@ -37,7 +36,6 @@ internal static class DisseminationEvents
                 LocalSilo = localSilo,
                 Key = digest.Key,
                 Version = digest.Version,
-                PayloadKind = digest.PayloadKind,
                 Result = reason,
                 PayloadBytes = payloadBytes,
                 Timestamp = DateTimeOffset.UtcNow,
@@ -51,15 +49,13 @@ internal sealed class DisseminationValueEvent
 {
     public string Topic { get; init; } = string.Empty;
 
-    public SiloAddress LocalSilo { get; init; } = default!;
+    public required SiloAddress LocalSilo { get; init; }
 
     public SiloAddress? Peer { get; init; }
 
     public string Key { get; init; } = string.Empty;
 
     public long Version { get; init; }
-
-    public string PayloadKind { get; init; } = string.Empty;
 
     public string Result { get; init; } = string.Empty;
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
@@ -8,7 +8,7 @@ internal static class DisseminationEvents
     public const string ListenerName = "Microsoft.Orleans.Dissemination";
     public static readonly DiagnosticListener Listener = new(ListenerName);
 
-    public static void EmitValue(string topic, DisseminationDigest digest, SiloAddress localSilo, SiloAddress? peer, DisseminationApplyResult result, int payloadBytes)
+    public static void EmitValue(string topic, DisseminationTopicDigest digest, SiloAddress localSilo, SiloAddress? peer, DisseminationApplyResult result, int payloadBytes)
     {
         if (Listener.IsEnabled("Dissemination.ValueApply"))
         {
@@ -26,7 +26,7 @@ internal static class DisseminationEvents
         }
     }
 
-    public static void EmitPayloadDrop(string topic, DisseminationDigest digest, SiloAddress localSilo, string reason, int payloadBytes)
+    public static void EmitPayloadDrop(string topic, DisseminationTopicDigest digest, SiloAddress localSilo, string reason, int payloadBytes)
     {
         if (Listener.IsEnabled("Dissemination.PayloadDrop"))
         {

--- a/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Orleans.Runtime.Dissemination;
+
+internal static class DisseminationEvents
+{
+    public const string ListenerName = "Microsoft.Orleans.Dissemination";
+    public static readonly DiagnosticListener Listener = new(ListenerName);
+
+    public static void EmitItem(DisseminationItemId id, SiloAddress localSilo, SiloAddress? peer, string result, int payloadBytes)
+    {
+        if (Listener.IsEnabled("Dissemination.ItemApply"))
+        {
+            Listener.Write("Dissemination.ItemApply", new DisseminationItemEvent
+            {
+                Topic = id.Topic,
+                LocalSilo = localSilo,
+                Peer = peer,
+                Key = id.Key.ToString(),
+                Version = id.Version,
+                PayloadKind = id.PayloadKind,
+                Result = result,
+                PayloadBytes = payloadBytes,
+                Timestamp = DateTimeOffset.UtcNow,
+            });
+        }
+    }
+
+    public static void EmitPayloadDrop(DisseminationItemId id, SiloAddress localSilo, string reason, int payloadBytes)
+    {
+        if (Listener.IsEnabled("Dissemination.PayloadDrop"))
+        {
+            Listener.Write("Dissemination.PayloadDrop", new DisseminationItemEvent
+            {
+                Topic = id.Topic,
+                LocalSilo = localSilo,
+                Key = id.Key.ToString(),
+                Version = id.Version,
+                PayloadKind = id.PayloadKind,
+                Result = reason,
+                PayloadBytes = payloadBytes,
+                Timestamp = DateTimeOffset.UtcNow,
+            });
+        }
+    }
+
+    public static void EmitCapabilityProbe(SiloAddress localSilo, SiloAddress peer, string topic, bool supported)
+    {
+        if (Listener.IsEnabled("Dissemination.CapabilityProbe"))
+        {
+            Listener.Write("Dissemination.CapabilityProbe", new Dictionary<string, object?>
+            {
+                ["LocalSilo"] = localSilo,
+                ["Peer"] = peer,
+                ["Topic"] = topic,
+                ["Supported"] = supported,
+                ["Timestamp"] = DateTimeOffset.UtcNow,
+            });
+        }
+    }
+}
+
+internal sealed class DisseminationItemEvent
+{
+    public string Topic { get; init; } = string.Empty;
+
+    public SiloAddress LocalSilo { get; init; } = default!;
+
+    public SiloAddress? Peer { get; init; }
+
+    public string Key { get; init; } = string.Empty;
+
+    public long Version { get; init; }
+
+    public string PayloadKind { get; init; } = string.Empty;
+
+    public string Result { get; init; } = string.Empty;
+
+    public int PayloadBytes { get; init; }
+
+    public DateTimeOffset Timestamp { get; init; }
+}

--- a/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
@@ -8,13 +8,13 @@ internal static class DisseminationEvents
     public const string ListenerName = "Microsoft.Orleans.Dissemination";
     public static readonly DiagnosticListener Listener = new(ListenerName);
 
-    public static void EmitValue(DisseminationDigest digest, SiloAddress localSilo, SiloAddress? peer, DisseminationApplyResult result, int payloadBytes)
+    public static void EmitValue(string topic, DisseminationDigest digest, SiloAddress localSilo, SiloAddress? peer, DisseminationApplyResult result, int payloadBytes)
     {
         if (Listener.IsEnabled("Dissemination.ValueApply"))
         {
             Listener.Write("Dissemination.ValueApply", new DisseminationValueEvent
             {
-                Topic = digest.Topic,
+                Topic = topic,
                 LocalSilo = localSilo,
                 Peer = peer,
                 Key = digest.Key,
@@ -26,13 +26,13 @@ internal static class DisseminationEvents
         }
     }
 
-    public static void EmitPayloadDrop(DisseminationDigest digest, SiloAddress localSilo, string reason, int payloadBytes)
+    public static void EmitPayloadDrop(string topic, DisseminationDigest digest, SiloAddress localSilo, string reason, int payloadBytes)
     {
         if (Listener.IsEnabled("Dissemination.PayloadDrop"))
         {
             Listener.Write("Dissemination.PayloadDrop", new DisseminationValueEvent
             {
-                Topic = digest.Topic,
+                Topic = topic,
                 LocalSilo = localSilo,
                 Key = digest.Key,
                 Version = digest.Version,

--- a/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Orleans.Runtime.Dissemination;
@@ -46,20 +45,6 @@ internal static class DisseminationEvents
         }
     }
 
-    public static void EmitCapabilityProbe(SiloAddress localSilo, SiloAddress peer, string topic, bool supported)
-    {
-        if (Listener.IsEnabled("Dissemination.CapabilityProbe"))
-        {
-            Listener.Write("Dissemination.CapabilityProbe", new Dictionary<string, object?>
-            {
-                ["LocalSilo"] = localSilo,
-                ["Peer"] = peer,
-                ["Topic"] = topic,
-                ["Supported"] = supported,
-                ["Timestamp"] = DateTimeOffset.UtcNow,
-            });
-        }
-    }
 }
 
 internal sealed class DisseminationValueEvent

--- a/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
@@ -9,18 +9,18 @@ internal static class DisseminationEvents
     public const string ListenerName = "Microsoft.Orleans.Dissemination";
     public static readonly DiagnosticListener Listener = new(ListenerName);
 
-    public static void EmitItem(DisseminationItemId id, SiloAddress localSilo, SiloAddress? peer, string result, int payloadBytes)
+    public static void EmitValue(DisseminationDigest digest, SiloAddress localSilo, SiloAddress? peer, string result, int payloadBytes)
     {
-        if (Listener.IsEnabled("Dissemination.ItemApply"))
+        if (Listener.IsEnabled("Dissemination.ValueApply"))
         {
-            Listener.Write("Dissemination.ItemApply", new DisseminationItemEvent
+            Listener.Write("Dissemination.ValueApply", new DisseminationValueEvent
             {
-                Topic = id.Topic,
+                Topic = digest.Topic,
                 LocalSilo = localSilo,
                 Peer = peer,
-                Key = id.Key.ToString(),
-                Version = id.Version,
-                PayloadKind = id.PayloadKind,
+                Key = digest.Key,
+                Version = digest.Version,
+                PayloadKind = digest.PayloadKind,
                 Result = result,
                 PayloadBytes = payloadBytes,
                 Timestamp = DateTimeOffset.UtcNow,
@@ -28,17 +28,17 @@ internal static class DisseminationEvents
         }
     }
 
-    public static void EmitPayloadDrop(DisseminationItemId id, SiloAddress localSilo, string reason, int payloadBytes)
+    public static void EmitPayloadDrop(DisseminationDigest digest, SiloAddress localSilo, string reason, int payloadBytes)
     {
         if (Listener.IsEnabled("Dissemination.PayloadDrop"))
         {
-            Listener.Write("Dissemination.PayloadDrop", new DisseminationItemEvent
+            Listener.Write("Dissemination.PayloadDrop", new DisseminationValueEvent
             {
-                Topic = id.Topic,
+                Topic = digest.Topic,
                 LocalSilo = localSilo,
-                Key = id.Key.ToString(),
-                Version = id.Version,
-                PayloadKind = id.PayloadKind,
+                Key = digest.Key,
+                Version = digest.Version,
+                PayloadKind = digest.PayloadKind,
                 Result = reason,
                 PayloadBytes = payloadBytes,
                 Timestamp = DateTimeOffset.UtcNow,
@@ -62,7 +62,7 @@ internal static class DisseminationEvents
     }
 }
 
-internal sealed class DisseminationItemEvent
+internal sealed class DisseminationValueEvent
 {
     public string Topic { get; init; } = string.Empty;
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationEvents.cs
@@ -43,6 +43,30 @@ internal static class DisseminationEvents
         }
     }
 
+    public static void EmitForwardFailure(
+        string topic,
+        DisseminationTopicDigest digest,
+        SiloAddress localSilo,
+        SiloAddress? peer,
+        string reason,
+        int payloadBytes)
+    {
+        if (Listener.IsEnabled("Dissemination.ForwardFailure"))
+        {
+            Listener.Write("Dissemination.ForwardFailure", new DisseminationValueEvent
+            {
+                Topic = topic,
+                LocalSilo = localSilo,
+                Peer = peer,
+                Key = digest.Key,
+                Version = digest.Version,
+                Result = reason,
+                PayloadBytes = payloadBytes,
+                Timestamp = DateTimeOffset.UtcNow,
+            });
+        }
+    }
+
 }
 
 internal sealed class DisseminationValueEvent

--- a/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
@@ -18,6 +18,7 @@ internal static class DisseminationInstruments
     private static readonly Counter<long> AntiEntropyValues = Meter.CreateCounter<long>("orleans.dissemination.anti_entropy.values", "values");
     private static readonly Counter<long> Fallbacks = Meter.CreateCounter<long>("orleans.dissemination.fallbacks", "operations");
     private static readonly Counter<long> PayloadDropped = Meter.CreateCounter<long>("orleans.dissemination.payload.dropped", "values");
+    private static readonly Counter<long> ForwardFailures = Meter.CreateCounter<long>("orleans.dissemination.forward.failures", "values");
 
     public static void OnGossipSent(string topic, string kind, int itemCount, int byteCount)
     {
@@ -144,6 +145,14 @@ internal static class DisseminationInstruments
         if (PayloadDropped.Enabled)
         {
             PayloadDropped.Add(1, Tag("topic", topic), Tag("reason", reason));
+        }
+    }
+
+    public static void OnForwardFailure(string topic, string reason)
+    {
+        if (ForwardFailures.Enabled)
+        {
+            ForwardFailures.Add(1, Tag("topic", topic), Tag("reason", reason));
         }
     }
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Metrics;
@@ -102,7 +103,15 @@ internal static class DisseminationInstruments
             return;
         }
 
-        ValuesApplied.Add(1, Tag("topic", topic), Tag("result", result.ToString()));
+        var resultTag = result switch
+        {
+            DisseminationApplyResult.Applied => "Applied",
+            DisseminationApplyResult.Duplicate => "Duplicate",
+            DisseminationApplyResult.Obsolete => "Obsolete",
+            DisseminationApplyResult.Rejected => "Rejected",
+            _ => throw new ArgumentOutOfRangeException(nameof(result), result, null)
+        };
+        ValuesApplied.Add(1, Tag("topic", topic), Tag("result", resultTag));
     }
 
     public static void OnAntiEntropyExchange(string direction, int digestCount, int itemCount, bool truncated)

--- a/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace Orleans.Runtime.Dissemination;
+
+internal static class DisseminationInstruments
+{
+    private static readonly Meter Meter = new("Microsoft.Orleans.Dissemination");
+    private static readonly Counter<long> GossipSent = Meter.CreateCounter<long>("orleans.dissemination.gossip.sent", "messages");
+    private static readonly Counter<long> GossipReceived = Meter.CreateCounter<long>("orleans.dissemination.gossip.received", "messages");
+    private static readonly Counter<long> ItemsSent = Meter.CreateCounter<long>("orleans.dissemination.items.sent", "items");
+    private static readonly Counter<long> ItemsApplied = Meter.CreateCounter<long>("orleans.dissemination.items.applied", "items");
+    private static readonly Counter<long> BytesSent = Meter.CreateCounter<long>("orleans.dissemination.bytes.sent", "bytes");
+    private static readonly Counter<long> AntiEntropyExchanges = Meter.CreateCounter<long>("orleans.dissemination.anti_entropy.exchanges", "operations");
+    private static readonly Counter<long> AntiEntropyDigests = Meter.CreateCounter<long>("orleans.dissemination.anti_entropy.digests", "digests");
+    private static readonly Counter<long> AntiEntropyItems = Meter.CreateCounter<long>("orleans.dissemination.anti_entropy.items", "items");
+    private static readonly Counter<long> Fallbacks = Meter.CreateCounter<long>("orleans.dissemination.fallbacks", "operations");
+    private static readonly Counter<long> PayloadDropped = Meter.CreateCounter<long>("orleans.dissemination.payload.dropped", "items");
+
+    public static void OnGossipSent(string topic, string kind, int itemCount, int byteCount)
+    {
+        GossipSent.Add(1, Tag("topic", topic), Tag("kind", kind));
+        ItemsSent.Add(itemCount, Tag("topic", topic), Tag("kind", kind));
+        BytesSent.Add(byteCount, Tag("topic", topic), Tag("kind", kind));
+    }
+
+    public static void OnGossipReceived(string topic, string kind, int itemCount)
+    {
+        GossipReceived.Add(1, Tag("topic", topic), Tag("kind", kind));
+        ItemsApplied.Add(itemCount, Tag("topic", topic), Tag("result", "received"));
+    }
+
+    public static void OnItemApplied(string topic, string result) =>
+        ItemsApplied.Add(1, Tag("topic", topic), Tag("result", result));
+
+    public static void OnAntiEntropyExchange(string direction, int digestCount, int itemCount, bool truncated)
+    {
+        AntiEntropyExchanges.Add(1, Tag("direction", direction), Tag("truncated", truncated));
+        AntiEntropyDigests.Add(digestCount, Tag("direction", direction));
+        AntiEntropyItems.Add(itemCount, Tag("direction", direction));
+    }
+
+    public static void OnFallback(string topic, string reason) => Fallbacks.Add(1, Tag("topic", topic), Tag("reason", reason));
+
+    public static void OnPayloadDropped(string topic, string reason) => PayloadDropped.Add(1, Tag("topic", topic), Tag("reason", reason));
+
+    private static KeyValuePair<string, object?> Tag(string name, object value) => new(name, value);
+}

--- a/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Metrics;
+using System.Linq;
 
 namespace Orleans.Runtime.Dissemination;
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
@@ -19,30 +19,118 @@ internal static class DisseminationInstruments
 
     public static void OnGossipSent(string topic, string kind, int itemCount, int byteCount)
     {
-        GossipSent.Add(1, Tag("topic", topic), Tag("kind", kind));
-        ValuesSent.Add(itemCount, Tag("topic", topic), Tag("kind", kind));
-        BytesSent.Add(byteCount, Tag("topic", topic), Tag("kind", kind));
+        var gossipSentEnabled = GossipSent.Enabled;
+        var valuesSentEnabled = ValuesSent.Enabled;
+        var bytesSentEnabled = BytesSent.Enabled;
+        if (!gossipSentEnabled && !valuesSentEnabled && !bytesSentEnabled)
+        {
+            return;
+        }
+
+        var topicTag = Tag("topic", topic);
+        var kindTag = Tag("kind", kind);
+        if (gossipSentEnabled)
+        {
+            GossipSent.Add(1, topicTag, kindTag);
+        }
+
+        if (valuesSentEnabled)
+        {
+            ValuesSent.Add(itemCount, topicTag, kindTag);
+        }
+
+        if (bytesSentEnabled)
+        {
+            BytesSent.Add(byteCount, topicTag, kindTag);
+        }
     }
 
     public static void OnGossipReceived(string topic, string kind, int itemCount)
     {
-        GossipReceived.Add(1, Tag("topic", topic), Tag("kind", kind));
-        ValuesApplied.Add(itemCount, Tag("topic", topic), Tag("result", "received"));
+        var gossipReceivedEnabled = GossipReceived.Enabled;
+        var valuesAppliedEnabled = ValuesApplied.Enabled;
+        if (!gossipReceivedEnabled && !valuesAppliedEnabled)
+        {
+            return;
+        }
+
+        var topicTag = Tag("topic", topic);
+        if (gossipReceivedEnabled)
+        {
+            GossipReceived.Add(1, topicTag, Tag("kind", kind));
+        }
+
+        if (valuesAppliedEnabled)
+        {
+            ValuesApplied.Add(itemCount, topicTag, Tag("result", "received"));
+        }
     }
 
-    public static void OnValueApplied(string topic, string result) =>
-        ValuesApplied.Add(1, Tag("topic", topic), Tag("result", result));
+    public static void OnGossipReceived(DisseminationValue[] values, string kind)
+    {
+        if (!GossipReceived.Enabled && !ValuesApplied.Enabled)
+        {
+            return;
+        }
+
+        foreach (var group in values.GroupBy(static item => item.Digest.Topic))
+        {
+            OnGossipReceived(group.Key, kind, group.Count());
+        }
+    }
+
+    public static void OnValueApplied(string topic, DisseminationApplyResult result)
+    {
+        if (!ValuesApplied.Enabled)
+        {
+            return;
+        }
+
+        ValuesApplied.Add(1, Tag("topic", topic), Tag("result", result.ToString()));
+    }
 
     public static void OnAntiEntropyExchange(string direction, int digestCount, int itemCount, bool truncated)
     {
-        AntiEntropyExchanges.Add(1, Tag("direction", direction), Tag("truncated", truncated));
-        AntiEntropyDigests.Add(digestCount, Tag("direction", direction));
-        AntiEntropyValues.Add(itemCount, Tag("direction", direction));
+        var antiEntropyExchangesEnabled = AntiEntropyExchanges.Enabled;
+        var antiEntropyDigestsEnabled = AntiEntropyDigests.Enabled;
+        var antiEntropyValuesEnabled = AntiEntropyValues.Enabled;
+        if (!antiEntropyExchangesEnabled && !antiEntropyDigestsEnabled && !antiEntropyValuesEnabled)
+        {
+            return;
+        }
+
+        var directionTag = Tag("direction", direction);
+        if (antiEntropyExchangesEnabled)
+        {
+            AntiEntropyExchanges.Add(1, directionTag, Tag("truncated", truncated));
+        }
+
+        if (antiEntropyDigestsEnabled)
+        {
+            AntiEntropyDigests.Add(digestCount, directionTag);
+        }
+
+        if (antiEntropyValuesEnabled)
+        {
+            AntiEntropyValues.Add(itemCount, directionTag);
+        }
     }
 
-    public static void OnFallback(string topic, string reason) => Fallbacks.Add(1, Tag("topic", topic), Tag("reason", reason));
+    public static void OnFallback(string topic, string reason)
+    {
+        if (Fallbacks.Enabled)
+        {
+            Fallbacks.Add(1, Tag("topic", topic), Tag("reason", reason));
+        }
+    }
 
-    public static void OnPayloadDropped(string topic, string reason) => PayloadDropped.Add(1, Tag("topic", topic), Tag("reason", reason));
+    public static void OnPayloadDropped(string topic, string reason)
+    {
+        if (PayloadDropped.Enabled)
+        {
+            PayloadDropped.Add(1, Tag("topic", topic), Tag("reason", reason));
+        }
+    }
 
     private static KeyValuePair<string, object?> Tag(string name, object value) => new(name, value);
 }

--- a/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Diagnostics.Metrics;
 
@@ -46,16 +47,16 @@ internal static class DisseminationInstruments
         }
     }
 
-    public static void OnGossipSent(ImmutableArray<DisseminationValue> values, string kind)
+    public static void OnGossipSent(FrozenDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic, string kind)
     {
         if (!GossipSent.Enabled && !ValuesSent.Enabled && !BytesSent.Enabled)
         {
             return;
         }
 
-        foreach (var group in values.GroupBy(static item => item.Digest.Topic))
+        foreach (var (topic, values) in valuesByTopic)
         {
-            OnGossipSent(group.Key, kind, group.Count(), group.Sum(static item => item.Payload.Length));
+            OnGossipSent(topic, kind, values.Length, values.Sum(static item => item.Payload.Length));
         }
     }
 
@@ -80,16 +81,16 @@ internal static class DisseminationInstruments
         }
     }
 
-    public static void OnGossipReceived(ImmutableArray<DisseminationValue> values, string kind)
+    public static void OnGossipReceived(FrozenDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic, string kind)
     {
         if (!GossipReceived.Enabled && !ValuesApplied.Enabled)
         {
             return;
         }
 
-        foreach (var group in values.GroupBy(static item => item.Digest.Topic))
+        foreach (var (topic, values) in valuesByTopic)
         {
-            OnGossipReceived(group.Key, kind, group.Count());
+            OnGossipReceived(topic, kind, values.Length);
         }
     }
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Diagnostics.Metrics;
 
@@ -47,7 +46,7 @@ internal static class DisseminationInstruments
         }
     }
 
-    public static void OnGossipSent(FrozenDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic, string kind)
+    public static void OnGossipSent(ImmutableDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic, string kind)
     {
         if (!GossipSent.Enabled && !ValuesSent.Enabled && !BytesSent.Enabled)
         {
@@ -81,7 +80,7 @@ internal static class DisseminationInstruments
         }
     }
 
-    public static void OnGossipReceived(FrozenDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic, string kind)
+    public static void OnGossipReceived(ImmutableDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic, string kind)
     {
         if (!GossipReceived.Enabled && !ValuesApplied.Enabled)
         {

--- a/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
@@ -8,36 +8,36 @@ internal static class DisseminationInstruments
     private static readonly Meter Meter = new("Microsoft.Orleans.Dissemination");
     private static readonly Counter<long> GossipSent = Meter.CreateCounter<long>("orleans.dissemination.gossip.sent", "messages");
     private static readonly Counter<long> GossipReceived = Meter.CreateCounter<long>("orleans.dissemination.gossip.received", "messages");
-    private static readonly Counter<long> ItemsSent = Meter.CreateCounter<long>("orleans.dissemination.items.sent", "items");
-    private static readonly Counter<long> ItemsApplied = Meter.CreateCounter<long>("orleans.dissemination.items.applied", "items");
+    private static readonly Counter<long> ValuesSent = Meter.CreateCounter<long>("orleans.dissemination.values.sent", "values");
+    private static readonly Counter<long> ValuesApplied = Meter.CreateCounter<long>("orleans.dissemination.values.applied", "values");
     private static readonly Counter<long> BytesSent = Meter.CreateCounter<long>("orleans.dissemination.bytes.sent", "bytes");
     private static readonly Counter<long> AntiEntropyExchanges = Meter.CreateCounter<long>("orleans.dissemination.anti_entropy.exchanges", "operations");
     private static readonly Counter<long> AntiEntropyDigests = Meter.CreateCounter<long>("orleans.dissemination.anti_entropy.digests", "digests");
-    private static readonly Counter<long> AntiEntropyItems = Meter.CreateCounter<long>("orleans.dissemination.anti_entropy.items", "items");
+    private static readonly Counter<long> AntiEntropyValues = Meter.CreateCounter<long>("orleans.dissemination.anti_entropy.values", "values");
     private static readonly Counter<long> Fallbacks = Meter.CreateCounter<long>("orleans.dissemination.fallbacks", "operations");
-    private static readonly Counter<long> PayloadDropped = Meter.CreateCounter<long>("orleans.dissemination.payload.dropped", "items");
+    private static readonly Counter<long> PayloadDropped = Meter.CreateCounter<long>("orleans.dissemination.payload.dropped", "values");
 
     public static void OnGossipSent(string topic, string kind, int itemCount, int byteCount)
     {
         GossipSent.Add(1, Tag("topic", topic), Tag("kind", kind));
-        ItemsSent.Add(itemCount, Tag("topic", topic), Tag("kind", kind));
+        ValuesSent.Add(itemCount, Tag("topic", topic), Tag("kind", kind));
         BytesSent.Add(byteCount, Tag("topic", topic), Tag("kind", kind));
     }
 
     public static void OnGossipReceived(string topic, string kind, int itemCount)
     {
         GossipReceived.Add(1, Tag("topic", topic), Tag("kind", kind));
-        ItemsApplied.Add(itemCount, Tag("topic", topic), Tag("result", "received"));
+        ValuesApplied.Add(itemCount, Tag("topic", topic), Tag("result", "received"));
     }
 
-    public static void OnItemApplied(string topic, string result) =>
-        ItemsApplied.Add(1, Tag("topic", topic), Tag("result", result));
+    public static void OnValueApplied(string topic, string result) =>
+        ValuesApplied.Add(1, Tag("topic", topic), Tag("result", result));
 
     public static void OnAntiEntropyExchange(string direction, int digestCount, int itemCount, bool truncated)
     {
         AntiEntropyExchanges.Add(1, Tag("direction", direction), Tag("truncated", truncated));
         AntiEntropyDigests.Add(digestCount, Tag("direction", direction));
-        AntiEntropyItems.Add(itemCount, Tag("direction", direction));
+        AntiEntropyValues.Add(itemCount, Tag("direction", direction));
     }
 
     public static void OnFallback(string topic, string reason) => Fallbacks.Add(1, Tag("topic", topic), Tag("reason", reason));

--- a/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
@@ -45,6 +45,19 @@ internal static class DisseminationInstruments
         }
     }
 
+    public static void OnGossipSent(DisseminationValue[] values, string kind)
+    {
+        if (!GossipSent.Enabled && !ValuesSent.Enabled && !BytesSent.Enabled)
+        {
+            return;
+        }
+
+        foreach (var group in values.GroupBy(static item => item.Digest.Topic))
+        {
+            OnGossipSent(group.Key, kind, group.Count(), group.Sum(static item => item.Payload.Length));
+        }
+    }
+
     public static void OnGossipReceived(string topic, string kind, int itemCount)
     {
         var gossipReceivedEnabled = GossipReceived.Enabled;

--- a/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationInstruments.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.Metrics;
 
 namespace Orleans.Runtime.Dissemination;
@@ -45,7 +46,7 @@ internal static class DisseminationInstruments
         }
     }
 
-    public static void OnGossipSent(DisseminationValue[] values, string kind)
+    public static void OnGossipSent(ImmutableArray<DisseminationValue> values, string kind)
     {
         if (!GossipSent.Enabled && !ValuesSent.Enabled && !BytesSent.Enabled)
         {
@@ -79,7 +80,7 @@ internal static class DisseminationInstruments
         }
     }
 
-    public static void OnGossipReceived(DisseminationValue[] values, string kind)
+    public static void OnGossipReceived(ImmutableArray<DisseminationValue> values, string kind)
     {
         if (!GossipReceived.Enabled && !ValuesApplied.Enabled)
         {

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -692,13 +692,35 @@ internal sealed partial class DisseminationProtocol(
         }
 
         var fanout = GetFanOutFactor(participants.Length);
-        var candidates = GetAntiEntropyCandidateIndexes(localIndex, participants.Length, fanout);
-        return [.. candidates
-            .Where(index => index != localIndex)
-            .OrderBy(index => GetRepairPeerScore(participants[index], topicName, round, localIndex))
-            .ThenBy(index => participants[index])
-            .Take(options.AntiEntropyPeerCount)
-            .Select(index => participants[index])];
+        var candidates = new List<(SiloAddress Peer, ulong Score)>();
+        foreach (var index in GetAntiEntropyCandidateIndexes(localIndex, participants.Length, fanout))
+        {
+            if (index != localIndex)
+            {
+                var peer = participants[index];
+                candidates.Add((peer, GetRepairPeerScore(peer, topicName, round, localIndex)));
+            }
+        }
+
+        var count = Math.Min(options.AntiEntropyPeerCount, candidates.Count);
+        if (count <= 0)
+        {
+            return [];
+        }
+
+        candidates.Sort(static (left, right) =>
+        {
+            var result = left.Score.CompareTo(right.Score);
+            return result != 0 ? result : left.Peer.CompareTo(right.Peer);
+        });
+
+        var result = ImmutableArray.CreateBuilder<SiloAddress>(count);
+        for (var i = 0; i < count; i++)
+        {
+            result.Add(candidates[i].Peer);
+        }
+
+        return result.MoveToImmutable();
     }
 
     private static IEnumerable<int> GetAntiEntropyCandidateIndexes(int localIndex, int participantCount, int fanout)

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -97,11 +97,10 @@ internal sealed partial class DisseminationProtocol(
             return AntiEntropyState.Empty;
         }
 
-        var digests = new List<DisseminationDigest>();
-        var topics = new List<string>();
-        var topicNames = new HashSet<string>(StringComparer.Ordinal);
+        var topics = new Dictionary<string, AntiEntropyTopicState>(StringComparer.Ordinal);
         var currentValueStreams = new HashSet<DigestKey>();
         var now = _timeProvider.GetUtcNow();
+        var round = Interlocked.Increment(ref _antiEntropyRound);
         foreach (var topic in _topics.Values)
         {
             if (!topic.IsEnabled)
@@ -109,64 +108,57 @@ internal sealed partial class DisseminationProtocol(
                 continue;
             }
 
-            foreach (var digest in topic.GetDigests())
+            List<DisseminationTopicDigest>? topicDigests = null;
+            foreach (var topicDigest in topic.GetDigests())
             {
-                if (string.Equals(digest.Topic, topic.Name, StringComparison.Ordinal))
+                var digest = CreateDigest(topic, topicDigest);
+                currentValueStreams.Add(GetDigestKey(digest));
+                if (ShouldRequestAntiEntropy(topic, digest, now))
                 {
-                    currentValueStreams.Add(GetDigestKey(digest));
-                    if (ShouldRequestAntiEntropy(topic, digest, now))
-                    {
-                        digests.Add(digest);
-                        if (topicNames.Add(digest.Topic))
-                        {
-                            topics.Add(digest.Topic);
-                        }
-                    }
+                    (topicDigests ??= []).Add(topicDigest);
                 }
             }
+
+            if (topicDigests is null)
+            {
+                continue;
+            }
+
+            topicDigests.Sort(static (left, right) =>
+            {
+                var result = string.Compare(left.Key, right.Key, StringComparison.Ordinal);
+                return result != 0 ? result : left.Version.CompareTo(right.Version);
+            });
+
+            topics.Add(topic.Name, new AntiEntropyTopicState(
+                SelectAntiEntropyPeers(topic.Name, topic.MembershipScope, round),
+                [.. topicDigests]));
         }
 
         PruneRecentUpdates(currentValueStreams);
-        var requestedTopics = topics.ToArray();
-        var round = Interlocked.Increment(ref _antiEntropyRound);
-        return new AntiEntropyState(
-            GetAntiEntropyPeersByTopic(requestedTopics, round),
-            requestedTopics,
-            SortDigests(digests).ToArray());
+        return topics.Count == 0
+            ? AntiEntropyState.Empty
+            : new AntiEntropyState(topics.ToFrozenDictionary(StringComparer.Ordinal));
     }
 
     public async Task<IReadOnlyList<DisseminationAntiEntropyResponse>> ExchangeAntiEntropy(
         AntiEntropyState state,
         CancellationToken cancellationToken)
     {
-        if (state.PeersByTopic.Count == 0 || state.Topics.Count == 0 || state.Digests.Count == 0)
+        if (state.Topics.Count == 0)
         {
             return [];
         }
 
-        var digestsByTopic = new Dictionary<string, List<DisseminationDigest>>(StringComparer.Ordinal);
-        foreach (var digest in state.Digests)
-        {
-            if (!digestsByTopic.TryGetValue(digest.Topic, out var topicDigests))
-            {
-                topicDigests = [];
-                digestsByTopic.Add(digest.Topic, topicDigests);
-            }
-
-            topicDigests.Add(digest);
-        }
-
         var requestsByPeer = new Dictionary<SiloAddress, (List<string> Topics, List<DisseminationDigest> Digests)>();
-        foreach (var topicName in state.Topics)
+        foreach (var (topicName, topicState) in state.Topics)
         {
-            if (!state.PeersByTopic.TryGetValue(topicName, out var peers)
-                || peers.Length == 0
-                || !digestsByTopic.TryGetValue(topicName, out var topicDigests))
+            if (topicState.Peers.Length == 0 || topicState.Digests.Length == 0)
             {
                 continue;
             }
 
-            foreach (var peer in peers)
+            foreach (var peer in topicState.Peers)
             {
                 if (!requestsByPeer.TryGetValue(peer, out var pendingRequest))
                 {
@@ -175,7 +167,10 @@ internal sealed partial class DisseminationProtocol(
                 }
 
                 pendingRequest.Topics.Add(topicName);
-                pendingRequest.Digests.AddRange(topicDigests);
+                foreach (var digest in topicState.Digests)
+                {
+                    pendingRequest.Digests.Add(new DisseminationDigest(topicName, digest.Key, digest.Version));
+                }
             }
         }
 
@@ -253,8 +248,9 @@ internal sealed partial class DisseminationProtocol(
                 continue;
             }
 
-            foreach (var localDigest in requestedTopic.GetDigests())
+            foreach (var topicDigest in requestedTopic.GetDigests())
             {
+                var localDigest = CreateDigest(requestedTopic, topicDigest);
                 var digestKey = GetDigestKey(localDigest);
                 if (!remoteDigests.TryGetValue(digestKey, out var remoteDigest)
                     || requestedTopic.CompareVersion(localDigest, remoteDigest) <= 0)
@@ -680,22 +676,6 @@ internal sealed partial class DisseminationProtocol(
                 }
             }
         }
-    }
-
-    private FrozenDictionary<string, ImmutableArray<SiloAddress>> GetAntiEntropyPeersByTopic(
-        IReadOnlyList<string> topics,
-        long round)
-    {
-        var result = new Dictionary<string, ImmutableArray<SiloAddress>>(StringComparer.Ordinal);
-        foreach (var topicName in topics)
-        {
-            if (_topics.TryGetValue(topicName, out var topic) && topic.IsEnabled)
-            {
-                result[topicName] = SelectAntiEntropyPeers(topicName, topic.MembershipScope, round);
-            }
-        }
-
-        return result.ToFrozenDictionary(StringComparer.Ordinal);
     }
 
     private ImmutableArray<SiloAddress> SelectAntiEntropyPeers(string topicName, DisseminationMembershipScope membershipScope, long round)
@@ -1155,24 +1135,19 @@ internal sealed partial class DisseminationProtocol(
         Truncated = truncated,
     };
 
-    private static IEnumerable<DisseminationDigest> SortDigests(IEnumerable<DisseminationDigest> digests) =>
-        digests
-            .OrderBy(static digest => digest.Topic, StringComparer.Ordinal)
-            .ThenBy(static digest => digest.Key, StringComparer.Ordinal)
-            .ThenBy(static digest => digest.Version);
-
     private static DigestKey GetDigestKey(DisseminationDigest digest) => new(digest.Topic, digest.Key);
 
-    public sealed record AntiEntropyState(
-        FrozenDictionary<string, ImmutableArray<SiloAddress>> PeersByTopic,
-        IReadOnlyList<string> Topics,
-        IReadOnlyList<DisseminationDigest> Digests)
+    private static DisseminationDigest CreateDigest(IDisseminationTopic topic, DisseminationTopicDigest digest) =>
+        new(topic.Name, digest.Key, digest.Version);
+
+    public sealed record AntiEntropyState(FrozenDictionary<string, AntiEntropyTopicState> Topics)
     {
-        public static readonly AntiEntropyState Empty = new(
-            FrozenDictionary<string, ImmutableArray<SiloAddress>>.Empty,
-            [],
-            []);
+        public static readonly AntiEntropyState Empty = new(FrozenDictionary<string, AntiEntropyTopicState>.Empty);
     }
+
+    public readonly record struct AntiEntropyTopicState(
+        ImmutableArray<SiloAddress> Peers,
+        ImmutableArray<DisseminationTopicDigest> Digests);
 
     private readonly record struct DigestKey(string Topic, string Key);
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -382,7 +382,7 @@ internal sealed partial class DisseminationProtocol(
             pending.AddOrReplace(key, item);
             if (pending.Values.Count >= _options.CurrentValue.MaxBatchItems
                 || pending.ByteCount >= _options.CurrentValue.MaxBatchBytes
-                || CountPendingTopicValues(pending, item.Digest.Topic) >= topic.Options.MaxPendingItemCount)
+                || pending.GetTopicCount(item.Digest.Topic) >= topic.Options.MaxPendingItemCount)
             {
                 pending.FlushAfter = now;
             }
@@ -510,23 +510,32 @@ internal sealed partial class DisseminationProtocol(
 
     private DateTimeOffset GetNextPendingGossipFlushUnsafe() => _pendingGossip.Values.Min(static pending => pending.FlushAfter);
 
-    private List<QueuedGossipBatch> DrainPendingGossip(bool force)
+    private List<(SiloAddress Peer, ImmutableArray<DisseminationValue> Values)> DrainPendingGossip(bool force)
     {
         var now = _timeProvider.GetUtcNow();
-        var result = new List<QueuedGossipBatch>();
+        var result = new List<(SiloAddress Peer, ImmutableArray<DisseminationValue> Values)>();
         lock (_gossipQueueLock)
         {
-            foreach (var (peer, pending) in _pendingGossip.ToArray())
+            List<SiloAddress>? drainedPeers = null;
+            foreach (var (peer, pending) in _pendingGossip)
             {
                 if (!force && pending.FlushAfter > now)
                 {
                     continue;
                 }
 
-                _pendingGossip.Remove(peer);
-                result.Add(new QueuedGossipBatch(peer, [.. pending.Values.Values
+                (drainedPeers ??= []).Add(peer);
+                result.Add((peer, [.. pending.Values.Values
                     .OrderBy(static value => value.Digest.Topic, StringComparer.Ordinal)
                     .ThenBy(static value => value.Digest.Key, StringComparer.Ordinal)]));
+            }
+
+            if (drainedPeers is not null)
+            {
+                foreach (var peer in drainedPeers)
+                {
+                    _pendingGossip.Remove(peer);
+                }
             }
         }
 
@@ -534,7 +543,7 @@ internal sealed partial class DisseminationProtocol(
         return result;
     }
 
-    private async Task SendGossipBatches(List<QueuedGossipBatch> batches, CancellationToken cancellationToken)
+    private async Task SendGossipBatches(List<(SiloAddress Peer, ImmutableArray<DisseminationValue> Values)> batches, CancellationToken cancellationToken)
     {
         foreach (var queued in batches)
         {
@@ -585,20 +594,6 @@ internal sealed partial class DisseminationProtocol(
         {
             DisseminationInstruments.OnGossipSent(values, "tree");
         }
-    }
-
-    private static int CountPendingTopicValues(PendingGossipBatch pending, string topic)
-    {
-        var result = 0;
-        foreach (var value in pending.Values.Values)
-        {
-            if (string.Equals(value.Digest.Topic, topic, StringComparison.Ordinal))
-            {
-                result++;
-            }
-        }
-
-        return result;
     }
 
     private async ValueTask<bool> SafeSend(SiloAddress peer, Func<SiloAddress, Task> send)
@@ -1213,21 +1208,27 @@ internal sealed partial class DisseminationProtocol(
 
     private readonly record struct ValueStreamKey(string Topic, string Key);
 
-    private readonly record struct QueuedGossipBatch(SiloAddress Peer, ImmutableArray<DisseminationValue> Values);
-
     private sealed class PendingGossipBatch(DateTimeOffset flushAfter)
     {
+        private readonly Dictionary<string, int> _topicCounts = new(StringComparer.Ordinal);
+
         public Dictionary<DigestKey, DisseminationValue> Values { get; } = [];
 
         public DateTimeOffset FlushAfter { get; set; } = flushAfter;
 
         public int ByteCount { get; private set; }
 
+        public int GetTopicCount(string topic) => _topicCounts.GetValueOrDefault(topic);
+
         public void AddOrReplace(DigestKey key, DisseminationValue value)
         {
             if (Values.Remove(key, out var previous))
             {
                 ByteCount -= previous.Payload.Length;
+            }
+            else
+            {
+                _topicCounts[key.Topic] = GetTopicCount(key.Topic) + 1;
             }
 
             Values[key] = value;

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -141,29 +141,49 @@ internal sealed partial class DisseminationProtocol(
             return [];
         }
 
-        var peers = state.PeersByTopic.Values.SelectMany(static value => value).Distinct().ToArray();
-        var responses = new List<DisseminationAntiEntropyResponse>(peers.Length);
-        foreach (var peer in peers)
+        var digestsByTopic = new Dictionary<string, List<DisseminationDigest>>(StringComparer.Ordinal);
+        foreach (var digest in state.Digests)
         {
-            var requestedTopics = state.Topics
-                .Where(topic => state.PeersByTopic.TryGetValue(topic, out var topicPeers) && topicPeers.Contains(peer))
-                .ToImmutableArray();
-            if (requestedTopics.Length == 0)
+            if (!digestsByTopic.TryGetValue(digest.Topic, out var topicDigests))
+            {
+                topicDigests = [];
+                digestsByTopic.Add(digest.Topic, topicDigests);
+            }
+
+            topicDigests.Add(digest);
+        }
+
+        var requestsByPeer = new Dictionary<SiloAddress, (List<string> Topics, List<DisseminationDigest> Digests)>();
+        foreach (var topicName in state.Topics)
+        {
+            if (!state.PeersByTopic.TryGetValue(topicName, out var peers)
+                || peers.Length == 0
+                || !digestsByTopic.TryGetValue(topicName, out var topicDigests))
             {
                 continue;
             }
 
-            var digests = state.Digests.Where(digest => requestedTopics.Contains(digest.Topic, StringComparer.Ordinal)).ToImmutableArray();
-            if (digests.Length == 0)
+            foreach (var peer in peers)
             {
-                continue;
-            }
+                if (!requestsByPeer.TryGetValue(peer, out var pendingRequest))
+                {
+                    pendingRequest = ([], []);
+                    requestsByPeer.Add(peer, pendingRequest);
+                }
 
+                pendingRequest.Topics.Add(topicName);
+                pendingRequest.Digests.AddRange(topicDigests);
+            }
+        }
+
+        var responses = new List<DisseminationAntiEntropyResponse>(requestsByPeer.Count);
+        foreach (var (peer, pendingRequest) in requestsByPeer)
+        {
             var request = new DisseminationAntiEntropyRequest
             {
                 Sender = _transport.LocalSilo,
-                Topics = requestedTopics,
-                Digests = digests,
+                Topics = [.. pendingRequest.Topics],
+                Digests = [.. pendingRequest.Digests],
             };
 
             var response = await SafeRequest(peer, target => _transport.ExchangeAntiEntropy(target, request, cancellationToken));

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -1,0 +1,811 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+
+namespace Orleans.Runtime.Dissemination;
+
+internal sealed partial class DisseminationProtocol
+{
+    private readonly IDisseminationTransport _transport;
+    private readonly IOptionsMonitor<DisseminationOptions> _options;
+    private readonly Dictionary<string, IDisseminationTopic> _topics;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<DisseminationProtocol> _logger;
+    private readonly Dictionary<CapabilityKey, CapabilityEntry> _capabilityCache = new();
+    private readonly Dictionary<CapabilityKey, DateTimeOffset> _capabilityProbeBackoffUntil = new();
+    private readonly Dictionary<SiloAddress, DateTimeOffset> _failureBackoffUntil = new();
+    private readonly object _capabilityLock = new();
+    private readonly object _failureLock = new();
+    private readonly object _topologyLock = new();
+    private readonly Dictionary<SiloAddress, string> _peerScores = new();
+    private ParticipantTopology _participantTopology = ParticipantTopology.Empty;
+
+    public DisseminationProtocol(
+        IDisseminationTransport transport,
+        IOptionsMonitor<DisseminationOptions> options,
+        IEnumerable<IDisseminationTopic> topics,
+        TimeProvider timeProvider,
+        ILogger<DisseminationProtocol> logger)
+    {
+        _transport = transport;
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _topics = topics.ToDictionary(static topic => topic.Name, StringComparer.Ordinal);
+    }
+
+    public IReadOnlyDictionary<string, IDisseminationTopic> Topics => _topics;
+
+    public async ValueTask<bool> Publish(
+        string topicName,
+        DisseminationItem item,
+        IReadOnlyCollection<SiloAddress>? targetPeers,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetEnabledTopic(topicName, out var topic))
+        {
+            return false;
+        }
+
+        if (!ValidatePayloadSize(topic, item))
+        {
+            await topic.OnFallbackRequired(default!, item.Id, cancellationToken);
+            DisseminationInstruments.OnFallback(item.Id.Topic, "oversize");
+            return false;
+        }
+
+        var root = item.Root is not null ? item.Root : _transport.LocalSilo;
+        item = EnsureRoot(item, root);
+        var peers = targetPeers is { Count: > 0 } ? targetPeers : _transport.GetActivePeers();
+        var topology = GetParticipantTopology(peers.Append(root), includeLocal: true);
+        if (!await AreParticipantsCapable(topology.Participants, topic, item.Id.PayloadKind, cancellationToken))
+        {
+            return false;
+        }
+
+        foreach (var peer in GetTreeChildren(topology, root))
+        {
+            await SendGossip(peer, item, cancellationToken);
+        }
+
+        return true;
+    }
+
+    public async Task ReceiveGossip(DisseminationGossipBatch batch, CancellationToken cancellationToken)
+    {
+        if (!_options.CurrentValue.Enabled)
+        {
+            return;
+        }
+
+        foreach (var group in batch.Items.GroupBy(static item => item.Id.Topic))
+        {
+            DisseminationInstruments.OnGossipReceived(group.Key, "tree", group.Count());
+        }
+
+        foreach (var item in batch.Items)
+        {
+            await ApplyReceivedItem(item, batch.Sender, forward: true, cancellationToken);
+        }
+    }
+
+    public AntiEntropyState CreateAntiEntropyState()
+    {
+        if (!_options.CurrentValue.Enabled)
+        {
+            return AntiEntropyState.Empty;
+        }
+
+        var topics = new List<DisseminationCapabilityRequest>();
+        var digests = new List<DisseminationItemId>();
+        foreach (var topic in _topics.Values)
+        {
+            if (!topic.IsEnabled)
+            {
+                continue;
+            }
+
+            topics.Add(new DisseminationCapabilityRequest
+            {
+                Topic = topic.Name,
+                ProtocolVersion = topic.ProtocolVersion,
+                PayloadKinds = topic.PayloadKinds.ToArray(),
+            });
+
+            foreach (var digest in topic.GetDigests())
+            {
+                if (string.Equals(digest.Topic, topic.Name, StringComparison.Ordinal)
+                    && topic.PayloadKinds.Contains(digest.PayloadKind))
+                {
+                    digests.Add(digest);
+                }
+            }
+        }
+
+        return new AntiEntropyState(
+            SelectAntiEntropyPeers(),
+            topics.ToArray(),
+            SortDigests(digests).ToArray());
+    }
+
+    public async Task<IReadOnlyList<DisseminationAntiEntropyResponse>> ExchangeAntiEntropy(
+        AntiEntropyState state,
+        CancellationToken cancellationToken)
+    {
+        if (state.Peers.Count == 0 || state.Topics.Count == 0)
+        {
+            return Array.Empty<DisseminationAntiEntropyResponse>();
+        }
+
+        var responses = new List<DisseminationAntiEntropyResponse>(state.Peers.Count);
+        foreach (var peer in state.Peers)
+        {
+            var topics = await GetCapableAntiEntropyTopics(peer, state.Topics, cancellationToken);
+            if (topics.Count == 0)
+            {
+                continue;
+            }
+
+            var digests = state.Digests.Where(digest => IsRequested(topics, digest)).ToArray();
+            var request = new DisseminationAntiEntropyRequest
+            {
+                Sender = _transport.LocalSilo,
+                Topics = topics.ToArray(),
+                Digests = digests,
+            };
+
+            var response = await SafeRequest(peer, target => _transport.ExchangeAntiEntropy(target, request, cancellationToken));
+            if (response is null)
+            {
+                continue;
+            }
+
+            DisseminationInstruments.OnAntiEntropyExchange("out", request.Digests.Length, response.Items.Length, response.Truncated);
+            responses.Add(response);
+        }
+
+        return responses;
+    }
+
+    public async Task ApplyAntiEntropyResponses(
+        IReadOnlyList<DisseminationAntiEntropyResponse> responses,
+        CancellationToken cancellationToken)
+    {
+        if (!_options.CurrentValue.Enabled)
+        {
+            return;
+        }
+
+        foreach (var response in responses)
+        {
+            foreach (var item in response.Items)
+            {
+                try
+                {
+                    await ApplyReceivedItem(item, response.Sender, forward: false, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    LogDebugAntiEntropyRepairItemFailed(_logger, exception, response.Sender, item.Id.Topic, item.Id.Key.ToString(), item.Id.Version);
+                }
+            }
+        }
+    }
+
+    public async ValueTask<DisseminationAntiEntropyResponse> ReceiveAntiEntropy(
+        DisseminationAntiEntropyRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!_options.CurrentValue.Enabled)
+        {
+            return CreateAntiEntropyResponse(Array.Empty<DisseminationItem>(), truncated: false);
+        }
+
+        var requestedTopics = GetRequestedTopics(request);
+        if (requestedTopics.Count == 0)
+        {
+            return CreateAntiEntropyResponse(Array.Empty<DisseminationItem>(), truncated: false);
+        }
+
+        var remoteDigests = GetRemoteDigestMap(request.Digests);
+        var items = new List<DisseminationItem>();
+        var byteCount = 0;
+        var truncated = false;
+        var options = _options.CurrentValue;
+
+        foreach (var requestedTopic in requestedTopics.Values.OrderBy(static topic => topic.Topic.Name, StringComparer.Ordinal))
+        {
+            foreach (var localDigest in SortDigests(requestedTopic.Topic.GetDigests()))
+            {
+                if (!requestedTopic.PayloadKinds.Contains(localDigest.PayloadKind))
+                {
+                    continue;
+                }
+
+                var digestKey = GetDigestKey(localDigest);
+                if (remoteDigests.TryGetValue(digestKey, out var remoteDigest)
+                    && requestedTopic.Topic.CompareVersion(localDigest, remoteDigest) <= 0)
+                {
+                    continue;
+                }
+
+                var item = await requestedTopic.Topic.GetItem(localDigest, cancellationToken);
+                if (item is null || !ValidatePayloadSize(requestedTopic.Topic, item))
+                {
+                    continue;
+                }
+
+                if (items.Count >= options.MaxBatchItems || byteCount + item.Payload.Length > options.MaxBatchBytes)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                items.Add(item);
+                byteCount += item.Payload.Length;
+            }
+
+            if (truncated)
+            {
+                break;
+            }
+        }
+
+        DisseminationInstruments.OnAntiEntropyExchange("in", request.Digests.Length, items.Count, truncated);
+        return CreateAntiEntropyResponse(items.ToArray(), truncated);
+    }
+
+    private async ValueTask<DisseminationApplyResult> ApplyReceivedItem(
+        DisseminationItem item,
+        SiloAddress sender,
+        bool forward,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetEnabledTopic(item.Id.Topic, out var topic))
+        {
+            EmitApplyResult(item, sender, DisseminationApplyResult.Rejected);
+            return DisseminationApplyResult.Rejected;
+        }
+
+        if (!topic.PayloadKinds.Contains(item.Id.PayloadKind))
+        {
+            EmitApplyResult(item, sender, DisseminationApplyResult.Rejected);
+            return DisseminationApplyResult.Rejected;
+        }
+
+        if (!ValidatePayloadSize(topic, item))
+        {
+            return DisseminationApplyResult.Rejected;
+        }
+
+        if (IsExpired(item) || topic.IsObsolete(item.Id))
+        {
+            EmitApplyResult(item, sender, DisseminationApplyResult.Obsolete);
+            return DisseminationApplyResult.Obsolete;
+        }
+
+        var result = await topic.ApplyItem(item, cancellationToken);
+        EmitApplyResult(item, sender, result);
+
+        if (result == DisseminationApplyResult.Applied && forward)
+        {
+            await Forward(item, sender, cancellationToken);
+        }
+
+        return result;
+    }
+
+    private async Task Forward(DisseminationItem item, SiloAddress sender, CancellationToken cancellationToken)
+    {
+        var root = item.Root is not null ? item.Root : sender;
+        item = EnsureRoot(item, root);
+        var topology = GetParticipantTopology(_transport.GetActivePeers().Append(root), includeLocal: true);
+        foreach (var peer in GetTreeChildren(topology, root))
+        {
+            if (!Equals(peer, sender))
+            {
+                await SendGossip(peer, item, cancellationToken);
+            }
+        }
+    }
+
+    private async ValueTask<bool> SendGossip(SiloAddress peer, DisseminationItem item, CancellationToken cancellationToken)
+    {
+        if (!_topics.TryGetValue(item.Id.Topic, out var topic)
+            || !await IsCapable(peer, topic, item.Id.PayloadKind, cancellationToken))
+        {
+            return false;
+        }
+
+        var batch = new DisseminationGossipBatch
+        {
+            Sender = _transport.LocalSilo,
+            Items = new[] { item },
+        };
+
+        var sent = await SafeSend(peer, target => _transport.SendGossip(target, batch, cancellationToken));
+        if (sent)
+        {
+            DisseminationInstruments.OnGossipSent(item.Id.Topic, "tree", 1, item.Payload.Length);
+        }
+
+        return sent;
+    }
+
+    private async ValueTask<bool> SafeSend(SiloAddress peer, Func<SiloAddress, Task> send)
+    {
+        if (IsPeerBackedOff(peer))
+        {
+            return false;
+        }
+
+        try
+        {
+            await send(peer);
+            ClearPeerBackoff(peer);
+            return true;
+        }
+        catch (Exception exception)
+        {
+            LogDebugDisseminationSendFailed(_logger, exception, peer);
+            SetPeerBackoff(peer);
+            return false;
+        }
+    }
+
+    private async ValueTask<DisseminationAntiEntropyResponse?> SafeRequest(
+        SiloAddress peer,
+        Func<SiloAddress, ValueTask<DisseminationAntiEntropyResponse>> request)
+    {
+        if (IsPeerBackedOff(peer))
+        {
+            return null;
+        }
+
+        try
+        {
+            var response = await request(peer);
+            ClearPeerBackoff(peer);
+            return response;
+        }
+        catch (Exception exception)
+        {
+            LogDebugDisseminationSendFailed(_logger, exception, peer);
+            SetPeerBackoff(peer);
+            return null;
+        }
+    }
+
+    private async ValueTask<bool> IsCapable(
+        SiloAddress peer,
+        IDisseminationTopic topic,
+        string payloadKind,
+        CancellationToken cancellationToken)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var key = new CapabilityKey(peer, topic.Name);
+        lock (_capabilityLock)
+        {
+            if (_capabilityCache.TryGetValue(key, out var cached) && cached.ExpiresAt > now)
+            {
+                return cached.Supported && cached.PayloadKinds.Contains(payloadKind);
+            }
+
+            if (_capabilityProbeBackoffUntil.TryGetValue(key, out var probeBackoffUntil))
+            {
+                if (probeBackoffUntil > now)
+                {
+                    return false;
+                }
+
+                _capabilityProbeBackoffUntil.Remove(key);
+            }
+        }
+
+        var request = new DisseminationCapabilityRequest
+        {
+            Topic = topic.Name,
+            ProtocolVersion = topic.ProtocolVersion,
+            PayloadKinds = topic.PayloadKinds.ToArray(),
+        };
+
+        try
+        {
+            var response = await _transport.GetCapabilities(peer, request, cancellationToken);
+            var supported = response.Supported && response.ProtocolVersion >= topic.ProtocolVersion;
+            var payloadKinds = response.PayloadKinds.ToHashSet(StringComparer.Ordinal);
+            lock (_capabilityLock)
+            {
+                _capabilityCache[key] = new CapabilityEntry(supported, payloadKinds, now + _options.CurrentValue.CapabilityCacheTtl);
+                _capabilityProbeBackoffUntil.Remove(key);
+            }
+
+            DisseminationEvents.EmitCapabilityProbe(_transport.LocalSilo, peer, topic.Name, supported);
+            return supported && payloadKinds.Contains(payloadKind);
+        }
+        catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            LogDebugCapabilityProbeFailed(_logger, exception, peer, topic.Name);
+            lock (_capabilityLock)
+            {
+                _capabilityCache.Remove(key);
+                _capabilityProbeBackoffUntil[key] = _timeProvider.GetUtcNow() + _options.CurrentValue.FailureBackoff;
+            }
+
+            DisseminationEvents.EmitCapabilityProbe(_transport.LocalSilo, peer, topic.Name, supported: false);
+            return false;
+        }
+    }
+
+    private async ValueTask<bool> AreParticipantsCapable(
+        IReadOnlyList<SiloAddress> participants,
+        IDisseminationTopic topic,
+        string payloadKind,
+        CancellationToken cancellationToken)
+    {
+        var probes = new List<Task<bool>>(participants.Count);
+        foreach (var peer in participants)
+        {
+            if (!Equals(peer, _transport.LocalSilo))
+            {
+                probes.Add(IsCapable(peer, topic, payloadKind, cancellationToken).AsTask());
+            }
+        }
+
+        if (probes.Count == 0)
+        {
+            return true;
+        }
+
+        var results = await Task.WhenAll(probes);
+        return results.All(static supported => supported);
+    }
+
+    private async ValueTask<List<DisseminationCapabilityRequest>> GetCapableAntiEntropyTopics(
+        SiloAddress peer,
+        IReadOnlyList<DisseminationCapabilityRequest> topics,
+        CancellationToken cancellationToken)
+    {
+        var result = new List<DisseminationCapabilityRequest>(topics.Count);
+        foreach (var request in topics)
+        {
+            if (!_topics.TryGetValue(request.Topic, out var topic) || !topic.IsEnabled)
+            {
+                continue;
+            }
+
+            var supportedPayloadKinds = new List<string>(request.PayloadKinds.Length);
+            foreach (var payloadKind in request.PayloadKinds)
+            {
+                if (await IsCapable(peer, topic, payloadKind, cancellationToken))
+                {
+                    supportedPayloadKinds.Add(payloadKind);
+                }
+            }
+
+            if (supportedPayloadKinds.Count > 0)
+            {
+                result.Add(new DisseminationCapabilityRequest
+                {
+                    Topic = request.Topic,
+                    ProtocolVersion = request.ProtocolVersion,
+                    PayloadKinds = supportedPayloadKinds.ToArray(),
+                });
+            }
+        }
+
+        return result;
+    }
+
+    private Dictionary<string, RequestedTopic> GetRequestedTopics(DisseminationAntiEntropyRequest request)
+    {
+        var result = new Dictionary<string, RequestedTopic>(StringComparer.Ordinal);
+        foreach (var requestedTopic in request.Topics)
+        {
+            if (!TryGetEnabledTopic(requestedTopic.Topic, out var topic)
+                || requestedTopic.ProtocolVersion > topic.ProtocolVersion)
+            {
+                continue;
+            }
+
+            var payloadKinds = topic.PayloadKinds
+                .Intersect(requestedTopic.PayloadKinds, StringComparer.Ordinal)
+                .ToHashSet(StringComparer.Ordinal);
+            if (payloadKinds.Count > 0)
+            {
+                result[topic.Name] = new RequestedTopic(topic, payloadKinds);
+            }
+        }
+
+        return result;
+    }
+
+    private Dictionary<DigestKey, DisseminationItemId> GetRemoteDigestMap(IEnumerable<DisseminationItemId> digests)
+    {
+        var result = new Dictionary<DigestKey, DisseminationItemId>();
+        foreach (var digest in digests)
+        {
+            if (!TryGetEnabledTopic(digest.Topic, out var topic))
+            {
+                continue;
+            }
+
+            var key = GetDigestKey(digest);
+            if (!result.TryGetValue(key, out var existing) || topic.CompareVersion(digest, existing) > 0)
+            {
+                result[key] = digest;
+            }
+        }
+
+        return result;
+    }
+
+    private IReadOnlyList<SiloAddress> SelectAntiEntropyPeers()
+    {
+        var options = _options.CurrentValue.Overlay;
+        var topology = GetParticipantTopology(_transport.GetActivePeers(), includeLocal: true);
+        var participants = topology.Participants;
+        if (participants.Count <= 1)
+        {
+            return Array.Empty<SiloAddress>();
+        }
+
+        if (!topology.Indices.TryGetValue(_transport.LocalSilo, out var localIndex))
+        {
+            return Array.Empty<SiloAddress>();
+        }
+
+        var result = new List<SiloAddress>(Math.Min(options.AntiEntropyPeerCount, participants.Count - 1));
+        for (var offset = 1; offset < participants.Count && result.Count < options.AntiEntropyPeerCount; offset++)
+        {
+            var peer = participants[(localIndex + offset) % participants.Count];
+            if (!Equals(peer, _transport.LocalSilo))
+            {
+                result.Add(peer);
+            }
+        }
+
+        return result;
+    }
+
+    private ParticipantTopology GetParticipantTopology(IEnumerable<SiloAddress> peers, bool includeLocal)
+    {
+        var peerSet = new HashSet<SiloAddress>();
+        if (includeLocal)
+        {
+            peerSet.Add(_transport.LocalSilo);
+        }
+
+        foreach (var peer in peers)
+        {
+            if (peer is not null)
+            {
+                peerSet.Add(peer);
+            }
+        }
+
+        lock (_topologyLock)
+        {
+            if (_participantTopology.ParticipantSet.SetEquals(peerSet))
+            {
+                return _participantTopology;
+            }
+
+            var participants = peerSet
+                .OrderBy(GetPeerScoreLocked, StringComparer.Ordinal)
+                .ToList();
+            var indices = new Dictionary<SiloAddress, int>(participants.Count);
+            for (var i = 0; i < participants.Count; i++)
+            {
+                indices[participants[i]] = i;
+            }
+
+            _participantTopology = new ParticipantTopology(participants, indices, peerSet);
+            return _participantTopology;
+        }
+    }
+
+    private string GetPeerScoreLocked(SiloAddress peer)
+    {
+        if (!_peerScores.TryGetValue(peer, out var score))
+        {
+            score = ComputePeerScore(peer);
+            _peerScores[peer] = score;
+        }
+
+        return score;
+    }
+
+    private IReadOnlyList<SiloAddress> GetTreeChildren(ParticipantTopology topology, SiloAddress root)
+    {
+        if (!topology.Indices.TryGetValue(root, out var rootIndex)
+            || !topology.Indices.TryGetValue(_transport.LocalSilo, out var localIndex))
+        {
+            return Array.Empty<SiloAddress>();
+        }
+
+        var fanout = _options.CurrentValue.Overlay.TreeFanout;
+        var count = topology.Participants.Count;
+        var localTreeIndex = localIndex >= rootIndex ? localIndex - rootIndex : localIndex + count - rootIndex;
+        var firstChild = (localTreeIndex * fanout) + 1;
+        if (firstChild >= count)
+        {
+            return Array.Empty<SiloAddress>();
+        }
+
+        var result = new List<SiloAddress>(Math.Min(fanout, count - firstChild));
+        for (var i = 0; i < fanout; i++)
+        {
+            var childTreeIndex = firstChild + i;
+            if (childTreeIndex >= count)
+            {
+                break;
+            }
+
+            result.Add(topology.Participants[(rootIndex + childTreeIndex) % count]);
+        }
+
+        return result;
+    }
+
+    private bool TryGetEnabledTopic(string topicName, out IDisseminationTopic topic)
+    {
+        if (_options.CurrentValue.Enabled
+            && _topics.TryGetValue(topicName, out topic!)
+            && topic.IsEnabled)
+        {
+            return true;
+        }
+
+        topic = default!;
+        return false;
+    }
+
+    private bool ValidatePayloadSize(IDisseminationTopic topic, DisseminationItem item)
+    {
+        var options = _options.CurrentValue;
+        if (item.Payload.Length > topic.Options.MaxPayloadBytes || item.Payload.Length > options.MaxBatchBytes)
+        {
+            DisseminationEvents.EmitPayloadDrop(item.Id, _transport.LocalSilo, "oversize", item.Payload.Length);
+            DisseminationInstruments.OnPayloadDropped(item.Id.Topic, "oversize");
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool IsExpired(DisseminationItem item) => item.ExpiresAt <= _timeProvider.GetUtcNow();
+
+    private bool IsPeerBackedOff(SiloAddress peer)
+    {
+        var now = _timeProvider.GetUtcNow();
+        lock (_failureLock)
+        {
+            return _failureBackoffUntil.TryGetValue(peer, out var until) && until > now;
+        }
+    }
+
+    private void ClearPeerBackoff(SiloAddress peer)
+    {
+        lock (_failureLock)
+        {
+            _failureBackoffUntil.Remove(peer);
+        }
+    }
+
+    private void SetPeerBackoff(SiloAddress peer)
+    {
+        lock (_failureLock)
+        {
+            _failureBackoffUntil[peer] = _timeProvider.GetUtcNow() + _options.CurrentValue.FailureBackoff;
+        }
+    }
+
+    private void EmitApplyResult(DisseminationItem item, SiloAddress sender, DisseminationApplyResult result)
+    {
+        DisseminationEvents.EmitItem(item.Id, _transport.LocalSilo, sender, result.ToString(), item.Payload.Length);
+        DisseminationInstruments.OnItemApplied(item.Id.Topic, result.ToString());
+    }
+
+    private DisseminationAntiEntropyResponse CreateAntiEntropyResponse(DisseminationItem[] items, bool truncated) => new()
+    {
+        Sender = _transport.LocalSilo,
+        Items = items,
+        Truncated = truncated,
+    };
+
+    private static DisseminationItem EnsureRoot(DisseminationItem item, SiloAddress root) =>
+        item.Root is not null
+            ? item
+            : new DisseminationItem
+            {
+                Id = item.Id,
+                Root = root,
+                ExpiresAt = item.ExpiresAt,
+                Payload = item.Payload,
+            };
+
+    private static bool IsRequested(IEnumerable<DisseminationCapabilityRequest> requests, DisseminationItemId digest)
+    {
+        foreach (var request in requests)
+        {
+            if (string.Equals(request.Topic, digest.Topic, StringComparison.Ordinal)
+                && request.PayloadKinds.Contains(digest.PayloadKind, StringComparer.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<DisseminationItemId> SortDigests(IEnumerable<DisseminationItemId> digests) =>
+        digests
+            .OrderBy(static digest => digest.Topic, StringComparer.Ordinal)
+            .ThenBy(static digest => digest.PayloadKind, StringComparer.Ordinal)
+            .ThenBy(static digest => digest.Key.ToString(), StringComparer.Ordinal)
+            .ThenBy(static digest => digest.Version);
+
+    private static DigestKey GetDigestKey(DisseminationItemId digest) => new(digest.Topic, digest.Key, digest.PayloadKind);
+
+    private static string ComputePeerScore(SiloAddress peer)
+    {
+        var bytes = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(peer.ToParsableString()));
+        return Convert.ToHexString(bytes);
+    }
+
+    public sealed record AntiEntropyState(
+        IReadOnlyList<SiloAddress> Peers,
+        IReadOnlyList<DisseminationCapabilityRequest> Topics,
+        IReadOnlyList<DisseminationItemId> Digests)
+    {
+        public static readonly AntiEntropyState Empty = new(
+            Array.Empty<SiloAddress>(),
+            Array.Empty<DisseminationCapabilityRequest>(),
+            Array.Empty<DisseminationItemId>());
+    }
+
+    private readonly record struct CapabilityKey(SiloAddress Peer, string Topic);
+
+    private readonly record struct CapabilityEntry(bool Supported, HashSet<string> PayloadKinds, DateTimeOffset ExpiresAt);
+
+    private readonly record struct DigestKey(string Topic, DisseminationValueKey Key, string PayloadKind);
+
+    private readonly record struct RequestedTopic(IDisseminationTopic Topic, HashSet<string> PayloadKinds);
+
+    private sealed record ParticipantTopology(
+        IReadOnlyList<SiloAddress> Participants,
+        IReadOnlyDictionary<SiloAddress, int> Indices,
+        HashSet<SiloAddress> ParticipantSet)
+    {
+        public static readonly ParticipantTopology Empty = new(
+            Array.Empty<SiloAddress>(),
+            new Dictionary<SiloAddress, int>(),
+            new HashSet<SiloAddress>());
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Dissemination send to {Peer} failed.")]
+    private static partial void LogDebugDisseminationSendFailed(ILogger logger, Exception exception, SiloAddress peer);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Dissemination capability probe to {Peer} for topic {Topic} failed.")]
+    private static partial void LogDebugCapabilityProbeFailed(ILogger logger, Exception exception, SiloAddress peer, string topic);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Failed to apply anti-entropy repair item from {Sender} for topic {Topic}, key {Key}, version {Version}.")]
+    private static partial void LogDebugAntiEntropyRepairItemFailed(ILogger logger, Exception exception, SiloAddress sender, string topic, string key, long version);
+}

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -930,21 +930,18 @@ internal sealed partial class DisseminationProtocol(
 
         lock (_gossipQueueLock)
         {
-            if (_pendingGossip.Count > 0)
+            foreach (var peer in _pendingGossip.Keys)
             {
-                foreach (var peer in _pendingGossip.Keys)
+                if (!IsCurrentParticipant(peer))
                 {
-                    if (!IsCurrentParticipant(peer))
-                    {
-                        _pendingGossip.Remove(peer);
-                    }
+                    _pendingGossip.Remove(peer);
                 }
+            }
 
-                if (_pendingGossip.Count == 0)
-                {
-                    _nextGossipFlushAt = null;
-                    _gossipFlushWakeup?.Cancel();
-                }
+            if (_pendingGossip.Count == 0)
+            {
+                _nextGossipFlushAt = null;
+                _gossipFlushWakeup?.Cancel();
             }
         }
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -106,6 +106,7 @@ internal sealed partial class DisseminationProtocol(
 
             foreach (var item in values)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 await ApplyReceivedValue(topicName, topic, item, batch.Sender, forward: true, cancellationToken);
             }
         }
@@ -404,7 +405,33 @@ internal sealed partial class DisseminationProtocol(
 
         if (result == DisseminationApplyResult.Applied && forward)
         {
-            await Forward(value, topic, sender, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                await Forward(value, topic, sender, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                LogDebugDisseminationValueForwardFailed(
+                    _logger,
+                    exception,
+                    sender,
+                    topicName,
+                    value.Digest.Key,
+                    value.Digest.Version);
+                DisseminationEvents.EmitForwardFailure(
+                    topicName,
+                    value.Digest,
+                    _transport.LocalSilo,
+                    (SiloAddress?)null,
+                    "exception",
+                    value.Payload.Length);
+                DisseminationInstruments.OnForwardFailure(topicName, "exception");
+            }
         }
 
         return result;
@@ -421,7 +448,23 @@ internal sealed partial class DisseminationProtocol(
 
         foreach (var peer in GetForwardingTreeTargets(topology, root, sender))
         {
-            EnqueueGossip(peer, item, topic);
+            if (!EnqueueGossip(peer, item, topic))
+            {
+                LogDebugDisseminationValueForwardRejected(
+                    _logger,
+                    peer,
+                    topic.Name,
+                    item.Digest.Key,
+                    item.Digest.Version);
+                DisseminationEvents.EmitForwardFailure(
+                    topic.Name,
+                    item.Digest,
+                    _transport.LocalSilo,
+                    peer,
+                    "queue-capacity",
+                    item.Payload.Length);
+                DisseminationInstruments.OnForwardFailure(topic.Name, "queue-capacity");
+            }
         }
     }
 
@@ -1747,6 +1790,16 @@ internal sealed partial class DisseminationProtocol(
         Level = LogLevel.Debug,
         Message = "Failed to apply dissemination value from {Sender} for topic {Topic}, key {Key}, version {Version}.")]
     private static partial void LogDebugDisseminationValueApplyFailed(ILogger logger, Exception exception, SiloAddress sender, string topic, string key, long version);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Failed to forward dissemination value from {Sender} for topic {Topic}, key {Key}, version {Version}.")]
+    private static partial void LogDebugDisseminationValueForwardFailed(ILogger logger, Exception exception, SiloAddress sender, string topic, string key, long version);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Failed to queue dissemination value for {Peer} because outbound queue limits were reached for topic {Topic}, key {Key}, version {Version}.")]
+    private static partial void LogDebugDisseminationValueForwardRejected(ILogger logger, SiloAddress peer, string topic, string key, long version);
 
     [LoggerMessage(
         Level = LogLevel.Debug,

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -256,7 +256,7 @@ internal sealed partial class DisseminationProtocol(
                     continue;
                 }
 
-                var localDigest = CreateDigest(requestedTopic, topicDigest);
+                var localDigest = new DisseminationDigest(requestedTopic.Name, topicDigest.Key, topicDigest.Version);
                 if (requestedTopic.CompareVersion(localDigest, remoteDigest) <= 0)
                 {
                     continue;
@@ -1132,9 +1132,6 @@ internal sealed partial class DisseminationProtocol(
         Values = values,
         Truncated = truncated,
     };
-
-    private static DisseminationDigest CreateDigest(IDisseminationTopic topic, DisseminationTopicDigest digest) =>
-        new(topic.Name, digest.Key, digest.Version);
 
     public sealed record AntiEntropyState(FrozenDictionary<string, AntiEntropyTopicState> Topics)
     {

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -194,7 +194,11 @@ internal sealed partial class DisseminationProtocol(
                 continue;
             }
 
-            DisseminationInstruments.OnAntiEntropyExchange("out", GetDigestCount(request.DigestsByTopic), response.Values.Length, response.Truncated);
+            DisseminationInstruments.OnAntiEntropyExchange(
+                "out",
+                GetDigestCount(request.DigestsByTopic),
+                GetValueCount(response.ValuesByTopic),
+                response.Truncated);
             responses.Add(response);
         }
 
@@ -212,19 +216,27 @@ internal sealed partial class DisseminationProtocol(
 
         foreach (var response in responses)
         {
-            foreach (var item in response.Values)
+            foreach (var (topicName, values) in response.ValuesByTopic)
             {
-                try
+                foreach (var item in values)
                 {
-                    await ApplyReceivedValue(item, response.Sender, forward: false, cancellationToken);
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    throw;
-                }
-                catch (Exception exception)
-                {
-                    LogDebugAntiEntropyRepairValueFailed(_logger, exception, response.Sender, item.Digest.Topic, item.Digest.Key, item.Digest.Version);
+                    if (!string.Equals(item.Digest.Topic, topicName, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        await ApplyReceivedValue(item, response.Sender, forward: false, cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception exception)
+                    {
+                        LogDebugAntiEntropyRepairValueFailed(_logger, exception, response.Sender, item.Digest.Topic, item.Digest.Key, item.Digest.Version);
+                    }
                 }
             }
         }
@@ -236,7 +248,7 @@ internal sealed partial class DisseminationProtocol(
     {
         if (!_options.CurrentValue.Enabled)
         {
-            return CreateAntiEntropyResponse([], truncated: false);
+            return CreateAntiEntropyResponse(FrozenDictionary<string, ImmutableArray<DisseminationValue>>.Empty, truncated: false);
         }
 
         var requestDigestCount = GetDigestCount(request.DigestsByTopic);
@@ -299,7 +311,7 @@ internal sealed partial class DisseminationProtocol(
         }
 
         DisseminationInstruments.OnAntiEntropyExchange("in", requestDigestCount, values.Count, truncated);
-        return CreateAntiEntropyResponse([.. values], truncated);
+        return CreateAntiEntropyResponse(GroupValuesByTopic(values), truncated);
     }
 
     private async ValueTask<DisseminationApplyResult> ApplyReceivedValue(
@@ -1168,10 +1180,12 @@ internal sealed partial class DisseminationProtocol(
         DisseminationInstruments.OnValueApplied(item.Digest.Topic, result);
     }
 
-    private DisseminationAntiEntropyResponse CreateAntiEntropyResponse(ImmutableArray<DisseminationValue> values, bool truncated) => new()
+    private DisseminationAntiEntropyResponse CreateAntiEntropyResponse(
+        FrozenDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic,
+        bool truncated) => new()
     {
         Sender = _transport.LocalSilo,
-        Values = values,
+        ValuesByTopic = valuesByTopic,
         Truncated = truncated,
     };
 
@@ -1181,6 +1195,17 @@ internal sealed partial class DisseminationProtocol(
         foreach (var digests in digestsByTopic.Values)
         {
             result += digests.Length;
+        }
+
+        return result;
+    }
+
+    private static int GetValueCount(FrozenDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic)
+    {
+        var result = 0;
+        foreach (var values in valuesByTopic.Values)
+        {
+            result += values.Length;
         }
 
         return result;

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -17,7 +17,7 @@ internal sealed partial class DisseminationProtocol(
     IOptionsMonitor<DisseminationOptions> options,
     IEnumerable<IDisseminationTopic> topics,
     TimeProvider timeProvider,
-    ILogger<DisseminationProtocol> logger)
+    ILogger<DisseminationProtocol> logger) : IAsyncDisposable
 {
     private readonly IDisseminationTransport _transport = transport;
     private readonly IOptionsMonitor<DisseminationOptions> _options = options;
@@ -26,6 +26,7 @@ internal sealed partial class DisseminationProtocol(
     private readonly ILogger<DisseminationProtocol> _logger = logger;
     private readonly Dictionary<SiloAddress, DateTimeOffset> _failureBackoffUntil = [];
     private readonly object _failureLock = new();
+    private readonly object _disposeLock = new();
     private readonly object _gossipQueueLock = new();
     private readonly object _peerCompatibilityLock = new();
     private readonly object _recentUpdateLock = new();
@@ -38,6 +39,7 @@ internal sealed partial class DisseminationProtocol(
     private DateTimeOffset? _nextGossipFlushAt;
     private CancellationTokenSource? _gossipFlushWakeup;
     private Task? _gossipFlushTask;
+    private Task? _disposeTask;
     private bool _gossipFlushScheduled;
     private bool _stopping;
     private ParticipantTopology _activeMembersTopology = ParticipantTopology.Empty;
@@ -45,6 +47,8 @@ internal sealed partial class DisseminationProtocol(
     private long _antiEntropyRound;
 
     public FrozenDictionary<string, IDisseminationTopic> Topics => _topics;
+
+    internal bool IsDisposed => _disposeTask?.IsCompletedSuccessfully == true;
 
     public async ValueTask<bool> Publish(
         string topicName,
@@ -469,6 +473,41 @@ internal sealed partial class DisseminationProtocol(
         {
             _gossipSendCts.Cancel();
         }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (_disposeLock)
+        {
+            return new ValueTask(_disposeTask ??= DisposeCoreAsync());
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        Task? scheduledFlush;
+        lock (_gossipQueueLock)
+        {
+            _stopping = true;
+            _gossipFlushWakeup?.Cancel();
+            scheduledFlush = _gossipFlushTask;
+        }
+
+        _gossipSendCts.Cancel();
+        if (scheduledFlush is not null)
+        {
+            await scheduledFlush;
+        }
+
+        await _gossipFlushLock.WaitAsync();
+        lock (_gossipQueueLock)
+        {
+            DisposeGossipFlushWakeupUnsafe();
+            _pendingGossip.Clear();
+        }
+
+        _gossipSendCts.Dispose();
+        _gossipFlushLock.Dispose();
     }
 
     private bool EnqueueGossip(SiloAddress peer, DisseminationValue item, IDisseminationTopic topic)

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -82,11 +82,17 @@ internal sealed partial class DisseminationProtocol(
             return;
         }
 
-        DisseminationInstruments.OnGossipReceived(batch.Values, "tree");
+        DisseminationInstruments.OnGossipReceived(batch.ValuesByTopic, "tree");
 
-        foreach (var item in batch.Values)
+        foreach (var (topicName, values) in batch.ValuesByTopic)
         {
-            await ApplyReceivedValue(item, batch.Sender, forward: true, cancellationToken);
+            foreach (var item in values)
+            {
+                if (string.Equals(item.Digest.Topic, topicName, StringComparison.Ordinal))
+                {
+                    await ApplyReceivedValue(item, batch.Sender, forward: true, cancellationToken);
+                }
+            }
         }
     }
 
@@ -573,7 +579,7 @@ internal sealed partial class DisseminationProtocol(
         var batch = new DisseminationGossipBatch
         {
             Sender = _transport.LocalSilo,
-            Values = values,
+            ValuesByTopic = GroupValuesByTopic(values),
         };
 
         var sent = await SafeSend(
@@ -582,7 +588,7 @@ internal sealed partial class DisseminationProtocol(
             target => _transport.SendGossip(target, batch, cancellationToken));
         if (sent)
         {
-            DisseminationInstruments.OnGossipSent(values, "tree");
+            DisseminationInstruments.OnGossipSent(batch.ValuesByTopic, "tree");
         }
     }
 
@@ -1178,6 +1184,26 @@ internal sealed partial class DisseminationProtocol(
         }
 
         return result;
+    }
+
+    private static FrozenDictionary<string, ImmutableArray<DisseminationValue>> GroupValuesByTopic(IReadOnlyList<DisseminationValue> values)
+    {
+        var result = new Dictionary<string, ImmutableArray<DisseminationValue>.Builder>(StringComparer.Ordinal);
+        foreach (var value in values)
+        {
+            if (!result.TryGetValue(value.Digest.Topic, out var topicValues))
+            {
+                topicValues = ImmutableArray.CreateBuilder<DisseminationValue>();
+                result.Add(value.Digest.Topic, topicValues);
+            }
+
+            topicValues.Add(value);
+        }
+
+        return result.ToFrozenDictionary(
+            static pair => pair.Key,
+            static pair => pair.Value.ToImmutable(),
+            StringComparer.Ordinal);
     }
 
     public sealed record AntiEntropyState(FrozenDictionary<string, AntiEntropyTopicState> Topics)

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -1030,9 +1030,13 @@ internal sealed partial class DisseminationProtocol(
         bool includeLocal,
         bool preserveOrder)
     {
-        List<SiloAddress> orderedParticipants = [..preserveOrder
-            ? participants.Distinct()
-            : participants.Distinct().OrderBy(static participant => participant)];
+        var orderedParticipants = new List<SiloAddress>();
+        var seen = new HashSet<SiloAddress>();
+        foreach (var participant in participants)
+        {
+            AddParticipant(participant);
+        }
+
         if (includeLocal)
         {
             AddParticipant(_transport.LocalSilo);
@@ -1052,7 +1056,7 @@ internal sealed partial class DisseminationProtocol(
 
         void AddParticipant(SiloAddress participant)
         {
-            if (!orderedParticipants.Contains(participant))
+            if (seen.Add(participant))
             {
                 orderedParticipants.Add(participant);
             }

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -10,16 +11,21 @@ using Orleans.Configuration;
 
 namespace Orleans.Runtime.Dissemination;
 
-internal sealed partial class DisseminationProtocol
+internal sealed partial class DisseminationProtocol(
+    IDisseminationTransport transport,
+    IOptionsMonitor<DisseminationOptions> options,
+    IEnumerable<IDisseminationTopic> topics,
+    TimeProvider timeProvider,
+    ILogger<DisseminationProtocol> logger)
 {
-    private readonly IDisseminationTransport _transport;
-    private readonly IOptionsMonitor<DisseminationOptions> _options;
-    private readonly Dictionary<string, IDisseminationTopic> _topics;
-    private readonly TimeProvider _timeProvider;
-    private readonly ILogger<DisseminationProtocol> _logger;
-    private readonly Dictionary<CapabilityKey, CapabilityEntry> _capabilityCache = new();
-    private readonly Dictionary<CapabilityKey, DateTimeOffset> _capabilityProbeBackoffUntil = new();
-    private readonly Dictionary<SiloAddress, DateTimeOffset> _failureBackoffUntil = new();
+    private readonly IDisseminationTransport _transport = transport;
+    private readonly IOptionsMonitor<DisseminationOptions> _options = options;
+    private readonly FrozenDictionary<string, IDisseminationTopic> _topics = topics.ToFrozenDictionary(static topic => topic.Name, StringComparer.Ordinal);
+    private readonly TimeProvider _timeProvider = timeProvider;
+    private readonly ILogger<DisseminationProtocol> _logger = logger;
+    private readonly Dictionary<CapabilityKey, CapabilityEntry> _capabilityCache = [];
+    private readonly Dictionary<CapabilityKey, DateTimeOffset> _capabilityProbeBackoffUntil = [];
+    private readonly Dictionary<SiloAddress, DateTimeOffset> _failureBackoffUntil = [];
     private readonly object _capabilityLock = new();
     private readonly object _failureLock = new();
     private readonly object _topologyLock = new();
@@ -27,21 +33,7 @@ internal sealed partial class DisseminationProtocol
     private ParticipantTopology _allMembersTopology = ParticipantTopology.Empty;
     private long _antiEntropyRound;
 
-    public DisseminationProtocol(
-        IDisseminationTransport transport,
-        IOptionsMonitor<DisseminationOptions> options,
-        IEnumerable<IDisseminationTopic> topics,
-        TimeProvider timeProvider,
-        ILogger<DisseminationProtocol> logger)
-    {
-        _transport = transport;
-        _options = options;
-        _timeProvider = timeProvider;
-        _logger = logger;
-        _topics = topics.ToDictionary(static topic => topic.Name, StringComparer.Ordinal);
-    }
-
-    public IReadOnlyDictionary<string, IDisseminationTopic> Topics => _topics;
+    public FrozenDictionary<string, IDisseminationTopic> Topics => _topics;
 
     public async ValueTask<bool> Publish(
         string topicName,
@@ -89,10 +81,7 @@ internal sealed partial class DisseminationProtocol
             return;
         }
 
-        foreach (var group in batch.Values.GroupBy(static item => item.Digest.Topic))
-        {
-            DisseminationInstruments.OnGossipReceived(group.Key, "tree", group.Count());
-        }
+        DisseminationInstruments.OnGossipReceived(batch.Values, "tree");
 
         foreach (var item in batch.Values)
         {
@@ -120,7 +109,7 @@ internal sealed partial class DisseminationProtocol
             {
                 Topic = topic.Name,
                 ProtocolVersion = topic.ProtocolVersion,
-                PayloadKinds = topic.PayloadKinds.ToArray(),
+                PayloadKinds = [.. topic.PayloadKinds],
             });
 
             foreach (var digest in topic.GetDigests())
@@ -146,7 +135,7 @@ internal sealed partial class DisseminationProtocol
     {
         if (state.PeersByTopic.Count == 0 || state.Topics.Count == 0)
         {
-            return Array.Empty<DisseminationAntiEntropyResponse>();
+            return [];
         }
 
         var peers = state.PeersByTopic.Values.SelectMany(static value => value).Distinct().ToArray();
@@ -166,7 +155,7 @@ internal sealed partial class DisseminationProtocol
             var request = new DisseminationAntiEntropyRequest
             {
                 Sender = _transport.LocalSilo,
-                Topics = topics.ToArray(),
+                Topics = [.. topics],
                 Digests = digests,
             };
 
@@ -218,13 +207,13 @@ internal sealed partial class DisseminationProtocol
     {
         if (!_options.CurrentValue.Enabled)
         {
-            return CreateAntiEntropyResponse(Array.Empty<DisseminationValue>(), truncated: false);
+            return CreateAntiEntropyResponse([], truncated: false);
         }
 
         var requestedTopics = GetRequestedTopics(request);
         if (requestedTopics.Count == 0)
         {
-            return CreateAntiEntropyResponse(Array.Empty<DisseminationValue>(), truncated: false);
+            return CreateAntiEntropyResponse([], truncated: false);
         }
 
         var remoteDigests = GetRemoteDigestMap(request.Digests);
@@ -278,7 +267,7 @@ internal sealed partial class DisseminationProtocol
         }
 
         DisseminationInstruments.OnAntiEntropyExchange("in", request.Digests.Length, values.Count, truncated);
-        return CreateAntiEntropyResponse(values.ToArray(), truncated);
+        return CreateAntiEntropyResponse([.. values], truncated);
     }
 
     private async ValueTask<DisseminationApplyResult> ApplyReceivedValue(
@@ -343,7 +332,7 @@ internal sealed partial class DisseminationProtocol
         var batch = new DisseminationGossipBatch
         {
             Sender = _transport.LocalSilo,
-            Values = new[] { item },
+            Values = [item],
         };
 
         var sent = await SafeSend(peer, target => _transport.SendGossip(target, batch, cancellationToken));
@@ -431,14 +420,14 @@ internal sealed partial class DisseminationProtocol
         {
             Topic = topic.Name,
             ProtocolVersion = topic.ProtocolVersion,
-            PayloadKinds = topic.PayloadKinds.ToArray(),
+            PayloadKinds = [.. topic.PayloadKinds],
         };
 
         try
         {
             var response = await _transport.GetCapabilities(peer, request, cancellationToken);
             var supported = response.Supported && response.ProtocolVersion >= topic.ProtocolVersion;
-            var payloadKinds = response.PayloadKinds.ToHashSet(StringComparer.Ordinal);
+            var payloadKinds = response.PayloadKinds.ToFrozenSet(StringComparer.Ordinal);
             lock (_capabilityLock)
             {
                 _capabilityCache[key] = new CapabilityEntry(supported, payloadKinds, now + _options.CurrentValue.CapabilityCacheTtl);
@@ -466,7 +455,7 @@ internal sealed partial class DisseminationProtocol
 
     private async ValueTask<bool> AreParticipantsCapable(
         ImmutableArray<SiloAddress> participants,
-        HashSet<SiloAddress> activeMembers,
+        FrozenSet<SiloAddress> activeMembers,
         IDisseminationTopic topic,
         string payloadKind,
         CancellationToken cancellationToken)
@@ -528,7 +517,7 @@ internal sealed partial class DisseminationProtocol
                 {
                     Topic = request.Topic,
                     ProtocolVersion = request.ProtocolVersion,
-                    PayloadKinds = supportedPayloadKinds.ToArray(),
+                    PayloadKinds = [.. supportedPayloadKinds],
                 });
             }
         }
@@ -536,7 +525,7 @@ internal sealed partial class DisseminationProtocol
         return result;
     }
 
-    private Dictionary<string, RequestedTopic> GetRequestedTopics(DisseminationAntiEntropyRequest request)
+    private FrozenDictionary<string, RequestedTopic> GetRequestedTopics(DisseminationAntiEntropyRequest request)
     {
         var result = new Dictionary<string, RequestedTopic>(StringComparer.Ordinal);
         foreach (var requestedTopic in request.Topics)
@@ -549,17 +538,17 @@ internal sealed partial class DisseminationProtocol
 
             var payloadKinds = topic.PayloadKinds
                 .Intersect(requestedTopic.PayloadKinds, StringComparer.Ordinal)
-                .ToHashSet(StringComparer.Ordinal);
+                .ToFrozenSet(StringComparer.Ordinal);
             if (payloadKinds.Count > 0)
             {
                 result[topic.Name] = new RequestedTopic(topic, payloadKinds);
             }
         }
 
-        return result;
+        return result.ToFrozenDictionary(StringComparer.Ordinal);
     }
 
-    private Dictionary<DigestKey, DisseminationDigest> GetRemoteDigestMap(IEnumerable<DisseminationDigest> digests)
+    private FrozenDictionary<DigestKey, DisseminationDigest> GetRemoteDigestMap(IEnumerable<DisseminationDigest> digests)
     {
         var result = new Dictionary<DigestKey, DisseminationDigest>();
         foreach (var digest in digests)
@@ -576,14 +565,14 @@ internal sealed partial class DisseminationProtocol
             }
         }
 
-        return result;
+        return result.ToFrozenDictionary();
     }
 
-    private IReadOnlyDictionary<string, IReadOnlyList<SiloAddress>> GetAntiEntropyPeersByTopic(
+    private FrozenDictionary<string, ImmutableArray<SiloAddress>> GetAntiEntropyPeersByTopic(
         IReadOnlyList<DisseminationCapabilityRequest> topics,
         long round)
     {
-        var result = new Dictionary<string, IReadOnlyList<SiloAddress>>(StringComparer.Ordinal);
+        var result = new Dictionary<string, ImmutableArray<SiloAddress>>(StringComparer.Ordinal);
         foreach (var request in topics)
         {
             if (_topics.TryGetValue(request.Topic, out var topic) && topic.IsEnabled)
@@ -592,33 +581,32 @@ internal sealed partial class DisseminationProtocol
             }
         }
 
-        return result;
+        return result.ToFrozenDictionary(StringComparer.Ordinal);
     }
 
-    private IReadOnlyList<SiloAddress> SelectAntiEntropyPeers(DisseminationMembershipScope membershipScope, long round)
+    private ImmutableArray<SiloAddress> SelectAntiEntropyPeers(DisseminationMembershipScope membershipScope, long round)
     {
         var options = _options.CurrentValue.Overlay;
         var topology = GetParticipantTopology(membershipScope, root: null, includeLocal: true);
         var participants = topology.Participants;
         if (participants.Length <= 1)
         {
-            return Array.Empty<SiloAddress>();
+            return [];
         }
 
         if (!topology.Indices.TryGetValue(_transport.LocalSilo, out var localIndex))
         {
-            return Array.Empty<SiloAddress>();
+            return [];
         }
 
         var fanout = GetFanOutFactor(participants.Length);
         var candidates = GetAntiEntropyCandidateIndexes(localIndex, participants.Length, fanout);
-        return candidates
+        return [.. candidates
             .Where(index => index != localIndex)
             .OrderBy(index => GetRepairPeerScore(participants[index], round, localIndex))
             .ThenBy(index => participants[index])
             .Take(options.AntiEntropyPeerCount)
-            .Select(index => participants[index])
-            .ToArray();
+            .Select(index => participants[index])];
     }
 
     private static IEnumerable<int> GetAntiEntropyCandidateIndexes(int localIndex, int participantCount, int fanout)
@@ -639,14 +627,14 @@ internal sealed partial class DisseminationProtocol
             yield break;
         }
 
-        var parentIndex = (localIndex / fanout) - 1;
+        var parentIndex = localIndex / fanout - 1;
         if (parentIndex < 0)
         {
             yield break;
         }
 
         var (previousLevelStart, previousLevelEnd) = GetLevelRange(parentIndex, participantCount, fanout);
-        var windowStart = previousLevelStart + (((parentIndex - previousLevelStart) / fanout) * fanout);
+        var windowStart = previousLevelStart + (parentIndex - previousLevelStart) / fanout * fanout;
         var windowEnd = Math.Min(previousLevelEnd, windowStart + fanout);
         for (var i = windowStart; i < windowEnd; i++)
         {
@@ -670,8 +658,8 @@ internal sealed partial class DisseminationProtocol
     private static ulong GetRepairPeerScore(SiloAddress peer, long round, int localIndex)
     {
         var value = (ulong)(uint)peer.GetConsistentHashCode();
-        value ^= ((ulong)round * 0x9E3779B97F4A7C15UL);
-        value ^= ((ulong)(uint)localIndex << 32);
+        value ^= (ulong)round * 0x9E3779B97F4A7C15UL;
+        value ^= (ulong)(uint)localIndex << 32;
         return Mix(value);
     }
 
@@ -717,7 +705,7 @@ internal sealed partial class DisseminationProtocol
     {
         if (!topology.Indices.TryGetValue(root, out var rootIndex))
         {
-            return Array.Empty<SiloAddress>();
+            return [];
         }
 
         var fanout = GetFanOutFactor(topology.Participants.Length);
@@ -731,7 +719,7 @@ internal sealed partial class DisseminationProtocol
     {
         if (!topology.Indices.TryGetValue(_transport.LocalSilo, out var localIndex))
         {
-            return Array.Empty<SiloAddress>();
+            return [];
         }
 
         var fanout = GetFanOutFactor(topology.Participants.Length);
@@ -776,7 +764,7 @@ internal sealed partial class DisseminationProtocol
 
     private static void AddTarget(SiloAddress peer, SiloAddress root, SiloAddress? except, List<SiloAddress> result)
     {
-        if (Equals(peer, root) || (except is { } excluded && Equals(peer, excluded)) || result.Contains(peer))
+        if (Equals(peer, root) || except is { } excluded && Equals(peer, excluded) || result.Contains(peer))
         {
             return;
         }
@@ -804,7 +792,7 @@ internal sealed partial class DisseminationProtocol
         return membershipScope == DisseminationMembershipScope.AllMembers ? allMembers : activeMembers;
     }
 
-    private HashSet<SiloAddress> GetActiveMemberSet(SiloAddress? root, bool includeLocal) =>
+    private FrozenSet<SiloAddress> GetActiveMemberSet(SiloAddress? root, bool includeLocal) =>
         GetCachedParticipantTopology(
             DisseminationMembershipScope.ActiveMembers,
             _transport.GetMembership().ActiveMembers,
@@ -858,10 +846,9 @@ internal sealed partial class DisseminationProtocol
         bool includeLocal,
         bool preserveOrder)
     {
-        var participantSet = new HashSet<SiloAddress>(participants);
-        var orderedParticipants = preserveOrder
-            ? participants.Where(participantSet.Remove).ToList()
-            : participantSet.OrderBy(static participant => participant).ToList();
+        List<SiloAddress> orderedParticipants = [..preserveOrder
+            ? participants.Distinct()
+            : participants.Distinct().OrderBy(static participant => participant)];
         if (includeLocal)
         {
             AddParticipant(_transport.LocalSilo);
@@ -877,7 +864,7 @@ internal sealed partial class DisseminationProtocol
             orderedParticipants.Sort(static (left, right) => left.CompareTo(right));
         }
 
-        return orderedParticipants.ToImmutableArray();
+        return [.. orderedParticipants];
 
         void AddParticipant(SiloAddress participant)
         {
@@ -888,7 +875,7 @@ internal sealed partial class DisseminationProtocol
                     orderedParticipants.Add(participant);
                 }
             }
-            else if (participantSet.Add(participant))
+            else if (!orderedParticipants.Contains(participant))
             {
                 orderedParticipants.Add(participant);
             }
@@ -903,7 +890,7 @@ internal sealed partial class DisseminationProtocol
             indices[sortedParticipants[i]] = i;
         }
 
-        return new ParticipantTopology(sortedParticipants, indices, sortedParticipants.ToHashSet());
+        return new ParticipantTopology(sortedParticipants, indices.ToFrozenDictionary(), sortedParticipants.ToFrozenSet());
     }
 
     private bool TryGetEnabledTopic(string topicName, out IDisseminationTopic topic)
@@ -961,8 +948,8 @@ internal sealed partial class DisseminationProtocol
 
     private void EmitApplyResult(DisseminationValue item, SiloAddress sender, DisseminationApplyResult result)
     {
-        DisseminationEvents.EmitValue(item.Digest, _transport.LocalSilo, sender, result.ToString(), item.Payload.Length);
-        DisseminationInstruments.OnValueApplied(item.Digest.Topic, result.ToString());
+        DisseminationEvents.EmitValue(item.Digest, _transport.LocalSilo, sender, result, item.Payload.Length);
+        DisseminationInstruments.OnValueApplied(item.Digest.Topic, result);
     }
 
     private DisseminationAntiEntropyResponse CreateAntiEntropyResponse(DisseminationValue[] values, bool truncated) => new()
@@ -1007,23 +994,23 @@ internal sealed partial class DisseminationProtocol
     private static DigestKey GetDigestKey(DisseminationDigest digest) => new(digest.Topic, digest.Key, digest.PayloadKind);
 
     public sealed record AntiEntropyState(
-        IReadOnlyDictionary<string, IReadOnlyList<SiloAddress>> PeersByTopic,
+        FrozenDictionary<string, ImmutableArray<SiloAddress>> PeersByTopic,
         IReadOnlyList<DisseminationCapabilityRequest> Topics,
         IReadOnlyList<DisseminationDigest> Digests)
     {
         public static readonly AntiEntropyState Empty = new(
-            new Dictionary<string, IReadOnlyList<SiloAddress>>(StringComparer.Ordinal),
-            Array.Empty<DisseminationCapabilityRequest>(),
-            Array.Empty<DisseminationDigest>());
+            FrozenDictionary<string, ImmutableArray<SiloAddress>>.Empty,
+            [],
+            []);
     }
 
     private readonly record struct CapabilityKey(SiloAddress Peer, string Topic);
 
-    private readonly record struct CapabilityEntry(bool Supported, HashSet<string> PayloadKinds, DateTimeOffset ExpiresAt);
+    private readonly record struct CapabilityEntry(bool Supported, FrozenSet<string> PayloadKinds, DateTimeOffset ExpiresAt);
 
     private readonly record struct DigestKey(string Topic, string Key, string PayloadKind);
 
-    private readonly record struct RequestedTopic(IDisseminationTopic Topic, HashSet<string> PayloadKinds);
+    private readonly record struct RequestedTopic(IDisseminationTopic Topic, FrozenSet<string> PayloadKinds);
 
     private enum CapabilityStatus
     {
@@ -1034,13 +1021,13 @@ internal sealed partial class DisseminationProtocol
 
     private sealed record ParticipantTopology(
         ImmutableArray<SiloAddress> Participants,
-        IReadOnlyDictionary<SiloAddress, int> Indices,
-        HashSet<SiloAddress> ParticipantSet)
+        FrozenDictionary<SiloAddress, int> Indices,
+        FrozenSet<SiloAddress> ParticipantSet)
     {
         public static readonly ParticipantTopology Empty = new(
-            ImmutableArray<SiloAddress>.Empty,
-            new Dictionary<SiloAddress, int>(),
-            new HashSet<SiloAddress>());
+            [],
+            FrozenDictionary<SiloAddress, int>.Empty,
+            FrozenSet<SiloAddress>.Empty);
     }
 
     [LoggerMessage(

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -3,6 +3,7 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -26,13 +27,19 @@ internal sealed partial class DisseminationProtocol(
     private readonly Dictionary<SiloAddress, DateTimeOffset> _failureBackoffUntil = [];
     private readonly object _failureLock = new();
     private readonly object _gossipQueueLock = new();
+    private readonly object _peerCompatibilityLock = new();
     private readonly object _recentUpdateLock = new();
     private readonly object _topologyLock = new();
+    private readonly SemaphoreSlim _gossipFlushLock = new(1, 1);
+    private readonly CancellationTokenSource _gossipSendCts = new();
     private readonly Dictionary<SiloAddress, PendingGossipBatch> _pendingGossip = [];
+    private readonly Dictionary<SiloAddress, Dictionary<string, DateTimeOffset>> _confirmedPeerTopics = [];
     private readonly Dictionary<DigestKey, DateTimeOffset> _lastUpdateReceivedAt = [];
     private DateTimeOffset? _nextGossipFlushAt;
     private CancellationTokenSource? _gossipFlushWakeup;
+    private Task? _gossipFlushTask;
     private bool _gossipFlushScheduled;
+    private bool _stopping;
     private ParticipantTopology _activeMembersTopology = ParticipantTopology.Empty;
     private ParticipantTopology _allMembersTopology = ParticipantTopology.Empty;
     private long _antiEntropyRound;
@@ -67,16 +74,18 @@ internal sealed partial class DisseminationProtocol(
         }
 
         RecordRecentUpdate(topic.Name, item.Digest);
+        var queued = true;
         foreach (var peer in GetOriginatorTreeTargets(topology, root))
         {
-            EnqueueGossip(peer, item, topic);
+            queued &= EnqueueGossip(peer, item, topic);
         }
 
-        return true;
+        return queued;
     }
 
     public async Task ReceiveGossip(DisseminationGossipBatch batch, CancellationToken cancellationToken)
     {
+        RecordCompatiblePeer(batch.Sender, batch.ValuesByTopic.Keys);
         if (!_options.CurrentValue.Enabled)
         {
             return;
@@ -179,29 +188,56 @@ internal sealed partial class DisseminationProtocol(
         }
 
         var responses = new List<DisseminationAntiEntropyResponse>(requestsByPeer.Count);
-        foreach (var (peer, pendingRequest) in requestsByPeer)
+        var retainedItemCount = 0;
+        var retainedByteCount = 0;
+        var options = _options.CurrentValue;
+        foreach (var (peer, pendingRequest) in requestsByPeer.OrderBy(static entry => entry.Key))
         {
-            var request = new DisseminationAntiEntropyRequest
+            foreach (var digestsByTopic in CreateAntiEntropyRequests(pendingRequest))
             {
-                Sender = _transport.LocalSilo,
-                DigestsByTopic = pendingRequest.ToImmutableDictionary(StringComparer.Ordinal),
-            };
+                if (retainedItemCount >= options.MaxBatchItems || retainedByteCount >= options.MaxBatchBytes)
+                {
+                    return responses;
+                }
 
-            var response = await SafeRequest(
-                peer,
-                cancellationToken,
-                target => _transport.ExchangeAntiEntropy(target, request, cancellationToken));
-            if (response is null)
-            {
-                continue;
+                var request = new DisseminationAntiEntropyRequest
+                {
+                    Sender = _transport.LocalSilo,
+                    DigestsByTopic = digestsByTopic,
+                };
+
+                var response = await SafeRequest(
+                    peer,
+                    cancellationToken,
+                    target => _transport.ExchangeAntiEntropy(target, request, cancellationToken));
+                if (response is null)
+                {
+                    continue;
+                }
+
+                SetCompatiblePeerTopics(peer, response.SupportedTopics);
+                DisseminationInstruments.OnAntiEntropyExchange(
+                    "out",
+                    GetDigestCount(request.DigestsByTopic),
+                    GetValueCount(response.ValuesByTopic),
+                    response.Truncated);
+                var limitedResponse = LimitAntiEntropyResponse(
+                    response,
+                    options.MaxBatchItems - retainedItemCount,
+                    options.MaxBatchBytes - retainedByteCount,
+                    out var roundLimitReached);
+                if (limitedResponse is not null)
+                {
+                    responses.Add(limitedResponse);
+                    retainedItemCount += GetValueCount(limitedResponse.ValuesByTopic);
+                    retainedByteCount += GetValueByteCount(limitedResponse.ValuesByTopic);
+                }
+
+                if (roundLimitReached)
+                {
+                    return responses;
+                }
             }
-
-            DisseminationInstruments.OnAntiEntropyExchange(
-                "out",
-                GetDigestCount(request.DigestsByTopic),
-                GetValueCount(response.ValuesByTopic),
-                response.Truncated);
-            responses.Add(response);
         }
 
         return responses;
@@ -248,6 +284,7 @@ internal sealed partial class DisseminationProtocol(
         DisseminationAntiEntropyRequest request,
         CancellationToken cancellationToken)
     {
+        RecordCompatiblePeer(request.Sender, request.DigestsByTopic.Keys);
         if (!_options.CurrentValue.Enabled)
         {
             return CreateAntiEntropyResponse(ImmutableDictionary<string, ImmutableArray<DisseminationValue>>.Empty, truncated: false);
@@ -366,12 +403,75 @@ internal sealed partial class DisseminationProtocol(
 
     internal async Task FlushPendingGossip(CancellationToken cancellationToken)
     {
-        var batches = DrainPendingGossip(force: true);
-        CancelScheduledGossipFlushDelay();
-        await SendGossipBatches(batches, cancellationToken);
+        await _gossipFlushLock.WaitAsync(cancellationToken);
+        try
+        {
+            var batches = DrainPendingGossip(force: true);
+            CancelScheduledGossipFlushDelay();
+            await SendGossipBatches(batches, cancellationToken);
+        }
+        finally
+        {
+            _gossipFlushLock.Release();
+        }
     }
 
-    private void EnqueueGossip(SiloAddress peer, DisseminationValue item, IDisseminationTopic topic)
+    internal IReadOnlyList<SiloAddress> GetUnconfirmedPeers(
+        string topicName,
+        DisseminationMembershipScope membershipScope,
+        IReadOnlyCollection<SiloAddress>? candidates = null)
+    {
+        var membership = _transport.GetMembership();
+        var participants = membershipScope == DisseminationMembershipScope.ActiveMembers
+            ? membership.ActiveMembers
+            : membership.AllMembers;
+        var participantSet = participants.ToHashSet();
+        var now = _timeProvider.GetUtcNow();
+        var confirmationTtl = GetPeerTopicConfirmationTtl(topicName);
+        lock (_peerCompatibilityLock)
+        {
+            foreach (var peer in _confirmedPeerTopics.Keys.Where(peer => !participantSet.Contains(peer)).ToArray())
+            {
+                _confirmedPeerTopics.Remove(peer);
+            }
+
+            return participants
+                .Where(peer => !Equals(peer, _transport.LocalSilo)
+                    && (candidates is null || candidates.Contains(peer))
+                    && (!_confirmedPeerTopics.TryGetValue(peer, out var topics)
+                        || !topics.TryGetValue(topicName, out var confirmedAt)
+                        || now - confirmedAt >= confirmationTtl))
+                .ToArray();
+        }
+    }
+
+    internal async Task StopAsync(CancellationToken cancellationToken)
+    {
+        Task? scheduledFlush;
+        lock (_gossipQueueLock)
+        {
+            _stopping = true;
+            _gossipFlushWakeup?.Cancel();
+            scheduledFlush = _gossipFlushTask;
+        }
+
+        using var cancellationRegistration = cancellationToken.Register(static state => ((CancellationTokenSource)state!).Cancel(), _gossipSendCts);
+        try
+        {
+            if (scheduledFlush is not null)
+            {
+                await scheduledFlush.WaitAsync(cancellationToken);
+            }
+
+            await FlushPendingGossip(cancellationToken);
+        }
+        finally
+        {
+            _gossipSendCts.Cancel();
+        }
+    }
+
+    private bool EnqueueGossip(SiloAddress peer, DisseminationValue item, IDisseminationTopic topic)
     {
         var now = _timeProvider.GetUtcNow();
         var key = new DigestKey(topic.Name, item.Digest.Key);
@@ -385,14 +485,23 @@ internal sealed partial class DisseminationProtocol(
             else if (pending.TryGetValue(key, out var existing)
                 && topic.CompareVersion(existing.Digest, item.Digest) >= 0)
             {
-                return;
+                return true;
             }
             else if (now + topic.Options.MaxCoalescingDelay < pending.FlushAfter)
             {
                 pending.FlushAfter = now + topic.Options.MaxCoalescingDelay;
             }
 
-            pending.AddOrReplace(key, item);
+            if (!pending.TryAddOrReplace(
+                key,
+                item,
+                topic.Options.MaxPendingItemCount,
+                _options.CurrentValue.MaxBatchItems,
+                _options.CurrentValue.MaxBatchBytes))
+            {
+                return false;
+            }
+
             if (pending.Count >= _options.CurrentValue.MaxBatchItems
                 || pending.ByteCount >= _options.CurrentValue.MaxBatchBytes
                 || pending.GetTopicCount(topic.Name) >= topic.Options.MaxPendingItemCount)
@@ -402,14 +511,19 @@ internal sealed partial class DisseminationProtocol(
         }
 
         ScheduleGossipFlush();
+        return true;
     }
 
     private void ScheduleGossipFlush()
     {
-        var startFlushLoop = false;
         lock (_gossipQueueLock)
         {
             if (_pendingGossip.Count == 0)
+            {
+                return;
+            }
+
+            if (_stopping)
             {
                 return;
             }
@@ -419,18 +533,13 @@ internal sealed partial class DisseminationProtocol(
             {
                 _gossipFlushScheduled = true;
                 _nextGossipFlushAt = next;
-                startFlushLoop = true;
+                _gossipFlushTask = Task.Run(RunScheduledGossipFlush);
             }
             else if (_nextGossipFlushAt is null || next < _nextGossipFlushAt.Value)
             {
                 _nextGossipFlushAt = next;
                 _gossipFlushWakeup?.Cancel();
             }
-        }
-
-        if (startFlushLoop)
-        {
-            _ = Task.Run(RunScheduledGossipFlush);
         }
     }
 
@@ -454,13 +563,32 @@ internal sealed partial class DisseminationProtocol(
                     }
                     catch (OperationCanceledException) when (wakeupToken.IsCancellationRequested)
                     {
+                        lock (_gossipQueueLock)
+                        {
+                            if (_stopping)
+                            {
+                                return;
+                            }
+                        }
+
                         continue;
                     }
                 }
 
-                var batches = DrainPendingGossip(force: false);
-                await SendGossipBatches(batches, CancellationToken.None);
+                await _gossipFlushLock.WaitAsync(_gossipSendCts.Token);
+                try
+                {
+                    var batches = DrainPendingGossip(force: false);
+                    await SendGossipBatches(batches, _gossipSendCts.Token);
+                }
+                finally
+                {
+                    _gossipFlushLock.Release();
+                }
             }
+        }
+        catch (OperationCanceledException) when (_gossipSendCts.IsCancellationRequested)
+        {
         }
         catch (Exception exception)
         {
@@ -474,7 +602,8 @@ internal sealed partial class DisseminationProtocol(
                 _gossipFlushScheduled = false;
                 _nextGossipFlushAt = null;
                 DisposeGossipFlushWakeupUnsafe();
-                reschedule = _pendingGossip.Count > 0;
+                _gossipFlushTask = null;
+                reschedule = !_stopping && _pendingGossip.Count > 0;
             }
 
             if (reschedule)
@@ -488,7 +617,7 @@ internal sealed partial class DisseminationProtocol(
     {
         lock (_gossipQueueLock)
         {
-            if (_pendingGossip.Count == 0)
+            if (_stopping || _pendingGossip.Count == 0)
             {
                 _nextGossipFlushAt = null;
                 DisposeGossipFlushWakeupUnsafe();
@@ -507,7 +636,7 @@ internal sealed partial class DisseminationProtocol(
             }
 
             DisposeGossipFlushWakeupUnsafe();
-            _gossipFlushWakeup = new CancellationTokenSource();
+            _gossipFlushWakeup = CancellationTokenSource.CreateLinkedTokenSource(_gossipSendCts.Token);
             wakeupToken = _gossipFlushWakeup.Token;
             return next - now;
         }
@@ -579,13 +708,18 @@ internal sealed partial class DisseminationProtocol(
         var byteCount = 0;
         foreach (var group in valuesByTopic)
         {
-            if (!TryGetEnabledTopic(group.Topic, out _))
+            if (!TryGetEnabledTopic(group.Topic, out var topic))
             {
                 continue;
             }
 
             foreach (var item in group.Values)
             {
+                if (IsExpired(item) || topic.IsObsolete(item.Digest))
+                {
+                    continue;
+                }
+
                 if (itemCount > 0
                     && (itemCount >= _options.CurrentValue.MaxBatchItems
                         || byteCount + item.Payload.Length > _options.CurrentValue.MaxBatchBytes))
@@ -640,6 +774,7 @@ internal sealed partial class DisseminationProtocol(
         try
         {
             await send(peer);
+            cancellationToken.ThrowIfCancellationRequested();
             ClearPeerBackoff(peer);
             return true;
         }
@@ -669,6 +804,7 @@ internal sealed partial class DisseminationProtocol(
         try
         {
             var response = await request(peer);
+            cancellationToken.ThrowIfCancellationRequested();
             ClearPeerBackoff(peer);
             return response;
         }
@@ -1185,6 +1321,163 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
+    private void RecordCompatiblePeer(SiloAddress peer, IEnumerable<string> topics)
+    {
+        if (Equals(peer, _transport.LocalSilo))
+        {
+            return;
+        }
+
+        lock (_peerCompatibilityLock)
+        {
+            if (!_confirmedPeerTopics.TryGetValue(peer, out var confirmedTopics))
+            {
+                confirmedTopics = new Dictionary<string, DateTimeOffset>(StringComparer.Ordinal);
+                _confirmedPeerTopics.Add(peer, confirmedTopics);
+            }
+
+            var now = _timeProvider.GetUtcNow();
+            foreach (var topic in topics)
+            {
+                confirmedTopics[topic] = now;
+            }
+        }
+    }
+
+    private void SetCompatiblePeerTopics(SiloAddress peer, IEnumerable<string> topics)
+    {
+        if (Equals(peer, _transport.LocalSilo))
+        {
+            return;
+        }
+
+        lock (_peerCompatibilityLock)
+        {
+            var confirmedTopics = new Dictionary<string, DateTimeOffset>(StringComparer.Ordinal);
+            var now = _timeProvider.GetUtcNow();
+            foreach (var topic in topics)
+            {
+                confirmedTopics[topic] = now;
+            }
+
+            if (confirmedTopics.Count == 0)
+            {
+                _confirmedPeerTopics.Remove(peer);
+            }
+            else
+            {
+                _confirmedPeerTopics[peer] = confirmedTopics;
+            }
+        }
+    }
+
+    private TimeSpan GetPeerTopicConfirmationTtl(string topicName)
+    {
+        var antiEntropyInterval = _options.CurrentValue.Overlay.AntiEntropyInterval;
+        var expectedUpdateCadence = _topics.TryGetValue(topicName, out var topic)
+            ? topic.Options.ExpectedUpdateCadence
+            : antiEntropyInterval;
+        return antiEntropyInterval >= expectedUpdateCadence
+            ? antiEntropyInterval + antiEntropyInterval
+            : expectedUpdateCadence + expectedUpdateCadence;
+    }
+
+    private IEnumerable<ImmutableDictionary<string, ImmutableArray<DisseminationTopicDigest>>> CreateAntiEntropyRequests(
+        Dictionary<string, ImmutableArray<DisseminationTopicDigest>> digestsByTopic)
+    {
+        var options = _options.CurrentValue;
+        var result = new Dictionary<string, ImmutableArray<DisseminationTopicDigest>.Builder>(StringComparer.Ordinal);
+        var itemCount = 0;
+        var byteCount = 0;
+        foreach (var (topic, digests) in digestsByTopic.OrderBy(static entry => entry.Key, StringComparer.Ordinal))
+        {
+            foreach (var digest in digests)
+            {
+                var digestSize = sizeof(long) + Encoding.UTF8.GetByteCount(topic) + Encoding.UTF8.GetByteCount(digest.Key);
+                if (digestSize > options.MaxBatchBytes)
+                {
+                    continue;
+                }
+
+                if (itemCount > 0
+                    && (itemCount >= options.MaxBatchItems || byteCount + digestSize > options.MaxBatchBytes))
+                {
+                    yield return CreateDigestGroups(result);
+                    result.Clear();
+                    itemCount = 0;
+                    byteCount = 0;
+                }
+
+                if (!result.TryGetValue(topic, out var topicDigests))
+                {
+                    topicDigests = ImmutableArray.CreateBuilder<DisseminationTopicDigest>();
+                    result.Add(topic, topicDigests);
+                }
+
+                topicDigests.Add(digest);
+                itemCount++;
+                byteCount += digestSize;
+            }
+        }
+
+        if (itemCount > 0)
+        {
+            yield return CreateDigestGroups(result);
+        }
+    }
+
+    private static ImmutableDictionary<string, ImmutableArray<DisseminationTopicDigest>> CreateDigestGroups(
+        Dictionary<string, ImmutableArray<DisseminationTopicDigest>.Builder> result) =>
+        result.ToImmutableDictionary(
+            static pair => pair.Key,
+            static pair => pair.Value.ToImmutable(),
+            StringComparer.Ordinal);
+
+    private static DisseminationAntiEntropyResponse? LimitAntiEntropyResponse(
+        DisseminationAntiEntropyResponse response,
+        int remainingItems,
+        int remainingBytes,
+        out bool roundLimitReached)
+    {
+        var values = new Dictionary<string, ImmutableArray<DisseminationValue>.Builder>(StringComparer.Ordinal);
+        var itemCount = 0;
+        var byteCount = 0;
+        roundLimitReached = false;
+        foreach (var (topic, topicValues) in response.ValuesByTopic.OrderBy(static entry => entry.Key, StringComparer.Ordinal))
+        {
+            foreach (var value in topicValues)
+            {
+                if (itemCount >= remainingItems || byteCount + value.Payload.Length > remainingBytes)
+                {
+                    roundLimitReached = true;
+                    break;
+                }
+
+                AddToValueGroups(values, topic, value);
+                itemCount++;
+                byteCount += value.Payload.Length;
+            }
+
+            if (roundLimitReached)
+            {
+                break;
+            }
+        }
+
+        if (itemCount == 0)
+        {
+            return null;
+        }
+
+        return new DisseminationAntiEntropyResponse
+        {
+            Sender = response.Sender,
+            ValuesByTopic = CreateValueGroups(values),
+            Truncated = response.Truncated || roundLimitReached,
+            SupportedTopics = response.SupportedTopics,
+        };
+    }
+
     private void SetPeerBackoff(SiloAddress peer)
     {
         lock (_failureLock)
@@ -1206,6 +1499,9 @@ internal sealed partial class DisseminationProtocol(
         Sender = _transport.LocalSilo,
         ValuesByTopic = valuesByTopic,
         Truncated = truncated,
+        SupportedTopics = _options.CurrentValue.Enabled
+            ? [.. _topics.Values.Where(static topic => topic.IsEnabled).Select(static topic => topic.Name).Order(StringComparer.Ordinal)]
+            : [],
     };
 
     private static int GetDigestCount(ImmutableDictionary<string, ImmutableArray<DisseminationTopicDigest>> digestsByTopic)
@@ -1225,6 +1521,20 @@ internal sealed partial class DisseminationProtocol(
         foreach (var values in valuesByTopic.Values)
         {
             result += values.Length;
+        }
+
+        return result;
+    }
+
+    private static int GetValueByteCount(ImmutableDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic)
+    {
+        var result = 0;
+        foreach (var values in valuesByTopic.Values)
+        {
+            foreach (var value in values)
+            {
+                result += value.Payload.Length;
+            }
         }
 
         return result;
@@ -1300,25 +1610,47 @@ internal sealed partial class DisseminationProtocol(
             return false;
         }
 
-        public void AddOrReplace(DigestKey key, DisseminationValue value)
+        public bool TryAddOrReplace(
+            DigestKey key,
+            DisseminationValue value,
+            int maxTopicItems,
+            int maxItems,
+            int maxBytes)
         {
             if (!_valuesByTopic.TryGetValue(key.Topic, out var topicValues))
             {
                 topicValues = new Dictionary<string, DisseminationValue>(StringComparer.Ordinal);
-                _valuesByTopic.Add(key.Topic, topicValues);
             }
 
             if (topicValues.TryGetValue(key.Key, out var previous))
             {
+                if (ByteCount - previous.Payload.Length + value.Payload.Length > maxBytes)
+                {
+                    return false;
+                }
+
                 ByteCount -= previous.Payload.Length;
             }
             else
             {
+                if (topicValues.Count >= maxTopicItems
+                    || Count >= maxItems
+                    || ByteCount + value.Payload.Length > maxBytes)
+                {
+                    return false;
+                }
+
+                if (topicValues.Count == 0)
+                {
+                    _valuesByTopic.Add(key.Topic, topicValues);
+                }
+
                 Count++;
             }
 
             topicValues[key.Key] = value;
             ByteCount += value.Payload.Length;
+            return true;
         }
 
         public ImmutableArray<PendingTopicValues> ToImmutableValuesByTopic()

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -93,10 +93,7 @@ internal sealed partial class DisseminationProtocol(
 
             foreach (var item in values)
             {
-                if (string.Equals(item.Digest.Topic, topicName, StringComparison.Ordinal))
-                {
-                    await ApplyReceivedValue(topicName, topic, item, batch.Sender, forward: true, cancellationToken);
-                }
+                await ApplyReceivedValue(topicName, topic, item, batch.Sender, forward: true, cancellationToken);
             }
         }
     }
@@ -230,11 +227,6 @@ internal sealed partial class DisseminationProtocol(
 
                 foreach (var item in values)
                 {
-                    if (!string.Equals(item.Digest.Topic, topicName, StringComparison.Ordinal))
-                    {
-                        continue;
-                    }
-
                     try
                     {
                         await ApplyReceivedValue(topicName, topic, item, response.Sender, forward: false, cancellationToken);
@@ -262,7 +254,7 @@ internal sealed partial class DisseminationProtocol(
         }
 
         var requestDigestCount = GetDigestCount(request.DigestsByTopic);
-        var values = new List<DisseminationValue>();
+        var values = new List<TopicValue>();
         var byteCount = 0;
         var truncated = false;
         var options = _options.CurrentValue;
@@ -287,7 +279,7 @@ internal sealed partial class DisseminationProtocol(
                     continue;
                 }
 
-                var localDigest = new DisseminationDigest(requestedTopic.Name, topicDigest.Key, topicDigest.Version);
+                var localDigest = topicDigest;
                 if (requestedTopic.CompareVersion(localDigest, remoteDigest) <= 0)
                 {
                     continue;
@@ -298,7 +290,6 @@ internal sealed partial class DisseminationProtocol(
                     remoteDigest,
                     cancellationToken);
                 if (item is null
-                    || !string.Equals(item.Digest.Topic, requestedTopic.Name, StringComparison.Ordinal)
                     || !ValidatePayloadSize(requestedTopic.Name, requestedTopic, item))
                 {
                     continue;
@@ -310,7 +301,7 @@ internal sealed partial class DisseminationProtocol(
                     break;
                 }
 
-                values.Add(item);
+                values.Add(new TopicValue(requestedTopic.Name, item));
                 byteCount += item.Payload.Length;
             }
 
@@ -532,10 +523,10 @@ internal sealed partial class DisseminationProtocol(
 
     private DateTimeOffset GetNextPendingGossipFlushUnsafe() => _pendingGossip.Values.Min(static pending => pending.FlushAfter);
 
-    private List<(SiloAddress Peer, ImmutableArray<DisseminationValue> Values)> DrainPendingGossip(bool force)
+    private List<(SiloAddress Peer, ImmutableArray<TopicValue> Values)> DrainPendingGossip(bool force)
     {
         var now = _timeProvider.GetUtcNow();
-        var result = new List<(SiloAddress Peer, ImmutableArray<DisseminationValue> Values)>();
+        var result = new List<(SiloAddress Peer, ImmutableArray<TopicValue> Values)>();
         lock (_gossipQueueLock)
         {
             foreach (var (peer, pending) in _pendingGossip)
@@ -546,7 +537,7 @@ internal sealed partial class DisseminationProtocol(
                 }
 
                 _pendingGossip.Remove(peer);
-                result.Add((peer, [.. pending.Values.Values]));
+                result.Add((peer, [.. pending.Values.Select(static item => new TopicValue(item.Key.Topic, item.Value))]));
             }
         }
 
@@ -554,7 +545,7 @@ internal sealed partial class DisseminationProtocol(
         return result;
     }
 
-    private async Task SendGossipBatches(List<(SiloAddress Peer, ImmutableArray<DisseminationValue> Values)> batches, CancellationToken cancellationToken)
+    private async Task SendGossipBatches(List<(SiloAddress Peer, ImmutableArray<TopicValue> Values)> batches, CancellationToken cancellationToken)
     {
         foreach (var queued in batches)
         {
@@ -562,20 +553,20 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private async Task SendGossipBatch(SiloAddress peer, IReadOnlyList<DisseminationValue> values, CancellationToken cancellationToken)
+    private async Task SendGossipBatch(SiloAddress peer, IReadOnlyList<TopicValue> values, CancellationToken cancellationToken)
     {
-        var currentBatch = new List<DisseminationValue>();
+        var currentBatch = new List<TopicValue>();
         var byteCount = 0;
         foreach (var item in values)
         {
-            if (!TryGetEnabledTopic(item.Digest.Topic, out var topic))
+            if (!TryGetEnabledTopic(item.Topic, out var topic))
             {
                 continue;
             }
 
             if (currentBatch.Count > 0
                 && (currentBatch.Count >= _options.CurrentValue.MaxBatchItems
-                    || byteCount + item.Payload.Length > _options.CurrentValue.MaxBatchBytes))
+                    || byteCount + item.Value.Payload.Length > _options.CurrentValue.MaxBatchBytes))
             {
                 await SendGossipBatchCore(peer, [.. currentBatch], cancellationToken);
                 currentBatch.Clear();
@@ -583,7 +574,7 @@ internal sealed partial class DisseminationProtocol(
             }
 
             currentBatch.Add(item);
-            byteCount += item.Payload.Length;
+            byteCount += item.Value.Payload.Length;
         }
 
         if (currentBatch.Count > 0)
@@ -592,7 +583,7 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private async Task SendGossipBatchCore(SiloAddress peer, ImmutableArray<DisseminationValue> values, CancellationToken cancellationToken)
+    private async Task SendGossipBatchCore(SiloAddress peer, ImmutableArray<TopicValue> values, CancellationToken cancellationToken)
     {
         var batch = new DisseminationGossipBatch
         {
@@ -665,17 +656,16 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private Dictionary<string, DisseminationDigest> GetRemoteDigestMap(
+    private Dictionary<string, DisseminationTopicDigest> GetRemoteDigestMap(
         IDisseminationTopic topic,
         ImmutableArray<DisseminationTopicDigest> digests)
     {
-        var result = new Dictionary<string, DisseminationDigest>(digests.Length, StringComparer.Ordinal);
+        var result = new Dictionary<string, DisseminationTopicDigest>(digests.Length, StringComparer.Ordinal);
         foreach (var topicDigest in digests)
         {
-            var digest = new DisseminationDigest(topic.Name, topicDigest.Key, topicDigest.Version);
-            if (!result.TryGetValue(topicDigest.Key, out var existing) || topic.CompareVersion(digest, existing) > 0)
+            if (!result.TryGetValue(topicDigest.Key, out var existing) || topic.CompareVersion(topicDigest, existing) > 0)
             {
-                result[topicDigest.Key] = digest;
+                result[topicDigest.Key] = topicDigest;
             }
         }
 
@@ -691,7 +681,7 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private void RecordRecentUpdate(string topicName, DisseminationDigest digest)
+    private void RecordRecentUpdate(string topicName, DisseminationTopicDigest digest)
     {
         var key = new DigestKey(topicName, digest.Key);
         lock (_recentUpdateLock)
@@ -1124,11 +1114,6 @@ internal sealed partial class DisseminationProtocol(
 
     private string? GetPublishValidationFailureReason(IDisseminationTopic topic, DisseminationValue item)
     {
-        if (!string.Equals(item.Digest.Topic, topic.Name, StringComparison.Ordinal))
-        {
-            return "topic";
-        }
-
         if (IsExpired(item))
         {
             return "expired";
@@ -1217,15 +1202,15 @@ internal sealed partial class DisseminationProtocol(
         return result;
     }
 
-    private static FrozenDictionary<string, ImmutableArray<DisseminationValue>> GroupValuesByTopic(IReadOnlyList<DisseminationValue> values)
+    private static FrozenDictionary<string, ImmutableArray<DisseminationValue>> GroupValuesByTopic(IReadOnlyList<TopicValue> values)
     {
         var result = new Dictionary<string, ImmutableArray<DisseminationValue>.Builder>(StringComparer.Ordinal);
-        foreach (var value in values)
+        foreach (var (topic, value) in values)
         {
-            if (!result.TryGetValue(value.Digest.Topic, out var topicValues))
+            if (!result.TryGetValue(topic, out var topicValues))
             {
                 topicValues = ImmutableArray.CreateBuilder<DisseminationValue>();
-                result.Add(value.Digest.Topic, topicValues);
+                result.Add(topic, topicValues);
             }
 
             topicValues.Add(value);
@@ -1247,6 +1232,8 @@ internal sealed partial class DisseminationProtocol(
         ImmutableArray<DisseminationTopicDigest> Digests);
 
     private readonly record struct DigestKey(string Topic, string Key);
+
+    private readonly record struct TopicValue(string Topic, DisseminationValue Value);
 
     private sealed class PendingGossipBatch(DateTimeOffset flushAfter)
     {

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -516,7 +516,6 @@ internal sealed partial class DisseminationProtocol(
         var result = new List<(SiloAddress Peer, ImmutableArray<DisseminationValue> Values)>();
         lock (_gossipQueueLock)
         {
-            List<SiloAddress>? drainedPeers = null;
             foreach (var (peer, pending) in _pendingGossip)
             {
                 if (!force && pending.FlushAfter > now)
@@ -524,16 +523,8 @@ internal sealed partial class DisseminationProtocol(
                     continue;
                 }
 
-                (drainedPeers ??= []).Add(peer);
+                _pendingGossip.Remove(peer);
                 result.Add((peer, [.. pending.Values.Values]));
-            }
-
-            if (drainedPeers is not null)
-            {
-                foreach (var peer in drainedPeers)
-                {
-                    _pendingGossip.Remove(peer);
-                }
             }
         }
 
@@ -681,23 +672,12 @@ internal sealed partial class DisseminationProtocol(
     {
         lock (_recentUpdateLock)
         {
-            List<DigestKey>? staleKeys = null;
             foreach (var key in _lastUpdateReceivedAt.Keys)
             {
                 if (!currentValueStreams.Contains(key))
                 {
-                    (staleKeys ??= []).Add(key);
+                    _lastUpdateReceivedAt.Remove(key);
                 }
-            }
-
-            if (staleKeys is null)
-            {
-                return;
-            }
-
-            foreach (var key in staleKeys)
-            {
-                _lastUpdateReceivedAt.Remove(key);
             }
         }
     }
@@ -939,23 +919,11 @@ internal sealed partial class DisseminationProtocol(
 
         lock (_failureLock)
         {
-            if (_failureBackoffUntil.Count > 0)
+            foreach (var (peer, until) in _failureBackoffUntil)
             {
-                List<SiloAddress>? peersToRemove = null;
-                foreach (var (peer, until) in _failureBackoffUntil)
+                if (until <= now || !IsCurrentParticipant(peer))
                 {
-                    if (until <= now || !IsCurrentParticipant(peer))
-                    {
-                        (peersToRemove ??= []).Add(peer);
-                    }
-                }
-
-                if (peersToRemove is not null)
-                {
-                    foreach (var peer in peersToRemove)
-                    {
-                        _failureBackoffUntil.Remove(peer);
-                    }
+                    _failureBackoffUntil.Remove(peer);
                 }
             }
         }
@@ -964,18 +932,9 @@ internal sealed partial class DisseminationProtocol(
         {
             if (_pendingGossip.Count > 0)
             {
-                List<SiloAddress>? peersToRemove = null;
                 foreach (var peer in _pendingGossip.Keys)
                 {
                     if (!IsCurrentParticipant(peer))
-                    {
-                        (peersToRemove ??= []).Add(peer);
-                    }
-                }
-
-                if (peersToRemove is not null)
-                {
-                    foreach (var peer in peersToRemove)
                     {
                         _pendingGossip.Remove(peer);
                     }

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -29,7 +29,7 @@ internal sealed partial class DisseminationProtocol(
     private readonly object _recentUpdateLock = new();
     private readonly object _topologyLock = new();
     private readonly Dictionary<SiloAddress, PendingGossipBatch> _pendingGossip = [];
-    private readonly Dictionary<ValueStreamKey, DateTimeOffset> _lastUpdateReceivedAt = [];
+    private readonly Dictionary<DigestKey, DateTimeOffset> _lastUpdateReceivedAt = [];
     private DateTimeOffset? _nextGossipFlushAt;
     private CancellationTokenSource? _gossipFlushWakeup;
     private bool _gossipFlushScheduled;
@@ -100,7 +100,7 @@ internal sealed partial class DisseminationProtocol(
         var digests = new List<DisseminationDigest>();
         var topics = new List<string>();
         var topicNames = new HashSet<string>(StringComparer.Ordinal);
-        var currentValueStreams = new HashSet<ValueStreamKey>();
+        var currentValueStreams = new HashSet<DigestKey>();
         var now = _timeProvider.GetUtcNow();
         foreach (var topic in _topics.Values)
         {
@@ -113,7 +113,7 @@ internal sealed partial class DisseminationProtocol(
             {
                 if (string.Equals(digest.Topic, topic.Name, StringComparison.Ordinal))
                 {
-                    currentValueStreams.Add(GetValueStreamKey(digest));
+                    currentValueStreams.Add(GetDigestKey(digest));
                     if (ShouldRequestAntiEntropy(topic, digest, now))
                     {
                         digests.Add(digest);
@@ -660,7 +660,7 @@ internal sealed partial class DisseminationProtocol(
 
     private bool ShouldRequestAntiEntropy(IDisseminationTopic topic, DisseminationDigest digest, DateTimeOffset now)
     {
-        var key = GetValueStreamKey(digest);
+        var key = GetDigestKey(digest);
         lock (_recentUpdateLock)
         {
             return !_lastUpdateReceivedAt.TryGetValue(key, out var lastReceived)
@@ -670,18 +670,18 @@ internal sealed partial class DisseminationProtocol(
 
     private void RecordRecentUpdate(DisseminationDigest digest)
     {
-        var key = GetValueStreamKey(digest);
+        var key = GetDigestKey(digest);
         lock (_recentUpdateLock)
         {
             _lastUpdateReceivedAt[key] = _timeProvider.GetUtcNow();
         }
     }
 
-    private void PruneRecentUpdates(HashSet<ValueStreamKey> currentValueStreams)
+    private void PruneRecentUpdates(HashSet<DigestKey> currentValueStreams)
     {
         lock (_recentUpdateLock)
         {
-            List<ValueStreamKey>? staleKeys = null;
+            List<DigestKey>? staleKeys = null;
             foreach (var key in _lastUpdateReceivedAt.Keys)
             {
                 if (!currentValueStreams.Contains(key))
@@ -1207,8 +1207,6 @@ internal sealed partial class DisseminationProtocol(
 
     private static DigestKey GetDigestKey(DisseminationDigest digest) => new(digest.Topic, digest.Key);
 
-    private static ValueStreamKey GetValueStreamKey(DisseminationDigest digest) => new(digest.Topic, digest.Key);
-
     public sealed record AntiEntropyState(
         FrozenDictionary<string, ImmutableArray<SiloAddress>> PeersByTopic,
         IReadOnlyList<string> Topics,
@@ -1221,8 +1219,6 @@ internal sealed partial class DisseminationProtocol(
     }
 
     private readonly record struct DigestKey(string Topic, string Key);
-
-    private readonly record struct ValueStreamKey(string Topic, string Key);
 
     private sealed class PendingGossipBatch(DateTimeOffset flushAfter)
     {

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -52,18 +52,21 @@ internal sealed partial class DisseminationProtocol(
 
         if (GetPublishValidationFailureReason(topic, item) is { } reason)
         {
-            await topic.OnFallbackRequired(default!, item.Digest, cancellationToken);
+            await topic.OnFallbackRequired(peer: null, item.Digest, cancellationToken);
             DisseminationInstruments.OnFallback(item.Digest.Topic, reason);
             return false;
         }
 
-        var root = item.Root is not null ? item.Root : _transport.LocalSilo;
-        item = EnsureRoot(item, root);
-        RecordRecentUpdate(item.Digest);
+        var root = item.Root;
         var topology = targetPeers is { Count: > 0 }
             ? BuildParticipantTopology(targetPeers, root, includeLocal: true)
-            : GetParticipantTopology(topic.MembershipScope, root, includeLocal: true);
+            : GetParticipantTopology(topic.MembershipScope);
+        if (!await EnsureRootParticipates(topology, root, cancellationToken))
+        {
+            return false;
+        }
 
+        RecordRecentUpdate(item.Digest);
         foreach (var peer in GetOriginatorTreeTargets(topology, root))
         {
             EnqueueGossip(peer, item);
@@ -106,8 +109,7 @@ internal sealed partial class DisseminationProtocol(
 
             foreach (var digest in topic.GetDigests())
             {
-                if (string.Equals(digest.Topic, topic.Name, StringComparison.Ordinal)
-                    && topic.PayloadKinds.Contains(digest.PayloadKind))
+                if (string.Equals(digest.Topic, topic.Name, StringComparison.Ordinal))
                 {
                     currentValueStreams.Add(GetValueStreamKey(digest));
                     if (ShouldRequestAntiEntropy(topic, digest, now))
@@ -243,7 +245,7 @@ internal sealed partial class DisseminationProtocol(
                     remoteDigest,
                     cancellationToken);
                 if (item is null
-                    || !requestedTopic.Topic.PayloadKinds.Contains(item.Digest.PayloadKind)
+                    || !string.Equals(item.Digest.Topic, requestedTopic.Topic.Name, StringComparison.Ordinal)
                     || !ValidatePayloadSize(requestedTopic.Topic, item))
                 {
                     continue;
@@ -281,12 +283,6 @@ internal sealed partial class DisseminationProtocol(
             return DisseminationApplyResult.Rejected;
         }
 
-        if (!topic.PayloadKinds.Contains(value.Digest.PayloadKind))
-        {
-            EmitApplyResult(value, sender, DisseminationApplyResult.Rejected);
-            return DisseminationApplyResult.Rejected;
-        }
-
         if (!ValidatePayloadSize(topic, value))
         {
             return DisseminationApplyResult.Rejected;
@@ -313,17 +309,19 @@ internal sealed partial class DisseminationProtocol(
         return result;
     }
 
-    private Task Forward(DisseminationValue item, IDisseminationTopic topic, SiloAddress sender, CancellationToken cancellationToken)
+    private async Task Forward(DisseminationValue item, IDisseminationTopic topic, SiloAddress sender, CancellationToken cancellationToken)
     {
-        var root = item.Root is not null ? item.Root : sender;
-        item = EnsureRoot(item, root);
-        var topology = GetParticipantTopology(topic.MembershipScope, root, includeLocal: true);
+        var root = item.Root;
+        var topology = GetParticipantTopology(topic.MembershipScope);
+        if (!await EnsureRootParticipates(topology, root, cancellationToken))
+        {
+            return;
+        }
+
         foreach (var peer in GetForwardingTreeTargets(topology, root, sender))
         {
             EnqueueGossip(peer, item);
         }
-
-        return Task.CompletedTask;
     }
 
     internal async Task FlushPendingGossip(CancellationToken cancellationToken)
@@ -440,7 +438,7 @@ internal sealed partial class DisseminationProtocol(
             {
                 _gossipFlushScheduled = false;
                 _nextGossipFlushAt = null;
-                _gossipFlushWakeup = null;
+                DisposeGossipFlushWakeupUnsafe();
                 reschedule = _pendingGossip.Count > 0;
             }
 
@@ -458,7 +456,7 @@ internal sealed partial class DisseminationProtocol(
             if (_pendingGossip.Count == 0)
             {
                 _nextGossipFlushAt = null;
-                _gossipFlushWakeup = null;
+                DisposeGossipFlushWakeupUnsafe();
                 wakeupToken = CancellationToken.None;
                 return null;
             }
@@ -468,11 +466,12 @@ internal sealed partial class DisseminationProtocol(
             _nextGossipFlushAt = next;
             if (next <= now)
             {
-                _gossipFlushWakeup = null;
+                DisposeGossipFlushWakeupUnsafe();
                 wakeupToken = CancellationToken.None;
                 return TimeSpan.Zero;
             }
 
+            DisposeGossipFlushWakeupUnsafe();
             _gossipFlushWakeup = new CancellationTokenSource();
             wakeupToken = _gossipFlushWakeup.Token;
             return next - now;
@@ -505,7 +504,6 @@ internal sealed partial class DisseminationProtocol(
                 _pendingGossip.Remove(peer);
                 result.Add(new QueuedGossipBatch(peer, [.. pending.Values.Values
                     .OrderBy(static value => value.Digest.Topic, StringComparer.Ordinal)
-                    .ThenBy(static value => value.Digest.PayloadKind, StringComparer.Ordinal)
                     .ThenBy(static value => value.Digest.Key, StringComparer.Ordinal)]));
             }
         }
@@ -528,8 +526,7 @@ internal sealed partial class DisseminationProtocol(
         var byteCount = 0;
         foreach (var item in values)
         {
-            if (!TryGetEnabledTopic(item.Digest.Topic, out var topic)
-                || !topic.PayloadKinds.Contains(item.Digest.PayloadKind))
+            if (!TryGetEnabledTopic(item.Digest.Topic, out var topic))
             {
                 continue;
             }
@@ -712,7 +709,7 @@ internal sealed partial class DisseminationProtocol(
     private ImmutableArray<SiloAddress> SelectAntiEntropyPeers(string topicName, DisseminationMembershipScope membershipScope, long round)
     {
         var options = _options.CurrentValue.Overlay;
-        var topology = GetParticipantTopology(membershipScope, root: null, includeLocal: true);
+        var topology = GetParticipantTopology(membershipScope);
         var participants = topology.Participants;
         if (participants.Length <= 1)
         {
@@ -914,57 +911,90 @@ internal sealed partial class DisseminationProtocol(
         result.Add(peer);
     }
 
-    private ParticipantTopology GetParticipantTopology(
-        DisseminationMembershipScope membershipScope,
-        SiloAddress? root,
-        bool includeLocal)
+    private ParticipantTopology GetParticipantTopology(DisseminationMembershipScope membershipScope)
     {
         var membership = _transport.GetMembership();
-        var activeMembers = GetCachedParticipantTopology(
-            DisseminationMembershipScope.ActiveMembers,
-            membership.ActiveMembers,
-            membershipScope == DisseminationMembershipScope.ActiveMembers ? root : null,
-            includeLocal);
-        var allMembers = GetCachedParticipantTopology(
-            DisseminationMembershipScope.AllMembers,
-            membership.AllMembers,
-            membershipScope == DisseminationMembershipScope.AllMembers ? root : null,
-            includeLocal);
+        PrunePeerState(membership);
+        return membershipScope == DisseminationMembershipScope.AllMembers
+            ? GetCachedParticipantTopology(membership.AllMembers, ref _allMembersTopology)
+            : GetCachedParticipantTopology(membership.ActiveMembers, ref _activeMembersTopology);
+    }
 
-        return membershipScope == DisseminationMembershipScope.AllMembers ? allMembers : activeMembers;
+    private void PrunePeerState(DisseminationMembership membership)
+    {
+        HashSet<SiloAddress>? currentParticipants = null;
+        var now = _timeProvider.GetUtcNow();
+
+        lock (_failureLock)
+        {
+            if (_failureBackoffUntil.Count > 0)
+            {
+                foreach (var (peer, until) in _failureBackoffUntil.ToArray())
+                {
+                    if (until <= now || !IsCurrentParticipant(peer))
+                    {
+                        _failureBackoffUntil.Remove(peer);
+                    }
+                }
+            }
+        }
+
+        lock (_gossipQueueLock)
+        {
+            if (_pendingGossip.Count > 0)
+            {
+                foreach (var peer in _pendingGossip.Keys.ToArray())
+                {
+                    if (!IsCurrentParticipant(peer))
+                    {
+                        _pendingGossip.Remove(peer);
+                    }
+                }
+
+                if (_pendingGossip.Count == 0)
+                {
+                    _nextGossipFlushAt = null;
+                    _gossipFlushWakeup?.Cancel();
+                }
+            }
+        }
+
+        bool IsCurrentParticipant(SiloAddress peer)
+        {
+            currentParticipants ??= CreateCurrentParticipantSet();
+            return currentParticipants.Contains(peer);
+        }
+
+        HashSet<SiloAddress> CreateCurrentParticipantSet()
+        {
+            var result = new HashSet<SiloAddress>(membership.AllMembers);
+            result.UnionWith(membership.ActiveMembers);
+            result.Add(_transport.LocalSilo);
+            return result;
+        }
+    }
+
+    private void DisposeGossipFlushWakeupUnsafe()
+    {
+        _gossipFlushWakeup?.Dispose();
+        _gossipFlushWakeup = null;
     }
 
     private ParticipantTopology GetCachedParticipantTopology(
-        DisseminationMembershipScope membershipScope,
         IEnumerable<SiloAddress> participants,
-        SiloAddress? root,
-        bool includeLocal)
+        ref ParticipantTopology cachedTopology)
     {
-        var orderedParticipants = GetOrderedParticipants(participants, root, includeLocal, preserveOrder: true);
+        var orderedParticipants = GetOrderedParticipants(participants, root: null, includeLocal: true, preserveOrder: true);
 
         lock (_topologyLock)
         {
-            var current = membershipScope switch
+            if (cachedTopology.Participants.SequenceEqual(orderedParticipants))
             {
-                DisseminationMembershipScope.AllMembers => _allMembersTopology,
-                _ => _activeMembersTopology,
-            };
-
-            if (current.Participants.SequenceEqual(orderedParticipants))
-            {
-                return current;
+                return cachedTopology;
             }
 
             var updated = BuildParticipantTopology(orderedParticipants);
-            if (membershipScope == DisseminationMembershipScope.AllMembers)
-            {
-                _allMembersTopology = updated;
-            }
-            else
-            {
-                _activeMembersTopology = updated;
-            }
-
+            cachedTopology = updated;
             return updated;
         }
     }
@@ -1003,29 +1033,37 @@ internal sealed partial class DisseminationProtocol(
 
         void AddParticipant(SiloAddress participant)
         {
-            if (preserveOrder)
-            {
-                if (!orderedParticipants.Contains(participant))
-                {
-                    orderedParticipants.Add(participant);
-                }
-            }
-            else if (!orderedParticipants.Contains(participant))
+            if (!orderedParticipants.Contains(participant))
             {
                 orderedParticipants.Add(participant);
             }
         }
     }
 
-    private static ParticipantTopology BuildParticipantTopology(ImmutableArray<SiloAddress> sortedParticipants)
+    private static ParticipantTopology BuildParticipantTopology(ImmutableArray<SiloAddress> participants)
     {
-        var indices = new Dictionary<SiloAddress, int>(sortedParticipants.Length);
-        for (var i = 0; i < sortedParticipants.Length; i++)
+        var indices = new Dictionary<SiloAddress, int>(participants.Length);
+        for (var i = 0; i < participants.Length; i++)
         {
-            indices[sortedParticipants[i]] = i;
+            indices[participants[i]] = i;
         }
 
-        return new ParticipantTopology(sortedParticipants, indices.ToFrozenDictionary(), sortedParticipants.ToFrozenSet());
+        return new ParticipantTopology(participants, indices.ToFrozenDictionary());
+    }
+
+    private async ValueTask<bool> EnsureRootParticipates(
+        ParticipantTopology topology,
+        SiloAddress root,
+        CancellationToken cancellationToken)
+    {
+        if (topology.Indices.ContainsKey(root))
+        {
+            return true;
+        }
+
+        LogDebugDisseminationRootMissing(_logger, root);
+        await _transport.RefreshMembership(cancellationToken);
+        return false;
     }
 
     private bool TryGetEnabledTopic(string topicName, out IDisseminationTopic topic)
@@ -1061,11 +1099,6 @@ internal sealed partial class DisseminationProtocol(
             return "topic";
         }
 
-        if (!topic.PayloadKinds.Contains(item.Digest.PayloadKind))
-        {
-            return "payload-kind";
-        }
-
         if (IsExpired(item))
         {
             return "expired";
@@ -1086,7 +1119,18 @@ internal sealed partial class DisseminationProtocol(
         var now = _timeProvider.GetUtcNow();
         lock (_failureLock)
         {
-            return _failureBackoffUntil.TryGetValue(peer, out var until) && until > now;
+            if (!_failureBackoffUntil.TryGetValue(peer, out var until))
+            {
+                return false;
+            }
+
+            if (until > now)
+            {
+                return true;
+            }
+
+            _failureBackoffUntil.Remove(peer);
+            return false;
         }
     }
 
@@ -1119,25 +1163,13 @@ internal sealed partial class DisseminationProtocol(
         Truncated = truncated,
     };
 
-    private static DisseminationValue EnsureRoot(DisseminationValue item, SiloAddress root) =>
-        item.Root is not null
-            ? item
-            : new DisseminationValue
-            {
-                Digest = item.Digest,
-                Root = root,
-                ExpiresAt = item.ExpiresAt,
-                Payload = item.Payload,
-            };
-
     private static IEnumerable<DisseminationDigest> SortDigests(IEnumerable<DisseminationDigest> digests) =>
         digests
             .OrderBy(static digest => digest.Topic, StringComparer.Ordinal)
-            .ThenBy(static digest => digest.PayloadKind, StringComparer.Ordinal)
             .ThenBy(static digest => digest.Key, StringComparer.Ordinal)
             .ThenBy(static digest => digest.Version);
 
-    private static DigestKey GetDigestKey(DisseminationDigest digest) => new(digest.Topic, digest.Key, digest.PayloadKind);
+    private static DigestKey GetDigestKey(DisseminationDigest digest) => new(digest.Topic, digest.Key);
 
     private static ValueStreamKey GetValueStreamKey(DisseminationDigest digest) => new(digest.Topic, digest.Key);
 
@@ -1152,7 +1184,7 @@ internal sealed partial class DisseminationProtocol(
             []);
     }
 
-    private readonly record struct DigestKey(string Topic, string Key, string PayloadKind);
+    private readonly record struct DigestKey(string Topic, string Key);
 
     private readonly record struct ValueStreamKey(string Topic, string Key);
 
@@ -1182,13 +1214,11 @@ internal sealed partial class DisseminationProtocol(
 
     private sealed record ParticipantTopology(
         ImmutableArray<SiloAddress> Participants,
-        FrozenDictionary<SiloAddress, int> Indices,
-        FrozenSet<SiloAddress> ParticipantSet)
+        FrozenDictionary<SiloAddress, int> Indices)
     {
         public static readonly ParticipantTopology Empty = new(
             [],
-            FrozenDictionary<SiloAddress, int>.Empty,
-            FrozenSet<SiloAddress>.Empty);
+            FrozenDictionary<SiloAddress, int>.Empty);
     }
 
     [LoggerMessage(
@@ -1205,4 +1235,9 @@ internal sealed partial class DisseminationProtocol(
         Level = LogLevel.Debug,
         Message = "Dissemination gossip batch flush failed.")]
     private static partial void LogDebugGossipFlushFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Dissemination root {Root} is missing from local membership; refreshing membership and skipping routing.")]
+    private static partial void LogDebugDisseminationRootMissing(ILogger logger, SiloAddress root);
 }

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -53,7 +53,7 @@ internal sealed partial class DisseminationProtocol(
         if (GetPublishValidationFailureReason(topic, item) is { } reason)
         {
             await topic.OnFallbackRequired(peer: null, item.Digest, cancellationToken);
-            DisseminationInstruments.OnFallback(item.Digest.Topic, reason);
+            DisseminationInstruments.OnFallback(topic.Name, reason);
             return false;
         }
 
@@ -66,7 +66,7 @@ internal sealed partial class DisseminationProtocol(
             return false;
         }
 
-        RecordRecentUpdate(item.Digest);
+        RecordRecentUpdate(topic.Name, item.Digest);
         foreach (var peer in GetOriginatorTreeTargets(topology, root))
         {
             EnqueueGossip(peer, item, topic);
@@ -86,11 +86,16 @@ internal sealed partial class DisseminationProtocol(
 
         foreach (var (topicName, values) in batch.ValuesByTopic)
         {
+            if (!TryGetEnabledTopic(topicName, out var topic))
+            {
+                continue;
+            }
+
             foreach (var item in values)
             {
                 if (string.Equals(item.Digest.Topic, topicName, StringComparison.Ordinal))
                 {
-                    await ApplyReceivedValue(item, batch.Sender, forward: true, cancellationToken);
+                    await ApplyReceivedValue(topicName, topic, item, batch.Sender, forward: true, cancellationToken);
                 }
             }
         }
@@ -218,6 +223,11 @@ internal sealed partial class DisseminationProtocol(
         {
             foreach (var (topicName, values) in response.ValuesByTopic)
             {
+                if (!TryGetEnabledTopic(topicName, out var topic))
+                {
+                    continue;
+                }
+
                 foreach (var item in values)
                 {
                     if (!string.Equals(item.Digest.Topic, topicName, StringComparison.Ordinal))
@@ -227,7 +237,7 @@ internal sealed partial class DisseminationProtocol(
 
                     try
                     {
-                        await ApplyReceivedValue(item, response.Sender, forward: false, cancellationToken);
+                        await ApplyReceivedValue(topicName, topic, item, response.Sender, forward: false, cancellationToken);
                     }
                     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
@@ -235,7 +245,7 @@ internal sealed partial class DisseminationProtocol(
                     }
                     catch (Exception exception)
                     {
-                        LogDebugAntiEntropyRepairValueFailed(_logger, exception, response.Sender, item.Digest.Topic, item.Digest.Key, item.Digest.Version);
+                        LogDebugAntiEntropyRepairValueFailed(_logger, exception, response.Sender, topicName, item.Digest.Key, item.Digest.Version);
                     }
                 }
             }
@@ -289,7 +299,7 @@ internal sealed partial class DisseminationProtocol(
                     cancellationToken);
                 if (item is null
                     || !string.Equals(item.Digest.Topic, requestedTopic.Name, StringComparison.Ordinal)
-                    || !ValidatePayloadSize(requestedTopic, item))
+                    || !ValidatePayloadSize(requestedTopic.Name, requestedTopic, item))
                 {
                     continue;
                 }
@@ -315,33 +325,29 @@ internal sealed partial class DisseminationProtocol(
     }
 
     private async ValueTask<DisseminationApplyResult> ApplyReceivedValue(
+        string topicName,
+        IDisseminationTopic topic,
         DisseminationValue value,
         SiloAddress sender,
         bool forward,
         CancellationToken cancellationToken)
     {
-        if (!TryGetEnabledTopic(value.Digest.Topic, out var topic))
-        {
-            EmitApplyResult(value, sender, DisseminationApplyResult.Rejected);
-            return DisseminationApplyResult.Rejected;
-        }
-
-        if (!ValidatePayloadSize(topic, value))
+        if (!ValidatePayloadSize(topicName, topic, value))
         {
             return DisseminationApplyResult.Rejected;
         }
 
         if (IsExpired(value) || topic.IsObsolete(value.Digest))
         {
-            EmitApplyResult(value, sender, DisseminationApplyResult.Obsolete);
+            EmitApplyResult(topicName, value, sender, DisseminationApplyResult.Obsolete);
             return DisseminationApplyResult.Obsolete;
         }
 
         var result = await topic.ApplyValue(value, cancellationToken);
-        EmitApplyResult(value, sender, result);
+        EmitApplyResult(topicName, value, sender, result);
         if (result is DisseminationApplyResult.Applied or DisseminationApplyResult.Duplicate)
         {
-            RecordRecentUpdate(value.Digest);
+            RecordRecentUpdate(topicName, value.Digest);
         }
 
         if (result == DisseminationApplyResult.Applied && forward)
@@ -377,7 +383,7 @@ internal sealed partial class DisseminationProtocol(
     private void EnqueueGossip(SiloAddress peer, DisseminationValue item, IDisseminationTopic topic)
     {
         var now = _timeProvider.GetUtcNow();
-        var key = new DigestKey(item.Digest.Topic, item.Digest.Key);
+        var key = new DigestKey(topic.Name, item.Digest.Key);
         lock (_gossipQueueLock)
         {
             if (!_pendingGossip.TryGetValue(peer, out var pending))
@@ -398,7 +404,7 @@ internal sealed partial class DisseminationProtocol(
             pending.AddOrReplace(key, item);
             if (pending.Values.Count >= _options.CurrentValue.MaxBatchItems
                 || pending.ByteCount >= _options.CurrentValue.MaxBatchBytes
-                || pending.GetTopicCount(item.Digest.Topic) >= topic.Options.MaxPendingItemCount)
+                || pending.GetTopicCount(topic.Name) >= topic.Options.MaxPendingItemCount)
             {
                 pending.FlushAfter = now;
             }
@@ -685,9 +691,9 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private void RecordRecentUpdate(DisseminationDigest digest)
+    private void RecordRecentUpdate(string topicName, DisseminationDigest digest)
     {
-        var key = new DigestKey(digest.Topic, digest.Key);
+        var key = new DigestKey(topicName, digest.Key);
         lock (_recentUpdateLock)
         {
             _lastUpdateReceivedAt[key] = _timeProvider.GetUtcNow();
@@ -1103,13 +1109,13 @@ internal sealed partial class DisseminationProtocol(
         return false;
     }
 
-    private bool ValidatePayloadSize(IDisseminationTopic topic, DisseminationValue item)
+    private bool ValidatePayloadSize(string topicName, IDisseminationTopic topic, DisseminationValue item)
     {
         var options = _options.CurrentValue;
         if (item.Payload.Length > topic.Options.MaxPayloadBytes || item.Payload.Length > options.MaxBatchBytes)
         {
-            DisseminationEvents.EmitPayloadDrop(item.Digest, _transport.LocalSilo, "oversize", item.Payload.Length);
-            DisseminationInstruments.OnPayloadDropped(item.Digest.Topic, "oversize");
+            DisseminationEvents.EmitPayloadDrop(topicName, item.Digest, _transport.LocalSilo, "oversize", item.Payload.Length);
+            DisseminationInstruments.OnPayloadDropped(topicName, "oversize");
             return false;
         }
 
@@ -1133,7 +1139,7 @@ internal sealed partial class DisseminationProtocol(
             return "obsolete";
         }
 
-        return ValidatePayloadSize(topic, item) ? null : "oversize";
+        return ValidatePayloadSize(topic.Name, topic, item) ? null : "oversize";
     }
 
     private bool IsExpired(DisseminationValue item) => item.ExpiresAt <= _timeProvider.GetUtcNow();
@@ -1174,10 +1180,10 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private void EmitApplyResult(DisseminationValue item, SiloAddress sender, DisseminationApplyResult result)
+    private void EmitApplyResult(string topicName, DisseminationValue item, SiloAddress sender, DisseminationApplyResult result)
     {
-        DisseminationEvents.EmitValue(item.Digest, _transport.LocalSilo, sender, result, item.Payload.Length);
-        DisseminationInstruments.OnValueApplied(item.Digest.Topic, result);
+        DisseminationEvents.EmitValue(topicName, item.Digest, _transport.LocalSilo, sender, result, item.Payload.Length);
+        DisseminationInstruments.OnValueApplied(topicName, result);
     }
 
     private DisseminationAntiEntropyResponse CreateAntiEntropyResponse(

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -547,9 +547,28 @@ internal sealed partial class DisseminationProtocol(
 
     private async Task SendGossipBatches(List<(SiloAddress Peer, ImmutableArray<PendingTopicValues> ValuesByTopic)> batches, CancellationToken cancellationToken)
     {
-        foreach (var queued in batches)
+        var nextBatch = -1;
+        var workers = new Task[Math.Min(batches.Count, _options.CurrentValue.MaxConcurrentSends)];
+        for (var i = 0; i < workers.Length; i++)
         {
-            await SendGossipBatch(queued.Peer, queued.ValuesByTopic, cancellationToken);
+            workers[i] = SendNextBatches();
+        }
+
+        await Task.WhenAll(workers);
+
+        async Task SendNextBatches()
+        {
+            while (true)
+            {
+                var index = Interlocked.Increment(ref nextBatch);
+                if (index >= batches.Count)
+                {
+                    return;
+                }
+
+                var queued = batches[index];
+                await SendGossipBatch(queued.Peer, queued.ValuesByTopic, cancellationToken);
+            }
         }
     }
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -50,10 +50,10 @@ internal sealed partial class DisseminationProtocol(
             return false;
         }
 
-        if (!ValidatePayloadSize(topic, item))
+        if (GetPublishValidationFailureReason(topic, item) is { } reason)
         {
             await topic.OnFallbackRequired(default!, item.Digest, cancellationToken);
-            DisseminationInstruments.OnFallback(item.Digest.Topic, "oversize");
+            DisseminationInstruments.OnFallback(item.Digest.Topic, reason);
             return false;
         }
 
@@ -702,14 +702,14 @@ internal sealed partial class DisseminationProtocol(
         {
             if (_topics.TryGetValue(topicName, out var topic) && topic.IsEnabled)
             {
-                result[topicName] = SelectAntiEntropyPeers(topic.MembershipScope, round);
+                result[topicName] = SelectAntiEntropyPeers(topicName, topic.MembershipScope, round);
             }
         }
 
         return result.ToFrozenDictionary(StringComparer.Ordinal);
     }
 
-    private ImmutableArray<SiloAddress> SelectAntiEntropyPeers(DisseminationMembershipScope membershipScope, long round)
+    private ImmutableArray<SiloAddress> SelectAntiEntropyPeers(string topicName, DisseminationMembershipScope membershipScope, long round)
     {
         var options = _options.CurrentValue.Overlay;
         var topology = GetParticipantTopology(membershipScope, root: null, includeLocal: true);
@@ -728,7 +728,7 @@ internal sealed partial class DisseminationProtocol(
         var candidates = GetAntiEntropyCandidateIndexes(localIndex, participants.Length, fanout);
         return [.. candidates
             .Where(index => index != localIndex)
-            .OrderBy(index => GetRepairPeerScore(participants[index], round, localIndex))
+            .OrderBy(index => GetRepairPeerScore(participants[index], topicName, round, localIndex))
             .ThenBy(index => participants[index])
             .Take(options.AntiEntropyPeerCount)
             .Select(index => participants[index])];
@@ -780,12 +780,29 @@ internal sealed partial class DisseminationProtocol(
         return ((int)start, (int)Math.Min(participantCount, start + width));
     }
 
-    private static ulong GetRepairPeerScore(SiloAddress peer, long round, int localIndex)
+    private static ulong GetRepairPeerScore(SiloAddress peer, string topicName, long round, int localIndex)
     {
         var value = (ulong)(uint)peer.GetConsistentHashCode();
+        value ^= Mix(GetStableStringHash(topicName));
         value ^= (ulong)round * 0x9E3779B97F4A7C15UL;
         value ^= (ulong)(uint)localIndex << 32;
         return Mix(value);
+    }
+
+    private static ulong GetStableStringHash(string value)
+    {
+        const ulong offsetBasis = 14695981039346656037UL;
+        const ulong prime = 1099511628211UL;
+        var hash = offsetBasis;
+        foreach (var ch in value)
+        {
+            hash ^= (byte)ch;
+            hash *= prime;
+            hash ^= (byte)(ch >> 8);
+            hash *= prime;
+        }
+
+        return hash;
     }
 
     private static ulong Mix(ulong value)
@@ -1035,6 +1052,31 @@ internal sealed partial class DisseminationProtocol(
         }
 
         return true;
+    }
+
+    private string? GetPublishValidationFailureReason(IDisseminationTopic topic, DisseminationValue item)
+    {
+        if (!string.Equals(item.Digest.Topic, topic.Name, StringComparison.Ordinal))
+        {
+            return "topic";
+        }
+
+        if (!topic.PayloadKinds.Contains(item.Digest.PayloadKind))
+        {
+            return "payload-kind";
+        }
+
+        if (IsExpired(item))
+        {
+            return "expired";
+        }
+
+        if (topic.IsObsolete(item.Digest))
+        {
+            return "obsolete";
+        }
+
+        return ValidatePayloadSize(topic, item) ? null : "oversize";
     }
 
     private bool IsExpired(DisseminationValue item) => item.ExpiresAt <= _timeProvider.GetUtcNow();

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -150,7 +150,7 @@ internal sealed partial class DisseminationProtocol(
             return [];
         }
 
-        var requestsByPeer = new Dictionary<SiloAddress, (List<string> Topics, List<DisseminationDigest> Digests)>();
+        var requestsByPeer = new Dictionary<SiloAddress, Dictionary<string, ImmutableArray<DisseminationTopicDigest>>>();
         foreach (var (topicName, topicState) in state.Topics)
         {
             if (topicState.Peers.Length == 0 || topicState.Digests.Length == 0)
@@ -162,15 +162,11 @@ internal sealed partial class DisseminationProtocol(
             {
                 if (!requestsByPeer.TryGetValue(peer, out var pendingRequest))
                 {
-                    pendingRequest = ([], []);
+                    pendingRequest = new Dictionary<string, ImmutableArray<DisseminationTopicDigest>>(StringComparer.Ordinal);
                     requestsByPeer.Add(peer, pendingRequest);
                 }
 
-                pendingRequest.Topics.Add(topicName);
-                foreach (var digest in topicState.Digests)
-                {
-                    pendingRequest.Digests.Add(new DisseminationDigest(topicName, digest.Key, digest.Version));
-                }
+                pendingRequest[topicName] = topicState.Digests;
             }
         }
 
@@ -180,8 +176,7 @@ internal sealed partial class DisseminationProtocol(
             var request = new DisseminationAntiEntropyRequest
             {
                 Sender = _transport.LocalSilo,
-                Topics = [.. pendingRequest.Topics],
-                Digests = [.. pendingRequest.Digests],
+                DigestsByTopic = pendingRequest.ToFrozenDictionary(StringComparer.Ordinal),
             };
 
             var response = await SafeRequest(
@@ -193,7 +188,7 @@ internal sealed partial class DisseminationProtocol(
                 continue;
             }
 
-            DisseminationInstruments.OnAntiEntropyExchange("out", request.Digests.Length, response.Values.Length, response.Truncated);
+            DisseminationInstruments.OnAntiEntropyExchange("out", GetDigestCount(request.DigestsByTopic), response.Values.Length, response.Truncated);
             responses.Add(response);
         }
 
@@ -238,23 +233,28 @@ internal sealed partial class DisseminationProtocol(
             return CreateAntiEntropyResponse([], truncated: false);
         }
 
-        var remoteDigests = GetRemoteDigestMap(request.Digests);
+        var requestDigestCount = GetDigestCount(request.DigestsByTopic);
         var values = new List<DisseminationValue>();
         var byteCount = 0;
         var truncated = false;
         var options = _options.CurrentValue;
 
-        foreach (var topicName in request.Topics)
+        foreach (var (topicName, remoteTopicDigests) in request.DigestsByTopic)
         {
             if (!TryGetEnabledTopic(topicName, out var requestedTopic))
             {
                 continue;
             }
 
+            var remoteDigests = GetRemoteDigestMap(requestedTopic, remoteTopicDigests);
+            if (remoteDigests.Count == 0)
+            {
+                continue;
+            }
+
             foreach (var topicDigest in requestedTopic.GetDigests())
             {
-                var digestKey = new DigestKey(requestedTopic.Name, topicDigest.Key);
-                if (!remoteDigests.TryGetValue(digestKey, out var remoteDigest))
+                if (!remoteDigests.TryGetValue(topicDigest.Key, out var remoteDigest))
                 {
                     continue;
                 }
@@ -292,7 +292,7 @@ internal sealed partial class DisseminationProtocol(
             }
         }
 
-        DisseminationInstruments.OnAntiEntropyExchange("in", request.Digests.Length, values.Count, truncated);
+        DisseminationInstruments.OnAntiEntropyExchange("in", requestDigestCount, values.Count, truncated);
         return CreateAntiEntropyResponse([.. values], truncated);
     }
 
@@ -641,20 +641,17 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private Dictionary<DigestKey, DisseminationDigest> GetRemoteDigestMap(ImmutableArray<DisseminationDigest> digests)
+    private Dictionary<string, DisseminationDigest> GetRemoteDigestMap(
+        IDisseminationTopic topic,
+        ImmutableArray<DisseminationTopicDigest> digests)
     {
-        var result = new Dictionary<DigestKey, DisseminationDigest>(digests.Length);
-        foreach (var digest in digests)
+        var result = new Dictionary<string, DisseminationDigest>(digests.Length, StringComparer.Ordinal);
+        foreach (var topicDigest in digests)
         {
-            if (!TryGetEnabledTopic(digest.Topic, out var topic))
+            var digest = new DisseminationDigest(topic.Name, topicDigest.Key, topicDigest.Version);
+            if (!result.TryGetValue(topicDigest.Key, out var existing) || topic.CompareVersion(digest, existing) > 0)
             {
-                continue;
-            }
-
-            var key = new DigestKey(digest.Topic, digest.Key);
-            if (!result.TryGetValue(key, out var existing) || topic.CompareVersion(digest, existing) > 0)
-            {
-                result[key] = digest;
+                result[topicDigest.Key] = digest;
             }
         }
 
@@ -1171,6 +1168,17 @@ internal sealed partial class DisseminationProtocol(
         Values = values,
         Truncated = truncated,
     };
+
+    private static int GetDigestCount(FrozenDictionary<string, ImmutableArray<DisseminationTopicDigest>> digestsByTopic)
+    {
+        var result = 0;
+        foreach (var digests in digestsByTopic.Values)
+        {
+            result += digests.Length;
+        }
+
+        return result;
+    }
 
     public sealed record AntiEntropyState(FrozenDictionary<string, AntiEntropyTopicState> Topics)
     {

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -98,7 +98,9 @@ internal sealed partial class DisseminationProtocol(
         }
 
         var digests = new List<DisseminationDigest>();
-        var currentValueStreams = new List<ValueStreamKey>();
+        var topics = new List<string>();
+        var topicNames = new HashSet<string>(StringComparer.Ordinal);
+        var currentValueStreams = new HashSet<ValueStreamKey>();
         var now = _timeProvider.GetUtcNow();
         foreach (var topic in _topics.Values)
         {
@@ -115,20 +117,21 @@ internal sealed partial class DisseminationProtocol(
                     if (ShouldRequestAntiEntropy(topic, digest, now))
                     {
                         digests.Add(digest);
+                        if (topicNames.Add(digest.Topic))
+                        {
+                            topics.Add(digest.Topic);
+                        }
                     }
                 }
             }
         }
 
-        PruneRecentUpdates(currentValueStreams.ToFrozenSet());
-        var topics = digests
-            .Select(static digest => digest.Topic)
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
+        PruneRecentUpdates(currentValueStreams);
+        var requestedTopics = topics.ToArray();
         var round = Interlocked.Increment(ref _antiEntropyRound);
         return new AntiEntropyState(
-            GetAntiEntropyPeersByTopic(topics, round),
-            topics,
+            GetAntiEntropyPeersByTopic(requestedTopics, round),
+            requestedTopics,
             SortDigests(digests).ToArray());
     }
 
@@ -681,16 +684,27 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private void PruneRecentUpdates(FrozenSet<ValueStreamKey> currentValueStreams)
+    private void PruneRecentUpdates(HashSet<ValueStreamKey> currentValueStreams)
     {
         lock (_recentUpdateLock)
         {
-            foreach (var key in _lastUpdateReceivedAt.Keys.ToArray())
+            List<ValueStreamKey>? staleKeys = null;
+            foreach (var key in _lastUpdateReceivedAt.Keys)
             {
                 if (!currentValueStreams.Contains(key))
                 {
-                    _lastUpdateReceivedAt.Remove(key);
+                    (staleKeys ??= []).Add(key);
                 }
+            }
+
+            if (staleKeys is null)
+            {
+                return;
+            }
+
+            foreach (var key in staleKeys)
+            {
+                _lastUpdateReceivedAt.Remove(key);
             }
         }
     }

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -28,7 +28,14 @@ internal sealed partial class DisseminationProtocol(
     private readonly Dictionary<SiloAddress, DateTimeOffset> _failureBackoffUntil = [];
     private readonly object _capabilityLock = new();
     private readonly object _failureLock = new();
+    private readonly object _gossipQueueLock = new();
+    private readonly object _recentUpdateLock = new();
     private readonly object _topologyLock = new();
+    private readonly Dictionary<SiloAddress, PendingGossipBatch> _pendingGossip = [];
+    private readonly Dictionary<ValueStreamKey, DateTimeOffset> _lastUpdateReceivedAt = [];
+    private DateTimeOffset? _nextGossipFlushAt;
+    private CancellationTokenSource? _gossipFlushWakeup;
+    private bool _gossipFlushScheduled;
     private ParticipantTopology _activeMembersTopology = ParticipantTopology.Empty;
     private ParticipantTopology _allMembersTopology = ParticipantTopology.Empty;
     private long _antiEntropyRound;
@@ -55,6 +62,7 @@ internal sealed partial class DisseminationProtocol(
 
         var root = item.Root is not null ? item.Root : _transport.LocalSilo;
         item = EnsureRoot(item, root);
+        RecordRecentUpdate(item.Digest);
         var topology = targetPeers is { Count: > 0 }
             ? BuildParticipantTopology(targetPeers, root, includeLocal: true)
             : GetParticipantTopology(topic.MembershipScope, root, includeLocal: true);
@@ -68,7 +76,7 @@ internal sealed partial class DisseminationProtocol(
 
         foreach (var peer in GetOriginatorTreeTargets(topology, root))
         {
-            await SendGossip(peer, item, cancellationToken);
+            EnqueueGossip(peer, item);
         }
 
         return true;
@@ -98,6 +106,8 @@ internal sealed partial class DisseminationProtocol(
 
         var topics = new List<DisseminationCapabilityRequest>();
         var digests = new List<DisseminationDigest>();
+        var currentValueStreams = new List<ValueStreamKey>();
+        var now = _timeProvider.GetUtcNow();
         foreach (var topic in _topics.Values)
         {
             if (!topic.IsEnabled)
@@ -117,11 +127,16 @@ internal sealed partial class DisseminationProtocol(
                 if (string.Equals(digest.Topic, topic.Name, StringComparison.Ordinal)
                     && topic.PayloadKinds.Contains(digest.PayloadKind))
                 {
-                    digests.Add(digest);
+                    currentValueStreams.Add(GetValueStreamKey(digest));
+                    if (ShouldRequestAntiEntropy(topic, digest, now))
+                    {
+                        digests.Add(digest);
+                    }
                 }
             }
         }
 
+        PruneRecentUpdates(currentValueStreams.ToFrozenSet());
         var round = Interlocked.Increment(ref _antiEntropyRound);
         return new AntiEntropyState(
             GetAntiEntropyPeersByTopic(topics, round),
@@ -152,6 +167,11 @@ internal sealed partial class DisseminationProtocol(
             }
 
             var digests = state.Digests.Where(digest => IsRequested(topics, digest)).ToArray();
+            if (digests.Length == 0)
+            {
+                continue;
+            }
+
             var request = new DisseminationAntiEntropyRequest
             {
                 Sender = _transport.LocalSilo,
@@ -232,15 +252,15 @@ internal sealed partial class DisseminationProtocol(
                 }
 
                 var digestKey = GetDigestKey(localDigest);
-                var hasRemoteDigest = remoteDigests.TryGetValue(digestKey, out var remoteDigest);
-                if (hasRemoteDigest && requestedTopic.Topic.CompareVersion(localDigest, remoteDigest) <= 0)
+                if (!remoteDigests.TryGetValue(digestKey, out var remoteDigest)
+                    || requestedTopic.Topic.CompareVersion(localDigest, remoteDigest) <= 0)
                 {
                     continue;
                 }
 
                 var item = await requestedTopic.Topic.GetValue(
                     localDigest,
-                    hasRemoteDigest ? remoteDigest : null,
+                    remoteDigest,
                     requestedTopic.PayloadKinds,
                     cancellationToken);
                 if (item is null
@@ -301,6 +321,10 @@ internal sealed partial class DisseminationProtocol(
 
         var result = await topic.ApplyValue(value, cancellationToken);
         EmitApplyResult(value, sender, result);
+        if (result is DisseminationApplyResult.Applied or DisseminationApplyResult.Duplicate)
+        {
+            RecordRecentUpdate(value.Digest);
+        }
 
         if (result == DisseminationApplyResult.Applied && forward)
         {
@@ -310,38 +334,273 @@ internal sealed partial class DisseminationProtocol(
         return result;
     }
 
-    private async Task Forward(DisseminationValue item, IDisseminationTopic topic, SiloAddress sender, CancellationToken cancellationToken)
+    private Task Forward(DisseminationValue item, IDisseminationTopic topic, SiloAddress sender, CancellationToken cancellationToken)
     {
         var root = item.Root is not null ? item.Root : sender;
         item = EnsureRoot(item, root);
         var topology = GetParticipantTopology(topic.MembershipScope, root, includeLocal: true);
         foreach (var peer in GetForwardingTreeTargets(topology, root, sender))
         {
-            await SendGossip(peer, item, cancellationToken);
+            EnqueueGossip(peer, item);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    internal async Task FlushPendingGossip(CancellationToken cancellationToken)
+    {
+        var batches = DrainPendingGossip(force: true);
+        CancelScheduledGossipFlushDelay();
+        await SendGossipBatches(batches, cancellationToken);
+    }
+
+    private void EnqueueGossip(SiloAddress peer, DisseminationValue item)
+    {
+        if (!_topics.TryGetValue(item.Digest.Topic, out var topic))
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+        var key = GetDigestKey(item.Digest);
+        lock (_gossipQueueLock)
+        {
+            if (!_pendingGossip.TryGetValue(peer, out var pending))
+            {
+                pending = new PendingGossipBatch(now + topic.Options.MaxCoalescingDelay);
+                _pendingGossip.Add(peer, pending);
+            }
+            else if (pending.Values.TryGetValue(key, out var existing)
+                && topic.CompareVersion(existing.Digest, item.Digest) >= 0)
+            {
+                return;
+            }
+            else if (now + topic.Options.MaxCoalescingDelay < pending.FlushAfter)
+            {
+                pending.FlushAfter = now + topic.Options.MaxCoalescingDelay;
+            }
+
+            pending.AddOrReplace(key, item);
+            if (pending.Values.Count >= _options.CurrentValue.MaxBatchItems
+                || pending.ByteCount >= _options.CurrentValue.MaxBatchBytes
+                || CountPendingTopicValues(pending, item.Digest.Topic) >= topic.Options.MaxPendingItemCount)
+            {
+                pending.FlushAfter = now;
+            }
+        }
+
+        ScheduleGossipFlush();
+    }
+
+    private void ScheduleGossipFlush()
+    {
+        var startFlushLoop = false;
+        lock (_gossipQueueLock)
+        {
+            if (_pendingGossip.Count == 0)
+            {
+                return;
+            }
+
+            var next = GetNextPendingGossipFlushUnsafe();
+            if (!_gossipFlushScheduled)
+            {
+                _gossipFlushScheduled = true;
+                _nextGossipFlushAt = next;
+                startFlushLoop = true;
+            }
+            else if (_nextGossipFlushAt is null || next < _nextGossipFlushAt.Value)
+            {
+                _nextGossipFlushAt = next;
+                _gossipFlushWakeup?.Cancel();
+            }
+        }
+
+        if (startFlushLoop)
+        {
+            _ = Task.Run(RunScheduledGossipFlush);
         }
     }
 
-    private async ValueTask<bool> SendGossip(SiloAddress peer, DisseminationValue item, CancellationToken cancellationToken)
+    private async Task RunScheduledGossipFlush()
     {
-        if (!_topics.TryGetValue(item.Digest.Topic, out var topic)
-            || await GetCapabilityStatus(peer, topic, item.Digest.PayloadKind, cancellationToken) != CapabilityStatus.Supported)
+        try
         {
-            return false;
+            while (true)
+            {
+                var delay = GetDelayUntilNextGossipFlush(out var wakeupToken);
+                if (delay is null)
+                {
+                    return;
+                }
+
+                if (delay > TimeSpan.Zero)
+                {
+                    try
+                    {
+                        await Task.Delay(delay.Value, _timeProvider, wakeupToken);
+                    }
+                    catch (OperationCanceledException) when (wakeupToken.IsCancellationRequested)
+                    {
+                        continue;
+                    }
+                }
+
+                var batches = DrainPendingGossip(force: false);
+                await SendGossipBatches(batches, CancellationToken.None);
+            }
+        }
+        catch (Exception exception)
+        {
+            LogDebugGossipFlushFailed(_logger, exception);
+        }
+        finally
+        {
+            var reschedule = false;
+            lock (_gossipQueueLock)
+            {
+                _gossipFlushScheduled = false;
+                _nextGossipFlushAt = null;
+                _gossipFlushWakeup = null;
+                reschedule = _pendingGossip.Count > 0;
+            }
+
+            if (reschedule)
+            {
+                ScheduleGossipFlush();
+            }
+        }
+    }
+
+    private TimeSpan? GetDelayUntilNextGossipFlush(out CancellationToken wakeupToken)
+    {
+        lock (_gossipQueueLock)
+        {
+            if (_pendingGossip.Count == 0)
+            {
+                _nextGossipFlushAt = null;
+                _gossipFlushWakeup = null;
+                wakeupToken = CancellationToken.None;
+                return null;
+            }
+
+            var now = _timeProvider.GetUtcNow();
+            var next = GetNextPendingGossipFlushUnsafe();
+            _nextGossipFlushAt = next;
+            if (next <= now)
+            {
+                _gossipFlushWakeup = null;
+                wakeupToken = CancellationToken.None;
+                return TimeSpan.Zero;
+            }
+
+            _gossipFlushWakeup = new CancellationTokenSource();
+            wakeupToken = _gossipFlushWakeup.Token;
+            return next - now;
+        }
+    }
+
+    private void CancelScheduledGossipFlushDelay()
+    {
+        lock (_gossipQueueLock)
+        {
+            _gossipFlushWakeup?.Cancel();
+        }
+    }
+
+    private DateTimeOffset GetNextPendingGossipFlushUnsafe() => _pendingGossip.Values.Min(static pending => pending.FlushAfter);
+
+    private List<QueuedGossipBatch> DrainPendingGossip(bool force)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var result = new List<QueuedGossipBatch>();
+        lock (_gossipQueueLock)
+        {
+            foreach (var (peer, pending) in _pendingGossip.ToArray())
+            {
+                if (!force && pending.FlushAfter > now)
+                {
+                    continue;
+                }
+
+                _pendingGossip.Remove(peer);
+                result.Add(new QueuedGossipBatch(peer, [.. pending.Values.Values
+                    .OrderBy(static value => value.Digest.Topic, StringComparer.Ordinal)
+                    .ThenBy(static value => value.Digest.PayloadKind, StringComparer.Ordinal)
+                    .ThenBy(static value => value.Digest.Key, StringComparer.Ordinal)]));
+            }
         }
 
+        result.Sort(static (left, right) => left.Peer.CompareTo(right.Peer));
+        return result;
+    }
+
+    private async Task SendGossipBatches(List<QueuedGossipBatch> batches, CancellationToken cancellationToken)
+    {
+        foreach (var queued in batches)
+        {
+            await SendGossipBatch(queued.Peer, queued.Values, cancellationToken);
+        }
+    }
+
+    private async Task SendGossipBatch(SiloAddress peer, IReadOnlyList<DisseminationValue> values, CancellationToken cancellationToken)
+    {
+        var currentBatch = new List<DisseminationValue>();
+        var byteCount = 0;
+        foreach (var item in values)
+        {
+            if (!_topics.TryGetValue(item.Digest.Topic, out var topic)
+                || await GetCapabilityStatus(peer, topic, item.Digest.PayloadKind, cancellationToken) != CapabilityStatus.Supported)
+            {
+                continue;
+            }
+
+            if (currentBatch.Count > 0
+                && (currentBatch.Count >= _options.CurrentValue.MaxBatchItems
+                    || byteCount + item.Payload.Length > _options.CurrentValue.MaxBatchBytes))
+            {
+                await SendGossipBatchCore(peer, [.. currentBatch], cancellationToken);
+                currentBatch.Clear();
+                byteCount = 0;
+            }
+
+            currentBatch.Add(item);
+            byteCount += item.Payload.Length;
+        }
+
+        if (currentBatch.Count > 0)
+        {
+            await SendGossipBatchCore(peer, [.. currentBatch], cancellationToken);
+        }
+    }
+
+    private async Task SendGossipBatchCore(SiloAddress peer, DisseminationValue[] values, CancellationToken cancellationToken)
+    {
         var batch = new DisseminationGossipBatch
         {
             Sender = _transport.LocalSilo,
-            Values = [item],
+            Values = values,
         };
 
         var sent = await SafeSend(peer, target => _transport.SendGossip(target, batch, cancellationToken));
         if (sent)
         {
-            DisseminationInstruments.OnGossipSent(item.Digest.Topic, "tree", 1, item.Payload.Length);
+            DisseminationInstruments.OnGossipSent(values, "tree");
+        }
+    }
+
+    private static int CountPendingTopicValues(PendingGossipBatch pending, string topic)
+    {
+        var result = 0;
+        foreach (var value in pending.Values.Values)
+        {
+            if (string.Equals(value.Digest.Topic, topic, StringComparison.Ordinal))
+            {
+                result++;
+            }
         }
 
-        return sent;
+        return result;
     }
 
     private async ValueTask<bool> SafeSend(SiloAddress peer, Func<SiloAddress, Task> send)
@@ -566,6 +825,39 @@ internal sealed partial class DisseminationProtocol(
         }
 
         return result.ToFrozenDictionary();
+    }
+
+    private bool ShouldRequestAntiEntropy(IDisseminationTopic topic, DisseminationDigest digest, DateTimeOffset now)
+    {
+        var key = GetValueStreamKey(digest);
+        lock (_recentUpdateLock)
+        {
+            return !_lastUpdateReceivedAt.TryGetValue(key, out var lastReceived)
+                || now - lastReceived >= topic.Options.ExpectedUpdateCadence;
+        }
+    }
+
+    private void RecordRecentUpdate(DisseminationDigest digest)
+    {
+        var key = GetValueStreamKey(digest);
+        lock (_recentUpdateLock)
+        {
+            _lastUpdateReceivedAt[key] = _timeProvider.GetUtcNow();
+        }
+    }
+
+    private void PruneRecentUpdates(FrozenSet<ValueStreamKey> currentValueStreams)
+    {
+        lock (_recentUpdateLock)
+        {
+            foreach (var key in _lastUpdateReceivedAt.Keys.ToArray())
+            {
+                if (!currentValueStreams.Contains(key))
+                {
+                    _lastUpdateReceivedAt.Remove(key);
+                }
+            }
+        }
     }
 
     private FrozenDictionary<string, ImmutableArray<SiloAddress>> GetAntiEntropyPeersByTopic(
@@ -993,6 +1285,8 @@ internal sealed partial class DisseminationProtocol(
 
     private static DigestKey GetDigestKey(DisseminationDigest digest) => new(digest.Topic, digest.Key, digest.PayloadKind);
 
+    private static ValueStreamKey GetValueStreamKey(DisseminationDigest digest) => new(digest.Topic, digest.Key);
+
     public sealed record AntiEntropyState(
         FrozenDictionary<string, ImmutableArray<SiloAddress>> PeersByTopic,
         IReadOnlyList<DisseminationCapabilityRequest> Topics,
@@ -1010,7 +1304,31 @@ internal sealed partial class DisseminationProtocol(
 
     private readonly record struct DigestKey(string Topic, string Key, string PayloadKind);
 
+    private readonly record struct ValueStreamKey(string Topic, string Key);
+
     private readonly record struct RequestedTopic(IDisseminationTopic Topic, FrozenSet<string> PayloadKinds);
+
+    private readonly record struct QueuedGossipBatch(SiloAddress Peer, ImmutableArray<DisseminationValue> Values);
+
+    private sealed class PendingGossipBatch(DateTimeOffset flushAfter)
+    {
+        public Dictionary<DigestKey, DisseminationValue> Values { get; } = [];
+
+        public DateTimeOffset FlushAfter { get; set; } = flushAfter;
+
+        public int ByteCount { get; private set; }
+
+        public void AddOrReplace(DigestKey key, DisseminationValue value)
+        {
+            if (Values.Remove(key, out var previous))
+            {
+                ByteCount -= previous.Payload.Length;
+            }
+
+            Values[key] = value;
+            ByteCount += value.Payload.Length;
+        }
+    }
 
     private enum CapabilityStatus
     {
@@ -1044,4 +1362,9 @@ internal sealed partial class DisseminationProtocol(
         Level = LogLevel.Debug,
         Message = "Failed to apply anti-entropy repair value from {Sender} for topic {Topic}, key {Key}, version {Version}.")]
     private static partial void LogDebugAntiEntropyRepairValueFailed(ILogger logger, Exception exception, SiloAddress sender, string topic, string key, long version);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Dissemination gossip batch flush failed.")]
+    private static partial void LogDebugGossipFlushFailed(ILogger logger, Exception exception);
 }

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -184,7 +184,7 @@ internal sealed partial class DisseminationProtocol(
             var request = new DisseminationAntiEntropyRequest
             {
                 Sender = _transport.LocalSilo,
-                DigestsByTopic = pendingRequest.ToFrozenDictionary(StringComparer.Ordinal),
+                DigestsByTopic = pendingRequest.ToImmutableDictionary(StringComparer.Ordinal),
             };
 
             var response = await SafeRequest(
@@ -250,7 +250,7 @@ internal sealed partial class DisseminationProtocol(
     {
         if (!_options.CurrentValue.Enabled)
         {
-            return CreateAntiEntropyResponse(FrozenDictionary<string, ImmutableArray<DisseminationValue>>.Empty, truncated: false);
+            return CreateAntiEntropyResponse(ImmutableDictionary<string, ImmutableArray<DisseminationValue>>.Empty, truncated: false);
         }
 
         var requestDigestCount = GetDigestCount(request.DigestsByTopic);
@@ -591,7 +591,7 @@ internal sealed partial class DisseminationProtocol(
 
     private async Task SendGossipBatchCore(
         SiloAddress peer,
-        FrozenDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic,
+        ImmutableDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic,
         CancellationToken cancellationToken)
     {
         var batch = new DisseminationGossipBatch
@@ -1181,7 +1181,7 @@ internal sealed partial class DisseminationProtocol(
     }
 
     private DisseminationAntiEntropyResponse CreateAntiEntropyResponse(
-        FrozenDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic,
+        ImmutableDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic,
         bool truncated) => new()
     {
         Sender = _transport.LocalSilo,
@@ -1189,7 +1189,7 @@ internal sealed partial class DisseminationProtocol(
         Truncated = truncated,
     };
 
-    private static int GetDigestCount(FrozenDictionary<string, ImmutableArray<DisseminationTopicDigest>> digestsByTopic)
+    private static int GetDigestCount(ImmutableDictionary<string, ImmutableArray<DisseminationTopicDigest>> digestsByTopic)
     {
         var result = 0;
         foreach (var digests in digestsByTopic.Values)
@@ -1200,7 +1200,7 @@ internal sealed partial class DisseminationProtocol(
         return result;
     }
 
-    private static int GetValueCount(FrozenDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic)
+    private static int GetValueCount(ImmutableDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic)
     {
         var result = 0;
         foreach (var values in valuesByTopic.Values)
@@ -1211,7 +1211,7 @@ internal sealed partial class DisseminationProtocol(
         return result;
     }
 
-    private static FrozenDictionary<string, ImmutableArray<DisseminationValue>> GroupValuesByTopic(IReadOnlyList<TopicValue> values)
+    private static ImmutableDictionary<string, ImmutableArray<DisseminationValue>> GroupValuesByTopic(IReadOnlyList<TopicValue> values)
     {
         var result = new Dictionary<string, ImmutableArray<DisseminationValue>.Builder>(StringComparer.Ordinal);
         foreach (var (topic, value) in values)
@@ -1236,9 +1236,9 @@ internal sealed partial class DisseminationProtocol(
         topicValues.Add(value);
     }
 
-    private static FrozenDictionary<string, ImmutableArray<DisseminationValue>> CreateValueGroups(
+    private static ImmutableDictionary<string, ImmutableArray<DisseminationValue>> CreateValueGroups(
         Dictionary<string, ImmutableArray<DisseminationValue>.Builder> result) =>
-        result.ToFrozenDictionary(
+        result.ToImmutableDictionary(
             static pair => pair.Key,
             static pair => pair.Value.ToImmutable(),
             StringComparer.Ordinal);

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -60,8 +60,8 @@ internal sealed partial class DisseminationProtocol(
         var root = item.Root;
         var topology = targetPeers is { Count: > 0 }
             ? BuildParticipantTopology(targetPeers, root, includeLocal: true)
-            : GetParticipantTopology(topic.MembershipScope);
-        if (!await EnsureRootParticipates(topology, root, cancellationToken))
+            : await GetParticipantTopologyForRouting(topic.MembershipScope, root, cancellationToken);
+        if (topology is null)
         {
             return false;
         }
@@ -217,36 +217,35 @@ internal sealed partial class DisseminationProtocol(
             return CreateAntiEntropyResponse([], truncated: false);
         }
 
-        var requestedTopics = GetRequestedTopics(request);
-        if (requestedTopics.Count == 0)
-        {
-            return CreateAntiEntropyResponse([], truncated: false);
-        }
-
         var remoteDigests = GetRemoteDigestMap(request.Digests);
         var values = new List<DisseminationValue>();
         var byteCount = 0;
         var truncated = false;
         var options = _options.CurrentValue;
 
-        foreach (var requestedTopic in requestedTopics.Values.OrderBy(static topic => topic.Topic.Name, StringComparer.Ordinal))
+        foreach (var topicName in request.Topics)
         {
-            foreach (var localDigest in SortDigests(requestedTopic.Topic.GetDigests()))
+            if (!TryGetEnabledTopic(topicName, out var requestedTopic))
+            {
+                continue;
+            }
+
+            foreach (var localDigest in requestedTopic.GetDigests())
             {
                 var digestKey = GetDigestKey(localDigest);
                 if (!remoteDigests.TryGetValue(digestKey, out var remoteDigest)
-                    || requestedTopic.Topic.CompareVersion(localDigest, remoteDigest) <= 0)
+                    || requestedTopic.CompareVersion(localDigest, remoteDigest) <= 0)
                 {
                     continue;
                 }
 
-                var item = await requestedTopic.Topic.GetValue(
+                var item = await requestedTopic.GetValue(
                     localDigest,
                     remoteDigest,
                     cancellationToken);
                 if (item is null
-                    || !string.Equals(item.Digest.Topic, requestedTopic.Topic.Name, StringComparison.Ordinal)
-                    || !ValidatePayloadSize(requestedTopic.Topic, item))
+                    || !string.Equals(item.Digest.Topic, requestedTopic.Name, StringComparison.Ordinal)
+                    || !ValidatePayloadSize(requestedTopic, item))
                 {
                     continue;
                 }
@@ -312,8 +311,8 @@ internal sealed partial class DisseminationProtocol(
     private async Task Forward(DisseminationValue item, IDisseminationTopic topic, SiloAddress sender, CancellationToken cancellationToken)
     {
         var root = item.Root;
-        var topology = GetParticipantTopology(topic.MembershipScope);
-        if (!await EnsureRootParticipates(topology, root, cancellationToken))
+        var topology = await GetParticipantTopologyForRouting(topic.MembershipScope, root, cancellationToken);
+        if (topology is null)
         {
             return;
         }
@@ -621,20 +620,6 @@ internal sealed partial class DisseminationProtocol(
             SetPeerBackoff(peer);
             return null;
         }
-    }
-
-    private FrozenDictionary<string, RequestedTopic> GetRequestedTopics(DisseminationAntiEntropyRequest request)
-    {
-        var result = new Dictionary<string, RequestedTopic>(StringComparer.Ordinal);
-        foreach (var topicName in request.Topics)
-        {
-            if (TryGetEnabledTopic(topicName, out var topic))
-            {
-                result[topic.Name] = new RequestedTopic(topic);
-            }
-        }
-
-        return result.ToFrozenDictionary(StringComparer.Ordinal);
     }
 
     private FrozenDictionary<DigestKey, DisseminationDigest> GetRemoteDigestMap(IEnumerable<DisseminationDigest> digests)
@@ -1051,19 +1036,21 @@ internal sealed partial class DisseminationProtocol(
         return new ParticipantTopology(participants, indices.ToFrozenDictionary());
     }
 
-    private async ValueTask<bool> EnsureRootParticipates(
-        ParticipantTopology topology,
+    private async ValueTask<ParticipantTopology?> GetParticipantTopologyForRouting(
+        DisseminationMembershipScope membershipScope,
         SiloAddress root,
         CancellationToken cancellationToken)
     {
+        var topology = GetParticipantTopology(membershipScope);
         if (topology.Indices.ContainsKey(root))
         {
-            return true;
+            return topology;
         }
 
         LogDebugDisseminationRootMissing(_logger, root);
         await _transport.RefreshMembership(cancellationToken);
-        return false;
+        topology = GetParticipantTopology(membershipScope);
+        return topology.Indices.ContainsKey(root) ? topology : null;
     }
 
     private bool TryGetEnabledTopic(string topicName, out IDisseminationTopic topic)
@@ -1188,8 +1175,6 @@ internal sealed partial class DisseminationProtocol(
 
     private readonly record struct ValueStreamKey(string Topic, string Key);
 
-    private readonly record struct RequestedTopic(IDisseminationTopic Topic);
-
     private readonly record struct QueuedGossipBatch(SiloAddress Peer, ImmutableArray<DisseminationValue> Values);
 
     private sealed class PendingGossipBatch(DateTimeOffset flushAfter)
@@ -1238,6 +1223,6 @@ internal sealed partial class DisseminationProtocol(
 
     [LoggerMessage(
         Level = LogLevel.Debug,
-        Message = "Dissemination root {Root} is missing from local membership; refreshing membership and skipping routing.")]
+        Message = "Dissemination root {Root} is missing from local membership; refreshing membership before routing.")]
     private static partial void LogDebugDisseminationRootMissing(ILogger logger, SiloAddress root);
 }

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -184,7 +184,10 @@ internal sealed partial class DisseminationProtocol(
                 Digests = [.. pendingRequest.Digests],
             };
 
-            var response = await SafeRequest(peer, target => _transport.ExchangeAntiEntropy(target, request, cancellationToken));
+            var response = await SafeRequest(
+                peer,
+                cancellationToken,
+                target => _transport.ExchangeAntiEntropy(target, request, cancellationToken));
             if (response is null)
             {
                 continue;
@@ -573,15 +576,19 @@ internal sealed partial class DisseminationProtocol(
             Values = values,
         };
 
-        var sent = await SafeSend(peer, target => _transport.SendGossip(target, batch, cancellationToken));
+        var sent = await SafeSend(
+            peer,
+            cancellationToken,
+            target => _transport.SendGossip(target, batch, cancellationToken));
         if (sent)
         {
             DisseminationInstruments.OnGossipSent(values, "tree");
         }
     }
 
-    private async ValueTask<bool> SafeSend(SiloAddress peer, Func<SiloAddress, Task> send)
+    private async ValueTask<bool> SafeSend(SiloAddress peer, CancellationToken cancellationToken, Func<SiloAddress, Task> send)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (IsPeerBackedOff(peer))
         {
             return false;
@@ -593,6 +600,10 @@ internal sealed partial class DisseminationProtocol(
             ClearPeerBackoff(peer);
             return true;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception exception)
         {
             LogDebugDisseminationSendFailed(_logger, exception, peer);
@@ -603,8 +614,10 @@ internal sealed partial class DisseminationProtocol(
 
     private async ValueTask<DisseminationAntiEntropyResponse?> SafeRequest(
         SiloAddress peer,
+        CancellationToken cancellationToken,
         Func<SiloAddress, ValueTask<DisseminationAntiEntropyResponse>> request)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (IsPeerBackedOff(peer))
         {
             return null;
@@ -615,6 +628,10 @@ internal sealed partial class DisseminationProtocol(
             var response = await request(peer);
             ClearPeerBackoff(peer);
             return response;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception exception)
         {

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -1161,7 +1161,7 @@ internal sealed partial class DisseminationProtocol(
 
         public void AddOrReplace(DigestKey key, DisseminationValue value)
         {
-            if (Values.Remove(key, out var previous))
+            if (Values.TryGetValue(key, out var previous))
             {
                 ByteCount -= previous.Payload.Length;
             }

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -69,7 +69,7 @@ internal sealed partial class DisseminationProtocol(
         RecordRecentUpdate(item.Digest);
         foreach (var peer in GetOriginatorTreeTargets(topology, root))
         {
-            EnqueueGossip(peer, item);
+            EnqueueGossip(peer, item, topic);
         }
 
         return true;
@@ -342,7 +342,7 @@ internal sealed partial class DisseminationProtocol(
 
         foreach (var peer in GetForwardingTreeTargets(topology, root, sender))
         {
-            EnqueueGossip(peer, item);
+            EnqueueGossip(peer, item, topic);
         }
     }
 
@@ -353,13 +353,8 @@ internal sealed partial class DisseminationProtocol(
         await SendGossipBatches(batches, cancellationToken);
     }
 
-    private void EnqueueGossip(SiloAddress peer, DisseminationValue item)
+    private void EnqueueGossip(SiloAddress peer, DisseminationValue item, IDisseminationTopic topic)
     {
-        if (!_topics.TryGetValue(item.Digest.Topic, out var topic))
-        {
-            return;
-        }
-
         var now = _timeProvider.GetUtcNow();
         var key = new DigestKey(item.Digest.Topic, item.Digest.Key);
         lock (_gossipQueueLock)

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -382,7 +382,7 @@ internal sealed partial class DisseminationProtocol(
                 pending = new PendingGossipBatch(now + topic.Options.MaxCoalescingDelay);
                 _pendingGossip.Add(peer, pending);
             }
-            else if (pending.Values.TryGetValue(key, out var existing)
+            else if (pending.TryGetValue(key, out var existing)
                 && topic.CompareVersion(existing.Digest, item.Digest) >= 0)
             {
                 return;
@@ -393,7 +393,7 @@ internal sealed partial class DisseminationProtocol(
             }
 
             pending.AddOrReplace(key, item);
-            if (pending.Values.Count >= _options.CurrentValue.MaxBatchItems
+            if (pending.Count >= _options.CurrentValue.MaxBatchItems
                 || pending.ByteCount >= _options.CurrentValue.MaxBatchBytes
                 || pending.GetTopicCount(topic.Name) >= topic.Options.MaxPendingItemCount)
             {
@@ -523,10 +523,10 @@ internal sealed partial class DisseminationProtocol(
 
     private DateTimeOffset GetNextPendingGossipFlushUnsafe() => _pendingGossip.Values.Min(static pending => pending.FlushAfter);
 
-    private List<(SiloAddress Peer, ImmutableArray<TopicValue> Values)> DrainPendingGossip(bool force)
+    private List<(SiloAddress Peer, ImmutableArray<PendingTopicValues> ValuesByTopic)> DrainPendingGossip(bool force)
     {
         var now = _timeProvider.GetUtcNow();
-        var result = new List<(SiloAddress Peer, ImmutableArray<TopicValue> Values)>();
+        var result = new List<(SiloAddress Peer, ImmutableArray<PendingTopicValues> ValuesByTopic)>();
         lock (_gossipQueueLock)
         {
             foreach (var (peer, pending) in _pendingGossip)
@@ -537,7 +537,7 @@ internal sealed partial class DisseminationProtocol(
                 }
 
                 _pendingGossip.Remove(peer);
-                result.Add((peer, [.. pending.Values.Select(static item => new TopicValue(item.Key.Topic, item.Value))]));
+                result.Add((peer, pending.ToImmutableValuesByTopic()));
             }
         }
 
@@ -545,50 +545,59 @@ internal sealed partial class DisseminationProtocol(
         return result;
     }
 
-    private async Task SendGossipBatches(List<(SiloAddress Peer, ImmutableArray<TopicValue> Values)> batches, CancellationToken cancellationToken)
+    private async Task SendGossipBatches(List<(SiloAddress Peer, ImmutableArray<PendingTopicValues> ValuesByTopic)> batches, CancellationToken cancellationToken)
     {
         foreach (var queued in batches)
         {
-            await SendGossipBatch(queued.Peer, queued.Values, cancellationToken);
+            await SendGossipBatch(queued.Peer, queued.ValuesByTopic, cancellationToken);
         }
     }
 
-    private async Task SendGossipBatch(SiloAddress peer, IReadOnlyList<TopicValue> values, CancellationToken cancellationToken)
+    private async Task SendGossipBatch(SiloAddress peer, IReadOnlyList<PendingTopicValues> valuesByTopic, CancellationToken cancellationToken)
     {
-        var currentBatch = new List<TopicValue>();
+        var currentBatch = new Dictionary<string, ImmutableArray<DisseminationValue>.Builder>(StringComparer.Ordinal);
+        var itemCount = 0;
         var byteCount = 0;
-        foreach (var item in values)
+        foreach (var group in valuesByTopic)
         {
-            if (!TryGetEnabledTopic(item.Topic, out var topic))
+            if (!TryGetEnabledTopic(group.Topic, out _))
             {
                 continue;
             }
 
-            if (currentBatch.Count > 0
-                && (currentBatch.Count >= _options.CurrentValue.MaxBatchItems
-                    || byteCount + item.Value.Payload.Length > _options.CurrentValue.MaxBatchBytes))
+            foreach (var item in group.Values)
             {
-                await SendGossipBatchCore(peer, [.. currentBatch], cancellationToken);
-                currentBatch.Clear();
-                byteCount = 0;
-            }
+                if (itemCount > 0
+                    && (itemCount >= _options.CurrentValue.MaxBatchItems
+                        || byteCount + item.Payload.Length > _options.CurrentValue.MaxBatchBytes))
+                {
+                    await SendGossipBatchCore(peer, CreateValueGroups(currentBatch), cancellationToken);
+                    currentBatch.Clear();
+                    itemCount = 0;
+                    byteCount = 0;
+                }
 
-            currentBatch.Add(item);
-            byteCount += item.Value.Payload.Length;
+                AddToValueGroups(currentBatch, group.Topic, item);
+                itemCount++;
+                byteCount += item.Payload.Length;
+            }
         }
 
-        if (currentBatch.Count > 0)
+        if (itemCount > 0)
         {
-            await SendGossipBatchCore(peer, [.. currentBatch], cancellationToken);
+            await SendGossipBatchCore(peer, CreateValueGroups(currentBatch), cancellationToken);
         }
     }
 
-    private async Task SendGossipBatchCore(SiloAddress peer, ImmutableArray<TopicValue> values, CancellationToken cancellationToken)
+    private async Task SendGossipBatchCore(
+        SiloAddress peer,
+        FrozenDictionary<string, ImmutableArray<DisseminationValue>> valuesByTopic,
+        CancellationToken cancellationToken)
     {
         var batch = new DisseminationGossipBatch
         {
             Sender = _transport.LocalSilo,
-            ValuesByTopic = GroupValuesByTopic(values),
+            ValuesByTopic = valuesByTopic,
         };
 
         var sent = await SafeSend(
@@ -1207,20 +1216,32 @@ internal sealed partial class DisseminationProtocol(
         var result = new Dictionary<string, ImmutableArray<DisseminationValue>.Builder>(StringComparer.Ordinal);
         foreach (var (topic, value) in values)
         {
-            if (!result.TryGetValue(topic, out var topicValues))
-            {
-                topicValues = ImmutableArray.CreateBuilder<DisseminationValue>();
-                result.Add(topic, topicValues);
-            }
-
-            topicValues.Add(value);
+            AddToValueGroups(result, topic, value);
         }
 
-        return result.ToFrozenDictionary(
+        return CreateValueGroups(result);
+    }
+
+    private static void AddToValueGroups(
+        Dictionary<string, ImmutableArray<DisseminationValue>.Builder> result,
+        string topic,
+        DisseminationValue value)
+    {
+        if (!result.TryGetValue(topic, out var topicValues))
+        {
+            topicValues = ImmutableArray.CreateBuilder<DisseminationValue>();
+            result.Add(topic, topicValues);
+        }
+
+        topicValues.Add(value);
+    }
+
+    private static FrozenDictionary<string, ImmutableArray<DisseminationValue>> CreateValueGroups(
+        Dictionary<string, ImmutableArray<DisseminationValue>.Builder> result) =>
+        result.ToFrozenDictionary(
             static pair => pair.Key,
             static pair => pair.Value.ToImmutable(),
             StringComparer.Ordinal);
-    }
 
     public sealed record AntiEntropyState(FrozenDictionary<string, AntiEntropyTopicState> Topics)
     {
@@ -1235,31 +1256,61 @@ internal sealed partial class DisseminationProtocol(
 
     private readonly record struct TopicValue(string Topic, DisseminationValue Value);
 
+    private readonly record struct PendingTopicValues(string Topic, ImmutableArray<DisseminationValue> Values);
+
     private sealed class PendingGossipBatch(DateTimeOffset flushAfter)
     {
-        private readonly Dictionary<string, int> _topicCounts = new(StringComparer.Ordinal);
-
-        public Dictionary<DigestKey, DisseminationValue> Values { get; } = [];
+        private readonly Dictionary<string, Dictionary<string, DisseminationValue>> _valuesByTopic = new(StringComparer.Ordinal);
 
         public DateTimeOffset FlushAfter { get; set; } = flushAfter;
 
+        public int Count { get; private set; }
+
         public int ByteCount { get; private set; }
 
-        public int GetTopicCount(string topic) => _topicCounts.GetValueOrDefault(topic);
+        public int GetTopicCount(string topic) => _valuesByTopic.TryGetValue(topic, out var values) ? values.Count : 0;
+
+        public bool TryGetValue(DigestKey key, out DisseminationValue value)
+        {
+            if (_valuesByTopic.TryGetValue(key.Topic, out var topicValues))
+            {
+                return topicValues.TryGetValue(key.Key, out value!);
+            }
+
+            value = default!;
+            return false;
+        }
 
         public void AddOrReplace(DigestKey key, DisseminationValue value)
         {
-            if (Values.TryGetValue(key, out var previous))
+            if (!_valuesByTopic.TryGetValue(key.Topic, out var topicValues))
+            {
+                topicValues = new Dictionary<string, DisseminationValue>(StringComparer.Ordinal);
+                _valuesByTopic.Add(key.Topic, topicValues);
+            }
+
+            if (topicValues.TryGetValue(key.Key, out var previous))
             {
                 ByteCount -= previous.Payload.Length;
             }
             else
             {
-                _topicCounts[key.Topic] = GetTopicCount(key.Topic) + 1;
+                Count++;
             }
 
-            Values[key] = value;
+            topicValues[key.Key] = value;
             ByteCount += value.Payload.Length;
+        }
+
+        public ImmutableArray<PendingTopicValues> ToImmutableValuesByTopic()
+        {
+            var result = ImmutableArray.CreateBuilder<PendingTopicValues>(_valuesByTopic.Count);
+            foreach (var (topic, values) in _valuesByTopic)
+            {
+                result.Add(new PendingTopicValues(topic, [.. values.Values]));
+            }
+
+            return result.ToImmutable();
         }
     }
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -375,7 +375,27 @@ internal sealed partial class DisseminationProtocol(
             return DisseminationApplyResult.Obsolete;
         }
 
-        var result = await topic.ApplyValue(value, cancellationToken);
+        DisseminationApplyResult result;
+        try
+        {
+            result = await topic.ApplyValue(value, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            result = DisseminationApplyResult.Rejected;
+            LogDebugDisseminationValueApplyFailed(
+                _logger,
+                exception,
+                sender,
+                topicName,
+                value.Digest.Key,
+                value.Digest.Version);
+        }
+
         EmitApplyResult(topicName, value, sender, result);
         if (result is DisseminationApplyResult.Applied or DisseminationApplyResult.Duplicate)
         {
@@ -1722,6 +1742,11 @@ internal sealed partial class DisseminationProtocol(
         Level = LogLevel.Debug,
         Message = "Failed to apply anti-entropy repair value from {Sender} for topic {Topic}, key {Key}, version {Version}.")]
     private static partial void LogDebugAntiEntropyRepairValueFailed(ILogger logger, Exception exception, SiloAddress sender, string topic, string key, long version);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Failed to apply dissemination value from {Sender} for topic {Topic}, key {Key}, version {Version}.")]
+    private static partial void LogDebugDisseminationValueApplyFailed(ILogger logger, Exception exception, SiloAddress sender, string topic, string key, long version);
 
     [LoggerMessage(
         Level = LogLevel.Debug,

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -111,9 +111,9 @@ internal sealed partial class DisseminationProtocol(
             List<DisseminationTopicDigest>? topicDigests = null;
             foreach (var topicDigest in topic.GetDigests())
             {
-                var digest = CreateDigest(topic, topicDigest);
-                currentValueStreams.Add(GetDigestKey(digest));
-                if (ShouldRequestAntiEntropy(topic, digest, now))
+                var digestKey = new DigestKey(topic.Name, topicDigest.Key);
+                currentValueStreams.Add(digestKey);
+                if (ShouldRequestAntiEntropy(topic, digestKey, now))
                 {
                     (topicDigests ??= []).Add(topicDigest);
                 }
@@ -250,10 +250,14 @@ internal sealed partial class DisseminationProtocol(
 
             foreach (var topicDigest in requestedTopic.GetDigests())
             {
+                var digestKey = new DigestKey(requestedTopic.Name, topicDigest.Key);
+                if (!remoteDigests.TryGetValue(digestKey, out var remoteDigest))
+                {
+                    continue;
+                }
+
                 var localDigest = CreateDigest(requestedTopic, topicDigest);
-                var digestKey = GetDigestKey(localDigest);
-                if (!remoteDigests.TryGetValue(digestKey, out var remoteDigest)
-                    || requestedTopic.CompareVersion(localDigest, remoteDigest) <= 0)
+                if (requestedTopic.CompareVersion(localDigest, remoteDigest) <= 0)
                 {
                     continue;
                 }
@@ -357,7 +361,7 @@ internal sealed partial class DisseminationProtocol(
         }
 
         var now = _timeProvider.GetUtcNow();
-        var key = GetDigestKey(item.Digest);
+        var key = new DigestKey(item.Digest.Topic, item.Digest.Key);
         lock (_gossipQueueLock)
         {
             if (!_pendingGossip.TryGetValue(peer, out var pending))
@@ -635,7 +639,7 @@ internal sealed partial class DisseminationProtocol(
                 continue;
             }
 
-            var key = GetDigestKey(digest);
+            var key = new DigestKey(digest.Topic, digest.Key);
             if (!result.TryGetValue(key, out var existing) || topic.CompareVersion(digest, existing) > 0)
             {
                 result[key] = digest;
@@ -645,9 +649,8 @@ internal sealed partial class DisseminationProtocol(
         return result;
     }
 
-    private bool ShouldRequestAntiEntropy(IDisseminationTopic topic, DisseminationDigest digest, DateTimeOffset now)
+    private bool ShouldRequestAntiEntropy(IDisseminationTopic topic, DigestKey key, DateTimeOffset now)
     {
-        var key = GetDigestKey(digest);
         lock (_recentUpdateLock)
         {
             return !_lastUpdateReceivedAt.TryGetValue(key, out var lastReceived)
@@ -657,7 +660,7 @@ internal sealed partial class DisseminationProtocol(
 
     private void RecordRecentUpdate(DisseminationDigest digest)
     {
-        var key = GetDigestKey(digest);
+        var key = new DigestKey(digest.Topic, digest.Key);
         lock (_recentUpdateLock)
         {
             _lastUpdateReceivedAt[key] = _timeProvider.GetUtcNow();
@@ -1134,8 +1137,6 @@ internal sealed partial class DisseminationProtocol(
         Values = values,
         Truncated = truncated,
     };
-
-    private static DigestKey GetDigestKey(DisseminationDigest digest) => new(digest.Topic, digest.Key);
 
     private static DisseminationDigest CreateDigest(IDisseminationTopic topic, DisseminationTopicDigest digest) =>
         new(topic.Name, digest.Key, digest.Version);

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -23,8 +23,8 @@ internal sealed partial class DisseminationProtocol
     private readonly object _capabilityLock = new();
     private readonly object _failureLock = new();
     private readonly object _topologyLock = new();
-    private readonly Dictionary<SiloAddress, string> _peerScores = new();
-    private ParticipantTopology _participantTopology = ParticipantTopology.Empty;
+    private ParticipantTopology _activeMembersTopology = ParticipantTopology.Empty;
+    private ParticipantTopology _allMembersTopology = ParticipantTopology.Empty;
 
     public DisseminationProtocol(
         IDisseminationTransport transport,
@@ -44,7 +44,7 @@ internal sealed partial class DisseminationProtocol
 
     public async ValueTask<bool> Publish(
         string topicName,
-        DisseminationItem item,
+        DisseminationValue item,
         IReadOnlyCollection<SiloAddress>? targetPeers,
         CancellationToken cancellationToken)
     {
@@ -55,16 +55,20 @@ internal sealed partial class DisseminationProtocol
 
         if (!ValidatePayloadSize(topic, item))
         {
-            await topic.OnFallbackRequired(default!, item.Id, cancellationToken);
-            DisseminationInstruments.OnFallback(item.Id.Topic, "oversize");
+            await topic.OnFallbackRequired(default!, item.Digest, cancellationToken);
+            DisseminationInstruments.OnFallback(item.Digest.Topic, "oversize");
             return false;
         }
 
         var root = item.Root is not null ? item.Root : _transport.LocalSilo;
         item = EnsureRoot(item, root);
-        var peers = targetPeers is { Count: > 0 } ? targetPeers : _transport.GetActivePeers();
-        var topology = GetParticipantTopology(peers.Append(root), includeLocal: true);
-        if (!await AreParticipantsCapable(topology.Participants, topic, item.Id.PayloadKind, cancellationToken))
+        var topology = targetPeers is { Count: > 0 }
+            ? BuildParticipantTopology(targetPeers, root, includeLocal: true)
+            : GetParticipantTopology(topic.MembershipScope, root, includeLocal: true);
+        var activeMembers = targetPeers is { Count: > 0 }
+            ? topology.ParticipantSet
+            : GetActiveMemberSet(root, includeLocal: true);
+        if (!await AreParticipantsCapable(topology.Participants, activeMembers, topic, item.Digest.PayloadKind, cancellationToken))
         {
             return false;
         }
@@ -84,14 +88,14 @@ internal sealed partial class DisseminationProtocol
             return;
         }
 
-        foreach (var group in batch.Items.GroupBy(static item => item.Id.Topic))
+        foreach (var group in batch.Values.GroupBy(static item => item.Digest.Topic))
         {
             DisseminationInstruments.OnGossipReceived(group.Key, "tree", group.Count());
         }
 
-        foreach (var item in batch.Items)
+        foreach (var item in batch.Values)
         {
-            await ApplyReceivedItem(item, batch.Sender, forward: true, cancellationToken);
+            await ApplyReceivedValue(item, batch.Sender, forward: true, cancellationToken);
         }
     }
 
@@ -103,7 +107,7 @@ internal sealed partial class DisseminationProtocol
         }
 
         var topics = new List<DisseminationCapabilityRequest>();
-        var digests = new List<DisseminationItemId>();
+        var digests = new List<DisseminationDigest>();
         foreach (var topic in _topics.Values)
         {
             if (!topic.IsEnabled)
@@ -129,7 +133,7 @@ internal sealed partial class DisseminationProtocol
         }
 
         return new AntiEntropyState(
-            SelectAntiEntropyPeers(),
+            GetAntiEntropyPeersByTopic(topics),
             topics.ToArray(),
             SortDigests(digests).ToArray());
     }
@@ -138,15 +142,19 @@ internal sealed partial class DisseminationProtocol
         AntiEntropyState state,
         CancellationToken cancellationToken)
     {
-        if (state.Peers.Count == 0 || state.Topics.Count == 0)
+        if (state.PeersByTopic.Count == 0 || state.Topics.Count == 0)
         {
             return Array.Empty<DisseminationAntiEntropyResponse>();
         }
 
-        var responses = new List<DisseminationAntiEntropyResponse>(state.Peers.Count);
-        foreach (var peer in state.Peers)
+        var peers = state.PeersByTopic.Values.SelectMany(static value => value).Distinct().ToArray();
+        var responses = new List<DisseminationAntiEntropyResponse>(peers.Length);
+        foreach (var peer in peers)
         {
-            var topics = await GetCapableAntiEntropyTopics(peer, state.Topics, cancellationToken);
+            var requestedTopics = state.Topics
+                .Where(request => state.PeersByTopic.TryGetValue(request.Topic, out var topicPeers) && topicPeers.Contains(peer))
+                .ToArray();
+            var topics = await GetCapableAntiEntropyTopics(peer, requestedTopics, cancellationToken);
             if (topics.Count == 0)
             {
                 continue;
@@ -166,7 +174,7 @@ internal sealed partial class DisseminationProtocol
                 continue;
             }
 
-            DisseminationInstruments.OnAntiEntropyExchange("out", request.Digests.Length, response.Items.Length, response.Truncated);
+            DisseminationInstruments.OnAntiEntropyExchange("out", request.Digests.Length, response.Values.Length, response.Truncated);
             responses.Add(response);
         }
 
@@ -184,11 +192,11 @@ internal sealed partial class DisseminationProtocol
 
         foreach (var response in responses)
         {
-            foreach (var item in response.Items)
+            foreach (var item in response.Values)
             {
                 try
                 {
-                    await ApplyReceivedItem(item, response.Sender, forward: false, cancellationToken);
+                    await ApplyReceivedValue(item, response.Sender, forward: false, cancellationToken);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -196,7 +204,7 @@ internal sealed partial class DisseminationProtocol
                 }
                 catch (Exception exception)
                 {
-                    LogDebugAntiEntropyRepairItemFailed(_logger, exception, response.Sender, item.Id.Topic, item.Id.Key.ToString(), item.Id.Version);
+                    LogDebugAntiEntropyRepairValueFailed(_logger, exception, response.Sender, item.Digest.Topic, item.Digest.Key, item.Digest.Version);
                 }
             }
         }
@@ -208,17 +216,17 @@ internal sealed partial class DisseminationProtocol
     {
         if (!_options.CurrentValue.Enabled)
         {
-            return CreateAntiEntropyResponse(Array.Empty<DisseminationItem>(), truncated: false);
+            return CreateAntiEntropyResponse(Array.Empty<DisseminationValue>(), truncated: false);
         }
 
         var requestedTopics = GetRequestedTopics(request);
         if (requestedTopics.Count == 0)
         {
-            return CreateAntiEntropyResponse(Array.Empty<DisseminationItem>(), truncated: false);
+            return CreateAntiEntropyResponse(Array.Empty<DisseminationValue>(), truncated: false);
         }
 
         var remoteDigests = GetRemoteDigestMap(request.Digests);
-        var items = new List<DisseminationItem>();
+        var values = new List<DisseminationValue>();
         var byteCount = 0;
         var truncated = false;
         var options = _options.CurrentValue;
@@ -239,19 +247,19 @@ internal sealed partial class DisseminationProtocol
                     continue;
                 }
 
-                var item = await requestedTopic.Topic.GetItem(localDigest, cancellationToken);
+                var item = await requestedTopic.Topic.GetValue(localDigest, cancellationToken);
                 if (item is null || !ValidatePayloadSize(requestedTopic.Topic, item))
                 {
                     continue;
                 }
 
-                if (items.Count >= options.MaxBatchItems || byteCount + item.Payload.Length > options.MaxBatchBytes)
+                if (values.Count >= options.MaxBatchItems || byteCount + item.Payload.Length > options.MaxBatchBytes)
                 {
                     truncated = true;
                     break;
                 }
 
-                items.Add(item);
+                values.Add(item);
                 byteCount += item.Payload.Length;
             }
 
@@ -261,55 +269,55 @@ internal sealed partial class DisseminationProtocol
             }
         }
 
-        DisseminationInstruments.OnAntiEntropyExchange("in", request.Digests.Length, items.Count, truncated);
-        return CreateAntiEntropyResponse(items.ToArray(), truncated);
+        DisseminationInstruments.OnAntiEntropyExchange("in", request.Digests.Length, values.Count, truncated);
+        return CreateAntiEntropyResponse(values.ToArray(), truncated);
     }
 
-    private async ValueTask<DisseminationApplyResult> ApplyReceivedItem(
-        DisseminationItem item,
+    private async ValueTask<DisseminationApplyResult> ApplyReceivedValue(
+        DisseminationValue value,
         SiloAddress sender,
         bool forward,
         CancellationToken cancellationToken)
     {
-        if (!TryGetEnabledTopic(item.Id.Topic, out var topic))
+        if (!TryGetEnabledTopic(value.Digest.Topic, out var topic))
         {
-            EmitApplyResult(item, sender, DisseminationApplyResult.Rejected);
+            EmitApplyResult(value, sender, DisseminationApplyResult.Rejected);
             return DisseminationApplyResult.Rejected;
         }
 
-        if (!topic.PayloadKinds.Contains(item.Id.PayloadKind))
+        if (!topic.PayloadKinds.Contains(value.Digest.PayloadKind))
         {
-            EmitApplyResult(item, sender, DisseminationApplyResult.Rejected);
+            EmitApplyResult(value, sender, DisseminationApplyResult.Rejected);
             return DisseminationApplyResult.Rejected;
         }
 
-        if (!ValidatePayloadSize(topic, item))
+        if (!ValidatePayloadSize(topic, value))
         {
             return DisseminationApplyResult.Rejected;
         }
 
-        if (IsExpired(item) || topic.IsObsolete(item.Id))
+        if (IsExpired(value) || topic.IsObsolete(value.Digest))
         {
-            EmitApplyResult(item, sender, DisseminationApplyResult.Obsolete);
+            EmitApplyResult(value, sender, DisseminationApplyResult.Obsolete);
             return DisseminationApplyResult.Obsolete;
         }
 
-        var result = await topic.ApplyItem(item, cancellationToken);
-        EmitApplyResult(item, sender, result);
+        var result = await topic.ApplyValue(value, cancellationToken);
+        EmitApplyResult(value, sender, result);
 
         if (result == DisseminationApplyResult.Applied && forward)
         {
-            await Forward(item, sender, cancellationToken);
+            await Forward(value, topic, sender, cancellationToken);
         }
 
         return result;
     }
 
-    private async Task Forward(DisseminationItem item, SiloAddress sender, CancellationToken cancellationToken)
+    private async Task Forward(DisseminationValue item, IDisseminationTopic topic, SiloAddress sender, CancellationToken cancellationToken)
     {
         var root = item.Root is not null ? item.Root : sender;
         item = EnsureRoot(item, root);
-        var topology = GetParticipantTopology(_transport.GetActivePeers().Append(root), includeLocal: true);
+        var topology = GetParticipantTopology(topic.MembershipScope, root, includeLocal: true);
         foreach (var peer in GetTreeChildren(topology, root))
         {
             if (!Equals(peer, sender))
@@ -319,10 +327,10 @@ internal sealed partial class DisseminationProtocol
         }
     }
 
-    private async ValueTask<bool> SendGossip(SiloAddress peer, DisseminationItem item, CancellationToken cancellationToken)
+    private async ValueTask<bool> SendGossip(SiloAddress peer, DisseminationValue item, CancellationToken cancellationToken)
     {
-        if (!_topics.TryGetValue(item.Id.Topic, out var topic)
-            || !await IsCapable(peer, topic, item.Id.PayloadKind, cancellationToken))
+        if (!_topics.TryGetValue(item.Digest.Topic, out var topic)
+            || await GetCapabilityStatus(peer, topic, item.Digest.PayloadKind, cancellationToken) != CapabilityStatus.Supported)
         {
             return false;
         }
@@ -330,13 +338,13 @@ internal sealed partial class DisseminationProtocol
         var batch = new DisseminationGossipBatch
         {
             Sender = _transport.LocalSilo,
-            Items = new[] { item },
+            Values = new[] { item },
         };
 
         var sent = await SafeSend(peer, target => _transport.SendGossip(target, batch, cancellationToken));
         if (sent)
         {
-            DisseminationInstruments.OnGossipSent(item.Id.Topic, "tree", 1, item.Payload.Length);
+            DisseminationInstruments.OnGossipSent(item.Digest.Topic, "tree", 1, item.Payload.Length);
         }
 
         return sent;
@@ -386,7 +394,7 @@ internal sealed partial class DisseminationProtocol
         }
     }
 
-    private async ValueTask<bool> IsCapable(
+    private async ValueTask<CapabilityStatus> GetCapabilityStatus(
         SiloAddress peer,
         IDisseminationTopic topic,
         string payloadKind,
@@ -398,14 +406,16 @@ internal sealed partial class DisseminationProtocol
         {
             if (_capabilityCache.TryGetValue(key, out var cached) && cached.ExpiresAt > now)
             {
-                return cached.Supported && cached.PayloadKinds.Contains(payloadKind);
+                return cached.Supported && cached.PayloadKinds.Contains(payloadKind)
+                    ? CapabilityStatus.Supported
+                    : CapabilityStatus.Unsupported;
             }
 
             if (_capabilityProbeBackoffUntil.TryGetValue(key, out var probeBackoffUntil))
             {
                 if (probeBackoffUntil > now)
                 {
-                    return false;
+                    return CapabilityStatus.Unavailable;
                 }
 
                 _capabilityProbeBackoffUntil.Remove(key);
@@ -431,7 +441,9 @@ internal sealed partial class DisseminationProtocol
             }
 
             DisseminationEvents.EmitCapabilityProbe(_transport.LocalSilo, peer, topic.Name, supported);
-            return supported && payloadKinds.Contains(payloadKind);
+            return supported && payloadKinds.Contains(payloadKind)
+                ? CapabilityStatus.Supported
+                : CapabilityStatus.Unsupported;
         }
         catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
         {
@@ -443,22 +455,23 @@ internal sealed partial class DisseminationProtocol
             }
 
             DisseminationEvents.EmitCapabilityProbe(_transport.LocalSilo, peer, topic.Name, supported: false);
-            return false;
+            return CapabilityStatus.Unavailable;
         }
     }
 
     private async ValueTask<bool> AreParticipantsCapable(
-        IReadOnlyList<SiloAddress> participants,
+        ImmutableArray<SiloAddress> participants,
+        HashSet<SiloAddress> activeMembers,
         IDisseminationTopic topic,
         string payloadKind,
         CancellationToken cancellationToken)
     {
-        var probes = new List<Task<bool>>(participants.Count);
-        foreach (var peer in participants)
+        var probes = new List<Task<(SiloAddress Participant, CapabilityStatus Status)>>(participants.Length);
+        foreach (var participant in participants)
         {
-            if (!Equals(peer, _transport.LocalSilo))
+            if (!Equals(participant, _transport.LocalSilo))
             {
-                probes.Add(IsCapable(peer, topic, payloadKind, cancellationToken).AsTask());
+                probes.Add(Probe(participant));
             }
         }
 
@@ -468,7 +481,18 @@ internal sealed partial class DisseminationProtocol
         }
 
         var results = await Task.WhenAll(probes);
-        return results.All(static supported => supported);
+        foreach (var (participant, status) in results)
+        {
+            if (activeMembers.Contains(participant) && status != CapabilityStatus.Supported)
+            {
+                return false;
+            }
+        }
+
+        return true;
+
+        async Task<(SiloAddress Participant, CapabilityStatus Status)> Probe(SiloAddress participant) =>
+            (participant, await GetCapabilityStatus(participant, topic, payloadKind, cancellationToken));
     }
 
     private async ValueTask<List<DisseminationCapabilityRequest>> GetCapableAntiEntropyTopics(
@@ -487,7 +511,7 @@ internal sealed partial class DisseminationProtocol
             var supportedPayloadKinds = new List<string>(request.PayloadKinds.Length);
             foreach (var payloadKind in request.PayloadKinds)
             {
-                if (await IsCapable(peer, topic, payloadKind, cancellationToken))
+                if (await GetCapabilityStatus(peer, topic, payloadKind, cancellationToken) == CapabilityStatus.Supported)
                 {
                     supportedPayloadKinds.Add(payloadKind);
                 }
@@ -530,9 +554,9 @@ internal sealed partial class DisseminationProtocol
         return result;
     }
 
-    private Dictionary<DigestKey, DisseminationItemId> GetRemoteDigestMap(IEnumerable<DisseminationItemId> digests)
+    private Dictionary<DigestKey, DisseminationDigest> GetRemoteDigestMap(IEnumerable<DisseminationDigest> digests)
     {
-        var result = new Dictionary<DigestKey, DisseminationItemId>();
+        var result = new Dictionary<DigestKey, DisseminationDigest>();
         foreach (var digest in digests)
         {
             if (!TryGetEnabledTopic(digest.Topic, out var topic))
@@ -550,12 +574,27 @@ internal sealed partial class DisseminationProtocol
         return result;
     }
 
-    private IReadOnlyList<SiloAddress> SelectAntiEntropyPeers()
+    private IReadOnlyDictionary<string, IReadOnlyList<SiloAddress>> GetAntiEntropyPeersByTopic(
+        IReadOnlyList<DisseminationCapabilityRequest> topics)
+    {
+        var result = new Dictionary<string, IReadOnlyList<SiloAddress>>(StringComparer.Ordinal);
+        foreach (var request in topics)
+        {
+            if (_topics.TryGetValue(request.Topic, out var topic) && topic.IsEnabled)
+            {
+                result[request.Topic] = SelectAntiEntropyPeers(topic.MembershipScope);
+            }
+        }
+
+        return result;
+    }
+
+    private IReadOnlyList<SiloAddress> SelectAntiEntropyPeers(DisseminationMembershipScope membershipScope)
     {
         var options = _options.CurrentValue.Overlay;
-        var topology = GetParticipantTopology(_transport.GetActivePeers(), includeLocal: true);
+        var topology = GetParticipantTopology(membershipScope, root: null, includeLocal: true);
         var participants = topology.Participants;
-        if (participants.Count <= 1)
+        if (participants.Length <= 1)
         {
             return Array.Empty<SiloAddress>();
         }
@@ -565,10 +604,10 @@ internal sealed partial class DisseminationProtocol
             return Array.Empty<SiloAddress>();
         }
 
-        var result = new List<SiloAddress>(Math.Min(options.AntiEntropyPeerCount, participants.Count - 1));
-        for (var offset = 1; offset < participants.Count && result.Count < options.AntiEntropyPeerCount; offset++)
+        var result = new List<SiloAddress>(Math.Min(options.AntiEntropyPeerCount, participants.Length - 1));
+        for (var offset = 1; offset < participants.Length && result.Count < options.AntiEntropyPeerCount; offset++)
         {
-            var peer = participants[(localIndex + offset) % participants.Count];
+            var peer = participants[(localIndex + offset) % participants.Length];
             if (!Equals(peer, _transport.LocalSilo))
             {
                 result.Add(peer);
@@ -578,52 +617,105 @@ internal sealed partial class DisseminationProtocol
         return result;
     }
 
-    private ParticipantTopology GetParticipantTopology(IEnumerable<SiloAddress> peers, bool includeLocal)
+    private ParticipantTopology GetParticipantTopology(
+        DisseminationMembershipScope membershipScope,
+        SiloAddress? root,
+        bool includeLocal)
     {
-        var peerSet = new HashSet<SiloAddress>();
-        if (includeLocal)
-        {
-            peerSet.Add(_transport.LocalSilo);
-        }
+        var membership = _transport.GetMembership();
+        var activeMembers = GetCachedParticipantTopology(
+            DisseminationMembershipScope.ActiveMembers,
+            membership.ActiveMembers,
+            membershipScope == DisseminationMembershipScope.ActiveMembers ? root : null,
+            includeLocal);
+        var allMembers = GetCachedParticipantTopology(
+            DisseminationMembershipScope.AllMembers,
+            membership.AllMembers,
+            membershipScope == DisseminationMembershipScope.AllMembers ? root : null,
+            includeLocal);
 
-        foreach (var peer in peers)
-        {
-            if (peer is not null)
-            {
-                peerSet.Add(peer);
-            }
-        }
+        return membershipScope == DisseminationMembershipScope.AllMembers ? allMembers : activeMembers;
+    }
+
+    private HashSet<SiloAddress> GetActiveMemberSet(SiloAddress? root, bool includeLocal) =>
+        GetCachedParticipantTopology(
+            DisseminationMembershipScope.ActiveMembers,
+            _transport.GetMembership().ActiveMembers,
+            root,
+            includeLocal).ParticipantSet;
+
+    private ParticipantTopology GetCachedParticipantTopology(
+        DisseminationMembershipScope membershipScope,
+        IEnumerable<SiloAddress> participants,
+        SiloAddress? root,
+        bool includeLocal)
+    {
+        var participantSet = GetParticipantSet(participants, root, includeLocal);
 
         lock (_topologyLock)
         {
-            if (_participantTopology.ParticipantSet.SetEquals(peerSet))
+            var current = membershipScope switch
             {
-                return _participantTopology;
+                DisseminationMembershipScope.AllMembers => _allMembersTopology,
+                _ => _activeMembersTopology,
+            };
+
+            if (current.ParticipantSet.SetEquals(participantSet))
+            {
+                return current;
             }
 
-            var participants = peerSet
-                .OrderBy(GetPeerScoreLocked, StringComparer.Ordinal)
-                .ToList();
-            var indices = new Dictionary<SiloAddress, int>(participants.Count);
-            for (var i = 0; i < participants.Count; i++)
+            var updated = BuildParticipantTopology(participantSet);
+            if (membershipScope == DisseminationMembershipScope.AllMembers)
             {
-                indices[participants[i]] = i;
+                _allMembersTopology = updated;
+            }
+            else
+            {
+                _activeMembersTopology = updated;
             }
 
-            _participantTopology = new ParticipantTopology(participants, indices, peerSet);
-            return _participantTopology;
+            return updated;
         }
     }
 
-    private string GetPeerScoreLocked(SiloAddress peer)
+    private ParticipantTopology BuildParticipantTopology(
+        IEnumerable<SiloAddress> participants,
+        SiloAddress? root,
+        bool includeLocal) =>
+        BuildParticipantTopology(GetParticipantSet(participants, root, includeLocal));
+
+    private HashSet<SiloAddress> GetParticipantSet(
+        IEnumerable<SiloAddress> participants,
+        SiloAddress? root,
+        bool includeLocal)
     {
-        if (!_peerScores.TryGetValue(peer, out var score))
+        var participantSet = new HashSet<SiloAddress>(participants);
+        if (includeLocal)
         {
-            score = ComputePeerScore(peer);
-            _peerScores[peer] = score;
+            participantSet.Add(_transport.LocalSilo);
         }
 
-        return score;
+        if (root is { } rootAddress)
+        {
+            participantSet.Add(rootAddress);
+        }
+
+        return participantSet;
+    }
+
+    private static ParticipantTopology BuildParticipantTopology(HashSet<SiloAddress> participantSet)
+    {
+        var sortedParticipants = participantSet
+            .OrderBy(static participant => participant)
+            .ToImmutableArray();
+        var indices = new Dictionary<SiloAddress, int>(sortedParticipants.Length);
+        for (var i = 0; i < sortedParticipants.Length; i++)
+        {
+            indices[sortedParticipants[i]] = i;
+        }
+
+        return new ParticipantTopology(sortedParticipants, indices, new HashSet<SiloAddress>(participantSet));
     }
 
     private IReadOnlyList<SiloAddress> GetTreeChildren(ParticipantTopology topology, SiloAddress root)
@@ -635,7 +727,7 @@ internal sealed partial class DisseminationProtocol
         }
 
         var fanout = _options.CurrentValue.Overlay.TreeFanout;
-        var count = topology.Participants.Count;
+        var count = topology.Participants.Length;
         var localTreeIndex = localIndex >= rootIndex ? localIndex - rootIndex : localIndex + count - rootIndex;
         var firstChild = (localTreeIndex * fanout) + 1;
         if (firstChild >= count)
@@ -671,20 +763,20 @@ internal sealed partial class DisseminationProtocol
         return false;
     }
 
-    private bool ValidatePayloadSize(IDisseminationTopic topic, DisseminationItem item)
+    private bool ValidatePayloadSize(IDisseminationTopic topic, DisseminationValue item)
     {
         var options = _options.CurrentValue;
         if (item.Payload.Length > topic.Options.MaxPayloadBytes || item.Payload.Length > options.MaxBatchBytes)
         {
-            DisseminationEvents.EmitPayloadDrop(item.Id, _transport.LocalSilo, "oversize", item.Payload.Length);
-            DisseminationInstruments.OnPayloadDropped(item.Id.Topic, "oversize");
+            DisseminationEvents.EmitPayloadDrop(item.Digest, _transport.LocalSilo, "oversize", item.Payload.Length);
+            DisseminationInstruments.OnPayloadDropped(item.Digest.Topic, "oversize");
             return false;
         }
 
         return true;
     }
 
-    private bool IsExpired(DisseminationItem item) => item.ExpiresAt <= _timeProvider.GetUtcNow();
+    private bool IsExpired(DisseminationValue item) => item.ExpiresAt <= _timeProvider.GetUtcNow();
 
     private bool IsPeerBackedOff(SiloAddress peer)
     {
@@ -711,31 +803,31 @@ internal sealed partial class DisseminationProtocol
         }
     }
 
-    private void EmitApplyResult(DisseminationItem item, SiloAddress sender, DisseminationApplyResult result)
+    private void EmitApplyResult(DisseminationValue item, SiloAddress sender, DisseminationApplyResult result)
     {
-        DisseminationEvents.EmitItem(item.Id, _transport.LocalSilo, sender, result.ToString(), item.Payload.Length);
-        DisseminationInstruments.OnItemApplied(item.Id.Topic, result.ToString());
+        DisseminationEvents.EmitValue(item.Digest, _transport.LocalSilo, sender, result.ToString(), item.Payload.Length);
+        DisseminationInstruments.OnValueApplied(item.Digest.Topic, result.ToString());
     }
 
-    private DisseminationAntiEntropyResponse CreateAntiEntropyResponse(DisseminationItem[] items, bool truncated) => new()
+    private DisseminationAntiEntropyResponse CreateAntiEntropyResponse(DisseminationValue[] values, bool truncated) => new()
     {
         Sender = _transport.LocalSilo,
-        Items = items,
+        Values = values,
         Truncated = truncated,
     };
 
-    private static DisseminationItem EnsureRoot(DisseminationItem item, SiloAddress root) =>
+    private static DisseminationValue EnsureRoot(DisseminationValue item, SiloAddress root) =>
         item.Root is not null
             ? item
-            : new DisseminationItem
+            : new DisseminationValue
             {
-                Id = item.Id,
+                Digest = item.Digest,
                 Root = root,
                 ExpiresAt = item.ExpiresAt,
                 Payload = item.Payload,
             };
 
-    private static bool IsRequested(IEnumerable<DisseminationCapabilityRequest> requests, DisseminationItemId digest)
+    private static bool IsRequested(IEnumerable<DisseminationCapabilityRequest> requests, DisseminationDigest digest)
     {
         foreach (var request in requests)
         {
@@ -749,47 +841,48 @@ internal sealed partial class DisseminationProtocol
         return false;
     }
 
-    private static IEnumerable<DisseminationItemId> SortDigests(IEnumerable<DisseminationItemId> digests) =>
+    private static IEnumerable<DisseminationDigest> SortDigests(IEnumerable<DisseminationDigest> digests) =>
         digests
             .OrderBy(static digest => digest.Topic, StringComparer.Ordinal)
             .ThenBy(static digest => digest.PayloadKind, StringComparer.Ordinal)
-            .ThenBy(static digest => digest.Key.ToString(), StringComparer.Ordinal)
+            .ThenBy(static digest => digest.Key, StringComparer.Ordinal)
             .ThenBy(static digest => digest.Version);
 
-    private static DigestKey GetDigestKey(DisseminationItemId digest) => new(digest.Topic, digest.Key, digest.PayloadKind);
-
-    private static string ComputePeerScore(SiloAddress peer)
-    {
-        var bytes = System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(peer.ToParsableString()));
-        return Convert.ToHexString(bytes);
-    }
+    private static DigestKey GetDigestKey(DisseminationDigest digest) => new(digest.Topic, digest.Key, digest.PayloadKind);
 
     public sealed record AntiEntropyState(
-        IReadOnlyList<SiloAddress> Peers,
+        IReadOnlyDictionary<string, IReadOnlyList<SiloAddress>> PeersByTopic,
         IReadOnlyList<DisseminationCapabilityRequest> Topics,
-        IReadOnlyList<DisseminationItemId> Digests)
+        IReadOnlyList<DisseminationDigest> Digests)
     {
         public static readonly AntiEntropyState Empty = new(
-            Array.Empty<SiloAddress>(),
+            new Dictionary<string, IReadOnlyList<SiloAddress>>(StringComparer.Ordinal),
             Array.Empty<DisseminationCapabilityRequest>(),
-            Array.Empty<DisseminationItemId>());
+            Array.Empty<DisseminationDigest>());
     }
 
     private readonly record struct CapabilityKey(SiloAddress Peer, string Topic);
 
     private readonly record struct CapabilityEntry(bool Supported, HashSet<string> PayloadKinds, DateTimeOffset ExpiresAt);
 
-    private readonly record struct DigestKey(string Topic, DisseminationValueKey Key, string PayloadKind);
+    private readonly record struct DigestKey(string Topic, string Key, string PayloadKind);
 
     private readonly record struct RequestedTopic(IDisseminationTopic Topic, HashSet<string> PayloadKinds);
 
+    private enum CapabilityStatus
+    {
+        Supported,
+        Unsupported,
+        Unavailable,
+    }
+
     private sealed record ParticipantTopology(
-        IReadOnlyList<SiloAddress> Participants,
+        ImmutableArray<SiloAddress> Participants,
         IReadOnlyDictionary<SiloAddress, int> Indices,
         HashSet<SiloAddress> ParticipantSet)
     {
         public static readonly ParticipantTopology Empty = new(
-            Array.Empty<SiloAddress>(),
+            ImmutableArray<SiloAddress>.Empty,
             new Dictionary<SiloAddress, int>(),
             new HashSet<SiloAddress>());
     }
@@ -806,6 +899,6 @@ internal sealed partial class DisseminationProtocol
 
     [LoggerMessage(
         Level = LogLevel.Debug,
-        Message = "Failed to apply anti-entropy repair item from {Sender} for topic {Topic}, key {Key}, version {Version}.")]
-    private static partial void LogDebugAntiEntropyRepairItemFailed(ILogger logger, Exception exception, SiloAddress sender, string topic, string key, long version);
+        Message = "Failed to apply anti-entropy repair value from {Sender} for topic {Topic}, key {Key}, version {Version}.")]
+    private static partial void LogDebugAntiEntropyRepairValueFailed(ILogger logger, Exception exception, SiloAddress sender, string topic, string key, long version);
 }

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -638,7 +638,7 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private FrozenDictionary<DigestKey, DisseminationDigest> GetRemoteDigestMap(IEnumerable<DisseminationDigest> digests)
+    private Dictionary<DigestKey, DisseminationDigest> GetRemoteDigestMap(IEnumerable<DisseminationDigest> digests)
     {
         var result = new Dictionary<DigestKey, DisseminationDigest>();
         foreach (var digest in digests)
@@ -655,7 +655,7 @@ internal sealed partial class DisseminationProtocol(
             }
         }
 
-        return result.ToFrozenDictionary();
+        return result;
     }
 
     private bool ShouldRequestAntiEntropy(IDisseminationTopic topic, DisseminationDigest digest, DateTimeOffset now)

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -25,6 +25,7 @@ internal sealed partial class DisseminationProtocol
     private readonly object _topologyLock = new();
     private ParticipantTopology _activeMembersTopology = ParticipantTopology.Empty;
     private ParticipantTopology _allMembersTopology = ParticipantTopology.Empty;
+    private long _antiEntropyRound;
 
     public DisseminationProtocol(
         IDisseminationTransport transport,
@@ -73,7 +74,7 @@ internal sealed partial class DisseminationProtocol
             return false;
         }
 
-        foreach (var peer in GetTreeChildren(topology, root))
+        foreach (var peer in GetOriginatorTreeTargets(topology, root))
         {
             await SendGossip(peer, item, cancellationToken);
         }
@@ -132,8 +133,9 @@ internal sealed partial class DisseminationProtocol
             }
         }
 
+        var round = Interlocked.Increment(ref _antiEntropyRound);
         return new AntiEntropyState(
-            GetAntiEntropyPeersByTopic(topics),
+            GetAntiEntropyPeersByTopic(topics, round),
             topics.ToArray(),
             SortDigests(digests).ToArray());
     }
@@ -241,14 +243,20 @@ internal sealed partial class DisseminationProtocol
                 }
 
                 var digestKey = GetDigestKey(localDigest);
-                if (remoteDigests.TryGetValue(digestKey, out var remoteDigest)
-                    && requestedTopic.Topic.CompareVersion(localDigest, remoteDigest) <= 0)
+                var hasRemoteDigest = remoteDigests.TryGetValue(digestKey, out var remoteDigest);
+                if (hasRemoteDigest && requestedTopic.Topic.CompareVersion(localDigest, remoteDigest) <= 0)
                 {
                     continue;
                 }
 
-                var item = await requestedTopic.Topic.GetValue(localDigest, cancellationToken);
-                if (item is null || !ValidatePayloadSize(requestedTopic.Topic, item))
+                var item = await requestedTopic.Topic.GetValue(
+                    localDigest,
+                    hasRemoteDigest ? remoteDigest : null,
+                    requestedTopic.PayloadKinds,
+                    cancellationToken);
+                if (item is null
+                    || !requestedTopic.PayloadKinds.Contains(item.Digest.PayloadKind)
+                    || !ValidatePayloadSize(requestedTopic.Topic, item))
                 {
                     continue;
                 }
@@ -318,12 +326,9 @@ internal sealed partial class DisseminationProtocol
         var root = item.Root is not null ? item.Root : sender;
         item = EnsureRoot(item, root);
         var topology = GetParticipantTopology(topic.MembershipScope, root, includeLocal: true);
-        foreach (var peer in GetTreeChildren(topology, root))
+        foreach (var peer in GetForwardingTreeTargets(topology, root, sender))
         {
-            if (!Equals(peer, sender))
-            {
-                await SendGossip(peer, item, cancellationToken);
-            }
+            await SendGossip(peer, item, cancellationToken);
         }
     }
 
@@ -575,21 +580,22 @@ internal sealed partial class DisseminationProtocol
     }
 
     private IReadOnlyDictionary<string, IReadOnlyList<SiloAddress>> GetAntiEntropyPeersByTopic(
-        IReadOnlyList<DisseminationCapabilityRequest> topics)
+        IReadOnlyList<DisseminationCapabilityRequest> topics,
+        long round)
     {
         var result = new Dictionary<string, IReadOnlyList<SiloAddress>>(StringComparer.Ordinal);
         foreach (var request in topics)
         {
             if (_topics.TryGetValue(request.Topic, out var topic) && topic.IsEnabled)
             {
-                result[request.Topic] = SelectAntiEntropyPeers(topic.MembershipScope);
+                result[request.Topic] = SelectAntiEntropyPeers(topic.MembershipScope, round);
             }
         }
 
         return result;
     }
 
-    private IReadOnlyList<SiloAddress> SelectAntiEntropyPeers(DisseminationMembershipScope membershipScope)
+    private IReadOnlyList<SiloAddress> SelectAntiEntropyPeers(DisseminationMembershipScope membershipScope, long round)
     {
         var options = _options.CurrentValue.Overlay;
         var topology = GetParticipantTopology(membershipScope, root: null, includeLocal: true);
@@ -604,17 +610,178 @@ internal sealed partial class DisseminationProtocol
             return Array.Empty<SiloAddress>();
         }
 
-        var result = new List<SiloAddress>(Math.Min(options.AntiEntropyPeerCount, participants.Length - 1));
-        for (var offset = 1; offset < participants.Length && result.Count < options.AntiEntropyPeerCount; offset++)
+        var fanout = GetFanOutFactor(participants.Length);
+        var candidates = GetAntiEntropyCandidateIndexes(localIndex, participants.Length, fanout);
+        return candidates
+            .Where(index => index != localIndex)
+            .OrderBy(index => GetRepairPeerScore(participants[index], round, localIndex))
+            .ThenBy(index => participants[index])
+            .Take(options.AntiEntropyPeerCount)
+            .Select(index => participants[index])
+            .ToArray();
+    }
+
+    private static IEnumerable<int> GetAntiEntropyCandidateIndexes(int localIndex, int participantCount, int fanout)
+    {
+        if (participantCount <= 1)
         {
-            var peer = participants[(localIndex + offset) % participants.Length];
-            if (!Equals(peer, _transport.LocalSilo))
-            {
-                result.Add(peer);
-            }
+            yield break;
         }
 
+        var topLevelEnd = Math.Min(fanout, participantCount);
+        if (localIndex < topLevelEnd)
+        {
+            for (var i = 0; i < topLevelEnd; i++)
+            {
+                yield return i;
+            }
+
+            yield break;
+        }
+
+        var parentIndex = (localIndex / fanout) - 1;
+        if (parentIndex < 0)
+        {
+            yield break;
+        }
+
+        var (previousLevelStart, previousLevelEnd) = GetLevelRange(parentIndex, participantCount, fanout);
+        var windowStart = previousLevelStart + (((parentIndex - previousLevelStart) / fanout) * fanout);
+        var windowEnd = Math.Min(previousLevelEnd, windowStart + fanout);
+        for (var i = windowStart; i < windowEnd; i++)
+        {
+            yield return i;
+        }
+    }
+
+    private static (int Start, int End) GetLevelRange(int index, int participantCount, int fanout)
+    {
+        var start = 0L;
+        var width = (long)fanout;
+        while (index >= start + width && start + width < participantCount)
+        {
+            start += width;
+            width = Math.Min(width * fanout, participantCount - start);
+        }
+
+        return ((int)start, (int)Math.Min(participantCount, start + width));
+    }
+
+    private static ulong GetRepairPeerScore(SiloAddress peer, long round, int localIndex)
+    {
+        var value = (ulong)(uint)peer.GetConsistentHashCode();
+        value ^= ((ulong)round * 0x9E3779B97F4A7C15UL);
+        value ^= ((ulong)(uint)localIndex << 32);
+        return Mix(value);
+    }
+
+    private static ulong Mix(ulong value)
+    {
+        value ^= value >> 30;
+        value *= 0xBF58476D1CE4E5B9UL;
+        value ^= value >> 27;
+        value *= 0x94D049BB133111EBUL;
+        value ^= value >> 31;
+        return value;
+    }
+
+    private int GetFanOutFactor(int participantCount)
+    {
+        if (participantCount <= 1)
+        {
+            return 1;
+        }
+
+        var overlay = _options.CurrentValue.Overlay;
+        var fanout = overlay.FanOutFactor?.Invoke(participantCount) ?? GetConfiguredFanOutFactor(overlay, participantCount);
+        return Math.Clamp(fanout, 1, participantCount);
+    }
+
+    private static int GetConfiguredFanOutFactor(DisseminationOverlayOptions options, int participantCount)
+    {
+        var count = Math.Max(1, participantCount);
+        var targetHopCount = Math.Max(1, options.TargetHopCount);
+        var scaled = targetHopCount switch
+        {
+            1 => count,
+            2 => Math.Sqrt(count),
+            3 => Math.Cbrt(count),
+            _ => Math.Pow(count, 1d / targetHopCount),
+        };
+        var min = Math.Max(1, options.MinFanOutFactor);
+        var max = Math.Max(min, options.MaxFanOutFactor);
+        return (int)Math.Ceiling(Math.Max(min, Math.Min(scaled, max)));
+    }
+
+    private IReadOnlyList<SiloAddress> GetOriginatorTreeTargets(ParticipantTopology topology, SiloAddress root)
+    {
+        if (!topology.Indices.TryGetValue(root, out var rootIndex))
+        {
+            return Array.Empty<SiloAddress>();
+        }
+
+        var fanout = GetFanOutFactor(topology.Participants.Length);
+        var result = new List<SiloAddress>(Math.Min(fanout * 2, topology.Participants.Length));
+        AddTopLevelTargets(topology, fanout, root, result);
+        AddFixedChildren(topology, rootIndex, fanout, root, except: null, result);
         return result;
+    }
+
+    private IReadOnlyList<SiloAddress> GetForwardingTreeTargets(ParticipantTopology topology, SiloAddress root, SiloAddress sender)
+    {
+        if (!topology.Indices.TryGetValue(_transport.LocalSilo, out var localIndex))
+        {
+            return Array.Empty<SiloAddress>();
+        }
+
+        var fanout = GetFanOutFactor(topology.Participants.Length);
+        var result = new List<SiloAddress>(Math.Min(fanout, topology.Participants.Length));
+        AddFixedChildren(topology, localIndex, fanout, root, sender, result);
+        return result;
+    }
+
+    private static void AddTopLevelTargets(
+        ParticipantTopology topology,
+        int fanout,
+        SiloAddress root,
+        List<SiloAddress> result)
+    {
+        var count = Math.Min(fanout, topology.Participants.Length);
+        for (var i = 0; i < count; i++)
+        {
+            AddTarget(topology.Participants[i], root, except: null, result);
+        }
+    }
+
+    private static void AddFixedChildren(
+        ParticipantTopology topology,
+        int index,
+        int fanout,
+        SiloAddress root,
+        SiloAddress? except,
+        List<SiloAddress> result)
+    {
+        var firstChild = (long)fanout * (index + 1);
+        for (var i = 0; i < fanout; i++)
+        {
+            var childIndex = firstChild + i;
+            if (childIndex >= topology.Participants.Length)
+            {
+                break;
+            }
+
+            AddTarget(topology.Participants[(int)childIndex], root, except, result);
+        }
+    }
+
+    private static void AddTarget(SiloAddress peer, SiloAddress root, SiloAddress? except, List<SiloAddress> result)
+    {
+        if (Equals(peer, root) || (except is { } excluded && Equals(peer, excluded)) || result.Contains(peer))
+        {
+            return;
+        }
+
+        result.Add(peer);
     }
 
     private ParticipantTopology GetParticipantTopology(
@@ -650,7 +817,7 @@ internal sealed partial class DisseminationProtocol
         SiloAddress? root,
         bool includeLocal)
     {
-        var participantSet = GetParticipantSet(participants, root, includeLocal);
+        var orderedParticipants = GetOrderedParticipants(participants, root, includeLocal, preserveOrder: true);
 
         lock (_topologyLock)
         {
@@ -660,12 +827,12 @@ internal sealed partial class DisseminationProtocol
                 _ => _activeMembersTopology,
             };
 
-            if (current.ParticipantSet.SetEquals(participantSet))
+            if (current.Participants.SequenceEqual(orderedParticipants))
             {
                 return current;
             }
 
-            var updated = BuildParticipantTopology(participantSet);
+            var updated = BuildParticipantTopology(orderedParticipants);
             if (membershipScope == DisseminationMembershipScope.AllMembers)
             {
                 _allMembersTopology = updated;
@@ -683,71 +850,60 @@ internal sealed partial class DisseminationProtocol
         IEnumerable<SiloAddress> participants,
         SiloAddress? root,
         bool includeLocal) =>
-        BuildParticipantTopology(GetParticipantSet(participants, root, includeLocal));
+        BuildParticipantTopology(GetOrderedParticipants(participants, root, includeLocal, preserveOrder: false));
 
-    private HashSet<SiloAddress> GetParticipantSet(
+    private ImmutableArray<SiloAddress> GetOrderedParticipants(
         IEnumerable<SiloAddress> participants,
         SiloAddress? root,
-        bool includeLocal)
+        bool includeLocal,
+        bool preserveOrder)
     {
         var participantSet = new HashSet<SiloAddress>(participants);
+        var orderedParticipants = preserveOrder
+            ? participants.Where(participantSet.Remove).ToList()
+            : participantSet.OrderBy(static participant => participant).ToList();
         if (includeLocal)
         {
-            participantSet.Add(_transport.LocalSilo);
+            AddParticipant(_transport.LocalSilo);
         }
 
         if (root is { } rootAddress)
         {
-            participantSet.Add(rootAddress);
+            AddParticipant(rootAddress);
         }
 
-        return participantSet;
+        if (!preserveOrder)
+        {
+            orderedParticipants.Sort(static (left, right) => left.CompareTo(right));
+        }
+
+        return orderedParticipants.ToImmutableArray();
+
+        void AddParticipant(SiloAddress participant)
+        {
+            if (preserveOrder)
+            {
+                if (!orderedParticipants.Contains(participant))
+                {
+                    orderedParticipants.Add(participant);
+                }
+            }
+            else if (participantSet.Add(participant))
+            {
+                orderedParticipants.Add(participant);
+            }
+        }
     }
 
-    private static ParticipantTopology BuildParticipantTopology(HashSet<SiloAddress> participantSet)
+    private static ParticipantTopology BuildParticipantTopology(ImmutableArray<SiloAddress> sortedParticipants)
     {
-        var sortedParticipants = participantSet
-            .OrderBy(static participant => participant)
-            .ToImmutableArray();
         var indices = new Dictionary<SiloAddress, int>(sortedParticipants.Length);
         for (var i = 0; i < sortedParticipants.Length; i++)
         {
             indices[sortedParticipants[i]] = i;
         }
 
-        return new ParticipantTopology(sortedParticipants, indices, new HashSet<SiloAddress>(participantSet));
-    }
-
-    private IReadOnlyList<SiloAddress> GetTreeChildren(ParticipantTopology topology, SiloAddress root)
-    {
-        if (!topology.Indices.TryGetValue(root, out var rootIndex)
-            || !topology.Indices.TryGetValue(_transport.LocalSilo, out var localIndex))
-        {
-            return Array.Empty<SiloAddress>();
-        }
-
-        var fanout = _options.CurrentValue.Overlay.TreeFanout;
-        var count = topology.Participants.Length;
-        var localTreeIndex = localIndex >= rootIndex ? localIndex - rootIndex : localIndex + count - rootIndex;
-        var firstChild = (localTreeIndex * fanout) + 1;
-        if (firstChild >= count)
-        {
-            return Array.Empty<SiloAddress>();
-        }
-
-        var result = new List<SiloAddress>(Math.Min(fanout, count - firstChild));
-        for (var i = 0; i < fanout; i++)
-        {
-            var childTreeIndex = firstChild + i;
-            if (childTreeIndex >= count)
-            {
-                break;
-            }
-
-            result.Add(topology.Participants[(rootIndex + childTreeIndex) % count]);
-        }
-
-        return result;
+        return new ParticipantTopology(sortedParticipants, indices, sortedParticipants.ToHashSet());
     }
 
     private bool TryGetEnabledTopic(string topicName, out IDisseminationTopic topic)

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -525,9 +525,7 @@ internal sealed partial class DisseminationProtocol(
                 }
 
                 (drainedPeers ??= []).Add(peer);
-                result.Add((peer, [.. pending.Values.Values
-                    .OrderBy(static value => value.Digest.Topic, StringComparer.Ordinal)
-                    .ThenBy(static value => value.Digest.Key, StringComparer.Ordinal)]));
+                result.Add((peer, [.. pending.Values.Values]));
             }
 
             if (drainedPeers is not null)

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -23,10 +23,7 @@ internal sealed partial class DisseminationProtocol(
     private readonly FrozenDictionary<string, IDisseminationTopic> _topics = topics.ToFrozenDictionary(static topic => topic.Name, StringComparer.Ordinal);
     private readonly TimeProvider _timeProvider = timeProvider;
     private readonly ILogger<DisseminationProtocol> _logger = logger;
-    private readonly Dictionary<CapabilityKey, CapabilityEntry> _capabilityCache = [];
-    private readonly Dictionary<CapabilityKey, DateTimeOffset> _capabilityProbeBackoffUntil = [];
     private readonly Dictionary<SiloAddress, DateTimeOffset> _failureBackoffUntil = [];
-    private readonly object _capabilityLock = new();
     private readonly object _failureLock = new();
     private readonly object _gossipQueueLock = new();
     private readonly object _recentUpdateLock = new();
@@ -66,13 +63,6 @@ internal sealed partial class DisseminationProtocol(
         var topology = targetPeers is { Count: > 0 }
             ? BuildParticipantTopology(targetPeers, root, includeLocal: true)
             : GetParticipantTopology(topic.MembershipScope, root, includeLocal: true);
-        var activeMembers = targetPeers is { Count: > 0 }
-            ? topology.ParticipantSet
-            : GetActiveMemberSet(root, includeLocal: true);
-        if (!await AreParticipantsCapable(topology.Participants, activeMembers, topic, item.Digest.PayloadKind, cancellationToken))
-        {
-            return false;
-        }
 
         foreach (var peer in GetOriginatorTreeTargets(topology, root))
         {
@@ -104,7 +94,6 @@ internal sealed partial class DisseminationProtocol(
             return AntiEntropyState.Empty;
         }
 
-        var topics = new List<DisseminationCapabilityRequest>();
         var digests = new List<DisseminationDigest>();
         var currentValueStreams = new List<ValueStreamKey>();
         var now = _timeProvider.GetUtcNow();
@@ -114,13 +103,6 @@ internal sealed partial class DisseminationProtocol(
             {
                 continue;
             }
-
-            topics.Add(new DisseminationCapabilityRequest
-            {
-                Topic = topic.Name,
-                ProtocolVersion = topic.ProtocolVersion,
-                PayloadKinds = [.. topic.PayloadKinds],
-            });
 
             foreach (var digest in topic.GetDigests())
             {
@@ -137,10 +119,14 @@ internal sealed partial class DisseminationProtocol(
         }
 
         PruneRecentUpdates(currentValueStreams.ToFrozenSet());
+        var topics = digests
+            .Select(static digest => digest.Topic)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
         var round = Interlocked.Increment(ref _antiEntropyRound);
         return new AntiEntropyState(
             GetAntiEntropyPeersByTopic(topics, round),
-            topics.ToArray(),
+            topics,
             SortDigests(digests).ToArray());
     }
 
@@ -148,7 +134,7 @@ internal sealed partial class DisseminationProtocol(
         AntiEntropyState state,
         CancellationToken cancellationToken)
     {
-        if (state.PeersByTopic.Count == 0 || state.Topics.Count == 0)
+        if (state.PeersByTopic.Count == 0 || state.Topics.Count == 0 || state.Digests.Count == 0)
         {
             return [];
         }
@@ -158,15 +144,14 @@ internal sealed partial class DisseminationProtocol(
         foreach (var peer in peers)
         {
             var requestedTopics = state.Topics
-                .Where(request => state.PeersByTopic.TryGetValue(request.Topic, out var topicPeers) && topicPeers.Contains(peer))
+                .Where(topic => state.PeersByTopic.TryGetValue(topic, out var topicPeers) && topicPeers.Contains(peer))
                 .ToArray();
-            var topics = await GetCapableAntiEntropyTopics(peer, requestedTopics, cancellationToken);
-            if (topics.Count == 0)
+            if (requestedTopics.Length == 0)
             {
                 continue;
             }
 
-            var digests = state.Digests.Where(digest => IsRequested(topics, digest)).ToArray();
+            var digests = state.Digests.Where(digest => requestedTopics.Contains(digest.Topic, StringComparer.Ordinal)).ToArray();
             if (digests.Length == 0)
             {
                 continue;
@@ -175,7 +160,7 @@ internal sealed partial class DisseminationProtocol(
             var request = new DisseminationAntiEntropyRequest
             {
                 Sender = _transport.LocalSilo,
-                Topics = [.. topics],
+                Topics = requestedTopics,
                 Digests = digests,
             };
 
@@ -246,11 +231,6 @@ internal sealed partial class DisseminationProtocol(
         {
             foreach (var localDigest in SortDigests(requestedTopic.Topic.GetDigests()))
             {
-                if (!requestedTopic.PayloadKinds.Contains(localDigest.PayloadKind))
-                {
-                    continue;
-                }
-
                 var digestKey = GetDigestKey(localDigest);
                 if (!remoteDigests.TryGetValue(digestKey, out var remoteDigest)
                     || requestedTopic.Topic.CompareVersion(localDigest, remoteDigest) <= 0)
@@ -261,10 +241,9 @@ internal sealed partial class DisseminationProtocol(
                 var item = await requestedTopic.Topic.GetValue(
                     localDigest,
                     remoteDigest,
-                    requestedTopic.PayloadKinds,
                     cancellationToken);
                 if (item is null
-                    || !requestedTopic.PayloadKinds.Contains(item.Digest.PayloadKind)
+                    || !requestedTopic.Topic.PayloadKinds.Contains(item.Digest.PayloadKind)
                     || !ValidatePayloadSize(requestedTopic.Topic, item))
                 {
                     continue;
@@ -549,8 +528,8 @@ internal sealed partial class DisseminationProtocol(
         var byteCount = 0;
         foreach (var item in values)
         {
-            if (!_topics.TryGetValue(item.Digest.Topic, out var topic)
-                || await GetCapabilityStatus(peer, topic, item.Digest.PayloadKind, cancellationToken) != CapabilityStatus.Supported)
+            if (!TryGetEnabledTopic(item.Digest.Topic, out var topic)
+                || !topic.PayloadKinds.Contains(item.Digest.PayloadKind))
             {
                 continue;
             }
@@ -647,160 +626,14 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private async ValueTask<CapabilityStatus> GetCapabilityStatus(
-        SiloAddress peer,
-        IDisseminationTopic topic,
-        string payloadKind,
-        CancellationToken cancellationToken)
-    {
-        var now = _timeProvider.GetUtcNow();
-        var key = new CapabilityKey(peer, topic.Name);
-        lock (_capabilityLock)
-        {
-            if (_capabilityCache.TryGetValue(key, out var cached) && cached.ExpiresAt > now)
-            {
-                return cached.Supported && cached.PayloadKinds.Contains(payloadKind)
-                    ? CapabilityStatus.Supported
-                    : CapabilityStatus.Unsupported;
-            }
-
-            if (_capabilityProbeBackoffUntil.TryGetValue(key, out var probeBackoffUntil))
-            {
-                if (probeBackoffUntil > now)
-                {
-                    return CapabilityStatus.Unavailable;
-                }
-
-                _capabilityProbeBackoffUntil.Remove(key);
-            }
-        }
-
-        var request = new DisseminationCapabilityRequest
-        {
-            Topic = topic.Name,
-            ProtocolVersion = topic.ProtocolVersion,
-            PayloadKinds = [.. topic.PayloadKinds],
-        };
-
-        try
-        {
-            var response = await _transport.GetCapabilities(peer, request, cancellationToken);
-            var supported = response.Supported && response.ProtocolVersion >= topic.ProtocolVersion;
-            var payloadKinds = response.PayloadKinds.ToFrozenSet(StringComparer.Ordinal);
-            lock (_capabilityLock)
-            {
-                _capabilityCache[key] = new CapabilityEntry(supported, payloadKinds, now + _options.CurrentValue.CapabilityCacheTtl);
-                _capabilityProbeBackoffUntil.Remove(key);
-            }
-
-            DisseminationEvents.EmitCapabilityProbe(_transport.LocalSilo, peer, topic.Name, supported);
-            return supported && payloadKinds.Contains(payloadKind)
-                ? CapabilityStatus.Supported
-                : CapabilityStatus.Unsupported;
-        }
-        catch (Exception exception) when (!cancellationToken.IsCancellationRequested)
-        {
-            LogDebugCapabilityProbeFailed(_logger, exception, peer, topic.Name);
-            lock (_capabilityLock)
-            {
-                _capabilityCache.Remove(key);
-                _capabilityProbeBackoffUntil[key] = _timeProvider.GetUtcNow() + _options.CurrentValue.FailureBackoff;
-            }
-
-            DisseminationEvents.EmitCapabilityProbe(_transport.LocalSilo, peer, topic.Name, supported: false);
-            return CapabilityStatus.Unavailable;
-        }
-    }
-
-    private async ValueTask<bool> AreParticipantsCapable(
-        ImmutableArray<SiloAddress> participants,
-        FrozenSet<SiloAddress> activeMembers,
-        IDisseminationTopic topic,
-        string payloadKind,
-        CancellationToken cancellationToken)
-    {
-        var probes = new List<Task<(SiloAddress Participant, CapabilityStatus Status)>>(participants.Length);
-        foreach (var participant in participants)
-        {
-            if (!Equals(participant, _transport.LocalSilo))
-            {
-                probes.Add(Probe(participant));
-            }
-        }
-
-        if (probes.Count == 0)
-        {
-            return true;
-        }
-
-        var results = await Task.WhenAll(probes);
-        foreach (var (participant, status) in results)
-        {
-            if (activeMembers.Contains(participant) && status != CapabilityStatus.Supported)
-            {
-                return false;
-            }
-        }
-
-        return true;
-
-        async Task<(SiloAddress Participant, CapabilityStatus Status)> Probe(SiloAddress participant) =>
-            (participant, await GetCapabilityStatus(participant, topic, payloadKind, cancellationToken));
-    }
-
-    private async ValueTask<List<DisseminationCapabilityRequest>> GetCapableAntiEntropyTopics(
-        SiloAddress peer,
-        IReadOnlyList<DisseminationCapabilityRequest> topics,
-        CancellationToken cancellationToken)
-    {
-        var result = new List<DisseminationCapabilityRequest>(topics.Count);
-        foreach (var request in topics)
-        {
-            if (!_topics.TryGetValue(request.Topic, out var topic) || !topic.IsEnabled)
-            {
-                continue;
-            }
-
-            var supportedPayloadKinds = new List<string>(request.PayloadKinds.Length);
-            foreach (var payloadKind in request.PayloadKinds)
-            {
-                if (await GetCapabilityStatus(peer, topic, payloadKind, cancellationToken) == CapabilityStatus.Supported)
-                {
-                    supportedPayloadKinds.Add(payloadKind);
-                }
-            }
-
-            if (supportedPayloadKinds.Count > 0)
-            {
-                result.Add(new DisseminationCapabilityRequest
-                {
-                    Topic = request.Topic,
-                    ProtocolVersion = request.ProtocolVersion,
-                    PayloadKinds = [.. supportedPayloadKinds],
-                });
-            }
-        }
-
-        return result;
-    }
-
     private FrozenDictionary<string, RequestedTopic> GetRequestedTopics(DisseminationAntiEntropyRequest request)
     {
         var result = new Dictionary<string, RequestedTopic>(StringComparer.Ordinal);
-        foreach (var requestedTopic in request.Topics)
+        foreach (var topicName in request.Topics)
         {
-            if (!TryGetEnabledTopic(requestedTopic.Topic, out var topic)
-                || requestedTopic.ProtocolVersion > topic.ProtocolVersion)
+            if (TryGetEnabledTopic(topicName, out var topic))
             {
-                continue;
-            }
-
-            var payloadKinds = topic.PayloadKinds
-                .Intersect(requestedTopic.PayloadKinds, StringComparer.Ordinal)
-                .ToFrozenSet(StringComparer.Ordinal);
-            if (payloadKinds.Count > 0)
-            {
-                result[topic.Name] = new RequestedTopic(topic, payloadKinds);
+                result[topic.Name] = new RequestedTopic(topic);
             }
         }
 
@@ -861,15 +694,15 @@ internal sealed partial class DisseminationProtocol(
     }
 
     private FrozenDictionary<string, ImmutableArray<SiloAddress>> GetAntiEntropyPeersByTopic(
-        IReadOnlyList<DisseminationCapabilityRequest> topics,
+        IReadOnlyList<string> topics,
         long round)
     {
         var result = new Dictionary<string, ImmutableArray<SiloAddress>>(StringComparer.Ordinal);
-        foreach (var request in topics)
+        foreach (var topicName in topics)
         {
-            if (_topics.TryGetValue(request.Topic, out var topic) && topic.IsEnabled)
+            if (_topics.TryGetValue(topicName, out var topic) && topic.IsEnabled)
             {
-                result[request.Topic] = SelectAntiEntropyPeers(topic.MembershipScope, round);
+                result[topicName] = SelectAntiEntropyPeers(topic.MembershipScope, round);
             }
         }
 
@@ -1084,13 +917,6 @@ internal sealed partial class DisseminationProtocol(
         return membershipScope == DisseminationMembershipScope.AllMembers ? allMembers : activeMembers;
     }
 
-    private FrozenSet<SiloAddress> GetActiveMemberSet(SiloAddress? root, bool includeLocal) =>
-        GetCachedParticipantTopology(
-            DisseminationMembershipScope.ActiveMembers,
-            _transport.GetMembership().ActiveMembers,
-            root,
-            includeLocal).ParticipantSet;
-
     private ParticipantTopology GetCachedParticipantTopology(
         DisseminationMembershipScope membershipScope,
         IEnumerable<SiloAddress> participants,
@@ -1262,20 +1088,6 @@ internal sealed partial class DisseminationProtocol(
                 Payload = item.Payload,
             };
 
-    private static bool IsRequested(IEnumerable<DisseminationCapabilityRequest> requests, DisseminationDigest digest)
-    {
-        foreach (var request in requests)
-        {
-            if (string.Equals(request.Topic, digest.Topic, StringComparison.Ordinal)
-                && request.PayloadKinds.Contains(digest.PayloadKind, StringComparer.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     private static IEnumerable<DisseminationDigest> SortDigests(IEnumerable<DisseminationDigest> digests) =>
         digests
             .OrderBy(static digest => digest.Topic, StringComparer.Ordinal)
@@ -1289,7 +1101,7 @@ internal sealed partial class DisseminationProtocol(
 
     public sealed record AntiEntropyState(
         FrozenDictionary<string, ImmutableArray<SiloAddress>> PeersByTopic,
-        IReadOnlyList<DisseminationCapabilityRequest> Topics,
+        IReadOnlyList<string> Topics,
         IReadOnlyList<DisseminationDigest> Digests)
     {
         public static readonly AntiEntropyState Empty = new(
@@ -1298,15 +1110,11 @@ internal sealed partial class DisseminationProtocol(
             []);
     }
 
-    private readonly record struct CapabilityKey(SiloAddress Peer, string Topic);
-
-    private readonly record struct CapabilityEntry(bool Supported, FrozenSet<string> PayloadKinds, DateTimeOffset ExpiresAt);
-
     private readonly record struct DigestKey(string Topic, string Key, string PayloadKind);
 
     private readonly record struct ValueStreamKey(string Topic, string Key);
 
-    private readonly record struct RequestedTopic(IDisseminationTopic Topic, FrozenSet<string> PayloadKinds);
+    private readonly record struct RequestedTopic(IDisseminationTopic Topic);
 
     private readonly record struct QueuedGossipBatch(SiloAddress Peer, ImmutableArray<DisseminationValue> Values);
 
@@ -1330,13 +1138,6 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private enum CapabilityStatus
-    {
-        Supported,
-        Unsupported,
-        Unavailable,
-    }
-
     private sealed record ParticipantTopology(
         ImmutableArray<SiloAddress> Participants,
         FrozenDictionary<SiloAddress, int> Indices,
@@ -1352,11 +1153,6 @@ internal sealed partial class DisseminationProtocol(
         Level = LogLevel.Debug,
         Message = "Dissemination send to {Peer} failed.")]
     private static partial void LogDebugDisseminationSendFailed(ILogger logger, Exception exception, SiloAddress peer);
-
-    [LoggerMessage(
-        Level = LogLevel.Debug,
-        Message = "Dissemination capability probe to {Peer} for topic {Topic} failed.")]
-    private static partial void LogDebugCapabilityProbeFailed(ILogger logger, Exception exception, SiloAddress peer, string topic);
 
     [LoggerMessage(
         Level = LogLevel.Debug,

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -145,13 +145,13 @@ internal sealed partial class DisseminationProtocol(
         {
             var requestedTopics = state.Topics
                 .Where(topic => state.PeersByTopic.TryGetValue(topic, out var topicPeers) && topicPeers.Contains(peer))
-                .ToArray();
+                .ToImmutableArray();
             if (requestedTopics.Length == 0)
             {
                 continue;
             }
 
-            var digests = state.Digests.Where(digest => requestedTopics.Contains(digest.Topic, StringComparer.Ordinal)).ToArray();
+            var digests = state.Digests.Where(digest => requestedTopics.Contains(digest.Topic, StringComparer.Ordinal)).ToImmutableArray();
             if (digests.Length == 0)
             {
                 continue;
@@ -553,7 +553,7 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private async Task SendGossipBatchCore(SiloAddress peer, DisseminationValue[] values, CancellationToken cancellationToken)
+    private async Task SendGossipBatchCore(SiloAddress peer, ImmutableArray<DisseminationValue> values, CancellationToken cancellationToken)
     {
         var batch = new DisseminationGossipBatch
         {
@@ -1112,7 +1112,7 @@ internal sealed partial class DisseminationProtocol(
         DisseminationInstruments.OnValueApplied(item.Digest.Topic, result);
     }
 
-    private DisseminationAntiEntropyResponse CreateAntiEntropyResponse(DisseminationValue[] values, bool truncated) => new()
+    private DisseminationAntiEntropyResponse CreateAntiEntropyResponse(ImmutableArray<DisseminationValue> values, bool truncated) => new()
     {
         Sender = _transport.LocalSilo,
         Values = values,

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -941,9 +941,18 @@ internal sealed partial class DisseminationProtocol(
         {
             if (_failureBackoffUntil.Count > 0)
             {
-                foreach (var (peer, until) in _failureBackoffUntil.ToArray())
+                List<SiloAddress>? peersToRemove = null;
+                foreach (var (peer, until) in _failureBackoffUntil)
                 {
                     if (until <= now || !IsCurrentParticipant(peer))
+                    {
+                        (peersToRemove ??= []).Add(peer);
+                    }
+                }
+
+                if (peersToRemove is not null)
+                {
+                    foreach (var peer in peersToRemove)
                     {
                         _failureBackoffUntil.Remove(peer);
                     }
@@ -955,9 +964,18 @@ internal sealed partial class DisseminationProtocol(
         {
             if (_pendingGossip.Count > 0)
             {
-                foreach (var peer in _pendingGossip.Keys.ToArray())
+                List<SiloAddress>? peersToRemove = null;
+                foreach (var peer in _pendingGossip.Keys)
                 {
                     if (!IsCurrentParticipant(peer))
+                    {
+                        (peersToRemove ??= []).Add(peer);
+                    }
+                }
+
+                if (peersToRemove is not null)
+                {
+                    foreach (var peer in peersToRemove)
                     {
                         _pendingGossip.Remove(peer);
                     }

--- a/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationProtocol.cs
@@ -624,9 +624,9 @@ internal sealed partial class DisseminationProtocol(
         }
     }
 
-    private Dictionary<DigestKey, DisseminationDigest> GetRemoteDigestMap(IEnumerable<DisseminationDigest> digests)
+    private Dictionary<DigestKey, DisseminationDigest> GetRemoteDigestMap(ImmutableArray<DisseminationDigest> digests)
     {
-        var result = new Dictionary<DigestKey, DisseminationDigest>();
+        var result = new Dictionary<DigestKey, DisseminationDigest>(digests.Length);
         foreach (var digest in digests)
         {
             if (!TryGetEnabledTopic(digest.Topic, out var topic))

--- a/src/Orleans.Runtime/Dissemination/DisseminationService.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationService.cs
@@ -15,7 +15,10 @@ internal sealed partial class DisseminationService
     private readonly IOptionsMonitor<DisseminationOptions> _options;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<DisseminationProtocol> _logger;
+    private readonly object _lifecycleLock = new();
+    private IDisposable? _optionsChangeRegistration;
     private CancellationTokenSource? _shutdownCts;
+    private CancellationTokenSource? _antiEntropyCts;
     private Task? _antiEntropyTask;
 
     public DisseminationService(
@@ -48,25 +51,63 @@ internal sealed partial class DisseminationService
 
     internal Task StartAsync(CancellationToken cancellationToken)
     {
-        if (_antiEntropyTask is { IsCompleted: false })
+        lock (_lifecycleLock)
         {
-            return Task.CompletedTask;
+            if (_shutdownCts is not null)
+            {
+                return Task.CompletedTask;
+            }
+
+            _shutdownCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _optionsChangeRegistration = _options.OnChange((updated, _) =>
+            {
+                if (updated.Enabled)
+                {
+                    StartAntiEntropyLoop();
+                }
+                else
+                {
+                    StopAntiEntropyLoop();
+                }
+            });
+            if (_options.CurrentValue.Enabled)
+            {
+                StartAntiEntropyLoopUnsafe();
+            }
         }
 
-        _shutdownCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _antiEntropyTask = Task.Run(() => RunAntiEntropyLoop(_shutdownCts.Token), CancellationToken.None);
         return Task.CompletedTask;
     }
+
+    internal bool IsAntiEntropyRunning => _antiEntropyTask is { IsCompleted: false };
 
     internal async Task StopAsync(CancellationToken cancellationToken)
     {
         await Execute(async () => await _protocol.FlushPendingGossip(cancellationToken));
-        _shutdownCts?.Cancel();
-        if (_antiEntropyTask is not null)
+        Task? antiEntropyTask;
+        CancellationTokenSource? shutdownCts;
+        CancellationTokenSource? antiEntropyCts;
+        IDisposable? optionsChangeRegistration;
+        lock (_lifecycleLock)
+        {
+            antiEntropyTask = _antiEntropyTask;
+            _antiEntropyTask = null;
+            antiEntropyCts = _antiEntropyCts;
+            _antiEntropyCts = null;
+            shutdownCts = _shutdownCts;
+            _shutdownCts = null;
+            optionsChangeRegistration = _optionsChangeRegistration;
+            _optionsChangeRegistration = null;
+            antiEntropyCts?.Cancel();
+            shutdownCts?.Cancel();
+        }
+
+        optionsChangeRegistration?.Dispose();
+        if (antiEntropyTask is not null)
         {
             try
             {
-                await _antiEntropyTask.WaitAsync(cancellationToken);
+                await antiEntropyTask.WaitAsync(cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -78,9 +119,8 @@ internal sealed partial class DisseminationService
             }
         }
 
-        _shutdownCts?.Dispose();
-        _shutdownCts = null;
-        _antiEntropyTask = null;
+        antiEntropyCts?.Dispose();
+        shutdownCts?.Dispose();
     }
 
     internal async Task RunAntiEntropy(CancellationToken cancellationToken)
@@ -108,6 +148,51 @@ internal sealed partial class DisseminationService
             {
                 LogDebugAntiEntropyLoopFailed(_logger, exception);
             }
+        }
+    }
+
+    private void StartAntiEntropyLoop()
+    {
+        lock (_lifecycleLock)
+        {
+            StartAntiEntropyLoopUnsafe();
+        }
+    }
+
+    private void StartAntiEntropyLoopUnsafe()
+    {
+        if (!_options.CurrentValue.Enabled
+            || _shutdownCts is not { IsCancellationRequested: false } shutdownCts)
+        {
+            return;
+        }
+
+        if (_antiEntropyTask is { IsCompleted: false } runningTask)
+        {
+            if (_antiEntropyCts?.IsCancellationRequested == true)
+            {
+                _ = runningTask.ContinueWith(
+                    static (_, state) => ((DisseminationService)state!).StartAntiEntropyLoop(),
+                    this,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+
+            return;
+        }
+
+        _antiEntropyCts?.Dispose();
+        _antiEntropyCts = CancellationTokenSource.CreateLinkedTokenSource(shutdownCts.Token);
+        var cancellationToken = _antiEntropyCts.Token;
+        _antiEntropyTask = Task.Run(() => RunAntiEntropyLoop(cancellationToken), CancellationToken.None);
+    }
+
+    private void StopAntiEntropyLoop()
+    {
+        lock (_lifecycleLock)
+        {
+            _antiEntropyCts?.Cancel();
         }
     }
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationService.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationService.cs
@@ -88,6 +88,7 @@ internal sealed partial class DisseminationService
 
     internal async Task StopAsync(CancellationToken cancellationToken)
     {
+        await Execute(async () => await _protocol.FlushPendingGossip(cancellationToken));
         _shutdownCts?.Cancel();
         if (_antiEntropyTask is not null)
         {

--- a/src/Orleans.Runtime/Dissemination/DisseminationService.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationService.cs
@@ -36,10 +36,10 @@ internal sealed partial class DisseminationService
 
     public ValueTask<bool> Publish(
         string topicName,
-        DisseminationItem item,
+        DisseminationValue value,
         IReadOnlyCollection<SiloAddress>? targetPeers,
         CancellationToken cancellationToken) =>
-        new(Execute(async () => await _protocol.Publish(topicName, item, targetPeers, cancellationToken)));
+        new(Execute(async () => await _protocol.Publish(topicName, value, targetPeers, cancellationToken)));
 
     public DisseminationCapabilityResponse GetCapabilities(DisseminationCapabilityRequest request)
     {

--- a/src/Orleans.Runtime/Dissemination/DisseminationService.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -16,7 +15,6 @@ internal sealed partial class DisseminationService
     private readonly IOptionsMonitor<DisseminationOptions> _options;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<DisseminationProtocol> _logger;
-    private readonly Dictionary<string, IDisseminationTopic> _topics;
     private CancellationTokenSource? _shutdownCts;
     private Task? _antiEntropyTask;
 
@@ -30,8 +28,7 @@ internal sealed partial class DisseminationService
         _options = options;
         _timeProvider = timeProvider;
         _logger = logger;
-        _topics = topics.ToDictionary(static topic => topic.Name, StringComparer.Ordinal);
-        _protocol = new DisseminationProtocol(transport, options, _topics.Values, timeProvider, logger);
+        _protocol = new DisseminationProtocol(transport, options, topics, timeProvider, logger);
     }
 
     public ValueTask<bool> Publish(
@@ -40,31 +37,6 @@ internal sealed partial class DisseminationService
         IReadOnlyCollection<SiloAddress>? targetPeers,
         CancellationToken cancellationToken) =>
         new(Execute(async () => await _protocol.Publish(topicName, value, targetPeers, cancellationToken)));
-
-    public DisseminationCapabilityResponse GetCapabilities(DisseminationCapabilityRequest request)
-    {
-        if (!_options.CurrentValue.Enabled
-            || !_topics.TryGetValue(request.Topic, out var topic)
-            || !topic.IsEnabled
-            || request.ProtocolVersion > topic.ProtocolVersion)
-        {
-            return new DisseminationCapabilityResponse
-            {
-                Topic = request.Topic,
-                ProtocolVersion = request.ProtocolVersion,
-                Supported = false,
-            };
-        }
-
-        var payloadKinds = topic.PayloadKinds.Intersect(request.PayloadKinds, StringComparer.Ordinal).ToArray();
-        return new DisseminationCapabilityResponse
-        {
-            Topic = request.Topic,
-            ProtocolVersion = topic.ProtocolVersion,
-            Supported = payloadKinds.Length > 0,
-            PayloadKinds = payloadKinds,
-        };
-    }
 
     public Task ReceiveGossip(DisseminationGossipBatch batch, CancellationToken cancellationToken) =>
         Execute(async () => await _protocol.ReceiveGossip(batch, cancellationToken));

--- a/src/Orleans.Runtime/Dissemination/DisseminationService.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationService.cs
@@ -49,6 +49,12 @@ internal sealed partial class DisseminationService
         CancellationToken cancellationToken) =>
         new(Execute(async () => await _protocol.ReceiveAntiEntropy(request, cancellationToken)));
 
+    internal IReadOnlyList<SiloAddress> GetUnconfirmedPeers(
+        string topicName,
+        DisseminationMembershipScope membershipScope,
+        IReadOnlyCollection<SiloAddress>? candidates = null) =>
+        _protocol.GetUnconfirmedPeers(topicName, membershipScope, candidates);
+
     internal Task StartAsync(CancellationToken cancellationToken)
     {
         lock (_lifecycleLock)
@@ -79,11 +85,14 @@ internal sealed partial class DisseminationService
         return Task.CompletedTask;
     }
 
-    internal bool IsAntiEntropyRunning => _antiEntropyTask is { IsCompleted: false };
+    internal bool IsAntiEntropyRunning =>
+        _shutdownCts is { IsCancellationRequested: false }
+        && _antiEntropyTask is { IsCompleted: false };
+
+    internal bool HasOutstandingAntiEntropyTask => _antiEntropyTask is not null;
 
     internal async Task StopAsync(CancellationToken cancellationToken)
     {
-        await Execute(async () => await _protocol.FlushPendingGossip(cancellationToken));
         Task? antiEntropyTask;
         CancellationTokenSource? shutdownCts;
         CancellationTokenSource? antiEntropyCts;
@@ -91,9 +100,7 @@ internal sealed partial class DisseminationService
         lock (_lifecycleLock)
         {
             antiEntropyTask = _antiEntropyTask;
-            _antiEntropyTask = null;
             antiEntropyCts = _antiEntropyCts;
-            _antiEntropyCts = null;
             shutdownCts = _shutdownCts;
             _shutdownCts = null;
             optionsChangeRegistration = _optionsChangeRegistration;
@@ -102,16 +109,91 @@ internal sealed partial class DisseminationService
             shutdownCts?.Cancel();
         }
 
-        optionsChangeRegistration?.Dispose();
-        if (antiEntropyTask is not null)
+        Exception? cancellationException = null;
+        var deferAntiEntropyCleanup = false;
+        try
+        {
+            optionsChangeRegistration?.Dispose();
+            if (antiEntropyTask is not null)
+            {
+                try
+                {
+                    await antiEntropyTask.WaitAsync(cancellationToken);
+                }
+                catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+                {
+                    cancellationException = exception;
+                    deferAntiEntropyCleanup = !antiEntropyTask.IsCompleted;
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected during silo shutdown.
+                }
+                catch (Exception exception)
+                {
+                    LogDebugAntiEntropyLoopFailed(_logger, exception);
+                }
+            }
+
+            try
+            {
+                await Execute(async () => await _protocol.StopAsync(cancellationToken));
+            }
+            catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+            {
+                cancellationException ??= exception;
+            }
+        }
+        finally
+        {
+            if (deferAntiEntropyCleanup && antiEntropyTask is not null)
+            {
+                ObserveAntiEntropyShutdown(antiEntropyTask, antiEntropyCts);
+            }
+            else
+            {
+                CompleteAntiEntropyShutdown(antiEntropyTask, antiEntropyCts);
+            }
+
+            shutdownCts?.Dispose();
+        }
+
+        if (cancellationException is not null)
+        {
+            throw cancellationException;
+        }
+    }
+
+    internal async Task RunAntiEntropy(CancellationToken cancellationToken)
+    {
+        var state = await Execute(() => Task.FromResult(_protocol.CreateAntiEntropyState()));
+        var responses = await _protocol.ExchangeAntiEntropy(state, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        await Execute(async () => await _protocol.ApplyAntiEntropyResponses(responses, cancellationToken));
+    }
+
+    private void ObserveAntiEntropyShutdown(Task task, CancellationTokenSource? cancellationTokenSource) =>
+        _ = task.ContinueWith(
+            static (completed, state) =>
+            {
+                var (service, source) = ((DisseminationService, CancellationTokenSource?))state!;
+                service.CompleteAntiEntropyShutdown(completed, source);
+            },
+            (this, cancellationTokenSource),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+    private void CompleteAntiEntropyShutdown(Task? task, CancellationTokenSource? cancellationTokenSource)
+    {
+        if (task is not null)
         {
             try
             {
-                await antiEntropyTask.WaitAsync(cancellationToken);
+                task.GetAwaiter().GetResult();
             }
             catch (OperationCanceledException)
             {
-                // Expected during silo shutdown.
             }
             catch (Exception exception)
             {
@@ -119,15 +201,20 @@ internal sealed partial class DisseminationService
             }
         }
 
-        antiEntropyCts?.Dispose();
-        shutdownCts?.Dispose();
-    }
+        lock (_lifecycleLock)
+        {
+            if (ReferenceEquals(_antiEntropyTask, task))
+            {
+                _antiEntropyTask = null;
+            }
 
-    internal async Task RunAntiEntropy(CancellationToken cancellationToken)
-    {
-        var state = await Execute(() => Task.FromResult(_protocol.CreateAntiEntropyState()));
-        var responses = await _protocol.ExchangeAntiEntropy(state, cancellationToken);
-        await Execute(async () => await _protocol.ApplyAntiEntropyResponses(responses, cancellationToken));
+            if (ReferenceEquals(_antiEntropyCts, cancellationTokenSource))
+            {
+                _antiEntropyCts = null;
+            }
+        }
+
+        cancellationTokenSource?.Dispose();
     }
 
     private async Task RunAntiEntropyLoop(CancellationToken cancellationToken)

--- a/src/Orleans.Runtime/Dissemination/DisseminationService.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationService.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+
+namespace Orleans.Runtime.Dissemination;
+
+internal sealed partial class DisseminationService
+{
+    private readonly Orleans.AsyncSerialExecutor<object?> _executor = new();
+    private readonly DisseminationProtocol _protocol;
+    private readonly IOptionsMonitor<DisseminationOptions> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<DisseminationProtocol> _logger;
+    private readonly Dictionary<string, IDisseminationTopic> _topics;
+    private CancellationTokenSource? _shutdownCts;
+    private Task? _antiEntropyTask;
+
+    public DisseminationService(
+        IDisseminationTransport transport,
+        IOptionsMonitor<DisseminationOptions> options,
+        IEnumerable<IDisseminationTopic> topics,
+        TimeProvider timeProvider,
+        ILogger<DisseminationProtocol> logger)
+    {
+        _options = options;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _topics = topics.ToDictionary(static topic => topic.Name, StringComparer.Ordinal);
+        _protocol = new DisseminationProtocol(transport, options, _topics.Values, timeProvider, logger);
+    }
+
+    public ValueTask<bool> Publish(
+        string topicName,
+        DisseminationItem item,
+        IReadOnlyCollection<SiloAddress>? targetPeers,
+        CancellationToken cancellationToken) =>
+        new(Execute(async () => await _protocol.Publish(topicName, item, targetPeers, cancellationToken)));
+
+    public DisseminationCapabilityResponse GetCapabilities(DisseminationCapabilityRequest request)
+    {
+        if (!_options.CurrentValue.Enabled
+            || !_topics.TryGetValue(request.Topic, out var topic)
+            || !topic.IsEnabled
+            || request.ProtocolVersion > topic.ProtocolVersion)
+        {
+            return new DisseminationCapabilityResponse
+            {
+                Topic = request.Topic,
+                ProtocolVersion = request.ProtocolVersion,
+                Supported = false,
+            };
+        }
+
+        var payloadKinds = topic.PayloadKinds.Intersect(request.PayloadKinds, StringComparer.Ordinal).ToArray();
+        return new DisseminationCapabilityResponse
+        {
+            Topic = request.Topic,
+            ProtocolVersion = topic.ProtocolVersion,
+            Supported = payloadKinds.Length > 0,
+            PayloadKinds = payloadKinds,
+        };
+    }
+
+    public Task ReceiveGossip(DisseminationGossipBatch batch, CancellationToken cancellationToken) =>
+        Execute(async () => await _protocol.ReceiveGossip(batch, cancellationToken));
+
+    public ValueTask<DisseminationAntiEntropyResponse> ReceiveAntiEntropy(
+        DisseminationAntiEntropyRequest request,
+        CancellationToken cancellationToken) =>
+        new(Execute(async () => await _protocol.ReceiveAntiEntropy(request, cancellationToken)));
+
+    internal Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_antiEntropyTask is { IsCompleted: false })
+        {
+            return Task.CompletedTask;
+        }
+
+        _shutdownCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _antiEntropyTask = Task.Run(() => RunAntiEntropyLoop(_shutdownCts.Token), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    internal async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _shutdownCts?.Cancel();
+        if (_antiEntropyTask is not null)
+        {
+            try
+            {
+                await _antiEntropyTask.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected during silo shutdown.
+            }
+            catch (Exception exception)
+            {
+                LogDebugAntiEntropyLoopFailed(_logger, exception);
+            }
+        }
+
+        _shutdownCts?.Dispose();
+        _shutdownCts = null;
+        _antiEntropyTask = null;
+    }
+
+    internal async Task RunAntiEntropy(CancellationToken cancellationToken)
+    {
+        var state = await Execute(() => Task.FromResult(_protocol.CreateAntiEntropyState()));
+        var responses = await _protocol.ExchangeAntiEntropy(state, cancellationToken);
+        await Execute(async () => await _protocol.ApplyAntiEntropyResponses(responses, cancellationToken));
+    }
+
+    private async Task RunAntiEntropyLoop(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                var interval = _options.CurrentValue.Overlay.AntiEntropyInterval;
+                await Task.Delay(interval, _timeProvider, cancellationToken);
+                await RunAntiEntropy(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Expected during silo shutdown.
+            }
+            catch (Exception exception)
+            {
+                LogDebugAntiEntropyLoopFailed(_logger, exception);
+            }
+        }
+    }
+
+    private async Task Execute(Func<Task> action)
+    {
+        await _executor.AddNext(async () =>
+        {
+            await action();
+            return null;
+        });
+    }
+
+    private async Task<T> Execute<T>(Func<Task<T>> action) =>
+        (T)(await _executor.AddNext(async () => await action()))!;
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Dissemination anti-entropy loop iteration failed.")]
+    private static partial void LogDebugAntiEntropyLoopFailed(ILogger logger, Exception exception);
+}

--- a/src/Orleans.Runtime/Dissemination/DisseminationService.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationService.cs
@@ -8,7 +8,7 @@ using Orleans.Configuration;
 
 namespace Orleans.Runtime.Dissemination;
 
-internal sealed partial class DisseminationService
+internal sealed partial class DisseminationService : IAsyncDisposable
 {
     private readonly Orleans.AsyncSerialExecutor<object?> _executor = new();
     private readonly DisseminationProtocol _protocol;
@@ -20,6 +20,7 @@ internal sealed partial class DisseminationService
     private CancellationTokenSource? _shutdownCts;
     private CancellationTokenSource? _antiEntropyCts;
     private Task? _antiEntropyTask;
+    private Task? _protocolDisposeTask;
 
     public DisseminationService(
         IDisseminationTransport transport,
@@ -59,7 +60,7 @@ internal sealed partial class DisseminationService
     {
         lock (_lifecycleLock)
         {
-            if (_shutdownCts is not null)
+            if (_shutdownCts is not null || _protocolDisposeTask is not null)
             {
                 return Task.CompletedTask;
             }
@@ -90,6 +91,8 @@ internal sealed partial class DisseminationService
         && _antiEntropyTask is { IsCompleted: false };
 
     internal bool HasOutstandingAntiEntropyTask => _antiEntropyTask is not null;
+
+    internal bool IsProtocolDisposed => _protocol.IsDisposed;
 
     internal async Task StopAsync(CancellationToken cancellationToken)
     {
@@ -158,10 +161,50 @@ internal sealed partial class DisseminationService
             shutdownCts?.Dispose();
         }
 
+        var protocolDisposeTask = GetProtocolDisposeTask();
+        if (cancellationException is null)
+        {
+            await protocolDisposeTask;
+        }
+
         if (cancellationException is not null)
         {
             throw cancellationException;
         }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Task? protocolDisposeTask;
+        Task? antiEntropyTask;
+        lock (_lifecycleLock)
+        {
+            protocolDisposeTask = _protocolDisposeTask;
+            antiEntropyTask = _antiEntropyTask;
+        }
+
+        if (protocolDisposeTask is null)
+        {
+            await StopAsync(CancellationToken.None);
+            return;
+        }
+
+        if (antiEntropyTask is not null)
+        {
+            try
+            {
+                await antiEntropyTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception exception)
+            {
+                LogDebugAntiEntropyLoopFailed(_logger, exception);
+            }
+        }
+
+        await protocolDisposeTask;
     }
 
     internal async Task RunAntiEntropy(CancellationToken cancellationToken)
@@ -215,6 +258,14 @@ internal sealed partial class DisseminationService
         }
 
         cancellationTokenSource?.Dispose();
+    }
+
+    private Task GetProtocolDisposeTask()
+    {
+        lock (_lifecycleLock)
+        {
+            return _protocolDisposeTask ??= _protocol.DisposeAsync().AsTask();
+        }
     }
 
     private async Task RunAntiEntropyLoop(CancellationToken cancellationToken)

--- a/src/Orleans.Runtime/Dissemination/DisseminationSystemTarget.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationSystemTarget.cs
@@ -1,0 +1,39 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Runtime.Scheduler;
+
+namespace Orleans.Runtime.Dissemination;
+
+internal sealed class DisseminationSystemTarget : SystemTarget, IDisseminationSystemTarget, ILifecycleParticipant<ISiloLifecycle>
+{
+    private readonly DisseminationService _service;
+
+    public DisseminationSystemTarget(DisseminationService service, SystemTargetShared shared)
+        : base(Constants.DisseminationSystemTargetType, shared)
+    {
+        _service = service;
+        shared.ActivationDirectory.RecordNewTarget(this);
+    }
+
+    public Task<DisseminationCapabilityResponse> GetCapabilities(DisseminationCapabilityRequest request) =>
+        Task.FromResult(_service.GetCapabilities(request));
+
+    public Task PushGossip(DisseminationGossipBatch batch) =>
+        this.RunOrQueueTask(() => _service.ReceiveGossip(batch, CancellationToken.None));
+
+    public async Task<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(DisseminationAntiEntropyRequest request)
+    {
+        DisseminationAntiEntropyResponse? response = null;
+        await this.RunOrQueueTask(async () => response = await _service.ReceiveAntiEntropy(request, CancellationToken.None));
+        return response!;
+    }
+
+    void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle observer)
+    {
+        observer.Subscribe(
+            nameof(DisseminationSystemTarget),
+            ServiceLifecycleStage.RuntimeServices,
+            _service.StartAsync,
+            _service.StopAsync);
+    }
+}

--- a/src/Orleans.Runtime/Dissemination/DisseminationSystemTarget.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationSystemTarget.cs
@@ -15,13 +15,15 @@ internal sealed class DisseminationSystemTarget : SystemTarget, IDisseminationSy
         shared.ActivationDirectory.RecordNewTarget(this);
     }
 
-    public Task PushGossip(DisseminationGossipBatch batch) =>
-        this.RunOrQueueTask(() => _service.ReceiveGossip(batch, CancellationToken.None));
+    public Task PushGossip(DisseminationGossipBatch batch, CancellationToken cancellationToken) =>
+        this.RunOrQueueTask(() => _service.ReceiveGossip(batch, cancellationToken));
 
-    public async Task<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(DisseminationAntiEntropyRequest request)
+    public async Task<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(
+        DisseminationAntiEntropyRequest request,
+        CancellationToken cancellationToken)
     {
         DisseminationAntiEntropyResponse? response = null;
-        await this.RunOrQueueTask(async () => response = await _service.ReceiveAntiEntropy(request, CancellationToken.None));
+        await this.RunOrQueueTask(async () => response = await _service.ReceiveAntiEntropy(request, cancellationToken));
         return response!;
     }
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationSystemTarget.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationSystemTarget.cs
@@ -15,9 +15,6 @@ internal sealed class DisseminationSystemTarget : SystemTarget, IDisseminationSy
         shared.ActivationDirectory.RecordNewTarget(this);
     }
 
-    public Task<DisseminationCapabilityResponse> GetCapabilities(DisseminationCapabilityRequest request) =>
-        Task.FromResult(_service.GetCapabilities(request));
-
     public Task PushGossip(DisseminationGossipBatch batch) =>
         this.RunOrQueueTask(() => _service.ReceiveGossip(batch, CancellationToken.None));
 

--- a/src/Orleans.Runtime/Dissemination/DisseminationTopicNames.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationTopicNames.cs
@@ -8,5 +8,6 @@ internal static class DisseminationTopicNames
 
     public const string SiloRuntimeStatistics = "SiloRuntimeStatistics";
     public const string MembershipSnapshot = "MembershipSnapshot";
+    public const string MembershipSnapshotDiff = "MembershipSnapshotDiff";
     public const string ManifestHash = "ManifestHash";
 }

--- a/src/Orleans.Runtime/Dissemination/DisseminationTopicNames.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationTopicNames.cs
@@ -5,9 +5,4 @@ internal static class DisseminationTopicNames
     public const string DeploymentLoad = "load";
     public const string Membership = "membership";
     public const string Manifest = "manifest";
-
-    public const string SiloRuntimeStatistics = "SiloRuntimeStatistics";
-    public const string MembershipSnapshot = "MembershipSnapshot";
-    public const string MembershipSnapshotDiff = "MembershipSnapshotDiff";
-    public const string ManifestHash = "ManifestHash";
 }

--- a/src/Orleans.Runtime/Dissemination/DisseminationTopicNames.cs
+++ b/src/Orleans.Runtime/Dissemination/DisseminationTopicNames.cs
@@ -1,0 +1,12 @@
+namespace Orleans.Runtime.Dissemination;
+
+internal static class DisseminationTopicNames
+{
+    public const string DeploymentLoad = "load";
+    public const string Membership = "membership";
+    public const string Manifest = "manifest";
+
+    public const string SiloRuntimeStatistics = "SiloRuntimeStatistics";
+    public const string MembershipSnapshot = "MembershipSnapshot";
+    public const string ManifestHash = "ManifestHash";
+}

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
@@ -18,18 +18,18 @@ internal interface IDisseminationTopic
 
     IReadOnlyList<DisseminationTopicDigest> GetDigests();
 
-    int CompareVersion(DisseminationDigest left, DisseminationDigest right);
+    int CompareVersion(DisseminationTopicDigest left, DisseminationTopicDigest right);
 
-    bool IsObsolete(DisseminationDigest digest);
+    bool IsObsolete(DisseminationTopicDigest digest);
 
     ValueTask<DisseminationValue?> GetValue(
-        DisseminationDigest digest,
-        DisseminationDigest? peerDigest,
+        DisseminationTopicDigest digest,
+        DisseminationTopicDigest? peerDigest,
         CancellationToken cancellationToken);
 
     ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken);
 
-    ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationDigest digest, CancellationToken cancellationToken);
+    ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationTopicDigest digest, CancellationToken cancellationToken);
 }
 
 internal enum DisseminationMembershipScope

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Orleans.Configuration;
+
+namespace Orleans.Runtime.Dissemination;
+
+internal interface IDisseminationTopic
+{
+    string Name { get; }
+
+    int ProtocolVersion { get; }
+
+    DisseminationTopicOptions Options { get; }
+
+    IReadOnlySet<string> PayloadKinds { get; }
+
+    bool IsEnabled { get; }
+
+    IReadOnlyList<DisseminationItemId> GetDigests();
+
+    int CompareVersion(DisseminationItemId left, DisseminationItemId right);
+
+    bool IsObsolete(DisseminationItemId id);
+
+    ValueTask<DisseminationItem?> GetItem(DisseminationItemId id, CancellationToken cancellationToken);
+
+    ValueTask<DisseminationApplyResult> ApplyItem(DisseminationItem item, CancellationToken cancellationToken);
+
+    ValueTask OnFallbackRequired(SiloAddress peer, DisseminationItemId id, CancellationToken cancellationToken);
+}

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,7 +16,7 @@ internal interface IDisseminationTopic
 
     bool IsEnabled { get; }
 
-    IReadOnlyList<DisseminationDigest> GetDigests();
+    IReadOnlyList<DisseminationTopicDigest> GetDigests();
 
     int CompareVersion(DisseminationDigest left, DisseminationDigest right);
 
@@ -35,4 +36,33 @@ internal enum DisseminationMembershipScope
 {
     ActiveMembers,
     AllMembers,
+}
+
+internal readonly struct DisseminationTopicDigest : IEquatable<DisseminationTopicDigest>
+{
+    public DisseminationTopicDigest(string key, long version)
+    {
+        Key = key ?? string.Empty;
+        Version = version;
+    }
+
+    public string Key { get; }
+
+    public long Version { get; }
+
+    public bool Equals(DisseminationTopicDigest other) =>
+        string.Equals(Key, other.Key, StringComparison.Ordinal)
+        && Version == other.Version;
+
+    public override bool Equals(object? obj) => obj is DisseminationTopicDigest other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(
+        StringComparer.Ordinal.GetHashCode(Key ?? string.Empty),
+        Version);
+
+    public override string ToString() => $"{Key}/{Version}";
+
+    public static bool operator ==(DisseminationTopicDigest left, DisseminationTopicDigest right) => left.Equals(right);
+
+    public static bool operator !=(DisseminationTopicDigest left, DisseminationTopicDigest right) => !left.Equals(right);
 }

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
@@ -11,21 +11,29 @@ internal interface IDisseminationTopic
 
     int ProtocolVersion { get; }
 
+    DisseminationMembershipScope MembershipScope { get; }
+
     DisseminationTopicOptions Options { get; }
 
     IReadOnlySet<string> PayloadKinds { get; }
 
     bool IsEnabled { get; }
 
-    IReadOnlyList<DisseminationItemId> GetDigests();
+    IReadOnlyList<DisseminationDigest> GetDigests();
 
-    int CompareVersion(DisseminationItemId left, DisseminationItemId right);
+    int CompareVersion(DisseminationDigest left, DisseminationDigest right);
 
-    bool IsObsolete(DisseminationItemId id);
+    bool IsObsolete(DisseminationDigest digest);
 
-    ValueTask<DisseminationItem?> GetItem(DisseminationItemId id, CancellationToken cancellationToken);
+    ValueTask<DisseminationValue?> GetValue(DisseminationDigest digest, CancellationToken cancellationToken);
 
-    ValueTask<DisseminationApplyResult> ApplyItem(DisseminationItem item, CancellationToken cancellationToken);
+    ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken);
 
-    ValueTask OnFallbackRequired(SiloAddress peer, DisseminationItemId id, CancellationToken cancellationToken);
+    ValueTask OnFallbackRequired(SiloAddress peer, DisseminationDigest digest, CancellationToken cancellationToken);
+}
+
+internal enum DisseminationMembershipScope
+{
+    ActiveMembers,
+    AllMembers,
 }

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
@@ -9,8 +9,6 @@ internal interface IDisseminationTopic
 {
     string Name { get; }
 
-    int ProtocolVersion { get; }
-
     DisseminationMembershipScope MembershipScope { get; }
 
     DisseminationTopicOptions Options { get; }
@@ -28,7 +26,6 @@ internal interface IDisseminationTopic
     ValueTask<DisseminationValue?> GetValue(
         DisseminationDigest digest,
         DisseminationDigest? peerDigest,
-        IReadOnlySet<string> peerPayloadKinds,
         CancellationToken cancellationToken);
 
     ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken);

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
@@ -13,8 +13,6 @@ internal interface IDisseminationTopic
 
     DisseminationTopicOptions Options { get; }
 
-    IReadOnlySet<string> PayloadKinds { get; }
-
     bool IsEnabled { get; }
 
     IReadOnlyList<DisseminationDigest> GetDigests();
@@ -30,7 +28,7 @@ internal interface IDisseminationTopic
 
     ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken);
 
-    ValueTask OnFallbackRequired(SiloAddress peer, DisseminationDigest digest, CancellationToken cancellationToken);
+    ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationDigest digest, CancellationToken cancellationToken);
 }
 
 internal enum DisseminationMembershipScope

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
@@ -37,32 +37,3 @@ internal enum DisseminationMembershipScope
     ActiveMembers,
     AllMembers,
 }
-
-internal readonly struct DisseminationTopicDigest : IEquatable<DisseminationTopicDigest>
-{
-    public DisseminationTopicDigest(string key, long version)
-    {
-        Key = key ?? string.Empty;
-        Version = version;
-    }
-
-    public string Key { get; }
-
-    public long Version { get; }
-
-    public bool Equals(DisseminationTopicDigest other) =>
-        string.Equals(Key, other.Key, StringComparison.Ordinal)
-        && Version == other.Version;
-
-    public override bool Equals(object? obj) => obj is DisseminationTopicDigest other && Equals(other);
-
-    public override int GetHashCode() => HashCode.Combine(
-        StringComparer.Ordinal.GetHashCode(Key ?? string.Empty),
-        Version);
-
-    public override string ToString() => $"{Key}/{Version}";
-
-    public static bool operator ==(DisseminationTopicDigest left, DisseminationTopicDigest right) => left.Equals(right);
-
-    public static bool operator !=(DisseminationTopicDigest left, DisseminationTopicDigest right) => !left.Equals(right);
-}

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTopic.cs
@@ -25,7 +25,11 @@ internal interface IDisseminationTopic
 
     bool IsObsolete(DisseminationDigest digest);
 
-    ValueTask<DisseminationValue?> GetValue(DisseminationDigest digest, CancellationToken cancellationToken);
+    ValueTask<DisseminationValue?> GetValue(
+        DisseminationDigest digest,
+        DisseminationDigest? peerDigest,
+        IReadOnlySet<string> peerPayloadKinds,
+        CancellationToken cancellationToken);
 
     ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken);
 

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTransport.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTransport.cs
@@ -11,11 +11,6 @@ internal interface IDisseminationTransport
 
     DisseminationMembership GetMembership();
 
-    ValueTask<DisseminationCapabilityResponse> GetCapabilities(
-        SiloAddress peer,
-        DisseminationCapabilityRequest request,
-        CancellationToken cancellationToken);
-
     Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken);
 
     ValueTask<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTransport.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTransport.cs
@@ -11,6 +11,8 @@ internal interface IDisseminationTransport
 
     DisseminationMembership GetMembership();
 
+    Task RefreshMembership(CancellationToken cancellationToken);
+
     Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken);
 
     ValueTask<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTransport.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTransport.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime.Dissemination;
+
+internal interface IDisseminationTransport
+{
+    SiloAddress LocalSilo { get; }
+
+    IReadOnlyList<SiloAddress> GetActivePeers();
+
+    ValueTask<DisseminationCapabilityResponse> GetCapabilities(
+        SiloAddress peer,
+        DisseminationCapabilityRequest request,
+        CancellationToken cancellationToken);
+
+    Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken);
+
+    ValueTask<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(
+        SiloAddress peer,
+        DisseminationAntiEntropyRequest request,
+        CancellationToken cancellationToken);
+}

--- a/src/Orleans.Runtime/Dissemination/IDisseminationTransport.cs
+++ b/src/Orleans.Runtime/Dissemination/IDisseminationTransport.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,7 +9,7 @@ internal interface IDisseminationTransport
 {
     SiloAddress LocalSilo { get; }
 
-    IReadOnlyList<SiloAddress> GetActivePeers();
+    DisseminationMembership GetMembership();
 
     ValueTask<DisseminationCapabilityResponse> GetCapabilities(
         SiloAddress peer,
@@ -22,3 +23,7 @@ internal interface IDisseminationTransport
         DisseminationAntiEntropyRequest request,
         CancellationToken cancellationToken);
 }
+
+internal readonly record struct DisseminationMembership(
+    ImmutableArray<SiloAddress> AllMembers,
+    ImmutableArray<SiloAddress> ActiveMembers);

--- a/src/Orleans.Runtime/Dissemination/ManifestHashCalculator.cs
+++ b/src/Orleans.Runtime/Dissemination/ManifestHashCalculator.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Orleans.Metadata;
+
+namespace Orleans.Runtime.Dissemination;
+
+internal static class ManifestHashCalculator
+{
+    public static ManifestHash ComputeHash(GrainManifest manifest)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        AppendSection(hash, "grains");
+        foreach (var grain in manifest.Grains.OrderBy(static entry => entry.Key.ToString(), StringComparer.Ordinal))
+        {
+            AppendString(hash, grain.Key.ToString() ?? string.Empty);
+            AppendProperties(hash, grain.Value.Properties);
+        }
+
+        AppendSection(hash, "interfaces");
+        foreach (var grainInterface in manifest.Interfaces.OrderBy(static entry => entry.Key.ToString(), StringComparer.Ordinal))
+        {
+            AppendString(hash, grainInterface.Key.ToString() ?? string.Empty);
+            AppendProperties(hash, grainInterface.Value.Properties);
+        }
+
+        return new ManifestHash(Convert.ToHexString(hash.GetHashAndReset()));
+    }
+
+    private static void AppendProperties(IncrementalHash hash, System.Collections.Immutable.ImmutableDictionary<string, string> properties)
+    {
+        foreach (var property in properties.OrderBy(static entry => entry.Key, StringComparer.Ordinal))
+        {
+            AppendString(hash, property.Key);
+            AppendString(hash, property.Value);
+        }
+    }
+
+    private static void AppendSection(IncrementalHash hash, string section)
+    {
+        AppendString(hash, section);
+        AppendString(hash, ":");
+    }
+
+    private static void AppendString(IncrementalHash hash, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value ?? string.Empty);
+        var length = Encoding.UTF8.GetBytes(bytes.Length.ToString(CultureInfo.InvariantCulture));
+        hash.AppendData(length);
+        hash.AppendData(new byte[] { 0 });
+        hash.AppendData(bytes);
+        hash.AppendData(new byte[] { 0xff });
+    }
+}

--- a/src/Orleans.Runtime/Dissemination/ManifestHashCalculator.cs
+++ b/src/Orleans.Runtime/Dissemination/ManifestHashCalculator.cs
@@ -1,56 +1,122 @@
 using System;
-using System.Globalization;
+using System.Buffers.Binary;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 using Orleans.Metadata;
 
 namespace Orleans.Runtime.Dissemination;
 
 internal static class ManifestHashCalculator
 {
+    private const int EncodingVersion = 1;
+
     public static ManifestHash ComputeHash(GrainManifest manifest)
     {
         using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
-        AppendSection(hash, "grains");
-        foreach (var grain in manifest.Grains.OrderBy(static entry => entry.Key.ToString(), StringComparer.Ordinal))
+        AppendToken(hash, HashToken.Manifest);
+        AppendInt32(hash, EncodingVersion);
+
+        AppendToken(hash, HashToken.Grains);
+        AppendInt32(hash, manifest.Grains.Count);
+        foreach (var grain in manifest.Grains.OrderBy(static entry => entry.Key))
         {
-            AppendString(hash, grain.Key.ToString() ?? string.Empty);
+            AppendToken(hash, HashToken.GrainEntry);
+            AppendToken(hash, HashToken.Type);
+            AppendBytes(hash, GrainType.UnsafeGetArray(grain.Key));
             AppendProperties(hash, grain.Value.Properties);
+            AppendToken(hash, HashToken.EndEntry);
         }
 
-        AppendSection(hash, "interfaces");
-        foreach (var grainInterface in manifest.Interfaces.OrderBy(static entry => entry.Key.ToString(), StringComparer.Ordinal))
+        AppendToken(hash, HashToken.Interfaces);
+        AppendInt32(hash, manifest.Interfaces.Count);
+        foreach (var grainInterface in manifest.Interfaces.OrderBy(static entry => entry.Key.Value))
         {
-            AppendString(hash, grainInterface.Key.ToString() ?? string.Empty);
+            AppendToken(hash, HashToken.InterfaceEntry);
+            AppendToken(hash, HashToken.Type);
+            AppendBytes(hash, IdSpan.UnsafeGetArray(grainInterface.Key.Value));
             AppendProperties(hash, grainInterface.Value.Properties);
+            AppendToken(hash, HashToken.EndEntry);
         }
 
+        AppendToken(hash, HashToken.EndManifest);
         return new ManifestHash(Convert.ToHexString(hash.GetHashAndReset()));
     }
 
     private static void AppendProperties(IncrementalHash hash, System.Collections.Immutable.ImmutableDictionary<string, string> properties)
     {
+        AppendToken(hash, HashToken.Properties);
+        AppendInt32(hash, properties.Count);
         foreach (var property in properties.OrderBy(static entry => entry.Key, StringComparer.Ordinal))
         {
+            AppendToken(hash, HashToken.PropertyEntry);
+            AppendToken(hash, HashToken.Key);
             AppendString(hash, property.Key);
+            AppendToken(hash, HashToken.Value);
             AppendString(hash, property.Value);
+            AppendToken(hash, HashToken.EndEntry);
         }
     }
 
-    private static void AppendSection(IncrementalHash hash, string section)
+    private static void AppendToken(IncrementalHash hash, HashToken token)
     {
-        AppendString(hash, section);
-        AppendString(hash, ":");
+        hash.AppendData(stackalloc byte[] { (byte)token });
     }
 
     private static void AppendString(IncrementalHash hash, string value)
     {
-        var bytes = Encoding.UTF8.GetBytes(value ?? string.Empty);
-        var length = Encoding.UTF8.GetBytes(bytes.Length.ToString(CultureInfo.InvariantCulture));
-        hash.AppendData(length);
-        hash.AppendData(stackalloc byte[] { 0 });
+        if (value is null)
+        {
+            AppendToken(hash, HashToken.NullString);
+            return;
+        }
+
+        AppendToken(hash, HashToken.String);
+        AppendInt32(hash, value.Length);
+        Span<byte> character = stackalloc byte[sizeof(char)];
+        foreach (var ch in value)
+        {
+            BinaryPrimitives.WriteUInt16BigEndian(character, ch);
+            hash.AppendData(character);
+        }
+    }
+
+    private static void AppendBytes(IncrementalHash hash, byte[]? value)
+    {
+        if (value is null)
+        {
+            AppendToken(hash, HashToken.NullBytes);
+            return;
+        }
+
+        AppendToken(hash, HashToken.Bytes);
+        AppendInt32(hash, value.Length);
+        hash.AppendData(value);
+    }
+
+    private static void AppendInt32(IncrementalHash hash, int value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(bytes, value);
         hash.AppendData(bytes);
-        hash.AppendData(stackalloc byte[] { 0xff });
+    }
+
+    private enum HashToken : byte
+    {
+        Manifest = 1,
+        Grains = 2,
+        GrainEntry = 3,
+        Interfaces = 4,
+        InterfaceEntry = 5,
+        Type = 6,
+        Properties = 7,
+        PropertyEntry = 8,
+        Key = 9,
+        Value = 10,
+        EndEntry = 11,
+        EndManifest = 12,
+        NullString = 13,
+        String = 14,
+        NullBytes = 15,
+        Bytes = 16,
     }
 }

--- a/src/Orleans.Runtime/Dissemination/ManifestHashCalculator.cs
+++ b/src/Orleans.Runtime/Dissemination/ManifestHashCalculator.cs
@@ -49,8 +49,8 @@ internal static class ManifestHashCalculator
         var bytes = Encoding.UTF8.GetBytes(value ?? string.Empty);
         var length = Encoding.UTF8.GetBytes(bytes.Length.ToString(CultureInfo.InvariantCulture));
         hash.AppendData(length);
-        hash.AppendData(new byte[] { 0 });
+        hash.AppendData(stackalloc byte[] { 0 });
         hash.AppendData(bytes);
-        hash.AppendData(new byte[] { 0xff });
+        hash.AppendData(stackalloc byte[] { 0xff });
     }
 }

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -94,6 +94,11 @@ internal sealed class MembershipDisseminationTopic(
         }
 
         var update = serializer.Deserialize<MembershipTableSnapshotUpdate>(value.Payload);
+        if (update is null)
+        {
+            return DisseminationApplyResult.Rejected;
+        }
+
         if (update.Diff is { } diff)
         {
             return update.Snapshot is null

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -248,8 +248,8 @@ internal sealed class MembershipDisseminationTopic(
         return new MembershipTableSnapshotDiff(
             baseSnapshot.Version,
             snapshot.Version,
-            updated.ToImmutable(),
-            removed.ToImmutable());
+            updated.ToArray(),
+            removed.ToArray());
     }
 
     private static MembershipEntry PreserveIAmAliveTime(MembershipTableSnapshot previousSnapshot, MembershipEntry entry)
@@ -325,8 +325,8 @@ internal sealed class MembershipTableSnapshotDiff
     public MembershipTableSnapshotDiff(
         MembershipVersion baseVersion,
         MembershipVersion version,
-        ImmutableArray<MembershipEntry> updatedEntries,
-        ImmutableArray<SiloAddress> removedSilos)
+        MembershipEntry[] updatedEntries,
+        SiloAddress[] removedSilos)
     {
         BaseVersion = baseVersion;
         Version = version;
@@ -341,8 +341,8 @@ internal sealed class MembershipTableSnapshotDiff
     public MembershipVersion Version { get; }
 
     [Id(2)]
-    public ImmutableArray<MembershipEntry> UpdatedEntries { get; }
+    public MembershipEntry[] UpdatedEntries { get; }
 
     [Id(3)]
-    public ImmutableArray<SiloAddress> RemovedSilos { get; }
+    public SiloAddress[] RemovedSilos { get; }
 }

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -239,8 +239,8 @@ internal sealed class MembershipDisseminationTopic(
         return new MembershipTableSnapshotDiff(
             baseSnapshot.Version,
             snapshot.Version,
-            updated.ToArray(),
-            removed.ToArray());
+            updated.ToImmutable(),
+            removed.ToImmutable());
     }
 
     private static MembershipEntry PreserveIAmAliveTime(MembershipTableSnapshot previousSnapshot, MembershipEntry entry)
@@ -316,8 +316,8 @@ internal sealed class MembershipTableSnapshotDiff
     public MembershipTableSnapshotDiff(
         MembershipVersion baseVersion,
         MembershipVersion version,
-        MembershipEntry[] updatedEntries,
-        SiloAddress[] removedSilos)
+        ImmutableArray<MembershipEntry> updatedEntries,
+        ImmutableArray<SiloAddress> removedSilos)
     {
         BaseVersion = baseVersion;
         Version = version;
@@ -332,8 +332,8 @@ internal sealed class MembershipTableSnapshotDiff
     public MembershipVersion Version { get; }
 
     [Id(2)]
-    public MembershipEntry[] UpdatedEntries { get; }
+    public ImmutableArray<MembershipEntry> UpdatedEntries { get; }
 
     [Id(3)]
-    public SiloAddress[] RemovedSilos { get; }
+    public ImmutableArray<SiloAddress> RemovedSilos { get; }
 }

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Runtime.MembershipService;
+using Orleans.Serialization;
+
+namespace Orleans.Runtime.Dissemination;
+
+internal sealed class MembershipDisseminationTopic(
+    IMembershipManager membershipManager,
+    IOptionsMonitor<ClusterMembershipOptions> options,
+    Serializer serializer,
+    TimeProvider timeProvider,
+    ILocalSiloDetails localSiloDetails) : IDisseminationTopic
+{
+    private static readonly DisseminationValueKey MembershipKey = DisseminationValueKey.FromString("cluster");
+    private static readonly HashSet<string> SupportedPayloadKinds = new(StringComparer.Ordinal)
+    {
+        DisseminationTopicNames.MembershipSnapshot,
+    };
+
+    public string Name => DisseminationTopicNames.Membership;
+
+    public int ProtocolVersion => 2;
+
+    public DisseminationTopicOptions Options => options.CurrentValue.Dissemination;
+
+    public IReadOnlySet<string> PayloadKinds => SupportedPayloadKinds;
+
+    public bool IsEnabled => Options.Enabled;
+
+    public DisseminationItem CreateItem(SiloAddress origin, MembershipTableSnapshot snapshot)
+    {
+        var payload = serializer.SerializeToArray(snapshot);
+        return new DisseminationItem
+        {
+            Id = new DisseminationItemId(Name, MembershipKey, snapshot.Version.Value, DisseminationTopicNames.MembershipSnapshot),
+            Root = origin,
+            ExpiresAt = timeProvider.GetUtcNow() + Options.StaleItemTtl,
+            Payload = payload,
+        };
+    }
+
+    public IReadOnlyList<DisseminationItemId> GetDigests()
+    {
+        var snapshot = membershipManager.CurrentSnapshot;
+        return new[]
+        {
+            new DisseminationItemId(Name, MembershipKey, snapshot.Version.Value, DisseminationTopicNames.MembershipSnapshot),
+        };
+    }
+
+    public int CompareVersion(DisseminationItemId left, DisseminationItemId right) => left.Version.CompareTo(right.Version);
+
+    public bool IsObsolete(DisseminationItemId id) =>
+        !string.Equals(id.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
+        || id.Key != MembershipKey
+        || membershipManager.CurrentSnapshot.Version.Value > id.Version;
+
+    public ValueTask<DisseminationItem?> GetItem(DisseminationItemId id, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(id.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
+            || id.Key != MembershipKey)
+        {
+            return ValueTask.FromResult<DisseminationItem?>(null);
+        }
+
+        var snapshot = membershipManager.CurrentSnapshot;
+        if (snapshot.Version.Value < id.Version)
+        {
+            return ValueTask.FromResult<DisseminationItem?>(null);
+        }
+
+        return ValueTask.FromResult<DisseminationItem?>(CreateItem(localSiloDetails.SiloAddress, snapshot));
+    }
+
+    public async ValueTask<DisseminationApplyResult> ApplyItem(DisseminationItem item, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(item.Id.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
+            || item.Id.Key != MembershipKey)
+        {
+            return DisseminationApplyResult.Rejected;
+        }
+
+        var snapshot = serializer.Deserialize<MembershipTableSnapshot>(item.Payload);
+        var currentVersion = membershipManager.CurrentSnapshot.Version;
+        if (snapshot.Version < currentVersion)
+        {
+            return DisseminationApplyResult.Obsolete;
+        }
+
+        if (snapshot.Version == currentVersion)
+        {
+            return DisseminationApplyResult.Duplicate;
+        }
+
+        await membershipManager.ProcessGossipSnapshot(snapshot, cancellationToken);
+        return DisseminationApplyResult.Applied;
+    }
+
+    public async ValueTask OnFallbackRequired(SiloAddress peer, DisseminationItemId id, CancellationToken cancellationToken)
+    {
+        if (Options.FallbackEnabled)
+        {
+            await membershipManager.Refresh(new MembershipVersion(id.Version), cancellationToken);
+        }
+    }
+}

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -101,12 +101,20 @@ internal sealed class MembershipDisseminationTopic(
 
         if (update.Diff is { } diff)
         {
-            return update.Snapshot is null
-                ? await ApplyDiff(diff, cancellationToken)
-                : DisseminationApplyResult.Rejected;
+            if (update.Snapshot is not null || diff.Version.Value != value.Digest.Version)
+            {
+                return DisseminationApplyResult.Rejected;
+            }
+
+            return await ApplyDiff(diff, cancellationToken);
         }
 
         if (update.Snapshot is not { } snapshot)
+        {
+            return DisseminationApplyResult.Rejected;
+        }
+
+        if (snapshot.Version.Value != value.Digest.Version)
         {
             return DisseminationApplyResult.Rejected;
         }

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -20,11 +20,6 @@ internal sealed class MembershipDisseminationTopic(
 {
     private const string MembershipKey = "cluster";
     private const int MaxSnapshotHistory = 32;
-    private static readonly HashSet<string> SupportedPayloadKinds = new(StringComparer.Ordinal)
-    {
-        DisseminationTopicNames.MembershipSnapshot,
-        DisseminationTopicNames.MembershipSnapshotDiff,
-    };
     private readonly object _historyLock = new();
     private readonly SortedDictionary<long, MembershipTableSnapshot> _snapshotHistory = new();
 
@@ -34,20 +29,17 @@ internal sealed class MembershipDisseminationTopic(
 
     public DisseminationTopicOptions Options => options.CurrentValue.Dissemination;
 
-    public IReadOnlySet<string> PayloadKinds => SupportedPayloadKinds;
-
     public bool IsEnabled => Options.Enabled;
 
     public DisseminationValue CreateItem(SiloAddress origin, MembershipTableSnapshot snapshot)
     {
         RememberSnapshot(snapshot);
-        var payload = serializer.SerializeToArray(snapshot);
         return new DisseminationValue
         {
-            Digest = new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value, DisseminationTopicNames.MembershipSnapshot),
+            Digest = new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value),
             Root = origin,
             ExpiresAt = timeProvider.GetUtcNow() + Options.StaleItemTtl,
-            Payload = payload,
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Snapshot = snapshot }),
         };
     }
 
@@ -57,15 +49,14 @@ internal sealed class MembershipDisseminationTopic(
         RememberSnapshot(snapshot);
         return new[]
         {
-            new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value, DisseminationTopicNames.MembershipSnapshot),
+            new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value),
         };
     }
 
     public int CompareVersion(DisseminationDigest left, DisseminationDigest right) => left.Version.CompareTo(right.Version);
 
     public bool IsObsolete(DisseminationDigest digest) =>
-        !IsSupportedPayloadKind(digest.PayloadKind)
-        || digest.Key != MembershipKey
+        digest.Key != MembershipKey
         || membershipManager.CurrentSnapshot.Version.Value > digest.Version;
 
     public ValueTask<DisseminationValue?> GetValue(
@@ -73,8 +64,7 @@ internal sealed class MembershipDisseminationTopic(
         DisseminationDigest? peerDigest,
         CancellationToken cancellationToken)
     {
-        if (!string.Equals(digest.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
-            || digest.Key != MembershipKey)
+        if (digest.Key != MembershipKey)
         {
             return ValueTask.FromResult<DisseminationValue?>(null);
         }
@@ -103,17 +93,19 @@ internal sealed class MembershipDisseminationTopic(
             return DisseminationApplyResult.Rejected;
         }
 
-        if (string.Equals(value.Digest.PayloadKind, DisseminationTopicNames.MembershipSnapshotDiff, StringComparison.Ordinal))
+        var update = serializer.Deserialize<MembershipTableSnapshotUpdate>(value.Payload);
+        if (update.Diff is { } diff)
         {
-            return await ApplyDiff(value, cancellationToken);
+            return update.Snapshot is null
+                ? await ApplyDiff(diff, cancellationToken)
+                : DisseminationApplyResult.Rejected;
         }
 
-        if (!string.Equals(value.Digest.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal))
+        if (update.Snapshot is not { } snapshot)
         {
             return DisseminationApplyResult.Rejected;
         }
 
-        var snapshot = serializer.Deserialize<MembershipTableSnapshot>(value.Payload);
         var currentVersion = membershipManager.CurrentSnapshot.Version;
         if (snapshot.Version < currentVersion)
         {
@@ -130,7 +122,7 @@ internal sealed class MembershipDisseminationTopic(
         return DisseminationApplyResult.Applied;
     }
 
-    public async ValueTask OnFallbackRequired(SiloAddress peer, DisseminationDigest digest, CancellationToken cancellationToken)
+    public async ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationDigest digest, CancellationToken cancellationToken)
     {
         if (Options.FallbackEnabled)
         {
@@ -151,22 +143,19 @@ internal sealed class MembershipDisseminationTopic(
             value = default!;
             return false;
         }
-
         var diff = CreateDiff(baseSnapshot, snapshot);
-        var payload = serializer.SerializeToArray(diff);
         value = new DisseminationValue
         {
-            Digest = new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value, DisseminationTopicNames.MembershipSnapshotDiff),
+            Digest = new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value),
             Root = localSiloDetails.SiloAddress,
             ExpiresAt = timeProvider.GetUtcNow() + Options.StaleItemTtl,
-            Payload = payload,
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Diff = diff }),
         };
         return true;
     }
 
-    private async ValueTask<DisseminationApplyResult> ApplyDiff(DisseminationValue value, CancellationToken cancellationToken)
+    private async ValueTask<DisseminationApplyResult> ApplyDiff(MembershipTableSnapshotDiff diff, CancellationToken cancellationToken)
     {
-        var diff = serializer.Deserialize<MembershipTableSnapshotDiff>(value.Payload);
         var current = membershipManager.CurrentSnapshot;
         if (current.Version.Value > diff.Version.Value)
         {
@@ -269,10 +258,6 @@ internal sealed class MembershipDisseminationTopic(
         IAmAliveTime = iAmAliveTime,
     };
 
-    private static bool IsSupportedPayloadKind(string payloadKind) =>
-        string.Equals(payloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
-        || string.Equals(payloadKind, DisseminationTopicNames.MembershipSnapshotDiff, StringComparison.Ordinal);
-
     private static bool MembershipEntriesEqual(MembershipEntry left, MembershipEntry right) =>
         left.SiloAddress == right.SiloAddress
         && left.Status == right.Status
@@ -308,6 +293,16 @@ internal sealed class MembershipDisseminationTopic(
 
         return true;
     }
+}
+
+[GenerateSerializer, Immutable]
+internal sealed class MembershipTableSnapshotUpdate
+{
+    [Id(0)]
+    public MembershipTableSnapshot? Snapshot { get; init; }
+
+    [Id(1)]
+    public MembershipTableSnapshotDiff? Diff { get; init; }
 }
 
 [GenerateSerializer, Immutable]

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -43,13 +43,13 @@ internal sealed class MembershipDisseminationTopic(
         };
     }
 
-    public IReadOnlyList<DisseminationDigest> GetDigests()
+    public IReadOnlyList<DisseminationTopicDigest> GetDigests()
     {
         var snapshot = membershipManager.CurrentSnapshot;
         RememberSnapshot(snapshot);
         return new[]
         {
-            new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value),
+            new DisseminationTopicDigest(MembershipKey, snapshot.Version.Value),
         };
     }
 

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -30,8 +30,6 @@ internal sealed class MembershipDisseminationTopic(
 
     public string Name => DisseminationTopicNames.Membership;
 
-    public int ProtocolVersion => 2;
-
     public DisseminationMembershipScope MembershipScope => DisseminationMembershipScope.AllMembers;
 
     public DisseminationTopicOptions Options => options.CurrentValue.Dissemination;
@@ -73,7 +71,6 @@ internal sealed class MembershipDisseminationTopic(
     public ValueTask<DisseminationValue?> GetValue(
         DisseminationDigest digest,
         DisseminationDigest? peerDigest,
-        IReadOnlySet<string> peerPayloadKinds,
         CancellationToken cancellationToken)
     {
         if (!string.Equals(digest.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
@@ -89,17 +86,11 @@ internal sealed class MembershipDisseminationTopic(
             return ValueTask.FromResult<DisseminationValue?>(null);
         }
 
-        if (peerPayloadKinds.Contains(DisseminationTopicNames.MembershipSnapshotDiff)
-            && peerDigest is { } remote
+        if (peerDigest is { } remote
             && remote.Version < snapshot.Version.Value
             && TryCreateDiffValue(remote.Version, snapshot, out var diffValue))
         {
             return ValueTask.FromResult<DisseminationValue?>(diffValue);
-        }
-
-        if (!peerPayloadKinds.Contains(DisseminationTopicNames.MembershipSnapshot))
-        {
-            return ValueTask.FromResult<DisseminationValue?>(null);
         }
 
         return ValueTask.FromResult<DisseminationValue?>(CreateItem(localSiloDetails.SiloAddress, snapshot));

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -122,9 +122,9 @@ internal sealed class MembershipDisseminationTopic(
             return DisseminationApplyResult.Duplicate;
         }
 
-        await membershipManager.ProcessGossipSnapshot(snapshot, cancellationToken);
-        RememberSnapshot(snapshot);
-        return DisseminationApplyResult.Applied;
+        return await membershipManager.ProcessGossipSnapshot(snapshot, cancellationToken)
+            ? RememberAppliedSnapshot(snapshot)
+            : GetRejectedApplyResult(snapshot.Version);
     }
 
     public async ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationTopicDigest digest, CancellationToken cancellationToken)
@@ -189,9 +189,28 @@ internal sealed class MembershipDisseminationTopic(
         }
 
         var snapshot = new MembershipTableSnapshot(diff.Version, entries.ToImmutable());
-        await membershipManager.ProcessGossipSnapshot(snapshot, cancellationToken);
+        return await membershipManager.ProcessGossipSnapshot(snapshot, cancellationToken)
+            ? RememberAppliedSnapshot(snapshot)
+            : GetRejectedApplyResult(snapshot.Version);
+    }
+
+    private DisseminationApplyResult RememberAppliedSnapshot(MembershipTableSnapshot snapshot)
+    {
         RememberSnapshot(snapshot);
         return DisseminationApplyResult.Applied;
+    }
+
+    private DisseminationApplyResult GetRejectedApplyResult(MembershipVersion proposedVersion)
+    {
+        var currentVersion = membershipManager.CurrentSnapshot.Version;
+        if (currentVersion > proposedVersion)
+        {
+            return DisseminationApplyResult.Obsolete;
+        }
+
+        return currentVersion == proposedVersion
+            ? DisseminationApplyResult.Duplicate
+            : DisseminationApplyResult.Rejected;
     }
 
     private void RememberSnapshot(MembershipTableSnapshot snapshot)

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -16,7 +16,7 @@ internal sealed class MembershipDisseminationTopic(
     TimeProvider timeProvider,
     ILocalSiloDetails localSiloDetails) : IDisseminationTopic
 {
-    private static readonly DisseminationValueKey MembershipKey = DisseminationValueKey.FromString("cluster");
+    private const string MembershipKey = "cluster";
     private static readonly HashSet<string> SupportedPayloadKinds = new(StringComparer.Ordinal)
     {
         DisseminationTopicNames.MembershipSnapshot,
@@ -26,66 +26,68 @@ internal sealed class MembershipDisseminationTopic(
 
     public int ProtocolVersion => 2;
 
+    public DisseminationMembershipScope MembershipScope => DisseminationMembershipScope.AllMembers;
+
     public DisseminationTopicOptions Options => options.CurrentValue.Dissemination;
 
     public IReadOnlySet<string> PayloadKinds => SupportedPayloadKinds;
 
     public bool IsEnabled => Options.Enabled;
 
-    public DisseminationItem CreateItem(SiloAddress origin, MembershipTableSnapshot snapshot)
+    public DisseminationValue CreateItem(SiloAddress origin, MembershipTableSnapshot snapshot)
     {
         var payload = serializer.SerializeToArray(snapshot);
-        return new DisseminationItem
+        return new DisseminationValue
         {
-            Id = new DisseminationItemId(Name, MembershipKey, snapshot.Version.Value, DisseminationTopicNames.MembershipSnapshot),
+            Digest = new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value, DisseminationTopicNames.MembershipSnapshot),
             Root = origin,
             ExpiresAt = timeProvider.GetUtcNow() + Options.StaleItemTtl,
             Payload = payload,
         };
     }
 
-    public IReadOnlyList<DisseminationItemId> GetDigests()
+    public IReadOnlyList<DisseminationDigest> GetDigests()
     {
         var snapshot = membershipManager.CurrentSnapshot;
         return new[]
         {
-            new DisseminationItemId(Name, MembershipKey, snapshot.Version.Value, DisseminationTopicNames.MembershipSnapshot),
+            new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value, DisseminationTopicNames.MembershipSnapshot),
         };
     }
 
-    public int CompareVersion(DisseminationItemId left, DisseminationItemId right) => left.Version.CompareTo(right.Version);
+    public int CompareVersion(DisseminationDigest left, DisseminationDigest right) => left.Version.CompareTo(right.Version);
 
-    public bool IsObsolete(DisseminationItemId id) =>
-        !string.Equals(id.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
-        || id.Key != MembershipKey
-        || membershipManager.CurrentSnapshot.Version.Value > id.Version;
+    public bool IsObsolete(DisseminationDigest digest) =>
+        !string.Equals(digest.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
+        || digest.Key != MembershipKey
+        || membershipManager.CurrentSnapshot.Version.Value > digest.Version;
 
-    public ValueTask<DisseminationItem?> GetItem(DisseminationItemId id, CancellationToken cancellationToken)
+    public ValueTask<DisseminationValue?> GetValue(DisseminationDigest digest, CancellationToken cancellationToken)
     {
-        if (!string.Equals(id.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
-            || id.Key != MembershipKey)
+        if (!string.Equals(digest.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
+            || digest.Key != MembershipKey)
         {
-            return ValueTask.FromResult<DisseminationItem?>(null);
+            return ValueTask.FromResult<DisseminationValue?>(null);
         }
 
         var snapshot = membershipManager.CurrentSnapshot;
-        if (snapshot.Version.Value < id.Version)
+        if (snapshot.Version.Value < digest.Version)
         {
-            return ValueTask.FromResult<DisseminationItem?>(null);
+            return ValueTask.FromResult<DisseminationValue?>(null);
         }
 
-        return ValueTask.FromResult<DisseminationItem?>(CreateItem(localSiloDetails.SiloAddress, snapshot));
+        return ValueTask.FromResult<DisseminationValue?>(CreateItem(localSiloDetails.SiloAddress, snapshot));
     }
 
-    public async ValueTask<DisseminationApplyResult> ApplyItem(DisseminationItem item, CancellationToken cancellationToken)
+    public async ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken)
     {
-        if (!string.Equals(item.Id.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
-            || item.Id.Key != MembershipKey)
+        if (!string.Equals(value.Digest.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
+            || value.Digest.Key != MembershipKey)
         {
             return DisseminationApplyResult.Rejected;
         }
 
-        var snapshot = serializer.Deserialize<MembershipTableSnapshot>(item.Payload);
+        var snapshot = serializer.Deserialize<MembershipTableSnapshot>(value.Payload);
         var currentVersion = membershipManager.CurrentSnapshot.Version;
         if (snapshot.Version < currentVersion)
         {
@@ -101,11 +103,11 @@ internal sealed class MembershipDisseminationTopic(
         return DisseminationApplyResult.Applied;
     }
 
-    public async ValueTask OnFallbackRequired(SiloAddress peer, DisseminationItemId id, CancellationToken cancellationToken)
+    public async ValueTask OnFallbackRequired(SiloAddress peer, DisseminationDigest digest, CancellationToken cancellationToken)
     {
         if (Options.FallbackEnabled)
         {
-            await membershipManager.Refresh(new MembershipVersion(id.Version), cancellationToken);
+            await membershipManager.Refresh(new MembershipVersion(digest.Version), cancellationToken);
         }
     }
 }

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
+using Orleans.Concurrency;
 using Orleans.Configuration;
 using Orleans.Runtime.MembershipService;
 using Orleans.Serialization;
@@ -17,10 +19,14 @@ internal sealed class MembershipDisseminationTopic(
     ILocalSiloDetails localSiloDetails) : IDisseminationTopic
 {
     private const string MembershipKey = "cluster";
+    private const int MaxSnapshotHistory = 32;
     private static readonly HashSet<string> SupportedPayloadKinds = new(StringComparer.Ordinal)
     {
         DisseminationTopicNames.MembershipSnapshot,
+        DisseminationTopicNames.MembershipSnapshotDiff,
     };
+    private readonly object _historyLock = new();
+    private readonly SortedDictionary<long, MembershipTableSnapshot> _snapshotHistory = new();
 
     public string Name => DisseminationTopicNames.Membership;
 
@@ -36,6 +42,7 @@ internal sealed class MembershipDisseminationTopic(
 
     public DisseminationValue CreateItem(SiloAddress origin, MembershipTableSnapshot snapshot)
     {
+        RememberSnapshot(snapshot);
         var payload = serializer.SerializeToArray(snapshot);
         return new DisseminationValue
         {
@@ -49,6 +56,7 @@ internal sealed class MembershipDisseminationTopic(
     public IReadOnlyList<DisseminationDigest> GetDigests()
     {
         var snapshot = membershipManager.CurrentSnapshot;
+        RememberSnapshot(snapshot);
         return new[]
         {
             new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value, DisseminationTopicNames.MembershipSnapshot),
@@ -58,11 +66,15 @@ internal sealed class MembershipDisseminationTopic(
     public int CompareVersion(DisseminationDigest left, DisseminationDigest right) => left.Version.CompareTo(right.Version);
 
     public bool IsObsolete(DisseminationDigest digest) =>
-        !string.Equals(digest.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
+        !IsSupportedPayloadKind(digest.PayloadKind)
         || digest.Key != MembershipKey
         || membershipManager.CurrentSnapshot.Version.Value > digest.Version;
 
-    public ValueTask<DisseminationValue?> GetValue(DisseminationDigest digest, CancellationToken cancellationToken)
+    public ValueTask<DisseminationValue?> GetValue(
+        DisseminationDigest digest,
+        DisseminationDigest? peerDigest,
+        IReadOnlySet<string> peerPayloadKinds,
+        CancellationToken cancellationToken)
     {
         if (!string.Equals(digest.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
             || digest.Key != MembershipKey)
@@ -71,7 +83,21 @@ internal sealed class MembershipDisseminationTopic(
         }
 
         var snapshot = membershipManager.CurrentSnapshot;
+        RememberSnapshot(snapshot);
         if (snapshot.Version.Value < digest.Version)
+        {
+            return ValueTask.FromResult<DisseminationValue?>(null);
+        }
+
+        if (peerPayloadKinds.Contains(DisseminationTopicNames.MembershipSnapshotDiff)
+            && peerDigest is { } remote
+            && remote.Version < snapshot.Version.Value
+            && TryCreateDiffValue(remote.Version, snapshot, out var diffValue))
+        {
+            return ValueTask.FromResult<DisseminationValue?>(diffValue);
+        }
+
+        if (!peerPayloadKinds.Contains(DisseminationTopicNames.MembershipSnapshot))
         {
             return ValueTask.FromResult<DisseminationValue?>(null);
         }
@@ -81,8 +107,17 @@ internal sealed class MembershipDisseminationTopic(
 
     public async ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken)
     {
-        if (!string.Equals(value.Digest.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
-            || value.Digest.Key != MembershipKey)
+        if (value.Digest.Key != MembershipKey)
+        {
+            return DisseminationApplyResult.Rejected;
+        }
+
+        if (string.Equals(value.Digest.PayloadKind, DisseminationTopicNames.MembershipSnapshotDiff, StringComparison.Ordinal))
+        {
+            return await ApplyDiff(value, cancellationToken);
+        }
+
+        if (!string.Equals(value.Digest.PayloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal))
         {
             return DisseminationApplyResult.Rejected;
         }
@@ -100,6 +135,7 @@ internal sealed class MembershipDisseminationTopic(
         }
 
         await membershipManager.ProcessGossipSnapshot(snapshot, cancellationToken);
+        RememberSnapshot(snapshot);
         return DisseminationApplyResult.Applied;
     }
 
@@ -110,4 +146,203 @@ internal sealed class MembershipDisseminationTopic(
             await membershipManager.Refresh(new MembershipVersion(digest.Version), cancellationToken);
         }
     }
+
+    private bool TryCreateDiffValue(long peerVersion, MembershipTableSnapshot snapshot, out DisseminationValue value)
+    {
+        MembershipTableSnapshot? baseSnapshot;
+        lock (_historyLock)
+        {
+            _snapshotHistory.TryGetValue(peerVersion, out baseSnapshot);
+        }
+
+        if (baseSnapshot is null)
+        {
+            value = default!;
+            return false;
+        }
+
+        var diff = CreateDiff(baseSnapshot, snapshot);
+        var payload = serializer.SerializeToArray(diff);
+        value = new DisseminationValue
+        {
+            Digest = new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value, DisseminationTopicNames.MembershipSnapshotDiff),
+            Root = localSiloDetails.SiloAddress,
+            ExpiresAt = timeProvider.GetUtcNow() + Options.StaleItemTtl,
+            Payload = payload,
+        };
+        return true;
+    }
+
+    private async ValueTask<DisseminationApplyResult> ApplyDiff(DisseminationValue value, CancellationToken cancellationToken)
+    {
+        var diff = serializer.Deserialize<MembershipTableSnapshotDiff>(value.Payload);
+        var current = membershipManager.CurrentSnapshot;
+        if (current.Version.Value > diff.Version.Value)
+        {
+            return DisseminationApplyResult.Obsolete;
+        }
+
+        if (current.Version.Value == diff.Version.Value)
+        {
+            return DisseminationApplyResult.Duplicate;
+        }
+
+        if (current.Version.Value != diff.BaseVersion.Value)
+        {
+            return DisseminationApplyResult.Rejected;
+        }
+
+        var entries = current.Entries.ToBuilder();
+        foreach (var silo in diff.RemovedSilos)
+        {
+            entries.Remove(silo);
+        }
+
+        foreach (var entry in diff.UpdatedEntries)
+        {
+            entries[entry.SiloAddress] = PreserveIAmAliveTime(current, entry);
+        }
+
+        var snapshot = new MembershipTableSnapshot(diff.Version, entries.ToImmutable());
+        await membershipManager.ProcessGossipSnapshot(snapshot, cancellationToken);
+        RememberSnapshot(snapshot);
+        return DisseminationApplyResult.Applied;
+    }
+
+    private void RememberSnapshot(MembershipTableSnapshot snapshot)
+    {
+        lock (_historyLock)
+        {
+            _snapshotHistory[snapshot.Version.Value] = snapshot;
+            while (_snapshotHistory.Count > MaxSnapshotHistory)
+            {
+                using var enumerator = _snapshotHistory.Keys.GetEnumerator();
+                if (enumerator.MoveNext())
+                {
+                    _snapshotHistory.Remove(enumerator.Current);
+                }
+            }
+        }
+    }
+
+    private static MembershipTableSnapshotDiff CreateDiff(MembershipTableSnapshot baseSnapshot, MembershipTableSnapshot snapshot)
+    {
+        var updated = ImmutableArray.CreateBuilder<MembershipEntry>();
+        foreach (var entry in snapshot.Entries)
+        {
+            if (!baseSnapshot.Entries.TryGetValue(entry.Key, out var previous) || !MembershipEntriesEqual(previous, entry.Value))
+            {
+                updated.Add(entry.Value);
+            }
+        }
+
+        var removed = ImmutableArray.CreateBuilder<SiloAddress>();
+        foreach (var entry in baseSnapshot.Entries)
+        {
+            if (!snapshot.Entries.ContainsKey(entry.Key))
+            {
+                removed.Add(entry.Key);
+            }
+        }
+
+        return new MembershipTableSnapshotDiff(
+            baseSnapshot.Version,
+            snapshot.Version,
+            updated.ToImmutable(),
+            removed.ToImmutable());
+    }
+
+    private static MembershipEntry PreserveIAmAliveTime(MembershipTableSnapshot previousSnapshot, MembershipEntry entry)
+    {
+        if (previousSnapshot.Entries.TryGetValue(entry.SiloAddress, out var previousEntry)
+            && previousEntry.IAmAliveTime > entry.IAmAliveTime)
+        {
+            return CopyWithIAmAliveTime(entry, previousEntry.IAmAliveTime);
+        }
+
+        return entry;
+    }
+
+    private static MembershipEntry CopyWithIAmAliveTime(MembershipEntry entry, DateTime iAmAliveTime) => new()
+    {
+        SiloAddress = entry.SiloAddress,
+        Status = entry.Status,
+        SuspectTimes = entry.SuspectTimes is null ? null : new(entry.SuspectTimes),
+        ProxyPort = entry.ProxyPort,
+        HostName = entry.HostName,
+        SiloName = entry.SiloName,
+        RoleName = entry.RoleName,
+        UpdateZone = entry.UpdateZone,
+        FaultZone = entry.FaultZone,
+        StartTime = entry.StartTime,
+        IAmAliveTime = iAmAliveTime,
+    };
+
+    private static bool IsSupportedPayloadKind(string payloadKind) =>
+        string.Equals(payloadKind, DisseminationTopicNames.MembershipSnapshot, StringComparison.Ordinal)
+        || string.Equals(payloadKind, DisseminationTopicNames.MembershipSnapshotDiff, StringComparison.Ordinal);
+
+    private static bool MembershipEntriesEqual(MembershipEntry left, MembershipEntry right) =>
+        left.SiloAddress == right.SiloAddress
+        && left.Status == right.Status
+        && EqualSuspectTimes(left.SuspectTimes, right.SuspectTimes)
+        && left.ProxyPort == right.ProxyPort
+        && string.Equals(left.HostName, right.HostName, StringComparison.Ordinal)
+        && string.Equals(left.SiloName, right.SiloName, StringComparison.Ordinal)
+        && string.Equals(left.RoleName, right.RoleName, StringComparison.Ordinal)
+        && left.UpdateZone == right.UpdateZone
+        && left.FaultZone == right.FaultZone
+        && left.StartTime == right.StartTime
+        && left.IAmAliveTime == right.IAmAliveTime;
+
+    private static bool EqualSuspectTimes(List<Tuple<SiloAddress, DateTime>>? left, List<Tuple<SiloAddress, DateTime>>? right)
+    {
+        if (left is null || right is null)
+        {
+            return left is null && right is null;
+        }
+
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < left.Count; i++)
+        {
+            if (!Equals(left[i].Item1, right[i].Item1) || left[i].Item2 != right[i].Item2)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+[GenerateSerializer, Immutable]
+internal sealed class MembershipTableSnapshotDiff
+{
+    public MembershipTableSnapshotDiff(
+        MembershipVersion baseVersion,
+        MembershipVersion version,
+        ImmutableArray<MembershipEntry> updatedEntries,
+        ImmutableArray<SiloAddress> removedSilos)
+    {
+        BaseVersion = baseVersion;
+        Version = version;
+        UpdatedEntries = updatedEntries;
+        RemovedSilos = removedSilos;
+    }
+
+    [Id(0)]
+    public MembershipVersion BaseVersion { get; }
+
+    [Id(1)]
+    public MembershipVersion Version { get; }
+
+    [Id(2)]
+    public ImmutableArray<MembershipEntry> UpdatedEntries { get; }
+
+    [Id(3)]
+    public ImmutableArray<SiloAddress> RemovedSilos { get; }
 }

--- a/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
+++ b/src/Orleans.Runtime/Dissemination/MembershipDisseminationTopic.cs
@@ -36,7 +36,7 @@ internal sealed class MembershipDisseminationTopic(
         RememberSnapshot(snapshot);
         return new DisseminationValue
         {
-            Digest = new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value),
+            Digest = new DisseminationTopicDigest(MembershipKey, snapshot.Version.Value),
             Root = origin,
             ExpiresAt = timeProvider.GetUtcNow() + Options.StaleItemTtl,
             Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Snapshot = snapshot }),
@@ -53,15 +53,15 @@ internal sealed class MembershipDisseminationTopic(
         };
     }
 
-    public int CompareVersion(DisseminationDigest left, DisseminationDigest right) => left.Version.CompareTo(right.Version);
+    public int CompareVersion(DisseminationTopicDigest left, DisseminationTopicDigest right) => left.Version.CompareTo(right.Version);
 
-    public bool IsObsolete(DisseminationDigest digest) =>
+    public bool IsObsolete(DisseminationTopicDigest digest) =>
         digest.Key != MembershipKey
         || membershipManager.CurrentSnapshot.Version.Value > digest.Version;
 
     public ValueTask<DisseminationValue?> GetValue(
-        DisseminationDigest digest,
-        DisseminationDigest? peerDigest,
+        DisseminationTopicDigest digest,
+        DisseminationTopicDigest? peerDigest,
         CancellationToken cancellationToken)
     {
         if (digest.Key != MembershipKey)
@@ -122,7 +122,7 @@ internal sealed class MembershipDisseminationTopic(
         return DisseminationApplyResult.Applied;
     }
 
-    public async ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationDigest digest, CancellationToken cancellationToken)
+    public async ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationTopicDigest digest, CancellationToken cancellationToken)
     {
         if (Options.FallbackEnabled)
         {
@@ -146,7 +146,7 @@ internal sealed class MembershipDisseminationTopic(
         var diff = CreateDiff(baseSnapshot, snapshot);
         value = new DisseminationValue
         {
-            Digest = new DisseminationDigest(Name, MembershipKey, snapshot.Version.Value),
+            Digest = new DisseminationTopicDigest(MembershipKey, snapshot.Version.Value),
             Root = localSiloDetails.SiloAddress,
             ExpiresAt = timeProvider.GetUtcNow() + Options.StaleItemTtl,
             Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Diff = diff }),

--- a/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
+++ b/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
@@ -11,11 +11,31 @@ internal sealed class OrleansDisseminationTransport(
     IMembershipManager membershipManager,
     IInternalGrainFactory grainFactory) : IDisseminationTransport
 {
+    private readonly object _membershipLock = new();
+    private MembershipVersion? _membershipVersion;
+    private DisseminationMembership _membership;
+
     public SiloAddress LocalSilo => localSiloDetails.SiloAddress;
 
     public DisseminationMembership GetMembership()
     {
-        var entries = membershipManager.CurrentSnapshot.Entries.Values;
+        var snapshot = membershipManager.CurrentSnapshot;
+        lock (_membershipLock)
+        {
+            if (_membershipVersion == snapshot.Version)
+            {
+                return _membership;
+            }
+
+            _membership = ComputeMembership(snapshot);
+            _membershipVersion = snapshot.Version;
+            return _membership;
+        }
+    }
+
+    private static DisseminationMembership ComputeMembership(MembershipTableSnapshot snapshot)
+    {
+        var entries = snapshot.Entries.Values;
         var allMembers = entries
             .Where(static entry => IsDisseminationParticipant(entry.Status))
             .OrderBy(static entry => GetStatusRank(entry.Status))

--- a/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
+++ b/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
@@ -38,7 +38,7 @@ internal sealed class OrleansDisseminationTransport(
     public Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken)
     {
         var target = grainFactory.GetSystemTarget<IDisseminationSystemTarget>(Constants.DisseminationSystemTargetType, peer);
-        return target.PushGossip(batch).WaitAsync(cancellationToken);
+        return target.PushGossip(batch, cancellationToken);
     }
 
     public async ValueTask<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(
@@ -47,7 +47,7 @@ internal sealed class OrleansDisseminationTransport(
         CancellationToken cancellationToken)
     {
         var target = grainFactory.GetSystemTarget<IDisseminationSystemTarget>(Constants.DisseminationSystemTargetType, peer);
-        return await target.ExchangeAntiEntropy(request).WaitAsync(cancellationToken);
+        return await target.ExchangeAntiEntropy(request, cancellationToken);
     }
 
     private static bool IsDisseminationParticipant(SiloStatus status) =>

--- a/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
+++ b/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -12,7 +14,27 @@ internal sealed class OrleansDisseminationTransport(
 {
     public SiloAddress LocalSilo => localSiloDetails.SiloAddress;
 
-    public IReadOnlyList<SiloAddress> GetActivePeers() => siloStatusOracle.GetApproximateSiloStatuses(true).Keys.ToArray();
+    public DisseminationMembership GetMembership()
+    {
+        var allMembers = ImmutableArray.CreateBuilder<SiloAddress>();
+        var activeMembers = ImmutableArray.CreateBuilder<SiloAddress>();
+        foreach (var (siloAddress, status) in siloStatusOracle.GetApproximateSiloStatuses(onlyActive: false))
+        {
+            if (IsDisseminationParticipant(status))
+            {
+                allMembers.Add(siloAddress);
+            }
+
+            if (status == SiloStatus.Active)
+            {
+                activeMembers.Add(siloAddress);
+            }
+        }
+
+        allMembers.Sort(static (left, right) => left.CompareTo(right));
+        activeMembers.Sort(static (left, right) => left.CompareTo(right));
+        return new DisseminationMembership(allMembers.ToImmutable(), activeMembers.ToImmutable());
+    }
 
     public async ValueTask<DisseminationCapabilityResponse> GetCapabilities(
         SiloAddress peer,
@@ -37,4 +59,7 @@ internal sealed class OrleansDisseminationTransport(
         var target = grainFactory.GetSystemTarget<IDisseminationSystemTarget>(Constants.DisseminationSystemTargetType, peer);
         return await target.ExchangeAntiEntropy(request).WaitAsync(cancellationToken);
     }
+
+    private static bool IsDisseminationParticipant(SiloStatus status) =>
+        status is SiloStatus.Joining or SiloStatus.Active or SiloStatus.ShuttingDown or SiloStatus.Stopping;
 }

--- a/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
+++ b/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Runtime.Dissemination;
+
+internal sealed class OrleansDisseminationTransport(
+    ILocalSiloDetails localSiloDetails,
+    ISiloStatusOracle siloStatusOracle,
+    IInternalGrainFactory grainFactory) : IDisseminationTransport
+{
+    public SiloAddress LocalSilo => localSiloDetails.SiloAddress;
+
+    public IReadOnlyList<SiloAddress> GetActivePeers() => siloStatusOracle.GetApproximateSiloStatuses(true).Keys.ToArray();
+
+    public async ValueTask<DisseminationCapabilityResponse> GetCapabilities(
+        SiloAddress peer,
+        DisseminationCapabilityRequest request,
+        CancellationToken cancellationToken)
+    {
+        var target = grainFactory.GetSystemTarget<IDisseminationSystemTarget>(Constants.DisseminationSystemTargetType, peer);
+        return await target.GetCapabilities(request).WaitAsync(cancellationToken);
+    }
+
+    public Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken)
+    {
+        var target = grainFactory.GetSystemTarget<IDisseminationSystemTarget>(Constants.DisseminationSystemTargetType, peer);
+        return target.PushGossip(batch).WaitAsync(cancellationToken);
+    }
+
+    public async ValueTask<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(
+        SiloAddress peer,
+        DisseminationAntiEntropyRequest request,
+        CancellationToken cancellationToken)
+    {
+        var target = grainFactory.GetSystemTarget<IDisseminationSystemTarget>(Constants.DisseminationSystemTargetType, peer);
+        return await target.ExchangeAntiEntropy(request).WaitAsync(cancellationToken);
+    }
+}

--- a/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
+++ b/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
@@ -1,39 +1,35 @@
-using System;
 using System.Collections.Immutable;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Orleans.Runtime.MembershipService;
 
 namespace Orleans.Runtime.Dissemination;
 
 internal sealed class OrleansDisseminationTransport(
     ILocalSiloDetails localSiloDetails,
-    ISiloStatusOracle siloStatusOracle,
+    IMembershipManager membershipManager,
     IInternalGrainFactory grainFactory) : IDisseminationTransport
 {
     public SiloAddress LocalSilo => localSiloDetails.SiloAddress;
 
     public DisseminationMembership GetMembership()
     {
-        var allMembers = ImmutableArray.CreateBuilder<SiloAddress>();
-        var activeMembers = ImmutableArray.CreateBuilder<SiloAddress>();
-        foreach (var (siloAddress, status) in siloStatusOracle.GetApproximateSiloStatuses(onlyActive: false))
-        {
-            if (IsDisseminationParticipant(status))
-            {
-                allMembers.Add(siloAddress);
-            }
-
-            if (status == SiloStatus.Active)
-            {
-                activeMembers.Add(siloAddress);
-            }
-        }
-
-        allMembers.Sort(static (left, right) => left.CompareTo(right));
-        activeMembers.Sort(static (left, right) => left.CompareTo(right));
-        return new DisseminationMembership(allMembers.ToImmutable(), activeMembers.ToImmutable());
+        var entries = membershipManager.CurrentSnapshot.Entries.Values;
+        var allMembers = entries
+            .Where(static entry => IsDisseminationParticipant(entry.Status))
+            .OrderBy(static entry => GetStatusRank(entry.Status))
+            .ThenBy(static entry => entry.StartTime)
+            .ThenBy(static entry => entry.SiloAddress)
+            .Select(static entry => entry.SiloAddress)
+            .ToImmutableArray();
+        var activeMembers = entries
+            .Where(static entry => entry.Status == SiloStatus.Active)
+            .OrderBy(static entry => entry.StartTime)
+            .ThenBy(static entry => entry.SiloAddress)
+            .Select(static entry => entry.SiloAddress)
+            .ToImmutableArray();
+        return new DisseminationMembership(allMembers, activeMembers);
     }
 
     public async ValueTask<DisseminationCapabilityResponse> GetCapabilities(
@@ -62,4 +58,13 @@ internal sealed class OrleansDisseminationTransport(
 
     private static bool IsDisseminationParticipant(SiloStatus status) =>
         status is SiloStatus.Joining or SiloStatus.Active or SiloStatus.ShuttingDown or SiloStatus.Stopping;
+
+    private static int GetStatusRank(SiloStatus status) => status switch
+    {
+        SiloStatus.Active => 0,
+        SiloStatus.Joining => 1,
+        SiloStatus.ShuttingDown => 2,
+        SiloStatus.Stopping => 3,
+        _ => 4,
+    };
 }

--- a/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
+++ b/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
@@ -32,6 +32,9 @@ internal sealed class OrleansDisseminationTransport(
         return new DisseminationMembership(allMembers, activeMembers);
     }
 
+    public Task RefreshMembership(CancellationToken cancellationToken) =>
+        membershipManager.Refresh(targetVersion: null, cancellationToken);
+
     public Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken)
     {
         var target = grainFactory.GetSystemTarget<IDisseminationSystemTarget>(Constants.DisseminationSystemTargetType, peer);

--- a/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
+++ b/src/Orleans.Runtime/Dissemination/OrleansDisseminationTransport.cs
@@ -32,15 +32,6 @@ internal sealed class OrleansDisseminationTransport(
         return new DisseminationMembership(allMembers, activeMembers);
     }
 
-    public async ValueTask<DisseminationCapabilityResponse> GetCapabilities(
-        SiloAddress peer,
-        DisseminationCapabilityRequest request,
-        CancellationToken cancellationToken)
-    {
-        var target = grainFactory.GetSystemTarget<IDisseminationSystemTarget>(Constants.DisseminationSystemTargetType, peer);
-        return await target.GetCapabilities(request).WaitAsync(cancellationToken);
-    }
-
     public Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken)
     {
         var target = grainFactory.GetSystemTarget<IDisseminationSystemTarget>(Constants.DisseminationSystemTargetType, peer);

--- a/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
@@ -1,5 +1,5 @@
-using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Orleans.Metadata;
 using Orleans.Runtime.Dissemination;
@@ -40,7 +40,7 @@ namespace Orleans.Runtime
                 hashes[siloManifest.Key] = ManifestHashCalculator.ComputeHash(siloManifest.Value);
             }
 
-            return new(new ClusterManifestHashSummary(manifest.Version, hashes.ToFrozenDictionary()));
+            return new(new ClusterManifestHashSummary(manifest.Version, hashes.ToImmutableDictionary()));
         }
 
         public ValueTask<ManifestHash> GetSiloManifestHash() => new(_siloManifestHash);

--- a/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
@@ -1,4 +1,5 @@
-using System.Collections.Immutable;
+using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans.Metadata;
 using Orleans.Runtime.Dissemination;
@@ -33,13 +34,13 @@ namespace Orleans.Runtime
         public ValueTask<ClusterManifestHashSummary> GetClusterManifestHashSummary()
         {
             var manifest = _clusterManifestProvider.Current;
-            var hashes = ImmutableDictionary.CreateBuilder<SiloAddress, ManifestHash>();
+            var hashes = new Dictionary<SiloAddress, ManifestHash>();
             foreach (var siloManifest in manifest.Silos)
             {
                 hashes[siloManifest.Key] = ManifestHashCalculator.ComputeHash(siloManifest.Value);
             }
 
-            return new(new ClusterManifestHashSummary(manifest.Version, hashes.ToImmutable()));
+            return new(new ClusterManifestHashSummary(manifest.Version, hashes.ToFrozenDictionary()));
         }
 
         public ValueTask<ManifestHash> GetSiloManifestHash() => new(_siloManifestHash);

--- a/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
+++ b/src/Orleans.Runtime/GrainTypeManager/ClusterManifestSystemTarget.cs
@@ -1,11 +1,14 @@
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Orleans.Metadata;
+using Orleans.Runtime.Dissemination;
 
 namespace Orleans.Runtime
 {
     internal sealed class ClusterManifestSystemTarget : SystemTarget, IClusterManifestSystemTarget, ISiloManifestSystemTarget, ILifecycleParticipant<ISiloLifecycle>
     {
         private readonly GrainManifest _siloManifest;
+        private readonly ManifestHash _siloManifestHash;
         private readonly IClusterMembershipService _clusterMembershipService;
         private readonly IClusterManifestProvider _clusterManifestProvider;
         private readonly ClusterManifestUpdate? _noUpdate = default;
@@ -19,12 +22,31 @@ namespace Orleans.Runtime
             : base(Constants.ManifestProviderType, shared)
         {
             _siloManifest = clusterManifestProvider.LocalGrainManifest;
+            _siloManifestHash = ManifestHashCalculator.ComputeHash(_siloManifest);
             _clusterMembershipService = clusterMembershipService;
             _clusterManifestProvider = clusterManifestProvider;
             shared.ActivationDirectory.RecordNewTarget(this);
         }
 
         public ValueTask<ClusterManifest> GetClusterManifest() => new(_clusterManifestProvider.Current);
+
+        public ValueTask<ClusterManifestHashSummary> GetClusterManifestHashSummary()
+        {
+            var manifest = _clusterManifestProvider.Current;
+            var hashes = ImmutableDictionary.CreateBuilder<SiloAddress, ManifestHash>();
+            foreach (var siloManifest in manifest.Silos)
+            {
+                hashes[siloManifest.Key] = ManifestHashCalculator.ComputeHash(siloManifest.Value);
+            }
+
+            return new(new ClusterManifestHashSummary(manifest.Version, hashes.ToImmutable()));
+        }
+
+        public ValueTask<ManifestHash> GetSiloManifestHash() => new(_siloManifestHash);
+
+        public ValueTask<GrainManifest?> GetSiloManifestByHash(ManifestHash hash) =>
+            new(hash == _siloManifestHash ? _siloManifest : null);
+
         public ValueTask<ClusterManifestUpdate?> GetClusterManifestUpdate(MajorMinorVersion version)
         {
             var manifest = _clusterManifestProvider.Current;

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -20,6 +20,7 @@ using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Runtime.Configuration;
 using Orleans.Runtime.ConsistentRing;
+using Orleans.Runtime.Dissemination;
 using Orleans.Runtime.GrainDirectory;
 using Orleans.Runtime.MembershipService;
 using Orleans.Runtime.Messaging;
@@ -171,8 +172,15 @@ namespace Orleans.Hosting
 
             services.AddSingleton<DeploymentLoadPublisher>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, DeploymentLoadPublisher>();
+            services.AddSingleton<DeploymentLoadStatisticsDisseminationTopic>();
+            services.AddFromExisting<IDisseminationTopic, DeploymentLoadStatisticsDisseminationTopic>();
 
             services.AddSingleton<IAsyncTimerFactory, AsyncTimerFactory>();
+
+            services.AddSingleton<IDisseminationTransport, OrleansDisseminationTransport>();
+            services.AddSingleton<DisseminationService>();
+            services.AddSingleton<DisseminationSystemTarget>();
+            services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, DisseminationSystemTarget>();
 
             services.TryAddSingleton<IMembershipManager, MembershipTableManager>();
             services.AddFromExisting<IHealthCheckParticipant, IMembershipManager>();
@@ -181,6 +189,8 @@ namespace Orleans.Hosting
             services.AddFromExisting<IMembershipService, MembershipSystemTarget>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, MembershipSystemTarget>();
             services.AddSingleton<IMembershipGossiper, MembershipGossiper>();
+            services.AddSingleton<MembershipDisseminationTopic>();
+            services.AddFromExisting<IDisseminationTopic, MembershipDisseminationTopic>();
             services.AddSingleton<IRemoteSiloProber, RemoteSiloProber>();
             services.AddSingleton<SiloStatusOracle>();
             services.TryAddFromExisting<ISiloStatusOracle, SiloStatusOracle>();
@@ -347,6 +357,7 @@ namespace Orleans.Hosting
             services.ConfigureFormatter<LoadSheddingOptions>();
             services.ConfigureFormatter<EndpointOptions>();
             services.ConfigureFormatter<ClusterOptions>();
+            services.ConfigureFormatter<DisseminationOptions>();
 
             // This validator needs to construct the IMembershipOracle and the IMembershipTable
             // so move it in the end so other validator are called first
@@ -355,6 +366,9 @@ namespace Orleans.Hosting
             services.AddTransient<IConfigurationValidator, DevelopmentClusterMembershipOptionsValidator>();
             services.AddTransient<IConfigurationValidator, GrainTypeOptionsValidator>();
             services.AddTransient<IValidateOptions<SiloMessagingOptions>, SiloMessagingOptionsValidator>();
+            services.AddTransient<IValidateOptions<DisseminationOptions>, DisseminationOptionsValidator>();
+            services.AddTransient<IValidateOptions<DeploymentLoadPublisherOptions>, DeploymentLoadPublisherOptionsValidator>();
+            services.AddTransient<IValidateOptions<ClusterMembershipOptions>, ClusterMembershipOptionsDisseminationValidator>();
             services.AddTransient<IOptions<MessagingOptions>>(static sp => sp.GetRequiredService<IOptions<SiloMessagingOptions>>());
 
             // Enable hosted client.

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -308,6 +308,7 @@ namespace Orleans.Runtime.Metadata
                             continue;
                         }
 
+                        _manifestCache[expectedHash] = manifest;
                         builder[silo] = manifest;
                         missing.Remove(silo);
                         modified = true;
@@ -422,6 +423,7 @@ namespace Orleans.Runtime.Metadata
                 var manifest = await remoteManifestProvider.GetSiloManifestByHash(hash).AsTask().WaitAsync(_shutdownCts.Token);
                 if (manifest is not null && ManifestHashCalculator.ComputeHash(manifest) == hash)
                 {
+                    _manifestCache[hash] = manifest;
                     return manifest;
                 }
             }

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -32,7 +33,7 @@ namespace Orleans.Runtime.Metadata
         private ClusterManifest _current;
         private IInternalGrainFactory? _grainFactory;
         private Task? _runTask;
-        private readonly Dictionary<ManifestHash, GrainManifest> _manifestCache = new();
+        private readonly ConcurrentDictionary<ManifestHash, GrainManifest> _manifestCache = new();
 
         public ClusterManifestProvider(
             ILocalSiloDetails localSiloDetails,

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -169,7 +169,7 @@ namespace Orleans.Runtime.Metadata
             var modified = false;
 
             // Fill missing entries.
-            var tasks = new List<Task<(SiloAddress Key, GrainManifest? Value, Exception? Exception)>>();
+            var missingSilos = new List<SiloAddress>();
             foreach (var entry in clusterMembership.Members)
             {
                 var member = entry.Value;
@@ -186,7 +186,21 @@ namespace Orleans.Runtime.Metadata
                     continue;
                 }
 
-                tasks.Add(GetManifest(siloAddress));
+                missingSilos.Add(siloAddress);
+            }
+
+            if (missingSilos.Count > 1 && await TryFillMissingManifestsFromPeers(clusterMembership, existingManifest.Version, builder, missingSilos))
+            {
+                modified = true;
+            }
+
+            var tasks = new List<Task<(SiloAddress Key, GrainManifest? Value, Exception? Exception)>>();
+            foreach (var siloAddress in missingSilos)
+            {
+                if (!builder.ContainsKey(siloAddress))
+                {
+                    tasks.Add(GetManifest(siloAddress));
+                }
             }
 
             async Task<(SiloAddress Key, GrainManifest? Value, Exception? Exception)> GetManifest(SiloAddress siloAddress)
@@ -239,6 +253,87 @@ namespace Orleans.Runtime.Metadata
                 return publishSuccess && fetchSuccess;
             }
             return fetchSuccess;
+        }
+
+        private async Task<bool> TryFillMissingManifestsFromPeers(
+            ClusterMembershipSnapshot clusterMembership,
+            MajorMinorVersion previousVersion,
+            ImmutableDictionary<SiloAddress, GrainManifest>.Builder builder,
+            List<SiloAddress> missingSilos)
+        {
+            var missing = new HashSet<SiloAddress>(missingSilos);
+            var modified = false;
+            foreach (var peer in clusterMembership.Members.Values
+                .Where(static member => member.Status == SiloStatus.Active)
+                .Select(static member => member.SiloAddress)
+                .OrderBy(static silo => silo))
+            {
+                if (missing.Count == 0)
+                {
+                    break;
+                }
+
+                if (peer == _localSiloAddress)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var remoteManifestProvider = _grainFactory!.GetSystemTarget<IClusterManifestSystemTarget>(Constants.ManifestProviderType, peer);
+                    var summary = await remoteManifestProvider.GetClusterManifestHashSummary().AsTask().WaitAsync(_shutdownCts.Token);
+                    FillFromCachedHashes(summary, missing, builder, ref modified);
+                    if (missing.Count == 0)
+                    {
+                        break;
+                    }
+
+                    var update = await remoteManifestProvider.GetClusterManifestUpdate(previousVersion).AsTask().WaitAsync(_shutdownCts.Token);
+                    if (update?.SiloManifests is null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var silo in missing.ToArray())
+                    {
+                        if (!summary.SiloManifestHashes.TryGetValue(silo, out var expectedHash)
+                            || !update.SiloManifests.TryGetValue(silo, out var manifest)
+                            || ManifestHashCalculator.ComputeHash(manifest) != expectedHash)
+                        {
+                            continue;
+                        }
+
+                        _manifestCache[expectedHash] = manifest;
+                        builder[silo] = manifest;
+                        missing.Remove(silo);
+                        modified = true;
+                    }
+                }
+                catch (Exception exception) when (exception is not OperationCanceledException)
+                {
+                    LogDebugErrorRetrievingClusterManifestFromPeer(exception, peer);
+                }
+            }
+
+            return modified;
+        }
+
+        private void FillFromCachedHashes(
+            ClusterManifestHashSummary summary,
+            HashSet<SiloAddress> missing,
+            ImmutableDictionary<SiloAddress, GrainManifest>.Builder builder,
+            ref bool modified)
+        {
+            foreach (var silo in missing.ToArray())
+            {
+                if (summary.SiloManifestHashes.TryGetValue(silo, out var hash)
+                    && _manifestCache.TryGetValue(hash, out var cached))
+                {
+                    builder[silo] = cached;
+                    missing.Remove(silo);
+                    modified = true;
+                }
+            }
         }
 
         private ClusterManifest CreateClusterManifest(
@@ -371,6 +466,12 @@ namespace Orleans.Runtime.Metadata
             Message = "Error retrieving silo manifest by hash for silo {SiloAddress}. Falling back to direct manifest fetch."
         )]
         private partial void LogDebugErrorRetrievingSiloManifestByHash(Exception exception, SiloAddress siloAddress);
+
+        [LoggerMessage(
+            Level = LogLevel.Debug,
+            Message = "Error retrieving cluster manifest from peer {SiloAddress}. Falling back to direct manifest fetch."
+        )]
+        private partial void LogDebugErrorRetrievingClusterManifestFromPeer(Exception exception, SiloAddress siloAddress);
 
         [LoggerMessage(
             Level = LogLevel.Debug,

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Orleans.Core.Diagnostics;
 using Orleans.Internal;
 using Orleans.Metadata;
+using Orleans.Runtime.Dissemination;
 using Orleans.Runtime.Utilities;
 
 namespace Orleans.Runtime.Metadata
@@ -31,6 +32,7 @@ namespace Orleans.Runtime.Metadata
         private ClusterManifest _current;
         private IInternalGrainFactory? _grainFactory;
         private Task? _runTask;
+        private readonly Dictionary<ManifestHash, GrainManifest> _manifestCache = new();
 
         public ClusterManifestProvider(
             ILocalSiloDetails localSiloDetails,
@@ -46,6 +48,7 @@ namespace Orleans.Runtime.Metadata
             _clusterMembershipService = clusterMembershipService;
             _fatalErrorHandler = fatalErrorHandler;
             LocalGrainManifest = siloManifestProvider.SiloManifest;
+            _manifestCache[ManifestHashCalculator.ComputeHash(LocalGrainManifest)] = LocalGrainManifest;
             _current = CreateClusterManifest(
                 MajorMinorVersion.MinValue,
                 ImmutableDictionary<SiloAddress, GrainManifest>.Empty);
@@ -190,9 +193,7 @@ namespace Orleans.Runtime.Metadata
             {
                 try
                 {
-                    // Get the manifest from the silo.
-                    var remoteManifestProvider = _grainFactory!.GetSystemTarget<ISiloManifestSystemTarget>(Constants.ManifestProviderType, siloAddress);
-                    var manifest = await remoteManifestProvider.GetSiloManifest().AsTask().WaitAsync(_shutdownCts.Token);
+                    var manifest = await GetSiloManifest(siloAddress);
                     return (siloAddress, manifest, null);
                 }
                 catch (Exception exception)
@@ -219,6 +220,7 @@ namespace Orleans.Runtime.Metadata
                     if (result.Value is not null)
                     {
                         modified = true;
+                        _manifestCache[ManifestHashCalculator.ComputeHash(result.Value)] = result.Value;
                         builder[result.Key] = result.Value;
                     }
                     else
@@ -236,7 +238,6 @@ namespace Orleans.Runtime.Metadata
                 var publishSuccess = TryPublishManifest(manifest);
                 return publishSuccess && fetchSuccess;
             }
-
             return fetchSuccess;
         }
 
@@ -275,6 +276,32 @@ namespace Orleans.Runtime.Metadata
             }
 
             return builder?.ToImmutable() ?? silos;
+        }
+
+        private async Task<GrainManifest> GetSiloManifest(SiloAddress siloAddress)
+        {
+            try
+            {
+                var remoteManifestProvider = _grainFactory!.GetSystemTarget<IClusterManifestSystemTarget>(Constants.ManifestProviderType, siloAddress);
+                var hash = await remoteManifestProvider.GetSiloManifestHash().AsTask().WaitAsync(_shutdownCts.Token);
+                if (_manifestCache.TryGetValue(hash, out var cached))
+                {
+                    return cached;
+                }
+
+                var manifest = await remoteManifestProvider.GetSiloManifestByHash(hash).AsTask().WaitAsync(_shutdownCts.Token);
+                if (manifest is not null && ManifestHashCalculator.ComputeHash(manifest) == hash)
+                {
+                    _manifestCache[hash] = manifest;
+                    return manifest;
+                }
+            }
+            catch (Exception exception) when (exception is not OperationCanceledException)
+            {
+                LogDebugErrorRetrievingSiloManifestByHash(exception, siloAddress);
+            }
+            var legacyManifestProvider = _grainFactory!.GetSystemTarget<ISiloManifestSystemTarget>(Constants.ManifestProviderType, siloAddress);
+            return await legacyManifestProvider.GetSiloManifest().AsTask().WaitAsync(_shutdownCts.Token);
         }
 
         [MemberNotNull(nameof(_runTask))]
@@ -338,6 +365,12 @@ namespace Orleans.Runtime.Metadata
             Message = "Error retrieving silo manifest for silo {SiloAddress}"
         )]
         private partial void LogWarningErrorRetrievingSiloManifest(Exception exception, SiloAddress siloAddress);
+
+        [LoggerMessage(
+            Level = LogLevel.Debug,
+            Message = "Error retrieving silo manifest by hash for silo {SiloAddress}. Falling back to direct manifest fetch."
+        )]
+        private partial void LogDebugErrorRetrievingSiloManifestByHash(Exception exception, SiloAddress siloAddress);
 
         [LoggerMessage(
             Level = LogLevel.Debug,

--- a/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
+++ b/src/Orleans.Runtime/Manifest/ClusterManifestProvider.cs
@@ -30,6 +30,7 @@ namespace Orleans.Runtime.Metadata
 #else
         private readonly object _currentLock = new();
 #endif
+        private readonly object _publishLock = new();
         private ClusterManifest _current;
         private IInternalGrainFactory? _grainFactory;
         private Task? _runTask;
@@ -64,6 +65,10 @@ namespace Orleans.Runtime.Metadata
         public IAsyncEnumerable<ClusterManifest> Updates => _updates;
 
         public GrainManifest LocalGrainManifest { get; }
+
+        internal int ManifestCacheCount => _manifestCache.Count;
+
+        internal bool IsManifestCached(ManifestHash hash) => _manifestCache.ContainsKey(hash);
 
         private ClusterManifest EnsureValidManifestForCurrentMembership(ClusterMembershipSnapshot clusterMembership)
         {
@@ -235,7 +240,6 @@ namespace Orleans.Runtime.Metadata
                     if (result.Value is not null)
                     {
                         modified = true;
-                        _manifestCache[ManifestHashCalculator.ComputeHash(result.Value)] = result.Value;
                         builder[result.Key] = result.Value;
                     }
                     else
@@ -304,7 +308,6 @@ namespace Orleans.Runtime.Metadata
                             continue;
                         }
 
-                        _manifestCache[expectedHash] = manifest;
                         builder[silo] = manifest;
                         missing.Remove(silo);
                         modified = true;
@@ -346,13 +349,44 @@ namespace Orleans.Runtime.Metadata
 
         private bool TryPublishManifest(ClusterManifest manifest)
         {
-            var publishSuccess = _updates.TryPublish(manifest);
+            bool publishSuccess;
+            lock (_publishLock)
+            {
+                publishSuccess = _updates.TryPublish(manifest);
+                if (publishSuccess)
+                {
+                    SynchronizeManifestCache(manifest);
+                }
+            }
+
             if (publishSuccess)
             {
                 ManifestEvents.EmitClusterManifestUpdated(this, manifest);
             }
 
             return publishSuccess;
+        }
+
+        private void SynchronizeManifestCache(ClusterManifest manifest)
+        {
+            var retainedHashes = new HashSet<ManifestHash>
+            {
+                ManifestHashCalculator.ComputeHash(LocalGrainManifest),
+            };
+            foreach (var siloManifest in manifest.Silos.Values)
+            {
+                var hash = ManifestHashCalculator.ComputeHash(siloManifest);
+                retainedHashes.Add(hash);
+                _manifestCache[hash] = siloManifest;
+            }
+
+            foreach (var hash in _manifestCache.Keys)
+            {
+                if (!retainedHashes.Contains(hash))
+                {
+                    _manifestCache.TryRemove(hash, out _);
+                }
+            }
         }
 
         private static ImmutableDictionary<SiloAddress, GrainManifest> RemoveNonActiveSilos(
@@ -388,7 +422,6 @@ namespace Orleans.Runtime.Metadata
                 var manifest = await remoteManifestProvider.GetSiloManifestByHash(hash).AsTask().WaitAsync(_shutdownCts.Token);
                 if (manifest is not null && ManifestHashCalculator.ComputeHash(manifest) == hash)
                 {
-                    _manifestCache[hash] = manifest;
                     return manifest;
                 }
             }

--- a/src/Orleans.Runtime/MembershipService/IMembershipManager.cs
+++ b/src/Orleans.Runtime/MembershipService/IMembershipManager.cs
@@ -83,7 +83,8 @@ internal interface IMembershipManager : ILifecycleParticipant<ISiloLifecycle>, I
     /// </summary>
     /// <param name="snapshot">The gossiped snapshot.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    Task ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken);
+    /// <returns><see langword="true"/> when the snapshot was applied; otherwise, <see langword="false"/>.</returns>
+    Task<bool> ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken);
 
     /// <summary>
     /// Updates the "I Am Alive" timestamp for the local silo.

--- a/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
@@ -20,18 +20,21 @@ internal partial class MembershipGossiper(IServiceProvider serviceProvider, ILog
     {
         if (gossipPartners.Count == 0) return;
 
-        if (await TryGossipViaDissemination(snapshot))
+        var fallbackPartners = await TryGossipViaDissemination(snapshot, gossipPartners);
+        if (fallbackPartners.Count == 0)
         {
             return;
         }
 
-        LogDebugGossipingStatusToPartners(logger, updatedSilo, updatedStatus, gossipPartners.Count);
+        LogDebugGossipingStatusToPartners(logger, updatedSilo, updatedStatus, fallbackPartners.Count);
 
         var systemTarget = _membershipSystemTarget ??= serviceProvider.GetRequiredService<MembershipSystemTarget>();
-        await systemTarget.GossipToRemoteSilos(gossipPartners, snapshot, updatedSilo, updatedStatus);
+        await systemTarget.GossipToRemoteSilos(fallbackPartners, snapshot, updatedSilo, updatedStatus);
     }
 
-    private async Task<bool> TryGossipViaDissemination(MembershipTableSnapshot snapshot)
+    private async Task<List<SiloAddress>> TryGossipViaDissemination(
+        MembershipTableSnapshot snapshot,
+        List<SiloAddress> gossipPartners)
     {
         try
         {
@@ -39,17 +42,22 @@ internal partial class MembershipGossiper(IServiceProvider serviceProvider, ILog
             var topic = serviceProvider.GetService<MembershipDisseminationTopic>();
             if (dissemination is null || topic is null || !topic.IsEnabled)
             {
-                return false;
+                return gossipPartners;
             }
 
             var localSilo = serviceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress;
             var item = topic.CreateItem(localSilo, snapshot);
-            return await dissemination.Publish(topic.Name, item, targetPeers: null, CancellationToken.None);
+            if (!await dissemination.Publish(topic.Name, item, targetPeers: null, CancellationToken.None))
+            {
+                return gossipPartners;
+            }
+
+            return [.. dissemination.GetUnconfirmedPeers(topic.Name, topic.MembershipScope, gossipPartners)];
         }
         catch (Exception exception)
         {
             LogDebugMembershipDisseminationFailed(logger, exception);
-            return false;
+            return gossipPartners;
         }
     }
 

--- a/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
@@ -20,7 +20,7 @@ internal partial class MembershipGossiper(IServiceProvider serviceProvider, ILog
     {
         if (gossipPartners.Count == 0) return;
 
-        if (await TryGossipViaDissemination(gossipPartners, snapshot))
+        if (await TryGossipViaDissemination(snapshot))
         {
             return;
         }
@@ -31,7 +31,7 @@ internal partial class MembershipGossiper(IServiceProvider serviceProvider, ILog
         await systemTarget.GossipToRemoteSilos(gossipPartners, snapshot, updatedSilo, updatedStatus);
     }
 
-    private async Task<bool> TryGossipViaDissemination(List<SiloAddress> gossipPartners, MembershipTableSnapshot snapshot)
+    private async Task<bool> TryGossipViaDissemination(MembershipTableSnapshot snapshot)
     {
         try
         {

--- a/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
@@ -20,12 +20,12 @@ internal partial class MembershipGossiper(IServiceProvider serviceProvider, ILog
     {
         if (gossipPartners.Count == 0) return;
 
-        LogDebugGossipingStatusToPartners(logger, updatedSilo, updatedStatus, gossipPartners.Count);
-
         if (await TryGossipViaDissemination(gossipPartners, snapshot))
         {
             return;
         }
+
+        LogDebugGossipingStatusToPartners(logger, updatedSilo, updatedStatus, gossipPartners.Count);
 
         var systemTarget = _membershipSystemTarget ??= serviceProvider.GetRequiredService<MembershipSystemTarget>();
         await systemTarget.GossipToRemoteSilos(gossipPartners, snapshot, updatedSilo, updatedStatus);

--- a/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipGossiper.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Orleans.Runtime.Dissemination;
 
 namespace Orleans.Runtime.MembershipService;
 
@@ -10,18 +12,45 @@ internal partial class MembershipGossiper(IServiceProvider serviceProvider, ILog
 {
     private MembershipSystemTarget? _membershipSystemTarget;
 
-    public Task GossipToRemoteSilos(
+    public async Task GossipToRemoteSilos(
         List<SiloAddress> gossipPartners,
         MembershipTableSnapshot snapshot,
         SiloAddress updatedSilo,
         SiloStatus updatedStatus)
     {
-        if (gossipPartners.Count == 0) return Task.CompletedTask;
+        if (gossipPartners.Count == 0) return;
 
         LogDebugGossipingStatusToPartners(logger, updatedSilo, updatedStatus, gossipPartners.Count);
 
+        if (await TryGossipViaDissemination(gossipPartners, snapshot))
+        {
+            return;
+        }
+
         var systemTarget = _membershipSystemTarget ??= serviceProvider.GetRequiredService<MembershipSystemTarget>();
-        return systemTarget.GossipToRemoteSilos(gossipPartners, snapshot, updatedSilo, updatedStatus);
+        await systemTarget.GossipToRemoteSilos(gossipPartners, snapshot, updatedSilo, updatedStatus);
+    }
+
+    private async Task<bool> TryGossipViaDissemination(List<SiloAddress> gossipPartners, MembershipTableSnapshot snapshot)
+    {
+        try
+        {
+            var dissemination = serviceProvider.GetService<DisseminationService>();
+            var topic = serviceProvider.GetService<MembershipDisseminationTopic>();
+            if (dissemination is null || topic is null || !topic.IsEnabled)
+            {
+                return false;
+            }
+
+            var localSilo = serviceProvider.GetRequiredService<ILocalSiloDetails>().SiloAddress;
+            var item = topic.CreateItem(localSilo, snapshot);
+            return await dissemination.Publish(topic.Name, item, targetPeers: null, CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            LogDebugMembershipDisseminationFailed(logger, exception);
+            return false;
+        }
     }
 
     [LoggerMessage(
@@ -29,4 +58,9 @@ internal partial class MembershipGossiper(IServiceProvider serviceProvider, ILog
         Message = "Gossiping {Silo} status {Status} to {NumPartners} partners"
     )]
     private static partial void LogDebugGossipingStatusToPartners(ILogger logger, SiloAddress silo, SiloStatus status, int numPartners);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Membership dissemination failed. Falling back to legacy membership gossip.")]
+    private static partial void LogDebugMembershipDisseminationFailed(ILogger logger, Exception exception);
 }

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -104,7 +104,7 @@ namespace Orleans.Runtime.MembershipService
         Task<bool> IMembershipManager.TryKillSilo(SiloAddress silo, CancellationToken cancellationToken) => this.TryKill(silo);
         Task<bool> IMembershipManager.TrySuspectSilo(SiloAddress silo, SiloAddress? indirectProbingSilo, CancellationToken cancellationToken) => this.TryToSuspectOrKill(silo, indirectProbingSilo);
         Task IMembershipManager.Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken) => this.Refresh(targetVersion, cancellationToken);
-        Task<bool> IMembershipManager.ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) => this.RefreshFromSnapshot(snapshot);
+        Task<bool> IMembershipManager.ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) => this.RefreshFromSnapshot(snapshot, cancellationToken);
         Task IMembershipManager.UpdateIAmAlive(CancellationToken cancellationToken) => this.UpdateIAmAlive();
 
         private bool IsStopping => this.siloLifecycle.IsStopping;
@@ -133,8 +133,10 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        public async Task<bool> RefreshFromSnapshot(MembershipTableSnapshot snapshot)
+        public async Task<bool> RefreshFromSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (snapshot.Version == MembershipVersion.MinValue)
                 throw new ArgumentException("Cannot call RefreshFromSnapshot with Version == MembershipVersion.MinValue");
 
@@ -142,7 +144,7 @@ namespace Orleans.Runtime.MembershipService
             var pending = this.pendingRefresh;
             if (pending != null && !pending.IsCompleted)
             {
-                await pending;
+                await pending.WaitAsync(cancellationToken);
             }
 
             LogInformationReceivedClusterMembershipSnapshot(this.log, snapshot);

--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -104,7 +104,7 @@ namespace Orleans.Runtime.MembershipService
         Task<bool> IMembershipManager.TryKillSilo(SiloAddress silo, CancellationToken cancellationToken) => this.TryKill(silo);
         Task<bool> IMembershipManager.TrySuspectSilo(SiloAddress silo, SiloAddress? indirectProbingSilo, CancellationToken cancellationToken) => this.TryToSuspectOrKill(silo, indirectProbingSilo);
         Task IMembershipManager.Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken) => this.Refresh(targetVersion, cancellationToken);
-        Task IMembershipManager.ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) => this.RefreshFromSnapshot(snapshot);
+        Task<bool> IMembershipManager.ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) => this.RefreshFromSnapshot(snapshot);
         Task IMembershipManager.UpdateIAmAlive(CancellationToken cancellationToken) => this.UpdateIAmAlive();
 
         private bool IsStopping => this.siloLifecycle.IsStopping;
@@ -133,7 +133,7 @@ namespace Orleans.Runtime.MembershipService
             }
         }
 
-        public async Task RefreshFromSnapshot(MembershipTableSnapshot snapshot)
+        public async Task<bool> RefreshFromSnapshot(MembershipTableSnapshot snapshot)
         {
             if (snapshot.Version == MembershipVersion.MinValue)
                 throw new ArgumentException("Cannot call RefreshFromSnapshot with Version == MembershipVersion.MinValue");
@@ -147,7 +147,7 @@ namespace Orleans.Runtime.MembershipService
 
             LogInformationReceivedClusterMembershipSnapshot(this.log, snapshot);
 
-            this.TryProcessMembershipUpdate(MembershipTableSnapshot.Update, snapshot, nameof(RefreshFromSnapshot));
+            return this.TryProcessMembershipUpdate(MembershipTableSnapshot.Update, snapshot, nameof(RefreshFromSnapshot));
         }
 
         private async Task<bool> RefreshInternal(bool requireCleanup)

--- a/src/Orleans.Runtime/OrleansContracts.txt
+++ b/src/Orleans.Runtime/OrleansContracts.txt
@@ -18,7 +18,7 @@ class [GrainType("clustermanifestsystemtarget")] Orleans.Runtime.ClusterManifest
 
 class [GrainType("deploymentloadpublisher")] Orleans.Runtime.DeploymentLoadPublisher
 
-class [GrainType("dissemination")] Orleans.Runtime.Dissemination.DisseminationSystemTarget
+class [GrainType("disseminationsystemtarget")] Orleans.Runtime.Dissemination.DisseminationSystemTarget
 
 class [GrainType("developmentleaseprovider")] Orleans.Runtime.Development.DevelopmentLeaseProviderGrain
 

--- a/src/Orleans.Runtime/OrleansContracts.txt
+++ b/src/Orleans.Runtime/OrleansContracts.txt
@@ -18,6 +18,8 @@ class [GrainType("clustermanifestsystemtarget")] Orleans.Runtime.ClusterManifest
 
 class [GrainType("deploymentloadpublisher")] Orleans.Runtime.DeploymentLoadPublisher
 
+class [GrainType("dissemination")] Orleans.Runtime.Dissemination.DisseminationSystemTarget
+
 class [GrainType("developmentleaseprovider")] Orleans.Runtime.Development.DevelopmentLeaseProviderGrain
 
 interface [GrainInterfaceType("Orleans.Runtime.Development.IDevelopmentLeaseProviderGrain")] Orleans.Runtime.Development.IDevelopmentLeaseProviderGrain [Version(0)]

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -30,6 +30,10 @@ namespace Orleans.Runtime
         private readonly IServiceProvider _serviceProvider;
         private readonly object _statisticsUpdateLock = new();
         private readonly ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics> _periodicStats;
+        private readonly Queue<SiloAddress> _pendingStatisticsNotificationOrder = [];
+        private readonly Dictionary<SiloAddress, SiloRuntimeStatistics?> _pendingStatisticsNotifications = [];
+        private readonly HashSet<SiloAddress> _terminatedSilos = [];
+        private bool _processingStatisticsNotifications;
         private readonly TimeSpan _statisticsRefreshTime;
         private readonly List<ISiloStatisticsChangeListener> _siloStatisticsChangeListeners;
         private readonly ILogger _logger;
@@ -151,7 +155,8 @@ namespace Orleans.Runtime
         {
             lock (_statisticsUpdateLock)
             {
-                if (_siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
+                if (_terminatedSilos.Contains(siloAddress)
+                    || _siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
                 {
                     return true;
                 }
@@ -214,9 +219,11 @@ namespace Orleans.Runtime
         private DisseminationApplyResult UpdateRuntimeStatisticsInternal(SiloAddress siloAddress, SiloRuntimeStatistics siloStats, bool rejectEqualTimestamp = false)
         {
             LogTraceUpdateRuntimeStatistics(_logger, siloAddress);
+            bool processNotifications;
             lock (_statisticsUpdateLock)
             {
-                if (_siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
+                if (_terminatedSilos.Contains(siloAddress)
+                    || _siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
                 {
                     return DisseminationApplyResult.Rejected;
                 }
@@ -234,10 +241,15 @@ namespace Orleans.Runtime
                 }
 
                 _periodicStats[siloAddress] = siloStats;
-                NotifyAllStatisticsChangeEventsSubscribers(siloAddress, siloStats);
-                DeploymentLoadPublisherEvents.EmitReceived(siloAddress, _siloDetails.SiloAddress, siloStats);
-                return DisseminationApplyResult.Applied;
+                processNotifications = EnqueueStatisticsNotificationUnsafe(siloAddress, siloStats);
             }
+
+            if (processNotifications)
+            {
+                ProcessStatisticsNotifications();
+            }
+
+            return DisseminationApplyResult.Applied;
         }
 
         internal async Task RefreshClusterStatistics()
@@ -290,18 +302,81 @@ namespace Orleans.Runtime
 
         private void NotifyAllStatisticsChangeEventsSubscribers(SiloAddress silo, SiloRuntimeStatistics? stats)
         {
+            ISiloStatisticsChangeListener[] subscribers;
             lock (_siloStatisticsChangeListeners)
             {
-                foreach (var subscriber in _siloStatisticsChangeListeners)
+                subscribers = [.. _siloStatisticsChangeListeners];
+            }
+
+            foreach (var subscriber in subscribers)
+            {
+                if (stats == null)
                 {
-                    if (stats == null)
+                    subscriber.RemoveSilo(silo);
+                }
+                else
+                {
+                    subscriber.SiloStatisticsChangeNotification(silo, stats);
+                }
+            }
+        }
+
+        private bool EnqueueStatisticsNotificationUnsafe(SiloAddress siloAddress, SiloRuntimeStatistics? statistics)
+        {
+            if (!_pendingStatisticsNotifications.ContainsKey(siloAddress))
+            {
+                _pendingStatisticsNotificationOrder.Enqueue(siloAddress);
+            }
+
+            _pendingStatisticsNotifications[siloAddress] = statistics;
+            if (_processingStatisticsNotifications)
+            {
+                return false;
+            }
+
+            _processingStatisticsNotifications = true;
+            return true;
+        }
+
+        private void ProcessStatisticsNotifications()
+        {
+            while (true)
+            {
+                SiloAddress siloAddress;
+                SiloRuntimeStatistics? statistics;
+                lock (_statisticsUpdateLock)
+                {
+                    if (_pendingStatisticsNotificationOrder.Count == 0)
                     {
-                        subscriber.RemoveSilo(silo);
+                        _processingStatisticsNotifications = false;
+                        return;
+                    }
+
+                    siloAddress = _pendingStatisticsNotificationOrder.Dequeue();
+                    statistics = _pendingStatisticsNotifications[siloAddress];
+                    _pendingStatisticsNotifications.Remove(siloAddress);
+                }
+
+                try
+                {
+                    NotifyAllStatisticsChangeEventsSubscribers(siloAddress, statistics);
+                    if (statistics is null)
+                    {
+                        DeploymentLoadPublisherEvents.EmitRemoved(siloAddress, _siloDetails.SiloAddress);
                     }
                     else
                     {
-                        subscriber.SiloStatisticsChangeNotification(silo, stats);
+                        DeploymentLoadPublisherEvents.EmitReceived(siloAddress, _siloDetails.SiloAddress, statistics);
                     }
+                }
+                catch
+                {
+                    lock (_statisticsUpdateLock)
+                    {
+                        _processingStatisticsNotifications = false;
+                    }
+
+                    throw;
                 }
             }
         }
@@ -318,11 +393,17 @@ namespace Orleans.Runtime
         {
             if (!status.IsTerminating()) return;
 
+            bool processNotifications;
             lock (_statisticsUpdateLock)
             {
+                _terminatedSilos.Add(updatedSilo);
                 _periodicStats.TryRemove(updatedSilo, out _);
-                NotifyAllStatisticsChangeEventsSubscribers(updatedSilo, null);
-                DeploymentLoadPublisherEvents.EmitRemoved(updatedSilo, _siloDetails.SiloAddress);
+                processNotifications = EnqueueStatisticsNotificationUnsafe(updatedSilo, statistics: null);
+            }
+
+            if (processNotifications)
+            {
+                ProcessStatisticsNotifications();
             }
         }
 

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -113,10 +113,9 @@ namespace Orleans.Runtime
                 DeploymentLoadPublisherEvents.EmitPublished(_siloDetails.SiloAddress, myStats);
 
                 // Inform other cluster members about our refreshed statistics.
-                var members = _siloStatusOracle.GetApproximateSiloStatuses(true).Keys.ToArray();
                 if (!await TryPublishStatisticsViaDissemination(myStats))
                 {
-                    await PublishStatisticsDirectly(myStats, members);
+                    await PublishStatisticsDirectly(myStats, _siloStatusOracle.GetApproximateSiloStatuses(true).Keys);
                 }
 
                 DeploymentLoadPublisherEvents.EmitClusterRefreshed(_siloDetails.SiloAddress, _periodicStats);

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -3,10 +3,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Runtime.Diagnostics;
+using Orleans.Runtime.Dissemination;
 using Orleans.Internal;
 using Orleans.Runtime.Scheduler;
 using Orleans.Statistics;
@@ -25,6 +27,7 @@ namespace Orleans.Runtime
         private readonly IActivationWorkingSet _activationWorkingSet;
         private readonly IEnvironmentStatisticsProvider _environmentStatisticsProvider;
         private readonly IOptions<LoadSheddingOptions> _loadSheddingOptions;
+        private readonly IServiceProvider _serviceProvider;
         private readonly ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics> _periodicStats;
         private readonly TimeSpan _statisticsRefreshTime;
         private readonly List<ISiloStatisticsChangeListener> _siloStatisticsChangeListeners;
@@ -47,6 +50,7 @@ namespace Orleans.Runtime
             IActivationWorkingSet activationWorkingSet,
             IEnvironmentStatisticsProvider environmentStatisticsProvider,
             IOptions<LoadSheddingOptions> loadSheddingOptions,
+            IServiceProvider serviceProvider,
             SystemTargetShared shared)
             : base(Constants.DeploymentLoadPublisherSystemTargetType, shared)
         {
@@ -58,6 +62,7 @@ namespace Orleans.Runtime
             _activationWorkingSet = activationWorkingSet;
             _environmentStatisticsProvider = environmentStatisticsProvider;
             _loadSheddingOptions = loadSheddingOptions;
+            _serviceProvider = serviceProvider;
             _statisticsRefreshTime = options.Value.DeploymentLoadPublisherRefreshTime;
             _periodicStats = new ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics>();
             _siloStatisticsChangeListeners = new List<ISiloStatisticsChangeListener>();
@@ -108,28 +113,12 @@ namespace Orleans.Runtime
                 DeploymentLoadPublisherEvents.EmitPublished(_siloDetails.SiloAddress, myStats);
 
                 // Inform other cluster members about our refreshed statistics.
-                var members = _siloStatusOracle.GetApproximateSiloStatuses(true).Keys;
-                var tasks = new List<Task>(members.Count);
-                foreach (var siloAddress in members)
+                var members = _siloStatusOracle.GetApproximateSiloStatuses(true).Keys.ToArray();
+                if (!await TryPublishStatisticsViaDissemination(myStats, members))
                 {
-                    // No need to make a grain call to ourselves.
-                    if (siloAddress.Equals(_siloDetails.SiloAddress))
-                    {
-                        continue;
-                    }
-
-                    try
-                    {
-                        var deploymentLoadPublisher = _grainFactory.GetSystemTarget<IDeploymentLoadPublisher>(Constants.DeploymentLoadPublisherSystemTargetType, siloAddress);
-                        tasks.Add(deploymentLoadPublisher.UpdateRuntimeStatistics(_siloDetails.SiloAddress, myStats));
-                    }
-                    catch (Exception exception)
-                    {
-                        LogWarningRuntimeStatisticsUpdateFailure1(_logger, exception);
-                    }
+                    await PublishStatisticsDirectly(myStats, members);
                 }
 
-                await Task.WhenAll(tasks);
                 DeploymentLoadPublisherEvents.EmitClusterRefreshed(_siloDetails.SiloAddress, _periodicStats);
             }
             catch (Exception exc)
@@ -144,23 +133,90 @@ namespace Orleans.Runtime
             return Task.CompletedTask;
         }
 
-        private void UpdateRuntimeStatisticsInternal(SiloAddress siloAddress, SiloRuntimeStatistics siloStats)
+        internal DisseminationApplyResult ApplyDisseminatedRuntimeStatistics(SiloAddress siloAddress, SiloRuntimeStatistics siloStats) =>
+            UpdateRuntimeStatisticsInternal(siloAddress, siloStats, rejectEqualTimestamp: true);
+
+        internal bool IsRuntimeStatisticsObsolete(SiloAddress siloAddress, long timestampTicks)
+        {
+            if (_siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
+            {
+                return true;
+            }
+
+            return _periodicStats.TryGetValue(siloAddress, out var old) && old.DateTime.Ticks > timestampTicks;
+        }
+
+        internal Task RefreshSiloStatisticsForDissemination(SiloAddress silo) => RefreshSiloStatistics(silo);
+
+        private async Task<bool> TryPublishStatisticsViaDissemination(SiloRuntimeStatistics myStats, IReadOnlyCollection<SiloAddress> members)
+        {
+            try
+            {
+                var dissemination = _serviceProvider.GetService<DisseminationService>();
+                var topic = _serviceProvider.GetService<DeploymentLoadStatisticsDisseminationTopic>();
+                if (dissemination is null || topic is null || !topic.IsEnabled)
+                {
+                    return false;
+                }
+
+                var item = topic.CreateItem(_siloDetails.SiloAddress, myStats);
+                return await dissemination.Publish(topic.Name, item, targetPeers: null, CancellationToken.None);
+            }
+            catch (Exception exception)
+            {
+                LogWarningRuntimeStatisticsUpdateFailure1(_logger, exception);
+                return false;
+            }
+        }
+
+        private async Task PublishStatisticsDirectly(SiloRuntimeStatistics myStats, IReadOnlyCollection<SiloAddress> members)
+        {
+            var tasks = new List<Task>(members.Count);
+            foreach (var siloAddress in members)
+            {
+                // No need to make a grain call to ourselves.
+                if (siloAddress == _siloDetails.SiloAddress)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var deploymentLoadPublisher = _grainFactory.GetSystemTarget<IDeploymentLoadPublisher>(Constants.DeploymentLoadPublisherSystemTargetType, siloAddress);
+                    tasks.Add(deploymentLoadPublisher.UpdateRuntimeStatistics(_siloDetails.SiloAddress, myStats));
+                }
+                catch (Exception exception)
+                {
+                    LogWarningRuntimeStatisticsUpdateFailure1(_logger, exception);
+                }
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        private DisseminationApplyResult UpdateRuntimeStatisticsInternal(SiloAddress siloAddress, SiloRuntimeStatistics siloStats, bool rejectEqualTimestamp = false)
         {
             LogTraceUpdateRuntimeStatistics(_logger, siloAddress);
             if (_siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
             {
-                return;
+                return DisseminationApplyResult.Rejected;
             }
 
             // Take only if newer.
             if (_periodicStats.TryGetValue(siloAddress, out var old) && old.DateTime > siloStats.DateTime)
             {
-                return;
+                return DisseminationApplyResult.Obsolete;
+            }
+
+            if (rejectEqualTimestamp && old is not null && old.DateTime == siloStats.DateTime)
+            {
+                return DisseminationApplyResult.Duplicate;
             }
 
             _periodicStats[siloAddress] = siloStats;
             NotifyAllStatisticsChangeEventsSubscribers(siloAddress, siloStats);
             DeploymentLoadPublisherEvents.EmitReceived(siloAddress, _siloDetails.SiloAddress, siloStats);
+            return DisseminationApplyResult.Applied;
         }
 
         internal async Task RefreshClusterStatistics()

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -113,7 +113,18 @@ namespace Orleans.Runtime
                 DeploymentLoadPublisherEvents.EmitPublished(_siloDetails.SiloAddress, myStats);
 
                 // Inform other cluster members about our refreshed statistics.
-                if (!await TryPublishStatisticsViaDissemination(myStats))
+                if (await TryPublishStatisticsViaDissemination(myStats))
+                {
+                    var dissemination = _serviceProvider.GetRequiredService<DisseminationService>();
+                    var unconfirmedPeers = dissemination.GetUnconfirmedPeers(
+                        DisseminationTopicNames.DeploymentLoad,
+                        DisseminationMembershipScope.ActiveMembers);
+                    if (unconfirmedPeers.Count > 0)
+                    {
+                        await PublishStatisticsDirectly(myStats, unconfirmedPeers);
+                    }
+                }
+                else
                 {
                     await PublishStatisticsDirectly(myStats, _siloStatusOracle.GetApproximateSiloStatuses(true).Keys);
                 }

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -28,6 +28,7 @@ namespace Orleans.Runtime
         private readonly IEnvironmentStatisticsProvider _environmentStatisticsProvider;
         private readonly IOptions<LoadSheddingOptions> _loadSheddingOptions;
         private readonly IServiceProvider _serviceProvider;
+        private readonly object _statisticsUpdateLock = new();
         private readonly ConcurrentDictionary<SiloAddress, SiloRuntimeStatistics> _periodicStats;
         private readonly TimeSpan _statisticsRefreshTime;
         private readonly List<ISiloStatisticsChangeListener> _siloStatisticsChangeListeners;
@@ -148,12 +149,15 @@ namespace Orleans.Runtime
 
         internal bool IsRuntimeStatisticsObsolete(SiloAddress siloAddress, long timestampTicks)
         {
-            if (_siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
+            lock (_statisticsUpdateLock)
             {
-                return true;
-            }
+                if (_siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
+                {
+                    return true;
+                }
 
-            return _periodicStats.TryGetValue(siloAddress, out var old) && old.DateTime.Ticks > timestampTicks;
+                return _periodicStats.TryGetValue(siloAddress, out var old) && old.DateTime.Ticks > timestampTicks;
+            }
         }
 
         internal Task RefreshSiloStatisticsForDissemination(SiloAddress silo) => RefreshSiloStatistics(silo);
@@ -210,26 +214,30 @@ namespace Orleans.Runtime
         private DisseminationApplyResult UpdateRuntimeStatisticsInternal(SiloAddress siloAddress, SiloRuntimeStatistics siloStats, bool rejectEqualTimestamp = false)
         {
             LogTraceUpdateRuntimeStatistics(_logger, siloAddress);
-            if (_siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
+            lock (_statisticsUpdateLock)
             {
-                return DisseminationApplyResult.Rejected;
-            }
+                if (_siloStatusOracle.GetApproximateSiloStatus(siloAddress) != SiloStatus.Active)
+                {
+                    return DisseminationApplyResult.Rejected;
+                }
 
-            // Take only if newer.
-            if (_periodicStats.TryGetValue(siloAddress, out var old) && old.DateTime > siloStats.DateTime)
-            {
-                return DisseminationApplyResult.Obsolete;
-            }
+                // Status and version are evaluated in the same mutation boundary as the write so
+                // direct publication, refresh, dissemination, and membership removal stay ordered.
+                if (_periodicStats.TryGetValue(siloAddress, out var old) && old.DateTime > siloStats.DateTime)
+                {
+                    return DisseminationApplyResult.Obsolete;
+                }
 
-            if (rejectEqualTimestamp && old is not null && old.DateTime == siloStats.DateTime)
-            {
-                return DisseminationApplyResult.Duplicate;
-            }
+                if (rejectEqualTimestamp && old is not null && old.DateTime == siloStats.DateTime)
+                {
+                    return DisseminationApplyResult.Duplicate;
+                }
 
-            _periodicStats[siloAddress] = siloStats;
-            NotifyAllStatisticsChangeEventsSubscribers(siloAddress, siloStats);
-            DeploymentLoadPublisherEvents.EmitReceived(siloAddress, _siloDetails.SiloAddress, siloStats);
-            return DisseminationApplyResult.Applied;
+                _periodicStats[siloAddress] = siloStats;
+                NotifyAllStatisticsChangeEventsSubscribers(siloAddress, siloStats);
+                DeploymentLoadPublisherEvents.EmitReceived(siloAddress, _siloDetails.SiloAddress, siloStats);
+                return DisseminationApplyResult.Applied;
+            }
         }
 
         internal async Task RefreshClusterStatistics()
@@ -306,13 +314,16 @@ namespace Orleans.Runtime
             });
         }
 
-        private void OnSiloStatusChange(SiloAddress updatedSilo, SiloStatus status)
+        internal void OnSiloStatusChange(SiloAddress updatedSilo, SiloStatus status)
         {
             if (!status.IsTerminating()) return;
 
-            DeploymentLoadPublisherEvents.EmitRemoved(updatedSilo, _siloDetails.SiloAddress);
-            _periodicStats.TryRemove(updatedSilo, out _);
-            NotifyAllStatisticsChangeEventsSubscribers(updatedSilo, null);
+            lock (_statisticsUpdateLock)
+            {
+                _periodicStats.TryRemove(updatedSilo, out _);
+                NotifyAllStatisticsChangeEventsSubscribers(updatedSilo, null);
+                DeploymentLoadPublisherEvents.EmitRemoved(updatedSilo, _siloDetails.SiloAddress);
+            }
         }
 
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle observer)

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -148,6 +148,9 @@ namespace Orleans.Runtime
 
         internal Task RefreshSiloStatisticsForDissemination(SiloAddress silo) => RefreshSiloStatistics(silo);
 
+        internal IReadOnlyCollection<SiloAddress> GetActiveSilosForDissemination() =>
+            _siloStatusOracle.GetApproximateSiloStatuses(onlyActive: true).Keys;
+
         private async Task<bool> TryPublishStatisticsViaDissemination(SiloRuntimeStatistics myStats, IReadOnlyCollection<SiloAddress> members)
         {
             try

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -188,7 +188,7 @@ namespace Orleans.Runtime
             foreach (var siloAddress in members)
             {
                 // No need to make a grain call to ourselves.
-                if (siloAddress == _siloDetails.SiloAddress)
+                if (siloAddress.Equals(_siloDetails.SiloAddress))
                 {
                     continue;
                 }

--- a/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
+++ b/src/Orleans.Runtime/Placement/DeploymentLoadPublisher.cs
@@ -91,7 +91,7 @@ namespace Orleans.Runtime
             LogDebugStartedDeploymentLoadPublisher(_logger);
         }
 
-        private async Task PublishStatistics()
+        internal async Task PublishStatistics()
         {
             try
             {
@@ -114,7 +114,7 @@ namespace Orleans.Runtime
 
                 // Inform other cluster members about our refreshed statistics.
                 var members = _siloStatusOracle.GetApproximateSiloStatuses(true).Keys.ToArray();
-                if (!await TryPublishStatisticsViaDissemination(myStats, members))
+                if (!await TryPublishStatisticsViaDissemination(myStats))
                 {
                     await PublishStatisticsDirectly(myStats, members);
                 }
@@ -151,7 +151,7 @@ namespace Orleans.Runtime
         internal IReadOnlyCollection<SiloAddress> GetActiveSilosForDissemination() =>
             _siloStatusOracle.GetApproximateSiloStatuses(onlyActive: true).Keys;
 
-        private async Task<bool> TryPublishStatisticsViaDissemination(SiloRuntimeStatistics myStats, IReadOnlyCollection<SiloAddress> members)
+        internal async Task<bool> TryPublishStatisticsViaDissemination(SiloRuntimeStatistics myStats)
         {
             try
             {

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -546,6 +546,8 @@ namespace Orleans.Configuration
     {
         public bool Enabled { get { throw null; } set { } }
 
+        public System.TimeSpan ExpectedUpdateCadence { get { throw null; } set { } }
+
         public bool FallbackEnabled { get { throw null; } set { } }
 
         public System.TimeSpan MaxCoalescingDelay { get { throw null; } set { } }

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -533,7 +533,13 @@ namespace Orleans.Configuration
 
         public int AntiEntropyPeerCount { get { throw null; } set { } }
 
-        public int TreeFanout { get { throw null; } set { } }
+        public System.Func<int, int>? FanOutFactor { get { throw null; } set { } }
+
+        public int MaxFanOutFactor { get { throw null; } set { } }
+
+        public int MinFanOutFactor { get { throw null; } set { } }
+
+        public int TargetHopCount { get { throw null; } set { } }
     }
 
     public sealed partial class DisseminationTopicOptions

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -445,6 +445,8 @@ namespace Orleans.Configuration
 
         public bool EnableConnectionLivenessCheck { get { throw null; } set { } }
 
+        public DisseminationTopicOptions Dissemination { get { throw null; } set { } }
+
         public bool EnableIndirectProbes { get { throw null; } set { } }
 
         public bool EvictWhenMaxJoinAttemptTimeExceeded { get { throw null; } set { } }
@@ -506,6 +508,47 @@ namespace Orleans.Configuration
         public System.TimeSpan OpenConnectionTimeout { get { throw null; } set { } }
 
         public Runtime.Messaging.NetworkProtocolVersion ProtocolVersion { get { throw null; } set { } }
+    }
+
+    public sealed partial class DisseminationOptions
+    {
+        public System.TimeSpan CapabilityCacheTtl { get { throw null; } set { } }
+
+        public bool Enabled { get { throw null; } set { } }
+
+        public System.TimeSpan FailureBackoff { get { throw null; } set { } }
+
+        public int MaxBatchBytes { get { throw null; } set { } }
+
+        public int MaxBatchItems { get { throw null; } set { } }
+
+        public int MaxConcurrentSends { get { throw null; } set { } }
+
+        public DisseminationOverlayOptions Overlay { get { throw null; } set { } }
+    }
+
+    public sealed partial class DisseminationOverlayOptions
+    {
+        public System.TimeSpan AntiEntropyInterval { get { throw null; } set { } }
+
+        public int AntiEntropyPeerCount { get { throw null; } set { } }
+
+        public int TreeFanout { get { throw null; } set { } }
+    }
+
+    public sealed partial class DisseminationTopicOptions
+    {
+        public bool Enabled { get { throw null; } set { } }
+
+        public bool FallbackEnabled { get { throw null; } set { } }
+
+        public System.TimeSpan MaxCoalescingDelay { get { throw null; } set { } }
+
+        public int MaxPayloadBytes { get { throw null; } set { } }
+
+        public int MaxPendingItemCount { get { throw null; } set { } }
+
+        public System.TimeSpan StaleItemTtl { get { throw null; } set { } }
     }
 
     public partial class GatewayOptions

--- a/src/api/Orleans.Core/Orleans.Core.cs
+++ b/src/api/Orleans.Core/Orleans.Core.cs
@@ -512,8 +512,6 @@ namespace Orleans.Configuration
 
     public sealed partial class DisseminationOptions
     {
-        public System.TimeSpan CapabilityCacheTtl { get { throw null; } set { } }
-
         public bool Enabled { get { throw null; } set { } }
 
         public System.TimeSpan FailureBackoff { get { throw null; } set { } }

--- a/src/api/Orleans.Runtime/Orleans.Runtime.cs
+++ b/src/api/Orleans.Runtime/Orleans.Runtime.cs
@@ -119,6 +119,8 @@ namespace Orleans.Configuration
     public partial class DeploymentLoadPublisherOptions
     {
         public static readonly System.TimeSpan DEFAULT_DEPLOYMENT_LOAD_PUBLISHER_REFRESH_TIME;
+        public DisseminationTopicOptions Dissemination { get { throw null; } set { } }
+
         public System.TimeSpan DeploymentLoadPublisherRefreshTime { get { throw null; } set { } }
     }
 

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
@@ -334,7 +334,7 @@ public class ClusterManifestProviderTests
         }
         finally
         {
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(TestContext.Current.CancellationToken);
             membership.Dispose();
         }
     }
@@ -392,7 +392,7 @@ public class ClusterManifestProviderTests
         }
         finally
         {
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(TestContext.Current.CancellationToken);
             membership.Dispose();
         }
     }
@@ -452,7 +452,7 @@ public class ClusterManifestProviderTests
         }
         finally
         {
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(TestContext.Current.CancellationToken);
             membership.Dispose();
         }
     }
@@ -509,7 +509,7 @@ public class ClusterManifestProviderTests
                 (localSilo, SiloStatus.Active),
                 (peer1, SiloStatus.Active),
                 (peer2, SiloStatus.Active)));
-            await updateRequested.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await updateRequested.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
             membership.Update(CreateMembershipSnapshot(
                 3,
@@ -527,7 +527,7 @@ public class ClusterManifestProviderTests
         }
         finally
         {
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(TestContext.Current.CancellationToken);
             membership.Dispose();
         }
     }
@@ -574,7 +574,7 @@ public class ClusterManifestProviderTests
                 2,
                 (localSilo, SiloStatus.Active),
                 (remoteSilo, SiloStatus.Active)));
-            await manifestRequested.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await manifestRequested.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 
             membership.Update(CreateMembershipSnapshot(
                 3,
@@ -590,7 +590,7 @@ public class ClusterManifestProviderTests
         }
         finally
         {
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(TestContext.Current.CancellationToken);
             membership.Dispose();
         }
     }
@@ -642,7 +642,7 @@ public class ClusterManifestProviderTests
         }
         finally
         {
-            await lifecycle.OnStop();
+            await lifecycle.OnStop(TestContext.Current.CancellationToken);
             membership.Dispose();
         }
     }

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
@@ -13,6 +13,7 @@ using NSubstitute;
 using Orleans.Configuration;
 using Orleans.Metadata;
 using Orleans.Runtime;
+using Orleans.Runtime.Dissemination;
 using Orleans.Runtime.Metadata;
 using Orleans.Runtime.Utilities;
 using Orleans.Runtime.Versions;
@@ -267,6 +268,242 @@ public class ClusterManifestProviderTests
         Assert.Equal(new[] { localSilo, remoteSilo }, supportedSilos.OrderBy(static silo => silo));
     }
 
+    /// <summary>
+    /// When two or more manifests are missing simultaneously, the provider should attempt to fill them from a single
+    /// peer's cluster manifest hash summary before falling back to individual per-silo manifest fetches. When the
+    /// advertised hash is already present in the local manifest cache (e.g. because it matches a manifest already
+    /// known to this silo), the value is reused directly and no additional peer needs to be contacted at all.
+    /// </summary>
+    [Fact]
+    public async Task Current_FillsMultipleMissingManifestsFromSinglePeerHashSummaryCache()
+    {
+        var localSilo = CreateSiloAddress(11131, 1);
+        var peer1 = CreateSiloAddress(11132, 1);
+        var peer2 = CreateSiloAddress(11133, 1);
+        var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
+            1,
+            (localSilo, SiloStatus.Active)));
+        var grainFactory = Substitute.For<IInternalGrainFactory>();
+        var siloManifestProvider = CreateSiloManifestProvider();
+        var localManifest = siloManifestProvider.SiloManifest;
+        var localHash = ManifestHashCalculator.ComputeHash(localManifest);
+
+        // Both peers advertise the same manifest hash as the local silo (a common case in a homogeneous cluster),
+        // so both should be satisfied entirely from the local manifest cache after a single hash-summary request to peer1.
+        var hashSummary = new ClusterManifestHashSummary(
+            new MajorMinorVersion(1, 0),
+            ImmutableDictionary<SiloAddress, ManifestHash>.Empty.Add(peer1, localHash).Add(peer2, localHash));
+        var peer1Target = new FakeClusterManifestSystemTarget(hashSummary);
+        grainFactory
+            .GetSystemTarget<IClusterManifestSystemTarget>(Constants.ManifestProviderType, peer1)
+            .Returns(peer1Target);
+
+        var services = new ServiceCollection().AddSingleton(grainFactory).BuildServiceProvider();
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        localSiloDetails.SiloAddress.Returns(localSilo);
+
+        var provider = new ClusterManifestProvider(
+            localSiloDetails,
+            siloManifestProvider,
+            membership,
+            Substitute.For<IFatalErrorHandler>(),
+            NullLogger<ClusterManifestProvider>.Instance,
+            services);
+
+        var lifecycle = await StartAsync(provider);
+        try
+        {
+            membership.Update(CreateMembershipSnapshot(
+                2,
+                (localSilo, SiloStatus.Active),
+                (peer1, SiloStatus.Active),
+                (peer2, SiloStatus.Active)));
+
+            await Until(() => provider.Current.Silos.ContainsKey(peer1) && provider.Current.Silos.ContainsKey(peer2));
+
+            Assert.Same(localManifest, provider.Current.Silos[peer1]);
+            Assert.Same(localManifest, provider.Current.Silos[peer2]);
+            Assert.Equal(1, peer1Target.HashSummaryRequests);
+            Assert.Equal(0, peer1Target.UpdateRequests);
+            grainFactory.DidNotReceive().GetSystemTarget<IClusterManifestSystemTarget>(Constants.ManifestProviderType, peer2);
+        }
+        finally
+        {
+            await lifecycle.OnStop();
+            membership.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// A single missing manifest (below the batch-fill threshold) is fetched via the new hash-based path
+    /// (<see cref="IClusterManifestSystemTarget.GetSiloManifestHash"/> + <see cref="IClusterManifestSystemTarget.GetSiloManifestByHash"/>)
+    /// and must not fall back to the legacy <see cref="ISiloManifestSystemTarget"/> when the hash-based fetch succeeds.
+    /// </summary>
+    [Fact]
+    public async Task Current_FetchesSingleMissingManifestViaHashPathWithoutLegacyFallback()
+    {
+        var localSilo = CreateSiloAddress(11134, 1);
+        var remoteSilo = CreateSiloAddress(11135, 1);
+        var remoteManifest = CreateGrainManifest();
+        var remoteHash = ManifestHashCalculator.ComputeHash(remoteManifest);
+        var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
+            1,
+            (localSilo, SiloStatus.Active)));
+        var grainFactory = Substitute.For<IInternalGrainFactory>();
+        var siloManifestProvider = CreateSiloManifestProvider();
+        var remoteTarget = new FakeHashOnlyClusterManifestSystemTarget(remoteHash, remoteManifest);
+        grainFactory
+            .GetSystemTarget<IClusterManifestSystemTarget>(Constants.ManifestProviderType, remoteSilo)
+            .Returns(remoteTarget);
+        var legacyTarget = new RecordingSiloManifestSystemTarget();
+        grainFactory
+            .GetSystemTarget<ISiloManifestSystemTarget>(Constants.ManifestProviderType, remoteSilo)
+            .Returns(legacyTarget);
+
+        var services = new ServiceCollection().AddSingleton(grainFactory).BuildServiceProvider();
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        localSiloDetails.SiloAddress.Returns(localSilo);
+
+        var provider = new ClusterManifestProvider(
+            localSiloDetails,
+            siloManifestProvider,
+            membership,
+            Substitute.For<IFatalErrorHandler>(),
+            NullLogger<ClusterManifestProvider>.Instance,
+            services);
+
+        var lifecycle = await StartAsync(provider);
+        try
+        {
+            membership.Update(CreateMembershipSnapshot(
+                2,
+                (localSilo, SiloStatus.Active),
+                (remoteSilo, SiloStatus.Active)));
+
+            await Until(() => provider.Current.Silos.ContainsKey(remoteSilo));
+
+            Assert.Same(remoteManifest, provider.Current.Silos[remoteSilo]);
+            Assert.False(legacyTarget.WasInvoked);
+        }
+        finally
+        {
+            await lifecycle.OnStop();
+            membership.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Current_FillsMultipleMissingManifestsFromPeerUpdateWhenHashesMatch()
+    {
+        var localSilo = CreateSiloAddress(11136, 1);
+        var peer1 = CreateSiloAddress(11137, 1);
+        var peer2 = CreateSiloAddress(11138, 1);
+        var manifest1 = CreateGrainManifest("2");
+        var manifest2 = CreateGrainManifest("3");
+        var hash1 = ManifestHashCalculator.ComputeHash(manifest1);
+        var hash2 = ManifestHashCalculator.ComputeHash(manifest2);
+        var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
+            1,
+            (localSilo, SiloStatus.Active)));
+        var grainFactory = Substitute.For<IInternalGrainFactory>();
+        var summary = new ClusterManifestHashSummary(
+            new MajorMinorVersion(2, 0),
+            ImmutableDictionary<SiloAddress, ManifestHash>.Empty.Add(peer1, hash1).Add(peer2, hash2));
+        var update = new ClusterManifestUpdate(
+            new MajorMinorVersion(2, 0),
+            ImmutableDictionary<SiloAddress, GrainManifest>.Empty.Add(peer1, manifest1).Add(peer2, manifest2),
+            includesAllActiveServers: true);
+        var peer1Target = new FakeClusterManifestSystemTarget(summary, update);
+        grainFactory
+            .GetSystemTarget<IClusterManifestSystemTarget>(Constants.ManifestProviderType, peer1)
+            .Returns(peer1Target);
+        var services = new ServiceCollection().AddSingleton(grainFactory).BuildServiceProvider();
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        localSiloDetails.SiloAddress.Returns(localSilo);
+        var provider = new ClusterManifestProvider(
+            localSiloDetails,
+            CreateSiloManifestProvider(),
+            membership,
+            Substitute.For<IFatalErrorHandler>(),
+            NullLogger<ClusterManifestProvider>.Instance,
+            services);
+
+        var lifecycle = await StartAsync(provider);
+        try
+        {
+            membership.Update(CreateMembershipSnapshot(
+                2,
+                (localSilo, SiloStatus.Active),
+                (peer1, SiloStatus.Active),
+                (peer2, SiloStatus.Active)));
+
+            await Until(() => provider.Current.Silos.ContainsKey(peer1) && provider.Current.Silos.ContainsKey(peer2));
+
+            Assert.Equal(hash1, ManifestHashCalculator.ComputeHash(provider.Current.Silos[peer1]));
+            Assert.Equal(hash2, ManifestHashCalculator.ComputeHash(provider.Current.Silos[peer2]));
+            Assert.Equal(1, peer1Target.HashSummaryRequests);
+            Assert.Equal(1, peer1Target.UpdateRequests);
+            grainFactory.DidNotReceive().GetSystemTarget<IClusterManifestSystemTarget>(Constants.ManifestProviderType, peer2);
+        }
+        finally
+        {
+            await lifecycle.OnStop();
+            membership.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Current_FallsBackToLegacyManifestWhenHashResponseDoesNotMatch()
+    {
+        var localSilo = CreateSiloAddress(11139, 1);
+        var remoteSilo = CreateSiloAddress(11140, 1);
+        var advertisedManifest = CreateGrainManifest("2");
+        var mismatchedManifest = CreateGrainManifest("3");
+        var legacyManifest = CreateGrainManifest("4");
+        var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
+            1,
+            (localSilo, SiloStatus.Active)));
+        var grainFactory = Substitute.For<IInternalGrainFactory>();
+        grainFactory
+            .GetSystemTarget<IClusterManifestSystemTarget>(Constants.ManifestProviderType, remoteSilo)
+            .Returns(new FakeHashOnlyClusterManifestSystemTarget(
+                ManifestHashCalculator.ComputeHash(advertisedManifest),
+                mismatchedManifest));
+        var legacyTarget = new RecordingSiloManifestSystemTarget(legacyManifest);
+        grainFactory
+            .GetSystemTarget<ISiloManifestSystemTarget>(Constants.ManifestProviderType, remoteSilo)
+            .Returns(legacyTarget);
+        var services = new ServiceCollection().AddSingleton(grainFactory).BuildServiceProvider();
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        localSiloDetails.SiloAddress.Returns(localSilo);
+        var provider = new ClusterManifestProvider(
+            localSiloDetails,
+            CreateSiloManifestProvider(),
+            membership,
+            Substitute.For<IFatalErrorHandler>(),
+            NullLogger<ClusterManifestProvider>.Instance,
+            services);
+
+        var lifecycle = await StartAsync(provider);
+        try
+        {
+            membership.Update(CreateMembershipSnapshot(
+                2,
+                (localSilo, SiloStatus.Active),
+                (remoteSilo, SiloStatus.Active)));
+
+            await Until(() => provider.Current.Silos.ContainsKey(remoteSilo));
+
+            Assert.Same(legacyManifest, provider.Current.Silos[remoteSilo]);
+            Assert.True(legacyTarget.WasInvoked);
+        }
+        finally
+        {
+            await lifecycle.OnStop();
+            membership.Dispose();
+        }
+    }
+
     private static ClusterManifestProvider CreateClusterManifestProvider(
         SiloAddress localSilo,
         TestClusterMembershipService membership,
@@ -330,7 +567,7 @@ public class ClusterManifestProviderTests
             silos.ToImmutableDictionary(silo => silo, _ => manifest));
     }
 
-    private static GrainManifest CreateGrainManifest()
+    private static GrainManifest CreateGrainManifest(string interfaceVersion = "1")
     {
         var grains = ImmutableDictionary.CreateRange(
         [
@@ -350,7 +587,7 @@ public class ClusterManifestProviderTests
                 new GrainInterfaceProperties(CreatePropertyDictionary(
                 [
                     new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.TypeName, "ITest"),
-                    new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.Version, "1")
+                    new KeyValuePair<string, string>(WellKnownGrainInterfaceProperties.Version, interfaceVersion)
                 ])))
         ]);
 
@@ -519,6 +756,73 @@ public class ClusterManifestProviderTests
     private sealed class TestSiloManifestSystemTarget(GrainManifest manifest) : ISiloManifestSystemTarget
     {
         public ValueTask<GrainManifest> GetSiloManifest() => new(manifest);
+    }
+
+    /// <summary>
+    /// Fake <see cref="IClusterManifestSystemTarget"/> that only supports <see cref="GetClusterManifestHashSummary"/>,
+    /// used to verify the batch-fill path in <see cref="ClusterManifestProvider"/> that resolves multiple missing
+    /// manifests from a single peer's hash summary.
+    /// </summary>
+    private sealed class FakeClusterManifestSystemTarget(
+        ClusterManifestHashSummary hashSummary,
+        ClusterManifestUpdate? update = null) : IClusterManifestSystemTarget
+    {
+        public int HashSummaryRequests { get; private set; }
+
+        public int UpdateRequests { get; private set; }
+
+        public ValueTask<ClusterManifest> GetClusterManifest() => throw new NotSupportedException();
+
+        public ValueTask<ClusterManifestUpdate?> GetClusterManifestUpdate(MajorMinorVersion previousVersion)
+        {
+            UpdateRequests++;
+            return new(update);
+        }
+
+        public ValueTask<ClusterManifestHashSummary> GetClusterManifestHashSummary()
+        {
+            HashSummaryRequests++;
+            return new(hashSummary);
+        }
+
+        public ValueTask<ManifestHash> GetSiloManifestHash() => throw new NotSupportedException();
+
+        public ValueTask<GrainManifest?> GetSiloManifestByHash(ManifestHash hash) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Fake <see cref="IClusterManifestSystemTarget"/> that only supports the single-silo hash-based fetch path
+    /// (<see cref="GetSiloManifestHash"/> + <see cref="GetSiloManifestByHash"/>).
+    /// </summary>
+    private sealed class FakeHashOnlyClusterManifestSystemTarget(ManifestHash hash, GrainManifest manifest) : IClusterManifestSystemTarget
+    {
+        public ValueTask<ClusterManifest> GetClusterManifest() => throw new NotSupportedException();
+
+        public ValueTask<ClusterManifestUpdate?> GetClusterManifestUpdate(MajorMinorVersion previousVersion) => throw new NotSupportedException();
+
+        public ValueTask<ClusterManifestHashSummary> GetClusterManifestHashSummary() => throw new NotSupportedException();
+
+        public ValueTask<ManifestHash> GetSiloManifestHash() => new(hash);
+
+        public ValueTask<GrainManifest?> GetSiloManifestByHash(ManifestHash requestedHash) =>
+            new(requestedHash == hash ? manifest : null);
+    }
+
+    /// <summary>
+    /// Fake legacy <see cref="ISiloManifestSystemTarget"/> that records whether it was ever invoked, so tests can
+    /// assert that the legacy fallback path was not used when the hash-based fetch succeeds.
+    /// </summary>
+    private sealed class RecordingSiloManifestSystemTarget(GrainManifest? manifest = null) : ISiloManifestSystemTarget
+    {
+        public bool WasInvoked { get; private set; }
+
+        public ValueTask<GrainManifest> GetSiloManifest()
+        {
+            WasInvoked = true;
+            return manifest is null
+                ? throw new InvalidOperationException("The legacy manifest fetch path should not be used when the hash-based fetch succeeds.")
+                : new(manifest);
+        }
     }
 
     private sealed class TestClusterManifestProvider(ClusterManifest initialManifest) : IClusterManifestProvider

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
@@ -458,6 +458,144 @@ public class ClusterManifestProviderTests
     }
 
     [Fact]
+    public async Task Current_CachesPeerUpdateManifestsWhenConcurrentPublicationWins()
+    {
+        var localSilo = CreateSiloAddress(11141, 1);
+        var peer1 = CreateSiloAddress(11142, 1);
+        var peer2 = CreateSiloAddress(11143, 1);
+        var manifest1 = CreateGrainManifest("2");
+        var manifest2 = CreateGrainManifest("3");
+        var hash1 = ManifestHashCalculator.ComputeHash(manifest1);
+        var hash2 = ManifestHashCalculator.ComputeHash(manifest2);
+        var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
+            1,
+            (localSilo, SiloStatus.Active)));
+        var grainFactory = Substitute.For<IInternalGrainFactory>();
+        var summary = new ClusterManifestHashSummary(
+            new MajorMinorVersion(2, 0),
+            ImmutableDictionary<SiloAddress, ManifestHash>.Empty.Add(peer1, hash1).Add(peer2, hash2));
+        var update = new ClusterManifestUpdate(
+            new MajorMinorVersion(2, 0),
+            ImmutableDictionary<SiloAddress, GrainManifest>.Empty.Add(peer1, manifest1).Add(peer2, manifest2),
+            includesAllActiveServers: true);
+        var updateRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseUpdate = new TaskCompletionSource<ClusterManifestUpdate?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var peer1Target = new FakeClusterManifestSystemTarget(
+            summary,
+            getUpdate: _ =>
+            {
+                updateRequested.TrySetResult();
+                return new(releaseUpdate.Task);
+            });
+        grainFactory
+            .GetSystemTarget<IClusterManifestSystemTarget>(Constants.ManifestProviderType, peer1)
+            .Returns(peer1Target);
+        var services = new ServiceCollection().AddSingleton(grainFactory).BuildServiceProvider();
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        localSiloDetails.SiloAddress.Returns(localSilo);
+        var provider = new ClusterManifestProvider(
+            localSiloDetails,
+            CreateSiloManifestProvider(),
+            membership,
+            Substitute.For<IFatalErrorHandler>(),
+            NullLogger<ClusterManifestProvider>.Instance,
+            services);
+
+        var lifecycle = await StartAsync(provider);
+        try
+        {
+            membership.Update(CreateMembershipSnapshot(
+                2,
+                (localSilo, SiloStatus.Active),
+                (peer1, SiloStatus.Active),
+                (peer2, SiloStatus.Active)));
+            await updateRequested.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            membership.Update(CreateMembershipSnapshot(
+                3,
+                (localSilo, SiloStatus.Active),
+                (peer1, SiloStatus.Active),
+                (peer2, SiloStatus.Active)));
+            Assert.Equal(new MajorMinorVersion(3, 0), provider.Current.Version);
+            releaseUpdate.SetResult(update);
+
+            await Until(() => provider.Current.Version == new MajorMinorVersion(3, 1));
+
+            Assert.Equal(1, peer1Target.UpdateRequests);
+            Assert.True(provider.IsManifestCached(hash1));
+            Assert.True(provider.IsManifestCached(hash2));
+        }
+        finally
+        {
+            await lifecycle.OnStop();
+            membership.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Current_CachesHashFetchedManifestWhenConcurrentPublicationWins()
+    {
+        var localSilo = CreateSiloAddress(11144, 1);
+        var remoteSilo = CreateSiloAddress(11145, 1);
+        var remoteManifest = CreateGrainManifest("2");
+        var remoteHash = ManifestHashCalculator.ComputeHash(remoteManifest);
+        var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
+            1,
+            (localSilo, SiloStatus.Active)));
+        var grainFactory = Substitute.For<IInternalGrainFactory>();
+        var manifestRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseManifest = new TaskCompletionSource<GrainManifest?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var remoteTarget = new FakeHashOnlyClusterManifestSystemTarget(
+            remoteHash,
+            remoteManifest,
+            getManifest: _ =>
+            {
+                manifestRequested.TrySetResult();
+                return new(releaseManifest.Task);
+            });
+        grainFactory
+            .GetSystemTarget<IClusterManifestSystemTarget>(Constants.ManifestProviderType, remoteSilo)
+            .Returns(remoteTarget);
+        var services = new ServiceCollection().AddSingleton(grainFactory).BuildServiceProvider();
+        var localSiloDetails = Substitute.For<ILocalSiloDetails>();
+        localSiloDetails.SiloAddress.Returns(localSilo);
+        var provider = new ClusterManifestProvider(
+            localSiloDetails,
+            CreateSiloManifestProvider(),
+            membership,
+            Substitute.For<IFatalErrorHandler>(),
+            NullLogger<ClusterManifestProvider>.Instance,
+            services);
+
+        var lifecycle = await StartAsync(provider);
+        try
+        {
+            membership.Update(CreateMembershipSnapshot(
+                2,
+                (localSilo, SiloStatus.Active),
+                (remoteSilo, SiloStatus.Active)));
+            await manifestRequested.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            membership.Update(CreateMembershipSnapshot(
+                3,
+                (localSilo, SiloStatus.Active),
+                (remoteSilo, SiloStatus.Active)));
+            Assert.Equal(new MajorMinorVersion(3, 0), provider.Current.Version);
+            releaseManifest.SetResult(remoteManifest);
+
+            await Until(() => provider.Current.Version == new MajorMinorVersion(3, 1));
+
+            Assert.Equal(1, remoteTarget.ManifestRequests);
+            Assert.True(provider.IsManifestCached(remoteHash));
+        }
+        finally
+        {
+            await lifecycle.OnStop();
+            membership.Dispose();
+        }
+    }
+
+    [Fact]
     public async Task Current_FallsBackToLegacyManifestWhenHashResponseDoesNotMatch()
     {
         var localSilo = CreateSiloAddress(11139, 1);
@@ -770,7 +908,8 @@ public class ClusterManifestProviderTests
     /// </summary>
     private sealed class FakeClusterManifestSystemTarget(
         ClusterManifestHashSummary hashSummary,
-        ClusterManifestUpdate? update = null) : IClusterManifestSystemTarget
+        ClusterManifestUpdate? update = null,
+        Func<MajorMinorVersion, ValueTask<ClusterManifestUpdate?>>? getUpdate = null) : IClusterManifestSystemTarget
     {
         public int HashSummaryRequests { get; private set; }
 
@@ -781,7 +920,7 @@ public class ClusterManifestProviderTests
         public ValueTask<ClusterManifestUpdate?> GetClusterManifestUpdate(MajorMinorVersion previousVersion)
         {
             UpdateRequests++;
-            return new(update);
+            return getUpdate?.Invoke(previousVersion) ?? new(update);
         }
 
         public ValueTask<ClusterManifestHashSummary> GetClusterManifestHashSummary()
@@ -799,8 +938,13 @@ public class ClusterManifestProviderTests
     /// Fake <see cref="IClusterManifestSystemTarget"/> that only supports the single-silo hash-based fetch path
     /// (<see cref="GetSiloManifestHash"/> + <see cref="GetSiloManifestByHash"/>).
     /// </summary>
-    private sealed class FakeHashOnlyClusterManifestSystemTarget(ManifestHash hash, GrainManifest manifest) : IClusterManifestSystemTarget
+    private sealed class FakeHashOnlyClusterManifestSystemTarget(
+        ManifestHash hash,
+        GrainManifest manifest,
+        Func<ManifestHash, ValueTask<GrainManifest?>>? getManifest = null) : IClusterManifestSystemTarget
     {
+        public int ManifestRequests { get; private set; }
+
         public ValueTask<ClusterManifest> GetClusterManifest() => throw new NotSupportedException();
 
         public ValueTask<ClusterManifestUpdate?> GetClusterManifestUpdate(MajorMinorVersion previousVersion) => throw new NotSupportedException();
@@ -809,8 +953,11 @@ public class ClusterManifestProviderTests
 
         public ValueTask<ManifestHash> GetSiloManifestHash() => new(hash);
 
-        public ValueTask<GrainManifest?> GetSiloManifestByHash(ManifestHash requestedHash) =>
-            new(requestedHash == hash ? manifest : null);
+        public ValueTask<GrainManifest?> GetSiloManifestByHash(ManifestHash requestedHash)
+        {
+            ManifestRequests++;
+            return getManifest?.Invoke(requestedHash) ?? new(requestedHash == hash ? manifest : null);
+        }
     }
 
     /// <summary>

--- a/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
+++ b/test/Orleans.Core.Tests/Manifest/ClusterManifestProviderTests.cs
@@ -84,7 +84,8 @@ public class ClusterManifestProviderTests
     {
         var localSilo = CreateSiloAddress(11111, 1);
         var remoteSilo = CreateSiloAddress(11112, 1);
-        var remoteManifest = CreateGrainManifest();
+        var remoteManifest = CreateGrainManifest("2");
+        var remoteHash = ManifestHashCalculator.ComputeHash(remoteManifest);
         var membership = new TestClusterMembershipService(CreateMembershipSnapshot(
             1,
             (localSilo, SiloStatus.Active),
@@ -97,6 +98,8 @@ public class ClusterManifestProviderTests
         {
             await Until(() => provider.Current.Version == new MajorMinorVersion(1, 1)
                 && provider.Current.Silos.ContainsKey(remoteSilo));
+            Assert.True(provider.IsManifestCached(remoteHash));
+            Assert.Equal(2, provider.ManifestCacheCount);
 
             membership.Update(CreateMembershipSnapshot(
                 2,
@@ -108,6 +111,8 @@ public class ClusterManifestProviderTests
             Assert.Equal(new MajorMinorVersion(2, 0), current.Version);
             Assert.Contains(localSilo, current.Silos.Keys);
             Assert.DoesNotContain(remoteSilo, current.Silos.Keys);
+            Assert.False(provider.IsManifestCached(remoteHash));
+            Assert.Equal(1, provider.ManifestCacheCount);
         }
         finally
         {

--- a/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableCleanupAgentTests.cs
@@ -303,7 +303,7 @@ namespace NonSilo.Tests.Membership
             public Task<bool> TryKillSilo(SiloAddress silo, CancellationToken cancellationToken) => Task.FromResult(false);
             public Task<bool> TrySuspectSilo(SiloAddress silo, SiloAddress? indirectProbingSilo, CancellationToken cancellationToken) => Task.FromResult(false);
             public Task Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken) => Task.CompletedTask;
-            public Task ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task<bool> ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) => Task.FromResult(false);
             public Task UpdateIAmAlive(CancellationToken cancellationToken) => Task.CompletedTask;
             public void Participate(ISiloLifecycle lifecycle) { }
 

--- a/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
@@ -486,12 +486,14 @@ namespace NonSilo.Tests.Membership
             var version = manager.MembershipTableSnapshot.Version;
             await manager.RefreshFromSnapshot(Snapshot(
                 new MembershipVersion(version.Value - 1),
-                Entry(this.localSilo, SiloStatus.Dead, DateTimeOffset.UtcNow)));
+                Entry(this.localSilo, SiloStatus.Dead, DateTimeOffset.UtcNow)),
+                cancellationToken);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
 
             await manager.RefreshFromSnapshot(Snapshot(
                 new MembershipVersion(version.Value + 1),
-                Entry(this.localSilo, SiloStatus.Dead, DateTimeOffset.UtcNow)));
+                Entry(this.localSilo, SiloStatus.Dead, DateTimeOffset.UtcNow)),
+                cancellationToken);
             this.fatalErrorHandler.ReceivedWithAnyArgs().OnFatalException(default, default, default);
             await this.lifecycle.OnStop(cancellationToken);
         }
@@ -562,17 +564,18 @@ namespace NonSilo.Tests.Membership
             var manager = this.CreateMembershipTableManager(membershipTable);
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
 
-            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(1)));
+            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(1)), cancellationToken);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
 
             await this.lifecycle.OnStart(cancellationToken);
             await manager.UpdateStatus(SiloStatus.Joining);
             var currentVersion = manager.MembershipTableSnapshot.Version;
 
-            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(currentVersion.Value - 1)));
+            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(currentVersion.Value - 1)), cancellationToken);
             await manager.RefreshFromSnapshot(Snapshot(
                 currentVersion,
-                Entry(otherSilo, SiloStatus.Active, now.AddMinutes(1))));
+                Entry(otherSilo, SiloStatus.Active, now.AddMinutes(1))),
+                cancellationToken);
             Assert.Equal(SiloStatus.Joining, manager.MembershipTableSnapshot.Entries[this.localSilo].Status);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
 
@@ -581,7 +584,8 @@ namespace NonSilo.Tests.Membership
 
             await manager.RefreshFromSnapshot(Snapshot(
                 new MembershipVersion(currentVersion.Value + 1),
-                Entry(otherSilo, SiloStatus.Active, now.AddMinutes(1))));
+                Entry(otherSilo, SiloStatus.Active, now.AddMinutes(1))),
+                cancellationToken);
             Assert.True(await membershipUpdates.MoveNextAsync());
             Assert.Equal(SiloStatus.Dead, membershipUpdates.Current.Entries[this.localSilo].Status);
             Assert.Equal(SiloStatus.Dead, manager.MembershipTableSnapshot.Entries[this.localSilo].Status);
@@ -599,12 +603,12 @@ namespace NonSilo.Tests.Membership
             ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
             await this.lifecycle.OnStart(cancellationToken);
 
-            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(125)));
+            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(125)), cancellationToken);
             await manager.UpdateStatus(SiloStatus.Joining);
             Assert.Equal(SiloStatus.Created, manager.CurrentStatus);
             Assert.DoesNotContain(this.localSilo, manager.MembershipTableSnapshot.Entries.Keys);
 
-            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(126)));
+            await manager.RefreshFromSnapshot(Snapshot(new MembershipVersion(126)), cancellationToken);
             this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
 
             await this.lifecycle.OnStop(cancellationToken);

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
@@ -576,7 +576,7 @@ internal sealed class LeaseTestMembershipManager(MembershipTableManager inner) :
 
     public void Participate(ISiloLifecycle lifecycle) => ((ILifecycleParticipant<ISiloLifecycle>)inner).Participate(lifecycle);
 
-    public Task ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) =>
+    public Task<bool> ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) =>
         ((IMembershipManager)inner).ProcessGossipSnapshot(snapshot, cancellationToken);
 
     public Task Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken) =>

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryShutdownMigrationTests.cs
@@ -260,7 +260,7 @@ internal sealed class DelayedMembershipManager(MembershipTableManager inner) : I
 
     public void Participate(ISiloLifecycle lifecycle) => ((ILifecycleParticipant<ISiloLifecycle>)inner).Participate(lifecycle);
 
-    public Task ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) =>
+    public Task<bool> ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) =>
         ((IMembershipManager)inner).ProcessGossipSnapshot(snapshot, cancellationToken);
 
     public Task Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken) =>

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -8,9 +8,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using CsCheck;
-#if NET10_0_OR_GREATER
 using Microsoft.Accordant;
-#endif
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -407,6 +405,72 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task GossipBatchingRejectsNewKeysAtPendingTopicLimit()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var firstSendStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstSend = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sendCount = 0;
+        transport.SendGossipHandler = async (target, batch, cancellationToken) =>
+        {
+            transport.GossipBatches.Add((target, batch));
+            if (Interlocked.Increment(ref sendCount) == 1)
+            {
+                firstSendStarted.TrySetResult(true);
+                await releaseFirstSend.Task.WaitAsync(cancellationToken);
+            }
+        };
+        var topic = new FakeTopic(local);
+        topic.Options.MaxCoalescingDelay = TimeSpan.FromMinutes(1);
+        topic.Options.MaxPendingItemCount = 1;
+        var protocol = CreateProtocol(transport, topic);
+
+        var first = await protocol.Publish(topic.Name, topic.CreateItem(local, "first", sequence: 1), [peer], CancellationToken.None);
+        await firstSendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var second = await protocol.Publish(topic.Name, topic.CreateItem(local, "second", sequence: 1), [peer], CancellationToken.None);
+        var third = await protocol.Publish(topic.Name, topic.CreateItem(local, "third", sequence: 1), [peer], CancellationToken.None);
+
+        Assert.True(first);
+        Assert.True(second);
+        Assert.False(third);
+
+        releaseFirstSend.SetResult(true);
+        await protocol.FlushPendingGossip(CancellationToken.None);
+
+        Assert.Equal(2, transport.GossipBatches.Count);
+        Assert.Equal(
+            new[] { "first", "second" },
+            transport.GossipBatches.Select(batch => Assert.Single(GetGossipValues(batch.Batch)).Digest.Key));
+    }
+
+    [Fact]
+    public async Task GossipBatchingDropsExpiredValuesBeforeSend()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var timeProvider = new TestTimeProvider();
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        topic.Options.MaxCoalescingDelay = TimeSpan.FromMinutes(1);
+        var protocol = CreateProtocol(transport, topic, timeProvider: timeProvider);
+        var item = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest(FakeTopic.DefaultKey, version: 1),
+            Root = local,
+            ExpiresAt = timeProvider.GetUtcNow().AddSeconds(1),
+            Payload = BitConverter.GetBytes(1L),
+        };
+
+        Assert.True(await protocol.Publish(topic.Name, item, [peer], CancellationToken.None));
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        await protocol.FlushPendingGossip(CancellationToken.None);
+
+        Assert.Empty(transport.GossipBatches);
+    }
+
+    [Fact]
     public async Task GossipSendsHonorConfiguredConcurrency()
     {
         var local = CreateSilo(11111);
@@ -460,6 +524,56 @@ public class DisseminationProtocolTests
 
         Assert.Equal(peers.Length, started);
         Assert.Equal(2, maxInFlight);
+    }
+
+    [Fact]
+    public async Task ScheduledAndExplicitFlushesShareConfiguredConcurrencyLimit()
+    {
+        var local = CreateSilo(11111);
+        var firstPeer = CreateSilo(11112);
+        var secondPeer = CreateSilo(11113);
+        var transport = new FakeTransport(local, firstPeer, secondPeer);
+        var firstSendStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstSend = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allSendsCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var inFlight = 0;
+        var maxInFlight = 0;
+        var completed = 0;
+        transport.SendGossipHandler = async (_, _, cancellationToken) =>
+        {
+            var current = Interlocked.Increment(ref inFlight);
+            UpdateMaximum(ref maxInFlight, current);
+            if (Interlocked.CompareExchange(ref completed, 0, 0) == 0)
+            {
+                firstSendStarted.TrySetResult(true);
+                await releaseFirstSend.Task.WaitAsync(cancellationToken);
+            }
+
+            Interlocked.Decrement(ref inFlight);
+            if (Interlocked.Increment(ref completed) == 2)
+            {
+                allSendsCompleted.TrySetResult(true);
+            }
+        };
+
+        var topic = new FakeTopic(local);
+        topic.Options.MaxCoalescingDelay = TimeSpan.FromMilliseconds(1);
+        var protocol = CreateProtocol(transport, topic, options =>
+        {
+            options.MaxConcurrentSends = 1;
+            options.Overlay.FanOutFactor = static _ => 1;
+        });
+
+        Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "first", sequence: 1), [firstPeer], CancellationToken.None));
+        await firstSendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "second", sequence: 1), [secondPeer], CancellationToken.None));
+        var explicitFlush = protocol.FlushPendingGossip(CancellationToken.None);
+
+        Assert.Equal(1, Volatile.Read(ref maxInFlight));
+        releaseFirstSend.SetResult(true);
+        await explicitFlush;
+        await allSendsCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(1, maxInFlight);
     }
 
     [Fact]
@@ -614,6 +728,7 @@ public class DisseminationProtocolTests
 
         var item = Assert.Single(GetAntiEntropyResponseValues(response));
         Assert.Equal("requested", item.Digest.Key);
+        Assert.Equal(new[] { topic.Name }, response.SupportedTopics);
     }
 
     [Fact]
@@ -790,6 +905,141 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task AntiEntropyRequestsAreChunkedAtConfiguredItemLimit()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        topic.SetValue("a", version: 1);
+        topic.SetValue("b", version: 1);
+        topic.SetValue("c", version: 1);
+        var protocol = CreateProtocol(transport, topic, options =>
+        {
+            options.MaxBatchItems = 2;
+            options.Overlay.AntiEntropyPeerCount = 1;
+        });
+
+        var responses = await protocol.ExchangeAntiEntropy(protocol.CreateAntiEntropyState(), CancellationToken.None);
+
+        Assert.Empty(responses);
+        Assert.Equal(2, transport.AntiEntropyRequests.Count);
+        Assert.All(
+            transport.AntiEntropyRequests,
+            entry => Assert.InRange(entry.Request.DigestsByTopic.Values.Sum(static digests => digests.Length), 1, 2));
+    }
+
+    [Fact]
+    public async Task EmptyAntiEntropyChunkDoesNotStarveLaterRepairChunk()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        topic.SetValue("a", version: 1);
+        topic.SetValue("b", version: 1);
+        transport.ExchangeAntiEntropyHandler = (target, request) =>
+        {
+            var digest = request.DigestsByTopic.Values.SelectMany(static digests => digests).Single();
+            return ValueTask.FromResult(new DisseminationAntiEntropyResponse
+            {
+                Sender = target,
+                ValuesByTopic = digest.Key == "b"
+                    ? CreateValueGroups(topic.CreateItem(target, digest.Key, sequence: 2))
+                    : ImmutableDictionary<string, ImmutableArray<DisseminationValue>>.Empty,
+                SupportedTopics = [topic.Name],
+            });
+        };
+        var protocol = CreateProtocol(transport, topic, options =>
+        {
+            options.MaxBatchItems = 1;
+            options.Overlay.AntiEntropyPeerCount = 1;
+        });
+
+        var responses = await protocol.ExchangeAntiEntropy(protocol.CreateAntiEntropyState(), CancellationToken.None);
+
+        Assert.Equal(2, transport.AntiEntropyRequests.Count);
+        var repaired = Assert.Single(responses);
+        Assert.Equal("b", Assert.Single(GetAntiEntropyResponseValues(repaired)).Digest.Key);
+    }
+
+    [Fact]
+    public async Task AntiEntropyRoundRetainsAtMostConfiguredItemsAcrossChunks()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        topic.SetValue("a", version: 1);
+        topic.SetValue("b", version: 1);
+        topic.SetValue("c", version: 1);
+        transport.ExchangeAntiEntropyHandler = (target, request) =>
+        {
+            var values = request.DigestsByTopic.Values
+                .SelectMany(static digests => digests)
+                .Select(digest => topic.CreateItem(target, digest.Key, sequence: 2))
+                .ToArray();
+            return ValueTask.FromResult(new DisseminationAntiEntropyResponse
+            {
+                Sender = target,
+                ValuesByTopic = CreateValueGroups(values),
+                SupportedTopics = [topic.Name],
+            });
+        };
+        var protocol = CreateProtocol(transport, topic, options =>
+        {
+            options.MaxBatchItems = 2;
+            options.Overlay.AntiEntropyPeerCount = 1;
+        });
+
+        var responses = await protocol.ExchangeAntiEntropy(protocol.CreateAntiEntropyState(), CancellationToken.None);
+
+        Assert.Single(transport.AntiEntropyRequests);
+        Assert.Equal(2, responses.Sum(static response => GetAntiEntropyResponseValues(response).Count()));
+    }
+
+    [Fact]
+    public async Task PeerTopicConfirmationExpiresAndAuthoritativeResponseCanRemoveIt()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var timeProvider = new TestTimeProvider();
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, timeProvider: timeProvider);
+
+        await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            DigestsByTopic = CreateAntiEntropyRequestDigests(
+                topic.Name,
+                new DisseminationTopicDigest(FakeTopic.DefaultKey, long.MinValue)),
+        }, CancellationToken.None);
+        Assert.Empty(protocol.GetUnconfirmedPeers(topic.Name, topic.MembershipScope));
+
+        timeProvider.Advance(TimeSpan.FromSeconds(20));
+        Assert.Equal(new[] { peer }, protocol.GetUnconfirmedPeers(topic.Name, topic.MembershipScope));
+
+        await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            DigestsByTopic = CreateAntiEntropyRequestDigests(
+                topic.Name,
+                new DisseminationTopicDigest(FakeTopic.DefaultKey, long.MinValue)),
+        }, CancellationToken.None);
+        transport.ExchangeAntiEntropyHandler = (target, _) => ValueTask.FromResult(new DisseminationAntiEntropyResponse
+        {
+            Sender = target,
+            SupportedTopics = [],
+        });
+        topic.SetValue(FakeTopic.DefaultKey, version: 1);
+
+        await protocol.ExchangeAntiEntropy(protocol.CreateAntiEntropyState(), CancellationToken.None);
+
+        Assert.Equal(new[] { peer }, protocol.GetUnconfirmedPeers(topic.Name, topic.MembershipScope));
+    }
+
+    [Fact]
     public async Task AntiEntropyAppliesReturnedRepairItemsWithoutForwarding()
     {
         var local = CreateSilo(11111);
@@ -896,7 +1146,6 @@ public class DisseminationProtocolTests
         }
     }
 
-#if NET10_0_OR_GREATER
     [Fact]
     public async Task MonotonicDisseminationModelConformsToAccordantSpec()
     {
@@ -938,7 +1187,6 @@ public class DisseminationProtocolTests
         var failures = results.Where(static result => !result.Success).ToArray();
         Assert.Empty(failures);
     }
-#endif
 
     [Fact]
     public async Task MembershipTopicReturnsAndAppliesDiffWhenPeerVersionIsRetained()
@@ -1052,6 +1300,65 @@ public class DisseminationProtocolTests
         Assert.Equal(DisseminationApplyResult.Obsolete, obsoleteResult);
         Assert.Equal(DisseminationApplyResult.Duplicate, duplicateResult);
         Assert.Equal(currentSnapshot.Version, manager.CurrentSnapshot.Version);
+    }
+
+    [Fact]
+    public async Task MembershipTopicDoesNotReportAppliedWhenConcurrentUpdateAdvancesPastSnapshot()
+    {
+        var local = CreateSilo(11123);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var currentSnapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var concurrentSnapshot = CreateMembershipSnapshot(3, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var manager = new FakeMembershipManager(currentSnapshot);
+        manager.ProcessGossipSnapshotHandler = _ =>
+        {
+            manager.CurrentSnapshot = concurrentSnapshot;
+            return Task.FromResult(false);
+        };
+        var topic = CreateMembershipTopic(local, manager, serializer);
+        var proposedSnapshot = CreateMembershipSnapshot(2, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("cluster", proposedSnapshot.Version.Value),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Snapshot = proposedSnapshot }),
+        };
+
+        var result = await topic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Obsolete, result);
+        Assert.Equal(concurrentSnapshot.Version, manager.CurrentSnapshot.Version);
+    }
+
+    [Fact]
+    public async Task MembershipTopicReportsDuplicateWhenConcurrentUpdateInstallsSameVersion()
+    {
+        var local = CreateSilo(11123);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var currentSnapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var proposedSnapshot = CreateMembershipSnapshot(2, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var manager = new FakeMembershipManager(currentSnapshot);
+        manager.ProcessGossipSnapshotHandler = snapshot =>
+        {
+            manager.CurrentSnapshot = snapshot;
+            return Task.FromResult(false);
+        };
+        var topic = CreateMembershipTopic(local, manager, serializer);
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("cluster", proposedSnapshot.Version.Value),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Snapshot = proposedSnapshot }),
+        };
+
+        var result = await topic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Duplicate, result);
+        Assert.Equal(proposedSnapshot.Version, manager.CurrentSnapshot.Version);
     }
 
     [Fact]
@@ -1359,6 +1666,7 @@ public class DisseminationProtocolTests
         {
             Sender = sender,
             ValuesByTopic = CreateValueGroups(value),
+            SupportedTopics = [FakeTopic.DefaultName],
         });
         var manifestSummary = RoundTrip(serializer, new ClusterManifestHashSummary(
             new MajorMinorVersion(1, 2),
@@ -1367,6 +1675,7 @@ public class DisseminationProtocolTests
         Assert.Equal(value.Digest, Assert.Single(GetGossipValues(gossip)).Digest);
         Assert.Equal(value.Digest, Assert.Single(request.DigestsByTopic.Values).Single());
         Assert.Equal(value.Digest, Assert.Single(GetAntiEntropyResponseValues(response)).Digest);
+        Assert.Equal(new[] { FakeTopic.DefaultName }, response.SupportedTopics);
         Assert.Equal(new ManifestHash("hash"), manifestSummary.SiloManifestHashes[sender]);
     }
 
@@ -1635,7 +1944,8 @@ public class DisseminationProtocolTests
         statusOracle.SetStatus(local, SiloStatus.Active);
         statusOracle.SetStatus(peer, SiloStatus.Active);
         var services = new MutableServiceProvider();
-        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, serviceProvider: services);
+        var grainFactory = new RecordingGrainFactory();
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, grainFactory, services);
         var topic = CreateDeploymentLoadTopic(
             publisher,
             serializer,
@@ -1656,7 +1966,7 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
-    public async Task PublishStatistics_DisseminationSuccessDoesNotReadFallbackMembership()
+    public async Task PublishStatistics_DisseminationSuccessSkipsLegacySendForConfirmedPeer()
     {
         using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
         var serializer = serializerProvider.GetRequiredService<Serializer>();
@@ -1666,7 +1976,50 @@ public class DisseminationProtocolTests
         statusOracle.SetStatus(local, SiloStatus.Active);
         statusOracle.SetStatus(peer, SiloStatus.Active);
         var services = new MutableServiceProvider();
-        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, serviceProvider: services);
+        var grainFactory = new RecordingGrainFactory();
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, grainFactory, services);
+        var topic = CreateDeploymentLoadTopic(
+            publisher,
+            serializer,
+            options => options.Dissemination.Enabled = true);
+        var transport = new FakeTransport(local, peer);
+        var dissemination = CreateService(transport, [topic]);
+        services.Add(dissemination);
+        services.Add(topic);
+        await dissemination.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            DigestsByTopic = CreateAntiEntropyRequestDigests(
+                topic.Name,
+                new DisseminationTopicDigest(local.ToParsableString(), long.MinValue)),
+        }, CancellationToken.None);
+
+        await publisher.PublishStatistics();
+        await dissemination.StopAsync(CancellationToken.None);
+
+        Assert.Empty(grainFactory.SystemTargetRequests);
+        Assert.Single(transport.GossipBatches);
+    }
+
+    [Fact]
+    public async Task PublishStatistics_DisseminationSuccessUsesLegacySendForUnconfirmedPeer()
+    {
+        using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serializerProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21017);
+        var peer = CreateSilo(21018);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(local, SiloStatus.Active);
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var services = new MutableServiceProvider();
+        var directTarget = new FakeDeploymentLoadPublisherTarget();
+        var grainFactory = new RecordingGrainFactory
+        {
+            Resolver = (type, _) => type == typeof(IDeploymentLoadPublisher)
+                ? directTarget
+                : throw new NotSupportedException(),
+        };
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, grainFactory, services);
         var topic = CreateDeploymentLoadTopic(
             publisher,
             serializer,
@@ -1679,8 +2032,10 @@ public class DisseminationProtocolTests
         await publisher.PublishStatistics();
         await dissemination.StopAsync(CancellationToken.None);
 
-        Assert.Equal(0, statusOracle.ApproximateStatusesRequests);
         Assert.Single(transport.GossipBatches);
+        var update = Assert.Single(directTarget.Updates);
+        Assert.Equal(local, update.Source);
+        Assert.Equal(peer, Assert.Single(grainFactory.SystemTargetRequests).Destination);
     }
 
     [Theory]
@@ -2278,6 +2633,7 @@ public class DisseminationProtocolTests
         var peers = Enumerable.Range(21502, 3).Select(CreateSilo).ToArray();
         var transport = new FakeTransport(local, peers);
         var topic = new FakeTopic(local);
+        topic.Options.MaxCoalescingDelay = TimeSpan.FromMinutes(1);
         var service = CreateService(transport, topic, options => options.Overlay.FanOutFactor = static _ => 3);
         var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
         var observedTokens = new List<CancellationToken>();
@@ -2293,6 +2649,87 @@ public class DisseminationProtocolTests
 
         Assert.NotEmpty(observedTokens);
         Assert.All(observedTokens, token => Assert.Equal(cts.Token, token));
+    }
+
+    [Fact]
+    public async Task DisseminationService_StopAsyncWaitsForScheduledFlushAndStopsBackgroundWork()
+    {
+        var local = CreateSilo(21510);
+        var peer = CreateSilo(21511);
+        var transport = new FakeTransport(local, peer);
+        var sendStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSend = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        transport.SendGossipHandler = async (target, batch, cancellationToken) =>
+        {
+            transport.GossipBatches.Add((target, batch));
+            sendStarted.TrySetResult(true);
+            await releaseSend.Task.WaitAsync(cancellationToken);
+        };
+        var topic = new FakeTopic(local);
+        topic.Options.MaxCoalescingDelay = TimeSpan.FromMilliseconds(1);
+        var service = CreateService(transport, topic);
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.True(await service.Publish(
+            topic.Name,
+            topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1),
+            [peer],
+            CancellationToken.None));
+        await sendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var stopTask = service.StopAsync(CancellationToken.None);
+        Assert.False(stopTask.IsCompleted);
+        releaseSend.SetResult(true);
+        await stopTask;
+
+        Assert.False(service.IsAntiEntropyRunning);
+        Assert.Single(transport.GossipBatches);
+    }
+
+    [Fact]
+    public async Task DisseminationService_StopAsyncHonorsCancellationWhileAntiEntropyTransportIsBlocked()
+    {
+        var local = CreateSilo(21512);
+        var peer = CreateSilo(21513);
+        var transport = new FakeTransport(local, peer);
+        var exchangeStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var exchangeCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseExchange = new TaskCompletionSource<DisseminationAntiEntropyResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        transport.ExchangeAntiEntropyHandler = ExchangeAntiEntropy;
+
+        async ValueTask<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(
+            SiloAddress target,
+            DisseminationAntiEntropyRequest _)
+        {
+            exchangeStarted.TrySetResult(true);
+            var response = await releaseExchange.Task;
+            exchangeCompleted.TrySetResult(true);
+            return response;
+        }
+
+        var topic = new FakeTopic(local);
+        topic.SetValue(FakeTopic.DefaultKey, version: 1);
+        var service = CreateService(
+            transport,
+            topic,
+            options => options.Overlay.AntiEntropyInterval = TimeSpan.FromMilliseconds(1));
+        await service.StartAsync(CancellationToken.None);
+        await exchangeStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.StopAsync(cts.Token));
+
+        Assert.False(service.IsAntiEntropyRunning);
+        Assert.True(service.HasOutstandingAntiEntropyTask);
+        releaseExchange.TrySetResult(new DisseminationAntiEntropyResponse
+        {
+            Sender = peer,
+            SupportedTopics = [topic.Name],
+        });
+        await exchangeCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await WaitUntil(() => !service.HasOutstandingAntiEntropyTask);
+        Assert.Equal(new[] { peer }, service.GetUnconfirmedPeers(topic.Name, topic.MembershipScope));
     }
 
     [Fact]
@@ -2324,7 +2761,7 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
-    public async Task MembershipGossiper_UsesDisseminationWhenTopicIsEnabledAndPublishSucceeds()
+    public async Task MembershipGossiper_UsesOnlyDisseminationForConfirmedPeer()
     {
         var local = CreateSilo(21402);
         var peer = CreateSilo(21403);
@@ -2342,8 +2779,39 @@ public class DisseminationProtocolTests
             .BuildServiceProvider();
         var gossiper = new MembershipGossiper(services, NullLogger<MembershipGossiper>.Instance);
 
-        // Must not throw: MembershipSystemTarget is deliberately not registered, so any fallback attempt would fail.
+        await disseminationService.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            DigestsByTopic = CreateAntiEntropyRequestDigests(
+                membershipTopic.Name,
+                new DisseminationTopicDigest("cluster", long.MinValue)),
+        }, CancellationToken.None);
         await gossiper.GossipToRemoteSilos(new List<SiloAddress> { peer }, snapshot, local, SiloStatus.Active);
+
+        await disseminationService.StopAsync(CancellationToken.None);
+        Assert.NotEmpty(transport.GossipBatches);
+    }
+
+    [Fact]
+    public async Task MembershipGossiper_UsesLegacyGossipForUnconfirmedPeer()
+    {
+        var local = CreateSilo(21410);
+        var peer = CreateSilo(21411);
+        using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serializerProvider.GetRequiredService<Serializer>();
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var membershipTopic = CreateMembershipTopic(local, new FakeMembershipManager(snapshot), serializer, options => options.Dissemination.Enabled = true);
+        var transport = new FakeTransport(local, peer);
+        var disseminationService = CreateService(transport, new IDisseminationTopic[] { membershipTopic });
+        var services = new ServiceCollection()
+            .AddSingleton(disseminationService)
+            .AddSingleton(membershipTopic)
+            .AddSingleton<ILocalSiloDetails>(new FakeLocalSiloDetails(local))
+            .BuildServiceProvider();
+        var gossiper = new MembershipGossiper(services, NullLogger<MembershipGossiper>.Instance);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => gossiper.GossipToRemoteSilos(new List<SiloAddress> { peer }, snapshot, local, SiloStatus.Active));
 
         await disseminationService.StopAsync(CancellationToken.None);
         Assert.NotEmpty(transport.GossipBatches);
@@ -2828,7 +3296,6 @@ public class DisseminationProtocolTests
             System.Collections.Immutable.ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty);
     }
 
-#if NET10_0_OR_GREATER
     private static Spec<MonotonicDisseminationState> CreateMonotonicDisseminationSpec()
     {
         var spec = new Spec<MonotonicDisseminationState>()
@@ -2876,7 +3343,6 @@ public class DisseminationProtocolTests
 
         return spec;
     }
-#endif
 
     private sealed class FakeTopic(SiloAddress localSilo, string name = FakeTopic.DefaultName) : IDisseminationTopic
     {
@@ -3077,7 +3543,6 @@ public class DisseminationProtocolTests
         };
     }
 
-#if NET10_0_OR_GREATER
     private sealed class MonotonicDisseminationHarness(SiloAddress localSilo)
     {
         private readonly FakeTopic _topic = new(localSilo);
@@ -3122,7 +3587,6 @@ public class DisseminationProtocolTests
             _ => ModelApplyResult.Rejected,
         };
     }
-#endif
 
     private sealed class FakeMembershipManager(MembershipTableSnapshot currentSnapshot) : IMembershipManager
     {
@@ -3140,16 +3604,23 @@ public class DisseminationProtocolTests
 
         public List<MembershipVersion?> RefreshCalls { get; } = new();
 
+        public Func<MembershipTableSnapshot, Task<bool>>? ProcessGossipSnapshotHandler { get; set; }
+
         public Task Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken)
         {
             RefreshCalls.Add(targetVersion);
             return Task.CompletedTask;
         }
 
-        public Task ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken)
+        public Task<bool> ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken)
         {
+            if (ProcessGossipSnapshotHandler is { } handler)
+            {
+                return handler(snapshot);
+            }
+
             CurrentSnapshot = snapshot;
-            return Task.CompletedTask;
+            return Task.FromResult(true);
         }
 
         public Task UpdateIAmAlive(CancellationToken cancellationToken) => Task.CompletedTask;
@@ -3439,7 +3910,6 @@ public class DisseminationProtocolTests
     }
 }
 
-#if NET10_0_OR_GREATER
 [State]
 public partial class MonotonicDisseminationState
 {
@@ -3457,4 +3927,3 @@ public enum ModelApplyResult
 public sealed record ModelApplyResponse(ModelApplyResult Result, long Version);
 
 public sealed record ModelRepairResponse(bool HasValue, long Version);
-#endif

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -36,6 +36,7 @@ public class DisseminationProtocolTests
         var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
 
         var result = await protocol.Publish(topic.Name, item, peers, CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
 
         Assert.True(result);
         var expectedChildren = GetOriginatorTreeTargets(local, peers, fanout: 2);
@@ -93,6 +94,7 @@ public class DisseminationProtocolTests
         var value = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
 
         var result = await protocol.Publish(topic.Name, value, targetPeers: null, CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
 
         Assert.True(result);
         Assert.Equal(new[] { active }, transport.GossipBatches.Select(batch => batch.Peer));
@@ -129,6 +131,7 @@ public class DisseminationProtocolTests
         var secondResult = await protocol.Publish(topic.Name, item, new[] { peer }, CancellationToken.None);
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var thirdResult = await protocol.Publish(topic.Name, item, new[] { peer }, CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
 
         Assert.False(firstResult);
         Assert.False(secondResult);
@@ -154,6 +157,7 @@ public class DisseminationProtocolTests
             Sender = root,
             Values = new[] { item },
         }, CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
 
         var expectedChildren = GetForwardingTreeTargets(local, root, peers, fanout: 2, sender: root);
         Assert.Equal(expectedChildren, transport.GossipBatches.Select(batch => batch.Peer));
@@ -178,6 +182,7 @@ public class DisseminationProtocolTests
 
         await protocol.ReceiveGossip(batch, CancellationToken.None);
         await protocol.ReceiveGossip(batch, CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
 
         var expectedChildren = GetForwardingTreeTargets(local, root, peers, fanout: 2, sender: root);
         Assert.Equal(expectedChildren.Count, transport.GossipBatches.Count);
@@ -195,6 +200,7 @@ public class DisseminationProtocolTests
         var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
 
         var initialResult = await protocol.Publish(topic.Name, item, targetPeers: null, CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
         var initialChildren = transport.GossipBatches.Select(batch => batch.Peer).ToArray();
 
         foreach (var peer in Enumerable.Range(11116, 8).Select(CreateSilo))
@@ -207,6 +213,7 @@ public class DisseminationProtocolTests
                 var updatedItem = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 2);
 
                 var updatedResult = await protocol.Publish(topic.Name, updatedItem, targetPeers: null, CancellationToken.None);
+                await protocol.FlushPendingGossip(CancellationToken.None);
 
                 Assert.True(initialResult);
                 Assert.True(updatedResult);
@@ -216,6 +223,56 @@ public class DisseminationProtocolTests
         }
 
         throw new InvalidOperationException("The test did not find a peer set which changes the local tree children.");
+    }
+
+    [Fact]
+    public async Task GossipBatchingCoalescesSamePeerValuesByLatestVersion()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic);
+
+        var first = await protocol.Publish(topic.Name, topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1), [peer], CancellationToken.None);
+        var second = await protocol.Publish(topic.Name, topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 2), [peer], CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
+
+        Assert.True(first);
+        Assert.True(second);
+        var batch = Assert.Single(transport.GossipBatches);
+        Assert.Equal(peer, batch.Peer);
+        var value = Assert.Single(batch.Batch.Values);
+        Assert.Equal(2, value.Digest.Version);
+    }
+
+    [Fact]
+    public async Task GossipBatchingWakesScheduledFlushWhenBatchLimitIsReached()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var sent = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        transport.SendGossipHandler = (target, batch, cancellationToken) =>
+        {
+            transport.GossipBatches.Add((target, batch));
+            sent.TrySetResult(true);
+            return Task.CompletedTask;
+        };
+
+        var topic = new FakeTopic(local);
+        topic.Options.MaxCoalescingDelay = TimeSpan.FromMinutes(1);
+        var protocol = CreateProtocol(transport, topic, options => options.MaxBatchItems = 2);
+
+        var first = await protocol.Publish(topic.Name, topic.CreateItem(local, "first", sequence: 1), [peer], CancellationToken.None);
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        var second = await protocol.Publish(topic.Name, topic.CreateItem(local, "second", sequence: 1), [peer], CancellationToken.None);
+
+        await sent.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.True(first);
+        Assert.True(second);
+        var batch = Assert.Single(transport.GossipBatches);
+        Assert.Equal(new[] { "first", "second" }, batch.Batch.Values.Select(static value => value.Digest.Key));
     }
 
     [Fact]
@@ -306,6 +363,72 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task AntiEntropyResponseOnlyIncludesRequestedDigestKeys()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic);
+        topic.SetValue("requested", version: 5);
+        topic.SetValue("omitted", version: 5);
+
+        var response = await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            Topics =
+            [
+                new DisseminationCapabilityRequest
+                {
+                    Topic = topic.Name,
+                    ProtocolVersion = topic.ProtocolVersion,
+                    PayloadKinds = [FakeTopic.PayloadKind],
+                },
+            ],
+            Digests =
+            [
+                new DisseminationDigest(topic.Name, "requested", version: 3, FakeTopic.PayloadKind),
+            ],
+        }, CancellationToken.None);
+
+        var item = Assert.Single(response.Values);
+        Assert.Equal("requested", item.Digest.Key);
+    }
+
+    [Fact]
+    public async Task AntiEntropyDigestRequestsAreSuppressedUntilExpectedCadenceExpires()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        var timeProvider = new TestTimeProvider();
+        topic.Options.ExpectedUpdateCadence = TimeSpan.FromSeconds(2);
+        var protocol = CreateProtocol(transport, topic, timeProvider: timeProvider);
+
+        await protocol.ReceiveGossip(new DisseminationGossipBatch
+        {
+            Sender = peer,
+            Values = [topic.CreateItem(peer, FakeTopic.DefaultKey, sequence: 1)],
+        }, CancellationToken.None);
+
+        var recentState = protocol.CreateAntiEntropyState();
+        Assert.Empty(recentState.Digests);
+        var recentResponses = await protocol.ExchangeAntiEntropy(recentState, CancellationToken.None);
+        Assert.Empty(recentResponses);
+        Assert.Empty(transport.AntiEntropyRequests);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(2) - TimeSpan.FromMilliseconds(1));
+        var beforeCadenceState = protocol.CreateAntiEntropyState();
+        Assert.Empty(beforeCadenceState.Digests);
+
+        timeProvider.Advance(TimeSpan.FromMilliseconds(1));
+        var staleState = protocol.CreateAntiEntropyState();
+        var digest = Assert.Single(staleState.Digests);
+        Assert.Equal(FakeTopic.DefaultKey, digest.Key);
+    }
+
+    [Fact]
     public async Task AntiEntropyAppliesReturnedRepairItemsWithoutForwarding()
     {
         var local = CreateSilo(11111);
@@ -313,6 +436,7 @@ public class DisseminationProtocolTests
         var transport = new FakeTransport(local, peer);
         var topic = new FakeTopic(local);
         var protocol = CreateProtocol(transport, topic);
+        topic.ExpectedKeys.Add(FakeTopic.DefaultKey);
         var repairItem = topic.CreateItem(peer, FakeTopic.DefaultKey, sequence: 7);
         transport.ExchangeAntiEntropyHandler = (target, request) => ValueTask.FromResult(new DisseminationAntiEntropyResponse
         {
@@ -327,7 +451,9 @@ public class DisseminationProtocolTests
         Assert.Equal(7, topic.GetVersion(FakeTopic.DefaultKey));
         Assert.Empty(transport.GossipBatches);
         Assert.Single(transport.AntiEntropyRequests);
-        Assert.Empty(transport.AntiEntropyRequests[0].Request.Digests);
+        var digest = Assert.Single(transport.AntiEntropyRequests[0].Request.Digests);
+        Assert.Equal(FakeTopic.DefaultKey, digest.Key);
+        Assert.Equal(long.MinValue, digest.Version);
         Assert.Equal(topic.Name, Assert.Single(transport.AntiEntropyRequests[0].Request.Topics).Topic);
     }
 
@@ -509,6 +635,23 @@ public class DisseminationProtocolTests
         var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
 
         Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void OptionsValidatorRejectsInvalidExpectedUpdateCadence()
+    {
+        var options = new DeploymentLoadPublisherOptions();
+        options.Dissemination.ExpectedUpdateCadence = TimeSpan.Zero;
+        var result = new DeploymentLoadPublisherOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void TopicOptionsUseExpectedUpdateCadenceDefaults()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(2), new DeploymentLoadPublisherOptions().Dissemination.ExpectedUpdateCadence);
+        Assert.Equal(TimeSpan.FromSeconds(10), new ClusterMembershipOptions().Dissemination.ExpectedUpdateCadence);
     }
 
     private static DisseminationProtocol CreateProtocol(
@@ -796,6 +939,8 @@ public class DisseminationProtocolTests
 
         public Dictionary<string, int> ApplyCounts { get; } = new(StringComparer.Ordinal);
 
+        public HashSet<string> ExpectedKeys { get; } = new(StringComparer.Ordinal);
+
         public string Name => "fake-topic";
 
         public int ProtocolVersion => 2;
@@ -822,8 +967,21 @@ public class DisseminationProtocolTests
 
         public long GetVersion(string key) => _versions.TryGetValue(key, out var version) ? version : 0;
 
-        public IReadOnlyList<DisseminationDigest> GetDigests() =>
-            _versions.Select(entry => new DisseminationDigest(Name, entry.Key, entry.Value, PayloadKind)).ToArray();
+        public IReadOnlyList<DisseminationDigest> GetDigests()
+        {
+            var digests = _versions
+                .Select(entry => new DisseminationDigest(Name, entry.Key, entry.Value, PayloadKind))
+                .ToList();
+            foreach (var key in ExpectedKeys)
+            {
+                if (!_versions.ContainsKey(key))
+                {
+                    digests.Add(new DisseminationDigest(Name, key, long.MinValue, PayloadKind));
+                }
+            }
+
+            return [.. digests.OrderBy(static digest => digest.Key, StringComparer.Ordinal)];
+        }
 
         public int CompareVersion(DisseminationDigest left, DisseminationDigest right) => left.Version.CompareTo(right.Version);
 
@@ -887,6 +1045,8 @@ public class DisseminationProtocolTests
 
         public Func<SiloAddress, DisseminationCapabilityRequest, CancellationToken, ValueTask<DisseminationCapabilityResponse>>? GetCapabilitiesHandler { get; set; }
 
+        public Func<SiloAddress, DisseminationGossipBatch, CancellationToken, Task>? SendGossipHandler { get; set; }
+
         public Func<SiloAddress, DisseminationAntiEntropyRequest, ValueTask<DisseminationAntiEntropyResponse>> ExchangeAntiEntropyHandler { get; set; } =
             static (peer, _) => ValueTask.FromResult(new DisseminationAntiEntropyResponse { Sender = peer });
 
@@ -942,6 +1102,11 @@ public class DisseminationProtocolTests
 
         public Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken)
         {
+            if (SendGossipHandler is not null)
+            {
+                return SendGossipHandler(peer, batch, cancellationToken);
+            }
+
             GossipBatches.Add((peer, batch));
             return Task.CompletedTask;
         }

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -523,7 +523,7 @@ public class DisseminationProtocolTests
         try
         {
             Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "in-flight", sequence: 1), [peer], CancellationToken.None));
-            await firstSendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            await firstSendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
             Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "queued", sequence: 1), [peer], CancellationToken.None));
 
             await protocol.ReceiveGossip(
@@ -620,10 +620,10 @@ public class DisseminationProtocolTests
         var protocol = CreateProtocol(transport, topic, options => options.MaxBatchItems = 2);
 
         var first = await protocol.Publish(topic.Name, topic.CreateItem(local, "first", sequence: 1), [peer], CancellationToken.None);
-        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        await Task.Delay(TimeSpan.FromMilliseconds(50), TestContext.Current.CancellationToken);
         var second = await protocol.Publish(topic.Name, topic.CreateItem(local, "second", sequence: 1), [peer], CancellationToken.None);
 
-        await sent.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await sent.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
         Assert.True(first);
         Assert.True(second);
         var batch = Assert.Single(transport.GossipBatches);
@@ -654,7 +654,7 @@ public class DisseminationProtocolTests
         var protocol = CreateProtocol(transport, topic);
 
         var first = await protocol.Publish(topic.Name, topic.CreateItem(local, "first", sequence: 1), [peer], CancellationToken.None);
-        await firstSendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await firstSendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
         var second = await protocol.Publish(topic.Name, topic.CreateItem(local, "second", sequence: 1), [peer], CancellationToken.None);
         var third = await protocol.Publish(topic.Name, topic.CreateItem(local, "third", sequence: 1), [peer], CancellationToken.None);
 
@@ -741,7 +741,7 @@ public class DisseminationProtocolTests
             CancellationToken.None));
         var flushTask = protocol.FlushPendingGossip(CancellationToken.None);
 
-        await concurrencyReached.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await concurrencyReached.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
         Assert.Equal(2, Volatile.Read(ref started));
         Assert.Equal(2, Volatile.Read(ref maxInFlight));
 
@@ -791,14 +791,14 @@ public class DisseminationProtocolTests
         });
 
         Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "first", sequence: 1), [firstPeer], CancellationToken.None));
-        await firstSendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await firstSendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
         Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "second", sequence: 1), [secondPeer], CancellationToken.None));
         var explicitFlush = protocol.FlushPendingGossip(CancellationToken.None);
 
         Assert.Equal(1, Volatile.Read(ref maxInFlight));
         releaseFirstSend.SetResult(true);
         await explicitFlush;
-        await allSendsCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await allSendsCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
         Assert.Equal(1, maxInFlight);
     }
 
@@ -2326,11 +2326,17 @@ public class DisseminationProtocolTests
         var older = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
         var newer = CreateStatistics(older.DateTime.AddSeconds(1));
 
-        var newerUpdate = Task.Run(() => publisher.ApplyDisseminatedRuntimeStatistics(peer, newer));
-        Assert.True(statusCheckEntered.Wait(TimeSpan.FromSeconds(2)), "The newer update did not enter the status/version boundary.");
-        var olderUpdate = Task.Run(() => publisher.UpdateRuntimeStatistics(peer, older));
+        var newerUpdate = Task.Run(
+            () => publisher.ApplyDisseminatedRuntimeStatistics(peer, newer),
+            TestContext.Current.CancellationToken);
+        Assert.True(
+            statusCheckEntered.Wait(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
+            "The newer update did not enter the status/version boundary.");
+        var olderUpdate = Task.Run(
+            () => publisher.UpdateRuntimeStatistics(peer, older),
+            TestContext.Current.CancellationToken);
         Assert.False(
-            olderStatusCheckEntered.Wait(TimeSpan.FromMilliseconds(100)),
+            olderStatusCheckEntered.Wait(TimeSpan.FromMilliseconds(100), TestContext.Current.CancellationToken),
             "The older update entered the status/version boundary while the newer update still owned it.");
         releaseStatusCheck.Set();
 
@@ -2366,10 +2372,16 @@ public class DisseminationProtocolTests
         blockStatusCheck = true;
         var lateStatistics = CreateStatistics(baseline.DateTime.AddSeconds(1));
 
-        var lateUpdate = Task.Run(() => publisher.ApplyDisseminatedRuntimeStatistics(peer, lateStatistics));
-        Assert.True(statusCheckEntered.Wait(TimeSpan.FromSeconds(2)), "The late update did not enter the status/version boundary.");
+        var lateUpdate = Task.Run(
+            () => publisher.ApplyDisseminatedRuntimeStatistics(peer, lateStatistics),
+            TestContext.Current.CancellationToken);
+        Assert.True(
+            statusCheckEntered.Wait(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken),
+            "The late update did not enter the status/version boundary.");
         statusOracle.SetStatus(peer, SiloStatus.Dead);
-        var termination = Task.Run(() => publisher.OnSiloStatusChange(peer, SiloStatus.Dead));
+        var termination = Task.Run(
+            () => publisher.OnSiloStatusChange(peer, SiloStatus.Dead),
+            TestContext.Current.CancellationToken);
         releaseStatusCheck.Set();
 
         await lateUpdate;
@@ -3256,7 +3268,7 @@ public class DisseminationProtocolTests
             topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1),
             [peer],
             CancellationToken.None));
-        await sendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await sendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
         var stopTask = service.StopAsync(CancellationToken.None);
         Assert.False(stopTask.IsCompleted);
@@ -3295,7 +3307,7 @@ public class DisseminationProtocolTests
             topic,
             options => options.Overlay.AntiEntropyInterval = TimeSpan.FromMilliseconds(1));
         await service.StartAsync(CancellationToken.None);
-        await exchangeStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await exchangeStarted.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
@@ -3308,7 +3320,7 @@ public class DisseminationProtocolTests
             Sender = peer,
             SupportedTopics = [topic.Name],
         });
-        await exchangeCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await exchangeCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
         await WaitUntil(() => !service.HasOutstandingAntiEntropyTask);
         await WaitUntil(() => service.IsProtocolDisposed);
         Assert.Equal(new[] { peer }, service.GetUnconfirmedPeers(topic.Name, topic.MembershipScope));

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -524,7 +524,7 @@ public class DisseminationProtocolTests
                 new DisseminationTopicDigest(FakeTopic.DefaultKey, version: 3)),
         }, CancellationToken.None);
 
-        var item = Assert.Single(response.Values);
+        var item = Assert.Single(GetAntiEntropyResponseValues(response));
         Assert.Equal(5, item.Digest.Version);
         Assert.False(response.Truncated);
     }
@@ -548,7 +548,7 @@ public class DisseminationProtocolTests
                 new DisseminationTopicDigest("requested", version: 3)),
         }, CancellationToken.None);
 
-        var item = Assert.Single(response.Values);
+        var item = Assert.Single(GetAntiEntropyResponseValues(response));
         Assert.Equal("requested", item.Digest.Key);
     }
 
@@ -596,7 +596,7 @@ public class DisseminationProtocolTests
         transport.ExchangeAntiEntropyHandler = (target, request) => ValueTask.FromResult(new DisseminationAntiEntropyResponse
         {
             Sender = target,
-            Values = [repairItem],
+            ValuesByTopic = CreateValueGroups(repairItem),
         });
 
         var state = protocol.CreateAntiEntropyState();
@@ -636,7 +636,7 @@ public class DisseminationProtocolTests
             new DisseminationAntiEntropyResponse
             {
                 Sender = peer,
-                Values = [badRepairItem, goodRepairItem],
+                ValuesByTopic = CreateValueGroups(badRepairItem, goodRepairItem),
             },
         }, CancellationToken.None);
 
@@ -668,11 +668,11 @@ public class DisseminationProtocolTests
             return ValueTask.FromResult(new DisseminationAntiEntropyResponse
             {
                 Sender = target,
-                Values = count switch
+                ValuesByTopic = count switch
                 {
-                    1 => [badRepairItem],
-                    2 => [goodRepairItem],
-                    _ => [],
+                    1 => CreateValueGroups(badRepairItem),
+                    2 => CreateValueGroups(goodRepairItem),
+                    _ => FrozenDictionary<string, ImmutableArray<DisseminationValue>>.Empty,
                 },
             });
         };
@@ -879,16 +879,22 @@ public class DisseminationProtocolTests
     private static DisseminationGossipBatch CreateGossipBatch(SiloAddress sender, params DisseminationValue[] values) => new()
     {
         Sender = sender,
-        ValuesByTopic = values
-            .GroupBy(static value => value.Digest.Topic, StringComparer.Ordinal)
-            .ToFrozenDictionary(
-                static group => group.Key,
-                static group => group.ToImmutableArray(),
-                StringComparer.Ordinal),
+        ValuesByTopic = CreateValueGroups(values),
     };
 
     private static IEnumerable<DisseminationValue> GetGossipValues(DisseminationGossipBatch batch) =>
         batch.ValuesByTopic.Values.SelectMany(static values => values);
+
+    private static IEnumerable<DisseminationValue> GetAntiEntropyResponseValues(DisseminationAntiEntropyResponse response) =>
+        response.ValuesByTopic.Values.SelectMany(static values => values);
+
+    private static FrozenDictionary<string, ImmutableArray<DisseminationValue>> CreateValueGroups(params DisseminationValue[] values) =>
+        values
+            .GroupBy(static value => value.Digest.Topic, StringComparer.Ordinal)
+            .ToFrozenDictionary(
+                static group => group.Key,
+                static group => group.ToImmutableArray(),
+                StringComparer.Ordinal);
 
     private static MembershipDisseminationTopic CreateMembershipTopic(
         SiloAddress local,

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -532,11 +533,9 @@ public class DisseminationProtocolTests
         var response = await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
         {
             Sender = peer,
-            Topics = [topic.Name],
-            Digests =
-            [
-                new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 3),
-            ],
+            DigestsByTopic = CreateAntiEntropyRequestDigests(
+                topic.Name,
+                new DisseminationTopicDigest(FakeTopic.DefaultKey, version: 3)),
         }, CancellationToken.None);
 
         var item = Assert.Single(response.Values);
@@ -558,11 +557,9 @@ public class DisseminationProtocolTests
         var response = await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
         {
             Sender = peer,
-            Topics = [topic.Name],
-            Digests =
-            [
-                new DisseminationDigest(topic.Name, "requested", version: 3),
-            ],
+            DigestsByTopic = CreateAntiEntropyRequestDigests(
+                topic.Name,
+                new DisseminationTopicDigest("requested", version: 3)),
         }, CancellationToken.None);
 
         var item = Assert.Single(response.Values);
@@ -625,10 +622,11 @@ public class DisseminationProtocolTests
         Assert.Equal(7, topic.GetVersion(FakeTopic.DefaultKey));
         Assert.Empty(transport.GossipBatches);
         Assert.Single(transport.AntiEntropyRequests);
-        var digest = Assert.Single(transport.AntiEntropyRequests[0].Request.Digests);
+        var digestsByTopic = Assert.Single(transport.AntiEntropyRequests[0].Request.DigestsByTopic);
+        Assert.Equal(topic.Name, digestsByTopic.Key);
+        var digest = Assert.Single(digestsByTopic.Value);
         Assert.Equal(FakeTopic.DefaultKey, digest.Key);
         Assert.Equal(long.MinValue, digest.Version);
-        Assert.Equal(topic.Name, Assert.Single(transport.AntiEntropyRequests[0].Request.Topics));
     }
 
     [Fact]
@@ -883,6 +881,14 @@ public class DisseminationProtocolTests
 
     private static SiloAddress[] CreateSilos(int count) =>
         Enumerable.Range(11111, count).Select(CreateSilo).OrderBy(static silo => silo).ToArray();
+
+    private static FrozenDictionary<string, ImmutableArray<DisseminationTopicDigest>> CreateAntiEntropyRequestDigests(
+        string topicName,
+        params DisseminationTopicDigest[] digests) =>
+        new Dictionary<string, ImmutableArray<DisseminationTopicDigest>>(StringComparer.Ordinal)
+        {
+            [topicName] = [.. digests],
+        }.ToFrozenDictionary(StringComparer.Ordinal);
 
     private static MembershipDisseminationTopic CreateMembershipTopic(
         SiloAddress local,

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -664,7 +663,7 @@ public class DisseminationProtocolTests
                 {
                     1 => CreateValueGroups(badRepairItem),
                     2 => CreateValueGroups(goodRepairItem),
-                    _ => FrozenDictionary<string, ImmutableArray<DisseminationValue>>.Empty,
+                    _ => ImmutableDictionary<string, ImmutableArray<DisseminationValue>>.Empty,
                 },
             });
         };
@@ -778,6 +777,45 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public void WirePayloadsRoundTripThroughSerializer()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var sender = CreateSilo(11111);
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest(FakeTopic.DefaultKey, version: 1),
+            Root = sender,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = new byte[] { 1, 2, 3 },
+        };
+
+        var gossip = RoundTrip(serializer, new DisseminationGossipBatch
+        {
+            Sender = sender,
+            ValuesByTopic = CreateValueGroups(value),
+        });
+        var request = RoundTrip(serializer, new DisseminationAntiEntropyRequest
+        {
+            Sender = sender,
+            DigestsByTopic = CreateAntiEntropyRequestDigests(FakeTopic.DefaultName, value.Digest),
+        });
+        var response = RoundTrip(serializer, new DisseminationAntiEntropyResponse
+        {
+            Sender = sender,
+            ValuesByTopic = CreateValueGroups(value),
+        });
+        var manifestSummary = RoundTrip(serializer, new ClusterManifestHashSummary(
+            new MajorMinorVersion(1, 2),
+            ImmutableDictionary<SiloAddress, ManifestHash>.Empty.Add(sender, new ManifestHash("hash"))));
+
+        Assert.Equal(value.Digest, Assert.Single(GetGossipValues(gossip)).Digest);
+        Assert.Equal(value.Digest, Assert.Single(request.DigestsByTopic.Values).Single());
+        Assert.Equal(value.Digest, Assert.Single(GetAntiEntropyResponseValues(response)).Digest);
+        Assert.Equal(new ManifestHash("hash"), manifestSummary.SiloManifestHashes[sender]);
+    }
+
+    [Fact]
     public void OptionsValidatorRejectsInvalidFanoutBounds()
     {
         var options = new DisseminationOptions();
@@ -858,13 +896,13 @@ public class DisseminationProtocolTests
     private static SiloAddress[] CreateSilos(int count) =>
         Enumerable.Range(11111, count).Select(CreateSilo).OrderBy(static silo => silo).ToArray();
 
-    private static FrozenDictionary<string, ImmutableArray<DisseminationTopicDigest>> CreateAntiEntropyRequestDigests(
+    private static ImmutableDictionary<string, ImmutableArray<DisseminationTopicDigest>> CreateAntiEntropyRequestDigests(
         string topicName,
         params DisseminationTopicDigest[] digests) =>
         new Dictionary<string, ImmutableArray<DisseminationTopicDigest>>(StringComparer.Ordinal)
         {
             [topicName] = [.. digests],
-        }.ToFrozenDictionary(StringComparer.Ordinal);
+        }.ToImmutableDictionary(StringComparer.Ordinal);
 
     private static DisseminationGossipBatch CreateGossipBatch(SiloAddress sender, params DisseminationValue[] values) => new()
     {
@@ -878,14 +916,17 @@ public class DisseminationProtocolTests
     private static IEnumerable<DisseminationValue> GetAntiEntropyResponseValues(DisseminationAntiEntropyResponse response) =>
         response.ValuesByTopic.Values.SelectMany(static values => values);
 
-    private static FrozenDictionary<string, ImmutableArray<DisseminationValue>> CreateValueGroups(params DisseminationValue[] values) =>
+    private static ImmutableDictionary<string, ImmutableArray<DisseminationValue>> CreateValueGroups(params DisseminationValue[] values) =>
         CreateValueGroups(FakeTopic.DefaultName, values);
 
-    private static FrozenDictionary<string, ImmutableArray<DisseminationValue>> CreateValueGroups(string topicName, params DisseminationValue[] values) =>
+    private static ImmutableDictionary<string, ImmutableArray<DisseminationValue>> CreateValueGroups(string topicName, params DisseminationValue[] values) =>
         new Dictionary<string, ImmutableArray<DisseminationValue>>(StringComparer.Ordinal)
         {
             [topicName] = [.. values],
-        }.ToFrozenDictionary(StringComparer.Ordinal);
+        }.ToImmutableDictionary(StringComparer.Ordinal);
+
+    private static T RoundTrip<T>(Serializer serializer, T value) =>
+        serializer.Deserialize<T>(serializer.SerializeToArray(value));
 
     private static MembershipDisseminationTopic CreateMembershipTopic(
         SiloAddress local,

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -14,12 +14,16 @@ using Microsoft.Accordant;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Orleans;
 using Orleans.Configuration;
 using Orleans.Metadata;
+using Orleans.Providers;
 using Orleans.Runtime;
 using Orleans.Runtime.Dissemination;
 using Orleans.Runtime.MembershipService;
 using Orleans.Serialization;
+using Orleans.Versions.Compatibility;
+using Orleans.Versions.Selector;
 using Xunit;
 
 namespace UnitTests.Dissemination;
@@ -554,6 +558,19 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public void CreateAntiEntropyStateReturnsEmptyWhenDisseminationIsDisabled()
+    {
+        var local = CreateSilo(11111);
+        var transport = new FakeTransport(local, CreateSilo(11112));
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, options => options.Enabled = false);
+
+        var state = protocol.CreateAntiEntropyState();
+
+        Assert.Empty(state.Topics);
+    }
+
+    [Fact]
     public async Task AntiEntropyResponseIncludesNewerLocalValues()
     {
         var local = CreateSilo(11111);
@@ -821,6 +838,288 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task MembershipTopicApplyValueRejectsWrongTopicKey()
+    {
+        var local = CreateSilo(11121);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var topic = CreateMembershipTopic(local, new FakeMembershipManager(snapshot), serializer);
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("not-cluster", 1),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Snapshot = snapshot }),
+        };
+
+        var result = await topic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Rejected, result);
+    }
+
+    [Fact]
+    public async Task MembershipTopicApplyValueRejectsNullDeserializedPayload()
+    {
+        var local = CreateSilo(11122);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var topic = CreateMembershipTopic(local, new FakeMembershipManager(snapshot), serializer);
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("cluster", 1),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray<MembershipTableSnapshotUpdate>(null!),
+        };
+
+        var result = await topic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Rejected, result);
+    }
+
+    [Fact]
+    public async Task MembershipTopicApplyValueReturnsObsoleteThenDuplicateForStaleVersions()
+    {
+        var local = CreateSilo(11123);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var currentSnapshot = CreateMembershipSnapshot(5, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var manager = new FakeMembershipManager(currentSnapshot);
+        var topic = CreateMembershipTopic(local, manager, serializer);
+        var olderSnapshot = CreateMembershipSnapshot(4, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var olderValue = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("cluster", olderSnapshot.Version.Value),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Snapshot = olderSnapshot }),
+        };
+        var sameVersionValue = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("cluster", currentSnapshot.Version.Value),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Snapshot = currentSnapshot }),
+        };
+
+        var obsoleteResult = await topic.ApplyValue(olderValue, CancellationToken.None);
+        var duplicateResult = await topic.ApplyValue(sameVersionValue, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Obsolete, obsoleteResult);
+        Assert.Equal(DisseminationApplyResult.Duplicate, duplicateResult);
+        Assert.Equal(currentSnapshot.Version, manager.CurrentSnapshot.Version);
+    }
+
+    [Fact]
+    public async Task MembershipTopicApplyValueRejectsDiffWithMismatchedBaseVersion()
+    {
+        var local = CreateSilo(11124);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var currentSnapshot = CreateMembershipSnapshot(5, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var manager = new FakeMembershipManager(currentSnapshot);
+        var topic = CreateMembershipTopic(local, manager, serializer);
+        var diff = new MembershipTableSnapshotDiff(
+            baseVersion: new MembershipVersion(1),
+            version: new MembershipVersion(6),
+            updatedEntries: ImmutableArray<MembershipEntry>.Empty,
+            removedSilos: ImmutableArray<SiloAddress>.Empty);
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("cluster", diff.Version.Value),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Diff = diff }),
+        };
+
+        var result = await topic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Rejected, result);
+        Assert.Equal(currentSnapshot.Version, manager.CurrentSnapshot.Version);
+    }
+
+    [Fact]
+    public async Task MembershipTopicApplyValueRejectsUpdateContainingSnapshotAndDiff()
+    {
+        var local = CreateSilo(11129);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var currentSnapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var manager = new FakeMembershipManager(currentSnapshot);
+        var topic = CreateMembershipTopic(local, manager, serializer);
+        var diff = new MembershipTableSnapshotDiff(
+            currentSnapshot.Version,
+            new MembershipVersion(2),
+            ImmutableArray<MembershipEntry>.Empty,
+            ImmutableArray<SiloAddress>.Empty);
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("cluster", 2),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate
+            {
+                Snapshot = currentSnapshot,
+                Diff = diff,
+            }),
+        };
+
+        var result = await topic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Rejected, result);
+        Assert.Equal(currentSnapshot.Version, manager.CurrentSnapshot.Version);
+    }
+
+    [Theory]
+    [InlineData(4, 5, (int)DisseminationApplyResult.Obsolete)]
+    [InlineData(5, 5, (int)DisseminationApplyResult.Duplicate)]
+    public async Task MembershipTopicApplyDiffRejectsNonNewerVersion(
+        long diffVersion,
+        long currentVersion,
+        int expected)
+    {
+        var local = CreateSilo(11130);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var currentSnapshot = CreateMembershipSnapshot(currentVersion, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var manager = new FakeMembershipManager(currentSnapshot);
+        var topic = CreateMembershipTopic(local, manager, serializer);
+        var diff = new MembershipTableSnapshotDiff(
+            new MembershipVersion(currentVersion - 1),
+            new MembershipVersion(diffVersion),
+            ImmutableArray<MembershipEntry>.Empty,
+            ImmutableArray<SiloAddress>.Empty);
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("cluster", diffVersion),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Diff = diff }),
+        };
+
+        var result = await topic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal((DisseminationApplyResult)expected, result);
+        Assert.Equal(currentSnapshot.Version, manager.CurrentSnapshot.Version);
+    }
+
+    [Fact]
+    public async Task MembershipTopicDiffPreservesNewerIAmAliveTimeAndAppliesSuspectTimeChange()
+    {
+        var local = CreateSilo(11131);
+        var peer = CreateSilo(11132);
+        var startTime = DateTime.UnixEpoch;
+        var baseEntry = CreateMembershipEntry(peer, SiloStatus.Active, startTime);
+        baseEntry.IAmAliveTime = startTime.AddMinutes(2);
+        baseEntry.SuspectTimes = [Tuple.Create(local, startTime.AddSeconds(1))];
+        var updatedEntry = CreateMembershipEntry(peer, SiloStatus.Active, startTime);
+        updatedEntry.IAmAliveTime = startTime.AddMinutes(1);
+        updatedEntry.SuspectTimes = [Tuple.Create(local, startTime.AddSeconds(2))];
+        var baseSnapshot = CreateMembershipSnapshot(1, baseEntry);
+        var updatedSnapshot = CreateMembershipSnapshot(2, updatedEntry);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var sourceManager = new FakeMembershipManager(baseSnapshot);
+        var sourceTopic = CreateMembershipTopic(local, sourceManager, serializer);
+        var peerDigest = Assert.Single(sourceTopic.GetDigests());
+        sourceManager.CurrentSnapshot = updatedSnapshot;
+        var localDigest = Assert.Single(sourceTopic.GetDigests());
+
+        var value = await sourceTopic.GetValue(localDigest, peerDigest, CancellationToken.None);
+        Assert.NotNull(value);
+        var receiverManager = new FakeMembershipManager(baseSnapshot);
+        var receiverTopic = CreateMembershipTopic(peer, receiverManager, serializer);
+
+        var result = await receiverTopic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Applied, result);
+        var appliedEntry = receiverManager.CurrentSnapshot.Entries[peer];
+        Assert.Equal(baseEntry.IAmAliveTime, appliedEntry.IAmAliveTime);
+        var suspectTime = Assert.Single(appliedEntry.SuspectTimes!);
+        Assert.Equal(updatedEntry.SuspectTimes![0], suspectTime);
+    }
+
+    [Fact]
+    public async Task MembershipTopicGetValueReturnsNullForWrongKeyOrStaleDigest()
+    {
+        var local = CreateSilo(11125);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var snapshot = CreateMembershipSnapshot(3, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var topic = CreateMembershipTopic(local, new FakeMembershipManager(snapshot), serializer);
+
+        var wrongKeyResult = await topic.GetValue(new DisseminationTopicDigest("not-cluster", 3), peerDigest: null, CancellationToken.None);
+        var staleDigestResult = await topic.GetValue(new DisseminationTopicDigest("cluster", 99), peerDigest: null, CancellationToken.None);
+
+        Assert.Null(wrongKeyResult);
+        Assert.Null(staleDigestResult);
+    }
+
+    [Fact]
+    public async Task MembershipTopicOnFallbackRequiredRefreshesMembershipWhenEnabled()
+    {
+        var local = CreateSilo(11126);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var manager = new FakeMembershipManager(snapshot);
+        var topic = CreateMembershipTopic(local, manager, serializer, options => options.Dissemination.FallbackEnabled = true);
+
+        await topic.OnFallbackRequired(peer: null, new DisseminationTopicDigest("cluster", 7), CancellationToken.None);
+
+        var refreshCall = Assert.Single(manager.RefreshCalls);
+        Assert.Equal(new MembershipVersion(7), refreshCall);
+    }
+
+    [Fact]
+    public async Task MembershipTopicOnFallbackRequiredSkipsRefreshWhenDisabled()
+    {
+        var local = CreateSilo(11127);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var manager = new FakeMembershipManager(snapshot);
+        var topic = CreateMembershipTopic(local, manager, serializer, options => options.Dissemination.FallbackEnabled = false);
+
+        await topic.OnFallbackRequired(peer: null, new DisseminationTopicDigest("cluster", 7), CancellationToken.None);
+
+        Assert.Empty(manager.RefreshCalls);
+    }
+
+    [Fact]
+    public async Task MembershipTopicSnapshotHistoryEvictionFallsBackToFullSnapshotForOldPeerVersion()
+    {
+        var local = CreateSilo(11128);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var initialSnapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var manager = new FakeMembershipManager(initialSnapshot);
+        var topic = CreateMembershipTopic(local, manager, serializer);
+        Assert.Single(topic.GetDigests());
+
+        // Exceed the 32-entry snapshot history so that version 1 is evicted.
+        for (var version = 2; version <= 40; version++)
+        {
+            manager.CurrentSnapshot = CreateMembershipSnapshot(version, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+            Assert.Single(topic.GetDigests());
+        }
+
+        var latestDigest = Assert.Single(topic.GetDigests());
+        var evictedPeerDigest = new DisseminationTopicDigest("cluster", 1);
+
+        var value = await topic.GetValue(latestDigest, evictedPeerDigest, CancellationToken.None);
+
+        Assert.NotNull(value);
+        var update = serializer.Deserialize<MembershipTableSnapshotUpdate>(value.Payload);
+        Assert.NotNull(update);
+        Assert.Null(update.Diff);
+        Assert.NotNull(update.Snapshot);
+        Assert.Equal(40, update.Snapshot.Version.Value);
+    }
+
+    [Fact]
     public void ManifestHashIsIndependentOfDictionaryOrdering()
     {
         var manifest1 = CreateManifest(
@@ -831,6 +1130,63 @@ public class DisseminationProtocolTests
             ("grain-b", "placement", "random"));
 
         Assert.Equal(ManifestHashCalculator.ComputeHash(manifest1), ManifestHashCalculator.ComputeHash(manifest2));
+    }
+
+    [Fact]
+    public void ManifestHashCalculator_ChangesWhenGrainPropertyValueChanges()
+    {
+        var original = CreateManifest(("grain-a", "placement", "local"));
+        var changed = CreateManifest(("grain-a", "placement", "random"));
+
+        Assert.NotEqual(ManifestHashCalculator.ComputeHash(original), ManifestHashCalculator.ComputeHash(changed));
+    }
+
+    [Fact]
+    public void ManifestHashCalculator_ChangesWhenGrainIsAdded()
+    {
+        var original = CreateManifest(("grain-a", "placement", "local"));
+        var withExtraGrain = CreateManifest(("grain-a", "placement", "local"), ("grain-b", "placement", "local"));
+
+        Assert.NotEqual(ManifestHashCalculator.ComputeHash(original), ManifestHashCalculator.ComputeHash(withExtraGrain));
+    }
+
+    [Fact]
+    public void ManifestHashCalculator_IsDeterministicForEmptyManifest()
+    {
+        var empty = new GrainManifest(
+            System.Collections.Immutable.ImmutableDictionary<GrainType, GrainProperties>.Empty,
+            System.Collections.Immutable.ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty);
+
+        var first = ManifestHashCalculator.ComputeHash(empty);
+        var second = ManifestHashCalculator.ComputeHash(empty);
+
+        Assert.Equal(first, second);
+        Assert.NotEqual(default(ManifestHash), first);
+    }
+
+    [Fact]
+    public void ManifestHashCalculator_ChangesWhenInterfacePropertiesChange()
+    {
+        static GrainManifest CreateManifestWithInterface(string propertyValue)
+        {
+            var interfaces = System.Collections.Immutable.ImmutableDictionary.CreateBuilder<GrainInterfaceType, GrainInterfaceProperties>();
+            var properties = System.Collections.Immutable.ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+            properties["version"] = propertyValue;
+            interfaces[GrainInterfaceType.Create("test.interface")] = new GrainInterfaceProperties(properties.ToImmutable());
+            return new GrainManifest(
+                System.Collections.Immutable.ImmutableDictionary<GrainType, GrainProperties>.Empty,
+                interfaces.ToImmutable());
+        }
+
+        var original = CreateManifestWithInterface("1");
+        var changed = CreateManifestWithInterface("2");
+        var identical = CreateManifestWithInterface("1");
+
+        Assert.NotEqual(ManifestHashCalculator.ComputeHash(original), ManifestHashCalculator.ComputeHash(changed));
+        Assert.Equal(ManifestHashCalculator.ComputeHash(original), ManifestHashCalculator.ComputeHash(identical));
+        Assert.NotEqual(ManifestHashCalculator.ComputeHash(original), ManifestHashCalculator.ComputeHash(new GrainManifest(
+            System.Collections.Immutable.ImmutableDictionary<GrainType, GrainProperties>.Empty,
+            System.Collections.Immutable.ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty)));
     }
 
     [Fact]
@@ -910,6 +1266,773 @@ public class DisseminationProtocolTests
         Assert.Equal(options.MaxBatchBytes, new DisseminationTopicOptions().MaxPayloadBytes);
     }
 
+    [Fact]
+    public void OptionsValidatorAcceptsDefaultOptions()
+    {
+        var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, new DisseminationOptions());
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void OptionsValidatorRejectsNonPositiveMaxConcurrentSends()
+    {
+        var options = new DisseminationOptions { MaxConcurrentSends = 0 };
+
+        var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void OptionsValidatorRejectsNonPositiveFailureBackoff()
+    {
+        var options = new DisseminationOptions { FailureBackoff = TimeSpan.Zero };
+
+        var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void OptionsValidatorRejectsNonPositiveMaxBatchBytes()
+    {
+        var options = new DisseminationOptions { MaxBatchBytes = 0 };
+
+        var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void OptionsValidatorRejectsNonPositiveMaxBatchItems()
+    {
+        var options = new DisseminationOptions { MaxBatchItems = 0 };
+
+        var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void OptionsValidatorRejectsNonPositiveTargetHopCount()
+    {
+        var options = new DisseminationOptions();
+        options.Overlay.TargetHopCount = 0;
+
+        var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void OptionsValidatorRejectsNonPositiveMinFanOutFactor()
+    {
+        var options = new DisseminationOptions();
+        options.Overlay.MinFanOutFactor = 0;
+
+        var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void OptionsValidatorRejectsNonPositiveAntiEntropyInterval()
+    {
+        var options = new DisseminationOptions();
+        options.Overlay.AntiEntropyInterval = TimeSpan.Zero;
+
+        var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void OptionsValidatorRejectsNonPositiveAntiEntropyPeerCount()
+    {
+        var options = new DisseminationOptions();
+        options.Overlay.AntiEntropyPeerCount = 0;
+
+        var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void TopicOptionsValidatorAcceptsDefaultOptions()
+    {
+        var result = DisseminationTopicOptionsValidator.Validate("Test", new DisseminationTopicOptions());
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void TopicOptionsValidatorRejectsNonPositiveMaxPendingItemCount()
+    {
+        var options = new DisseminationTopicOptions { MaxPendingItemCount = 0 };
+
+        var result = DisseminationTopicOptionsValidator.Validate("Test", options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void TopicOptionsValidatorRejectsNonPositiveMaxCoalescingDelay()
+    {
+        var options = new DisseminationTopicOptions { MaxCoalescingDelay = TimeSpan.Zero };
+
+        var result = DisseminationTopicOptionsValidator.Validate("Test", options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void TopicOptionsValidatorRejectsStaleItemTtlNotGreaterThanCoalescingDelay()
+    {
+        var options = new DisseminationTopicOptions
+        {
+            MaxCoalescingDelay = TimeSpan.FromSeconds(5),
+            StaleItemTtl = TimeSpan.FromSeconds(5),
+        };
+
+        var result = DisseminationTopicOptionsValidator.Validate("Test", options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void TopicOptionsValidatorRejectsNonPositiveMaxPayloadBytes()
+    {
+        var options = new DisseminationTopicOptions { MaxPayloadBytes = 0 };
+
+        var result = DisseminationTopicOptionsValidator.Validate("Test", options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void ClusterMembershipOptionsDisseminationValidatorRejectsNonPositiveMaxPendingItemCount()
+    {
+        var options = new ClusterMembershipOptions();
+        options.Dissemination.MaxPendingItemCount = 0;
+
+        var result = new ClusterMembershipOptionsDisseminationValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void ApplyDisseminatedRuntimeStatistics_AppliesNewerRejectsInactiveObsoleteAndDuplicate()
+    {
+        var local = CreateSilo(21001);
+        var peer = CreateSilo(21002);
+        var statusOracle = new FakeSiloStatusOracle();
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var baseline = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var rejectedForInactive = publisher.ApplyDisseminatedRuntimeStatistics(peer, baseline);
+
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var applied = publisher.ApplyDisseminatedRuntimeStatistics(peer, baseline);
+        var duplicate = publisher.ApplyDisseminatedRuntimeStatistics(peer, baseline);
+        var obsolete = publisher.ApplyDisseminatedRuntimeStatistics(peer, CreateStatistics(baseline.DateTime.AddSeconds(-1)));
+
+        Assert.Equal(DisseminationApplyResult.Rejected, rejectedForInactive);
+        Assert.Equal(DisseminationApplyResult.Applied, applied);
+        Assert.Equal(DisseminationApplyResult.Duplicate, duplicate);
+        Assert.Equal(DisseminationApplyResult.Obsolete, obsolete);
+        Assert.Equal(baseline.DateTime, publisher.PeriodicStatistics[peer].DateTime);
+    }
+
+    [Fact]
+    public void IsRuntimeStatisticsObsolete_ReflectsSiloActivityAndStatisticsRecency()
+    {
+        var local = CreateSilo(21003);
+        var peer = CreateSilo(21004);
+        var statusOracle = new FakeSiloStatusOracle();
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+
+        Assert.True(publisher.IsRuntimeStatisticsObsolete(peer, DateTime.UtcNow.Ticks));
+
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        Assert.False(publisher.IsRuntimeStatisticsObsolete(peer, DateTime.UtcNow.Ticks));
+
+        var current = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        publisher.ApplyDisseminatedRuntimeStatistics(peer, current);
+
+        Assert.False(publisher.IsRuntimeStatisticsObsolete(peer, current.DateTime.Ticks + 1));
+        Assert.True(publisher.IsRuntimeStatisticsObsolete(peer, current.DateTime.Ticks - 1));
+        // Boundary: a request for the exact same timestamp as the stored statistics is not obsolete (strictly-greater comparison).
+        Assert.False(publisher.IsRuntimeStatisticsObsolete(peer, current.DateTime.Ticks));
+    }
+
+    [Fact]
+    public void GetActiveSilosForDissemination_ReturnsOnlyActiveSilos()
+    {
+        var local = CreateSilo(21005);
+        var activePeer = CreateSilo(21006);
+        var joiningPeer = CreateSilo(21007);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(activePeer, SiloStatus.Active);
+        statusOracle.SetStatus(joiningPeer, SiloStatus.Joining);
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+
+        var activeSilos = publisher.GetActiveSilosForDissemination();
+
+        Assert.Equal(new[] { activePeer }, activeSilos);
+    }
+
+    [Fact]
+    public void DeploymentLoadTopic_CreateItemProducesDigestKeyedByOriginWithSerializedPayload()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21101);
+        var publisher = CreateDeploymentLoadPublisher(local, new FakeSiloStatusOracle());
+        var topic = CreateDeploymentLoadTopic(publisher, serializer);
+        var statistics = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var item = topic.CreateItem(local, statistics);
+
+        Assert.Equal(local.ToParsableString(), item.Digest.Key);
+        Assert.Equal(statistics.DateTime.Ticks, item.Digest.Version);
+        Assert.Equal(local, item.Root);
+        var deserialized = serializer.Deserialize<SiloRuntimeStatistics>(item.Payload) ?? throw new InvalidOperationException("Expected non-null statistics.");
+        Assert.Equal(statistics.DateTime, deserialized.DateTime);
+        Assert.Equal(statistics.ActivationCount, deserialized.ActivationCount);
+    }
+
+    [Fact]
+    public void DeploymentLoadTopic_GetDigestsSortsAndMarksStaleOrMissingActiveSilosAsMinVersion()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21102);
+        var siloWithoutStats = CreateSilo(21103);
+        var siloWithFreshStats = CreateSilo(21104);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(siloWithFreshStats, SiloStatus.Active);
+        statusOracle.SetStatus(siloWithoutStats, SiloStatus.Active);
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var topic = CreateDeploymentLoadTopic(publisher, serializer);
+        var freshStats = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        publisher.ApplyDisseminatedRuntimeStatistics(siloWithFreshStats, freshStats);
+
+        var digests = topic.GetDigests();
+
+        Assert.Equal(2, digests.Count);
+        Assert.Equal(digests.OrderBy(d => d.Key, StringComparer.Ordinal).Select(d => d.Key), digests.Select(d => d.Key));
+        var freshDigest = digests.Single(d => d.Key == siloWithFreshStats.ToParsableString());
+        var missingDigest = digests.Single(d => d.Key == siloWithoutStats.ToParsableString());
+        Assert.Equal(freshStats.DateTime.Ticks, freshDigest.Version);
+        Assert.Equal(long.MinValue, missingDigest.Version);
+    }
+
+    [Fact]
+    public async Task DeploymentLoadTopic_GetValueReturnsNullForMalformedKey()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21105);
+        var publisher = CreateDeploymentLoadPublisher(local, new FakeSiloStatusOracle());
+        var topic = CreateDeploymentLoadTopic(publisher, serializer);
+
+        var value = await topic.GetValue(new DisseminationTopicDigest("not-a-silo-address", 1), peerDigest: null, CancellationToken.None);
+
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public async Task DeploymentLoadTopic_GetValueReturnsNullWhenStatisticsMissingOrDigestIsNewerThanLocal()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21106);
+        var peer = CreateSilo(21107);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var topic = CreateDeploymentLoadTopic(publisher, serializer);
+
+        var missingResult = await topic.GetValue(new DisseminationTopicDigest(peer.ToParsableString(), 1), peerDigest: null, CancellationToken.None);
+
+        var statistics = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        publisher.ApplyDisseminatedRuntimeStatistics(peer, statistics);
+        var staleResult = await topic.GetValue(
+            new DisseminationTopicDigest(peer.ToParsableString(), statistics.DateTime.Ticks + 1),
+            peerDigest: null,
+            CancellationToken.None);
+
+        Assert.Null(missingResult);
+        Assert.Null(staleResult);
+    }
+
+    [Fact]
+    public async Task DeploymentLoadTopic_GetValueReturnsSerializedStatisticsWhenDigestIsCurrent()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21108);
+        var peer = CreateSilo(21109);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var topic = CreateDeploymentLoadTopic(publisher, serializer);
+        var statistics = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        publisher.ApplyDisseminatedRuntimeStatistics(peer, statistics);
+
+        var value = await topic.GetValue(new DisseminationTopicDigest(peer.ToParsableString(), statistics.DateTime.Ticks), peerDigest: null, CancellationToken.None);
+
+        Assert.NotNull(value);
+        Assert.Equal(peer, value.Root);
+        var roundTripped = serializer.Deserialize<SiloRuntimeStatistics>(value.Payload) ?? throw new InvalidOperationException("Expected non-null statistics.");
+        Assert.Equal(statistics.DateTime, roundTripped.DateTime);
+    }
+
+    [Fact]
+    public async Task DeploymentLoadTopic_ApplyValueRejectsMalformedKey()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21110);
+        var publisher = CreateDeploymentLoadPublisher(local, new FakeSiloStatusOracle());
+        var topic = CreateDeploymentLoadTopic(publisher, serializer);
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("not-a-silo-address", 1),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(CreateStatistics(DateTime.UtcNow)),
+        };
+
+        var result = await topic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Rejected, result);
+    }
+
+    [Fact]
+    public async Task DeploymentLoadTopic_ApplyValueRejectsNullDeserializedPayload()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21111);
+        var peer = CreateSilo(21112);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var topic = CreateDeploymentLoadTopic(publisher, serializer);
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest(peer.ToParsableString(), 1),
+            Root = peer,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray<SiloRuntimeStatistics>(null!),
+        };
+
+        var result = await topic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Rejected, result);
+    }
+
+    [Fact]
+    public async Task DeploymentLoadTopic_ApplyValueDelegatesResultToPublisher()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21113);
+        var peer = CreateSilo(21114);
+        var statusOracle = new FakeSiloStatusOracle();
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var topic = CreateDeploymentLoadTopic(publisher, serializer);
+
+        DisseminationValue CreateValue(DateTime dateTime) => new()
+        {
+            Digest = new DisseminationTopicDigest(peer.ToParsableString(), dateTime.Ticks),
+            Root = peer,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(CreateStatistics(dateTime)),
+        };
+
+        var rejectedResult = await topic.ApplyValue(CreateValue(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)), CancellationToken.None);
+
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var appliedResult = await topic.ApplyValue(CreateValue(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)), CancellationToken.None);
+        var duplicateResult = await topic.ApplyValue(CreateValue(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)), CancellationToken.None);
+        var obsoleteResult = await topic.ApplyValue(CreateValue(new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc)), CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Rejected, rejectedResult);
+        Assert.Equal(DisseminationApplyResult.Applied, appliedResult);
+        Assert.Equal(DisseminationApplyResult.Duplicate, duplicateResult);
+        Assert.Equal(DisseminationApplyResult.Obsolete, obsoleteResult);
+    }
+
+    [Fact]
+    public async Task DeploymentLoadTopic_OnFallbackRequiredRefreshesStatisticsWhenEnabledForValidSilo()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21115);
+        var peer = CreateSilo(21116);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var remoteStatistics = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var grainFactory = new RecordingGrainFactory
+        {
+            Resolver = (_, _) => new FakeSiloControl(() => Task.FromResult(remoteStatistics)),
+        };
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, grainFactory);
+        var topic = CreateDeploymentLoadTopic(publisher, serializer, configure: options => options.Dissemination.FallbackEnabled = true);
+
+        await topic.OnFallbackRequired(peer: null, new DisseminationTopicDigest(peer.ToParsableString(), 1), CancellationToken.None);
+
+        Assert.Single(grainFactory.SystemTargetRequests);
+        Assert.Equal(remoteStatistics.DateTime, publisher.PeriodicStatistics[peer].DateTime);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public async Task DeploymentLoadTopic_OnFallbackRequiredSkipsRefreshWhenDisabledOrKeyInvalid(bool fallbackEnabled, bool validKey)
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21117);
+        var peer = CreateSilo(21118);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var grainFactory = new RecordingGrainFactory();
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, grainFactory);
+        var topic = CreateDeploymentLoadTopic(publisher, serializer, configure: options => options.Dissemination.FallbackEnabled = fallbackEnabled);
+        var key = validKey ? peer.ToParsableString() : "not-a-silo-address";
+
+        await topic.OnFallbackRequired(peer: null, new DisseminationTopicDigest(key, 1), CancellationToken.None);
+
+        Assert.Empty(grainFactory.SystemTargetRequests);
+    }
+
+    [Fact]
+    public void OrleansTransport_GetMembershipOrdersAndFiltersByStatus()
+    {
+        var local = CreateSilo(21201);
+        var active1 = CreateSilo(21202);
+        var active2 = CreateSilo(21203);
+        var joining = CreateSilo(21204);
+        var shuttingDown = CreateSilo(21205);
+        var stopping = CreateSilo(21206);
+        var dead = CreateSilo(21207);
+        var created = CreateSilo(21208);
+        var snapshot = CreateMembershipSnapshot(
+            1,
+            CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch),
+            CreateMembershipEntry(active2, SiloStatus.Active, DateTime.UnixEpoch.AddSeconds(2)),
+            CreateMembershipEntry(active1, SiloStatus.Active, DateTime.UnixEpoch.AddSeconds(1)),
+            CreateMembershipEntry(joining, SiloStatus.Joining, DateTime.UnixEpoch),
+            CreateMembershipEntry(shuttingDown, SiloStatus.ShuttingDown, DateTime.UnixEpoch),
+            CreateMembershipEntry(stopping, SiloStatus.Stopping, DateTime.UnixEpoch),
+            CreateMembershipEntry(dead, SiloStatus.Dead, DateTime.UnixEpoch),
+            CreateMembershipEntry(created, SiloStatus.Created, DateTime.UnixEpoch));
+        var membershipManager = new FakeMembershipManager(snapshot);
+        var transport = new OrleansDisseminationTransport(new FakeLocalSiloDetails(local), membershipManager, new RecordingGrainFactory());
+
+        var membership = transport.GetMembership();
+
+        Assert.Equal(new[] { local, active1, active2, joining, shuttingDown, stopping }, membership.AllMembers);
+        Assert.DoesNotContain(dead, membership.AllMembers);
+        Assert.DoesNotContain(created, membership.AllMembers);
+        Assert.Equal(new[] { local, active1, active2 }, membership.ActiveMembers);
+    }
+
+    [Fact]
+    public void OrleansTransport_GetMembershipCachesResultUntilMembershipVersionChanges()
+    {
+        var local = CreateSilo(21209);
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var membershipManager = new FakeMembershipManager(snapshot);
+        var transport = new OrleansDisseminationTransport(new FakeLocalSiloDetails(local), membershipManager, new RecordingGrainFactory());
+
+        var first = transport.GetMembership();
+        var second = transport.GetMembership();
+
+        Assert.True(first.AllMembers == second.AllMembers);
+        Assert.True(first.ActiveMembers == second.ActiveMembers);
+
+        var peer = CreateSilo(21210);
+        membershipManager.CurrentSnapshot = CreateMembershipSnapshot(
+            2,
+            CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch),
+            CreateMembershipEntry(peer, SiloStatus.Active, DateTime.UnixEpoch));
+        var third = transport.GetMembership();
+
+        Assert.False(first.AllMembers == third.AllMembers);
+        Assert.Equal(2, third.AllMembers.Length);
+    }
+
+    [Fact]
+    public async Task OrleansTransport_RefreshMembershipDelegatesToMembershipManager()
+    {
+        var local = CreateSilo(21211);
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var membershipManager = new FakeMembershipManager(snapshot);
+        var transport = new OrleansDisseminationTransport(new FakeLocalSiloDetails(local), membershipManager, new RecordingGrainFactory());
+
+        await transport.RefreshMembership(CancellationToken.None);
+
+        var refreshCall = Assert.Single(membershipManager.RefreshCalls);
+        Assert.Null(refreshCall);
+    }
+
+    [Fact]
+    public async Task OrleansTransport_SendGossipDelegatesToDisseminationSystemTarget()
+    {
+        var local = CreateSilo(21212);
+        var peer = CreateSilo(21213);
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var membershipManager = new FakeMembershipManager(snapshot);
+        DisseminationGossipBatch? receivedBatch = null;
+        var grainFactory = new RecordingGrainFactory
+        {
+            Resolver = (_, _) => new FakeDisseminationSystemTarget(pushGossip: (batch, _) =>
+            {
+                receivedBatch = batch;
+                return Task.CompletedTask;
+            }),
+        };
+        var transport = new OrleansDisseminationTransport(new FakeLocalSiloDetails(local), membershipManager, grainFactory);
+        var batchToSend = new DisseminationGossipBatch { Sender = local };
+
+        await transport.SendGossip(peer, batchToSend, CancellationToken.None);
+
+        var request = Assert.Single(grainFactory.SystemTargetRequests);
+        Assert.Equal(typeof(IDisseminationSystemTarget), request.Interface);
+        Assert.Equal(peer, request.Destination);
+        Assert.Same(batchToSend, receivedBatch);
+    }
+
+    [Fact]
+    public async Task OrleansTransport_ExchangeAntiEntropyDelegatesToDisseminationSystemTarget()
+    {
+        var local = CreateSilo(21214);
+        var peer = CreateSilo(21215);
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var membershipManager = new FakeMembershipManager(snapshot);
+        var expectedResponse = new DisseminationAntiEntropyResponse { Sender = peer };
+        var grainFactory = new RecordingGrainFactory
+        {
+            Resolver = (_, _) => new FakeDisseminationSystemTarget(exchangeAntiEntropy: (_, _) => Task.FromResult(expectedResponse)),
+        };
+        var transport = new OrleansDisseminationTransport(new FakeLocalSiloDetails(local), membershipManager, grainFactory);
+        var request = new DisseminationAntiEntropyRequest { Sender = local };
+
+        var response = await transport.ExchangeAntiEntropy(peer, request, CancellationToken.None);
+
+        Assert.Same(expectedResponse, response);
+    }
+
+    [Fact]
+    public async Task DisseminationService_PublishQueuesGossipAndStopAsyncFlushesIt()
+    {
+        var local = CreateSilo(21301);
+        var peers = Enumerable.Range(21302, 4).Select(CreateSilo).ToArray();
+        var transport = new FakeTransport(local, peers);
+        var topic = new FakeTopic(local);
+        var service = CreateService(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
+        var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
+
+        var result = await service.Publish(topic.Name, item, peers, CancellationToken.None);
+        Assert.True(result);
+        Assert.Empty(transport.GossipBatches);
+
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Equal(GetOriginatorTreeTargets(local, peers, fanout: 2), transport.GossipBatches.Select(batch => batch.Peer));
+    }
+
+    [Fact]
+    public async Task DisseminationService_ReceiveGossipAppliesValuesToTopic()
+    {
+        var local = CreateSilo(21303);
+        var sender = CreateSilo(21304);
+        var transport = new FakeTransport(local, sender);
+        var topic = new FakeTopic(local);
+        var service = CreateService(transport, topic);
+        var value = topic.CreateItem(sender, FakeTopic.DefaultKey, sequence: 5);
+        var batch = CreateGossipBatch(sender, value);
+
+        await service.ReceiveGossip(batch, CancellationToken.None);
+
+        Assert.Equal(1, topic.ApplyCounts[FakeTopic.DefaultKey]);
+        Assert.Equal(5, topic.GetVersion(FakeTopic.DefaultKey));
+    }
+
+    [Fact]
+    public async Task DisseminationService_ReceiveAntiEntropyReturnsLocalValuesNewerThanRequestDigest()
+    {
+        var local = CreateSilo(21305);
+        var peer = CreateSilo(21306);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        topic.SetValue(FakeTopic.DefaultKey, 3);
+        var service = CreateService(transport, topic);
+        var request = new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            DigestsByTopic = CreateAntiEntropyRequestDigests(topic.Name, new DisseminationTopicDigest(FakeTopic.DefaultKey, 1)),
+        };
+
+        var response = await service.ReceiveAntiEntropy(request, CancellationToken.None);
+
+        var value = Assert.Single(GetAntiEntropyResponseValues(response));
+        Assert.Equal(3, BitConverter.ToInt64(value.Payload.Span));
+    }
+
+    [Fact]
+    public async Task DisseminationService_StopAsyncWithoutStartAsyncCompletesWithoutThrowing()
+    {
+        var local = CreateSilo(21309);
+        var transport = new FakeTransport(local);
+        var topic = new FakeTopic(local);
+        var service = CreateService(transport, topic);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DisseminationService_StopAsyncPropagatesItsCancellationTokenToPendingGossipSends()
+    {
+        var local = CreateSilo(21501);
+        var peers = Enumerable.Range(21502, 3).Select(CreateSilo).ToArray();
+        var transport = new FakeTransport(local, peers);
+        var topic = new FakeTopic(local);
+        var service = CreateService(transport, topic, options => options.Overlay.FanOutFactor = static _ => 3);
+        var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
+        var observedTokens = new List<CancellationToken>();
+        transport.SendGossipHandler = (target, batch, cancellationToken) =>
+        {
+            observedTokens.Add(cancellationToken);
+            return Task.CompletedTask;
+        };
+        using var cts = new CancellationTokenSource();
+
+        await service.Publish(topic.Name, item, peers, CancellationToken.None);
+        await service.StopAsync(cts.Token);
+
+        Assert.NotEmpty(observedTokens);
+        Assert.All(observedTokens, token => Assert.Equal(cts.Token, token));
+    }
+
+    [Fact]
+    public async Task DisseminationService_RunAntiEntropyPropagatesItsCancellationTokenToTransport()
+    {
+        var local = CreateSilo(21503);
+        var peers = Enumerable.Range(21504, 3).Select(CreateSilo).ToArray();
+        var transport = new FakeTransport(local, peers);
+        var topic = new FakeTopic(local);
+        topic.SetValue(FakeTopic.DefaultKey, 1);
+        var service = CreateService(transport, topic, options => options.Overlay.AntiEntropyPeerCount = 3);
+        using var cts = new CancellationTokenSource();
+
+        await service.RunAntiEntropy(cts.Token);
+
+        Assert.NotEmpty(transport.ExchangeAntiEntropyCancellationTokens);
+        Assert.All(transport.ExchangeAntiEntropyCancellationTokens, token => Assert.Equal(cts.Token, token));
+    }
+
+    [Fact]
+    public async Task MembershipGossiper_NoOpWhenNoPartners()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var gossiper = new MembershipGossiper(services, NullLogger<MembershipGossiper>.Instance);
+        var local = CreateSilo(21401);
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+
+        await gossiper.GossipToRemoteSilos(new List<SiloAddress>(), snapshot, local, SiloStatus.Active);
+    }
+
+    [Fact]
+    public async Task MembershipGossiper_UsesDisseminationWhenTopicIsEnabledAndPublishSucceeds()
+    {
+        var local = CreateSilo(21402);
+        var peer = CreateSilo(21403);
+        using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serializerProvider.GetRequiredService<Serializer>();
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var membershipManager = new FakeMembershipManager(snapshot);
+        var membershipTopic = CreateMembershipTopic(local, membershipManager, serializer, options => options.Dissemination.Enabled = true);
+        var transport = new FakeTransport(local, peer);
+        var disseminationService = CreateService(transport, new IDisseminationTopic[] { membershipTopic });
+        var services = new ServiceCollection()
+            .AddSingleton(disseminationService)
+            .AddSingleton(membershipTopic)
+            .AddSingleton<ILocalSiloDetails>(new FakeLocalSiloDetails(local))
+            .BuildServiceProvider();
+        var gossiper = new MembershipGossiper(services, NullLogger<MembershipGossiper>.Instance);
+
+        // Must not throw: MembershipSystemTarget is deliberately not registered, so any fallback attempt would fail.
+        await gossiper.GossipToRemoteSilos(new List<SiloAddress> { peer }, snapshot, local, SiloStatus.Active);
+
+        await disseminationService.StopAsync(CancellationToken.None);
+        Assert.NotEmpty(transport.GossipBatches);
+    }
+
+    [Fact]
+    public async Task MembershipGossiper_FallsBackWhenDisseminationServiceNotRegistered()
+    {
+        var local = CreateSilo(21404);
+        var peer = CreateSilo(21405);
+        using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serializerProvider.GetRequiredService<Serializer>();
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var membershipTopic = CreateMembershipTopic(local, new FakeMembershipManager(snapshot), serializer, options => options.Dissemination.Enabled = true);
+        var services = new ServiceCollection()
+            .AddSingleton(membershipTopic)
+            .AddSingleton<ILocalSiloDetails>(new FakeLocalSiloDetails(local))
+            .BuildServiceProvider();
+        var gossiper = new MembershipGossiper(services, NullLogger<MembershipGossiper>.Instance);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => gossiper.GossipToRemoteSilos(new List<SiloAddress> { peer }, snapshot, local, SiloStatus.Active));
+    }
+
+    [Fact]
+    public async Task MembershipGossiper_FallsBackWhenMembershipTopicNotRegistered()
+    {
+        var local = CreateSilo(21406);
+        var peer = CreateSilo(21407);
+        var transport = new FakeTransport(local, peer);
+        var disseminationService = CreateService(transport, Array.Empty<IDisseminationTopic>());
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var services = new ServiceCollection()
+            .AddSingleton(disseminationService)
+            .AddSingleton<ILocalSiloDetails>(new FakeLocalSiloDetails(local))
+            .BuildServiceProvider();
+        var gossiper = new MembershipGossiper(services, NullLogger<MembershipGossiper>.Instance);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => gossiper.GossipToRemoteSilos(new List<SiloAddress> { peer }, snapshot, local, SiloStatus.Active));
+    }
+
+    [Fact]
+    public async Task MembershipGossiper_FallsBackWhenMembershipTopicDisabled()
+    {
+        var local = CreateSilo(21408);
+        var peer = CreateSilo(21409);
+        using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serializerProvider.GetRequiredService<Serializer>();
+        var snapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var membershipTopic = CreateMembershipTopic(local, new FakeMembershipManager(snapshot), serializer, options => options.Dissemination.Enabled = false);
+        var transport = new FakeTransport(local, peer);
+        var disseminationService = CreateService(transport, new IDisseminationTopic[] { membershipTopic });
+        var services = new ServiceCollection()
+            .AddSingleton(disseminationService)
+            .AddSingleton(membershipTopic)
+            .AddSingleton<ILocalSiloDetails>(new FakeLocalSiloDetails(local))
+            .BuildServiceProvider();
+        var gossiper = new MembershipGossiper(services, NullLogger<MembershipGossiper>.Instance);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => gossiper.GossipToRemoteSilos(new List<SiloAddress> { peer }, snapshot, local, SiloStatus.Active));
+    }
+
     private static DisseminationProtocol CreateProtocol(
         FakeTransport transport,
         FakeTopic topic,
@@ -936,17 +2059,97 @@ public class DisseminationProtocolTests
     private static DisseminationService CreateService(
         FakeTransport transport,
         FakeTopic topic,
-        Action<DisseminationOptions>? configure = null)
+        Action<DisseminationOptions>? configure = null) =>
+        CreateService(transport, new IDisseminationTopic[] { topic }, configure);
+
+    private static DisseminationService CreateService(
+        IDisseminationTransport transport,
+        IReadOnlyList<IDisseminationTopic> topics,
+        Action<DisseminationOptions>? configure = null,
+        TimeProvider? timeProvider = null)
     {
         var options = new DisseminationOptions { Enabled = true };
         configure?.Invoke(options);
         return new DisseminationService(
             transport,
             new TestOptionsMonitor<DisseminationOptions>(options),
-            new[] { topic },
-            TimeProvider.System,
+            topics,
+            timeProvider ?? TimeProvider.System,
             NullLogger<DisseminationProtocol>.Instance);
     }
+
+    private static SystemTargetShared CreateSystemTargetShared(SiloAddress localSilo) => new(
+        runtimeClient: null!,
+        new FakeLocalSiloDetails(localSilo),
+        NullLoggerFactory.Instance,
+        Options.Create(new SchedulingOptions()),
+        grainReferenceActivator: null!,
+        timerRegistry: null!,
+        activations: new ActivationDirectory(CreateCatalogInstruments()),
+        schedulerInstruments: CreateSchedulerInstruments(),
+        grainInstruments: CreateGrainInstruments(),
+        messagingInstruments: CreateMessagingInstruments(),
+        messagingProcessingInstruments: CreateMessagingProcessingInstruments());
+
+    private static CatalogInstruments CreateCatalogInstruments() => CreateInstruments<CatalogInstruments>();
+
+    private static SchedulerInstruments CreateSchedulerInstruments() => CreateInstruments<SchedulerInstruments>();
+
+    private static GrainInstruments CreateGrainInstruments() => CreateInstruments<GrainInstruments>();
+
+    private static MessagingInstruments CreateMessagingInstruments() => CreateInstruments<MessagingInstruments>();
+
+    private static MessagingProcessingInstruments CreateMessagingProcessingInstruments() => CreateInstruments<MessagingProcessingInstruments>();
+
+    private static T CreateInstruments<T>() where T : class
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
+        services.AddSingleton<T>();
+        return services.BuildServiceProvider().GetRequiredService<T>();
+    }
+
+    private static DeploymentLoadPublisher CreateDeploymentLoadPublisher(
+        SiloAddress local,
+        FakeSiloStatusOracle statusOracle,
+        IInternalGrainFactory? grainFactory = null,
+        IServiceProvider? serviceProvider = null) =>
+        new(
+            new FakeLocalSiloDetails(local),
+            statusOracle,
+            Options.Create(new DeploymentLoadPublisherOptions()),
+            grainFactory ?? new RecordingGrainFactory(),
+            NullLoggerFactory.Instance,
+            new ActivationDirectory(CreateCatalogInstruments()),
+            activationWorkingSet: null!,
+            environmentStatisticsProvider: null!,
+            Options.Create(new LoadSheddingOptions()),
+            serviceProvider ?? new ServiceCollection().BuildServiceProvider(),
+            CreateSystemTargetShared(local));
+
+    private static DeploymentLoadStatisticsDisseminationTopic CreateDeploymentLoadTopic(
+        DeploymentLoadPublisher publisher,
+        Serializer serializer,
+        Action<DeploymentLoadPublisherOptions>? configure = null,
+        TimeProvider? timeProvider = null)
+    {
+        var options = new DeploymentLoadPublisherOptions();
+        configure?.Invoke(options);
+        return new DeploymentLoadStatisticsDisseminationTopic(
+            publisher,
+            new TestOptionsMonitor<DeploymentLoadPublisherOptions>(options),
+            serializer,
+            timeProvider ?? TimeProvider.System);
+    }
+
+    private static SiloRuntimeStatistics CreateStatistics(DateTime dateTime, int activationCount = 0) =>
+        new(
+            activationCount,
+            recentlyUsedActivationCount: 0,
+            new FakeEnvironmentStatisticsProvider(),
+            Options.Create(new LoadSheddingOptions()),
+            dateTime);
 
     private static SiloAddress CreateSilo(int port) => SiloAddress.New(new IPEndPoint(IPAddress.Loopback, port), port);
 
@@ -1006,13 +2209,18 @@ public class DisseminationProtocolTests
     private static MembershipDisseminationTopic CreateMembershipTopic(
         SiloAddress local,
         FakeMembershipManager membershipManager,
-        Serializer serializer) =>
-        new(
+        Serializer serializer,
+        Action<ClusterMembershipOptions>? configure = null)
+    {
+        var options = new ClusterMembershipOptions();
+        configure?.Invoke(options);
+        return new(
             membershipManager,
-            new TestOptionsMonitor<ClusterMembershipOptions>(new ClusterMembershipOptions()),
+            new TestOptionsMonitor<ClusterMembershipOptions>(options),
             serializer,
             TimeProvider.System,
             new FakeLocalSiloDetails(local));
+    }
 
     private static MembershipTableSnapshot CreateMembershipSnapshot(long version, params MembershipEntry[] entries) =>
         new(new MembershipVersion(version), entries.ToImmutableDictionary(static entry => entry.SiloAddress));
@@ -1458,12 +2666,15 @@ public class DisseminationProtocolTests
             return Task.CompletedTask;
         }
 
+        public List<CancellationToken> ExchangeAntiEntropyCancellationTokens { get; } = new();
+
         public ValueTask<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(
             SiloAddress peer,
             DisseminationAntiEntropyRequest request,
             CancellationToken cancellationToken)
         {
             AntiEntropyRequests.Add((peer, request));
+            ExchangeAntiEntropyCancellationTokens.Add(cancellationToken);
             return ExchangeAntiEntropyHandler(peer, request);
         }
 
@@ -1538,7 +2749,13 @@ public class DisseminationProtocolTests
 
         public Task<bool> TrySuspectSilo(SiloAddress silo, SiloAddress? indirectProbingSilo, CancellationToken cancellationToken) => Task.FromResult(false);
 
-        public Task Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken) => Task.CompletedTask;
+        public List<MembershipVersion?> RefreshCalls { get; } = new();
+
+        public Task Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken)
+        {
+            RefreshCalls.Add(targetVersion);
+            return Task.CompletedTask;
+        }
 
         public Task ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken)
         {
@@ -1585,6 +2802,173 @@ public class DisseminationProtocolTests
         public T Get(string? name) => currentValue;
 
         public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private sealed class FakeSiloStatusOracle : ISiloStatusOracle
+    {
+        private readonly Dictionary<SiloAddress, SiloStatus> _statuses = new();
+
+        public SiloStatus CurrentStatus => SiloStatus.Active;
+
+        public string SiloName => "local";
+
+        public SiloAddress SiloAddress { get; set; } = default!;
+
+        public void SetStatus(SiloAddress silo, SiloStatus status) => _statuses[silo] = status;
+
+        public SiloAddress[] GetActiveSilos() =>
+            _statuses.Where(static kvp => kvp.Value == SiloStatus.Active).Select(static kvp => kvp.Key).ToArray();
+
+        public SiloStatus GetApproximateSiloStatus(SiloAddress siloAddress) =>
+            _statuses.TryGetValue(siloAddress, out var status) ? status : SiloStatus.None;
+
+        public Dictionary<SiloAddress, SiloStatus> GetApproximateSiloStatuses(bool onlyActive = false) =>
+            _statuses
+                .Where(kvp => !onlyActive || kvp.Value == SiloStatus.Active)
+                .ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value);
+
+        public bool TryGetSiloName(SiloAddress siloAddress, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? siloName)
+        {
+            siloName = siloAddress.ToParsableString();
+            return true;
+        }
+
+        public bool IsFunctionalDirectory(SiloAddress siloAddress) => true;
+
+        public bool IsDeadSilo(SiloAddress silo) => _statuses.TryGetValue(silo, out var status) && status == SiloStatus.Dead;
+
+        public bool SubscribeToSiloStatusEvents(ISiloStatusListener observer) => true;
+
+        public bool UnSubscribeFromSiloStatusEvents(ISiloStatusListener observer) => true;
+    }
+
+    private sealed class FakeEnvironmentStatisticsProvider : Orleans.Statistics.IEnvironmentStatisticsProvider
+    {
+        public Orleans.Statistics.EnvironmentStatistics GetEnvironmentStatistics() => default;
+    }
+
+    private sealed class FakeSiloControl(Func<Task<SiloRuntimeStatistics>>? getRuntimeStatistics = null) : ISiloControl
+    {
+        public Task<SiloRuntimeStatistics> GetRuntimeStatistics() =>
+            getRuntimeStatistics?.Invoke() ?? throw new NotSupportedException();
+
+        public Task Ping(string message) => throw new NotSupportedException();
+
+        public Task ForceGarbageCollection() => throw new NotSupportedException();
+
+        public Task ForceActivationCollection(TimeSpan ageLimit) => throw new NotSupportedException();
+
+        public Task ForceRuntimeStatisticsCollection() => throw new NotSupportedException();
+
+        public Task<List<Tuple<GrainId, string, int>>> GetGrainStatistics() => throw new NotSupportedException();
+
+        public Task<List<DetailedGrainStatistic>> GetDetailedGrainStatistics(string[]? types = null) => throw new NotSupportedException();
+
+        public Task<SimpleGrainStatistic[]> GetSimpleGrainStatistics() => throw new NotSupportedException();
+
+        public Task<DetailedGrainReport> GetDetailedGrainReport(GrainId grainId) => throw new NotSupportedException();
+
+        public Task<int> GetActivationCount() => throw new NotSupportedException();
+
+        public Task MigrateRandomActivations(SiloAddress target, int count) => throw new NotSupportedException();
+
+        public Task<object?> SendControlCommandToProvider<T>(string providerName, int command, object? arg) where T : IControllable =>
+            throw new NotSupportedException();
+
+        public Task<List<GrainId>> GetActiveGrains(GrainType grainType) => throw new NotSupportedException();
+
+        public Task SetCompatibilityStrategy(CompatibilityStrategy strategy) => throw new NotSupportedException();
+
+        public Task SetSelectorStrategy(VersionSelectorStrategy strategy) => throw new NotSupportedException();
+
+        public Task SetCompatibilityStrategy(GrainInterfaceType interfaceType, CompatibilityStrategy strategy) => throw new NotSupportedException();
+
+        public Task SetSelectorStrategy(GrainInterfaceType interfaceType, VersionSelectorStrategy strategy) => throw new NotSupportedException();
+    }
+
+    private sealed class FakeDisseminationSystemTarget(
+        Func<DisseminationGossipBatch, CancellationToken, Task>? pushGossip = null,
+        Func<DisseminationAntiEntropyRequest, CancellationToken, Task<DisseminationAntiEntropyResponse>>? exchangeAntiEntropy = null) : IDisseminationSystemTarget
+    {
+        public Task PushGossip(DisseminationGossipBatch batch, CancellationToken cancellationToken) =>
+            pushGossip?.Invoke(batch, cancellationToken) ?? Task.CompletedTask;
+
+        public Task<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(DisseminationAntiEntropyRequest request, CancellationToken cancellationToken) =>
+            exchangeAntiEntropy?.Invoke(request, cancellationToken) ?? Task.FromResult(new DisseminationAntiEntropyResponse { Sender = request.Sender });
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IInternalGrainFactory"/> fake that records <see cref="GetSystemTarget{TGrainInterface}(GrainType, SiloAddress)"/>
+    /// requests and resolves them via a configurable delegate. All other members are unused by the dissemination
+    /// subsystem and therefore throw if invoked.
+    /// </summary>
+    private sealed class RecordingGrainFactory : IInternalGrainFactory
+    {
+        public List<(Type Interface, SiloAddress Destination)> SystemTargetRequests { get; } = new();
+
+        public Func<Type, SiloAddress, object>? Resolver { get; set; }
+
+        public TGrainInterface GetSystemTarget<TGrainInterface>(GrainType grainType, SiloAddress destination) where TGrainInterface : ISystemTarget
+        {
+            SystemTargetRequests.Add((typeof(TGrainInterface), destination));
+            if (Resolver is { } resolver)
+            {
+                return (TGrainInterface)resolver(typeof(TGrainInterface), destination);
+            }
+
+            throw new NotSupportedException($"No resolver configured for {typeof(TGrainInterface)}.");
+        }
+
+        public TGrainInterface GetSystemTarget<TGrainInterface>(GrainId grainId) where TGrainInterface : ISystemTarget =>
+            throw new NotSupportedException();
+
+        public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IAddressable obj) where TGrainObserverInterface : IAddressable =>
+            throw new NotSupportedException();
+
+        public TGrainInterface Cast<TGrainInterface>(IAddressable grain) => throw new NotSupportedException();
+
+        public object Cast(IAddressable grain, Type interfaceType) => throw new NotSupportedException();
+
+        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string? grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidKey =>
+            throw new NotSupportedException();
+
+        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string? grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerKey =>
+            throw new NotSupportedException();
+
+        public TGrainInterface GetGrain<TGrainInterface>(string primaryKey, string? grainClassNamePrefix = null) where TGrainInterface : IGrainWithStringKey =>
+            throw new NotSupportedException();
+
+        public TGrainInterface GetGrain<TGrainInterface>(Guid primaryKey, string keyExtension, string? grainClassNamePrefix = null) where TGrainInterface : IGrainWithGuidCompoundKey =>
+            throw new NotSupportedException();
+
+        public TGrainInterface GetGrain<TGrainInterface>(long primaryKey, string keyExtension, string? grainClassNamePrefix = null) where TGrainInterface : IGrainWithIntegerCompoundKey =>
+            throw new NotSupportedException();
+
+        public TGrainObserverInterface CreateObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver =>
+            throw new NotSupportedException();
+
+        public void DeleteObjectReference<TGrainObserverInterface>(IGrainObserver obj) where TGrainObserverInterface : IGrainObserver =>
+            throw new NotSupportedException();
+
+        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey) => throw new NotSupportedException();
+
+        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey) => throw new NotSupportedException();
+
+        public IGrain GetGrain(Type grainInterfaceType, string grainPrimaryKey) => throw new NotSupportedException();
+
+        public IGrain GetGrain(Type grainInterfaceType, Guid grainPrimaryKey, string keyExtension) => throw new NotSupportedException();
+
+        public IGrain GetGrain(Type grainInterfaceType, long grainPrimaryKey, string keyExtension) => throw new NotSupportedException();
+
+        public TGrainInterface GetGrain<TGrainInterface>(GrainId grainId) where TGrainInterface : IAddressable => throw new NotSupportedException();
+
+        public IAddressable GetGrain(GrainId grainId) => throw new NotSupportedException();
+
+        public IAddressable GetGrain(GrainId grainId, GrainInterfaceType interfaceType) => throw new NotSupportedException();
+
+        public IAddressable GetGrain(Type interfaceType, IdSpan grainKey, string grainClassNamePrefix) => throw new NotSupportedException();
+
+        public IAddressable GetGrain(Type interfaceType, IdSpan grainKey) => throw new NotSupportedException();
     }
 
     private sealed class TestTimeProvider : TimeProvider

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -467,7 +467,7 @@ public class DisseminationProtocolTests
             });
 
             var state = protocol.CreateAntiEntropyState();
-            var peers = state.PeersByTopic[topic.Name];
+            var peers = state.Topics[topic.Name].Peers;
             var expectedCandidates = GetAntiEntropyCandidateIndexes(testCase.LocalIndex, testCase.Count, testCase.Fanout)
                 .Where(index => index != testCase.LocalIndex)
                 .Select(index => silos[index])
@@ -510,8 +510,8 @@ public class DisseminationProtocolTests
 
                 var state = protocol.CreateAntiEntropyState();
 
-                Assert.Equal(expectedFirst, state.PeersByTopic[firstTopic.Name]);
-                Assert.Equal(expectedSecond, state.PeersByTopic[secondTopic.Name]);
+                Assert.Equal(expectedFirst, state.Topics[firstTopic.Name].Peers);
+                Assert.Equal(expectedSecond, state.Topics[secondTopic.Name].Peers);
                 return;
             }
         }
@@ -587,18 +587,18 @@ public class DisseminationProtocolTests
         }, CancellationToken.None);
 
         var recentState = protocol.CreateAntiEntropyState();
-        Assert.Empty(recentState.Digests);
+        Assert.Empty(recentState.Topics);
         var recentResponses = await protocol.ExchangeAntiEntropy(recentState, CancellationToken.None);
         Assert.Empty(recentResponses);
         Assert.Empty(transport.AntiEntropyRequests);
 
         timeProvider.Advance(TimeSpan.FromSeconds(2) - TimeSpan.FromMilliseconds(1));
         var beforeCadenceState = protocol.CreateAntiEntropyState();
-        Assert.Empty(beforeCadenceState.Digests);
+        Assert.Empty(beforeCadenceState.Topics);
 
         timeProvider.Advance(TimeSpan.FromMilliseconds(1));
         var staleState = protocol.CreateAntiEntropyState();
-        var digest = Assert.Single(staleState.Digests);
+        var digest = Assert.Single(staleState.Topics[topic.Name].Digests);
         Assert.Equal(FakeTopic.DefaultKey, digest.Key);
     }
 
@@ -766,9 +766,11 @@ public class DisseminationProtocolTests
         var serializer = serviceProvider.GetRequiredService<Serializer>();
         var sourceManager = new FakeMembershipManager(baseSnapshot);
         var sourceTopic = CreateMembershipTopic(local, sourceManager, serializer);
-        var peerDigest = Assert.Single(sourceTopic.GetDigests());
+        var peerTopicDigest = Assert.Single(sourceTopic.GetDigests());
+        var peerDigest = new DisseminationDigest(sourceTopic.Name, peerTopicDigest.Key, peerTopicDigest.Version);
         sourceManager.CurrentSnapshot = updatedSnapshot;
-        var localDigest = Assert.Single(sourceTopic.GetDigests());
+        var localTopicDigest = Assert.Single(sourceTopic.GetDigests());
+        var localDigest = new DisseminationDigest(sourceTopic.Name, localTopicDigest.Key, localTopicDigest.Version);
 
         var value = await sourceTopic.GetValue(
             localDigest,
@@ -1205,16 +1207,16 @@ public class DisseminationProtocolTests
 
         public long GetVersion(string key) => _versions.TryGetValue(key, out var version) ? version : 0;
 
-        public IReadOnlyList<DisseminationDigest> GetDigests()
+        public IReadOnlyList<DisseminationTopicDigest> GetDigests()
         {
             var digests = _versions
-                .Select(entry => new DisseminationDigest(Name, entry.Key, entry.Value))
+                .Select(entry => new DisseminationTopicDigest(entry.Key, entry.Value))
                 .ToList();
             foreach (var key in ExpectedKeys)
             {
                 if (!_versions.ContainsKey(key))
                 {
-                    digests.Add(new DisseminationDigest(Name, key, long.MinValue));
+                    digests.Add(new DisseminationTopicDigest(key, long.MinValue));
                 }
             }
 
@@ -1374,14 +1376,15 @@ public class DisseminationProtocolTests
                 return new ModelRepairResponse(false, 0);
             }
 
+            var fullLocalDigest = new DisseminationDigest(_topic.Name, localDigest.Key, localDigest.Version);
             var peerDigest = new DisseminationDigest(_topic.Name, FakeTopic.DefaultKey, peerVersion);
-            if (_topic.CompareVersion(localDigest, peerDigest) <= 0)
+            if (_topic.CompareVersion(fullLocalDigest, peerDigest) <= 0)
             {
                 return new ModelRepairResponse(false, 0);
             }
 
             var value = await _topic.GetValue(
-                localDigest,
+                fullLocalDigest,
                 peerDigest,
                 CancellationToken.None);
             return value is null

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -274,6 +274,100 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task ReceiveGossipRejectsTopicApplyExceptionAndContinuesBatch()
+    {
+        var local = CreateSilo(11111);
+        var sender = CreateSilo(11112);
+        var transport = new FakeTransport(local, sender);
+        var appliedKeys = new List<string>();
+        var topic = new FakeTopic(local)
+        {
+            ApplyValueHandler = (value, _) =>
+            {
+                if (value.Digest.Key == "malformed")
+                {
+                    throw new InvalidOperationException("Malformed payload.");
+                }
+
+                appliedKeys.Add(value.Digest.Key);
+                return ValueTask.FromResult(DisseminationApplyResult.Applied);
+            },
+        };
+        await using var protocol = CreateProtocol(transport, topic);
+
+        await protocol.ReceiveGossip(
+            CreateGossipBatch(
+                sender,
+                topic.CreateItem(sender, "malformed", sequence: 1),
+                topic.CreateItem(sender, "valid", sequence: 1)),
+            CancellationToken.None);
+
+        Assert.Equal(new[] { "valid" }, appliedKeys);
+    }
+
+    [Fact]
+    public async Task ReceiveGossipRejectsUnrelatedOperationCanceledExceptionAndContinuesBatch()
+    {
+        var local = CreateSilo(11111);
+        var sender = CreateSilo(11112);
+        var transport = new FakeTransport(local, sender);
+        var appliedKeys = new List<string>();
+        var topic = new FakeTopic(local)
+        {
+            ApplyValueHandler = (value, _) =>
+            {
+                if (value.Digest.Key == "canceled")
+                {
+                    throw new OperationCanceledException("Topic operation canceled independently.");
+                }
+
+                appliedKeys.Add(value.Digest.Key);
+                return ValueTask.FromResult(DisseminationApplyResult.Applied);
+            },
+        };
+        await using var protocol = CreateProtocol(transport, topic);
+
+        await protocol.ReceiveGossip(
+            CreateGossipBatch(
+                sender,
+                topic.CreateItem(sender, "canceled", sequence: 1),
+                topic.CreateItem(sender, "valid", sequence: 1)),
+            CancellationToken.None);
+
+        Assert.Equal(new[] { "valid" }, appliedKeys);
+    }
+
+    [Fact]
+    public async Task ReceiveGossipPropagatesCallerCancellationFromTopicApply()
+    {
+        var local = CreateSilo(11111);
+        var sender = CreateSilo(11112);
+        var transport = new FakeTransport(local, sender);
+        var applyAttempts = new List<string>();
+        var topic = new FakeTopic(local)
+        {
+            ApplyValueHandler = (value, cancellationToken) =>
+            {
+                applyAttempts.Add(value.Digest.Key);
+                cancellationToken.ThrowIfCancellationRequested();
+                return ValueTask.FromResult(DisseminationApplyResult.Applied);
+            },
+        };
+        await using var protocol = CreateProtocol(transport, topic);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => protocol.ReceiveGossip(
+            CreateGossipBatch(
+                sender,
+                topic.CreateItem(sender, "first", sequence: 1),
+                topic.CreateItem(sender, "second", sequence: 1)),
+            cancellation.Token));
+
+        Assert.Equal(new[] { "first" }, applyAttempts);
+    }
+
+    [Fact]
     public async Task ReceiveGossipWithMissingRootRefreshesMembershipAndDoesNotForward()
     {
         var root = CreateSilo(11111);
@@ -3391,6 +3485,8 @@ public class DisseminationProtocolTests
 
         public Func<DisseminationTopicDigest, DisseminationTopicDigest?, DisseminationValue?>? GetValueHandler { get; set; }
 
+        public Func<DisseminationValue, CancellationToken, ValueTask<DisseminationApplyResult>>? ApplyValueHandler { get; set; }
+
         public string Name => name;
 
         public DisseminationMembershipScope MembershipScope { get; set; } = DisseminationMembershipScope.ActiveMembers;
@@ -3454,6 +3550,11 @@ public class DisseminationProtocolTests
 
         public ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken)
         {
+            if (ApplyValueHandler is { } handler)
+            {
+                return handler(value, cancellationToken);
+            }
+
             var version = BitConverter.ToInt64(value.Payload.Span);
             if (_versions.TryGetValue(value.Digest.Key, out var current))
             {

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -44,7 +44,7 @@ public class DisseminationProtocolTests
         Assert.True(result);
         var expectedChildren = GetOriginatorTreeTargets(local, peers, fanout: 2);
         Assert.Equal(expectedChildren, transport.GossipBatches.Select(batch => batch.Peer));
-        Assert.All(transport.GossipBatches, batch => Assert.Equal(item.Digest, batch.Batch.Values.Single().Digest));
+        Assert.All(transport.GossipBatches, batch => Assert.Equal(item.Digest, GetGossipValues(batch.Batch).Single().Digest));
     }
 
     [Fact]
@@ -251,11 +251,7 @@ public class DisseminationProtocolTests
         var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
         var item = topic.CreateItem(root, FakeTopic.DefaultKey, sequence: 1);
 
-        await protocol.ReceiveGossip(new DisseminationGossipBatch
-        {
-            Sender = root,
-            Values = [item],
-        }, CancellationToken.None);
+        await protocol.ReceiveGossip(CreateGossipBatch(root, item), CancellationToken.None);
         await protocol.FlushPendingGossip(CancellationToken.None);
 
         var expectedChildren = GetForwardingTreeTargets(local, root, peers, fanout: 2, sender: root);
@@ -273,11 +269,7 @@ public class DisseminationProtocolTests
         var topic = new FakeTopic(local);
         var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
         var item = topic.CreateItem(root, FakeTopic.DefaultKey, sequence: 1);
-        var batch = new DisseminationGossipBatch
-        {
-            Sender = root,
-            Values = [item],
-        };
+        var batch = CreateGossipBatch(root, item);
 
         await protocol.ReceiveGossip(batch, CancellationToken.None);
         await protocol.ReceiveGossip(batch, CancellationToken.None);
@@ -300,11 +292,7 @@ public class DisseminationProtocolTests
         var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
         var item = topic.CreateItem(root, FakeTopic.DefaultKey, sequence: 1);
 
-        await protocol.ReceiveGossip(new DisseminationGossipBatch
-        {
-            Sender = sender,
-            Values = [item],
-        }, CancellationToken.None);
+        await protocol.ReceiveGossip(CreateGossipBatch(sender, item), CancellationToken.None);
         await protocol.FlushPendingGossip(CancellationToken.None);
 
         Assert.Equal(1, topic.GetVersion(FakeTopic.DefaultKey));
@@ -329,11 +317,7 @@ public class DisseminationProtocolTests
         var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
         var item = topic.CreateItem(root, FakeTopic.DefaultKey, sequence: 1);
 
-        await protocol.ReceiveGossip(new DisseminationGossipBatch
-        {
-            Sender = sender,
-            Values = [item],
-        }, CancellationToken.None);
+        await protocol.ReceiveGossip(CreateGossipBatch(sender, item), CancellationToken.None);
         await protocol.FlushPendingGossip(CancellationToken.None);
 
         Assert.Equal(1, topic.GetVersion(FakeTopic.DefaultKey));
@@ -394,7 +378,7 @@ public class DisseminationProtocolTests
         Assert.True(second);
         var batch = Assert.Single(transport.GossipBatches);
         Assert.Equal(peer, batch.Peer);
-        var value = Assert.Single(batch.Batch.Values);
+        var value = Assert.Single(GetGossipValues(batch.Batch));
         Assert.Equal(2, value.Digest.Version);
     }
 
@@ -424,7 +408,7 @@ public class DisseminationProtocolTests
         Assert.True(first);
         Assert.True(second);
         var batch = Assert.Single(transport.GossipBatches);
-        Assert.Equal(new[] { "first", "second" }, batch.Batch.Values.Select(static value => value.Digest.Key));
+        Assert.Equal(new[] { "first", "second" }, GetGossipValues(batch.Batch).Select(static value => value.Digest.Key));
     }
 
     [Fact]
@@ -579,11 +563,9 @@ public class DisseminationProtocolTests
         topic.Options.ExpectedUpdateCadence = TimeSpan.FromSeconds(2);
         var protocol = CreateProtocol(transport, topic, timeProvider: timeProvider);
 
-        await protocol.ReceiveGossip(new DisseminationGossipBatch
-        {
-            Sender = peer,
-            Values = [topic.CreateItem(peer, FakeTopic.DefaultKey, sequence: 1)],
-        }, CancellationToken.None);
+        await protocol.ReceiveGossip(
+            CreateGossipBatch(peer, topic.CreateItem(peer, FakeTopic.DefaultKey, sequence: 1)),
+            CancellationToken.None);
 
         var recentState = protocol.CreateAntiEntropyState();
         Assert.Empty(recentState.Topics);
@@ -893,6 +875,20 @@ public class DisseminationProtocolTests
         {
             [topicName] = [.. digests],
         }.ToFrozenDictionary(StringComparer.Ordinal);
+
+    private static DisseminationGossipBatch CreateGossipBatch(SiloAddress sender, params DisseminationValue[] values) => new()
+    {
+        Sender = sender,
+        ValuesByTopic = values
+            .GroupBy(static value => value.Digest.Topic, StringComparer.Ordinal)
+            .ToFrozenDictionary(
+                static group => group.Key,
+                static group => group.ToImmutableArray(),
+                StringComparer.Ordinal),
+    };
+
+    private static IEnumerable<DisseminationValue> GetGossipValues(DisseminationGossipBatch batch) =>
+        batch.ValuesByTopic.Values.SelectMany(static values => values);
 
     private static MembershipDisseminationTopic CreateMembershipTopic(
         SiloAddress local,

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -2580,6 +2580,38 @@ public class DisseminationProtocolTests
         var service = CreateService(transport, topic);
 
         await service.StopAsync(CancellationToken.None);
+
+        Assert.True(service.IsProtocolDisposed);
+    }
+
+    [Fact]
+    public async Task DisseminationService_DisposeAsyncStopsAndDisposesProtocol()
+    {
+        var local = CreateSilo(21312);
+        var transport = new FakeTransport(local);
+        var topic = new FakeTopic(local);
+        var service = CreateService(transport, topic);
+        await service.StartAsync(CancellationToken.None);
+
+        await service.DisposeAsync();
+        await service.DisposeAsync();
+
+        Assert.False(service.IsAntiEntropyRunning);
+        Assert.True(service.IsProtocolDisposed);
+    }
+
+    [Fact]
+    public async Task DisseminationProtocol_DisposeAsyncDisposesOwnedResources()
+    {
+        var local = CreateSilo(21313);
+        var protocol = CreateProtocol(new FakeTransport(local), new FakeTopic(local));
+
+        await protocol.DisposeAsync();
+        await protocol.DisposeAsync();
+
+        Assert.True(protocol.IsDisposed);
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => protocol.FlushPendingGossip(CancellationToken.None));
     }
 
     [Fact]
@@ -2729,6 +2761,7 @@ public class DisseminationProtocolTests
         });
         await exchangeCompleted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await WaitUntil(() => !service.HasOutstandingAntiEntropyTask);
+        await WaitUntil(() => service.IsProtocolDisposed);
         Assert.Equal(new[] { peer }, service.GetUnconfirmedPeers(topic.Name, topic.MembershipScope));
     }
 

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -192,7 +192,7 @@ public class DisseminationProtocolTests
         await protocol.ReceiveGossip(new DisseminationGossipBatch
         {
             Sender = root,
-            Values = new[] { item },
+            Values = [item],
         }, CancellationToken.None);
         await protocol.FlushPendingGossip(CancellationToken.None);
 
@@ -214,7 +214,7 @@ public class DisseminationProtocolTests
         var batch = new DisseminationGossipBatch
         {
             Sender = root,
-            Values = new[] { item },
+            Values = [item],
         };
 
         await protocol.ReceiveGossip(batch, CancellationToken.None);
@@ -421,10 +421,10 @@ public class DisseminationProtocolTests
         {
             Sender = peer,
             Topics = [topic.Name],
-            Digests = new[]
-            {
+            Digests =
+            [
                 new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 3, FakeTopic.PayloadKind),
-            },
+            ],
         }, CancellationToken.None);
 
         var item = Assert.Single(response.Values);
@@ -503,7 +503,7 @@ public class DisseminationProtocolTests
         transport.ExchangeAntiEntropyHandler = (target, request) => ValueTask.FromResult(new DisseminationAntiEntropyResponse
         {
             Sender = target,
-            Values = new[] { repairItem },
+            Values = [repairItem],
         });
 
         var state = protocol.CreateAntiEntropyState();
@@ -542,7 +542,7 @@ public class DisseminationProtocolTests
             new DisseminationAntiEntropyResponse
             {
                 Sender = peer,
-                Values = new[] { badRepairItem, goodRepairItem },
+                Values = [badRepairItem, goodRepairItem],
             },
         }, CancellationToken.None);
 
@@ -576,9 +576,9 @@ public class DisseminationProtocolTests
                 Sender = target,
                 Values = count switch
                 {
-                    1 => new[] { badRepairItem },
-                    2 => new[] { goodRepairItem },
-                    _ => Array.Empty<DisseminationValue>(),
+                    1 => [badRepairItem],
+                    2 => [goodRepairItem],
+                    _ => [],
                 },
             });
         };
@@ -1132,7 +1132,7 @@ public class DisseminationProtocolTests
 
         public ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken)
         {
-            var version = BitConverter.ToInt64(value.Payload);
+            var version = BitConverter.ToInt64(value.Payload.Span);
             if (_versions.TryGetValue(value.Digest.Key, out var current))
             {
                 if (current > version)

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -1,0 +1,592 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Metadata;
+using Orleans.Runtime;
+using Orleans.Runtime.Dissemination;
+using Xunit;
+
+namespace UnitTests.Dissemination;
+
+[TestCategory("BVT"), TestCategory("Dissemination")]
+public class DisseminationProtocolTests
+{
+    [Fact]
+    public async Task PublishSendsGossipToDeterministicTreeChildren()
+    {
+        var local = CreateSilo(11111);
+        var peers = Enumerable.Range(11112, 6).Select(CreateSilo).ToArray();
+        var transport = new FakeTransport(local, peers);
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.TreeFanout = 2);
+        var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
+
+        var result = await protocol.Publish(topic.Name, item, peers, CancellationToken.None);
+
+        Assert.True(result);
+        var expectedChildren = GetTreeChildren(local, local, peers, fanout: 2);
+        Assert.Equal(expectedChildren, transport.GossipBatches.Select(batch => batch.Peer));
+        Assert.All(transport.GossipBatches, batch => Assert.Equal(item.Id, batch.Batch.Items.Single().Id));
+    }
+
+    [Fact]
+    public async Task PublishReturnsFalseWhenAnyParticipantIsIncapable()
+    {
+        var local = CreateSilo(11111);
+        var peers = Enumerable.Range(11112, 6).Select(CreateSilo).ToArray();
+        var transport = new FakeTransport(local, peers)
+        {
+            IncapablePeers = { peers[^1] },
+        };
+
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.TreeFanout = 2);
+        var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
+
+        var result = await protocol.Publish(topic.Name, item, peers, CancellationToken.None);
+
+        Assert.False(result);
+        Assert.Empty(transport.GossipBatches);
+    }
+
+    [Fact]
+    public async Task CapabilityProbeFailureUsesFailureBackoffInsteadOfCapabilityCache()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var timeProvider = new TestTimeProvider();
+        var probeCount = 0;
+        transport.GetCapabilitiesHandler = (target, request, cancellationToken) =>
+        {
+            if (Interlocked.Increment(ref probeCount) == 1)
+            {
+                timeProvider.Advance(TimeSpan.FromSeconds(10));
+                throw new InvalidOperationException("transient probe failure");
+            }
+
+            return ValueTask.FromResult(transport.CreateCapabilityResponse(target, request));
+        };
+
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, options =>
+        {
+            options.CapabilityCacheTtl = TimeSpan.FromHours(1);
+            options.FailureBackoff = TimeSpan.FromSeconds(5);
+        }, timeProvider);
+        var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
+
+        var firstResult = await protocol.Publish(topic.Name, item, new[] { peer }, CancellationToken.None);
+        var secondResult = await protocol.Publish(topic.Name, item, new[] { peer }, CancellationToken.None);
+        timeProvider.Advance(TimeSpan.FromSeconds(5));
+        var thirdResult = await protocol.Publish(topic.Name, item, new[] { peer }, CancellationToken.None);
+
+        Assert.False(firstResult);
+        Assert.False(secondResult);
+        Assert.True(thirdResult);
+        Assert.Equal(2, probeCount);
+        Assert.Single(transport.GossipBatches);
+    }
+
+    [Fact]
+    public async Task ReceiveGossipForwardsOnlyToLocalTreeChildren()
+    {
+        var silos = Enumerable.Range(11111, 8).Select(CreateSilo).OrderBy(GetPeerScore, StringComparer.Ordinal).ToArray();
+        var root = silos[0];
+        var local = silos[1];
+        var peers = silos.Where(silo => !Equals(silo, local)).ToArray();
+        var transport = new FakeTransport(local, peers);
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.TreeFanout = 2);
+        var item = topic.CreateItem(root, FakeTopic.DefaultKey, sequence: 1);
+
+        await protocol.ReceiveGossip(new DisseminationGossipBatch
+        {
+            Sender = root,
+            Items = new[] { item },
+        }, CancellationToken.None);
+
+        var expectedChildren = GetTreeChildren(local, root, peers, fanout: 2);
+        Assert.Equal(expectedChildren, transport.GossipBatches.Select(batch => batch.Peer));
+    }
+
+    [Fact]
+    public async Task DuplicateGossipDoesNotForwardAgain()
+    {
+        var silos = Enumerable.Range(11111, 8).Select(CreateSilo).OrderBy(GetPeerScore, StringComparer.Ordinal).ToArray();
+        var root = silos[0];
+        var local = silos[1];
+        var peers = silos.Where(silo => !Equals(silo, local)).ToArray();
+        var transport = new FakeTransport(local, peers);
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.TreeFanout = 2);
+        var item = topic.CreateItem(root, FakeTopic.DefaultKey, sequence: 1);
+        var batch = new DisseminationGossipBatch
+        {
+            Sender = root,
+            Items = new[] { item },
+        };
+
+        await protocol.ReceiveGossip(batch, CancellationToken.None);
+        await protocol.ReceiveGossip(batch, CancellationToken.None);
+
+        var expectedChildren = GetTreeChildren(local, root, peers, fanout: 2);
+        Assert.Equal(expectedChildren.Count, transport.GossipBatches.Count);
+        Assert.Equal(1, topic.ApplyCounts[item.Id.Key]);
+    }
+
+    [Fact]
+    public async Task TreeRoutingInvalidatesCachedTopologyWhenActivePeersChange()
+    {
+        var local = CreateSilo(11111);
+        var initialPeers = Enumerable.Range(11112, 4).Select(CreateSilo).ToList();
+        var transport = new FakeTransport(local, initialPeers.ToArray());
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.TreeFanout = 2);
+        var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
+
+        var initialResult = await protocol.Publish(topic.Name, item, targetPeers: null, CancellationToken.None);
+        var initialChildren = transport.GossipBatches.Select(batch => batch.Peer).ToArray();
+
+        foreach (var peer in Enumerable.Range(11116, 8).Select(CreateSilo))
+        {
+            transport.Peers.Add(peer);
+            var updatedChildren = GetTreeChildren(local, local, transport.Peers, fanout: 2);
+            if (!initialChildren.SequenceEqual(updatedChildren))
+            {
+                transport.GossipBatches.Clear();
+                var updatedItem = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 2);
+
+                var updatedResult = await protocol.Publish(topic.Name, updatedItem, targetPeers: null, CancellationToken.None);
+
+                Assert.True(initialResult);
+                Assert.True(updatedResult);
+                Assert.Equal(updatedChildren, transport.GossipBatches.Select(batch => batch.Peer));
+                return;
+            }
+        }
+
+        throw new InvalidOperationException("The test did not find a peer set which changes the local tree children.");
+    }
+
+    [Fact]
+    public async Task AntiEntropyResponseIncludesNewerLocalValues()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic);
+        topic.SetValue(FakeTopic.DefaultKey, version: 5);
+
+        var response = await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            Topics = new[]
+            {
+                new DisseminationCapabilityRequest
+                {
+                    Topic = topic.Name,
+                    ProtocolVersion = topic.ProtocolVersion,
+                    PayloadKinds = new[] { FakeTopic.PayloadKind },
+                },
+            },
+            Digests = new[]
+            {
+                new DisseminationItemId(topic.Name, FakeTopic.DefaultKey, version: 3, FakeTopic.PayloadKind),
+            },
+        }, CancellationToken.None);
+
+        var item = Assert.Single(response.Items);
+        Assert.Equal(5, item.Id.Version);
+        Assert.False(response.Truncated);
+    }
+
+    [Fact]
+    public async Task AntiEntropyAppliesReturnedRepairItemsWithoutForwarding()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic);
+        var repairItem = topic.CreateItem(peer, FakeTopic.DefaultKey, sequence: 7);
+        transport.ExchangeAntiEntropyHandler = (target, request) => ValueTask.FromResult(new DisseminationAntiEntropyResponse
+        {
+            Sender = target,
+            Items = new[] { repairItem },
+        });
+
+        var state = protocol.CreateAntiEntropyState();
+        var responses = await protocol.ExchangeAntiEntropy(state, CancellationToken.None);
+        await protocol.ApplyAntiEntropyResponses(responses, CancellationToken.None);
+
+        Assert.Equal(7, topic.GetVersion(FakeTopic.DefaultKey));
+        Assert.Empty(transport.GossipBatches);
+        Assert.Single(transport.AntiEntropyRequests);
+        Assert.Empty(transport.AntiEntropyRequests[0].Request.Digests);
+        Assert.Equal(topic.Name, Assert.Single(transport.AntiEntropyRequests[0].Request.Topics).Topic);
+    }
+
+    [Fact]
+    public async Task AntiEntropyAppliesValidItemsAfterFailedRepairItem()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic);
+        topic.SetValue(FakeTopic.DefaultKey, version: 1);
+        var badRepairItem = new DisseminationItem
+        {
+            Id = new DisseminationItemId(topic.Name, FakeTopic.DefaultKey, version: 2, FakeTopic.PayloadKind),
+            Root = peer,
+            ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
+            Payload = Array.Empty<byte>(),
+        };
+        var goodRepairItem = topic.CreateItem(peer, FakeTopic.DefaultKey, sequence: 3);
+
+        await protocol.ApplyAntiEntropyResponses(new[]
+        {
+            new DisseminationAntiEntropyResponse
+            {
+                Sender = peer,
+                Items = new[] { badRepairItem, goodRepairItem },
+            },
+        }, CancellationToken.None);
+
+        Assert.Equal(3, topic.GetVersion(FakeTopic.DefaultKey));
+    }
+
+    [Fact]
+    public async Task AntiEntropyLoopContinuesAfterApplyFailure()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        var service = CreateService(transport, topic, options => options.Overlay.AntiEntropyInterval = TimeSpan.FromMilliseconds(1));
+        topic.SetValue(FakeTopic.DefaultKey, version: 1);
+
+        var badRepairItem = new DisseminationItem
+        {
+            Id = new DisseminationItemId(topic.Name, FakeTopic.DefaultKey, version: 2, FakeTopic.PayloadKind),
+            Root = peer,
+            ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
+            Payload = Array.Empty<byte>(),
+        };
+        var goodRepairItem = topic.CreateItem(peer, FakeTopic.DefaultKey, sequence: 3);
+        var exchangeCount = 0;
+        transport.ExchangeAntiEntropyHandler = (target, request) =>
+        {
+            var count = Interlocked.Increment(ref exchangeCount);
+            return ValueTask.FromResult(new DisseminationAntiEntropyResponse
+            {
+                Sender = target,
+                Items = count switch
+                {
+                    1 => new[] { badRepairItem },
+                    2 => new[] { goodRepairItem },
+                    _ => Array.Empty<DisseminationItem>(),
+                },
+            });
+        };
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            await WaitUntil(() => topic.GetVersion(FakeTopic.DefaultKey) == 3);
+
+            Assert.True(Volatile.Read(ref exchangeCount) >= 2);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public void ManifestHashIsIndependentOfDictionaryOrdering()
+    {
+        var manifest1 = CreateManifest(
+            ("grain-b", "placement", "random"),
+            ("grain-a", "placement", "local"));
+        var manifest2 = CreateManifest(
+            ("grain-a", "placement", "local"),
+            ("grain-b", "placement", "random"));
+
+        Assert.Equal(ManifestHashCalculator.ComputeHash(manifest1), ManifestHashCalculator.ComputeHash(manifest2));
+    }
+
+    [Fact]
+    public void OptionsValidatorRejectsInvalidTreeFanout()
+    {
+        var options = new DisseminationOptions();
+        options.Overlay.TreeFanout = 0;
+        var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    private static DisseminationProtocol CreateProtocol(
+        FakeTransport transport,
+        FakeTopic topic,
+        Action<DisseminationOptions>? configure = null,
+        TimeProvider? timeProvider = null)
+    {
+        var options = new DisseminationOptions { Enabled = true };
+        configure?.Invoke(options);
+        return new DisseminationProtocol(
+            transport,
+            new TestOptionsMonitor<DisseminationOptions>(options),
+            new[] { topic },
+            timeProvider ?? TimeProvider.System,
+            NullLogger<DisseminationProtocol>.Instance);
+    }
+
+    private static DisseminationService CreateService(
+        FakeTransport transport,
+        FakeTopic topic,
+        Action<DisseminationOptions>? configure = null)
+    {
+        var options = new DisseminationOptions { Enabled = true };
+        configure?.Invoke(options);
+        return new DisseminationService(
+            transport,
+            new TestOptionsMonitor<DisseminationOptions>(options),
+            new[] { topic },
+            TimeProvider.System,
+            NullLogger<DisseminationProtocol>.Instance);
+    }
+
+    private static SiloAddress CreateSilo(int port) => SiloAddress.New(new IPEndPoint(IPAddress.Loopback, port), port);
+
+    private static async Task WaitUntil(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (!condition())
+        {
+            if (DateTime.UtcNow >= deadline)
+            {
+                Assert.True(condition(), "Condition was not satisfied within the timeout.");
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+    }
+
+    private static IReadOnlyList<SiloAddress> GetTreeChildren(
+        SiloAddress local,
+        SiloAddress root,
+        IEnumerable<SiloAddress> peers,
+        int fanout)
+    {
+        var participants = peers
+            .Append(local)
+            .Append(root)
+            .Distinct()
+            .OrderBy(GetPeerScore, StringComparer.Ordinal)
+            .ToList();
+        var rootIndex = participants.FindIndex(silo => Equals(silo, root));
+        if (rootIndex > 0)
+        {
+            participants = participants.Skip(rootIndex).Concat(participants.Take(rootIndex)).ToList();
+        }
+
+        var localIndex = participants.FindIndex(silo => Equals(silo, local));
+        if (localIndex < 0)
+        {
+            return Array.Empty<SiloAddress>();
+        }
+
+        var firstChild = localIndex * fanout + 1;
+        return Enumerable.Range(firstChild, fanout)
+            .Where(index => index < participants.Count)
+            .Select(index => participants[index])
+            .ToArray();
+    }
+
+    private static string GetPeerScore(SiloAddress silo)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(silo.ToParsableString()));
+        return Convert.ToHexString(bytes);
+    }
+
+    private static GrainManifest CreateManifest(params (string Grain, string Key, string Value)[] grains)
+    {
+        var grainBuilder = System.Collections.Immutable.ImmutableDictionary.CreateBuilder<GrainType, GrainProperties>();
+        foreach (var grain in grains)
+        {
+            var properties = System.Collections.Immutable.ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+            properties[grain.Key] = grain.Value;
+            grainBuilder[GrainType.Create(grain.Grain)] = new GrainProperties(
+                properties.ToImmutable());
+        }
+
+        return new GrainManifest(
+            grainBuilder.ToImmutable(),
+            System.Collections.Immutable.ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty);
+    }
+
+    private sealed class FakeTopic(SiloAddress localSilo) : IDisseminationTopic
+    {
+        public const string PayloadKind = "fake";
+        public static readonly DisseminationValueKey DefaultKey = DisseminationValueKey.FromString("value");
+        private static readonly HashSet<string> Kinds = new(StringComparer.Ordinal) { PayloadKind };
+        private readonly Dictionary<DisseminationValueKey, long> _versions = new();
+
+        public Dictionary<DisseminationValueKey, int> ApplyCounts { get; } = new();
+
+        public string Name => "fake-topic";
+
+        public int ProtocolVersion => 2;
+
+        public DisseminationTopicOptions Options { get; } = new() { Enabled = true };
+
+        public IReadOnlySet<string> PayloadKinds => Kinds;
+
+        public bool IsEnabled => true;
+
+        public DisseminationItem CreateItem(SiloAddress root, DisseminationValueKey key, long sequence) => new()
+        {
+            Id = new DisseminationItemId(Name, key, sequence, PayloadKind),
+            Root = root,
+            ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
+            Payload = BitConverter.GetBytes(sequence),
+        };
+
+        public void SetValue(DisseminationValueKey key, long version) => _versions[key] = version;
+
+        public long GetVersion(DisseminationValueKey key) => _versions.TryGetValue(key, out var version) ? version : 0;
+
+        public IReadOnlyList<DisseminationItemId> GetDigests() =>
+            _versions.Select(entry => new DisseminationItemId(Name, entry.Key, entry.Value, PayloadKind)).ToArray();
+
+        public int CompareVersion(DisseminationItemId left, DisseminationItemId right) => left.Version.CompareTo(right.Version);
+
+        public bool IsObsolete(DisseminationItemId id) =>
+            !string.Equals(id.PayloadKind, PayloadKind, StringComparison.Ordinal)
+            || (_versions.TryGetValue(id.Key, out var version) && version > id.Version);
+
+        public ValueTask<DisseminationItem?> GetItem(DisseminationItemId id, CancellationToken cancellationToken)
+        {
+            if (!_versions.TryGetValue(id.Key, out var version) || version < id.Version)
+            {
+                return ValueTask.FromResult<DisseminationItem?>(null);
+            }
+
+            return ValueTask.FromResult<DisseminationItem?>(CreateItem(localSilo, id.Key, version));
+        }
+
+        public ValueTask<DisseminationApplyResult> ApplyItem(DisseminationItem item, CancellationToken cancellationToken)
+        {
+            var version = BitConverter.ToInt64(item.Payload);
+            if (_versions.TryGetValue(item.Id.Key, out var current))
+            {
+                if (current > version)
+                {
+                    return ValueTask.FromResult(DisseminationApplyResult.Obsolete);
+                }
+
+                if (current == version)
+                {
+                    return ValueTask.FromResult(DisseminationApplyResult.Duplicate);
+                }
+            }
+
+            _versions[item.Id.Key] = version;
+            ApplyCounts[item.Id.Key] = ApplyCounts.TryGetValue(item.Id.Key, out var count) ? count + 1 : 1;
+            return ValueTask.FromResult(DisseminationApplyResult.Applied);
+        }
+
+        public ValueTask OnFallbackRequired(SiloAddress peer, DisseminationItemId id, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+    }
+
+    private sealed class FakeTransport(SiloAddress localSilo, params SiloAddress[] peers) : IDisseminationTransport
+    {
+        private readonly List<SiloAddress> _peers = peers.ToList();
+
+        public List<(SiloAddress Peer, DisseminationGossipBatch Batch)> GossipBatches { get; } = new();
+
+        public List<(SiloAddress Peer, DisseminationAntiEntropyRequest Request)> AntiEntropyRequests { get; } = new();
+
+        public List<SiloAddress> Peers => _peers;
+
+        public HashSet<SiloAddress> IncapablePeers { get; } = new();
+
+        public Func<SiloAddress, DisseminationCapabilityRequest, CancellationToken, ValueTask<DisseminationCapabilityResponse>>? GetCapabilitiesHandler { get; set; }
+
+        public Func<SiloAddress, DisseminationAntiEntropyRequest, ValueTask<DisseminationAntiEntropyResponse>> ExchangeAntiEntropyHandler { get; set; } =
+            static (peer, _) => ValueTask.FromResult(new DisseminationAntiEntropyResponse { Sender = peer });
+
+        public SiloAddress LocalSilo => localSilo;
+
+        public IReadOnlyList<SiloAddress> GetActivePeers() => _peers;
+
+        public ValueTask<DisseminationCapabilityResponse> GetCapabilities(
+            SiloAddress peer,
+            DisseminationCapabilityRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (GetCapabilitiesHandler is not null)
+            {
+                return GetCapabilitiesHandler(peer, request, cancellationToken);
+            }
+
+            return ValueTask.FromResult(CreateCapabilityResponse(peer, request));
+        }
+
+        public DisseminationCapabilityResponse CreateCapabilityResponse(
+            SiloAddress peer,
+            DisseminationCapabilityRequest request) => new()
+            {
+                Topic = request.Topic,
+                ProtocolVersion = request.ProtocolVersion,
+                Supported = !IncapablePeers.Contains(peer),
+                PayloadKinds = IncapablePeers.Contains(peer) ? Array.Empty<string>() : request.PayloadKinds,
+            };
+
+        public Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken)
+        {
+            GossipBatches.Add((peer, batch));
+            return Task.CompletedTask;
+        }
+
+        public ValueTask<DisseminationAntiEntropyResponse> ExchangeAntiEntropy(
+            SiloAddress peer,
+            DisseminationAntiEntropyRequest request,
+            CancellationToken cancellationToken)
+        {
+            AntiEntropyRequests.Add((peer, request));
+            return ExchangeAntiEntropyHandler(peer, request);
+        }
+    }
+
+    private sealed class TestOptionsMonitor<T>(T currentValue) : IOptionsMonitor<T>
+    {
+        public T CurrentValue => currentValue;
+
+        public T Get(string? name) => currentValue;
+
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private sealed class TestTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan value) => _utcNow += value;
+    }
+}

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -266,7 +266,7 @@ public class DisseminationProtocolTests
                 .Select(index => silos[index])
                 .ToHashSet();
 
-            Assert.True(peers.Count <= Math.Min(testCase.PeerCount, Math.Max(0, expectedCandidates.Count)));
+            Assert.True(peers.Length <= Math.Min(testCase.PeerCount, Math.Max(0, expectedCandidates.Count)));
             Assert.DoesNotContain(local, peers);
             Assert.All(peers, peer => Assert.Contains(peer, expectedCandidates));
         });

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -403,6 +403,62 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task GossipSendsHonorConfiguredConcurrency()
+    {
+        var local = CreateSilo(11111);
+        var peers = Enumerable.Range(11112, 4).Select(CreateSilo).ToArray();
+        var transport = new FakeTransport(local, peers);
+        var releaseSends = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var concurrencyReached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = 0;
+        var inFlight = 0;
+        var maxInFlight = 0;
+        transport.SendGossipHandler = async (_, _, cancellationToken) =>
+        {
+            Interlocked.Increment(ref started);
+            var current = Interlocked.Increment(ref inFlight);
+            UpdateMaximum(ref maxInFlight, current);
+            if (current == 2)
+            {
+                concurrencyReached.TrySetResult(true);
+            }
+
+            try
+            {
+                await releaseSends.Task.WaitAsync(cancellationToken);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref inFlight);
+            }
+        };
+
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, options =>
+        {
+            options.MaxConcurrentSends = 2;
+            options.Overlay.FanOutFactor = _ => peers.Length;
+        });
+
+        Assert.True(await protocol.Publish(
+            topic.Name,
+            topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1),
+            peers,
+            CancellationToken.None));
+        var flushTask = protocol.FlushPendingGossip(CancellationToken.None);
+
+        await concurrencyReached.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(2, Volatile.Read(ref started));
+        Assert.Equal(2, Volatile.Read(ref maxInFlight));
+
+        releaseSends.SetResult(true);
+        await flushTask;
+
+        Assert.Equal(peers.Length, started);
+        Assert.Equal(2, maxInFlight);
+    }
+
+    [Fact]
     public void FixedTreeRoutingSatisfiesReachabilityAndFanoutInvariants()
     {
         Gen.Select(Gen.Int[1, 64], Gen.Int[1, 8], Gen.Int[0, 63], static (count, fanout, rootSeed) =>
@@ -752,6 +808,7 @@ public class DisseminationProtocolTests
 
         Assert.NotNull(value);
         var update = serializer.Deserialize<MembershipTableSnapshotUpdate>(value.Payload);
+        Assert.NotNull(update);
         Assert.NotNull(update.Diff);
         Assert.Null(update.Snapshot);
         var receiverManager = new FakeMembershipManager(baseSnapshot);
@@ -925,8 +982,26 @@ public class DisseminationProtocolTests
             [topicName] = [.. values],
         }.ToImmutableDictionary(StringComparer.Ordinal);
 
-    private static T RoundTrip<T>(Serializer serializer, T value) =>
-        serializer.Deserialize<T>(serializer.SerializeToArray(value));
+    private static T RoundTrip<T>(Serializer serializer, T value)
+    {
+        var result = serializer.Deserialize<T>(serializer.SerializeToArray(value));
+        return result is null ? throw new InvalidOperationException("The serialized value unexpectedly round-tripped as null.") : result;
+    }
+
+    private static void UpdateMaximum(ref int maximum, int value)
+    {
+        var current = Volatile.Read(ref maximum);
+        while (value > current)
+        {
+            var observed = Interlocked.CompareExchange(ref maximum, value, current);
+            if (observed == current)
+            {
+                return;
+            }
+
+            current = observed;
+        }
+    }
 
     private static MembershipDisseminationTopic CreateMembershipTopic(
         SiloAddress local,

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -1,11 +1,10 @@
 #nullable enable
 
 using System;
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -36,7 +35,7 @@ public class DisseminationProtocolTests
         Assert.True(result);
         var expectedChildren = GetTreeChildren(local, local, peers, fanout: 2);
         Assert.Equal(expectedChildren, transport.GossipBatches.Select(batch => batch.Peer));
-        Assert.All(transport.GossipBatches, batch => Assert.Equal(item.Id, batch.Batch.Items.Single().Id));
+        Assert.All(transport.GossipBatches, batch => Assert.Equal(item.Digest, batch.Batch.Values.Single().Digest));
     }
 
     [Fact]
@@ -57,6 +56,41 @@ public class DisseminationProtocolTests
 
         Assert.False(result);
         Assert.Empty(transport.GossipBatches);
+    }
+
+    [Fact]
+    public async Task PublishDoesNotFailWhenJoiningParticipantIsUnavailable()
+    {
+        var local = CreateSilo(11111);
+        var joining = CreateSilo(11112);
+        var active = CreateSilo(11113);
+        var transport = new FakeTransport(local, joining, active);
+        transport.PeerStatuses[joining] = SiloStatus.Joining;
+        transport.GetCapabilitiesHandler = (target, request, cancellationToken) =>
+        {
+            if (Equals(target, joining))
+            {
+                throw new InvalidOperationException("joining peer is not yet reachable");
+            }
+
+            return ValueTask.FromResult(transport.CreateCapabilityResponse(target, request));
+        };
+
+        var topic = new FakeTopic(local)
+        {
+            MembershipScope = DisseminationMembershipScope.AllMembers,
+        };
+        var protocol = CreateProtocol(transport, topic, options =>
+        {
+            options.FailureBackoff = TimeSpan.FromSeconds(5);
+            options.Overlay.TreeFanout = 2;
+        });
+        var value = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
+
+        var result = await protocol.Publish(topic.Name, value, targetPeers: null, CancellationToken.None);
+
+        Assert.True(result);
+        Assert.Equal(new[] { active }, transport.GossipBatches.Select(batch => batch.Peer));
     }
 
     [Fact]
@@ -101,7 +135,7 @@ public class DisseminationProtocolTests
     [Fact]
     public async Task ReceiveGossipForwardsOnlyToLocalTreeChildren()
     {
-        var silos = Enumerable.Range(11111, 8).Select(CreateSilo).OrderBy(GetPeerScore, StringComparer.Ordinal).ToArray();
+        var silos = Enumerable.Range(11111, 8).Select(CreateSilo).OrderBy(static silo => silo).ToArray();
         var root = silos[0];
         var local = silos[1];
         var peers = silos.Where(silo => !Equals(silo, local)).ToArray();
@@ -113,7 +147,7 @@ public class DisseminationProtocolTests
         await protocol.ReceiveGossip(new DisseminationGossipBatch
         {
             Sender = root,
-            Items = new[] { item },
+            Values = new[] { item },
         }, CancellationToken.None);
 
         var expectedChildren = GetTreeChildren(local, root, peers, fanout: 2);
@@ -123,7 +157,7 @@ public class DisseminationProtocolTests
     [Fact]
     public async Task DuplicateGossipDoesNotForwardAgain()
     {
-        var silos = Enumerable.Range(11111, 8).Select(CreateSilo).OrderBy(GetPeerScore, StringComparer.Ordinal).ToArray();
+        var silos = Enumerable.Range(11111, 8).Select(CreateSilo).OrderBy(static silo => silo).ToArray();
         var root = silos[0];
         var local = silos[1];
         var peers = silos.Where(silo => !Equals(silo, local)).ToArray();
@@ -134,7 +168,7 @@ public class DisseminationProtocolTests
         var batch = new DisseminationGossipBatch
         {
             Sender = root,
-            Items = new[] { item },
+            Values = new[] { item },
         };
 
         await protocol.ReceiveGossip(batch, CancellationToken.None);
@@ -142,14 +176,14 @@ public class DisseminationProtocolTests
 
         var expectedChildren = GetTreeChildren(local, root, peers, fanout: 2);
         Assert.Equal(expectedChildren.Count, transport.GossipBatches.Count);
-        Assert.Equal(1, topic.ApplyCounts[item.Id.Key]);
+        Assert.Equal(1, topic.ApplyCounts[item.Digest.Key]);
     }
 
     [Fact]
     public async Task TreeRoutingInvalidatesCachedTopologyWhenActivePeersChange()
     {
-        var local = CreateSilo(11111);
-        var initialPeers = Enumerable.Range(11112, 4).Select(CreateSilo).ToList();
+        var local = CreateSilo(11115);
+        var initialPeers = Enumerable.Range(11112, 3).Select(CreateSilo).ToList();
         var transport = new FakeTransport(local, initialPeers.ToArray());
         var topic = new FakeTopic(local);
         var protocol = CreateProtocol(transport, topic, options => options.Overlay.TreeFanout = 2);
@@ -203,12 +237,12 @@ public class DisseminationProtocolTests
             },
             Digests = new[]
             {
-                new DisseminationItemId(topic.Name, FakeTopic.DefaultKey, version: 3, FakeTopic.PayloadKind),
+                new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 3, FakeTopic.PayloadKind),
             },
         }, CancellationToken.None);
 
-        var item = Assert.Single(response.Items);
-        Assert.Equal(5, item.Id.Version);
+        var item = Assert.Single(response.Values);
+        Assert.Equal(5, item.Digest.Version);
         Assert.False(response.Truncated);
     }
 
@@ -224,7 +258,7 @@ public class DisseminationProtocolTests
         transport.ExchangeAntiEntropyHandler = (target, request) => ValueTask.FromResult(new DisseminationAntiEntropyResponse
         {
             Sender = target,
-            Items = new[] { repairItem },
+            Values = new[] { repairItem },
         });
 
         var state = protocol.CreateAntiEntropyState();
@@ -247,9 +281,9 @@ public class DisseminationProtocolTests
         var topic = new FakeTopic(local);
         var protocol = CreateProtocol(transport, topic);
         topic.SetValue(FakeTopic.DefaultKey, version: 1);
-        var badRepairItem = new DisseminationItem
+        var badRepairItem = new DisseminationValue
         {
-            Id = new DisseminationItemId(topic.Name, FakeTopic.DefaultKey, version: 2, FakeTopic.PayloadKind),
+            Digest = new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 2, FakeTopic.PayloadKind),
             Root = peer,
             ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
             Payload = Array.Empty<byte>(),
@@ -261,7 +295,7 @@ public class DisseminationProtocolTests
             new DisseminationAntiEntropyResponse
             {
                 Sender = peer,
-                Items = new[] { badRepairItem, goodRepairItem },
+                Values = new[] { badRepairItem, goodRepairItem },
             },
         }, CancellationToken.None);
 
@@ -278,9 +312,9 @@ public class DisseminationProtocolTests
         var service = CreateService(transport, topic, options => options.Overlay.AntiEntropyInterval = TimeSpan.FromMilliseconds(1));
         topic.SetValue(FakeTopic.DefaultKey, version: 1);
 
-        var badRepairItem = new DisseminationItem
+        var badRepairItem = new DisseminationValue
         {
-            Id = new DisseminationItemId(topic.Name, FakeTopic.DefaultKey, version: 2, FakeTopic.PayloadKind),
+            Digest = new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 2, FakeTopic.PayloadKind),
             Root = peer,
             ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
             Payload = Array.Empty<byte>(),
@@ -293,11 +327,11 @@ public class DisseminationProtocolTests
             return ValueTask.FromResult(new DisseminationAntiEntropyResponse
             {
                 Sender = target,
-                Items = count switch
+                Values = count switch
                 {
                     1 => new[] { badRepairItem },
                     2 => new[] { goodRepairItem },
-                    _ => Array.Empty<DisseminationItem>(),
+                    _ => Array.Empty<DisseminationValue>(),
                 },
             });
         };
@@ -395,7 +429,7 @@ public class DisseminationProtocolTests
             .Append(local)
             .Append(root)
             .Distinct()
-            .OrderBy(GetPeerScore, StringComparer.Ordinal)
+            .OrderBy(static silo => silo)
             .ToList();
         var rootIndex = participants.FindIndex(silo => Equals(silo, root));
         if (rootIndex > 0)
@@ -414,12 +448,6 @@ public class DisseminationProtocolTests
             .Where(index => index < participants.Count)
             .Select(index => participants[index])
             .ToArray();
-    }
-
-    private static string GetPeerScore(SiloAddress silo)
-    {
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(silo.ToParsableString()));
-        return Convert.ToHexString(bytes);
     }
 
     private static GrainManifest CreateManifest(params (string Grain, string Key, string Value)[] grains)
@@ -441,15 +469,17 @@ public class DisseminationProtocolTests
     private sealed class FakeTopic(SiloAddress localSilo) : IDisseminationTopic
     {
         public const string PayloadKind = "fake";
-        public static readonly DisseminationValueKey DefaultKey = DisseminationValueKey.FromString("value");
+        public const string DefaultKey = "value";
         private static readonly HashSet<string> Kinds = new(StringComparer.Ordinal) { PayloadKind };
-        private readonly Dictionary<DisseminationValueKey, long> _versions = new();
+        private readonly Dictionary<string, long> _versions = new(StringComparer.Ordinal);
 
-        public Dictionary<DisseminationValueKey, int> ApplyCounts { get; } = new();
+        public Dictionary<string, int> ApplyCounts { get; } = new(StringComparer.Ordinal);
 
         public string Name => "fake-topic";
 
         public int ProtocolVersion => 2;
+
+        public DisseminationMembershipScope MembershipScope { get; set; } = DisseminationMembershipScope.ActiveMembers;
 
         public DisseminationTopicOptions Options { get; } = new() { Enabled = true };
 
@@ -457,41 +487,41 @@ public class DisseminationProtocolTests
 
         public bool IsEnabled => true;
 
-        public DisseminationItem CreateItem(SiloAddress root, DisseminationValueKey key, long sequence) => new()
+        public DisseminationValue CreateItem(SiloAddress root, string key, long sequence) => new()
         {
-            Id = new DisseminationItemId(Name, key, sequence, PayloadKind),
+            Digest = new DisseminationDigest(Name, key, sequence, PayloadKind),
             Root = root,
             ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
             Payload = BitConverter.GetBytes(sequence),
         };
 
-        public void SetValue(DisseminationValueKey key, long version) => _versions[key] = version;
+        public void SetValue(string key, long version) => _versions[key] = version;
 
-        public long GetVersion(DisseminationValueKey key) => _versions.TryGetValue(key, out var version) ? version : 0;
+        public long GetVersion(string key) => _versions.TryGetValue(key, out var version) ? version : 0;
 
-        public IReadOnlyList<DisseminationItemId> GetDigests() =>
-            _versions.Select(entry => new DisseminationItemId(Name, entry.Key, entry.Value, PayloadKind)).ToArray();
+        public IReadOnlyList<DisseminationDigest> GetDigests() =>
+            _versions.Select(entry => new DisseminationDigest(Name, entry.Key, entry.Value, PayloadKind)).ToArray();
 
-        public int CompareVersion(DisseminationItemId left, DisseminationItemId right) => left.Version.CompareTo(right.Version);
+        public int CompareVersion(DisseminationDigest left, DisseminationDigest right) => left.Version.CompareTo(right.Version);
 
-        public bool IsObsolete(DisseminationItemId id) =>
-            !string.Equals(id.PayloadKind, PayloadKind, StringComparison.Ordinal)
-            || (_versions.TryGetValue(id.Key, out var version) && version > id.Version);
+        public bool IsObsolete(DisseminationDigest digest) =>
+            !string.Equals(digest.PayloadKind, PayloadKind, StringComparison.Ordinal)
+            || (_versions.TryGetValue(digest.Key, out var version) && version > digest.Version);
 
-        public ValueTask<DisseminationItem?> GetItem(DisseminationItemId id, CancellationToken cancellationToken)
+        public ValueTask<DisseminationValue?> GetValue(DisseminationDigest digest, CancellationToken cancellationToken)
         {
-            if (!_versions.TryGetValue(id.Key, out var version) || version < id.Version)
+            if (!_versions.TryGetValue(digest.Key, out var version) || version < digest.Version)
             {
-                return ValueTask.FromResult<DisseminationItem?>(null);
+                return ValueTask.FromResult<DisseminationValue?>(null);
             }
 
-            return ValueTask.FromResult<DisseminationItem?>(CreateItem(localSilo, id.Key, version));
+            return ValueTask.FromResult<DisseminationValue?>(CreateItem(localSilo, digest.Key, version));
         }
 
-        public ValueTask<DisseminationApplyResult> ApplyItem(DisseminationItem item, CancellationToken cancellationToken)
+        public ValueTask<DisseminationApplyResult> ApplyValue(DisseminationValue value, CancellationToken cancellationToken)
         {
-            var version = BitConverter.ToInt64(item.Payload);
-            if (_versions.TryGetValue(item.Id.Key, out var current))
+            var version = BitConverter.ToInt64(value.Payload);
+            if (_versions.TryGetValue(value.Digest.Key, out var current))
             {
                 if (current > version)
                 {
@@ -504,12 +534,12 @@ public class DisseminationProtocolTests
                 }
             }
 
-            _versions[item.Id.Key] = version;
-            ApplyCounts[item.Id.Key] = ApplyCounts.TryGetValue(item.Id.Key, out var count) ? count + 1 : 1;
+            _versions[value.Digest.Key] = version;
+            ApplyCounts[value.Digest.Key] = ApplyCounts.TryGetValue(value.Digest.Key, out var count) ? count + 1 : 1;
             return ValueTask.FromResult(DisseminationApplyResult.Applied);
         }
 
-        public ValueTask OnFallbackRequired(SiloAddress peer, DisseminationItemId id, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public ValueTask OnFallbackRequired(SiloAddress peer, DisseminationDigest digest, CancellationToken cancellationToken) => ValueTask.CompletedTask;
     }
 
     private sealed class FakeTransport(SiloAddress localSilo, params SiloAddress[] peers) : IDisseminationTransport
@@ -522,6 +552,8 @@ public class DisseminationProtocolTests
 
         public List<SiloAddress> Peers => _peers;
 
+        public Dictionary<SiloAddress, SiloStatus> PeerStatuses { get; } = new();
+
         public HashSet<SiloAddress> IncapablePeers { get; } = new();
 
         public Func<SiloAddress, DisseminationCapabilityRequest, CancellationToken, ValueTask<DisseminationCapabilityResponse>>? GetCapabilitiesHandler { get; set; }
@@ -531,7 +563,28 @@ public class DisseminationProtocolTests
 
         public SiloAddress LocalSilo => localSilo;
 
-        public IReadOnlyList<SiloAddress> GetActivePeers() => _peers;
+        public DisseminationMembership GetMembership()
+        {
+            var allMembers = ImmutableArray.CreateBuilder<SiloAddress>();
+            var activeMembers = ImmutableArray.CreateBuilder<SiloAddress>();
+            foreach (var peer in _peers)
+            {
+                var status = PeerStatuses.TryGetValue(peer, out var peerStatus) ? peerStatus : SiloStatus.Active;
+                if (status is SiloStatus.Joining or SiloStatus.Active or SiloStatus.ShuttingDown or SiloStatus.Stopping)
+                {
+                    allMembers.Add(peer);
+                }
+
+                if (status == SiloStatus.Active)
+                {
+                    activeMembers.Add(peer);
+                }
+            }
+
+            allMembers.Sort(static (left, right) => left.CompareTo(right));
+            activeMembers.Sort(static (left, right) => left.CompareTo(right));
+            return new DisseminationMembership(allMembers.ToImmutable(), activeMembers.ToImmutable());
+        }
 
         public ValueTask<DisseminationCapabilityResponse> GetCapabilities(
             SiloAddress peer,

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -2422,6 +2422,87 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task RuntimeStatisticsUpdateCallbackDoesNotHoldMutationLock()
+    {
+        var local = CreateSilo(21025);
+        var peer = CreateSilo(21026);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var callbackEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCallback = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbackCount = 0;
+        publisher.SubscribeToStatisticsChangeEvents(new DelegateStatisticsListener(
+            onUpdate: (_, _) =>
+            {
+                if (Interlocked.Increment(ref callbackCount) == 1)
+                {
+                    callbackEntered.TrySetResult();
+                    releaseCallback.Task.GetAwaiter().GetResult();
+                }
+            }));
+        var first = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var second = CreateStatistics(first.DateTime.AddSeconds(1));
+
+        var firstUpdate = Task.Run(
+            () => publisher.ApplyDisseminatedRuntimeStatistics(peer, first),
+            TestContext.Current.CancellationToken);
+        await callbackEntered.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+
+        var secondResult = await Task.Run(
+            () => publisher.ApplyDisseminatedRuntimeStatistics(peer, second),
+            TestContext.Current.CancellationToken).WaitAsync(
+                TimeSpan.FromSeconds(2),
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(DisseminationApplyResult.Applied, secondResult);
+        Assert.Equal(second.DateTime, publisher.PeriodicStatistics[peer].DateTime);
+        Assert.Equal(1, Volatile.Read(ref callbackCount));
+        releaseCallback.TrySetResult();
+        await firstUpdate;
+        Assert.Equal(2, callbackCount);
+    }
+
+    [Fact]
+    public async Task RuntimeStatisticsRemovalCallbackDoesNotHoldMutationLockOrPermitResurrection()
+    {
+        var local = CreateSilo(21027);
+        var peer = CreateSilo(21028);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var baseline = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        Assert.Equal(DisseminationApplyResult.Applied, publisher.ApplyDisseminatedRuntimeStatistics(peer, baseline));
+        var callbackEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCallback = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        publisher.SubscribeToStatisticsChangeEvents(new DelegateStatisticsListener(
+            onRemove: _ =>
+            {
+                callbackEntered.TrySetResult();
+                releaseCallback.Task.GetAwaiter().GetResult();
+            }));
+        statusOracle.SetStatus(peer, SiloStatus.Dead);
+
+        var removal = Task.Run(
+            () => publisher.OnSiloStatusChange(peer, SiloStatus.Dead),
+            TestContext.Current.CancellationToken);
+        await callbackEntered.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+
+        var lateResult = await Task.Run(
+            () => publisher.ApplyDisseminatedRuntimeStatistics(
+                peer,
+                CreateStatistics(baseline.DateTime.AddSeconds(1))),
+            TestContext.Current.CancellationToken).WaitAsync(
+                TimeSpan.FromSeconds(2),
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(DisseminationApplyResult.Rejected, lateResult);
+        Assert.False(publisher.PeriodicStatistics.ContainsKey(peer));
+        releaseCallback.TrySetResult();
+        await removal;
+    }
+
+    [Fact]
     public void IsRuntimeStatisticsObsolete_ReflectsSiloActivityAndStatisticsRecency()
     {
         var local = CreateSilo(21003);
@@ -4349,6 +4430,16 @@ public class DisseminationProtocolTests
     private sealed class FakeEnvironmentStatisticsProvider : Orleans.Statistics.IEnvironmentStatisticsProvider
     {
         public Orleans.Statistics.EnvironmentStatistics GetEnvironmentStatistics() => default;
+    }
+
+    private sealed class DelegateStatisticsListener(
+        Action<SiloAddress, SiloRuntimeStatistics>? onUpdate = null,
+        Action<SiloAddress>? onRemove = null) : ISiloStatisticsChangeListener
+    {
+        public void SiloStatisticsChangeNotification(SiloAddress updatedSilo, SiloRuntimeStatistics newStats) =>
+            onUpdate?.Invoke(updatedSilo, newStats);
+
+        public void RemoveSilo(SiloAddress removedSilo) => onRemove?.Invoke(removedSilo);
     }
 
     private sealed class ActionObserver<T>(Action<T> onNext) : IObserver<T>

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -62,6 +62,43 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task PublishRejectsInvalidValuesBeforeQueueing()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic);
+        topic.SetValue("obsolete", version: 10);
+
+        var unsupportedPayloadKind = new DisseminationValue
+        {
+            Digest = new DisseminationDigest(topic.Name, "unsupported", version: 1, payloadKind: "unsupported"),
+            Root = local,
+            ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
+            Payload = BitConverter.GetBytes(1L),
+        };
+        var expired = new DisseminationValue
+        {
+            Digest = new DisseminationDigest(topic.Name, "expired", version: 1, FakeTopic.PayloadKind),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UnixEpoch,
+            Payload = BitConverter.GetBytes(1L),
+        };
+        var obsolete = topic.CreateItem(local, "obsolete", sequence: 5);
+
+        Assert.False(await protocol.Publish(topic.Name, unsupportedPayloadKind, [peer], CancellationToken.None));
+        Assert.False(await protocol.Publish(topic.Name, expired, [peer], CancellationToken.None));
+        Assert.False(await protocol.Publish(topic.Name, obsolete, [peer], CancellationToken.None));
+        await protocol.FlushPendingGossip(CancellationToken.None);
+
+        Assert.Empty(transport.GossipBatches);
+        Assert.Equal(
+            new[] { unsupportedPayloadKind.Digest, expired.Digest, obsolete.Digest },
+            topic.FallbackDigests);
+    }
+
+    [Fact]
     public async Task PublishAttemptsJoiningParticipantAndReliesOnSendBackoff()
     {
         var local = CreateSilo(11111);
@@ -328,6 +365,46 @@ public class DisseminationProtocolTests
             Assert.DoesNotContain(local, peers);
             Assert.All(peers, peer => Assert.Contains(peer, expectedCandidates));
         });
+    }
+
+    [Fact]
+    public void AntiEntropyPeerSelectionUsesTopicSpecificSalt()
+    {
+        const int fanout = 3;
+        const int peerCount = 1;
+        for (var count = 6; count < 32; count++)
+        {
+            var silos = CreateSilos(count);
+            for (var localIndex = 0; localIndex < silos.Length; localIndex++)
+            {
+                var local = silos[localIndex];
+                var expectedFirst = GetExpectedAntiEntropyPeers("topic-a", silos, localIndex, fanout, peerCount, round: 1);
+                var expectedSecond = GetExpectedAntiEntropyPeers("topic-b", silos, localIndex, fanout, peerCount, round: 1);
+                if (expectedFirst.SequenceEqual(expectedSecond))
+                {
+                    continue;
+                }
+
+                var transport = new FakeTransport(local, silos.Where(silo => !Equals(silo, local)).ToArray());
+                var firstTopic = new FakeTopic(local, "topic-a");
+                var secondTopic = new FakeTopic(local, "topic-b");
+                firstTopic.ExpectedKeys.Add(FakeTopic.DefaultKey);
+                secondTopic.ExpectedKeys.Add(FakeTopic.DefaultKey);
+                var protocol = CreateProtocol(transport, new IDisseminationTopic[] { firstTopic, secondTopic }, options =>
+                {
+                    options.Overlay.FanOutFactor = static _ => fanout;
+                    options.Overlay.AntiEntropyPeerCount = peerCount;
+                });
+
+                var state = protocol.CreateAntiEntropyState();
+
+                Assert.Equal(expectedFirst, state.PeersByTopic[firstTopic.Name]);
+                Assert.Equal(expectedSecond, state.PeersByTopic[secondTopic.Name]);
+                return;
+            }
+        }
+
+        throw new InvalidOperationException("The test did not find a topology where topic salt changes peer selection.");
     }
 
     [Fact]
@@ -642,6 +719,13 @@ public class DisseminationProtocolTests
         FakeTransport transport,
         FakeTopic topic,
         Action<DisseminationOptions>? configure = null,
+        TimeProvider? timeProvider = null) =>
+        CreateProtocol(transport, new IDisseminationTopic[] { topic }, configure, timeProvider);
+
+    private static DisseminationProtocol CreateProtocol(
+        FakeTransport transport,
+        IReadOnlyList<IDisseminationTopic> topics,
+        Action<DisseminationOptions>? configure = null,
         TimeProvider? timeProvider = null)
     {
         var options = new DisseminationOptions { Enabled = true };
@@ -649,7 +733,7 @@ public class DisseminationProtocolTests
         return new DisseminationProtocol(
             transport,
             new TestOptionsMonitor<DisseminationOptions>(options),
-            new[] { topic },
+            topics,
             timeProvider ?? TimeProvider.System,
             NullLogger<DisseminationProtocol>.Instance);
     }
@@ -837,6 +921,21 @@ public class DisseminationProtocolTests
         return Enumerable.Range(windowStart, windowEnd - windowStart);
     }
 
+    private static IReadOnlyList<SiloAddress> GetExpectedAntiEntropyPeers(
+        string topicName,
+        IReadOnlyList<SiloAddress> participants,
+        int localIndex,
+        int fanout,
+        int peerCount,
+        long round) =>
+        GetAntiEntropyCandidateIndexes(localIndex, participants.Count, fanout)
+            .Where(index => index != localIndex)
+            .OrderBy(index => GetRepairPeerScore(participants[index], topicName, round, localIndex))
+            .ThenBy(index => participants[index])
+            .Take(peerCount)
+            .Select(index => participants[index])
+            .ToArray();
+
     private static (int Start, int End) GetLevelRange(int index, int participantCount, int fanout)
     {
         var start = 0L;
@@ -848,6 +947,41 @@ public class DisseminationProtocolTests
         }
 
         return ((int)start, (int)Math.Min(participantCount, start + width));
+    }
+
+    private static ulong GetRepairPeerScore(SiloAddress peer, string topicName, long round, int localIndex)
+    {
+        var value = (ulong)(uint)peer.GetConsistentHashCode();
+        value ^= Mix(GetStableStringHash(topicName));
+        value ^= (ulong)round * 0x9E3779B97F4A7C15UL;
+        value ^= (ulong)(uint)localIndex << 32;
+        return Mix(value);
+    }
+
+    private static ulong GetStableStringHash(string value)
+    {
+        const ulong offsetBasis = 14695981039346656037UL;
+        const ulong prime = 1099511628211UL;
+        var hash = offsetBasis;
+        foreach (var ch in value)
+        {
+            hash ^= (byte)ch;
+            hash *= prime;
+            hash ^= (byte)(ch >> 8);
+            hash *= prime;
+        }
+
+        return hash;
+    }
+
+    private static ulong Mix(ulong value)
+    {
+        value ^= value >> 30;
+        value *= 0xBF58476D1CE4E5B9UL;
+        value ^= value >> 27;
+        value *= 0x94D049BB133111EBUL;
+        value ^= value >> 31;
+        return value;
     }
 
     private static GrainManifest CreateManifest(params (string Grain, string Key, string Value)[] grains)
@@ -914,7 +1048,7 @@ public class DisseminationProtocolTests
         return spec;
     }
 
-    private sealed class FakeTopic(SiloAddress localSilo) : IDisseminationTopic
+    private sealed class FakeTopic(SiloAddress localSilo, string name = "fake-topic") : IDisseminationTopic
     {
         public const string PayloadKind = "fake";
         public const string DefaultKey = "value";
@@ -925,7 +1059,9 @@ public class DisseminationProtocolTests
 
         public HashSet<string> ExpectedKeys { get; } = new(StringComparer.Ordinal);
 
-        public string Name => "fake-topic";
+        public List<DisseminationDigest> FallbackDigests { get; } = new();
+
+        public string Name => name;
 
         public DisseminationMembershipScope MembershipScope { get; set; } = DisseminationMembershipScope.ActiveMembers;
 
@@ -1005,7 +1141,11 @@ public class DisseminationProtocolTests
             return ValueTask.FromResult(DisseminationApplyResult.Applied);
         }
 
-        public ValueTask OnFallbackRequired(SiloAddress peer, DisseminationDigest digest, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+        public ValueTask OnFallbackRequired(SiloAddress peer, DisseminationDigest digest, CancellationToken cancellationToken)
+        {
+            FallbackDigests.Add(digest);
+            return ValueTask.CompletedTask;
+        }
     }
 
     private sealed class FakeTransport(SiloAddress localSilo, params SiloAddress[] peers) : IDisseminationTransport

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -71,30 +71,30 @@ public class DisseminationProtocolTests
         var protocol = CreateProtocol(transport, topic);
         topic.SetValue("obsolete", version: 10);
 
-        var unsupportedPayloadKind = new DisseminationValue
+        var mismatchedTopic = new DisseminationValue
         {
-            Digest = new DisseminationDigest(topic.Name, "unsupported", version: 1, payloadKind: "unsupported"),
+            Digest = new DisseminationDigest("other-topic", "unsupported", version: 1),
             Root = local,
             ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
             Payload = BitConverter.GetBytes(1L),
         };
         var expired = new DisseminationValue
         {
-            Digest = new DisseminationDigest(topic.Name, "expired", version: 1, FakeTopic.PayloadKind),
+            Digest = new DisseminationDigest(topic.Name, "expired", version: 1),
             Root = local,
             ExpiresAt = DateTimeOffset.UnixEpoch,
             Payload = BitConverter.GetBytes(1L),
         };
         var obsolete = topic.CreateItem(local, "obsolete", sequence: 5);
 
-        Assert.False(await protocol.Publish(topic.Name, unsupportedPayloadKind, [peer], CancellationToken.None));
+        Assert.False(await protocol.Publish(topic.Name, mismatchedTopic, [peer], CancellationToken.None));
         Assert.False(await protocol.Publish(topic.Name, expired, [peer], CancellationToken.None));
         Assert.False(await protocol.Publish(topic.Name, obsolete, [peer], CancellationToken.None));
         await protocol.FlushPendingGossip(CancellationToken.None);
 
         Assert.Empty(transport.GossipBatches);
         Assert.Equal(
-            new[] { unsupportedPayloadKind.Digest, expired.Digest, obsolete.Digest },
+            new[] { mismatchedTopic.Digest, expired.Digest, obsolete.Digest },
             topic.FallbackDigests);
     }
 
@@ -178,6 +178,65 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task MembershipRefreshPrunesFailureBackoffForRemovedPeers()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var sendCount = 0;
+        transport.SendGossipHandler = (target, batch, cancellationToken) =>
+        {
+            if (++sendCount == 1)
+            {
+                throw new InvalidOperationException("peer failed before removal");
+            }
+
+            transport.GossipBatches.Add((target, batch));
+            return Task.CompletedTask;
+        };
+
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, options =>
+        {
+            options.FailureBackoff = TimeSpan.FromMinutes(1);
+            options.Overlay.FanOutFactor = static _ => 1;
+        }, new TestTimeProvider());
+
+        Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "before-removal", sequence: 1), targetPeers: null, CancellationToken.None));
+        await protocol.FlushPendingGossip(CancellationToken.None);
+        Assert.Equal(1, sendCount);
+
+        transport.Peers.Remove(peer);
+        Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "during-removal", sequence: 2), targetPeers: null, CancellationToken.None));
+
+        transport.Peers.Add(peer);
+        Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "after-return", sequence: 3), targetPeers: null, CancellationToken.None));
+        await protocol.FlushPendingGossip(CancellationToken.None);
+
+        Assert.Equal(2, sendCount);
+        Assert.Single(transport.GossipBatches);
+    }
+
+    [Fact]
+    public async Task MembershipRefreshDropsPendingGossipForRemovedPeers()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        topic.Options.MaxCoalescingDelay = TimeSpan.FromMinutes(1);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 1);
+
+        Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "before-removal", sequence: 1), targetPeers: null, CancellationToken.None));
+
+        transport.Peers.Remove(peer);
+        Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "during-removal", sequence: 2), targetPeers: null, CancellationToken.None));
+        await protocol.FlushPendingGossip(CancellationToken.None);
+
+        Assert.Empty(transport.GossipBatches);
+    }
+
+    [Fact]
     public async Task ReceiveGossipForwardsOnlyToLocalTreeChildren()
     {
         var silos = Enumerable.Range(11111, 8).Select(CreateSilo).OrderBy(static silo => silo).ToArray();
@@ -224,6 +283,30 @@ public class DisseminationProtocolTests
         var expectedChildren = GetForwardingTreeTargets(local, root, peers, fanout: 2, sender: root);
         Assert.Equal(expectedChildren.Count, transport.GossipBatches.Count);
         Assert.Equal(1, topic.ApplyCounts[item.Digest.Key]);
+    }
+
+    [Fact]
+    public async Task ReceiveGossipWithMissingRootRefreshesMembershipAndDoesNotForward()
+    {
+        var root = CreateSilo(11111);
+        var local = CreateSilo(11112);
+        var sender = CreateSilo(11113);
+        var peer = CreateSilo(11114);
+        var transport = new FakeTransport(local, sender, peer);
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
+        var item = topic.CreateItem(root, FakeTopic.DefaultKey, sequence: 1);
+
+        await protocol.ReceiveGossip(new DisseminationGossipBatch
+        {
+            Sender = sender,
+            Values = [item],
+        }, CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
+
+        Assert.Equal(1, topic.GetVersion(FakeTopic.DefaultKey));
+        Assert.Equal(1, transport.RefreshMembershipCallCount);
+        Assert.Empty(transport.GossipBatches);
     }
 
     [Fact]
@@ -423,7 +506,7 @@ public class DisseminationProtocolTests
             Topics = [topic.Name],
             Digests =
             [
-                new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 3, FakeTopic.PayloadKind),
+                new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 3),
             ],
         }, CancellationToken.None);
 
@@ -449,7 +532,7 @@ public class DisseminationProtocolTests
             Topics = [topic.Name],
             Digests =
             [
-                new DisseminationDigest(topic.Name, "requested", version: 3, FakeTopic.PayloadKind),
+                new DisseminationDigest(topic.Name, "requested", version: 3),
             ],
         }, CancellationToken.None);
 
@@ -530,7 +613,7 @@ public class DisseminationProtocolTests
         topic.SetValue(FakeTopic.DefaultKey, version: 1);
         var badRepairItem = new DisseminationValue
         {
-            Digest = new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 2, FakeTopic.PayloadKind),
+            Digest = new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 2),
             Root = peer,
             ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
             Payload = Array.Empty<byte>(),
@@ -561,7 +644,7 @@ public class DisseminationProtocolTests
 
         var badRepairItem = new DisseminationValue
         {
-            Digest = new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 2, FakeTopic.PayloadKind),
+            Digest = new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 2),
             Root = peer,
             ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
             Payload = Array.Empty<byte>(),
@@ -664,7 +747,9 @@ public class DisseminationProtocolTests
             CancellationToken.None);
 
         Assert.NotNull(value);
-        Assert.Equal(DisseminationTopicNames.MembershipSnapshotDiff, value.Digest.PayloadKind);
+        var update = serializer.Deserialize<MembershipTableSnapshotUpdate>(value.Payload);
+        Assert.NotNull(update.Diff);
+        Assert.Null(update.Snapshot);
         var receiverManager = new FakeMembershipManager(baseSnapshot);
         var receiverTopic = CreateMembershipTopic(peer, receiverManager, serializer);
         var result = await receiverTopic.ApplyValue(value, CancellationToken.None);
@@ -1060,9 +1145,7 @@ public class DisseminationProtocolTests
 
     private sealed class FakeTopic(SiloAddress localSilo, string name = "fake-topic") : IDisseminationTopic
     {
-        public const string PayloadKind = "fake";
         public const string DefaultKey = "value";
-        private static readonly HashSet<string> Kinds = new(StringComparer.Ordinal) { PayloadKind };
         private readonly Dictionary<string, long> _versions = new(StringComparer.Ordinal);
 
         public Dictionary<string, int> ApplyCounts { get; } = new(StringComparer.Ordinal);
@@ -1077,13 +1160,11 @@ public class DisseminationProtocolTests
 
         public DisseminationTopicOptions Options { get; } = new() { Enabled = true };
 
-        public IReadOnlySet<string> PayloadKinds => Kinds;
-
         public bool IsEnabled => true;
 
         public DisseminationValue CreateItem(SiloAddress root, string key, long sequence) => new()
         {
-            Digest = new DisseminationDigest(Name, key, sequence, PayloadKind),
+            Digest = new DisseminationDigest(Name, key, sequence),
             Root = root,
             ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
             Payload = BitConverter.GetBytes(sequence),
@@ -1098,13 +1179,13 @@ public class DisseminationProtocolTests
         public IReadOnlyList<DisseminationDigest> GetDigests()
         {
             var digests = _versions
-                .Select(entry => new DisseminationDigest(Name, entry.Key, entry.Value, PayloadKind))
+                .Select(entry => new DisseminationDigest(Name, entry.Key, entry.Value))
                 .ToList();
             foreach (var key in ExpectedKeys)
             {
                 if (!_versions.ContainsKey(key))
                 {
-                    digests.Add(new DisseminationDigest(Name, key, long.MinValue, PayloadKind));
+                    digests.Add(new DisseminationDigest(Name, key, long.MinValue));
                 }
             }
 
@@ -1114,8 +1195,7 @@ public class DisseminationProtocolTests
         public int CompareVersion(DisseminationDigest left, DisseminationDigest right) => left.Version.CompareTo(right.Version);
 
         public bool IsObsolete(DisseminationDigest digest) =>
-            !string.Equals(digest.PayloadKind, PayloadKind, StringComparison.Ordinal)
-            || (_versions.TryGetValue(digest.Key, out var version) && version > digest.Version);
+            _versions.TryGetValue(digest.Key, out var version) && version > digest.Version;
 
         public ValueTask<DisseminationValue?> GetValue(
             DisseminationDigest digest,
@@ -1151,7 +1231,7 @@ public class DisseminationProtocolTests
             return ValueTask.FromResult(DisseminationApplyResult.Applied);
         }
 
-        public ValueTask OnFallbackRequired(SiloAddress peer, DisseminationDigest digest, CancellationToken cancellationToken)
+        public ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationDigest digest, CancellationToken cancellationToken)
         {
             FallbackDigests.Add(digest);
             return ValueTask.CompletedTask;
@@ -1179,6 +1259,8 @@ public class DisseminationProtocolTests
 
         public SiloAddress LocalSilo => localSilo;
 
+        public int RefreshMembershipCallCount { get; private set; }
+
         public DisseminationMembership GetMembership()
         {
             var members = _peers.Append(localSilo).Distinct().Select(peer =>
@@ -1202,6 +1284,12 @@ public class DisseminationProtocolTests
                 .Select(static member => member.Peer)
                 .ToImmutableArray();
             return new DisseminationMembership(allMembers, activeMembers);
+        }
+
+        public Task RefreshMembership(CancellationToken cancellationToken)
+        {
+            RefreshMembershipCallCount++;
+            return Task.CompletedTask;
         }
 
         public Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken)
@@ -1255,7 +1343,7 @@ public class DisseminationProtocolTests
                 return new ModelRepairResponse(false, 0);
             }
 
-            var peerDigest = new DisseminationDigest(_topic.Name, FakeTopic.DefaultKey, peerVersion, FakeTopic.PayloadKind);
+            var peerDigest = new DisseminationDigest(_topic.Name, FakeTopic.DefaultKey, peerVersion);
             if (_topic.CompareVersion(localDigest, peerDigest) <= 0)
             {
                 return new ModelRepairResponse(false, 0);

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -74,30 +74,22 @@ public class DisseminationProtocolTests
         var protocol = CreateProtocol(transport, topic);
         topic.SetValue("obsolete", version: 10);
 
-        var mismatchedTopic = new DisseminationValue
-        {
-            Digest = new DisseminationDigest("other-topic", "unsupported", version: 1),
-            Root = local,
-            ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
-            Payload = BitConverter.GetBytes(1L),
-        };
         var expired = new DisseminationValue
         {
-            Digest = new DisseminationDigest(topic.Name, "expired", version: 1),
+            Digest = new DisseminationTopicDigest("expired", version: 1),
             Root = local,
             ExpiresAt = DateTimeOffset.UnixEpoch,
             Payload = BitConverter.GetBytes(1L),
         };
         var obsolete = topic.CreateItem(local, "obsolete", sequence: 5);
 
-        Assert.False(await protocol.Publish(topic.Name, mismatchedTopic, [peer], CancellationToken.None));
         Assert.False(await protocol.Publish(topic.Name, expired, [peer], CancellationToken.None));
         Assert.False(await protocol.Publish(topic.Name, obsolete, [peer], CancellationToken.None));
         await protocol.FlushPendingGossip(CancellationToken.None);
 
         Assert.Empty(transport.GossipBatches);
         Assert.Equal(
-            new[] { mismatchedTopic.Digest, expired.Digest, obsolete.Digest },
+            new[] { expired.Digest, obsolete.Digest },
             topic.FallbackDigests);
     }
 
@@ -624,7 +616,7 @@ public class DisseminationProtocolTests
         topic.SetValue(FakeTopic.DefaultKey, version: 1);
         var badRepairItem = new DisseminationValue
         {
-            Digest = new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 2),
+            Digest = new DisseminationTopicDigest(FakeTopic.DefaultKey, version: 2),
             Root = peer,
             ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
             Payload = Array.Empty<byte>(),
@@ -655,7 +647,7 @@ public class DisseminationProtocolTests
 
         var badRepairItem = new DisseminationValue
         {
-            Digest = new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 2),
+            Digest = new DisseminationTopicDigest(FakeTopic.DefaultKey, version: 2),
             Root = peer,
             ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
             Payload = Array.Empty<byte>(),
@@ -750,11 +742,9 @@ public class DisseminationProtocolTests
         var serializer = serviceProvider.GetRequiredService<Serializer>();
         var sourceManager = new FakeMembershipManager(baseSnapshot);
         var sourceTopic = CreateMembershipTopic(local, sourceManager, serializer);
-        var peerTopicDigest = Assert.Single(sourceTopic.GetDigests());
-        var peerDigest = new DisseminationDigest(sourceTopic.Name, peerTopicDigest.Key, peerTopicDigest.Version);
+        var peerDigest = Assert.Single(sourceTopic.GetDigests());
         sourceManager.CurrentSnapshot = updatedSnapshot;
-        var localTopicDigest = Assert.Single(sourceTopic.GetDigests());
-        var localDigest = new DisseminationDigest(sourceTopic.Name, localTopicDigest.Key, localTopicDigest.Version);
+        var localDigest = Assert.Single(sourceTopic.GetDigests());
 
         var value = await sourceTopic.GetValue(
             localDigest,
@@ -889,12 +879,13 @@ public class DisseminationProtocolTests
         response.ValuesByTopic.Values.SelectMany(static values => values);
 
     private static FrozenDictionary<string, ImmutableArray<DisseminationValue>> CreateValueGroups(params DisseminationValue[] values) =>
-        values
-            .GroupBy(static value => value.Digest.Topic, StringComparer.Ordinal)
-            .ToFrozenDictionary(
-                static group => group.Key,
-                static group => group.ToImmutableArray(),
-                StringComparer.Ordinal);
+        CreateValueGroups(FakeTopic.DefaultName, values);
+
+    private static FrozenDictionary<string, ImmutableArray<DisseminationValue>> CreateValueGroups(string topicName, params DisseminationValue[] values) =>
+        new Dictionary<string, ImmutableArray<DisseminationValue>>(StringComparer.Ordinal)
+        {
+            [topicName] = [.. values],
+        }.ToFrozenDictionary(StringComparer.Ordinal);
 
     private static MembershipDisseminationTopic CreateMembershipTopic(
         SiloAddress local,
@@ -1188,8 +1179,9 @@ public class DisseminationProtocolTests
     }
 #endif
 
-    private sealed class FakeTopic(SiloAddress localSilo, string name = "fake-topic") : IDisseminationTopic
+    private sealed class FakeTopic(SiloAddress localSilo, string name = FakeTopic.DefaultName) : IDisseminationTopic
     {
+        public const string DefaultName = "fake-topic";
         public const string DefaultKey = "value";
         private readonly Dictionary<string, long> _versions = new(StringComparer.Ordinal);
 
@@ -1197,7 +1189,7 @@ public class DisseminationProtocolTests
 
         public HashSet<string> ExpectedKeys { get; } = new(StringComparer.Ordinal);
 
-        public List<DisseminationDigest> FallbackDigests { get; } = new();
+        public List<DisseminationTopicDigest> FallbackDigests { get; } = new();
 
         public string Name => name;
 
@@ -1209,7 +1201,7 @@ public class DisseminationProtocolTests
 
         public DisseminationValue CreateItem(SiloAddress root, string key, long sequence) => new()
         {
-            Digest = new DisseminationDigest(Name, key, sequence),
+            Digest = new DisseminationTopicDigest(key, sequence),
             Root = root,
             ExpiresAt = TimeProvider.System.GetUtcNow().AddMinutes(1),
             Payload = BitConverter.GetBytes(sequence),
@@ -1237,14 +1229,14 @@ public class DisseminationProtocolTests
             return [.. digests.OrderBy(static digest => digest.Key, StringComparer.Ordinal)];
         }
 
-        public int CompareVersion(DisseminationDigest left, DisseminationDigest right) => left.Version.CompareTo(right.Version);
+        public int CompareVersion(DisseminationTopicDigest left, DisseminationTopicDigest right) => left.Version.CompareTo(right.Version);
 
-        public bool IsObsolete(DisseminationDigest digest) =>
+        public bool IsObsolete(DisseminationTopicDigest digest) =>
             _versions.TryGetValue(digest.Key, out var version) && version > digest.Version;
 
         public ValueTask<DisseminationValue?> GetValue(
-            DisseminationDigest digest,
-            DisseminationDigest? peerDigest,
+            DisseminationTopicDigest digest,
+            DisseminationTopicDigest? peerDigest,
             CancellationToken cancellationToken)
         {
             if (!_versions.TryGetValue(digest.Key, out var version) || version < digest.Version)
@@ -1276,7 +1268,7 @@ public class DisseminationProtocolTests
             return ValueTask.FromResult(DisseminationApplyResult.Applied);
         }
 
-        public ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationDigest digest, CancellationToken cancellationToken)
+        public ValueTask OnFallbackRequired(SiloAddress? peer, DisseminationTopicDigest digest, CancellationToken cancellationToken)
         {
             FallbackDigests.Add(digest);
             return ValueTask.CompletedTask;
@@ -1391,15 +1383,14 @@ public class DisseminationProtocolTests
                 return new ModelRepairResponse(false, 0);
             }
 
-            var fullLocalDigest = new DisseminationDigest(_topic.Name, localDigest.Key, localDigest.Version);
-            var peerDigest = new DisseminationDigest(_topic.Name, FakeTopic.DefaultKey, peerVersion);
-            if (_topic.CompareVersion(fullLocalDigest, peerDigest) <= 0)
+            var peerDigest = new DisseminationTopicDigest(FakeTopic.DefaultKey, peerVersion);
+            if (_topic.CompareVersion(localDigest, peerDigest) <= 0)
             {
                 return new ModelRepairResponse(false, 0);
             }
 
             var value = await _topic.GetValue(
-                fullLocalDigest,
+                localDigest,
                 peerDigest,
                 CancellationToken.None);
             return value is null

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -1655,6 +1655,34 @@ public class DisseminationProtocolTests
         Assert.Single(GetGossipValues(batch.Batch));
     }
 
+    [Fact]
+    public async Task PublishStatistics_DisseminationSuccessDoesNotReadFallbackMembership()
+    {
+        using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serializerProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21015);
+        var peer = CreateSilo(21016);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(local, SiloStatus.Active);
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var services = new MutableServiceProvider();
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, serviceProvider: services);
+        var topic = CreateDeploymentLoadTopic(
+            publisher,
+            serializer,
+            options => options.Dissemination.Enabled = true);
+        var transport = new FakeTransport(local, peer);
+        var dissemination = CreateService(transport, [topic]);
+        services.Add(dissemination);
+        services.Add(topic);
+
+        await publisher.PublishStatistics();
+        await dissemination.StopAsync(CancellationToken.None);
+
+        Assert.Equal(0, statusOracle.ApproximateStatusesRequests);
+        Assert.Single(transport.GossipBatches);
+    }
+
     [Theory]
     [InlineData(false, true, true)]
     [InlineData(true, false, true)]
@@ -1782,6 +1810,7 @@ public class DisseminationProtocolTests
         Assert.Equal(local, update.Source);
         Assert.Equal(publisher.LocalRuntimeStatistics.DateTime, update.Statistics.DateTime);
         Assert.Equal(peer, Assert.Single(grainFactory.SystemTargetRequests).Destination);
+        Assert.Equal(1, statusOracle.ApproximateStatusesRequests);
     }
 
     [Fact]
@@ -3200,6 +3229,8 @@ public class DisseminationProtocolTests
     {
         private readonly Dictionary<SiloAddress, SiloStatus> _statuses = new();
 
+        public int ApproximateStatusesRequests { get; private set; }
+
         public SiloStatus CurrentStatus => SiloStatus.Active;
 
         public string SiloName => "local";
@@ -3214,10 +3245,13 @@ public class DisseminationProtocolTests
         public SiloStatus GetApproximateSiloStatus(SiloAddress siloAddress) =>
             _statuses.TryGetValue(siloAddress, out var status) ? status : SiloStatus.None;
 
-        public Dictionary<SiloAddress, SiloStatus> GetApproximateSiloStatuses(bool onlyActive = false) =>
-            _statuses
+        public Dictionary<SiloAddress, SiloStatus> GetApproximateSiloStatuses(bool onlyActive = false)
+        {
+            ApproximateStatusesRequests++;
+            return _statuses
                 .Where(kvp => !onlyActive || kvp.Value == SiloStatus.Active)
                 .ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value);
+        }
 
         public bool TryGetSiloName(SiloAddress siloAddress, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? siloName)
         {

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -1496,6 +1496,58 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task MembershipTopicApplyValueRejectsDiffWithMismatchedDigestVersion()
+    {
+        var local = CreateSilo(11132);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var currentSnapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var manager = new FakeMembershipManager(currentSnapshot);
+        var topic = CreateMembershipTopic(local, manager, serializer);
+        var diff = new MembershipTableSnapshotDiff(
+            currentSnapshot.Version,
+            new MembershipVersion(2),
+            ImmutableArray<MembershipEntry>.Empty,
+            ImmutableArray<SiloAddress>.Empty);
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("cluster", 3),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Diff = diff }),
+        };
+
+        var result = await topic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Rejected, result);
+        Assert.Equal(currentSnapshot.Version, manager.CurrentSnapshot.Version);
+    }
+
+    [Fact]
+    public async Task MembershipTopicApplyValueRejectsSnapshotWithMismatchedDigestVersion()
+    {
+        var local = CreateSilo(11133);
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var currentSnapshot = CreateMembershipSnapshot(1, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var manager = new FakeMembershipManager(currentSnapshot);
+        var topic = CreateMembershipTopic(local, manager, serializer);
+        var proposedSnapshot = CreateMembershipSnapshot(2, CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var value = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest("cluster", 3),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(new MembershipTableSnapshotUpdate { Snapshot = proposedSnapshot }),
+        };
+
+        var result = await topic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Rejected, result);
+        Assert.Equal(currentSnapshot.Version, manager.CurrentSnapshot.Version);
+    }
+
+    [Fact]
     public async Task MembershipTopicApplyValueReturnsObsoleteThenDuplicateForStaleVersions()
     {
         var local = CreateSilo(11123);
@@ -2780,6 +2832,41 @@ public class DisseminationProtocolTests
         var result = await topic.ApplyValue(value, CancellationToken.None);
 
         Assert.Equal(DisseminationApplyResult.Rejected, result);
+    }
+
+    [Fact]
+    public async Task DeploymentLoadTopic_ApplyValueRejectsDigestPayloadMismatch()
+    {
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21115);
+        var peer = CreateSilo(21116);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var topic = CreateDeploymentLoadTopic(publisher, serializer);
+        var statistics = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var mismatchedRoot = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest(peer.ToParsableString(), statistics.DateTime.Ticks),
+            Root = local,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(statistics),
+        };
+        var mismatchedVersion = new DisseminationValue
+        {
+            Digest = new DisseminationTopicDigest(peer.ToParsableString(), statistics.DateTime.Ticks + 1),
+            Root = peer,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+            Payload = serializer.SerializeToArray(statistics),
+        };
+
+        var rootResult = await topic.ApplyValue(mismatchedRoot, CancellationToken.None);
+        var versionResult = await topic.ApplyValue(mismatchedVersion, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Rejected, rootResult);
+        Assert.Equal(DisseminationApplyResult.Rejected, versionResult);
     }
 
     [Fact]

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -617,6 +617,148 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task AntiEntropyResponseIsEmptyWhenDisseminationIsDisabled()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        topic.SetValue(FakeTopic.DefaultKey, version: 5);
+        var protocol = CreateProtocol(transport, topic, options => options.Enabled = false);
+
+        var response = await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            DigestsByTopic = CreateAntiEntropyRequestDigests(
+                topic.Name,
+                new DisseminationTopicDigest(FakeTopic.DefaultKey, version: 3)),
+        }, CancellationToken.None);
+
+        Assert.Equal(local, response.Sender);
+        Assert.Empty(response.ValuesByTopic);
+        Assert.False(response.Truncated);
+    }
+
+    [Fact]
+    public async Task AntiEntropyResponseSkipsUnknownTopicsEmptyRequestsAndCurrentRemoteValues()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        var emptyTopic = new FakeTopic(local, "empty");
+        topic.SetValue("equal", version: 5);
+        topic.SetValue("remote-newer", version: 5);
+        var protocol = CreateProtocol(transport, new IDisseminationTopic[] { topic, emptyTopic });
+        var digestsByTopic = ImmutableDictionary<string, ImmutableArray<DisseminationTopicDigest>>.Empty
+            .Add("unknown", [new DisseminationTopicDigest("value", version: 1)])
+            .Add("empty", [])
+            .Add(topic.Name,
+            [
+                new DisseminationTopicDigest("equal", version: 5),
+                new DisseminationTopicDigest("remote-newer", version: 6),
+            ]);
+
+        var response = await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            DigestsByTopic = digestsByTopic,
+        }, CancellationToken.None);
+
+        Assert.Empty(response.ValuesByTopic);
+        Assert.False(response.Truncated);
+    }
+
+    [Fact]
+    public async Task AntiEntropyResponseSkipsNullAndOversizedValues()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        topic.Options.MaxPayloadBytes = 8;
+        topic.SetValue("null", version: 2);
+        topic.SetValue("oversized", version: 2);
+        topic.SetValue("valid", version: 2);
+        topic.GetValueHandler = (digest, _) => digest.Key switch
+        {
+            "null" => null,
+            "oversized" => new DisseminationValue
+            {
+                Digest = digest,
+                Root = local,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(1),
+                Payload = new byte[9],
+            },
+            _ => topic.CreateItem(local, digest.Key, digest.Version),
+        };
+        var protocol = CreateProtocol(transport, topic);
+
+        var response = await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            DigestsByTopic = CreateAntiEntropyRequestDigests(
+                topic.Name,
+                new DisseminationTopicDigest("null", version: 1),
+                new DisseminationTopicDigest("oversized", version: 1),
+                new DisseminationTopicDigest("valid", version: 1)),
+        }, CancellationToken.None);
+
+        var value = Assert.Single(GetAntiEntropyResponseValues(response));
+        Assert.Equal("valid", value.Digest.Key);
+        Assert.False(response.Truncated);
+    }
+
+    [Fact]
+    public async Task AntiEntropyResponseTruncatesAtItemLimit()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        topic.SetValue("a", version: 2);
+        topic.SetValue("b", version: 2);
+        var protocol = CreateProtocol(transport, topic, options => options.MaxBatchItems = 1);
+
+        var response = await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            DigestsByTopic = CreateAntiEntropyRequestDigests(
+                topic.Name,
+                new DisseminationTopicDigest("a", version: 1),
+                new DisseminationTopicDigest("b", version: 1)),
+        }, CancellationToken.None);
+
+        Assert.Single(GetAntiEntropyResponseValues(response));
+        Assert.True(response.Truncated);
+    }
+
+    [Fact]
+    public async Task AntiEntropyResponseTruncatesBeforeExceedingByteLimit()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var transport = new FakeTransport(local, peer);
+        var topic = new FakeTopic(local);
+        topic.SetValue("a", version: 2);
+        topic.SetValue("b", version: 2);
+        var protocol = CreateProtocol(transport, topic, options => options.MaxBatchBytes = sizeof(long) + 1);
+
+        var response = await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
+        {
+            Sender = peer,
+            DigestsByTopic = CreateAntiEntropyRequestDigests(
+                topic.Name,
+                new DisseminationTopicDigest("a", version: 1),
+                new DisseminationTopicDigest("b", version: 1)),
+        }, CancellationToken.None);
+
+        var value = Assert.Single(GetAntiEntropyResponseValues(response));
+        Assert.Equal(sizeof(long), value.Payload.Length);
+        Assert.True(response.Truncated);
+    }
+
+    [Fact]
     public async Task AntiEntropyDigestRequestsAreSuppressedUntilExpectedCadenceExpires()
     {
         var local = CreateSilo(11111);
@@ -1483,6 +1625,166 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task TryPublishStatisticsViaDisseminationPublishesWhenEnabled()
+    {
+        using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serializerProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21008);
+        var peer = CreateSilo(21009);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(local, SiloStatus.Active);
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var services = new MutableServiceProvider();
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, serviceProvider: services);
+        var topic = CreateDeploymentLoadTopic(
+            publisher,
+            serializer,
+            options => options.Dissemination.Enabled = true);
+        var transport = new FakeTransport(local, peer);
+        var dissemination = CreateService(transport, [topic]);
+        services.Add(dissemination);
+        services.Add(topic);
+
+        var result = await publisher.TryPublishStatisticsViaDissemination(
+            CreateStatistics(DateTime.UtcNow));
+        await dissemination.StopAsync(CancellationToken.None);
+
+        Assert.True(result);
+        var batch = Assert.Single(transport.GossipBatches);
+        Assert.Equal(peer, batch.Peer);
+        Assert.Single(GetGossipValues(batch.Batch));
+    }
+
+    [Theory]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    public async Task TryPublishStatisticsViaDisseminationReturnsFalseWhenDependencyIsMissingOrTopicDisabled(
+        bool registerDissemination,
+        bool registerTopic,
+        bool topicEnabled)
+    {
+        using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serializerProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21010);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(local, SiloStatus.Active);
+        var services = new MutableServiceProvider();
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, serviceProvider: services);
+        var topic = CreateDeploymentLoadTopic(
+            publisher,
+            serializer,
+            options => options.Dissemination.Enabled = topicEnabled);
+        var dissemination = CreateService(new FakeTransport(local), [topic]);
+        if (registerDissemination)
+        {
+            services.Add(dissemination);
+        }
+
+        if (registerTopic)
+        {
+            services.Add(topic);
+        }
+
+        var result = await publisher.TryPublishStatisticsViaDissemination(
+            CreateStatistics(DateTime.UtcNow));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task TryPublishStatisticsViaDisseminationReturnsFalseWhenProtocolDeclinesTopic()
+    {
+        using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serializerProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21011);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(local, SiloStatus.Active);
+        var services = new MutableServiceProvider();
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, serviceProvider: services);
+        var topic = CreateDeploymentLoadTopic(
+            publisher,
+            serializer,
+            options => options.Dissemination.Enabled = true);
+        services.Add(CreateService(new FakeTransport(local), []));
+        services.Add(topic);
+
+        var result = await publisher.TryPublishStatisticsViaDissemination(
+            CreateStatistics(DateTime.UtcNow));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task TryPublishStatisticsViaDisseminationReturnsFalseWhenPublishThrows()
+    {
+        using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serializerProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21012);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(local, SiloStatus.Active);
+        var services = new MutableServiceProvider();
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle, serviceProvider: services);
+        var topic = CreateDeploymentLoadTopic(
+            publisher,
+            serializer,
+            options => options.Dissemination.Enabled = true);
+        var transport = new FakeTransport(local)
+        {
+            GetMembershipHandler = static () => throw new InvalidOperationException("test failure"),
+        };
+        services.Add(CreateService(transport, [topic]));
+        services.Add(topic);
+
+        var result = await publisher.TryPublishStatisticsViaDissemination(
+            CreateStatistics(DateTime.UtcNow));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task PublishStatisticsFallsBackToDirectSendWhenDisseminationThrows()
+    {
+        using var serializerProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serializerProvider.GetRequiredService<Serializer>();
+        var local = CreateSilo(21013);
+        var peer = CreateSilo(21014);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(local, SiloStatus.Active);
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var services = new MutableServiceProvider();
+        var directTarget = new FakeDeploymentLoadPublisherTarget();
+        var grainFactory = new RecordingGrainFactory
+        {
+            Resolver = (type, _) => type == typeof(IDeploymentLoadPublisher)
+                ? directTarget
+                : throw new NotSupportedException(),
+        };
+        var publisher = CreateDeploymentLoadPublisher(
+            local,
+            statusOracle,
+            grainFactory,
+            services);
+        var topic = CreateDeploymentLoadTopic(
+            publisher,
+            serializer,
+            options => options.Dissemination.Enabled = true);
+        var transport = new FakeTransport(local, peer)
+        {
+            GetMembershipHandler = static () => throw new InvalidOperationException("test failure"),
+        };
+        services.Add(CreateService(transport, [topic]));
+        services.Add(topic);
+
+        await publisher.PublishStatistics();
+
+        var update = Assert.Single(directTarget.Updates);
+        Assert.Equal(local, update.Source);
+        Assert.Equal(publisher.LocalRuntimeStatistics.DateTime, update.Statistics.DateTime);
+        Assert.Equal(peer, Assert.Single(grainFactory.SystemTargetRequests).Destination);
+    }
+
+    [Fact]
     public void DeploymentLoadTopic_CreateItemProducesDigestKeyedByOriginWithSerializedPayload()
     {
         using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
@@ -2122,8 +2424,8 @@ public class DisseminationProtocolTests
             grainFactory ?? new RecordingGrainFactory(),
             NullLoggerFactory.Instance,
             new ActivationDirectory(CreateCatalogInstruments()),
-            activationWorkingSet: null!,
-            environmentStatisticsProvider: null!,
+            new FakeActivationWorkingSet(),
+            new FakeEnvironmentStatisticsProvider(),
             Options.Create(new LoadSheddingOptions()),
             serviceProvider ?? new ServiceCollection().BuildServiceProvider(),
             CreateSystemTargetShared(local));
@@ -2515,6 +2817,8 @@ public class DisseminationProtocolTests
 
         public List<DisseminationTopicDigest> FallbackDigests { get; } = new();
 
+        public Func<DisseminationTopicDigest, DisseminationTopicDigest?, DisseminationValue?>? GetValueHandler { get; set; }
+
         public string Name => name;
 
         public DisseminationMembershipScope MembershipScope { get; set; } = DisseminationMembershipScope.ActiveMembers;
@@ -2563,6 +2867,11 @@ public class DisseminationProtocolTests
             DisseminationTopicDigest? peerDigest,
             CancellationToken cancellationToken)
         {
+            if (GetValueHandler is { } handler)
+            {
+                return ValueTask.FromResult(handler(digest, peerDigest));
+            }
+
             if (!_versions.TryGetValue(digest.Key, out var version) || version < digest.Version)
             {
                 return ValueTask.FromResult<DisseminationValue?>(null);
@@ -2620,12 +2929,19 @@ public class DisseminationProtocolTests
 
         public Func<CancellationToken, Task>? RefreshMembershipHandler { get; set; }
 
+        public Func<DisseminationMembership>? GetMembershipHandler { get; set; }
+
         public SiloAddress LocalSilo => localSilo;
 
         public int RefreshMembershipCallCount { get; private set; }
 
         public DisseminationMembership GetMembership()
         {
+            if (GetMembershipHandler is { } handler)
+            {
+                return handler();
+            }
+
             var members = _peers.Append(localSilo).Distinct().Select(peer =>
             {
                 var status = PeerStatuses.TryGetValue(peer, out var peerStatus) ? peerStatus : SiloStatus.Active;
@@ -2804,6 +3120,16 @@ public class DisseminationProtocolTests
         public IDisposable? OnChange(Action<T, string?> listener) => null;
     }
 
+    private sealed class MutableServiceProvider : IServiceProvider
+    {
+        private readonly Dictionary<Type, object> _services = [];
+
+        public void Add<T>(T service) where T : class => _services[typeof(T)] = service;
+
+        public object? GetService(Type serviceType) =>
+            _services.TryGetValue(serviceType, out var service) ? service : null;
+    }
+
     private sealed class FakeSiloStatusOracle : ISiloStatusOracle
     {
         private readonly Dictionary<SiloAddress, SiloStatus> _statuses = new();
@@ -2845,6 +3171,38 @@ public class DisseminationProtocolTests
     private sealed class FakeEnvironmentStatisticsProvider : Orleans.Statistics.IEnvironmentStatisticsProvider
     {
         public Orleans.Statistics.EnvironmentStatistics GetEnvironmentStatistics() => default;
+    }
+
+    private sealed class FakeActivationWorkingSet : IActivationWorkingSet
+    {
+        public int Count => 0;
+
+        public void OnActivated(IActivationWorkingSetMember member)
+        {
+        }
+
+        public void OnActive(IActivationWorkingSetMember member)
+        {
+        }
+
+        public void OnDeactivating(IActivationWorkingSetMember member)
+        {
+        }
+
+        public void OnDeactivated(IActivationWorkingSetMember member)
+        {
+        }
+    }
+
+    private sealed class FakeDeploymentLoadPublisherTarget : IDeploymentLoadPublisher
+    {
+        public List<(SiloAddress Source, SiloRuntimeStatistics Statistics)> Updates { get; } = [];
+
+        public Task UpdateRuntimeStatistics(SiloAddress siloAddress, SiloRuntimeStatistics siloStats)
+        {
+            Updates.Add((siloAddress, siloStats));
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class FakeSiloControl(Func<Task<SiloRuntimeStatistics>>? getRuntimeStatistics = null) : ISiloControl

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -2199,6 +2199,50 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task DisseminationService_StartAsyncDoesNotStartAntiEntropyWhenDisabled()
+    {
+        var local = CreateSilo(21310);
+        var transport = new FakeTransport(local);
+        var topic = new FakeTopic(local);
+        var options = new DisseminationOptions { Enabled = false };
+        var optionsMonitor = new TestOptionsMonitor<DisseminationOptions>(options);
+        var service = new DisseminationService(
+            transport,
+            optionsMonitor,
+            [topic],
+            TimeProvider.System,
+            NullLogger<DisseminationProtocol>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.False(service.IsAntiEntropyRunning);
+        options.Enabled = true;
+        optionsMonitor.Update(options);
+        await WaitUntil(() => service.IsAntiEntropyRunning);
+        Assert.True(service.IsAntiEntropyRunning);
+        options.Enabled = false;
+        optionsMonitor.Update(options);
+        await WaitUntil(() => !service.IsAntiEntropyRunning);
+        Assert.False(service.IsAntiEntropyRunning);
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task DisseminationService_StartAsyncStartsAntiEntropyWhenEnabled()
+    {
+        var local = CreateSilo(21311);
+        var transport = new FakeTransport(local);
+        var topic = new FakeTopic(local);
+        var service = CreateService(transport, topic);
+
+        await service.StartAsync(CancellationToken.None);
+
+        Assert.True(service.IsAntiEntropyRunning);
+        await service.StopAsync(CancellationToken.None);
+        Assert.False(service.IsAntiEntropyRunning);
+    }
+
+    [Fact]
     public async Task DisseminationService_StopAsyncPropagatesItsCancellationTokenToPendingGossipSends()
     {
         var local = CreateSilo(21501);
@@ -3113,11 +3157,33 @@ public class DisseminationProtocolTests
 
     private sealed class TestOptionsMonitor<T>(T currentValue) : IOptionsMonitor<T>
     {
-        public T CurrentValue => currentValue;
+        private readonly List<Action<T, string?>> _listeners = [];
 
-        public T Get(string? name) => currentValue;
+        public T CurrentValue { get; private set; } = currentValue;
 
-        public IDisposable? OnChange(Action<T, string?> listener) => null;
+        public T Get(string? name) => CurrentValue;
+
+        public IDisposable OnChange(Action<T, string?> listener)
+        {
+            _listeners.Add(listener);
+            return new ListenerRegistration(_listeners, listener);
+        }
+
+        public void Update(T value)
+        {
+            CurrentValue = value;
+            foreach (var listener in _listeners.ToArray())
+            {
+                listener(value, Options.DefaultName);
+            }
+        }
+
+        private sealed class ListenerRegistration(
+            List<Action<T, string?>> listeners,
+            Action<T, string?> listener) : IDisposable
+        {
+            public void Dispose() => listeners.Remove(listener);
+        }
     }
 
     private sealed class MutableServiceProvider : IServiceProvider

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -9,7 +9,9 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using CsCheck;
+#if NET10_0_OR_GREATER
 using Microsoft.Accordant;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -706,6 +708,7 @@ public class DisseminationProtocolTests
         }
     }
 
+#if NET10_0_OR_GREATER
     [Fact]
     public async Task MonotonicDisseminationModelConformsToAccordantSpec()
     {
@@ -747,6 +750,7 @@ public class DisseminationProtocolTests
         var failures = results.Where(static result => !result.Success).ToArray();
         Assert.Empty(failures);
     }
+#endif
 
     [Fact]
     public async Task MembershipTopicReturnsAndAppliesDiffWhenPeerVersionIsRetained()
@@ -1132,6 +1136,7 @@ public class DisseminationProtocolTests
             System.Collections.Immutable.ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty);
     }
 
+#if NET10_0_OR_GREATER
     private static Spec<MonotonicDisseminationState> CreateMonotonicDisseminationSpec()
     {
         var spec = new Spec<MonotonicDisseminationState>()
@@ -1179,6 +1184,7 @@ public class DisseminationProtocolTests
 
         return spec;
     }
+#endif
 
     private sealed class FakeTopic(SiloAddress localSilo, string name = "fake-topic") : IDisseminationTopic
     {
@@ -1361,6 +1367,7 @@ public class DisseminationProtocolTests
         };
     }
 
+#if NET10_0_OR_GREATER
     private sealed class MonotonicDisseminationHarness(SiloAddress localSilo)
     {
         private readonly FakeTopic _topic = new(localSilo);
@@ -1406,6 +1413,7 @@ public class DisseminationProtocolTests
             _ => ModelApplyResult.Rejected,
         };
     }
+#endif
 
     private sealed class FakeMembershipManager(MembershipTableSnapshot currentSnapshot) : IMembershipManager
     {
@@ -1480,6 +1488,7 @@ public class DisseminationProtocolTests
     }
 }
 
+#if NET10_0_OR_GREATER
 [State]
 public partial class MonotonicDisseminationState
 {
@@ -1497,3 +1506,4 @@ public enum ModelApplyResult
 public sealed record ModelApplyResponse(ModelApplyResult Result, long Version);
 
 public sealed record ModelRepairResponse(bool HasValue, long Version);
+#endif

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -310,6 +310,35 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task ReceiveGossipWithMissingRootForwardsAfterMembershipRefresh()
+    {
+        var local = CreateSilo(11111);
+        var sender = CreateSilo(11112);
+        var peer = CreateSilo(11113);
+        var root = CreateSilo(11120);
+        var transport = new FakeTransport(local, sender, peer);
+        transport.RefreshMembershipHandler = _ =>
+        {
+            transport.Peers.Add(root);
+            return Task.CompletedTask;
+        };
+        var topic = new FakeTopic(local);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
+        var item = topic.CreateItem(root, FakeTopic.DefaultKey, sequence: 1);
+
+        await protocol.ReceiveGossip(new DisseminationGossipBatch
+        {
+            Sender = sender,
+            Values = [item],
+        }, CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
+
+        Assert.Equal(1, topic.GetVersion(FakeTopic.DefaultKey));
+        Assert.Equal(1, transport.RefreshMembershipCallCount);
+        Assert.Equal(new[] { peer }, transport.GossipBatches.Select(static batch => batch.Peer));
+    }
+
+    [Fact]
     public async Task TreeRoutingInvalidatesCachedTopologyWhenActivePeersChange()
     {
         var local = CreateSilo(11115);
@@ -1257,6 +1286,8 @@ public class DisseminationProtocolTests
         public Func<SiloAddress, DisseminationAntiEntropyRequest, ValueTask<DisseminationAntiEntropyResponse>> ExchangeAntiEntropyHandler { get; set; } =
             static (peer, _) => ValueTask.FromResult(new DisseminationAntiEntropyResponse { Sender = peer });
 
+        public Func<CancellationToken, Task>? RefreshMembershipHandler { get; set; }
+
         public SiloAddress LocalSilo => localSilo;
 
         public int RefreshMembershipCallCount { get; private set; }
@@ -1289,7 +1320,7 @@ public class DisseminationProtocolTests
         public Task RefreshMembership(CancellationToken cancellationToken)
         {
             RefreshMembershipCallCount++;
-            return Task.CompletedTask;
+            return RefreshMembershipHandler?.Invoke(cancellationToken) ?? Task.CompletedTask;
         }
 
         public Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken)

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -17,6 +18,7 @@ using Orleans.Configuration;
 using Orleans.Metadata;
 using Orleans.Providers;
 using Orleans.Runtime;
+using Orleans.Runtime.Diagnostics;
 using Orleans.Runtime.Dissemination;
 using Orleans.Runtime.MembershipService;
 using Orleans.Serialization;
@@ -338,7 +340,7 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
-    public async Task ReceiveGossipPropagatesCallerCancellationFromTopicApply()
+    public async Task ReceiveGossipChecksCallerCancellationBeforeApplyingValue()
     {
         var local = CreateSilo(11111);
         var sender = CreateSilo(11112);
@@ -346,10 +348,9 @@ public class DisseminationProtocolTests
         var applyAttempts = new List<string>();
         var topic = new FakeTopic(local)
         {
-            ApplyValueHandler = (value, cancellationToken) =>
+            ApplyValueHandler = (value, _) =>
             {
                 applyAttempts.Add(value.Digest.Key);
-                cancellationToken.ThrowIfCancellationRequested();
                 return ValueTask.FromResult(DisseminationApplyResult.Applied);
             },
         };
@@ -364,7 +365,32 @@ public class DisseminationProtocolTests
                 topic.CreateItem(sender, "second", sequence: 1)),
             cancellation.Token));
 
-        Assert.Equal(new[] { "first" }, applyAttempts);
+        Assert.Empty(applyAttempts);
+    }
+
+    [Fact]
+    public async Task ReceiveGossipPropagatesCancellationRaisedDuringApplyBeforeForwarding()
+    {
+        var local = CreateSilo(11111);
+        var sender = CreateSilo(11112);
+        var peer = CreateSilo(11113);
+        var transport = new FakeTransport(local, sender, peer);
+        using var cancellation = new CancellationTokenSource();
+        var topic = new FakeTopic(local)
+        {
+            ApplyValueHandler = (_, _) =>
+            {
+                cancellation.Cancel();
+                return ValueTask.FromResult(DisseminationApplyResult.Applied);
+            },
+        };
+        await using var protocol = CreateProtocol(transport, topic);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => protocol.ReceiveGossip(
+            CreateGossipBatch(sender, topic.CreateItem(sender, "value", sequence: 1)),
+            cancellation.Token));
+
+        Assert.Empty(transport.GossipBatches);
     }
 
     [Fact]
@@ -410,6 +436,112 @@ public class DisseminationProtocolTests
         Assert.Equal(1, topic.GetVersion(FakeTopic.DefaultKey));
         Assert.Equal(1, transport.RefreshMembershipCallCount);
         Assert.Equal(new[] { peer }, transport.GossipBatches.Select(static batch => batch.Peer));
+    }
+
+    [Fact]
+    public async Task ReceiveGossipContinuesAfterForwardFailure()
+    {
+        var local = CreateSilo(11111);
+        var sender = CreateSilo(11112);
+        var peer = CreateSilo(11113);
+        var root = CreateSilo(11120);
+        var transport = new FakeTransport(local, sender, peer);
+        transport.RefreshMembershipHandler = _ =>
+        {
+            if (transport.RefreshMembershipCallCount == 1)
+            {
+                throw new InvalidOperationException("Transient membership refresh failure.");
+            }
+
+            transport.Peers.Add(root);
+            return Task.CompletedTask;
+        };
+        var topic = new FakeTopic(local);
+        await using var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
+        var failures = new List<DisseminationValueEvent>();
+        using var subscription = DisseminationEvents.Listener.Subscribe(
+            new ActionObserver<KeyValuePair<string, object?>>(entry =>
+            {
+                if (entry.Key == "Dissemination.ForwardFailure" && entry.Value is DisseminationValueEvent value)
+                {
+                    failures.Add(value);
+                }
+            }));
+
+        await protocol.ReceiveGossip(
+            CreateGossipBatch(
+                sender,
+                topic.CreateItem(root, "first", sequence: 1),
+                topic.CreateItem(root, "second", sequence: 1)),
+            CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
+
+        Assert.Equal(1, topic.GetVersion("first"));
+        Assert.Equal(1, topic.GetVersion("second"));
+        Assert.Equal(2, transport.RefreshMembershipCallCount);
+        var forwarded = Assert.Single(transport.GossipBatches);
+        Assert.Equal(peer, forwarded.Peer);
+        Assert.Equal("second", Assert.Single(GetGossipValues(forwarded.Batch)).Digest.Key);
+        var failure = Assert.Single(failures);
+        Assert.Equal("exception", failure.Result);
+        Assert.Null(failure.Peer);
+    }
+
+    [Fact]
+    public async Task ReceiveGossipDiagnosesForwardQueueCapacityFailure()
+    {
+        var root = CreateSilo(11111);
+        var local = CreateSilo(11112);
+        var peer = CreateSilo(11113);
+        var transport = new FakeTransport(local, root, peer);
+        var firstSendStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstSend = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sendCount = 0;
+        transport.SendGossipHandler = async (target, batch, cancellationToken) =>
+        {
+            transport.GossipBatches.Add((target, batch));
+            if (Interlocked.Increment(ref sendCount) == 1)
+            {
+                firstSendStarted.TrySetResult(true);
+                await releaseFirstSend.Task.WaitAsync(cancellationToken);
+            }
+        };
+        var topic = new FakeTopic(local);
+        topic.Options.MaxPendingItemCount = 1;
+        topic.Options.MaxCoalescingDelay = TimeSpan.FromMinutes(1);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 1);
+        var failures = new List<DisseminationValueEvent>();
+        using var subscription = DisseminationEvents.Listener.Subscribe(
+            new ActionObserver<KeyValuePair<string, object?>>(entry =>
+            {
+                if (entry.Key == "Dissemination.ForwardFailure" && entry.Value is DisseminationValueEvent value)
+                {
+                    failures.Add(value);
+                }
+            }));
+
+        try
+        {
+            Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "in-flight", sequence: 1), [peer], CancellationToken.None));
+            await firstSendStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.True(await protocol.Publish(topic.Name, topic.CreateItem(local, "queued", sequence: 1), [peer], CancellationToken.None));
+
+            await protocol.ReceiveGossip(
+                CreateGossipBatch(root, topic.CreateItem(root, "rejected", sequence: 1)),
+                CancellationToken.None);
+
+            var failure = Assert.Single(failures);
+            Assert.Equal(topic.Name, failure.Topic);
+            Assert.Equal("rejected", failure.Key);
+            Assert.Equal("queue-capacity", failure.Result);
+            Assert.Equal(peer, failure.Peer);
+        }
+        finally
+        {
+            releaseFirstSend.TrySetResult(true);
+            await protocol.FlushPendingGossip(CancellationToken.None);
+            await protocol.DisposeAsync();
+        }
     }
 
     [Fact]
@@ -1694,6 +1826,103 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public void ManifestHashCalculator_DistinguishesNestedStructuresWithSameFlattenedStrings()
+    {
+        var firstGrains = System.Collections.Immutable.ImmutableDictionary.CreateBuilder<GrainType, GrainProperties>();
+        firstGrains[GrainType.Create("G1")] = new GrainProperties(
+            System.Collections.Immutable.ImmutableDictionary.Create<string, string>(StringComparer.Ordinal).Add("K", "V"));
+        firstGrains[GrainType.Create("G2")] = new GrainProperties(
+            System.Collections.Immutable.ImmutableDictionary.Create<string, string>(StringComparer.Ordinal));
+        var first = new GrainManifest(
+            firstGrains.ToImmutable(),
+            System.Collections.Immutable.ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty);
+
+        var secondGrains = System.Collections.Immutable.ImmutableDictionary.CreateBuilder<GrainType, GrainProperties>();
+        secondGrains[GrainType.Create("G1")] = new GrainProperties(
+            System.Collections.Immutable.ImmutableDictionary.Create<string, string>(StringComparer.Ordinal));
+        secondGrains[GrainType.Create("K")] = new GrainProperties(
+            System.Collections.Immutable.ImmutableDictionary.Create<string, string>(StringComparer.Ordinal).Add("V", "G2"));
+        var second = new GrainManifest(
+            secondGrains.ToImmutable(),
+            System.Collections.Immutable.ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty);
+
+        Assert.NotEqual(ManifestHashCalculator.ComputeHash(first), ManifestHashCalculator.ComputeHash(second));
+    }
+
+    [Fact]
+    public void ManifestHashCalculator_PreservesRawTypeBytesAndInvalidUtf16()
+    {
+        static GrainManifest Create(byte grainType, string propertyValue)
+        {
+            var grains = System.Collections.Immutable.ImmutableDictionary.CreateBuilder<GrainType, GrainProperties>();
+            grains[new GrainType([grainType])] = new GrainProperties(
+                System.Collections.Immutable.ImmutableDictionary.Create<string, string>(StringComparer.Ordinal)
+                    .Add("value", propertyValue));
+            return new GrainManifest(
+                grains.ToImmutable(),
+                System.Collections.Immutable.ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty);
+        }
+
+        Assert.NotEqual(
+            ManifestHashCalculator.ComputeHash(Create(0x80, "value")),
+            ManifestHashCalculator.ComputeHash(Create(0x81, "value")));
+        Assert.NotEqual(
+            ManifestHashCalculator.ComputeHash(Create(0x80, "\uD800")),
+            ManifestHashCalculator.ComputeHash(Create(0x80, "\uD801")));
+    }
+
+    [Fact]
+    public void ManifestHashCalculator_DistinguishesNullAndEmptyPropertyValues()
+    {
+        static GrainManifest Create(string? propertyValue)
+        {
+            var grains = System.Collections.Immutable.ImmutableDictionary.CreateBuilder<GrainType, GrainProperties>();
+            grains[GrainType.Create("grain")] = new GrainProperties(
+                System.Collections.Immutable.ImmutableDictionary.Create<string, string>(StringComparer.Ordinal)
+                    .Add("value", propertyValue!));
+            return new GrainManifest(
+                grains.ToImmutable(),
+                System.Collections.Immutable.ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty);
+        }
+
+        Assert.NotEqual(
+            ManifestHashCalculator.ComputeHash(Create(propertyValue: null)),
+            ManifestHashCalculator.ComputeHash(Create(string.Empty)));
+    }
+
+    [Fact]
+    public void ManifestHashCalculator_DistinguishesDefaultAndEmptyTypeIdentifiers()
+    {
+        static GrainManifest CreateGrainManifest(GrainType grainType)
+        {
+            var grains = System.Collections.Immutable.ImmutableDictionary.CreateBuilder<GrainType, GrainProperties>();
+            grains[grainType] = new GrainProperties(
+                System.Collections.Immutable.ImmutableDictionary.Create<string, string>(StringComparer.Ordinal));
+            return new GrainManifest(
+                grains.ToImmutable(),
+                System.Collections.Immutable.ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty);
+        }
+
+        static GrainManifest CreateInterfaceManifest(GrainInterfaceType interfaceType)
+        {
+            var interfaces = System.Collections.Immutable.ImmutableDictionary.CreateBuilder<GrainInterfaceType, GrainInterfaceProperties>();
+            interfaces[interfaceType] = new GrainInterfaceProperties(
+                System.Collections.Immutable.ImmutableDictionary.Create<string, string>(StringComparer.Ordinal));
+            return new GrainManifest(
+                System.Collections.Immutable.ImmutableDictionary<GrainType, GrainProperties>.Empty,
+                interfaces.ToImmutable());
+        }
+
+        Assert.NotEqual(
+            ManifestHashCalculator.ComputeHash(CreateGrainManifest(default)),
+            ManifestHashCalculator.ComputeHash(CreateGrainManifest(new GrainType(Array.Empty<byte>()))));
+        Assert.NotEqual(
+            ManifestHashCalculator.ComputeHash(CreateInterfaceManifest(default)),
+            ManifestHashCalculator.ComputeHash(CreateInterfaceManifest(
+                new GrainInterfaceType(new IdSpan(Array.Empty<byte>())))));
+    }
+
+    [Fact]
     public void ManifestHashCalculator_IsDeterministicForEmptyManifest()
     {
         var empty = new GrainManifest(
@@ -1893,6 +2122,17 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public void OptionsValidatorRejectsAntiEntropyIntervalBeyondTimerMaximum()
+    {
+        var options = new DisseminationOptions();
+        options.Overlay.AntiEntropyInterval = TimeSpan.FromMilliseconds(uint.MaxValue);
+
+        var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
     public void OptionsValidatorRejectsNonPositiveAntiEntropyPeerCount()
     {
         var options = new DisseminationOptions();
@@ -1925,6 +2165,20 @@ public class DisseminationProtocolTests
     public void TopicOptionsValidatorRejectsNonPositiveMaxCoalescingDelay()
     {
         var options = new DisseminationTopicOptions { MaxCoalescingDelay = TimeSpan.Zero };
+
+        var result = DisseminationTopicOptionsValidator.Validate("Test", options);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void TopicOptionsValidatorRejectsMaxCoalescingDelayBeyondTimerMaximum()
+    {
+        var options = new DisseminationTopicOptions
+        {
+            MaxCoalescingDelay = TimeSpan.FromMilliseconds(uint.MaxValue),
+            StaleItemTtl = TimeSpan.FromMilliseconds(uint.MaxValue + 1d),
+        };
 
         var result = DisseminationTopicOptionsValidator.Validate("Test", options);
 
@@ -1987,6 +2241,120 @@ public class DisseminationProtocolTests
         Assert.Equal(DisseminationApplyResult.Duplicate, duplicate);
         Assert.Equal(DisseminationApplyResult.Obsolete, obsolete);
         Assert.Equal(baseline.DateTime, publisher.PeriodicStatistics[peer].DateTime);
+    }
+
+    [Fact]
+    public async Task RuntimeStatisticsConcurrentNewerAndOlderUpdatesRemainMonotonic()
+    {
+        var local = CreateSilo(21019);
+        var peer = CreateSilo(21020);
+        using var statusCheckEntered = new ManualResetEventSlim();
+        using var releaseStatusCheck = new ManualResetEventSlim();
+        using var olderStatusCheckEntered = new ManualResetEventSlim();
+        var statusCalls = 0;
+        var statusOracle = new FakeSiloStatusOracle
+        {
+            GetStatusHandler = _ =>
+            {
+                if (Interlocked.Increment(ref statusCalls) == 1)
+                {
+                    statusCheckEntered.Set();
+                    releaseStatusCheck.Wait();
+                }
+                else
+                {
+                    olderStatusCheckEntered.Set();
+                }
+
+                return SiloStatus.Active;
+            },
+        };
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var older = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var newer = CreateStatistics(older.DateTime.AddSeconds(1));
+
+        var newerUpdate = Task.Run(() => publisher.ApplyDisseminatedRuntimeStatistics(peer, newer));
+        Assert.True(statusCheckEntered.Wait(TimeSpan.FromSeconds(2)), "The newer update did not enter the status/version boundary.");
+        var olderUpdate = Task.Run(() => publisher.UpdateRuntimeStatistics(peer, older));
+        Assert.False(
+            olderStatusCheckEntered.Wait(TimeSpan.FromMilliseconds(100)),
+            "The older update entered the status/version boundary while the newer update still owned it.");
+        releaseStatusCheck.Set();
+
+        Assert.Equal(DisseminationApplyResult.Applied, await newerUpdate);
+        await olderUpdate;
+        Assert.Equal(newer.DateTime, publisher.PeriodicStatistics[peer].DateTime);
+    }
+
+    [Fact]
+    public async Task RuntimeStatisticsTerminationRaceCannotResurrectRemovedSilo()
+    {
+        var local = CreateSilo(21021);
+        var peer = CreateSilo(21022);
+        using var statusCheckEntered = new ManualResetEventSlim();
+        using var releaseStatusCheck = new ManualResetEventSlim();
+        var blockStatusCheck = false;
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.GetStatusHandler = silo =>
+        {
+            var status = statusOracle.GetStoredStatus(silo);
+            if (blockStatusCheck)
+            {
+                statusCheckEntered.Set();
+                releaseStatusCheck.Wait();
+            }
+
+            return status;
+        };
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var baseline = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        Assert.Equal(DisseminationApplyResult.Applied, publisher.ApplyDisseminatedRuntimeStatistics(peer, baseline));
+        blockStatusCheck = true;
+        var lateStatistics = CreateStatistics(baseline.DateTime.AddSeconds(1));
+
+        var lateUpdate = Task.Run(() => publisher.ApplyDisseminatedRuntimeStatistics(peer, lateStatistics));
+        Assert.True(statusCheckEntered.Wait(TimeSpan.FromSeconds(2)), "The late update did not enter the status/version boundary.");
+        statusOracle.SetStatus(peer, SiloStatus.Dead);
+        var termination = Task.Run(() => publisher.OnSiloStatusChange(peer, SiloStatus.Dead));
+        releaseStatusCheck.Set();
+
+        await lateUpdate;
+        await termination;
+        Assert.False(publisher.PeriodicStatistics.ContainsKey(peer));
+
+        var postTermination = publisher.ApplyDisseminatedRuntimeStatistics(
+            peer,
+            CreateStatistics(lateStatistics.DateTime.AddSeconds(1)));
+        Assert.Equal(DisseminationApplyResult.Rejected, postTermination);
+        Assert.False(publisher.PeriodicStatistics.ContainsKey(peer));
+    }
+
+    [Fact]
+    public void RuntimeStatisticsRemovedEventObservesCompletedRemoval()
+    {
+        var local = CreateSilo(21023);
+        var peer = CreateSilo(21024);
+        var statusOracle = new FakeSiloStatusOracle();
+        statusOracle.SetStatus(peer, SiloStatus.Active);
+        var publisher = CreateDeploymentLoadPublisher(local, statusOracle);
+        var statistics = CreateStatistics(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        Assert.Equal(DisseminationApplyResult.Applied, publisher.ApplyDisseminatedRuntimeStatistics(peer, statistics));
+        bool? entryPresentWhenRemovedEventRaised = null;
+        using var subscription = DeploymentLoadPublisherEvents.AllEvents.Subscribe(
+            new ActionObserver<DeploymentLoadPublisherEvents.DeploymentLoadPublisherEvent>(evt =>
+            {
+                if (evt is DeploymentLoadPublisherEvents.Removed removed && removed.RemovedSilo.Equals(peer))
+                {
+                    entryPresentWhenRemovedEventRaised = publisher.PeriodicStatistics.ContainsKey(peer);
+                }
+            }));
+
+        statusOracle.SetStatus(peer, SiloStatus.Dead);
+        publisher.OnSiloStatusChange(peer, SiloStatus.Dead);
+
+        Assert.False(entryPresentWhenRemovedEventRaised);
     }
 
     [Fact]
@@ -3832,9 +4200,12 @@ public class DisseminationProtocolTests
 
     private sealed class FakeSiloStatusOracle : ISiloStatusOracle
     {
-        private readonly Dictionary<SiloAddress, SiloStatus> _statuses = new();
+        private readonly ConcurrentDictionary<SiloAddress, SiloStatus> _statuses = new();
+        private int _approximateStatusesRequests;
 
-        public int ApproximateStatusesRequests { get; private set; }
+        public int ApproximateStatusesRequests => Volatile.Read(ref _approximateStatusesRequests);
+
+        public Func<SiloAddress, SiloStatus>? GetStatusHandler { get; set; }
 
         public SiloStatus CurrentStatus => SiloStatus.Active;
 
@@ -3844,15 +4215,18 @@ public class DisseminationProtocolTests
 
         public void SetStatus(SiloAddress silo, SiloStatus status) => _statuses[silo] = status;
 
+        public SiloStatus GetStoredStatus(SiloAddress siloAddress) =>
+            _statuses.TryGetValue(siloAddress, out var status) ? status : SiloStatus.None;
+
         public SiloAddress[] GetActiveSilos() =>
             _statuses.Where(static kvp => kvp.Value == SiloStatus.Active).Select(static kvp => kvp.Key).ToArray();
 
         public SiloStatus GetApproximateSiloStatus(SiloAddress siloAddress) =>
-            _statuses.TryGetValue(siloAddress, out var status) ? status : SiloStatus.None;
+            GetStatusHandler?.Invoke(siloAddress) ?? GetStoredStatus(siloAddress);
 
         public Dictionary<SiloAddress, SiloStatus> GetApproximateSiloStatuses(bool onlyActive = false)
         {
-            ApproximateStatusesRequests++;
+            Interlocked.Increment(ref _approximateStatusesRequests);
             return _statuses
                 .Where(kvp => !onlyActive || kvp.Value == SiloStatus.Active)
                 .ToDictionary(static kvp => kvp.Key, static kvp => kvp.Value);
@@ -3876,6 +4250,19 @@ public class DisseminationProtocolTests
     private sealed class FakeEnvironmentStatisticsProvider : Orleans.Statistics.IEnvironmentStatisticsProvider
     {
         public Orleans.Statistics.EnvironmentStatistics GetEnvironmentStatistics() => default;
+    }
+
+    private sealed class ActionObserver<T>(Action<T> onNext) : IObserver<T>
+    {
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(T value) => onNext(value);
     }
 
     private sealed class FakeActivationWorkingSet : IActivationWorkingSet

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -45,41 +45,39 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
-    public async Task PublishReturnsFalseWhenAnyParticipantIsIncapable()
+    public async Task PublishQueuesTreeGossipWithoutCapabilityProbing()
     {
         var local = CreateSilo(11111);
         var peers = Enumerable.Range(11112, 6).Select(CreateSilo).ToArray();
-        var transport = new FakeTransport(local, peers)
-        {
-            IncapablePeers = { peers[^1] },
-        };
-
+        var transport = new FakeTransport(local, peers);
         var topic = new FakeTopic(local);
         var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
         var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
 
         var result = await protocol.Publish(topic.Name, item, peers, CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
 
-        Assert.False(result);
-        Assert.Empty(transport.GossipBatches);
+        Assert.True(result);
+        Assert.Equal(GetOriginatorTreeTargets(local, peers, fanout: 2), transport.GossipBatches.Select(batch => batch.Peer));
     }
 
     [Fact]
-    public async Task PublishDoesNotFailWhenJoiningParticipantIsUnavailable()
+    public async Task PublishAttemptsJoiningParticipantAndReliesOnSendBackoff()
     {
         var local = CreateSilo(11111);
         var joining = CreateSilo(11112);
         var active = CreateSilo(11113);
         var transport = new FakeTransport(local, joining, active);
         transport.PeerStatuses[joining] = SiloStatus.Joining;
-        transport.GetCapabilitiesHandler = (target, request, cancellationToken) =>
+        transport.SendGossipHandler = (target, batch, cancellationToken) =>
         {
             if (Equals(target, joining))
             {
                 throw new InvalidOperationException("joining peer is not yet reachable");
             }
 
-            return ValueTask.FromResult(transport.CreateCapabilityResponse(target, request));
+            transport.GossipBatches.Add((target, batch));
+            return Task.CompletedTask;
         };
 
         var topic = new FakeTopic(local)
@@ -101,42 +99,44 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
-    public async Task CapabilityProbeFailureUsesFailureBackoffInsteadOfCapabilityCache()
+    public async Task SendFailureUsesFailureBackoff()
     {
         var local = CreateSilo(11111);
         var peer = CreateSilo(11112);
         var transport = new FakeTransport(local, peer);
         var timeProvider = new TestTimeProvider();
-        var probeCount = 0;
-        transport.GetCapabilitiesHandler = (target, request, cancellationToken) =>
+        var sendCount = 0;
+        transport.SendGossipHandler = (target, batch, cancellationToken) =>
         {
-            if (Interlocked.Increment(ref probeCount) == 1)
+            if (Interlocked.Increment(ref sendCount) == 1)
             {
                 timeProvider.Advance(TimeSpan.FromSeconds(10));
-                throw new InvalidOperationException("transient probe failure");
+                throw new InvalidOperationException("transient send failure");
             }
 
-            return ValueTask.FromResult(transport.CreateCapabilityResponse(target, request));
+            transport.GossipBatches.Add((target, batch));
+            return Task.CompletedTask;
         };
 
         var topic = new FakeTopic(local);
         var protocol = CreateProtocol(transport, topic, options =>
         {
-            options.CapabilityCacheTtl = TimeSpan.FromHours(1);
             options.FailureBackoff = TimeSpan.FromSeconds(5);
         }, timeProvider);
         var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
 
         var firstResult = await protocol.Publish(topic.Name, item, new[] { peer }, CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
         var secondResult = await protocol.Publish(topic.Name, item, new[] { peer }, CancellationToken.None);
+        await protocol.FlushPendingGossip(CancellationToken.None);
         timeProvider.Advance(TimeSpan.FromSeconds(5));
         var thirdResult = await protocol.Publish(topic.Name, item, new[] { peer }, CancellationToken.None);
         await protocol.FlushPendingGossip(CancellationToken.None);
 
-        Assert.False(firstResult);
-        Assert.False(secondResult);
+        Assert.True(firstResult);
+        Assert.True(secondResult);
         Assert.True(thirdResult);
-        Assert.Equal(2, probeCount);
+        Assert.Equal(2, sendCount);
         Assert.Single(transport.GossipBatches);
     }
 
@@ -310,6 +310,7 @@ public class DisseminationProtocolTests
             var local = silos[testCase.LocalIndex];
             var transport = new FakeTransport(local, silos.Where(silo => !Equals(silo, local)).ToArray());
             var topic = new FakeTopic(local);
+            topic.ExpectedKeys.Add(FakeTopic.DefaultKey);
             var protocol = CreateProtocol(transport, topic, options =>
             {
                 options.Overlay.FanOutFactor = _ => testCase.Fanout;
@@ -342,15 +343,7 @@ public class DisseminationProtocolTests
         var response = await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
         {
             Sender = peer,
-            Topics = new[]
-            {
-                new DisseminationCapabilityRequest
-                {
-                    Topic = topic.Name,
-                    ProtocolVersion = topic.ProtocolVersion,
-                    PayloadKinds = new[] { FakeTopic.PayloadKind },
-                },
-            },
+            Topics = [topic.Name],
             Digests = new[]
             {
                 new DisseminationDigest(topic.Name, FakeTopic.DefaultKey, version: 3, FakeTopic.PayloadKind),
@@ -376,15 +369,7 @@ public class DisseminationProtocolTests
         var response = await protocol.ReceiveAntiEntropy(new DisseminationAntiEntropyRequest
         {
             Sender = peer,
-            Topics =
-            [
-                new DisseminationCapabilityRequest
-                {
-                    Topic = topic.Name,
-                    ProtocolVersion = topic.ProtocolVersion,
-                    PayloadKinds = [FakeTopic.PayloadKind],
-                },
-            ],
+            Topics = [topic.Name],
             Digests =
             [
                 new DisseminationDigest(topic.Name, "requested", version: 3, FakeTopic.PayloadKind),
@@ -454,7 +439,7 @@ public class DisseminationProtocolTests
         var digest = Assert.Single(transport.AntiEntropyRequests[0].Request.Digests);
         Assert.Equal(FakeTopic.DefaultKey, digest.Key);
         Assert.Equal(long.MinValue, digest.Version);
-        Assert.Equal(topic.Name, Assert.Single(transport.AntiEntropyRequests[0].Request.Topics).Topic);
+        Assert.Equal(topic.Name, Assert.Single(transport.AntiEntropyRequests[0].Request.Topics));
     }
 
     [Fact]
@@ -599,7 +584,6 @@ public class DisseminationProtocolTests
         var value = await sourceTopic.GetValue(
             localDigest,
             peerDigest,
-            sourceTopic.PayloadKinds,
             CancellationToken.None);
 
         Assert.NotNull(value);
@@ -943,8 +927,6 @@ public class DisseminationProtocolTests
 
         public string Name => "fake-topic";
 
-        public int ProtocolVersion => 2;
-
         public DisseminationMembershipScope MembershipScope { get; set; } = DisseminationMembershipScope.ActiveMembers;
 
         public DisseminationTopicOptions Options { get; } = new() { Enabled = true };
@@ -992,10 +974,9 @@ public class DisseminationProtocolTests
         public ValueTask<DisseminationValue?> GetValue(
             DisseminationDigest digest,
             DisseminationDigest? peerDigest,
-            IReadOnlySet<string> peerPayloadKinds,
             CancellationToken cancellationToken)
         {
-            if (!peerPayloadKinds.Contains(PayloadKind) || !_versions.TryGetValue(digest.Key, out var version) || version < digest.Version)
+            if (!_versions.TryGetValue(digest.Key, out var version) || version < digest.Version)
             {
                 return ValueTask.FromResult<DisseminationValue?>(null);
             }
@@ -1041,10 +1022,6 @@ public class DisseminationProtocolTests
 
         public Dictionary<SiloAddress, DateTime> StartTimes { get; } = new();
 
-        public HashSet<SiloAddress> IncapablePeers { get; } = new();
-
-        public Func<SiloAddress, DisseminationCapabilityRequest, CancellationToken, ValueTask<DisseminationCapabilityResponse>>? GetCapabilitiesHandler { get; set; }
-
         public Func<SiloAddress, DisseminationGossipBatch, CancellationToken, Task>? SendGossipHandler { get; set; }
 
         public Func<SiloAddress, DisseminationAntiEntropyRequest, ValueTask<DisseminationAntiEntropyResponse>> ExchangeAntiEntropyHandler { get; set; } =
@@ -1076,29 +1053,6 @@ public class DisseminationProtocolTests
                 .ToImmutableArray();
             return new DisseminationMembership(allMembers, activeMembers);
         }
-
-        public ValueTask<DisseminationCapabilityResponse> GetCapabilities(
-            SiloAddress peer,
-            DisseminationCapabilityRequest request,
-            CancellationToken cancellationToken)
-        {
-            if (GetCapabilitiesHandler is not null)
-            {
-                return GetCapabilitiesHandler(peer, request, cancellationToken);
-            }
-
-            return ValueTask.FromResult(CreateCapabilityResponse(peer, request));
-        }
-
-        public DisseminationCapabilityResponse CreateCapabilityResponse(
-            SiloAddress peer,
-            DisseminationCapabilityRequest request) => new()
-            {
-                Topic = request.Topic,
-                ProtocolVersion = request.ProtocolVersion,
-                Supported = !IncapablePeers.Contains(peer),
-                PayloadKinds = IncapablePeers.Contains(peer) ? Array.Empty<string>() : request.PayloadKinds,
-            };
 
         public Task SendGossip(SiloAddress peer, DisseminationGossipBatch batch, CancellationToken cancellationToken)
         {
@@ -1160,7 +1114,6 @@ public class DisseminationProtocolTests
             var value = await _topic.GetValue(
                 localDigest,
                 peerDigest,
-                new HashSet<string>(StringComparer.Ordinal) { FakeTopic.PayloadKind },
                 CancellationToken.None);
             return value is null
                 ? new ModelRepairResponse(false, 0)

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -715,6 +715,16 @@ public class DisseminationProtocolTests
         Assert.Equal(TimeSpan.FromSeconds(10), new ClusterMembershipOptions().Dissemination.ExpectedUpdateCadence);
     }
 
+    [Fact]
+    public void DisseminationOptionsUseBatchDefaults()
+    {
+        var options = new DisseminationOptions();
+
+        Assert.Equal(1024 * 1024, options.MaxBatchBytes);
+        Assert.Equal(8 * 1024, options.MaxBatchItems);
+        Assert.Equal(options.MaxBatchBytes, new DisseminationTopicOptions().MaxPayloadBytes);
+    }
+
     private static DisseminationProtocol CreateProtocol(
         FakeTransport transport,
         FakeTopic topic,

--- a/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/Dissemination/DisseminationProtocolTests.cs
@@ -1,18 +1,23 @@
 #nullable enable
 
 using System;
-using System.Collections.Immutable;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using CsCheck;
+using Microsoft.Accordant;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Metadata;
 using Orleans.Runtime;
 using Orleans.Runtime.Dissemination;
+using Orleans.Runtime.MembershipService;
+using Orleans.Serialization;
 using Xunit;
 
 namespace UnitTests.Dissemination;
@@ -27,13 +32,13 @@ public class DisseminationProtocolTests
         var peers = Enumerable.Range(11112, 6).Select(CreateSilo).ToArray();
         var transport = new FakeTransport(local, peers);
         var topic = new FakeTopic(local);
-        var protocol = CreateProtocol(transport, topic, options => options.Overlay.TreeFanout = 2);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
         var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
 
         var result = await protocol.Publish(topic.Name, item, peers, CancellationToken.None);
 
         Assert.True(result);
-        var expectedChildren = GetTreeChildren(local, local, peers, fanout: 2);
+        var expectedChildren = GetOriginatorTreeTargets(local, peers, fanout: 2);
         Assert.Equal(expectedChildren, transport.GossipBatches.Select(batch => batch.Peer));
         Assert.All(transport.GossipBatches, batch => Assert.Equal(item.Digest, batch.Batch.Values.Single().Digest));
     }
@@ -49,7 +54,7 @@ public class DisseminationProtocolTests
         };
 
         var topic = new FakeTopic(local);
-        var protocol = CreateProtocol(transport, topic, options => options.Overlay.TreeFanout = 2);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
         var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
 
         var result = await protocol.Publish(topic.Name, item, peers, CancellationToken.None);
@@ -83,7 +88,7 @@ public class DisseminationProtocolTests
         var protocol = CreateProtocol(transport, topic, options =>
         {
             options.FailureBackoff = TimeSpan.FromSeconds(5);
-            options.Overlay.TreeFanout = 2;
+            options.Overlay.FanOutFactor = static _ => 2;
         });
         var value = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
 
@@ -141,7 +146,7 @@ public class DisseminationProtocolTests
         var peers = silos.Where(silo => !Equals(silo, local)).ToArray();
         var transport = new FakeTransport(local, peers);
         var topic = new FakeTopic(local);
-        var protocol = CreateProtocol(transport, topic, options => options.Overlay.TreeFanout = 2);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
         var item = topic.CreateItem(root, FakeTopic.DefaultKey, sequence: 1);
 
         await protocol.ReceiveGossip(new DisseminationGossipBatch
@@ -150,7 +155,7 @@ public class DisseminationProtocolTests
             Values = new[] { item },
         }, CancellationToken.None);
 
-        var expectedChildren = GetTreeChildren(local, root, peers, fanout: 2);
+        var expectedChildren = GetForwardingTreeTargets(local, root, peers, fanout: 2, sender: root);
         Assert.Equal(expectedChildren, transport.GossipBatches.Select(batch => batch.Peer));
     }
 
@@ -163,7 +168,7 @@ public class DisseminationProtocolTests
         var peers = silos.Where(silo => !Equals(silo, local)).ToArray();
         var transport = new FakeTransport(local, peers);
         var topic = new FakeTopic(local);
-        var protocol = CreateProtocol(transport, topic, options => options.Overlay.TreeFanout = 2);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
         var item = topic.CreateItem(root, FakeTopic.DefaultKey, sequence: 1);
         var batch = new DisseminationGossipBatch
         {
@@ -174,7 +179,7 @@ public class DisseminationProtocolTests
         await protocol.ReceiveGossip(batch, CancellationToken.None);
         await protocol.ReceiveGossip(batch, CancellationToken.None);
 
-        var expectedChildren = GetTreeChildren(local, root, peers, fanout: 2);
+        var expectedChildren = GetForwardingTreeTargets(local, root, peers, fanout: 2, sender: root);
         Assert.Equal(expectedChildren.Count, transport.GossipBatches.Count);
         Assert.Equal(1, topic.ApplyCounts[item.Digest.Key]);
     }
@@ -186,7 +191,7 @@ public class DisseminationProtocolTests
         var initialPeers = Enumerable.Range(11112, 3).Select(CreateSilo).ToList();
         var transport = new FakeTransport(local, initialPeers.ToArray());
         var topic = new FakeTopic(local);
-        var protocol = CreateProtocol(transport, topic, options => options.Overlay.TreeFanout = 2);
+        var protocol = CreateProtocol(transport, topic, options => options.Overlay.FanOutFactor = static _ => 2);
         var item = topic.CreateItem(local, FakeTopic.DefaultKey, sequence: 1);
 
         var initialResult = await protocol.Publish(topic.Name, item, targetPeers: null, CancellationToken.None);
@@ -195,7 +200,7 @@ public class DisseminationProtocolTests
         foreach (var peer in Enumerable.Range(11116, 8).Select(CreateSilo))
         {
             transport.Peers.Add(peer);
-            var updatedChildren = GetTreeChildren(local, local, transport.Peers, fanout: 2);
+            var updatedChildren = GetOriginatorTreeTargets(local, transport.Peers, fanout: 2);
             if (!initialChildren.SequenceEqual(updatedChildren))
             {
                 transport.GossipBatches.Clear();
@@ -211,6 +216,60 @@ public class DisseminationProtocolTests
         }
 
         throw new InvalidOperationException("The test did not find a peer set which changes the local tree children.");
+    }
+
+    [Fact]
+    public void FixedTreeRoutingSatisfiesReachabilityAndFanoutInvariants()
+    {
+        Gen.Select(Gen.Int[1, 64], Gen.Int[1, 8], Gen.Int[0, 63], static (count, fanout, rootSeed) =>
+        {
+            var rootIndex = rootSeed % count;
+            return (Count: count, Fanout: fanout, RootIndex: rootIndex);
+        }).Sample(testCase =>
+        {
+            var silos = CreateSilos(testCase.Count);
+            var root = silos[testCase.RootIndex];
+            var directTargets = GetOriginatorTreeTargets(root, silos.Where(silo => !Equals(silo, root)), testCase.Fanout);
+
+            Assert.DoesNotContain(root, directTargets);
+            Assert.Equal(directTargets.Count, directTargets.Distinct().Count());
+            Assert.True(directTargets.Count <= Math.Min((testCase.Fanout * 2), Math.Max(0, testCase.Count - 1)));
+
+            var reached = GetReachedParticipants(root, silos, testCase.Fanout);
+            Assert.Equal(silos.OrderBy(static silo => silo), reached.OrderBy(static silo => silo));
+        });
+    }
+
+    [Fact]
+    public void AntiEntropyPeerSelectionUsesFixedTreeLevels()
+    {
+        Gen.Select(Gen.Int[2, 64], Gen.Int[1, 8], Gen.Int[0, 63], Gen.Int[1, 8], static (count, fanout, localSeed, peerCount) =>
+        {
+            var localIndex = localSeed % count;
+            return (Count: count, Fanout: fanout, LocalIndex: localIndex, PeerCount: peerCount);
+        }).Sample(testCase =>
+        {
+            var silos = CreateSilos(testCase.Count);
+            var local = silos[testCase.LocalIndex];
+            var transport = new FakeTransport(local, silos.Where(silo => !Equals(silo, local)).ToArray());
+            var topic = new FakeTopic(local);
+            var protocol = CreateProtocol(transport, topic, options =>
+            {
+                options.Overlay.FanOutFactor = _ => testCase.Fanout;
+                options.Overlay.AntiEntropyPeerCount = testCase.PeerCount;
+            });
+
+            var state = protocol.CreateAntiEntropyState();
+            var peers = state.PeersByTopic[topic.Name];
+            var expectedCandidates = GetAntiEntropyCandidateIndexes(testCase.LocalIndex, testCase.Count, testCase.Fanout)
+                .Where(index => index != testCase.LocalIndex)
+                .Select(index => silos[index])
+                .ToHashSet();
+
+            Assert.True(peers.Count <= Math.Min(testCase.PeerCount, Math.Max(0, expectedCandidates.Count)));
+            Assert.DoesNotContain(local, peers);
+            Assert.All(peers, peer => Assert.Contains(peer, expectedCandidates));
+        });
     }
 
     [Fact]
@@ -350,6 +409,85 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
+    public async Task MonotonicDisseminationModelConformsToAccordantSpec()
+    {
+        var spec = CreateMonotonicDisseminationSpec();
+        spec.ExecuteWith<MonotonicDisseminationHarness>()
+            .BindAsync<long, ModelApplyResponse>("Receive", static (harness, version) => harness.Receive(version))
+            .BindAsync<long, ModelRepairResponse>("RepairPeer", static (harness, peerVersion) => harness.RepairPeer(peerVersion));
+
+        var receive = spec.GetOperation<long, ModelApplyResponse>("Receive");
+        var repairPeer = spec.GetOperation<long, ModelRepairResponse>("RepairPeer");
+        var inputs = new InputSet
+        {
+            receive.With(1, "Receive version 1"),
+            receive.With(2, "Receive version 2"),
+            receive.With(3, "Receive version 3"),
+            repairPeer.With(0, "Repair peer with no value"),
+            repairPeer.With(1, "Repair peer at version 1"),
+            repairPeer.With(3, "Repair peer at version 3"),
+        };
+        var initialState = new MonotonicDisseminationState();
+        var testCases = spec.GenerateTests(initialState, inputs, new TestGenerationOptions { MaxDepth = 4 });
+        var harness = new MonotonicDisseminationHarness(CreateSilo(11111));
+        var context = spec.CreateTestingContext();
+        context.Register(harness);
+
+        var results = await spec.RunTests(
+            context,
+            initialState,
+            testCases,
+            new TestExecutionOptions
+            {
+                BeforeEachAsync = testContext =>
+                {
+                    testContext.Context.Get<MonotonicDisseminationHarness>().Reset();
+                    return Task.CompletedTask;
+                },
+            });
+
+        var failures = results.Where(static result => !result.Success).ToArray();
+        Assert.Empty(failures);
+    }
+
+    [Fact]
+    public async Task MembershipTopicReturnsAndAppliesDiffWhenPeerVersionIsRetained()
+    {
+        var local = CreateSilo(11111);
+        var peer = CreateSilo(11112);
+        var baseSnapshot = CreateMembershipSnapshot(
+            version: 1,
+            CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch));
+        var updatedSnapshot = CreateMembershipSnapshot(
+            version: 2,
+            CreateMembershipEntry(local, SiloStatus.Active, DateTime.UnixEpoch),
+            CreateMembershipEntry(peer, SiloStatus.Active, DateTime.UnixEpoch.AddSeconds(1)));
+        using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
+        var serializer = serviceProvider.GetRequiredService<Serializer>();
+        var sourceManager = new FakeMembershipManager(baseSnapshot);
+        var sourceTopic = CreateMembershipTopic(local, sourceManager, serializer);
+        var peerDigest = Assert.Single(sourceTopic.GetDigests());
+        sourceManager.CurrentSnapshot = updatedSnapshot;
+        var localDigest = Assert.Single(sourceTopic.GetDigests());
+
+        var value = await sourceTopic.GetValue(
+            localDigest,
+            peerDigest,
+            sourceTopic.PayloadKinds,
+            CancellationToken.None);
+
+        Assert.NotNull(value);
+        Assert.Equal(DisseminationTopicNames.MembershipSnapshotDiff, value.Digest.PayloadKind);
+        var receiverManager = new FakeMembershipManager(baseSnapshot);
+        var receiverTopic = CreateMembershipTopic(peer, receiverManager, serializer);
+        var result = await receiverTopic.ApplyValue(value, CancellationToken.None);
+
+        Assert.Equal(DisseminationApplyResult.Applied, result);
+        Assert.Equal(updatedSnapshot.Version, receiverManager.CurrentSnapshot.Version);
+        Assert.True(receiverManager.CurrentSnapshot.Entries.ContainsKey(peer));
+    }
+
+    [Fact]
     public void ManifestHashIsIndependentOfDictionaryOrdering()
     {
         var manifest1 = CreateManifest(
@@ -363,10 +501,11 @@ public class DisseminationProtocolTests
     }
 
     [Fact]
-    public void OptionsValidatorRejectsInvalidTreeFanout()
+    public void OptionsValidatorRejectsInvalidFanoutBounds()
     {
         var options = new DisseminationOptions();
-        options.Overlay.TreeFanout = 0;
+        options.Overlay.MinFanOutFactor = 8;
+        options.Overlay.MaxFanOutFactor = 4;
         var result = new DisseminationOptionsValidator().Validate(Options.DefaultName, options);
 
         Assert.True(result.Failed);
@@ -405,6 +544,35 @@ public class DisseminationProtocolTests
 
     private static SiloAddress CreateSilo(int port) => SiloAddress.New(new IPEndPoint(IPAddress.Loopback, port), port);
 
+    private static SiloAddress[] CreateSilos(int count) =>
+        Enumerable.Range(11111, count).Select(CreateSilo).OrderBy(static silo => silo).ToArray();
+
+    private static MembershipDisseminationTopic CreateMembershipTopic(
+        SiloAddress local,
+        FakeMembershipManager membershipManager,
+        Serializer serializer) =>
+        new(
+            membershipManager,
+            new TestOptionsMonitor<ClusterMembershipOptions>(new ClusterMembershipOptions()),
+            serializer,
+            TimeProvider.System,
+            new FakeLocalSiloDetails(local));
+
+    private static MembershipTableSnapshot CreateMembershipSnapshot(long version, params MembershipEntry[] entries) =>
+        new(new MembershipVersion(version), entries.ToImmutableDictionary(static entry => entry.SiloAddress));
+
+    private static MembershipEntry CreateMembershipEntry(SiloAddress silo, SiloStatus status, DateTime startTime) => new()
+    {
+        SiloAddress = silo,
+        Status = status,
+        ProxyPort = silo.Endpoint.Port,
+        HostName = "localhost",
+        SiloName = silo.ToParsableString(),
+        RoleName = "test",
+        StartTime = startTime,
+        IAmAliveTime = startTime,
+    };
+
     private static async Task WaitUntil(Func<bool> condition)
     {
         var deadline = DateTime.UtcNow.AddSeconds(5);
@@ -419,35 +587,140 @@ public class DisseminationProtocolTests
         }
     }
 
-    private static IReadOnlyList<SiloAddress> GetTreeChildren(
-        SiloAddress local,
+    private static IReadOnlyList<SiloAddress> GetOriginatorTreeTargets(
         SiloAddress root,
         IEnumerable<SiloAddress> peers,
         int fanout)
     {
-        var participants = peers
+        var participants = GetSortedParticipants(root, root, peers);
+        var rootIndex = participants.FindIndex(silo => Equals(silo, root));
+        var result = new List<SiloAddress>();
+        AddTopLevelTargets(participants, fanout, root, result);
+        AddFixedChildren(participants, rootIndex, fanout, root, except: null, result);
+        return result;
+    }
+
+    private static IReadOnlyList<SiloAddress> GetForwardingTreeTargets(
+        SiloAddress local,
+        SiloAddress root,
+        IEnumerable<SiloAddress> peers,
+        int fanout,
+        SiloAddress sender)
+    {
+        var participants = GetSortedParticipants(local, root, peers);
+        var localIndex = participants.FindIndex(silo => Equals(silo, local));
+        var result = new List<SiloAddress>();
+        AddFixedChildren(participants, localIndex, fanout, root, sender, result);
+        return result;
+    }
+
+    private static List<SiloAddress> GetSortedParticipants(
+        SiloAddress local,
+        SiloAddress root,
+        IEnumerable<SiloAddress> peers) =>
+        peers
             .Append(local)
             .Append(root)
             .Distinct()
             .OrderBy(static silo => silo)
             .ToList();
-        var rootIndex = participants.FindIndex(silo => Equals(silo, root));
-        if (rootIndex > 0)
+
+    private static void AddTopLevelTargets(
+        IReadOnlyList<SiloAddress> participants,
+        int fanout,
+        SiloAddress root,
+        List<SiloAddress> result)
+    {
+        var count = Math.Min(fanout, participants.Count);
+        for (var i = 0; i < count; i++)
         {
-            participants = participants.Skip(rootIndex).Concat(participants.Take(rootIndex)).ToList();
+            AddTarget(participants[i], root, except: null, result);
+        }
+    }
+
+    private static void AddFixedChildren(
+        IReadOnlyList<SiloAddress> participants,
+        int index,
+        int fanout,
+        SiloAddress root,
+        SiloAddress? except,
+        List<SiloAddress> result)
+    {
+        if (index < 0)
+        {
+            return;
         }
 
-        var localIndex = participants.FindIndex(silo => Equals(silo, local));
-        if (localIndex < 0)
+        var firstChild = (long)fanout * (index + 1);
+        for (var i = 0; i < fanout; i++)
         {
-            return Array.Empty<SiloAddress>();
+            var childIndex = firstChild + i;
+            if (childIndex >= participants.Count)
+            {
+                break;
+            }
+
+            AddTarget(participants[(int)childIndex], root, except, result);
+        }
+    }
+
+    private static void AddTarget(SiloAddress peer, SiloAddress root, SiloAddress? except, List<SiloAddress> result)
+    {
+        if (Equals(peer, root) || (except is { } excluded && Equals(peer, excluded)) || result.Contains(peer))
+        {
+            return;
         }
 
-        var firstChild = localIndex * fanout + 1;
-        return Enumerable.Range(firstChild, fanout)
-            .Where(index => index < participants.Count)
-            .Select(index => participants[index])
-            .ToArray();
+        result.Add(peer);
+    }
+
+    private static HashSet<SiloAddress> GetReachedParticipants(SiloAddress root, IReadOnlyList<SiloAddress> participants, int fanout)
+    {
+        var reached = new HashSet<SiloAddress> { root };
+        var pending = new Queue<SiloAddress>(GetOriginatorTreeTargets(root, participants.Where(silo => !Equals(silo, root)), fanout));
+        while (pending.Count > 0)
+        {
+            var current = pending.Dequeue();
+            if (!reached.Add(current))
+            {
+                continue;
+            }
+
+            foreach (var child in GetForwardingTreeTargets(current, root, participants.Where(silo => !Equals(silo, current)), fanout, sender: root))
+            {
+                pending.Enqueue(child);
+            }
+        }
+
+        return reached;
+    }
+
+    private static IEnumerable<int> GetAntiEntropyCandidateIndexes(int localIndex, int participantCount, int fanout)
+    {
+        var topLevelEnd = Math.Min(fanout, participantCount);
+        if (localIndex < topLevelEnd)
+        {
+            return Enumerable.Range(0, topLevelEnd);
+        }
+
+        var parentIndex = (localIndex / fanout) - 1;
+        var (previousLevelStart, previousLevelEnd) = GetLevelRange(parentIndex, participantCount, fanout);
+        var windowStart = previousLevelStart + (((parentIndex - previousLevelStart) / fanout) * fanout);
+        var windowEnd = Math.Min(previousLevelEnd, windowStart + fanout);
+        return Enumerable.Range(windowStart, windowEnd - windowStart);
+    }
+
+    private static (int Start, int End) GetLevelRange(int index, int participantCount, int fanout)
+    {
+        var start = 0L;
+        var width = (long)fanout;
+        while (index >= start + width && start + width < participantCount)
+        {
+            start += width;
+            width = Math.Min(width * fanout, participantCount - start);
+        }
+
+        return ((int)start, (int)Math.Min(participantCount, start + width));
     }
 
     private static GrainManifest CreateManifest(params (string Grain, string Key, string Value)[] grains)
@@ -464,6 +737,54 @@ public class DisseminationProtocolTests
         return new GrainManifest(
             grainBuilder.ToImmutable(),
             System.Collections.Immutable.ImmutableDictionary<GrainInterfaceType, GrainInterfaceProperties>.Empty);
+    }
+
+    private static Spec<MonotonicDisseminationState> CreateMonotonicDisseminationSpec()
+    {
+        var spec = new Spec<MonotonicDisseminationState>()
+            .WithJsonPrinters();
+
+        spec.Operation<long, ModelApplyResponse>("Receive", static (version, state) =>
+        {
+            if (version < state.Version)
+            {
+                return Expect.That<ModelApplyResponse>(
+                    response => response.Result == ModelApplyResult.Obsolete && response.Version == state.Version,
+                    "Older values are obsolete and do not change state")
+                    .SameState();
+            }
+
+            if (version == state.Version && state.Version > 0)
+            {
+                return Expect.That<ModelApplyResponse>(
+                    response => response.Result == ModelApplyResult.Duplicate && response.Version == state.Version,
+                    "Equal versions are duplicates")
+                    .SameState();
+            }
+
+            return Expect.That<ModelApplyResponse>(
+                response => response.Result == ModelApplyResult.Applied && response.Version == version,
+                "Newer versions are applied")
+                .ThenState<MonotonicDisseminationState>(nextState => nextState.Version = version);
+        });
+
+        spec.Operation<long, ModelRepairResponse>("RepairPeer", static (peerVersion, state) =>
+        {
+            if (state.Version > peerVersion)
+            {
+                return Expect.That<ModelRepairResponse>(
+                    response => response.HasValue && response.Version == state.Version,
+                    "Repair returns the local newer value")
+                    .SameState();
+            }
+
+            return Expect.That<ModelRepairResponse>(
+                response => !response.HasValue && response.Version == 0,
+                "Repair returns no value when the peer is current or newer")
+                .SameState();
+        });
+
+        return spec;
     }
 
     private sealed class FakeTopic(SiloAddress localSilo) : IDisseminationTopic
@@ -497,6 +818,8 @@ public class DisseminationProtocolTests
 
         public void SetValue(string key, long version) => _versions[key] = version;
 
+        public void Clear() => _versions.Clear();
+
         public long GetVersion(string key) => _versions.TryGetValue(key, out var version) ? version : 0;
 
         public IReadOnlyList<DisseminationDigest> GetDigests() =>
@@ -508,9 +831,13 @@ public class DisseminationProtocolTests
             !string.Equals(digest.PayloadKind, PayloadKind, StringComparison.Ordinal)
             || (_versions.TryGetValue(digest.Key, out var version) && version > digest.Version);
 
-        public ValueTask<DisseminationValue?> GetValue(DisseminationDigest digest, CancellationToken cancellationToken)
+        public ValueTask<DisseminationValue?> GetValue(
+            DisseminationDigest digest,
+            DisseminationDigest? peerDigest,
+            IReadOnlySet<string> peerPayloadKinds,
+            CancellationToken cancellationToken)
         {
-            if (!_versions.TryGetValue(digest.Key, out var version) || version < digest.Version)
+            if (!peerPayloadKinds.Contains(PayloadKind) || !_versions.TryGetValue(digest.Key, out var version) || version < digest.Version)
             {
                 return ValueTask.FromResult<DisseminationValue?>(null);
             }
@@ -554,6 +881,8 @@ public class DisseminationProtocolTests
 
         public Dictionary<SiloAddress, SiloStatus> PeerStatuses { get; } = new();
 
+        public Dictionary<SiloAddress, DateTime> StartTimes { get; } = new();
+
         public HashSet<SiloAddress> IncapablePeers { get; } = new();
 
         public Func<SiloAddress, DisseminationCapabilityRequest, CancellationToken, ValueTask<DisseminationCapabilityResponse>>? GetCapabilitiesHandler { get; set; }
@@ -565,25 +894,27 @@ public class DisseminationProtocolTests
 
         public DisseminationMembership GetMembership()
         {
-            var allMembers = ImmutableArray.CreateBuilder<SiloAddress>();
-            var activeMembers = ImmutableArray.CreateBuilder<SiloAddress>();
-            foreach (var peer in _peers)
+            var members = _peers.Append(localSilo).Distinct().Select(peer =>
             {
                 var status = PeerStatuses.TryGetValue(peer, out var peerStatus) ? peerStatus : SiloStatus.Active;
-                if (status is SiloStatus.Joining or SiloStatus.Active or SiloStatus.ShuttingDown or SiloStatus.Stopping)
-                {
-                    allMembers.Add(peer);
-                }
+                var startTime = StartTimes.TryGetValue(peer, out var value) ? value : DateTime.UnixEpoch;
+                return (Peer: peer, Status: status, StartTime: startTime);
+            }).ToArray();
 
-                if (status == SiloStatus.Active)
-                {
-                    activeMembers.Add(peer);
-                }
-            }
-
-            allMembers.Sort(static (left, right) => left.CompareTo(right));
-            activeMembers.Sort(static (left, right) => left.CompareTo(right));
-            return new DisseminationMembership(allMembers.ToImmutable(), activeMembers.ToImmutable());
+            var allMembers = members
+                .Where(static member => member.Status is SiloStatus.Joining or SiloStatus.Active or SiloStatus.ShuttingDown or SiloStatus.Stopping)
+                .OrderBy(static member => GetStatusRank(member.Status))
+                .ThenBy(static member => member.StartTime)
+                .ThenBy(static member => member.Peer)
+                .Select(static member => member.Peer)
+                .ToImmutableArray();
+            var activeMembers = members
+                .Where(static member => member.Status == SiloStatus.Active)
+                .OrderBy(static member => member.StartTime)
+                .ThenBy(static member => member.Peer)
+                .Select(static member => member.Peer)
+                .ToImmutableArray();
+            return new DisseminationMembership(allMembers, activeMembers);
         }
 
         public ValueTask<DisseminationCapabilityResponse> GetCapabilities(
@@ -623,6 +954,115 @@ public class DisseminationProtocolTests
             AntiEntropyRequests.Add((peer, request));
             return ExchangeAntiEntropyHandler(peer, request);
         }
+
+        private static int GetStatusRank(SiloStatus status) => status switch
+        {
+            SiloStatus.Active => 0,
+            SiloStatus.Joining => 1,
+            SiloStatus.ShuttingDown => 2,
+            SiloStatus.Stopping => 3,
+            _ => 4,
+        };
+    }
+
+    private sealed class MonotonicDisseminationHarness(SiloAddress localSilo)
+    {
+        private readonly FakeTopic _topic = new(localSilo);
+
+        public void Reset() => _topic.Clear();
+
+        public async Task<ModelApplyResponse> Receive(long version)
+        {
+            var value = _topic.CreateItem(localSilo, FakeTopic.DefaultKey, version);
+            var result = await _topic.ApplyValue(value, CancellationToken.None);
+            return new ModelApplyResponse(ToModelResult(result), _topic.GetVersion(FakeTopic.DefaultKey));
+        }
+
+        public async Task<ModelRepairResponse> RepairPeer(long peerVersion)
+        {
+            var localDigest = _topic.GetDigests().SingleOrDefault();
+            if (localDigest.Version == 0)
+            {
+                return new ModelRepairResponse(false, 0);
+            }
+
+            var peerDigest = new DisseminationDigest(_topic.Name, FakeTopic.DefaultKey, peerVersion, FakeTopic.PayloadKind);
+            if (_topic.CompareVersion(localDigest, peerDigest) <= 0)
+            {
+                return new ModelRepairResponse(false, 0);
+            }
+
+            var value = await _topic.GetValue(
+                localDigest,
+                peerDigest,
+                new HashSet<string>(StringComparer.Ordinal) { FakeTopic.PayloadKind },
+                CancellationToken.None);
+            return value is null
+                ? new ModelRepairResponse(false, 0)
+                : new ModelRepairResponse(true, value.Digest.Version);
+        }
+
+        private static ModelApplyResult ToModelResult(DisseminationApplyResult result) => result switch
+        {
+            DisseminationApplyResult.Applied => ModelApplyResult.Applied,
+            DisseminationApplyResult.Duplicate => ModelApplyResult.Duplicate,
+            DisseminationApplyResult.Obsolete => ModelApplyResult.Obsolete,
+            _ => ModelApplyResult.Rejected,
+        };
+    }
+
+    private sealed class FakeMembershipManager(MembershipTableSnapshot currentSnapshot) : IMembershipManager
+    {
+        public MembershipTableSnapshot CurrentSnapshot { get; set; } = currentSnapshot;
+
+        public IAsyncEnumerable<MembershipTableSnapshot> MembershipUpdates => EmptyUpdates();
+
+        public SiloStatus LocalSiloStatus => SiloStatus.Active;
+
+        public Task UpdateLocalStatus(SiloStatus status, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task<bool> TryKillSilo(SiloAddress silo, CancellationToken cancellationToken) => Task.FromResult(false);
+
+        public Task<bool> TrySuspectSilo(SiloAddress silo, SiloAddress? indirectProbingSilo, CancellationToken cancellationToken) => Task.FromResult(false);
+
+        public Task Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken)
+        {
+            CurrentSnapshot = snapshot;
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateIAmAlive(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public bool CheckHealth(DateTime lastCheckTime, out string reason)
+        {
+            reason = string.Empty;
+            return true;
+        }
+
+        public void Participate(ISiloLifecycle lifecycle)
+        {
+        }
+
+        private static async IAsyncEnumerable<MembershipTableSnapshot> EmptyUpdates()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    private sealed class FakeLocalSiloDetails(SiloAddress localSilo) : ILocalSiloDetails
+    {
+        public string Name => "local";
+
+        public string ClusterId => "test-cluster";
+
+        public string DnsHostName => "localhost";
+
+        public SiloAddress SiloAddress => localSilo;
+
+        public SiloAddress GatewayAddress => localSilo;
     }
 
     private sealed class TestOptionsMonitor<T>(T currentValue) : IOptionsMonitor<T>
@@ -643,3 +1083,21 @@ public class DisseminationProtocolTests
         public void Advance(TimeSpan value) => _utcNow += value;
     }
 }
+
+[State]
+public partial class MonotonicDisseminationState
+{
+    public long Version { get; set; }
+}
+
+public enum ModelApplyResult
+{
+    Applied,
+    Duplicate,
+    Obsolete,
+    Rejected,
+}
+
+public sealed record ModelApplyResponse(ModelApplyResult Result, long Version);
+
+public sealed record ModelRepairResponse(bool HasValue, long Version);

--- a/test/Orleans.Runtime.Internal.Tests/Orleans.Runtime.Internal.Tests.csproj
+++ b/test/Orleans.Runtime.Internal.Tests/Orleans.Runtime.Internal.Tests.csproj
@@ -8,11 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="CsCheck" />
-    <PackageReference Include="Microsoft.Accordant" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Accordant" Condition="'$(TargetFramework)' == 'net10.0'" PrivateAssets="all" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.0" PrivateAssets="all" />
-    <PackageReference Include="System.IO.Pipelines" VersionOverride="10.0.5" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Json" VersionOverride="10.0.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Orleans.Runtime.Internal.Tests/Orleans.Runtime.Internal.Tests.csproj
+++ b/test/Orleans.Runtime.Internal.Tests/Orleans.Runtime.Internal.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="CsCheck" />
-    <PackageReference Include="Microsoft.Accordant" Condition="'$(TargetFramework)' == 'net10.0'" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Accordant" PrivateAssets="all" />
     <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 

--- a/test/Orleans.Runtime.Internal.Tests/Orleans.Runtime.Internal.Tests.csproj
+++ b/test/Orleans.Runtime.Internal.Tests/Orleans.Runtime.Internal.Tests.csproj
@@ -8,7 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="CsCheck" />
+    <PackageReference Include="Microsoft.Accordant" PrivateAssets="all" />
     <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.IO.Pipelines" VersionOverride="10.0.5" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" VersionOverride="10.0.5" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Orleans currently relies on all-to-all publication for several kinds of silo runtime state, including deployment load statistics, which scales poorly as clusters grow.

This adds an internal topic-based dissemination subsystem using deterministic fixed-tree broadcast with digest-based anti-entropy repair. It integrates deployment load statistics, membership snapshots, and cluster manifests while retaining their existing correctness backstops. Dissemination remains opt-in globally and per topic so existing behavior is preserved by default.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10324)