### PR TITLE
docs: modernize security and observability guidance

### DIFF
--- a/docs/site/src/content/docs/dashboard/index.md
+++ b/docs/site/src/content/docs/dashboard/index.md
@@ -46,10 +46,10 @@ builder.UseOrleans(siloBuilder =>
 var app = builder.Build();
 
 app.MapOrleansDashboard("/dashboard")
-    .RequireAuthorization("DashboardOperators");
+    .RequireAuthorization();
 ```
 
-The route group includes static dashboard assets and its backing APIs. Apply authentication, authorization, rate limits, headers, and other endpoint conventions to the returned group rather than protecting only the HTML page.
+The route group includes static dashboard assets and its backing APIs. Apply authentication, authorization, rate limits, headers, and other endpoint conventions to the returned group rather than protecting only the HTML page. Use the policy-based configuration in the preceding secure dashboard example when dashboard access is limited to an operator role.
 
 ## Configure collection
 

--- a/docs/site/src/content/docs/dashboard/index.md
+++ b/docs/site/src/content/docs/dashboard/index.md
@@ -31,7 +31,7 @@ Validate the authorization behavior with an unauthenticated request and with use
 
 ## Install and map the dashboard
 
-Add [Microsoft.Orleans.Dashboard](https://www.nuget.org/packages/Microsoft.Orleans.Dashboard) to the web host. `Microsoft.Orleans.Dashboard.Abstractions` contains shared types such as <xref:Orleans.Dashboard.NoProfilingAttribute> and is brought in by the main package.
+Add [Microsoft.Orleans.Dashboard](https://www.nuget.org/packages/Microsoft.Orleans.Dashboard) to the web host. [Microsoft.Orleans.Dashboard.Abstractions](https://www.nuget.org/packages/Microsoft.Orleans.Dashboard.Abstractions) contains shared types such as <xref:Orleans.Dashboard.NoProfilingAttribute> and is brought in by the main package.
 
 Call `AddDashboard()` on the silo builder and map the route after building the ASP.NET Core app. A route prefix is recommended to avoid claiming the web application's root:
 

--- a/docs/site/src/content/docs/dashboard/index.md
+++ b/docs/site/src/content/docs/dashboard/index.md
@@ -12,12 +12,12 @@ The Orleans Dashboard provides live inspection of silos, grain activations, call
 ## Secure the dashboard before exposing it
 
 > [!WARNING]
-> `MapOrleansDashboard()` doesn't require authentication by default. The dashboard can expose topology, grain type and key information, runtime properties, method activity, log messages, reminder metadata, and serialized grain state. Never expose it to the public internet or an untrusted application network without authentication, authorization, and transport security.
+> <xref:Orleans.Dashboard.ServiceCollectionExtensions.MapOrleansDashboard*?displayProperty=nameWithType> doesn't require authentication by default. The dashboard can expose topology, grain type and key information, runtime properties, method activity, log messages, reminder metadata, and serialized grain state. Never expose it to the public internet or an untrusted application network without authentication, authorization, and transport security.
 
 Use defense in depth:
 
 1. **Authenticate operators.** Integrate the ASP.NET Core host with your organization's identity provider. Don't rely on a hard-to-guess route.
-2. **Authorize the entire route group.** Apply a policy to the `RouteGroupBuilder` returned by `MapOrleansDashboard()`.
+2. **Authorize the entire route group.** Apply a policy to the <xref:Microsoft.AspNetCore.Routing.RouteGroupBuilder> returned by `MapOrleansDashboard()`.
 3. **Restrict the network path.** Bind an administrative listener or put the route behind a private ingress, VPN, firewall, or zero-trust access proxy. A route prefix isn't a security boundary.
 4. **Use HTTPS.** Protect credentials, cookies, dashboard responses, and streamed logs in transit.
 5. **Limit sensitive data.** Grain state and logs can contain secrets or personal data. Apply normal data classification, retention, and access-audit requirements.
@@ -33,7 +33,7 @@ Validate the authorization behavior with an unauthenticated request and with use
 
 Add [Microsoft.Orleans.Dashboard](https://www.nuget.org/packages/Microsoft.Orleans.Dashboard) to the web host. [Microsoft.Orleans.Dashboard.Abstractions](https://www.nuget.org/packages/Microsoft.Orleans.Dashboard.Abstractions) contains shared types such as <xref:Orleans.Dashboard.NoProfilingAttribute> and is brought in by the main package.
 
-Call `AddDashboard()` on the silo builder and map the route after building the ASP.NET Core app. A route prefix is recommended to avoid claiming the web application's root:
+Call <xref:Orleans.Dashboard.ServiceCollectionExtensions.AddDashboard*?displayProperty=nameWithType> on the silo builder and map the route after building the ASP.NET Core app. A route prefix is recommended to avoid claiming the web application's root:
 
 ```csharp
 builder.UseOrleans(siloBuilder =>
@@ -64,9 +64,9 @@ siloBuilder.AddDashboard(options =>
 
 | Option | Default | Operational effect |
 |---|---:|---|
-| `HideTrace` | `false` | Disables the live log-streaming endpoint when `true`. |
-| `CounterUpdateIntervalMs` | `1000` | Sets the counter sampling interval in milliseconds; the minimum is 1000. |
-| `HistoryLength` | `100` | Controls retained in-memory dashboard history. Larger values consume more memory. |
+| <xref:Orleans.Dashboard.DashboardOptions.HideTrace> | `false` | Disables the live log-streaming endpoint when `true`. |
+| <xref:Orleans.Dashboard.DashboardOptions.CounterUpdateIntervalMs> | `1000` | Sets the counter sampling interval in milliseconds; the minimum is 1000. |
+| <xref:Orleans.Dashboard.DashboardOptions.HistoryLength> | `100` | Controls retained in-memory dashboard history. Larger values consume more memory. |
 
 The dashboard registers a logging provider and collects runtime metrics for display. Method profiling adds an incoming grain-call filter. By default, profiling becomes inactive after one minute without dashboard queries. Continuous profiling is available but has ongoing overhead:
 
@@ -78,7 +78,7 @@ builder.Services.Configure<GrainProfilerOptions>(options =>
 });
 ```
 
-Leave `TraceAlways` disabled unless continuous method statistics justify the cost. Load test representative traffic with the dashboard configuration you plan to deploy. Use <xref:Orleans.Dashboard.NoProfilingAttribute> on a grain class or method only when omitting it from dashboard method statistics is acceptable.
+Leave <xref:Orleans.Dashboard.GrainProfilerOptions.TraceAlways> disabled unless continuous method statistics justify the cost. Load test representative traffic with the dashboard configuration you plan to deploy. Use <xref:Orleans.Dashboard.NoProfilingAttribute> on a grain class or method only when omitting it from dashboard method statistics is acceptable.
 
 ## Choose a deployment boundary
 
@@ -118,7 +118,7 @@ Confirm the dashboard host has an active Orleans client connection, can resolve/
 
 ### Profiling data is empty
 
-Generate calls to the grain method, keep the page active, and confirm neither the class nor method has <xref:Orleans.Dashboard.NoProfilingAttribute>. If `TraceAlways` is `false`, profiling stops after `DeactivationTime` without dashboard queries.
+Generate calls to the grain method, keep the page active, and confirm neither the class nor method has <xref:Orleans.Dashboard.NoProfilingAttribute>. If `TraceAlways` is `false`, profiling stops after <xref:Orleans.Dashboard.GrainProfilerOptions.DeactivationTime> without dashboard queries.
 
 ### Live logs return 403
 

--- a/docs/site/src/content/docs/dashboard/index.md
+++ b/docs/site/src/content/docs/dashboard/index.md
@@ -1,295 +1,130 @@
 ---
 title: Orleans Dashboard
-description: Learn how to use the Orleans Dashboard for real-time monitoring of your Orleans cluster, silos, and grains.
-ms.date: 01/20/2026
+description: Securely deploy and operate the Orleans 10 dashboard for live cluster inspection.
+ms.date: 08/02/2026
 ms.topic: concept-article
-zone_pivot_groups: orleans-version
 ---
 
 # Orleans Dashboard
 
-:::zone target="docs" pivot="orleans-10-0"
+The Orleans Dashboard is a released Orleans 10 feature for live inspection of silos, grain activations, calls, reminders, runtime counters, logs, and grain state. It is an administrative surface, not a public application endpoint or a replacement for retained OpenTelemetry data.
 
-The Orleans Dashboard is a built-in web-based monitoring tool that provides real-time visibility into your Orleans cluster. It allows you to monitor silo health, grain activations, method calls, reminders, and system metrics without requiring external monitoring infrastructure.
+## Secure the dashboard before exposing it
 
-For Orleans 10.0, use the official dashboard packages: `Microsoft.Orleans.Dashboard` and `Microsoft.Orleans.Dashboard.Abstractions`.
+> [!WARNING]
+> `MapOrleansDashboard()` doesn't require authentication by default. The dashboard can expose topology, grain type and key information, runtime properties, method activity, log messages, reminder metadata, and serialized grain state. Never expose it to the public internet or an untrusted application network without authentication, authorization, and transport security.
 
-[!INCLUDE [orleans-10-preview](../includes/orleans-10-preview.md)]
+Use defense in depth:
 
-## Features
+1. **Authenticate operators.** Integrate the ASP.NET Core host with your organization's identity provider. Don't rely on a hard-to-guess route.
+2. **Authorize the entire route group.** Apply a policy to the `RouteGroupBuilder` returned by `MapOrleansDashboard()`.
+3. **Restrict the network path.** Bind an administrative listener or put the route behind a private ingress, VPN, firewall, or zero-trust access proxy. A route prefix isn't a security boundary.
+4. **Use HTTPS.** Protect credentials, cookies, dashboard responses, and streamed logs in transit.
+5. **Limit sensitive data.** Grain state and logs can contain secrets or personal data. Apply normal data classification, retention, and access-audit requirements.
+6. **Disable features you don't need.** Set `HideTrace = true` when live log streaming isn't required. Avoid exposing grain-state inspection to operators who don't need it.
 
-The Orleans Dashboard provides the following capabilities:
+The following example assumes the application has a cookie sign-in flow backed by its identity provider. It protects every dashboard asset and API endpoint with one policy:
 
-- **Cluster overview**: View all silos in the cluster with their status, uptime, and resource utilization.
-- **Grain monitoring**: Track grain activations, method calls, and performance metrics per grain type.
-- **Method profiling**: Analyze grain method call frequency, latency, and error rates.
-- **Reminder management**: Browse and monitor all registered reminders across the cluster.
-- **Live log streaming**: View real-time log output from the cluster.
-- **Silo details**: Inspect individual silo properties, counters, and grain distributions.
-- **Grain state inspection**: View the current state of individual grain instances.
+:::code language="csharp" source="./snippets/secure-dashboard/Program.cs" id="SecureDashboard":::
 
-## Installation
+Validate the authorization behavior with an unauthenticated request and with users inside and outside the operator role. Also check proxy forwarding and route-prefix behavior in the deployed topology.
 
-The Orleans Dashboard is distributed in two NuGet packages:
+## Install and map the dashboard
 
-| Package | Description |
-|---------|-------------|
-| [Microsoft.Orleans.Dashboard](https://www.nuget.org/packages/Microsoft.Orleans.Dashboard) | Main dashboard package with UI and API endpoints |
-| [Microsoft.Orleans.Dashboard.Abstractions](https://www.nuget.org/packages/Microsoft.Orleans.Dashboard.Abstractions) | Abstractions for dashboard integration (e.g., `NoProfilingAttribute`) |
+Add [Microsoft.Orleans.Dashboard](https://www.nuget.org/packages/Microsoft.Orleans.Dashboard) to the web host. `Microsoft.Orleans.Dashboard.Abstractions` contains shared types such as <xref:Orleans.Dashboard.NoProfilingAttribute> and is brought in by the main package.
 
-### Basic setup
-
-To add the Orleans Dashboard to your application, call `AddDashboard()` on your silo builder and `MapOrleansDashboard()` to map the dashboard endpoints:
+Call `AddDashboard()` on the silo builder and map the route after building the ASP.NET Core app. A route prefix is recommended to avoid claiming the web application's root:
 
 ```csharp
-using Orleans.Dashboard;
-
-var builder = WebApplication.CreateBuilder(args);
-
-// Configure Orleans with the dashboard
 builder.UseOrleans(siloBuilder =>
 {
-    siloBuilder.UseLocalhostClustering();
-    siloBuilder.AddMemoryGrainStorageAsDefault();
-    
-    // Add the dashboard services
-    siloBuilder.AddDashboard();
+    siloBuilder
+        .UseLocalhostClustering()
+        .AddDashboard();
 });
 
 var app = builder.Build();
 
-// Map dashboard endpoints at the root path
-app.MapOrleansDashboard();
-
-app.Run();
+app.MapOrleansDashboard("/dashboard")
+    .RequireAuthorization("DashboardOperators");
 ```
 
-After starting your application, navigate to `http://localhost:5000/` (or your configured URL) to access the dashboard.
+The route group includes static dashboard assets and its backing APIs. Apply authentication, authorization, rate limits, headers, and other endpoint conventions to the returned group rather than protecting only the HTML page.
 
-### Custom route prefix
-
-You can host the dashboard at a custom path by specifying a route prefix:
-
-```csharp
-// Map dashboard endpoints at /dashboard
-app.MapOrleansDashboard(routePrefix: "/dashboard");
-```
-
-With this configuration, access the dashboard at `http://localhost:5000/dashboard/`.
-
-## Configuration
-
-### Dashboard options
-
-Configure dashboard behavior using `DashboardOptions`:
+## Configure collection
 
 ```csharp
 siloBuilder.AddDashboard(options =>
 {
-    // Disable the live log streaming endpoint
     options.HideTrace = true;
-    
-    // Set the counter update interval (minimum 1000ms)
-    options.CounterUpdateIntervalMs = 2000;
-    
-    // Set the history buffer length for metrics
-    options.HistoryLength = 200;
+    options.CounterUpdateIntervalMs = 2_000;
+    options.HistoryLength = 100;
 });
 ```
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `HideTrace` | `bool` | `false` | When `true`, disables the live log streaming endpoint. |
-| `CounterUpdateIntervalMs` | `int` | `1000` | Milliseconds between counter samples. Must be >= 1000. |
-| `HistoryLength` | `int` | `100` | Number of historical data points to maintain for metrics. |
+| Option | Default | Operational effect |
+|---|---:|---|
+| `HideTrace` | `false` | Disables the live log-streaming endpoint when `true`. |
+| `CounterUpdateIntervalMs` | `1000` | Sets the counter sampling interval in milliseconds; the minimum is 1000. |
+| `HistoryLength` | `100` | Controls retained in-memory dashboard history. Larger values consume more memory. |
 
-### Grain profiler options
-
-The grain profiler collects method-level performance data. Configure it using `GrainProfilerOptions`:
+The dashboard registers a logging provider and collects runtime metrics for display. Method profiling adds an incoming grain-call filter. By default, profiling becomes inactive after one minute without dashboard queries. Continuous profiling is available but has ongoing overhead:
 
 ```csharp
 builder.Services.Configure<GrainProfilerOptions>(options =>
 {
-    // Always collect profiling data, even when dashboard is inactive
     options.TraceAlways = true;
-    
-    // Time after which profiling stops if dashboard is inactive
     options.DeactivationTime = TimeSpan.FromMinutes(5);
 });
 ```
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `TraceAlways` | `bool` | `false` | When `true`, profiling data is continuously collected even when the dashboard is not being queried. |
-| `DeactivationTime` | <xref:System.TimeSpan> | 1 minute | Duration of inactivity after which profiling automatically stops. Only applies when `TraceAlways` is `false`. |
+Leave `TraceAlways` disabled unless continuous method statistics justify the cost. Load test representative traffic with the dashboard configuration you plan to deploy. Use <xref:Orleans.Dashboard.NoProfilingAttribute> on a grain class or method only when omitting it from dashboard method statistics is acceptable.
 
-### Excluding grains from profiling
+## Choose a deployment boundary
 
-Use the `[NoProfiling]` attribute to exclude specific grains from performance profiling:
+### Co-host with a silo
 
-```csharp
-using Orleans.Dashboard;
+Co-hosting is the simplest setup and gives the dashboard access to local silo services. Put its HTTP route on an administrative network boundary distinct from public application routes. Adding the dashboard to a silo doesn't itself open an HTTP listener; `MapOrleansDashboard()` maps endpoints on the ASP.NET Core host.
 
-[NoProfiling]
-public class HighFrequencyGrain : Grain, IHighFrequencyGrain
-{
-    // This grain won't be included in profiling data
-}
-```
+### Use a separate Orleans client host
 
-## Deployment patterns
-
-### Co-hosted with silo (recommended)
-
-The simplest deployment pattern is to host the dashboard directly with your Orleans silo. This is the recommended approach for most scenarios:
+An Orleans client can host the web UI:
 
 ```csharp
-using Orleans.Dashboard;
-
-var builder = WebApplication.CreateBuilder(args);
-
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder.UseLocalhostClustering();
-    siloBuilder.UseInMemoryReminderService();
-    siloBuilder.AddMemoryGrainStorageAsDefault();
-    siloBuilder.AddDashboard();
-});
-
-var app = builder.Build();
-
-app.MapOrleansDashboard();
-
-app.Run();
-```
-
-### Separate dashboard host
-
-For scenarios where you want to run the dashboard separately from your silos (for example, to provide a dedicated monitoring endpoint), you can host the dashboard on an Orleans client:
-
-```csharp
-using Orleans.Configuration;
-using Orleans.Dashboard;
-using System.Net;
-
-// Start the silo host
-var siloHostBuilder = Host.CreateApplicationBuilder(args);
-siloHostBuilder.UseOrleans(builder =>
-{
-    builder.UseDevelopmentClustering(options => 
-        options.PrimarySiloEndpoint = new IPEndPoint(IPAddress.Loopback, 11111));
-    builder.UseInMemoryReminderService();
-    builder.AddMemoryGrainStorageAsDefault();
-    builder.ConfigureEndpoints(IPAddress.Loopback, 11111, 30000);
-    
-    // Dashboard must also be added to silos
-    builder.AddDashboard();
-});
-using var siloHost = siloHostBuilder.Build();
-await siloHost.StartAsync();
-
-// Create a separate web application for the dashboard
-var dashboardBuilder = WebApplication.CreateBuilder(args);
-
-// Configure Orleans client
 dashboardBuilder.UseOrleansClient(clientBuilder =>
 {
-    clientBuilder.UseStaticClustering(options => 
-        options.Gateways.Add(new IPEndPoint(IPAddress.Loopback, 30000).ToGatewayUri()));
-    
-    // Add dashboard services to the client
-    clientBuilder.AddDashboard();
+    clientBuilder
+        .UseStaticClustering(options => options.Gateways.Add(gatewayAddress))
+        .AddDashboard();
 });
-
-var dashboardApp = dashboardBuilder.Build();
-
-// Map dashboard endpoints on the client
-dashboardApp.MapOrleansDashboard();
-
-await dashboardApp.RunAsync();
-
-await siloHost.StopAsync();
 ```
 
-> [!IMPORTANT]
-> When using a separate dashboard host, you must still call `AddDashboard()` on the silo builder. The silos need the dashboard services to collect and provide metrics data.
+Every silo must still call `AddDashboard()` so cluster data and profiling are available. Protect the client host's route and its network access to gateways. A separate host reduces direct HTTP exposure on silos, but it doesn't make the dashboard data non-sensitive.
 
-## Authorization
+## Operate it in production
 
-The dashboard endpoints support ASP.NET Core authorization. Use the `RequireAuthorization()` extension method to protect access:
-
-```csharp
-// Require authentication for dashboard access
-app.MapOrleansDashboard()
-   .RequireAuthorization();
-```
-
-You can also apply specific authorization policies:
-
-```csharp
-// Configure authorization
-builder.Services.AddAuthorization(options =>
-{
-    options.AddPolicy("DashboardAccess", policy =>
-        policy.RequireRole("Admin", "Operator"));
-});
-
-builder.Services.AddAuthentication(/* your auth configuration */);
-
-var app = builder.Build();
-
-app.UseAuthentication();
-app.UseAuthorization();
-
-// Apply the policy to dashboard endpoints
-app.MapOrleansDashboard()
-   .RequireAuthorization("DashboardAccess");
-```
+- Use the dashboard for short-lived interactive diagnosis and OpenTelemetry for durable metrics, traces, logs, alerts, and retention.
+- Monitor dashboard request volume, process CPU/memory, and grain-call latency after enabling profiling.
+- Keep dashboard and Orleans package versions aligned.
+- Audit operator access using the surrounding authentication/proxy platform.
+- Don't paste grain state or live logs into tickets or chats without redaction.
+- Disable or remove dashboard mapping in environments where no operational access path is approved.
 
 ## Troubleshooting
 
-### Dashboard shows "lost connectivity" message
+### The dashboard reports lost connectivity
 
-This error occurs when the dashboard cannot communicate with the Orleans cluster. Common causes:
+Confirm the dashboard host has an active Orleans client connection, can resolve/reach advertised gateways, and uses the same cluster/service identifiers and clustering provider as the silos. For a separate host, verify `AddDashboard()` is also configured on every silo. Follow the [client connection runbook](../host/monitoring/troubleshooting.md#client-cant-connect).
 
-1. **Silo not started**: Ensure your Orleans silo is running before accessing the dashboard.
-2. **Network issues**: Verify network connectivity between the dashboard host and silos.
-3. **Cluster misconfiguration**: Check that clustering is properly configured.
+### Profiling data is empty
 
-### Profiling data not appearing
+Generate calls to the grain method, keep the page active, and confirm neither the class nor method has <xref:Orleans.Dashboard.NoProfilingAttribute>. If `TraceAlways` is `false`, profiling stops after `DeactivationTime` without dashboard queries.
 
-If grain method profiling data is empty:
+### Live logs return 403
 
-1. **Make grain calls**: Profiling only shows data after grain methods are invoked.
-2. **Check `TraceAlways`**: By default, profiling stops after 1 minute of dashboard inactivity. Set `TraceAlways = true` for continuous profiling.
-3. **Check `[NoProfiling]`**: Ensure the grain isn't marked with the `[NoProfiling]` attribute.
-
-### Live trace endpoint is disabled
-
-If the `/Trace` endpoint returns 403 Forbidden:
-
-- Check that `DashboardOptions.HideTrace` is not set to `true`.
+`HideTrace = true` intentionally disables the trace endpoint. If it is `false`, check the dashboard authorization policy and the authenticated user's claims before changing the option.
 
 ## See also
 
-- [Observability in Orleans](../host/monitoring/index.md)
-- [NuGet packages](../resources/nuget-packages.md)
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-9-0,orleans-8-0,orleans-7-0"
-
-The Orleans Dashboard is a built-in monitoring tool introduced in Orleans 10.0. For Orleans 9.0, 8.0, and 7.0, use the unofficial community dashboard package:
-
-- **[OrleansDashboard (community)](https://github.com/OrleansContrib/OrleansDashboard)**: A community-maintained dashboard package for Orleans versions earlier than 10.0.
-- **OpenTelemetry integration**: Built-in observability features are available in Orleans 7.0 and later. See [Observability in Orleans](../host/monitoring/index.md).
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-The Orleans Dashboard is a built-in monitoring tool introduced in Orleans 10.0. For Orleans 3.x, use the unofficial community dashboard package:
-
-- **[OrleansDashboard (community)](https://github.com/OrleansContrib/OrleansDashboard)**: A community-maintained dashboard package for Orleans versions earlier than 10.0.
-
-:::zone-end
+- [Orleans observability](../host/monitoring/index.md)
+- [Interpret Orleans observability signals](../host/monitoring/signals.md)

--- a/docs/site/src/content/docs/dashboard/index.md
+++ b/docs/site/src/content/docs/dashboard/index.md
@@ -1,13 +1,13 @@
 ---
 title: Orleans Dashboard
-description: Securely deploy and operate the Orleans 10 dashboard for live cluster inspection.
+description: Securely deploy and operate the Orleans Dashboard for live cluster inspection.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
 # Orleans Dashboard
 
-The Orleans Dashboard is a released Orleans 10 feature for live inspection of silos, grain activations, calls, reminders, runtime counters, logs, and grain state. It is an administrative surface, not a public application endpoint or a replacement for retained OpenTelemetry data.
+The Orleans Dashboard provides live inspection of silos, grain activations, calls, reminders, runtime counters, logs, and grain state. It is an administrative surface, not a public application endpoint or a replacement for retained OpenTelemetry data.
 
 ## Secure the dashboard before exposing it
 

--- a/docs/site/src/content/docs/dashboard/snippets/secure-dashboard/Program.cs
+++ b/docs/site/src/content/docs/dashboard/snippets/secure-dashboard/Program.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.Hosting;
+using Orleans.Dashboard;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// <SecureDashboard>
+builder.Services
+    .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie();
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("DashboardOperators", policy =>
+    {
+        policy.RequireAuthenticatedUser();
+        policy.RequireRole("OrleansOperator");
+    });
+});
+
+builder.UseOrleans(siloBuilder =>
+{
+    siloBuilder
+        .UseLocalhostClustering()
+        .AddDashboard(options =>
+        {
+            options.HideTrace = true;
+            options.CounterUpdateIntervalMs = 2_000;
+            options.HistoryLength = 100;
+        });
+});
+
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapOrleansDashboard("/dashboard")
+    .RequireAuthorization("DashboardOperators");
+// </SecureDashboard>
+
+await app.RunAsync();

--- a/docs/site/src/content/docs/dashboard/snippets/secure-dashboard/SecureDashboard.csproj
+++ b/docs/site/src/content/docs/dashboard/snippets/secure-dashboard/SecureDashboard.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Dashboard" Version="10.0.0" />
     <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/site/src/content/docs/dashboard/snippets/secure-dashboard/SecureDashboard.csproj
+++ b/docs/site/src/content/docs/dashboard/snippets/secure-dashboard/SecureDashboard.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Dashboard" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.16.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/docs/site/src/content/docs/dashboard/snippets/secure-dashboard/SecureDashboard.csproj
+++ b/docs/site/src/content/docs/dashboard/snippets/secure-dashboard/SecureDashboard.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Dashboard" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Dashboard" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.2" />
   </ItemGroup>
 
 </Project>

--- a/docs/site/src/content/docs/dashboard/snippets/secure-dashboard/SecureDashboard.csproj
+++ b/docs/site/src/content/docs/dashboard/snippets/secure-dashboard/SecureDashboard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,10 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Dashboard" Version="10.0.0" />
     <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/docs/site/src/content/docs/host/monitoring/client-error-code-monitoring.md
+++ b/docs/site/src/content/docs/host/monitoring/client-error-code-monitoring.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 The previous hand-maintained client error-code table was removed because it drifted from the runtime and encouraged alerts on numeric ranges without service context.
 
-For current definitions, use the generated <xref:Orleans.ErrorCode> API reference. To inspect definitions under active development, see the [error-code source on the `main` branch](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs). Preserve structured `EventId`, category, exception, trace ID, and span ID fields in your log backend.
+For current definitions, use the generated <xref:Orleans.ErrorCode> API reference. To inspect definitions under active development, see the [error-code source on the `main` branch](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs). Preserve structured <xref:Microsoft.Extensions.Logging.EventId>, category, exception, trace ID, and span ID fields in your log backend.
 
 For alert design and diagnosis, see:
 

--- a/docs/site/src/content/docs/host/monitoring/client-error-code-monitoring.md
+++ b/docs/site/src/content/docs/host/monitoring/client-error-code-monitoring.md
@@ -1,16 +1,18 @@
 ---
-title: Client error code monitoring
-description: Explore the various client error code monitoring values in .NET Orleans.
-ms.date: 05/23/2025
-ms.topic: error-reference
+title: Client diagnostic events
+description: Find current Orleans client event IDs and use symptom-based observability guidance.
+ms.date: 08/02/2026
+ms.topic: reference
 ---
 
-# Client error code monitoring
+# Client diagnostic events
 
-| Group | Log type | Log code values | Threshold | Description |
-|--|--|--|--|--|
-| Azure Problems | Warning or Error | 100800 - 100899 | Any Error or Warning | Transient problems reading or writing to Azure table store will be logged as Warning. Transient read errors will automatically be retried. A final Error log message means there is a real problem connecting to Azure table storage. |
-| Gateway connectivity problems | Warning or Error | 100901 - 100904, 100912, 100913, 100921, 100923, 100158, 100161, 100178, , 101313 | Any Error or Warning | Problems connecting to gateways. No active gateways in the Azure table. Connection to active gateway lost. |
-| Grain call timeouts | Warning | 100157 | Multiple Warnings logged in a short amount of time | Grain-call timeout problems are generally caused by temporary network connectivity issues or silo restart/reboot problems. The system should recover after a short time (depending on Liveness config settings) at which point Timeouts should clear. Ideally, monitoring for just the bulk log code 600157 variety of these warnings should be sufficient. |
-| Network Socket Problems | Warning or Error | 101000 to 101999, 100307, 100015, 100016 | Any Error or Warning | Socket disconnects are logged as Warning messages. Problems opening sockets or during message transmission, are logged as Errors. |
-| Bulk log message compaction | Any | 500000 or higher | Message summary based on bulk message threshold settings | If multiple logs of the same log code occur within a designated time interval (the default is >5 within 1 minute) then additional log messages with that log code are suppressed and output as a "bulk" entry with log code equal to the original log code + 500000. So for example, multiple 100157 entries will show in the logs as 5 x 100157 + 1 x 600157 log entries per minute. |
+The previous hand-maintained client error-code table was removed because it drifted from the runtime and encouraged alerts on numeric ranges without service context.
+
+For current definitions, use the generated <xref:Orleans.ErrorCode> API reference or the [error-code source for the Orleans version you deploy](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs). Preserve structured `EventId`, category, exception, trace ID, and span ID fields in your log backend.
+
+For alert design and diagnosis, see:
+
+- [Interpret Orleans observability signals](signals.md)
+- [Client can't connect](troubleshooting.md#client-cant-connect)
+- [Grain calls time out](troubleshooting.md#grain-calls-time-out)

--- a/docs/site/src/content/docs/host/monitoring/client-error-code-monitoring.md
+++ b/docs/site/src/content/docs/host/monitoring/client-error-code-monitoring.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 The previous hand-maintained client error-code table was removed because it drifted from the runtime and encouraged alerts on numeric ranges without service context.
 
-For current definitions, use the generated <xref:Orleans.ErrorCode> API reference or the [error-code source for the Orleans version you deploy](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs). Preserve structured `EventId`, category, exception, trace ID, and span ID fields in your log backend.
+For current definitions, use the generated <xref:Orleans.ErrorCode> API reference. To inspect definitions under active development, see the [error-code source on the `main` branch](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs). Preserve structured `EventId`, category, exception, trace ID, and span ID fields in your log backend.
 
 For alert design and diagnosis, see:
 

--- a/docs/site/src/content/docs/host/monitoring/index.md
+++ b/docs/site/src/content/docs/host/monitoring/index.md
@@ -9,15 +9,15 @@ ms.topic: overview
 
 Orleans uses standard .NET observability APIs:
 
-- `Microsoft.Extensions.Logging` for structured logs.
-- A <xref:System.Diagnostics.Metrics.Meter> named `Microsoft.Orleans` for runtime metrics.
-- Several <xref:System.Diagnostics.ActivitySource> instances for distributed traces.
+- [Microsoft.Extensions.Logging](https://learn.microsoft.com/dotnet/core/extensions/logging/overview) for structured logs.
+- A <xref:System.Diagnostics.Metrics.Meter> named `Microsoft.Orleans` for [.NET metrics](https://learn.microsoft.com/dotnet/core/diagnostics/metrics).
+- Several <xref:System.Diagnostics.ActivitySource> instances for [.NET distributed tracing](https://learn.microsoft.com/dotnet/core/diagnostics/distributed-tracing).
 
 These signals are complementary. Metrics detect a change, traces locate it in a request path, and logs explain discrete events or failures. The [Orleans Dashboard](../../dashboard/index.md) is useful for interactive inspection, but an external telemetry backend is the durable source for alerting, retention, and cross-service correlation.
 
 ## Configure OpenTelemetry once
 
-Install these packages in the host which runs Orleans:
+[OpenTelemetry](https://opentelemetry.io/docs/) provides a vendor-neutral pipeline for logs, metrics, and traces. Install these packages in the host which runs Orleans:
 
 - [OpenTelemetry.Extensions.Hosting](https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting)
 - [OpenTelemetry.Exporter.OpenTelemetryProtocol](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol)
@@ -27,9 +27,9 @@ The following configuration works for a silo. Apply the same OpenTelemetry confi
 
 :::code language="csharp" source="./snippets/observability/Program.cs" id="OpenTelemetry":::
 
-Set `OTEL_EXPORTER_OTLP_ENDPOINT` to the OTLP endpoint, for example `http://localhost:4317`. The OpenTelemetry .NET SDK honors standard `OTEL_*` environment variables. In a .NET Aspire application, the AppHost supplies the OTLP endpoint to referenced projects, so this configuration sends telemetry to the Aspire dashboard without an Orleans-specific exporter.
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/) endpoint, for example `http://localhost:4317`. The OpenTelemetry .NET SDK honors standard `OTEL_*` environment variables. In a .NET Aspire application, the AppHost supplies the OTLP endpoint to referenced projects, so this configuration sends telemetry to the Aspire dashboard without an Orleans-specific exporter.
 
-Use a collector between applications and the final backend when you need buffering, routing, redaction, or backend-specific authentication.
+Use an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) between applications and the final backend when you need buffering, routing, redaction, or backend-specific authentication.
 
 ## Meter versus ActivitySource
 

--- a/docs/site/src/content/docs/host/monitoring/index.md
+++ b/docs/site/src/content/docs/host/monitoring/index.md
@@ -1,462 +1,83 @@
 ---
 title: Orleans observability
-description: Explore the various runtime monitoring, logging, distributed tracing, and metrics options available in .NET Orleans.
-ms.date: 05/23/2025
+description: Configure OpenTelemetry logging, metrics, and tracing for Orleans 10.
+ms.date: 08/02/2026
 ms.topic: overview
-zone_pivot_groups: orleans-version
-ms.custom: sfi-image-nochange
 ---
 
 # Orleans observability
 
-Observability is one of the most important aspects of a distributed system. It's the ability to understand the system's state at any given time. You can achieve this in various ways, including logging, metrics, and distributed tracing.
-
-## Logging
-
-Orleans uses [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging) for all silo and client logs. You can use any logging provider compatible with `Microsoft.Extensions.Logging`. Your app code relies on [dependency injection](../../../core/extensions/dependency-injection/overview.md) to get an instance of <xref:Microsoft.Extensions.Logging.ILogger`1> and uses it to log messages. For more information, see [Logging in .NET](../../../core/extensions/logging/overview.md).
-
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0,orleans-8-0,orleans-7-0"
-
-## Metrics
-
-Metrics are numerical measurements reported over time. You most often use them to monitor an application's health and generate alerts. For more information, see [Metrics in .NET](../../../core/diagnostics/metrics.md). Orleans uses the [System.Diagnostics.Metrics](../../../core/diagnostics/compare-metric-apis.md#systemdiagnosticsmetrics) APIs to collect metrics. These metrics are exposed to the [OpenTelemetry](https://opentelemetry.io) project, which exports them to various monitoring systems.
-
-To monitor your app without making any code changes, use the `dotnet counters` .NET diagnostic tool. To monitor Orleans <xref:System.Diagnostics.ActivitySource> counters for a specific `<ProcessName>`, use the `dotnet counters monitor` command as shown:
-
-```dotnetcli
-dotnet counters monitor -n <ProcessName> --counters Microsoft.Orleans
-```
-
-Imagine you're running the [Orleans GPS Tracker sample app](/samples/dotnet/samples/orleans-gps-device-tracker-sample) and monitoring it in a separate terminal with the `dotnet counters monitor` command. The following output is typical:
-
-```dotnetcli
-Press p to pause, r to resume, q to quit.
-    Status: Running
-[Microsoft.Orleans]
-    orleans-app-requests-latency-bucket (Count / 1 sec)                    0
-        duration=10000ms                                                   0
-        duration=1000ms                                                    0
-        duration=100ms                                                     0
-        duration=10ms                                                      0
-        duration=15000ms                                                   0
-        duration=1500ms                                                    0
-        duration=1ms                                                   2,530
-        duration=2000ms                                                    0
-        duration=200ms                                                     0
-        duration=2ms                                                       0
-        duration=400ms                                                     0
-        duration=4ms                                                       0
-        duration=5000ms                                                    0
-        duration=50ms                                                      0
-        duration=6ms                                                       0
-        duration=800ms                                                     0
-        duration=8ms                                                       0
-        duration=9223372036854775807ms                                     0
-    orleans-app-requests-latency-count (Count / 1 sec)                 2,530
-    orleans-app-requests-latency-sum (Count / 1 sec)                       0
-    orleans-catalog-activation-working-set                                36
-    orleans-catalog-activations                                           38
-    orleans-consistent-ring-range-percentage-average                     100
-    orleans-consistent-ring-range-percentage-local                       100
-    orleans-consistent-ring-size                                           1
-    orleans-directory-cache-size                                          27
-    orleans-directory-partition-size                                      26
-    orleans-directory-ring-local-portion-average-percentage              100
-    orleans-directory-ring-local-portion-distance                          0
-    orleans-directory-ring-local-portion-percentage                        0
-    orleans-directory-ring-size                                        1,295
-    orleans-gateway-received (Count / 1 sec)                           1,291
-    orleans-gateway-sent (Count / 1 sec)                               2,582
-    orleans-messaging-processing-activation-data                           0
-    orleans-messaging-processing-dispatcher-forwarded (Count / 1           0
-    orleans-messaging-processing-dispatcher-processed (Count / 1       2,543
-        Direction=Request,Status=Ok                                    2,582
-    orleans-messaging-processing-dispatcher-received (Count / 1        1,271
-        Context=Grain,Direction=Request                                1,291
-        Context=None,Direction=Request                                 1,291
-    orleans-messaging-processing-ima-enqueued (Count / 1 sec)          5,113
-```
-
-For more information, see [Investigate performance counters (dotnet-counters)](../../../core/diagnostics/dotnet-counters.md).
-
-### Orleans meters
-
-Orleans uses the [System.Diagnostics.Metrics](../../../core/diagnostics/compare-metric-apis.md#systemdiagnosticsmetrics) APIs to collect metrics. Orleans categorizes each meter into domain-centric concerns, such as networking, messaging, gateway, etc. The following subsections describe the meters Orleans uses.
-
-#### Networking
-
-The following table shows a collection of networking meters used to monitor the Orleans networking layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-networking-sockets-closed` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of sockets that have closed. |
-| `orleans-networking-sockets-opened` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of sockets that have opened. |
-
-#### Messaging
-
-The following table shows a collection of messaging meters used to monitor the Orleans messaging layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-messaging-sent-messages-size` | <xref:System.Diagnostics.Metrics.Histogram`1> | A histogram representing the size of messages in bytes that have been sent. |
-| `orleans-messaging-received-messages-size` | <xref:System.Diagnostics.Metrics.Histogram`1> | A histogram representing the size of messages in bytes that have been received. |
-| `orleans-messaging-sent-header-size` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number of header bytes sent. |
-| `orleans-messaging-received-header-size` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number of header bytes received. |
-| `orleans-messaging-sent-failed` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of failed sent messages. |
-| `orleans-messaging-sent-dropped` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of dropped sent messages. |
-| `orleans-messaging-processing-dispatcher-received` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number dispatcher received messages. |
-| `orleans-messaging-processing-dispatcher-processed` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number dispatcher processed messages. |
-| `orleans-messaging-processing-dispatcher-forwarded` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number dispatcher forwarded messages. |
-| `orleans-messaging-processing-ima-received` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number of incoming messages received. |
-| `orleans-messaging-processing-ima-enqueued` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number of incoming messages enqueued. |
-| `orleans-messaging-processing-activation-data` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing all of the processing activation data. |
-| `orleans-messaging-pings-sent` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of pings sent. |
-| `orleans-messaging-pings-received` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of pings received. |
-| `orleans-messaging-pings-reply-received` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of ping replies received. |
-| `orleans-messaging-pings-reply-missed` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of ping replies missed. |
-| `orleans-messaging-expired"` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of messages that have expired. |
-| `orleans-messaging-rejected` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of messages that have been rejected. |
-| `orleans-messaging-rerouted` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of messages that have been rerouted. |
-| `orleans-messaging-sent-local` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number of local messages sent. |
-
-#### Gateway
-
-The following table shows a collection of gateway meters used to monitor the Orleans gateway layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-gateway-connected-clients` | <xref:System.Diagnostics.Metrics.UpDownCounter`1> | An up/down counter representing the number of connected clients. |
-| `orleans-gateway-sent` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of gateway messages sent. |
-| `orleans-gateway-received` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of gateway messages received. |
-| `orleans-gateway-load-shedding` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of gateway (load shedding) messages that have been rejected due to the gateway being overloaded. |
-
-#### Runtime
-
-The following table shows a collection of runtime meters used to monitor the Orleans runtime layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-scheduler-long-running-turns` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of long running turns within the scheduler. |
-| `orleans-runtime-total-physical-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the total number of memory (in MB) of the Orleans runtime. |
-| `orleans-runtime-available-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the available memory (in MB) for the Orleans runtime. |
-
-#### Catalog
-
-The following table shows a collection of catalog meters used to monitor the Orleans catalog layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-catalog-activations` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the number of catalog activations. |
-| `orleans-catalog-activation-working-set` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the number of activations within the working set. |
-| `orleans-catalog-activation-created` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of created activations. |
-| `orleans-catalog-activation-destroyed` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of destroyed activations. |
-| `orleans-catalog-activation-failed-to-activate` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of activations that failed to activate. |
-| `orleans-catalog-activation-collections` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of idle activation collections. |
-| `orleans-catalog-activation-shutdown` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of shutdown activations. |
-| `orleans-catalog-activation-non-existent` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of non-existent activations. |
-| `orleans-catalog-activation-concurrent-registration-attempts` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of concurrent activation registration attempts. |
-
-#### Directory
-
-The following table shows a collection of directory meters used to monitor the Orleans directory layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-directory-lookups-local-issued` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of local lookups issued. |
-| `orleans-directory-lookups-local-successes` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of local successful lookups. |
-| `orleans-directory-lookups-full-issued` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of full directory lookups issued. |
-| `orleans-directory-lookups-remote-sent` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of remote directory lookups sent. |
-| `orleans-directory-lookups-remote-received` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of remote directory lookups received. |
-| `orleans-directory-lookups-local-directory-issued` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of local directory lookups issued. |
-| `orleans-directory-lookups-local-directory-successes` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of local directory successful lookups. |
-| `orleans-directory-lookups-cache-issued` | <xref:System.Diagnostics.Metrics.Counter`1> | A count cached lookups issued. |
-| `orleans-directory-lookups-cache-successes` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of cached successful lookups. |
-| `orleans-directory-validations-cache-received` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory cache validations received. |
-| `orleans-directory-partition-size` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the directory partition size. |
-| `orleans-directory-cache-size` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the directory cache size. |
-| `orleans-directory-ring-size` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the directory ring size. |
-| `orleans-directory-ring-local-portion-distance` |<xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the ring range owned by the local directory partition. |
-| `orleans-directory-ring-local-portion-percentage` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the ring range owned by the local directory, represented as a percentage of the total range. |
-| `orleans-directory-ring-local-portion-average-percentage` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the average percentage of the directory ring range owned by each silo, giving a representation of how balanced directory ownership. |
-| `orleans-directory-registrations-single-act-issued` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory single activation registrations issued. |
-| `orleans-directory-registrations-single-act-local` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory single activation registrations handled by the local directory partition. |
-| `orleans-directory-registrations-single-act-remote-sent` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory single activation registrations sent to a remote directory partition. |
-| `orleans-directory-registrations-single-act-remote-received` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory single activation registrations received from remote hosts. |
-| `orleans-directory-unregistrations-issued` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory deregistrations issued. |
-| `orleans-directory-unregistrations-local` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory deregistrations handled by the local directory partition. |
-| `orleans-directory-unregistrations-remote-sent` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory deregistrations sent to remote directory partitions. |
-| `orleans-directory-unregistrations-remote-received` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory deregistrations received from remote hosts. |
-| `orleans-directory-unregistrations-many-issued` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory multi-activation deregistrations issued. |
-| `orleans-directory-unregistrations-many-remote-sent` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory multi-activations deregistrations sent to remote directory partitions. |
-| `orleans-directory-unregistrations-many-remote-received` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory multi-activation deregistrations received from remote hosts. |
-
-#### Consistent ring
-
-The following table shows a collection of consistent ring meters used to monitor the Orleans consistent ring layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-consistent-ring-size` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the consistent ring size. |
-| `orleans-consistent-ring-range-percentage-local` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the consistent ring local percentage. |
-| `orleans-consistent-ring-range-percentage-average` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the consistent ring average percentage. |
-
-#### Watchdog
-
-The following table shows a collection of watchdog meters used to monitor the Orleans watchdog layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-watchdog-health-checks` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of watchdog health checks. |
-| `orleans-watchdog-health-checks-failed` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of failed watchdog health checks. |
-
-#### Client
-
-The following table shows a collection of client meters used to monitor the Orleans client layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-client-connected-gateways` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the number of connected gateway clients. |
-
-#### Miscellaneous
-
-The following table shows a collection of miscellaneous meters used to monitor various layers.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-grains` | <xref:System.Diagnostics.Metrics.Counter`1> | A count representing the number of grains. |
-| `orleans-system-targets` | <xref:System.Diagnostics.Metrics.Counter`1> | A count representing the number of system targets. |
-
-#### App requests
-
-The following table shows a collection of app request meters used to monitor the Orleans app request layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-app-requests-latency` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing app request latency. |
-| `orleans-app-requests-timedout` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> |  An observable counter representing app requests that have timed out. |
-
-#### Reminders
-
-The following table shows a collection of reminder meters used to monitor the Orleans reminder layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-reminders-tardiness` | <xref:System.Diagnostics.Metrics.Histogram`1> | A histogram representing the number of seconds a reminder is tardy. |
-| `orleans-reminders-active` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the number active reminders. |
-| `orleans-reminders-ticks-delivered` | <xref:System.Diagnostics.Metrics.Counter`1> | A count representing the number of reminder ticks that have been delivered. |
-
-#### Storage
-
-The following table shows a collection of storage meters used to monitor the Orleans storage layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-storage-read-errors` | <xref:System.Diagnostics.Metrics.Counter`1> |  A count representing the number of storage read errors. |
-| `orleans-storage-write-errors` | <xref:System.Diagnostics.Metrics.Counter`1> |  A count representing the number of storage write errors. |
-| `orleans-storage-clear-errors` | <xref:System.Diagnostics.Metrics.Counter`1> |  A count representing the number of storage clear errors. |
-| `orleans-storage-read-latency` | <xref:System.Diagnostics.Metrics.Histogram`1> | A histogram representing the storage read latency in milliseconds. |
-| `orleans-storage-write-latency` | <xref:System.Diagnostics.Metrics.Histogram`1> | A histogram representing the storage write latency in milliseconds. |
-| `orleans-storage-clear-latency` | <xref:System.Diagnostics.Metrics.Histogram`1> | A histogram representing the storage clear latency in milliseconds. |
-
-#### Streams
-
-The following table shows a collection of stream meters used to monitor the Orleans stream layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-streams-pubsub-producers-added` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of streaming pubsub producers added. |
-| `orleans-streams-pubsub-producers-removed` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of streaming pubsub producers removed. |
-| `orleans-streams-pubsub-producers` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of streaming pubsub producers. |
-| `orleans-streams-pubsub-consumers-added` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of streaming pubsub consumers added. |
-| `orleans-streams-pubsub-consumers-removed` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of streaming pubsub consumers removed. |
-| `orleans-streams-pubsub-consumers` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of streaming pubsub consumers. |
-| `orleans-streams-persistent-stream-pulling-agents` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the number of persistent stream pulling agents. |
-| `orleans-streams-persistent-stream-messages-read` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of persistent stream messages read. |
-| `orleans-streams-persistent-stream-messages-sent` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of persistent stream messages sent. |
-| `orleans-streams-persistent-stream-pubsub-cache-size` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the persistent stream pubsub cache size. |
-| `orleans-streams-queue-initialization-failures` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of steam queue initialization failures. |
-| `orleans-streams-queue-initialization-duration` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of steam queue initialization occurrences. |
-| `orleans-streams-queue-initialization-exceptions` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of steam queue initialization exceptions. |
-| `orleans-streams-queue-read-failures` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of steam queue read failures. |
-| `orleans-streams-queue-read-duration` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of steam queue read occurrences. |
-| `orleans-streams-queue-read-exceptions` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of steam queue read exceptions. |
-| `orleans-streams-queue-shutdown-failures` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of steam queue shutdown failures. |
-| `orleans-streams-queue-shutdown-duration` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of steam queue shutdown occurrences. |
-| `orleans-streams-queue-shutdown-exceptions` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of steam queue shutdown exceptions. |
-| `orleans-streams-queue-messages-received` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number of stream queue messages received. |
-| `orleans-streams-queue-oldest-message-enqueue-age` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the age of the oldest enqueued message. |
-| `orleans-streams-queue-newest-message-enqueue-age` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the age of the newest enqueued message. |
-| `orleans-streams-block-pool-total-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream block pool total memory in bytes. |
-| `orleans-streams-block-pool-available-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream block pool available memory in bytes. |
-| `orleans-streams-block-pool-claimed-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream block pool claimed memory in bytes. |
-| `orleans-streams-block-pool-released-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream block pool released memory in bytes. |
-| `orleans-streams-block-pool-allocated-memory` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream block pool allocated memory in bytes. |
-| `orleans-streams-queue-cache-size` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream queue cache size in bytes. |
-| `orleans-streams-queue-cache-length` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream queue length. |
-| `orleans-streams-queue-cache-messages-added` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream queue messages added. |
-| `orleans-streams-queue-cache-messages-purged` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream queue messages purged. |
-| `orleans-streams-queue-cache-memory-allocated` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream queue memory allocated. |
-| `orleans-streams-queue-cache-memory-released` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream queue memory released. |
-| `orleans-streams-queue-cache-oldest-to-newest-duration` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the duration from the oldest to the newest stream queue cache. |
-| `orleans-streams-queue-cache-oldest-age` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the age of the oldest cached message. |
-| `orleans-streams-queue-cache-pressure` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the pressure on the stream queue cache. |
-| `orleans-streams-queue-cache-under-pressure` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing whether the stream queue cache is under pressure. |
-| `orleans-streams-queue-cache-pressure-contribution-count` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the stream queue cache pressure contributions. |
-
-#### Transactions
-
-The following table shows a collection of transaction meters used to monitor the Orleans transaction layer.
-
-| Meter name | Type | Description |
-|--|--|--|
-| `orleans-transactions-started` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number of started transactions. |
-| `orleans-transactions-successful` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number of successful transactions. |
-| `orleans-transactions-failed` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number of failed transactions. |
-| `orleans-transactions-throttled` | <xref:System.Diagnostics.Metrics.ObservableCounter`1> | An observable counter representing the number of throttled transactions. |
-
-### Export metrics
-
-Various third-party metrics providers are available for use with Orleans. Export metrics from your app using the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/). Many observability platforms consume OTLP data directly or through an OpenTelemetry Collector, including [Prometheus](https://prometheus.io), Grafana, and Azure Monitor.
-
-To export metrics using OTLP with Orleans, install the [OpenTelemetry.Exporter.OpenTelemetryProtocol](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol/) NuGet package and call the following <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection> extension method:
-
-```csharp
-builder.Services.AddOpenTelemetry()
-    .WithMetrics(metrics =>
-    {
-        metrics
-            .AddOtlpExporter()
-            .AddMeter("Microsoft.Orleans");
-    });
-```
-
-The `AddOtlpExporter` method ensures the OTLP exporter is added to the `builder`. Orleans uses a <xref:System.Diagnostics.Metrics.Meter> named `"Microsoft.Orleans"` to create <xref:System.Diagnostics.Metrics.Counter`1> instances for many Orleans-specific metrics. Use the `AddMeter` method to specify the name of the meter to subscribe to, in this case, `"Microsoft.Orleans"`.
-
-You can configure the OTLP exporter endpoint and other options as needed. For example:
-
-```csharp
-builder.Services.AddOpenTelemetry()
-    .WithMetrics(metrics =>
-    {
-        metrics
-            .AddOtlpExporter(options =>
-            {
-                options.Endpoint = new Uri("http://localhost:4317");
-            })
-            .AddMeter("Microsoft.Orleans");
-    });
-```
-
-> [!NOTE]
-> The default OTLP exporter configuration uses gRPC (typically port `4317`). To export metrics to Prometheus, send telemetry through an OpenTelemetry Collector or configure OTLP/HTTP settings instead.
-
-## Distributed tracing
-
-Distributed tracing is a set of tools and practices for monitoring and troubleshooting distributed applications. It's a key component of observability and a critical tool for understanding your app's behavior. Orleans supports distributed tracing with [OpenTelemetry](https://opentelemetry.io).
-
-Regardless of the distributed tracing exporter you choose, call:
-
-- <xref:Orleans.Hosting.CoreHostingExtensions.AddActivityPropagation(Orleans.Hosting.ISiloBuilder)>: which enables distributed tracing for the silo.
-- <xref:Orleans.Hosting.ClientBuilderExtensions.AddActivityPropagation(Orleans.Hosting.IClientBuilder)>: which enables distributed tracing for the client.
-
-Or set the `EnableDistributedTracing` config option to `true`.
-
-Referring back to the [Orleans GPS Tracker sample app](/samples/dotnet/samples/orleans-gps-device-tracker-sample), you can export distributed traces using the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/). To use OpenTelemetry with OTLP and Orleans, install the [OpenTelemetry.Exporter.OpenTelemetryProtocol](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol/) NuGet package and call the following <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection> extension method in _Program.cs_:
-
-```csharp
-builder.Services.AddOpenTelemetry()
-    .WithTracing(tracing =>
-    {
-        // Set a service name
-        tracing.SetResourceBuilder(
-            ResourceBuilder.CreateDefault()
-                .AddService(serviceName: "GPSTracker", serviceVersion: "1.0"));
-
-        // Good baseline for general Orleans observability
-        tracing.AddSource(Orleans.Diagnostics.ActivitySources.ApplicationGrainActivitySourceName);
-        tracing.AddSource(Orleans.Diagnostics.ActivitySources.LifecycleActivitySourceName);
-
-        /*
-        // Other source also available
-        // Persistence spans
-        tracing.AddSource(Orleans.Diagnostics.ActivitySources.StorageActivitySourceName);
-        // Internal Runtime spans
-        tracing.AddSource(Orleans.Diagnostics.ActivitySources.RuntimeActivitySourceName);
-        */
-
-        /*
-        // Optionally add all Microsoft.Orleans.* Sources at once
-        tracing.AddSource(Orleans.Diagnostics.ActivitySources.AllActivitySourceName);
-        */
-
-        tracing.AddOtlpExporter(otlp =>
-        {
-            otlp.Endpoint = new Uri("http://localhost:4317");
-        });
-    });
-```
-
-The OTLP exporter works with many observability backends including Jaeger, Zipkin, Grafana Tempo, and Azure Monitor. The traces can be visualized in tools like Jaeger UI:
-
-:::image type="content" source="../media/jaeger-ui.png" lightbox="../media/jaeger-ui.png" alt-text="Orleans GPS Tracker sample app: Jaeger UI trace.":::
-
-For more information, see [Distributed tracing](../../../core/diagnostics/distributed-tracing.md).
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-Orleans outputs its runtime statistics and metrics through the <xref:Orleans.Runtime.ITelemetryConsumer> interface. Your application can register one or more telemetry consumers for its silos and clients to receive statistics and metrics the Orleans runtime periodically publishes. These can be consumers for popular telemetry analytics solutions or custom ones for any other destination and purpose. Three telemetry consumers are currently included in the Orleans codebase.
-
-They're released as separate NuGet packages:
-
-- `Microsoft.Orleans.OrleansTelemetryConsumers.AI`: For publishing to [Azure Application Insights](/azure/azure-monitor/app/app-insights-overview).
-
-- `Microsoft.Orleans.OrleansTelemetryConsumers.Counters`: For publishing to Windows performance counters. The Orleans runtime continually updates many of them. The _CounterControl.exe_ tool, included in the [`Microsoft.Orleans.CounterControl`](https://www.nuget.org/packages/Microsoft.Orleans.CounterControl/) NuGet package, helps register necessary performance counter categories. It must run with elevated privileges. Monitor the performance counters using any standard monitoring tools.
-
-- `Microsoft.Orleans.OrleansTelemetryConsumers.NewRelic`: For publishing to [New Relic](https://newrelic.com/).
-
-To configure your silo and client to use telemetry consumers, the silo configuration code looks like this:
-
-```csharp
-var siloHostBuilder = new HostBuilder()
-    .UseOrleans(c =>
-    {
-        c.AddApplicationInsightsTelemetryConsumer("INSTRUMENTATION_KEY");
-    });
-```
-
-The client configuration code looks like this:
-
-```csharp
-var clientBuilder = new ClientBuilder();
-clientBuilder.AddApplicationInsightsTelemetryConsumer("INSTRUMENTATION_KEY");
-```
-
-To use a custom-defined <xref:Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration> (which might have <xref:Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.TelemetryProcessors>, <xref:Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.TelemetrySinks>, etc.), the silo configuration code looks like this:
-
-```csharp
-var telemetryConfiguration = TelemetryConfiguration.CreateDefault();
-var siloHostBuilder = new HostBuilder()
-    .UseOrleans(c =>
-    {
-        c.AddApplicationInsightsTelemetryConsumer(telemetryConfiguration);
-    });
-```
-
-Client configuration code look like this:
-
-```csharp
-var clientBuilder = new ClientBuilder();
-var telemetryConfiguration = TelemetryConfiguration.CreateDefault();
-clientBuilder.AddApplicationInsightsTelemetryConsumer(telemetryConfiguration);
-```
-
-:::zone-end
-
-## See also
-
-- [Logging in .NET](../../../core/extensions/logging/overview.md)
-- [.NET metrics](../../../core/diagnostics/metrics.md)
-- [Investigate performance counters (dotnet-counters)](../../../core/diagnostics/dotnet-counters.md)
-- [.NET distributed tracing](../../../core/diagnostics/distributed-tracing.md)
+Orleans 10 uses standard .NET observability APIs:
+
+- `Microsoft.Extensions.Logging` for structured logs.
+- A <xref:System.Diagnostics.Metrics.Meter> named `Microsoft.Orleans` for runtime metrics.
+- Several <xref:System.Diagnostics.ActivitySource> instances for distributed traces.
+
+These signals are complementary. Metrics detect a change, traces locate it in a request path, and logs explain discrete events or failures. The [Orleans Dashboard](../../dashboard/index.md) is useful for interactive inspection, but an external telemetry backend is the durable source for alerting, retention, and cross-service correlation.
+
+## Configure OpenTelemetry once
+
+Install these packages in the host which runs Orleans:
+
+- [OpenTelemetry.Extensions.Hosting](https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting)
+- [OpenTelemetry.Exporter.OpenTelemetryProtocol](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol)
+- Instrumentation packages for the surrounding application, such as `OpenTelemetry.Instrumentation.AspNetCore`, `OpenTelemetry.Instrumentation.Http`, and `OpenTelemetry.Instrumentation.Runtime`
+
+The following configuration works for a silo. Apply the same OpenTelemetry configuration to an Orleans client and call `AddActivityPropagation()` on its `IClientBuilder`.
+
+:::code language="csharp" source="./snippets/observability/Program.cs" id="OpenTelemetry":::
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to the OTLP endpoint, for example `http://localhost:4317`. The OpenTelemetry .NET SDK honors standard `OTEL_*` environment variables. In a .NET Aspire application, the AppHost supplies the OTLP endpoint to referenced projects, so this configuration sends telemetry to the Aspire dashboard without an Orleans-specific exporter.
+
+Use a collector between applications and the final backend when you need buffering, routing, redaction, or backend-specific authentication.
+
+## Meter versus ActivitySource
+
+`AddMeter("Microsoft.Orleans")` subscribes to numeric Orleans instruments. It doesn't enable traces. Use metrics for rates, counts, queue pressure, latency distributions, and alerts.
+
+`AddSource(...)` subscribes to spans. It doesn't collect Orleans metrics. Orleans exposes these source names through <xref:Orleans.Diagnostics.ActivitySources>:
+
+| Source | Scope |
+|---|---|
+| `Microsoft.Orleans.Application` | Application grain calls |
+| `Microsoft.Orleans.Runtime` | Runtime operations |
+| `Microsoft.Orleans.Lifecycle` | Activation, migration, and deactivation |
+| `Microsoft.Orleans.Storage` | Grain storage operations |
+| `Microsoft.Orleans.DurableJobs` | Durable job scheduling and execution |
+| `Microsoft.Orleans.*` | Wildcard for all Orleans activity sources |
+
+The example selects the first four sources explicitly so the collected scope is visible in code. Add durable jobs when used. A wildcard is convenient during investigation but can begin collecting new sources after an Orleans upgrade, so review its volume and data policy.
+
+## Propagate trace context through grain calls
+
+Register `AddActivityPropagation()` on every silo and Orleans client which participates in a trace. It installs grain-call filters which carry the current W3C trace context and baggage through Orleans messages. Without it, Orleans spans can still be exported, but an incoming HTTP span and the resulting grain-call spans won't form one distributed trace.
+
+Treat baggage as transmitted application data. Don't put secrets, credentials, personal data, or unbounded user input in baggage. Prefer a small set of approved correlation fields.
+
+## Set resource identity
+
+Every process should set stable resource attributes:
+
+- `service.name`: the logical service, such as `orders-silo`.
+- `service.version`: the deployed application version.
+- `service.instance.id`: a unique process or pod identifier.
+- `deployment.environment.name`: the environment.
+
+Don't use a silo address as `service.name`; put changing instance identity in `service.instance.id`. Configure cluster, region, or tenant attributes only when their value set is bounded and permitted by your telemetry data policy.
+
+## Control cost and volume
+
+- Export metrics continuously at an interval appropriate for your alerting objectives.
+- Use parent-based trace sampling so a request keeps one sampling decision across HTTP, Orleans, and downstream calls.
+- Keep errors and slow requests with a tail-sampling collector when the backend supports it.
+- Increase sampling temporarily during an incident instead of running full-fidelity tracing indefinitely.
+- Keep metric dimensions bounded. Grain IDs, request IDs, user IDs, and exception messages are unsuitable metric attributes.
+- Filter noisy log categories at the provider and avoid logging full grain state or message payloads.
+
+The example's 10% head-sampling ratio is a starting point, not a universal production value. Select it from traffic volume, retention cost, and the probability of capturing rare failures.
+
+## Next steps
+
+- [Interpret Orleans signals](signals.md)
+- [Troubleshoot Orleans incidents](troubleshooting.md)
+- [Secure and operate the Orleans Dashboard](../../dashboard/index.md)

--- a/docs/site/src/content/docs/host/monitoring/index.md
+++ b/docs/site/src/content/docs/host/monitoring/index.md
@@ -1,13 +1,13 @@
 ---
 title: Orleans observability
-description: Configure OpenTelemetry logging, metrics, and tracing for Orleans 10.
+description: Configure OpenTelemetry logging, metrics, and tracing for Orleans.
 ms.date: 08/02/2026
 ms.topic: overview
 ---
 
 # Orleans observability
 
-Orleans 10 uses standard .NET observability APIs:
+Orleans uses standard .NET observability APIs:
 
 - `Microsoft.Extensions.Logging` for structured logs.
 - A <xref:System.Diagnostics.Metrics.Meter> named `Microsoft.Orleans` for runtime metrics.

--- a/docs/site/src/content/docs/host/monitoring/index.md
+++ b/docs/site/src/content/docs/host/monitoring/index.md
@@ -23,7 +23,7 @@ These signals are complementary. Metrics detect a change, traces locate it in a 
 - [OpenTelemetry.Exporter.OpenTelemetryProtocol](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol)
 - Instrumentation packages for the surrounding application, such as `OpenTelemetry.Instrumentation.AspNetCore`, `OpenTelemetry.Instrumentation.Http`, and `OpenTelemetry.Instrumentation.Runtime`
 
-The following configuration works for a silo. Apply the same OpenTelemetry configuration to an Orleans client and call `AddActivityPropagation()` on its `IClientBuilder`.
+The following configuration works for a silo. Register <xref:Orleans.Hosting.CoreHostingExtensions.AddActivityPropagation*?displayProperty=nameWithType> on silos and <xref:Orleans.Hosting.ClientBuilderExtensions.AddActivityPropagation*?displayProperty=nameWithType> on Orleans clients.
 
 :::code language="csharp" source="./snippets/observability/Program.cs" id="OpenTelemetry":::
 

--- a/docs/site/src/content/docs/host/monitoring/signals.md
+++ b/docs/site/src/content/docs/host/monitoring/signals.md
@@ -26,7 +26,7 @@ Record application correlation fields in structured properties or an approved ac
 Subscribe to the `Microsoft.Orleans` meter. Discover the exact instrument set emitted by your deployed version instead of copying a static list:
 
 ```dotnetcli
-dotnet counters monitor -n <ProcessName> --counters Microsoft.Orleans
+dotnet-counters monitor -n <ProcessName> --counters Microsoft.Orleans
 ```
 
 The current source of truth is [InstrumentNames.cs](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Diagnostics/Metrics/InstrumentNames.cs). Provider packages can add instruments beyond that runtime set.

--- a/docs/site/src/content/docs/host/monitoring/signals.md
+++ b/docs/site/src/content/docs/host/monitoring/signals.md
@@ -1,0 +1,90 @@
+---
+title: Interpret Orleans observability signals
+description: Use Orleans logs, metrics, traces, correlation, and alerts without relying on stale catalogs.
+ms.date: 08/02/2026
+ms.topic: concept-article
+---
+
+# Interpret Orleans observability signals
+
+Start with service-level symptoms, then use Orleans telemetry to narrow the cause. Alerting on every runtime event or instrument creates noise and couples operations to implementation details.
+
+## Logs
+
+Orleans writes through `Microsoft.Extensions.Logging`. Preserve the structured fields supplied by the provider, including category, level, event ID, exception, trace ID, and span ID. Configure category levels using normal .NET logging configuration.
+
+An Orleans `EventId` is a diagnostic identifier, not a complete incident definition. Numeric ranges and event assignments can change as the runtime evolves. Instead of maintaining a copied table:
+
+- Query the generated <xref:Orleans.ErrorCode> API reference when investigating a known ID.
+- Consult the current [runtime error-code source](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs) for the version you deploy.
+- Alert on a sustained symptom, exception type, or known event plus service impact, rather than every warning.
+
+Record application correlation fields in structured properties or an approved activity tag. Don't parse rendered log text when a structured field is available.
+
+## Metrics
+
+Subscribe to the `Microsoft.Orleans` meter. Discover the exact instrument set emitted by your deployed version instead of copying a static list:
+
+```dotnetcli
+dotnet counters monitor -n <ProcessName> --counters Microsoft.Orleans
+```
+
+The current source of truth is [InstrumentNames.cs](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Diagnostics/Metrics/InstrumentNames.cs). Provider packages can add instruments beyond that runtime set.
+
+Useful starting signals include:
+
+| Concern | Signals to correlate |
+|---|---|
+| Requests | `orleans-app-requests-latency`, timed-out/canceled requests, application error rate |
+| Connectivity | open/closed sockets, failed/dropped sends, connected gateways, ping replies missed |
+| Overload | rejected messages, gateway load shedding, activation working set, host CPU and thread-pool metrics |
+| Stuck turns | `orleans-scheduler-long-running-turns`, request latency, process CPU, traces |
+| Storage | storage latency and error instruments, provider logs, backend health |
+| Memory | Orleans available/physical memory, .NET GC heap, allocation rate, working set, container limit |
+| Membership | membership warnings, ping failures, active-silo view, membership-store health |
+
+Counter values usually need a rate or increase over a time window. Histograms need percentiles and request volume. Compare each silo with the cluster aggregate: one outlier suggests a host or partition problem, while a cluster-wide shift suggests a shared dependency or traffic change.
+
+### Cardinality
+
+Metric backends create a time series for each unique attribute set. Bound attributes to small values such as operation, direction, status, grain type, provider name, and silo identity. Never add grain key, trace ID, request ID, stack trace, URL query, or arbitrary exception text as a metric attribute.
+
+Estimate the series count before adding a dimension:
+
+`instruments x attribute-value combinations x instances`
+
+Large combinations increase memory, network, and backend cost even when each individual label seems reasonable.
+
+## Traces
+
+Use application spans to follow grain calls and runtime, lifecycle, and storage spans to explain where time was spent. A useful trace should answer:
+
+1. Which entry point initiated the call?
+2. Which grain operation was invoked?
+3. Was time spent waiting, executing application code, activating, placing, or accessing storage?
+4. Which exception or status ended the operation?
+
+If spans appear as separate traces, confirm `AddActivityPropagation()` is registered on the client and all silos on the path. Also verify that samplers honor the parent decision and that proxies preserve W3C `traceparent`.
+
+Avoid recording grain keys and state values by default. They can be high-cardinality or sensitive. If an incident requires them, use restricted, time-limited capture and remove it afterward.
+
+## Baseline alerts
+
+Tune alerts against normal traffic and service objectives. A practical initial set is:
+
+- Client has no connected gateway for longer than the expected reconnect window.
+- Request timeout or error ratio exceeds the service objective over multiple windows.
+- P95/P99 request latency is high while request volume is nonzero.
+- Rejected, dropped, or load-shed messages increase.
+- Storage error rate or latency rises above the provider baseline.
+- Long-running turns increase and remain elevated.
+- Available memory approaches the configured process/container limit or GC pause time rises.
+- Active membership differs from the expected deployment for longer than a rollout or restart.
+- Graceful shutdown doesn't complete within the orchestrator termination budget.
+- TLS certificates are approaching expiration.
+
+Page on user impact or imminent data/availability risk. Route isolated warnings and capacity trends to tickets or dashboards unless they cross a sustained threshold.
+
+## Dashboard and telemetry backends
+
+The Orleans Dashboard provides a current operational view and method profiling. It isn't a replacement for retained logs, metrics, traces, or alerts. Secure it as an administrative endpoint and use OTLP for durable telemetry. See [Orleans Dashboard](../../dashboard/index.md).

--- a/docs/site/src/content/docs/host/monitoring/signals.md
+++ b/docs/site/src/content/docs/host/monitoring/signals.md
@@ -13,7 +13,7 @@ Start with service-level symptoms, then use Orleans telemetry to narrow the caus
 
 Orleans writes through [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/dotnet/core/extensions/logging/overview). Preserve the structured fields supplied by the provider, including category, level, event ID, exception, trace ID, and span ID. Configure category levels using normal .NET logging configuration.
 
-An Orleans `EventId` is a diagnostic identifier, not a complete incident definition. Numeric ranges and event assignments can change as the runtime evolves. Instead of maintaining a copied table:
+An Orleans <xref:Microsoft.Extensions.Logging.EventId> is a diagnostic identifier, not a complete incident definition. Numeric ranges and event assignments can change as the runtime evolves. Instead of maintaining a copied table:
 
 - Query the generated <xref:Orleans.ErrorCode> API reference when investigating a known ID.
 - To inspect definitions under active development, consult the [runtime error-code source on the `main` branch](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs).
@@ -64,7 +64,7 @@ Use application spans to follow grain calls and runtime, lifecycle, and storage 
 3. Was time spent waiting, executing application code, activating, placing, or accessing storage?
 4. Which exception or status ended the operation?
 
-If spans appear as separate traces, confirm `AddActivityPropagation()` is registered on the client and all silos on the path. Also verify that samplers honor the parent decision and that proxies preserve W3C `traceparent`.
+If spans appear as separate traces, confirm <xref:Orleans.Hosting.ClientBuilderExtensions.AddActivityPropagation*?displayProperty=nameWithType> is registered on the client and the corresponding silo registration is present on all silos in the path. Also verify that samplers honor the parent decision and that proxies preserve W3C `traceparent`.
 
 Avoid recording grain keys and state values by default. They can be high-cardinality or sensitive. If an incident requires them, use restricted, time-limited capture and remove it afterward.
 

--- a/docs/site/src/content/docs/host/monitoring/signals.md
+++ b/docs/site/src/content/docs/host/monitoring/signals.md
@@ -11,19 +11,19 @@ Start with service-level symptoms, then use Orleans telemetry to narrow the caus
 
 ## Logs
 
-Orleans writes through `Microsoft.Extensions.Logging`. Preserve the structured fields supplied by the provider, including category, level, event ID, exception, trace ID, and span ID. Configure category levels using normal .NET logging configuration.
+Orleans writes through [`Microsoft.Extensions.Logging`](https://learn.microsoft.com/dotnet/core/extensions/logging/overview). Preserve the structured fields supplied by the provider, including category, level, event ID, exception, trace ID, and span ID. Configure category levels using normal .NET logging configuration.
 
 An Orleans `EventId` is a diagnostic identifier, not a complete incident definition. Numeric ranges and event assignments can change as the runtime evolves. Instead of maintaining a copied table:
 
 - Query the generated <xref:Orleans.ErrorCode> API reference when investigating a known ID.
-- Consult the current [runtime error-code source](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs) for the version you deploy.
+- To inspect definitions under active development, consult the [runtime error-code source on the `main` branch](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs).
 - Alert on a sustained symptom, exception type, or known event plus service impact, rather than every warning.
 
 Record application correlation fields in structured properties or an approved activity tag. Don't parse rendered log text when a structured field is available.
 
 ## Metrics
 
-Subscribe to the `Microsoft.Orleans` meter. Discover the exact instrument set emitted by your deployed version instead of copying a static list:
+Subscribe to the `Microsoft.Orleans` meter. Discover the exact instrument set emitted by your deployed version instead of copying a static list. For installation and command details, see the [`dotnet-counters` diagnostic tool](https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-counters):
 
 ```dotnetcli
 dotnet-counters monitor -n <ProcessName> --counters Microsoft.Orleans

--- a/docs/site/src/content/docs/host/monitoring/silo-error-code-monitoring.md
+++ b/docs/site/src/content/docs/host/monitoring/silo-error-code-monitoring.md
@@ -9,7 +9,7 @@ ms.topic: reference
 
 The previous hand-maintained silo error-code table was removed because it drifted from the runtime and mixed implementation event IDs with operational alert thresholds.
 
-For current definitions, use the generated <xref:Orleans.ErrorCode> API reference or the [error-code source for the Orleans version you deploy](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs). Alert on sustained service symptoms and use event IDs to narrow an investigation.
+For current definitions, use the generated <xref:Orleans.ErrorCode> API reference. To inspect definitions under active development, see the [error-code source on the `main` branch](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs). Alert on sustained service symptoms and use event IDs to narrow an investigation.
 
 For current workflows, see:
 

--- a/docs/site/src/content/docs/host/monitoring/silo-error-code-monitoring.md
+++ b/docs/site/src/content/docs/host/monitoring/silo-error-code-monitoring.md
@@ -1,17 +1,17 @@
 ---
-title: Silo error code monitoring
-description: Explore the various silo error code monitoring values in .NET Orleans.
-ms.date: 05/23/2025
-ms.topic: error-reference
+title: Silo diagnostic events
+description: Find current Orleans silo event IDs and use symptom-based observability guidance.
+ms.date: 08/02/2026
+ms.topic: reference
 ---
 
-# Silo error code monitoring
+# Silo diagnostic events
 
-| Group | Log Type | Log Code Values | Threshold | Description |
-|--|--|--|--|--|
-| Azure Problems | Warning or Error | 100800 - 100899 | Any Error or Warning | Transient problems reading or writing to Azure table store will be logged as Warning. Transient read errors will automatically be retried. A final Error log message means there is a real problem connecting to Azure table storage. |
-| Membership Connectivity Problems | Warning or Error | 100600 - 100699 | Any Error or Warning | Warning logs are an early indication of network connectivity problems and/or silo restart/migration. Ping timeouts and silo-dead votes will show up as Warning messages. Silo detecting it was voted dead will show as an Error message. |
-| Grain call timeouts | Warning | 100157 | Multiple Warnings logged in a short amount of time | Grain-call timeout problems are generally caused by temporary network connectivity issues or silo restart/reboot problems. The system should recover after a short time (depending on Liveness config settings) at which point Timeouts should clear. Ideally, monitoring for just the bulk log code 600157 variety of these warnings should be sufficient. |
-| Silo Restart / Migration | Warning | 100601 or 100602 | Any Warning | Warning printed when silo detects it was restarted on same machine (100602) or migrated to a different machine (100601) |
-| Network Socket Problems | Warning or Error | 101000 to 101999, 100307,100015, 100016 | Any Error or Warning | Socket disconnects are logged as Warning messages. Problems opening sockets or during message transmission, are logged as Errors. |
-| Grain problems | Warning or Error | 101534 | Any Error or Warning | Detection of "stuck" requests for non-reentrant grains. The error code is reported every time a request takes longer than 5x request timeout time to execute. |
+The previous hand-maintained silo error-code table was removed because it drifted from the runtime and mixed implementation event IDs with operational alert thresholds.
+
+For current definitions, use the generated <xref:Orleans.ErrorCode> API reference or the [error-code source for the Orleans version you deploy](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core.Abstractions/Logging/ErrorCodes.cs). Alert on sustained service symptoms and use event IDs to narrow an investigation.
+
+For current workflows, see:
+
+- [Interpret Orleans observability signals](signals.md)
+- [Troubleshoot Orleans incidents](troubleshooting.md)

--- a/docs/site/src/content/docs/host/monitoring/snippets/observability/Observability.csproj
+++ b/docs/site/src/content/docs/host/monitoring/snippets/observability/Observability.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.2" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />

--- a/docs/site/src/content/docs/host/monitoring/snippets/observability/Observability.csproj
+++ b/docs/site/src/content/docs/host/monitoring/snippets/observability/Observability.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/docs/site/src/content/docs/host/monitoring/snippets/observability/Observability.csproj
+++ b/docs/site/src/content/docs/host/monitoring/snippets/observability/Observability.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,10 +14,6 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/docs/site/src/content/docs/host/monitoring/snippets/observability/Program.cs
+++ b/docs/site/src/content/docs/host/monitoring/snippets/observability/Program.cs
@@ -1,0 +1,60 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// <OpenTelemetry>
+builder.Logging.AddOpenTelemetry(logging =>
+{
+    logging.IncludeFormattedMessage = true;
+    logging.IncludeScopes = true;
+});
+
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource
+        .AddService(
+            serviceName: "orders-silo",
+            serviceVersion: typeof(Program).Assembly.GetName().Version?.ToString(),
+            serviceInstanceId: Environment.MachineName)
+        .AddAttributes([
+            new("deployment.environment.name", builder.Environment.EnvironmentName),
+        ]))
+    .WithMetrics(metrics => metrics
+        .AddMeter("Microsoft.Orleans")
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddRuntimeInstrumentation())
+    .WithTracing(tracing => tracing
+        .AddSource(
+            "Microsoft.Orleans.Application",
+            "Microsoft.Orleans.Runtime",
+            "Microsoft.Orleans.Lifecycle",
+            "Microsoft.Orleans.Storage")
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .SetSampler(new ParentBasedSampler(
+            new TraceIdRatioBasedSampler(0.1))));
+
+if (!string.IsNullOrWhiteSpace(
+    builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]))
+{
+    builder.Services.AddOpenTelemetry().UseOtlpExporter();
+}
+
+builder.UseOrleans(siloBuilder =>
+{
+    siloBuilder
+        .UseLocalhostClustering()
+        .AddActivityPropagation();
+});
+// </OpenTelemetry>
+
+var app = builder.Build();
+await app.RunAsync();

--- a/docs/site/src/content/docs/host/monitoring/snippets/observability/Program.cs
+++ b/docs/site/src/content/docs/host/monitoring/snippets/observability/Program.cs
@@ -2,19 +2,25 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
+var exportToOtlp = !string.IsNullOrWhiteSpace(
+    builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
 
 // <OpenTelemetry>
 builder.Logging.AddOpenTelemetry(logging =>
 {
     logging.IncludeFormattedMessage = true;
     logging.IncludeScopes = true;
+
+    if (exportToOtlp)
+    {
+        logging.AddOtlpExporter();
+    }
 });
 
 builder.Services.AddOpenTelemetry()
@@ -26,27 +32,37 @@ builder.Services.AddOpenTelemetry()
         .AddAttributes([
             new("deployment.environment.name", builder.Environment.EnvironmentName),
         ]))
-    .WithMetrics(metrics => metrics
-        .AddMeter("Microsoft.Orleans")
-        .AddAspNetCoreInstrumentation()
-        .AddHttpClientInstrumentation()
-        .AddRuntimeInstrumentation())
-    .WithTracing(tracing => tracing
-        .AddSource(
-            "Microsoft.Orleans.Application",
-            "Microsoft.Orleans.Runtime",
-            "Microsoft.Orleans.Lifecycle",
-            "Microsoft.Orleans.Storage")
-        .AddAspNetCoreInstrumentation()
-        .AddHttpClientInstrumentation()
-        .SetSampler(new ParentBasedSampler(
-            new TraceIdRatioBasedSampler(0.1))));
+    .WithMetrics(metrics =>
+    {
+        metrics
+            .AddMeter("Microsoft.Orleans")
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddRuntimeInstrumentation();
 
-if (!string.IsNullOrWhiteSpace(
-    builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]))
-{
-    builder.Services.AddOpenTelemetry().UseOtlpExporter();
-}
+        if (exportToOtlp)
+        {
+            metrics.AddOtlpExporter();
+        }
+    })
+    .WithTracing(tracing =>
+    {
+        tracing
+            .AddSource(
+                "Microsoft.Orleans.Application",
+                "Microsoft.Orleans.Runtime",
+                "Microsoft.Orleans.Lifecycle",
+                "Microsoft.Orleans.Storage")
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .SetSampler(new ParentBasedSampler(
+                new TraceIdRatioBasedSampler(0.1)));
+
+        if (exportToOtlp)
+        {
+            tracing.AddOtlpExporter();
+        }
+    });
 
 builder.UseOrleans(siloBuilder =>
 {

--- a/docs/site/src/content/docs/host/monitoring/troubleshooting.md
+++ b/docs/site/src/content/docs/host/monitoring/troubleshooting.md
@@ -102,4 +102,4 @@ For intermittent or production-only failures, retain:
 - Membership snapshots and provider health.
 - A process trace or dump when scheduler, CPU, or memory behavior is involved.
 
-Redact secrets and grain state before sharing artifacts. See [.NET diagnostics](../../../core/diagnostics/) for `dotnet-counters`, `dotnet-trace`, and dump collection guidance.
+Redact secrets and grain state before sharing artifacts. See [.NET diagnostics](https://learn.microsoft.com/dotnet/core/diagnostics/) for `dotnet-counters`, `dotnet-trace`, and dump collection guidance.

--- a/docs/site/src/content/docs/host/monitoring/troubleshooting.md
+++ b/docs/site/src/content/docs/host/monitoring/troubleshooting.md
@@ -1,0 +1,105 @@
+---
+title: Troubleshoot Orleans incidents
+description: Operational runbooks for common Orleans connection, timeout, membership, storage, overload, memory, and shutdown incidents.
+ms.date: 08/02/2026
+ms.topic: troubleshooting
+---
+
+# Troubleshoot Orleans incidents
+
+Use these runbooks as investigation sequences, not as automatic proof of one root cause. Capture the incident window, deployment changes, cluster topology, and traffic level before changing configuration. Prefer a rollback or traffic reduction when user impact is growing.
+
+## Client can't connect
+
+**Evidence:** no connected gateways, repeated connection failures, `ConnectionFailedException`, or a dashboard/client reporting lost cluster connectivity.
+
+1. Confirm the client and silos use the same cluster and service IDs and the same clustering provider.
+2. Query the membership/gateway source from the client's network boundary. Confirm it returns active silos with reachable advertised gateway addresses.
+3. Test DNS and TCP reachability to those addresses. Check firewalls, network policy, NAT, and load balancers.
+4. If TLS is enabled, inspect handshake errors, certificate validity, SAN/`TargetHost`, trust chain, EKU, and whether the silo unexpectedly requires a client certificate.
+5. Compare all silo logs. One reachable gateway can mask a partial routing problem.
+
+Don't add retries around startup indefinitely. Bound startup/reconnect behavior and expose readiness as false while the client has no usable gateway.
+
+## Grain calls time out
+
+**Evidence:** increased `orleans-app-requests-timedout`, high request latency, or `TimeoutException` at callers.
+
+1. Follow a sampled trace from the caller. Determine whether the call reached a silo and whether it waited before grain execution, inside the grain, or in a dependency.
+2. Compare timeout growth with rejected/dropped messages, gateway connectivity, long-running turns, CPU, thread-pool starvation, GC pauses, and storage latency.
+3. Check whether the timeout started with a deployment, traffic increase, membership change, or dependency degradation.
+4. Inspect the target grain type and operation. Look for blocking calls, lock contention, synchronous I/O, fan-out, or calls which don't honor cancellation.
+5. Increase a timeout only when the operation's valid latency exceeds the existing budget. A larger timeout doesn't fix overload or a blocked turn and can increase queued work.
+
+## Membership is unstable
+
+**Evidence:** silos repeatedly transition out of `Active`, ping replies are missed, or membership warnings occur across the cluster.
+
+1. Compare each silo's membership view and timestamps. Account for an intentional rollout before treating changes as failures.
+2. Check host pauses, CPU starvation, GC pauses, packet loss, DNS changes, and clock synchronization.
+3. Verify membership-store latency, availability, credentials, and throttling from every silo.
+4. Confirm advertised silo addresses are stable and mutually reachable; don't advertise loopback or an ephemeral address across hosts.
+5. Avoid loosening liveness settings until infrastructure stalls and store latency are understood. Longer detection can reduce false positives but also delays failure recovery.
+
+## Grain turns appear stuck
+
+**Evidence:** `orleans-scheduler-long-running-turns` increases, one grain's queue grows, or traces show long application execution.
+
+1. Identify the grain type and method from traces, dashboard profiling, and logs.
+2. Capture a process trace or dump while the issue is active. Inspect managed stacks, CPU consumers, thread-pool queues, and monitor contention.
+3. Look for synchronous blocking (`.Result`, `.Wait()`), unbounded loops, CPU-heavy work, external calls without timeouts, and non-reentrant grains waiting through cyclic calls.
+4. Reduce incoming load or isolate the affected operation before restarting. A restart clears evidence and may only move the blockage.
+5. Move blocking/CPU-heavy work out of grain turns or split it into bounded asynchronous steps.
+
+## Storage operations fail
+
+**Evidence:** Orleans storage error instruments increase, storage spans fail, activation fails, or provider exceptions appear.
+
+1. Separate reads, writes, and clears and identify the storage provider and grain type.
+2. Check backend health, throttling, authentication, DNS/TLS, connection pools, and latency from the affected silo.
+3. Determine whether failures are transient, concurrency/ETag conflicts, serialization failures, or deterministic data/schema problems.
+4. Compare affected silos and partitions. A single host suggests local connectivity or credentials; a shared partition suggests backend hot-spotting.
+5. Don't retry deterministic serialization or concurrency failures indefinitely. Use bounded retry for provider-documented transient failures and preserve idempotency.
+
+## The cluster is overloaded
+
+**Evidence:** rejected messages, gateway load shedding, rising queue/latency, high CPU, or falling throughput while demand rises.
+
+1. Verify whether pressure is at gateways, grain execution, storage, streams, or another dependency.
+2. Compare request rate, completion rate, latency, rejections, activation count, CPU, thread pool, and GC across silos.
+3. Reduce admission or shed optional work. Retrying rejected work immediately amplifies overload; use bounded exponential backoff with jitter at an appropriate boundary.
+4. Scale only if work partitions across additional silos and the bottleneck isn't a shared dependency or hot grain.
+5. After recovery, set capacity alerts below the rejection point and add load tests for the triggering traffic shape.
+
+## Memory pressure rises
+
+**Evidence:** low `orleans-runtime-available-memory`, growing working set/GC heap, long GC pauses, container OOM kills, or activation collection churn.
+
+1. Compare process working set, GC heap size, allocation rate, collection count/pause time, Orleans activation working set, and stream cache metrics.
+2. Check the real container or host memory limit. Physical-host availability can mislead a containerized process.
+3. Capture a dump or GC trace before restart if safe. Group retained objects by type and retention path.
+4. Check unbounded grain state, caches, stream buffers, request payloads, telemetry cardinality, and activation growth.
+5. Lower load or scale out to stabilize. Don't simply raise limits without identifying whether memory is intentionally bounded.
+
+## Shutdown doesn't complete
+
+**Evidence:** the orchestrator kills silos after the grace period, membership remains `ShuttingDown`/`Stopping`, or logs report that graceful shutdown was aborted.
+
+1. Compare the host shutdown timeout with the orchestrator termination grace period. Leave time for Orleans and other hosted services to stop before forced termination.
+2. Stop accepting new external work before stopping the silo.
+3. Inspect the final lifecycle logs and traces for long-running grain calls, deactivation, membership-store updates, stream shutdown, or blocked hosted services.
+4. Ensure `StopAsync` cancellation is propagated and custom lifecycle participants complete promptly.
+5. Treat repeated forced termination as an availability risk. Fix the blocking component rather than relying on process kill.
+
+## Preserve diagnostic evidence
+
+For intermittent or production-only failures, retain:
+
+- UTC timestamps and deployment/version identifiers.
+- Logs from all involved clients and silos.
+- Metrics covering before, during, and after the event.
+- Representative trace IDs and unsampled request counts.
+- Membership snapshots and provider health.
+- A process trace or dump when scheduler, CPU, or memory behavior is involved.
+
+Redact secrets and grain state before sharing artifacts. See [.NET diagnostics](../../../core/diagnostics/) for `dotnet-counters`, `dotnet-trace`, and dump collection guidance.

--- a/docs/site/src/content/docs/host/monitoring/troubleshooting.md
+++ b/docs/site/src/content/docs/host/monitoring/troubleshooting.md
@@ -11,7 +11,7 @@ Use these runbooks as investigation sequences, not as automatic proof of one roo
 
 ## Client can't connect
 
-**Evidence:** no connected gateways, repeated connection failures, `ConnectionFailedException`, or a dashboard/client reporting lost cluster connectivity.
+**Evidence:** no connected gateways, repeated connection failures, <xref:Orleans.Runtime.Messaging.ConnectionFailedException>, or a dashboard/client reporting lost cluster connectivity.
 
 1. Confirm the client and silos use the same cluster and service IDs and the same clustering provider.
 2. Query the membership/gateway source from the client's network boundary. Confirm it returns active silos with reachable advertised gateway addresses.
@@ -23,7 +23,7 @@ Don't add retries around startup indefinitely. Bound startup/reconnect behavior 
 
 ## Grain calls time out
 
-**Evidence:** increased `orleans-app-requests-timedout`, high request latency, or `TimeoutException` at callers.
+**Evidence:** increased `orleans-app-requests-timedout`, high request latency, or <xref:System.TimeoutException> at callers.
 
 1. Follow a sampled trace from the caller. Determine whether the call reached a silo and whether it waited before grain execution, inside the grain, or in a dependency.
 2. Compare timeout growth with rejected/dropped messages, gateway connectivity, long-running turns, CPU, thread-pool starvation, GC pauses, and storage latency.
@@ -88,7 +88,7 @@ Don't add retries around startup indefinitely. Bound startup/reconnect behavior 
 1. Compare the host shutdown timeout with the orchestrator termination grace period. Leave time for Orleans and other hosted services to stop before forced termination.
 2. Stop accepting new external work before stopping the silo.
 3. Inspect the final lifecycle logs and traces for long-running grain calls, deactivation, membership-store updates, stream shutdown, or blocked hosted services.
-4. Ensure `StopAsync` cancellation is propagated and custom lifecycle participants complete promptly.
+4. Ensure <xref:Orleans.ILifecycleObserver.OnStop*> honors cancellation and custom lifecycle participants complete promptly.
 5. Treat repeated forced termination as an availability risk. Fix the blocking component rather than relying on process kill.
 
 ## Preserve diagnostic evidence

--- a/docs/site/src/content/docs/host/snippets/transport-layer-security/README.md
+++ b/docs/site/src/content/docs/host/snippets/transport-layer-security/README.md
@@ -1,14 +1,18 @@
 # Orleans transport layer security snippets
 
-This folder contains the runnable snippet projects used by `docs/orleans/host/transport-layer-security.md`.
+This folder contains the compile-checked snippet projects used by
+`docs/site/src/content/docs/host/transport-layer-security.md`.
 
-## Run the sample locally
+## Build the snippets
 
-1. Open a terminal in `docs/orleans/host/snippets/transport-layer-security/csharp/SiloExample`.
-2. Run `dotnet build` and then `dotnet run`.
-3. Open a second terminal in `docs/orleans/host/snippets/transport-layer-security/csharp/ClientExample`.
-4. Run `dotnet build` and then `dotnet run`.
+Run `dotnet build` for each project:
 
-The executable entry points create temporary self-signed certificates in memory and configure Orleans for development-only certificate validation so the sample can run locally without any certificate store setup. The generated certificate is loaded into user key storage so Windows TLS can use it for the server-side handshake.
+- `csharp/SiloExample/SiloExample.csproj`
+- `csharp/ClientExample/ClientExample.csproj`
 
-The inline snippets in each `Program.cs` file remain focused on the certificate store and certificate file configuration patterns described in the article.
+The entry points intentionally don't start a silo or client. The article examples
+require deployment-specific certificates, names, and trust stores and are
+designed to compile without embedding development-only certificate bypasses.
+
+For a locally runnable mTLS example which creates a development certificate, see
+the [Orleans Transport Layer Security sample](https://learn.microsoft.com/samples/dotnet/samples/orleans-transport-layer-security-tls/).

--- a/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/ClientExample/ClientExample.csproj
+++ b/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/ClientExample/ClientExample.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Client" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="10.2.2" />
   </ItemGroup>
 
 </Project>

--- a/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/ClientExample/Program.cs
+++ b/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/ClientExample/Program.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Hosting;
+using Orleans.Connections.Security;
 using Orleans.Hosting;
 
 Console.WriteLine("TLS configuration examples");
@@ -17,11 +18,16 @@ internal static class TlsExamples
                 .UseLocalhostClustering()
                 .UseTls(options =>
                 {
+                    options.RemoteCertificateMode =
+                        RemoteCertificateMode.RequireCertificate;
+                    options.ClientCertificateMode =
+                        RemoteCertificateMode.NoCertificate;
                     options.OnAuthenticateAsClient = (_, sslOptions) =>
                     {
                         sslOptions.TargetHost = "orleans.example.net";
+                        sslOptions.CertificateRevocationCheckMode =
+                            X509RevocationMode.Online;
                     };
-                    options.CheckCertificateRevocation = true;
                 });
         });
 
@@ -40,11 +46,16 @@ internal static class TlsExamples
                 .UseLocalhostClustering()
                 .UseTls(clientCertificate, options =>
                 {
+                    options.RemoteCertificateMode =
+                        RemoteCertificateMode.RequireCertificate;
+                    options.ClientCertificateMode =
+                        RemoteCertificateMode.RequireCertificate;
                     options.OnAuthenticateAsClient = (_, sslOptions) =>
                     {
                         sslOptions.TargetHost = "orleans.example.net";
+                        sslOptions.CertificateRevocationCheckMode =
+                            X509RevocationMode.Online;
                     };
-                    options.CheckCertificateRevocation = true;
                 });
         });
 

--- a/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/ClientExample/Program.cs
+++ b/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/ClientExample/Program.cs
@@ -1,162 +1,54 @@
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Orleans.Connections.Security;
 using Orleans.Hosting;
 
-using var certificate = SampleCertificates.CreateDevelopmentCertificate("localhost");
-using IHost host = Host.CreateDefaultBuilder(args)
-    .UseEnvironment(Environments.Development)
-    .UseOrleansClient(builder =>
-    {
-        builder
-            .UseLocalhostClustering()
-            .UseTls(certificate, options =>
-            {
-                options.AllowAnyRemoteCertificate();
-                options.OnAuthenticateAsClient = (connection, sslOptions) =>
-                {
-                    sslOptions.TargetHost = "localhost";
-                };
-            });
-    })
-    .ConfigureLogging(logging => logging.AddConsole())
-    .Build();
+Console.WriteLine("TLS configuration examples");
 
-await host.StartAsync();
-Console.WriteLine("ClientExample connected with development TLS. Press Ctrl+C to exit.");
-await host.WaitForShutdownAsync();
-
-class BasicClientExample
+internal static class TlsExamples
 {
-    public static async Task ConfigureBasicTls()
+    public static IHost CreateServerAuthenticatedClient()
     {
-        // <BasicClientTlsConfiguration>
-        using IHost host = Host.CreateDefaultBuilder()
-            .UseOrleansClient(builder =>
-            {
-                builder
-                    .UseLocalhostClustering()
-                    .UseTls(StoreName.My, "my-certificate-subject", allowInvalid: false, StoreLocation.CurrentUser, options =>
-                    {
-                        options.OnAuthenticateAsClient = (connection, sslOptions) =>
-                        {
-                            sslOptions.TargetHost = "my-certificate-subject";
-                        };
-                    });
-            })
-            .ConfigureLogging(logging => logging.AddConsole())
-            .Build();
+        // <ServerAuthenticatedTls>
+        var builder = Host.CreateApplicationBuilder();
 
-        await host.RunAsync();
-        // </BasicClientTlsConfiguration>
-    }
-}
-
-class ClientDevelopmentExample
-{
-    public static async Task ConfigureDevelopmentTls()
-    {
-        // <ClientDevelopmentTlsConfiguration>
-        var hostBuilder = Host.CreateDefaultBuilder()
-            .UseEnvironment(Environments.Development);
-
-        using IHost host = hostBuilder
-            .UseOrleansClient((context, builder) =>
-            {
-                var isDevelopment = context.HostingEnvironment.IsDevelopment();
-
-                builder
-                    .UseLocalhostClustering()
-                    .UseTls(StoreName.My, "localhost", allowInvalid: isDevelopment, StoreLocation.CurrentUser, options =>
-                    {
-                        if (isDevelopment)
-                        {
-                            options.AllowAnyRemoteCertificate();
-                        }
-
-                        options.OnAuthenticateAsClient = (connection, sslOptions) =>
-                        {
-                            sslOptions.TargetHost = "localhost";
-                        };
-                    });
-            })
-            .ConfigureLogging(logging => logging.AddConsole())
-            .Build();
-
-        await host.RunAsync();
-        // </ClientDevelopmentTlsConfiguration>
-    }
-}
-
-class ClientCertificateExample
-{
-    public static async Task ConfigureTlsWithCertificate()
-    {
-        // <ClientCertificateTlsConfiguration>
-        using var cert = X509CertificateLoader.LoadPkcs12FromFile("path/to/certificate.pfx", "password");
-
-        using IHost host = Host.CreateDefaultBuilder()
-            .UseOrleansClient(builder =>
-            {
-                builder
-                    .UseLocalhostClustering()
-                    .UseTls(cert, options =>
-                    {
-                        options.OnAuthenticateAsClient = (connection, sslOptions) =>
-                        {
-                            sslOptions.TargetHost = cert.GetNameInfo(X509NameType.DnsName, false) ?? "my-certificate-subject";
-                        };
-                    });
-            })
-            .ConfigureLogging(logging => logging.AddConsole())
-            .Build();
-
-        await host.RunAsync();
-        // </ClientCertificateTlsConfiguration>
-    }
-}
-
-static class SampleCertificates
-{
-    public static X509Certificate2 CreateDevelopmentCertificate(string dnsName)
-    {
-        using var rsa = RSA.Create(2048);
-
-        var request = new CertificateRequest(
-            $"CN={dnsName}",
-            rsa,
-            HashAlgorithmName.SHA256,
-            RSASignaturePadding.Pkcs1);
-
-        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
-        request.CertificateExtensions.Add(new X509KeyUsageExtension(
-            X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
-            critical: true));
-        request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
-
-        var subjectAlternativeNames = new SubjectAlternativeNameBuilder();
-        subjectAlternativeNames.AddDnsName(dnsName);
-        request.CertificateExtensions.Add(subjectAlternativeNames.Build());
-
-        var usages = new OidCollection
+        builder.UseOrleansClient(clientBuilder =>
         {
-            new("1.3.6.1.5.5.7.3.1"),
-            new("1.3.6.1.5.5.7.3.2"),
-        };
-        request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(usages, critical: true));
+            clientBuilder
+                .UseLocalhostClustering()
+                .UseTls(options =>
+                {
+                    options.OnAuthenticateAsClient = (_, sslOptions) =>
+                    {
+                        sslOptions.TargetHost = "orleans.example.net";
+                    };
+                    options.CheckCertificateRevocation = true;
+                });
+        });
 
-        using var created = request.CreateSelfSigned(
-            DateTimeOffset.UtcNow.AddDays(-1),
-            DateTimeOffset.UtcNow.AddDays(30));
+        return builder.Build();
+        // </ServerAuthenticatedTls>
+    }
 
-        var password = Guid.NewGuid().ToString("N");
-        // Windows server-side TLS requires a key container instead of an ephemeral key.
-        return X509CertificateLoader.LoadPkcs12(
-            created.Export(X509ContentType.Pfx, password),
-            password,
-            X509KeyStorageFlags.Exportable | X509KeyStorageFlags.UserKeySet,
-            Pkcs12LoaderLimits.Defaults);
+    public static IHost CreateMutualTlsClient(X509Certificate2 clientCertificate)
+    {
+        // <MutualTls>
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.UseOrleansClient(clientBuilder =>
+        {
+            clientBuilder
+                .UseLocalhostClustering()
+                .UseTls(clientCertificate, options =>
+                {
+                    options.OnAuthenticateAsClient = (_, sslOptions) =>
+                    {
+                        sslOptions.TargetHost = "orleans.example.net";
+                    };
+                    options.CheckCertificateRevocation = true;
+                });
+        });
+
+        return builder.Build();
+        // </MutualTls>
     }
 }

--- a/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/SiloExample/Program.cs
+++ b/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/SiloExample/Program.cs
@@ -18,11 +18,16 @@ internal static class TlsExamples
                 .UseLocalhostClustering()
                 .UseTls(serverCertificate, options =>
                 {
+                    options.RemoteCertificateMode =
+                        RemoteCertificateMode.NoCertificate;
+                    options.ClientCertificateMode =
+                        RemoteCertificateMode.NoCertificate;
                     options.OnAuthenticateAsClient = (_, sslOptions) =>
                     {
                         sslOptions.TargetHost = "orleans.example.net";
+                        sslOptions.CertificateRevocationCheckMode =
+                            X509RevocationMode.Online;
                     };
-                    options.CheckCertificateRevocation = true;
                 });
         });
 
@@ -41,11 +46,15 @@ internal static class TlsExamples
                 .UseLocalhostClustering()
                 .UseTls(siloCertificate, options =>
                 {
+                    options.RemoteCertificateMode =
+                        RemoteCertificateMode.RequireCertificate;
                     options.ClientCertificateMode =
                         RemoteCertificateMode.RequireCertificate;
                     options.OnAuthenticateAsClient = (_, sslOptions) =>
                     {
                         sslOptions.TargetHost = "orleans.example.net";
+                        sslOptions.CertificateRevocationCheckMode =
+                            X509RevocationMode.Online;
                     };
                     options.CheckCertificateRevocation = true;
                 });

--- a/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/SiloExample/Program.cs
+++ b/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/SiloExample/Program.cs
@@ -1,207 +1,57 @@
-using System.Net.Security;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Orleans.Connections.Security;
 using Orleans.Hosting;
 
-using var certificate = SampleCertificates.CreateDevelopmentCertificate("localhost");
-using IHost host = Host.CreateDefaultBuilder(args)
-    .UseEnvironment(Environments.Development)
-    .UseOrleans(builder =>
-    {
-        builder
-            .UseLocalhostClustering()
-            .UseTls(certificate, options =>
-            {
-                options.AllowAnyRemoteCertificate();
-                options.OnAuthenticateAsClient = (connection, sslOptions) =>
-                {
-                    sslOptions.TargetHost = "localhost";
-                };
-            });
-    })
-    .ConfigureLogging(logging => logging.AddConsole())
-    .Build();
+Console.WriteLine("TLS configuration examples");
 
-await host.StartAsync();
-Console.WriteLine("SiloExample started with development TLS. Press Ctrl+C to exit.");
-await host.WaitForShutdownAsync();
-
-class BasicExample
+internal static class TlsExamples
 {
-    public static async Task ConfigureBasicTls()
+    public static IHost CreateServerAuthenticatedSilo(X509Certificate2 serverCertificate)
     {
-        // <BasicTlsConfiguration>
-        using IHost host = Host.CreateDefaultBuilder()
-            .UseOrleans(builder =>
-            {
-                builder
-                    .UseLocalhostClustering()
-                    .UseTls(StoreName.My, "my-certificate-subject", allowInvalid: false, StoreLocation.CurrentUser, options =>
-                    {
-                        options.OnAuthenticateAsClient = (connection, sslOptions) =>
-                        {
-                            sslOptions.TargetHost = "my-certificate-subject";
-                        };
-                    });
-            })
-            .ConfigureLogging(logging => logging.AddConsole())
-            .Build();
+        // <ServerAuthenticatedTls>
+        var builder = Host.CreateApplicationBuilder();
 
-        await host.RunAsync();
-        // </BasicTlsConfiguration>
-    }
-}
-
-class DevelopmentExample
-{
-    public static async Task ConfigureDevelopmentTls()
-    {
-        // <DevelopmentTlsConfiguration>
-        var hostBuilder = Host.CreateDefaultBuilder()
-            .UseEnvironment(Environments.Development);
-
-        using IHost host = hostBuilder
-            .UseOrleans((context, builder) =>
-            {
-                var isDevelopment = context.HostingEnvironment.IsDevelopment();
-
-                builder
-                    .UseLocalhostClustering()
-                    .UseTls(StoreName.My, "localhost", allowInvalid: isDevelopment, StoreLocation.CurrentUser, options =>
-                    {
-                        options.OnAuthenticateAsClient = (connection, sslOptions) =>
-                        {
-                            sslOptions.TargetHost = "localhost";
-                        };
-
-                        if (isDevelopment)
-                        {
-                            options.AllowAnyRemoteCertificate();
-                        }
-                    });
-            })
-            .ConfigureLogging(logging => logging.AddConsole())
-            .Build();
-
-        await host.RunAsync();
-        // </DevelopmentTlsConfiguration>
-    }
-}
-
-class CertificateExample
-{
-    public static async Task ConfigureTlsWithCertificate()
-    {
-        // <CertificateTlsConfiguration>
-        using var cert = X509CertificateLoader.LoadPkcs12FromFile("path/to/certificate.pfx", "password");
-
-        using IHost host = Host.CreateDefaultBuilder()
-            .UseOrleans(builder =>
-            {
-                builder
-                    .UseLocalhostClustering()
-                    .UseTls(cert, options =>
-                    {
-                        options.OnAuthenticateAsClient = (connection, sslOptions) =>
-                        {
-                            sslOptions.TargetHost = cert.GetNameInfo(X509NameType.DnsName, false) ?? "my-certificate-subject";
-                        };
-                    });
-            })
-            .ConfigureLogging(logging => logging.AddConsole())
-            .Build();
-
-        await host.RunAsync();
-        // </CertificateTlsConfiguration>
-    }
-}
-
-class AdvancedExample
-{
-    public static async Task ConfigureAdvancedTls()
-    {
-        // <AdvancedTlsConfiguration>
-        using IHost host = Host.CreateDefaultBuilder()
-            .UseOrleans(builder =>
-            {
-                builder
-                    .UseLocalhostClustering()
-                    .UseTls(StoreName.My, "my-certificate-subject", allowInvalid: false, StoreLocation.LocalMachine, options =>
-                    {
-                        options.LocalServerCertificateSelector = (connection, serverName) =>
-                        {
-                            using var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
-                            store.Open(OpenFlags.ReadOnly);
-
-                            var certificates = store.Certificates.Find(
-                                X509FindType.FindBySubjectName,
-                                serverName ?? "my-certificate-subject",
-                                validOnly: true);
-
-                            return certificates.Count > 0 ? certificates[0] : null;
-                        };
-
-                        options.RemoteCertificateValidation = (certificate, chain, sslPolicyErrors) =>
-                            sslPolicyErrors == SslPolicyErrors.None;
-
-                        options.OnAuthenticateAsClient = (connection, sslOptions) =>
-                        {
-                            sslOptions.TargetHost = "my-certificate-subject";
-                        };
-
-                        options.CheckCertificateRevocation = true;
-                    });
-            })
-            .ConfigureLogging(logging => logging.AddConsole())
-            .Build();
-
-        await host.RunAsync();
-        // </AdvancedTlsConfiguration>
-    }
-}
-
-static class SampleCertificates
-{
-    public static X509Certificate2 CreateDevelopmentCertificate(string dnsName)
-    {
-        using var rsa = RSA.Create(2048);
-
-        var request = new CertificateRequest(
-            $"CN={dnsName}",
-            rsa,
-            HashAlgorithmName.SHA256,
-            RSASignaturePadding.Pkcs1);
-
-        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
-        request.CertificateExtensions.Add(new X509KeyUsageExtension(
-            X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
-            critical: true));
-        request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
-
-        var subjectAlternativeNames = new SubjectAlternativeNameBuilder();
-        subjectAlternativeNames.AddDnsName(dnsName);
-        request.CertificateExtensions.Add(subjectAlternativeNames.Build());
-
-        var usages = new OidCollection
+        builder.UseOrleans(siloBuilder =>
         {
-            new("1.3.6.1.5.5.7.3.1"),
-            new("1.3.6.1.5.5.7.3.2"),
-        };
-        request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(usages, critical: true));
+            siloBuilder
+                .UseLocalhostClustering()
+                .UseTls(serverCertificate, options =>
+                {
+                    options.OnAuthenticateAsClient = (_, sslOptions) =>
+                    {
+                        sslOptions.TargetHost = "orleans.example.net";
+                    };
+                    options.CheckCertificateRevocation = true;
+                });
+        });
 
-        using var created = request.CreateSelfSigned(
-            DateTimeOffset.UtcNow.AddDays(-1),
-            DateTimeOffset.UtcNow.AddDays(30));
+        return builder.Build();
+        // </ServerAuthenticatedTls>
+    }
 
-        var password = Guid.NewGuid().ToString("N");
-        // Windows server-side TLS requires a key container instead of an ephemeral key.
-        return X509CertificateLoader.LoadPkcs12(
-            created.Export(X509ContentType.Pfx, password),
-            password,
-            X509KeyStorageFlags.Exportable | X509KeyStorageFlags.UserKeySet,
-            Pkcs12LoaderLimits.Defaults);
+    public static IHost CreateMutualTlsSilo(X509Certificate2 siloCertificate)
+    {
+        // <MutualTls>
+        var builder = Host.CreateApplicationBuilder();
+
+        builder.UseOrleans(siloBuilder =>
+        {
+            siloBuilder
+                .UseLocalhostClustering()
+                .UseTls(siloCertificate, options =>
+                {
+                    options.ClientCertificateMode =
+                        RemoteCertificateMode.RequireCertificate;
+                    options.OnAuthenticateAsClient = (_, sslOptions) =>
+                    {
+                        sslOptions.TargetHost = "orleans.example.net";
+                    };
+                    options.CheckCertificateRevocation = true;
+                });
+        });
+
+        return builder.Build();
+        // </MutualTls>
     }
 }

--- a/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/SiloExample/SiloExample.csproj
+++ b/docs/site/src/content/docs/host/snippets/transport-layer-security/csharp/SiloExample/SiloExample.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Connections.Security" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.2" />
   </ItemGroup>
 
 </Project>

--- a/docs/site/src/content/docs/host/transport-layer-security.md
+++ b/docs/site/src/content/docs/host/transport-layer-security.md
@@ -101,4 +101,4 @@ Certificate selectors are called during authentication, but certificate loading,
 
 - <xref:Orleans.Connections.Security.TlsOptions>
 - <xref:Orleans.Hosting.OrleansConnectionSecurityHostingExtensions.UseTls*>
-- [.NET TLS/SSL best practices](../../core/extensions/sslstream-best-practices.md)
+- [.NET TLS/SSL best practices](https://learn.microsoft.com/dotnet/core/extensions/sslstream-best-practices)

--- a/docs/site/src/content/docs/host/transport-layer-security.md
+++ b/docs/site/src/content/docs/host/transport-layer-security.md
@@ -10,7 +10,7 @@ ms.topic: how-to
 Orleans can protect client-to-silo and silo-to-silo connections with Transport Layer Security (TLS). TLS encrypts traffic and authenticates the endpoint acting as the TLS server. Mutual TLS (mTLS) additionally requires and authenticates the endpoint acting as the TLS client.
 
 > [!IMPORTANT]
-> <xref:Orleans.Connections.Security.TlsOptions.RemoteCertificateMode> defaults to `RequireCertificate`. On a silo's inbound connections, this default requires the connecting silo or Orleans client to present a certificate. To configure server-authenticated TLS without client certificates, explicitly set `RemoteCertificateMode` to `NoCertificate` on every silo.
+> <xref:Orleans.Connections.Security.TlsOptions.RemoteCertificateMode> defaults to `RequireCertificate`. On a silo's inbound connections, this default requires the connecting silo or Orleans client to present a certificate. To configure server-authenticated TLS without client certificates, explicitly set it to `NoCertificate` on every silo.
 
 Install [Microsoft.Orleans.Connections.Security](https://www.nuget.org/packages/Microsoft.Orleans.Connections.Security) in every silo and client process.
 
@@ -42,7 +42,7 @@ Configure an Orleans client without a local certificate:
 
 :::code language="csharp" source="./snippets/transport-layer-security/csharp/ClientExample/Program.cs" id="ServerAuthenticatedTls":::
 
-`TargetHost` must match a DNS Subject Alternative Name (SAN) on the server certificate. Use the stable service name clients use to reach the silos, not an arbitrary certificate subject.
+<xref:Orleans.Connections.Security.TlsClientAuthenticationOptions.TargetHost> must match a DNS Subject Alternative Name (SAN) on the server certificate. Use the stable service name clients use to reach the silos, not an arbitrary certificate subject.
 
 ## Configure mutual TLS
 

--- a/docs/site/src/content/docs/host/transport-layer-security.md
+++ b/docs/site/src/content/docs/host/transport-layer-security.md
@@ -10,24 +10,31 @@ ms.topic: how-to
 Orleans can protect client-to-silo and silo-to-silo connections with Transport Layer Security (TLS). TLS encrypts traffic and authenticates the endpoint acting as the TLS server. Mutual TLS (mTLS) additionally requires and authenticates the endpoint acting as the TLS client.
 
 > [!IMPORTANT]
-> Calling `UseTls` doesn't enable mTLS by itself. <xref:Orleans.Connections.Security.TlsOptions.ClientCertificateMode> defaults to `AllowCertificate`, so a client certificate is optional. Set it to <xref:Orleans.Connections.Security.RemoteCertificateMode.RequireCertificate> on every silo to require mTLS.
+> <xref:Orleans.Connections.Security.TlsOptions.RemoteCertificateMode> defaults to `RequireCertificate`. On a silo's inbound connections, this default requires the connecting silo or Orleans client to present a certificate. To configure server-authenticated TLS without client certificates, explicitly set `RemoteCertificateMode` to `NoCertificate` on every silo.
 
 Install [Microsoft.Orleans.Connections.Security](https://www.nuget.org/packages/Microsoft.Orleans.Connections.Security) in every silo and client process.
 
 ## Choose an authentication model
 
-| Model | What is authenticated | Silo setting | Typical boundary |
+| Model | Inbound silo policy | Outbound local-certificate policy | Typical boundary |
 |---|---|---|---|
-| Server-authenticated TLS | The endpoint accepting each connection | Default `ClientCertificateMode` (`AllowCertificate`) | Clients already authenticate at an application gateway or another trusted layer |
-| mTLS | Both endpoints in each TLS connection | `ClientCertificateMode = RequireCertificate` | Direct connections across a network where both workloads need cryptographic identity |
+| Server-authenticated TLS | `RemoteCertificateMode = NoCertificate` | `ClientCertificateMode = NoCertificate` | Clients already authenticate at an application gateway or another trusted layer |
+| mTLS | `RemoteCertificateMode = RequireCertificate` (the default) | `ClientCertificateMode = RequireCertificate` | Direct connections across a network where both workloads need cryptographic identity |
 
-Every silo both accepts and initiates connections. A silo certificate therefore commonly needs the Server Authentication extended key usage (EKU) for inbound connections and the Client Authentication EKU for outbound connections. An Orleans client certificate needs Client Authentication. Certificate identity, issuance, and trust should reflect workload roles rather than reusing one certificate and private key across the cluster.
+The two similarly named options apply at different stages:
+
+- <xref:Orleans.Connections.Security.TlsOptions.RemoteCertificateMode> controls whether the remote endpoint must present a certificate. In server middleware, `RequireCertificate` requires a certificate from an inbound Orleans client or silo, `AllowCertificate` requests one but permits none, and `NoCertificate` doesn't request one. Silo configuration uses this same value for outbound middleware; the TLS server still presents a certificate and platform validation authenticates it when no custom callback is installed.
+- <xref:Orleans.Connections.Security.TlsOptions.ClientCertificateMode> controls selection of the local client certificate in client middleware. On a silo, it applies when the silo initiates a silo-to-silo connection. On an Orleans client, it applies when the client initiates a gateway connection. It doesn't control inbound silo behavior.
+
+`ClientCertificateMode` defaults to `AllowCertificate`: a configured local certificate is sent when it's valid for client authentication, but a missing or unsuitable local certificate is tolerated. Setting it to `RequireCertificate` makes the outbound requirement explicit and fails configuration or connection setup when an appropriate local certificate isn't available.
+
+Every silo both accepts and initiates connections. For mTLS, a silo certificate therefore needs the Server Authentication extended key usage (EKU) for inbound connections and the Client Authentication EKU for outbound connections. For server-authenticated TLS, the silo certificate only needs Server Authentication. An Orleans client certificate used for mTLS needs Client Authentication. Certificate identity, issuance, and trust should reflect workload roles rather than reusing one certificate and private key across the cluster.
 
 TLS provides confidentiality, integrity, and certificate-based peer authentication for the Orleans transport. It doesn't authorize grain calls, isolate tenants, protect data after either process receives it, or secure membership/storage provider traffic unless those providers are separately configured. Compromise of a trusted certificate or private key can let an attacker impersonate that workload.
 
 ## Configure server-authenticated TLS
 
-The silo presents a server certificate. Clients validate its chain, validity period, EKU, and DNS name but don't need to present a certificate.
+The silo presents a server certificate. Connecting clients and silos validate its chain, validity period, EKU, and DNS name but don't present a client certificate. The silo configuration explicitly disables remote certificates for inbound connections and local client certificates for outbound silo-to-silo connections.
 
 :::code language="csharp" source="./snippets/transport-layer-security/csharp/SiloExample/Program.cs" id="ServerAuthenticatedTls":::
 
@@ -39,7 +46,7 @@ Configure an Orleans client without a local certificate:
 
 ## Configure mutual TLS
 
-For mTLS, silos require a client certificate and clients provide one:
+For mTLS, silos require a certificate from every inbound Orleans client or silo and require a local client certificate for every outbound silo-to-silo connection:
 
 :::code language="csharp" source="./snippets/transport-layer-security/csharp/SiloExample/Program.cs" id="MutualTls":::
 
@@ -64,7 +71,7 @@ Keep trust stores narrow. Don't place unrelated public or corporate roots in a w
 
 <xref:Orleans.Connections.Security.TlsOptions.SslProtocols> defaults to TLS 1.2 and TLS 1.3. Retain those defaults unless an interoperability or policy requirement calls for a narrower set. Orleans doesn't enable TLS 1.0 or TLS 1.1 by default.
 
-Set <xref:Orleans.Connections.Security.TlsOptions.CheckCertificateRevocation> according to your public key infrastructure (PKI). Before enabling it, verify that every workload can reach the certificate revocation list (CRL) or Online Certificate Status Protocol (OCSP) service and decide how outages should affect availability.
+Set <xref:Orleans.Connections.Security.TlsOptions.CheckCertificateRevocation> to check remote certificates on inbound silo connections. For outbound connections, set <xref:Orleans.Connections.Security.TlsClientAuthenticationOptions.CertificateRevocationCheckMode> in <xref:Orleans.Connections.Security.TlsOptions.OnAuthenticateAsClient>. Before enabling revocation checks, verify that every workload can reach the certificate revocation list (CRL) or Online Certificate Status Protocol (OCSP) service and decide how outages should affect availability.
 
 ## Rotate certificates
 
@@ -83,7 +90,8 @@ Certificate selectors are called during authentication, but certificate loading,
 - Give private-key files or key-store entries only to the workload identity that needs them.
 - Prefer separate certificates per workload or instance over one exported cluster-wide private key.
 - Validate SANs, EKUs, chain trust, validity, and revocation behavior.
-- Set `ClientCertificateMode` to `RequireCertificate` everywhere mTLS is required.
+- For server-authenticated TLS, set `RemoteCertificateMode` and `ClientCertificateMode` to `NoCertificate` on silos.
+- For mTLS, set `RemoteCertificateMode` and `ClientCertificateMode` to `RequireCertificate` on silos and configure a client-authentication certificate on every connecting Orleans client.
 - Protect gateway and silo ports with network policy even when TLS is enabled.
 - Keep clocks synchronized because certificate validity checks depend on time.
 - Monitor TLS handshake failures and certificate expiration; don't log private keys or certificate passwords.

--- a/docs/site/src/content/docs/host/transport-layer-security.md
+++ b/docs/site/src/content/docs/host/transport-layer-security.md
@@ -101,4 +101,7 @@ Certificate selectors are called during authentication, but certificate loading,
 
 - <xref:Orleans.Connections.Security.TlsOptions>
 - <xref:Orleans.Hosting.OrleansConnectionSecurityHostingExtensions.UseTls*>
+- [Client configuration](configuration-guide/client-configuration.md)
+- [Server configuration](configuration-guide/server-configuration.md)
 - [.NET TLS/SSL best practices](https://learn.microsoft.com/dotnet/core/extensions/sslstream-best-practices)
+- [Orleans Transport Layer Security (TLS) sample](https://learn.microsoft.com/samples/dotnet/samples/orleans-transport-layer-security-tls/)

--- a/docs/site/src/content/docs/host/transport-layer-security.md
+++ b/docs/site/src/content/docs/host/transport-layer-security.md
@@ -1,129 +1,96 @@
 ---
-title: Orleans Transport Layer Security (TLS)
-description: Learn how to configure Transport Layer Security (TLS) and mutual TLS (mTLS) in .NET Orleans to secure network communication between hosts.
-ms.date: 03/11/2026
+title: Secure Orleans connections with TLS
+description: Configure server-authenticated TLS or mutual TLS for Orleans silo and client connections.
+ms.date: 08/02/2026
 ms.topic: how-to
-ai-usage: ai-assisted
 ---
 
-# Orleans Transport Layer Security (TLS)
+# Secure Orleans connections with TLS
 
-Transport Layer Security (TLS) is a cryptographic protocol that secures network communication between Orleans silos and clients. Configure TLS to implement mutual authentication (mTLS) and encrypt data in transit, protecting your Orleans deployment from unauthorized access and eavesdropping.
+Orleans can protect client-to-silo and silo-to-silo connections with Transport Layer Security (TLS). TLS encrypts traffic and authenticates the endpoint acting as the TLS server. Mutual TLS (mTLS) additionally requires and authenticates the endpoint acting as the TLS client.
 
-## Prerequisites
+> [!IMPORTANT]
+> Calling `UseTls` doesn't enable mTLS by itself. <xref:Orleans.Connections.Security.TlsOptions.ClientCertificateMode> defaults to `AllowCertificate`, so a client certificate is optional. Set it to <xref:Orleans.Connections.Security.RemoteCertificateMode.RequireCertificate> on every silo to require mTLS.
 
-Before configuring TLS, ensure you have:
+Install [Microsoft.Orleans.Connections.Security](https://www.nuget.org/packages/Microsoft.Orleans.Connections.Security) in every silo and client process.
 
-- An Orleans application with the [Microsoft.Orleans.Server](https://www.nuget.org/packages/Microsoft.Orleans.Server) NuGet package installed for silos.
-- The [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client) NuGet package installed for clients.
-- The [Microsoft.Orleans.Connections.Security](https://www.nuget.org/packages/Microsoft.Orleans.Connections.Security) NuGet package installed for both silos and clients.
-- A valid X.509 certificate for authentication, either in the Windows certificate store or as a file.
+## Choose an authentication model
 
-> [!TIP]
-> The accompanying `SiloExample` and `ClientExample` projects include a development-only startup path that creates temporary self-signed certificates so you can run the sample locally. The inline snippets below focus on the certificate store and certificate file patterns you would typically adapt for your own deployments.
+| Model | What is authenticated | Silo setting | Typical boundary |
+|---|---|---|---|
+| Server-authenticated TLS | The endpoint accepting each connection | Default `ClientCertificateMode` (`AllowCertificate`) | Clients already authenticate at an application gateway or another trusted layer |
+| mTLS | Both endpoints in each TLS connection | `ClientCertificateMode = RequireCertificate` | Direct connections across a network where both workloads need cryptographic identity |
 
-## Configure TLS on silos
+Every silo both accepts and initiates connections. A silo certificate therefore commonly needs the Server Authentication extended key usage (EKU) for inbound connections and the Client Authentication EKU for outbound connections. An Orleans client certificate needs Client Authentication. Certificate identity, issuance, and trust should reflect workload roles rather than reusing one certificate and private key across the cluster.
 
-To enable TLS on an Orleans silo, use the <xref:Orleans.Hosting.OrleansConnectionSecurityHostingExtensions.UseTls*> extension method. This method provides several overloads for different certificate configuration scenarios.
+TLS provides confidentiality, integrity, and certificate-based peer authentication for the Orleans transport. It doesn't authorize grain calls, isolate tenants, protect data after either process receives it, or secure membership/storage provider traffic unless those providers are separately configured. Compromise of a trusted certificate or private key can let an attacker impersonate that workload.
 
-### Basic TLS configuration
+## Configure server-authenticated TLS
 
-The following example shows how to configure TLS using a certificate from the Windows certificate store:
+The silo presents a server certificate. Clients validate its chain, validity period, EKU, and DNS name but don't need to present a certificate.
 
-:::code language="csharp" source="./snippets/transport-layer-security/csharp/SiloExample/Program.cs" id="BasicTlsConfiguration":::
+:::code language="csharp" source="./snippets/transport-layer-security/csharp/SiloExample/Program.cs" id="ServerAuthenticatedTls":::
 
-In the preceding code:
+Configure an Orleans client without a local certificate:
 
-- The `StoreName.My` parameter specifies the certificate store location (Personal certificates).
-- The `"my-certificate-subject"` parameter identifies the certificate by its subject name.
-- The `allowInvalid: false` parameter ensures that only valid certificates are accepted in production.
-- The `StoreLocation.CurrentUser` parameter specifies the certificate store scope.
-- The `OnAuthenticateAsClient` callback sets the `TargetHost` for outbound connections initiated by the silo.
+:::code language="csharp" source="./snippets/transport-layer-security/csharp/ClientExample/Program.cs" id="ServerAuthenticatedTls":::
 
-### Development environment configuration
+`TargetHost` must match a DNS Subject Alternative Name (SAN) on the server certificate. Use the stable service name clients use to reach the silos, not an arbitrary certificate subject.
 
-For development and testing, you might need to use self-signed certificates. The following example shows how to configure TLS with relaxed validation for development:
+## Configure mutual TLS
 
-:::code language="csharp" source="./snippets/transport-layer-security/csharp/SiloExample/Program.cs" id="DevelopmentTlsConfiguration":::
+For mTLS, silos require a client certificate and clients provide one:
 
-In the preceding code:
+:::code language="csharp" source="./snippets/transport-layer-security/csharp/SiloExample/Program.cs" id="MutualTls":::
 
-- The `context.HostingEnvironment.IsDevelopment()` method checks if the application is running in a development environment.
-- The <xref:Orleans.Connections.Security.TlsOptions.AllowAnyRemoteCertificate*> method disables certificate validation in development.
+:::code language="csharp" source="./snippets/transport-layer-security/csharp/ClientExample/Program.cs" id="MutualTls":::
+
+The default platform validation applies when <xref:Orleans.Connections.Security.TlsOptions.RemoteCertificateValidation> isn't set. If you provide that callback, keep normal chain and name checks and add only the deployment-specific policy you require. A callback which returns `true` unconditionally defeats peer authentication.
 
 > [!WARNING]
-> Never use `AllowAnyRemoteCertificate()` or `allowInvalid: true` in production deployments. These settings disable important security checks and expose your application to security vulnerabilities.
+> <xref:Orleans.Connections.Security.TlsOptions.AllowAnyRemoteCertificate> is suitable only for isolated local development. It accepts any remote certificate and therefore doesn't protect against impersonation or an active man-in-the-middle.
 
-### Certificate file configuration
+## Establish certificate trust
 
-If you have a certificate file instead of using the certificate store, configure TLS as shown in the following example:
+Treat these as separate trust decisions:
 
-:::code language="csharp" source="./snippets/transport-layer-security/csharp/SiloExample/Program.cs" id="CertificateTlsConfiguration":::
+- **Clients trust silos:** The issuing CA for silo server certificates is trusted by Orleans clients. The certificate SAN matches `TargetHost`.
+- **Silos trust clients:** For mTLS, the issuing CA for client certificates is trusted by every silo. Use a private CA or an additional validation policy when possession of an arbitrary public certificate isn't sufficient authorization.
+- **Silos trust silos:** Each silo validates the server certificate on outbound silo-to-silo connections. With mTLS, each silo also presents a client-authentication certificate.
 
-In the preceding code:
+Keep trust stores narrow. Don't place unrelated public or corporate roots in a workload-specific trust bundle when any certificate from those roots would be accepted as a cluster identity. Network policy should still restrict silo and gateway ports to expected peers.
 
-- The <xref:System.Security.Cryptography.X509Certificates.X509CertificateLoader.LoadPkcs12FromFile*> method loads a certificate from a PKCS#12 file (PFX format).
-- The certificate is passed directly to the `UseTls` method.
+## Protocols and revocation
 
-### Advanced TLS configuration
+<xref:Orleans.Connections.Security.TlsOptions.SslProtocols> defaults to TLS 1.2 and TLS 1.3. Retain those defaults unless an interoperability or policy requirement calls for a narrower set. Orleans doesn't enable TLS 1.0 or TLS 1.1 by default.
 
-For production deployments, you might need more control over certificate selection and validation. The following example demonstrates advanced TLS configuration:
+Set <xref:Orleans.Connections.Security.TlsOptions.CheckCertificateRevocation> according to your public key infrastructure (PKI). Before enabling it, verify that every workload can reach the certificate revocation list (CRL) or Online Certificate Status Protocol (OCSP) service and decide how outages should affect availability.
 
-:::code language="csharp" source="./snippets/transport-layer-security/csharp/SiloExample/Program.cs" id="AdvancedTlsConfiguration":::
+## Rotate certificates
 
-In the preceding code:
+Plan rotation before deployment:
 
-- The <xref:Orleans.Connections.Security.TlsOptions.LocalServerCertificateSelector*> callback dynamically selects the appropriate server certificate.
-- The <xref:Orleans.Connections.Security.TlsOptions.RemoteCertificateValidation*> callback provides custom validation logic for remote certificates.
-- The <xref:Orleans.Connections.Security.TlsOptions.CheckCertificateRevocation> property enables certificate revocation checking.
+1. Issue the replacement certificate with the same required names and EKUs.
+2. Distribute the new issuing chain to trust stores before any endpoint presents the new certificate.
+3. Make both old and new chains valid during an overlap window.
+4. Restart processes with the replacement certificate, or use <xref:Orleans.Connections.Security.TlsOptions.LocalServerCertificateSelector> and <xref:Orleans.Connections.Security.TlsOptions.LocalClientCertificateSelector> to select certificates dynamically.
+5. Confirm new connections use the replacement, then remove the old certificate and obsolete trust roots.
 
-## Configure TLS on clients
+Certificate selectors are called during authentication, but certificate loading, caching, disposal, and refresh are application responsibilities. Test rotation under normal reconnect and silo restart behavior. Alert on certificate expiration well before the overlap window closes.
 
-Orleans clients require similar TLS configuration to securely connect to TLS-enabled silos.
+## Production checklist
 
-### Basic client TLS configuration
-
-The following example shows how to configure TLS on an Orleans client:
-
-:::code language="csharp" source="./snippets/transport-layer-security/csharp/ClientExample/Program.cs" id="BasicClientTlsConfiguration":::
-
-In the preceding code:
-
-- The <xref:Orleans.Hosting.OrleansConnectionSecurityHostingExtensions.UseTls*> extension method configures TLS for the client.
-- The <xref:Orleans.Connections.Security.TlsOptions.OnAuthenticateAsClient*> callback configures client-side TLS options and sets the `TargetHost` to match the server certificate name.
-- When you call `UseTls` with a client certificate, the client sends that certificate during the TLS handshake so the silo can enforce mutual TLS.
-
-### Development client configuration
-
-For development environments, configure the client with relaxed validation as shown in the following example:
-
-:::code language="csharp" source="./snippets/transport-layer-security/csharp/ClientExample/Program.cs" id="ClientDevelopmentTlsConfiguration":::
-
-### Certificate file client configuration
-
-Configure a client using a certificate file as shown in the following example:
-
-:::code language="csharp" source="./snippets/transport-layer-security/csharp/ClientExample/Program.cs" id="ClientCertificateTlsConfiguration":::
-
-## Best practices
-
-Follow these best practices when configuring TLS in Orleans:
-
-- **Use the latest TLS protocol**: Always prefer TLS 1.2 or TLS 1.3 for the strongest security. Avoid TLS 1.0 and TLS 1.1, which have known vulnerabilities.
-- **Let the OS choose the protocol version**: Don't explicitly set TLS protocol versions in production code. Instead, defer to operating system defaults to automatically select the best protocol. Only explicitly set protocol versions if you have a specific compatibility requirement with legacy systems. When you explicitly set protocol versions, your application can't automatically benefit from newer protocols added in future OS updates.
-- **Validate certificates**: Always validate certificate chains, expiration dates, and hostname matches in production. Never use `AllowAnyRemoteCertificate()` or disable certificate validation outside of development environments.
-- **Enable certificate revocation checking**: Use <xref:Orleans.Connections.Security.TlsOptions.CheckCertificateRevocation*> to verify that certificates haven't been revoked.
-- **Use strong certificates**: Ensure your X.509 certificates use strong key lengths (at least 2048 bits for RSA) and are signed by a trusted Certificate Authority (CA).
-- **Secure certificate storage**: Protect private keys with appropriate file permissions or by using hardware security modules (HSMs).
-- **Keep certificates current**: Monitor certificate expiration dates and renew certificates before they expire.
-- **Keep software updated**: Regularly update your .NET runtime and operating system to receive the latest security patches and protocol support.
-
-For more information on .NET TLS best practices, see [TLS/SSL best practices](../../core/extensions/sslstream-best-practices.md).
+- Give private-key files or key-store entries only to the workload identity that needs them.
+- Prefer separate certificates per workload or instance over one exported cluster-wide private key.
+- Validate SANs, EKUs, chain trust, validity, and revocation behavior.
+- Set `ClientCertificateMode` to `RequireCertificate` everywhere mTLS is required.
+- Protect gateway and silo ports with network policy even when TLS is enabled.
+- Keep clocks synchronized because certificate validity checks depend on time.
+- Monitor TLS handshake failures and certificate expiration; don't log private keys or certificate passwords.
+- Store PFX passwords in a secret store rather than source or ordinary configuration files.
 
 ## See also
 
-- [Client configuration](configuration-guide/client-configuration.md)
-- [Server configuration](configuration-guide/server-configuration.md)
 - <xref:Orleans.Connections.Security.TlsOptions>
 - <xref:Orleans.Hosting.OrleansConnectionSecurityHostingExtensions.UseTls*>
-- [Orleans Transport Layer Security (TLS) sample](/samples/dotnet/samples/orleans-transport-layer-security-tls/)
+- [.NET TLS/SSL best practices](../../core/extensions/sslstream-best-practices.md)


### PR DESCRIPTION
Rewrites Orleans 10 TLS guidance to distinguish server-authenticated TLS from mTLS and adds production certificate, trust, rotation, and threat-model guidance. Rebuilds observability around verified OpenTelemetry configuration, signal interpretation, and incident runbooks, and makes dashboard security and operating costs prominent.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10328)