### PR TITLE
feat(cosmos): add configuration support for grain storage

### DIFF
--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorageProviderBuilder.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorageProviderBuilder.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Persistence.Cosmos;
+using Orleans.Providers;
+
+[assembly: RegisterProvider("AzureCosmosDB", "GrainStorage", "Silo", typeof(CosmosGrainStorageProviderBuilder))]
+
+namespace Orleans.Hosting;
+
+internal sealed class CosmosGrainStorageProviderBuilder : IProviderBuilder<ISiloBuilder>
+{
+    public void Configure(ISiloBuilder builder, string? name, IConfigurationSection configurationSection)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var documentIdProviderKey = configurationSection["DocumentIdProviderKey"];
+        if (!string.IsNullOrEmpty(documentIdProviderKey))
+        {
+            builder.Services.AddKeyedSingleton<IDocumentIdProvider>(
+                name,
+                (services, _) => services.GetRequiredKeyedService<IDocumentIdProvider>(documentIdProviderKey));
+        }
+
+        builder.AddCosmosGrainStorage(name, (OptionsBuilder<CosmosGrainStorageOptions> optionsBuilder) =>
+        {
+            optionsBuilder.Bind(configurationSection);
+            optionsBuilder.Configure<IServiceProvider>((options, services) =>
+            {
+                var serviceKey = configurationSection["ServiceKey"];
+                if (!string.IsNullOrEmpty(serviceKey))
+                {
+                    options.ConfigureCosmosClient(
+                        provider => new ValueTask<CosmosClient>(provider.GetRequiredKeyedService<CosmosClient>(serviceKey)));
+                    return;
+                }
+
+                var connectionName = configurationSection["ConnectionName"];
+                var connectionString = configurationSection["ConnectionString"];
+                if (!string.IsNullOrEmpty(connectionName) && string.IsNullOrEmpty(connectionString))
+                {
+                    connectionString = services.GetRequiredService<IConfiguration>().GetConnectionString(connectionName);
+                }
+
+                if (!string.IsNullOrEmpty(connectionString))
+                {
+                    options.ConfigureCosmosClient(connectionString);
+                }
+            });
+        });
+    }
+}

--- a/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorageProviderBuilder.cs
+++ b/src/Azure/Orleans.Persistence.Cosmos/CosmosGrainStorageProviderBuilder.cs
@@ -40,6 +40,10 @@ internal sealed class CosmosGrainStorageProviderBuilder : IProviderBuilder<ISilo
                 if (!string.IsNullOrEmpty(connectionName) && string.IsNullOrEmpty(connectionString))
                 {
                     connectionString = services.GetRequiredService<IConfiguration>().GetConnectionString(connectionName);
+                    if (string.IsNullOrEmpty(connectionString))
+                    {
+                        throw new InvalidOperationException($"Connection string '{connectionName}' was not found.");
+                    }
                 }
 
                 if (!string.IsNullOrEmpty(connectionString))

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosHostingExtensionsTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosHostingExtensionsTests.cs
@@ -1,5 +1,7 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Persistence.Cosmos;
@@ -22,6 +24,39 @@ public class CosmosHostingExtensionsTests
 
         Assert.IsType<FirstDocumentIdProvider>(host.Services.GetRequiredKeyedService<IDocumentIdProvider>("first"));
         Assert.IsType<SecondDocumentIdProvider>(host.Services.GetRequiredKeyedService<IDocumentIdProvider>("second"));
+    }
+
+    [Fact]
+    public void CosmosGrainStorageProviderBuilder_UsesConfiguredDocumentIdProviderFromDI()
+    {
+        const string storageName = "configured-storage";
+        const string documentIdProviderKey = "custom-document-ids";
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Cosmos:DatabaseName"] = "configured-database",
+                ["Cosmos:DocumentIdProviderKey"] = documentIdProviderKey
+            })
+            .Build();
+
+        using var host = new HostBuilder()
+            .UseOrleans(builder =>
+            {
+                builder.Services.AddSingleton<DocumentIdProviderDependency>();
+                builder.Services.AddKeyedSingleton<IDocumentIdProvider, ConfiguredDocumentIdProvider>(documentIdProviderKey);
+                new CosmosGrainStorageProviderBuilder().Configure(builder, storageName, configuration.GetSection("Cosmos"));
+            })
+            .Build();
+
+        var configuredProvider = host.Services.GetRequiredKeyedService<IDocumentIdProvider>(storageName);
+        var registeredProvider = host.Services.GetRequiredKeyedService<IDocumentIdProvider>(documentIdProviderKey);
+        var options = host.Services.GetRequiredService<IOptionsMonitor<CosmosGrainStorageOptions>>().Get(storageName);
+
+        Assert.Same(registeredProvider, configuredProvider);
+        Assert.Same(
+            host.Services.GetRequiredService<DocumentIdProviderDependency>(),
+            Assert.IsType<ConfiguredDocumentIdProvider>(configuredProvider).Dependency);
+        Assert.Equal("configured-database", options.DatabaseName);
     }
 
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -74,6 +109,17 @@ public class CosmosHostingExtensionsTests
     private sealed class SecondDocumentIdProvider : IDocumentIdProvider
     {
         public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(string grainType, GrainId grainId) => default;
+    }
+
+    private sealed class ConfiguredDocumentIdProvider(DocumentIdProviderDependency dependency) : IDocumentIdProvider
+    {
+        public DocumentIdProviderDependency Dependency { get; } = dependency;
+
+        public ValueTask<(string DocumentId, string PartitionKey)> GetDocumentIdentifiers(string grainType, GrainId grainId) => default;
+    }
+
+    private sealed class DocumentIdProviderDependency
+    {
     }
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosHostingExtensionsTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosHostingExtensionsTests.cs
@@ -59,6 +59,29 @@ public class CosmosHostingExtensionsTests
         Assert.Equal("configured-database", options.DatabaseName);
     }
 
+    [Fact]
+    public void CosmosGrainStorageProviderBuilder_ThrowsWhenNamedConnectionStringIsMissing()
+    {
+        const string storageName = "configured-storage";
+        const string connectionName = "missing";
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Cosmos:ConnectionName"] = connectionName
+            })
+            .Build();
+
+        using var host = new HostBuilder()
+            .UseOrleans(builder =>
+                new CosmosGrainStorageProviderBuilder().Configure(builder, storageName, configuration.GetSection("Cosmos")))
+            .Build();
+
+        var options = host.Services.GetRequiredService<IOptionsMonitor<CosmosGrainStorageOptions>>();
+        var exception = Assert.Throws<InvalidOperationException>(() => options.Get(storageName));
+
+        Assert.Equal($"Connection string '{connectionName}' was not found.", exception.Message);
+    }
+
 #pragma warning disable CS0618 // Type or member is obsolete
     [Fact]
     public void AddCosmosGrainStorage_LegacyPartitionKeyProvidersAreRegisteredByKey()


### PR DESCRIPTION
Follow-up to #8699.

Adds `IConfiguration` support for Cosmos grain storage and addresses the document ID provider configuration feedback.

- Registers `AzureCosmosDB` as a `GrainStorage` provider.
- Binds `CosmosGrainStorageOptions` from the provider configuration section.
- Supports `ServiceKey`, `ConnectionName`, and `ConnectionString` for the Cosmos client.
- Supports `DocumentIdProviderKey`, resolving an application-registered keyed `IDocumentIdProvider` through dependency injection and aliasing it to the storage provider name.
- Keeps service selection out of `CosmosGrainStorageOptions` and avoids reflection/type-name activation.

Tests cover keyed provider resolution, constructor dependency injection, and named options binding on net8.0 and net10.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10326)