### PR TITLE
docs: expand Orleans architecture documentation

### DIFF
--- a/docs/site/src/content/docs/implementation/activation-lifecycle.md
+++ b/docs/site/src/content/docs/implementation/activation-lifecycle.md
@@ -1,0 +1,99 @@
+---
+title: Activation lifecycle and migration
+description: Understand activation creation, activation, collection, deactivation, and migration in Orleans 10.
+ms.date: 08/02/2026
+ms.topic: concept-article
+---
+
+# Activation lifecycle and migration
+
+A grain identity can outlive every process in the cluster. An activation is the temporary, in-memory realization of that identity on one silo. `ActivationData` is the runtime state machine which owns the grain instance, request queues, scheduler, directory registration, lifecycle, and deactivation reason.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Creating: message needs activation
+    Creating --> Activating: instance and context created
+    Activating --> Valid: OnActivateAsync completes
+    Valid --> Deactivating: collection, failure, migration, or request
+    Deactivating --> Invalid: stop accepting new turns
+    Invalid --> [*]: unregister and dispose
+    Valid --> Migrating: migration selected
+    Migrating --> Deactivating: dehydrate state
+    Deactivating --> Creating: target rehydrates same grain identity
+```
+
+## Creation and activation
+
+When routing cannot find a valid activation, the target silo's `Catalog.GetOrCreateActivation` creates or obtains an `ActivationData`. Creation has several distinct steps:
+
+1. Resolve the grain type, implementation, shared type metadata, storage facet, and activation configurators.
+1. Create the grain context, per-activation `WorkItemGroup`, and grain instance.
+1. Register the local activation and, when required by the grain directory policy, register its address.
+1. Notify `IActivationLifecycleObserver.OnCreateActivation`.
+1. Run grain lifecycle start and <xref:Orleans.IGrainBase.OnActivateAsync*> on the activation scheduler.
+1. Mark the activation valid and release queued requests for turn scheduling.
+
+Activation is asynchronous. Requests which arrive while it is in progress remain queued. If activation fails, the runtime rejects or reroutes requests and tears down the incomplete activation rather than exposing a partially initialized instance.
+
+Source: [`Catalog`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Catalog/Catalog.cs) and [`ActivationData`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Catalog/ActivationData.cs).
+
+## Working set and collection
+
+`ActivationWorkingSet` tracks activations which recently performed work. `ActivationCollector` schedules collection tickets in time buckets and scans stale buckets. The important invariant is that an activation selected for collection must still be idle when collection begins. New work can cancel or reschedule its ticket.
+
+Collection is not persistence. It releases an idle activation. Durable grain state survives only through a configured storage provider and grain code which writes that state. Operational collection settings belong in [activation collection configuration](../host/configuration-guide/activation-collection.md).
+
+The implementation and its edge cases are covered by [`ActivationCollector`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Catalog/ActivationCollector.cs) and [`ActivationCollectorTests`](https://github.com/dotnet/orleans/blob/main/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationCollectorTests.cs).
+
+## Deactivation
+
+Deactivation first prevents new application turns from starting, then drains or rejects pending work according to the reason. It runs <xref:Orleans.IGrainBase.OnDeactivateAsync*> and lifecycle stop on the activation scheduler. Finally, the runtime unregisters the directory address, removes the local activation, disposes resources, and publishes deactivation events.
+
+A deactivation reason distinguishes normal collection, application-requested deactivation, silo shutdown, failure, and migration. Grain code should treat deactivation as best-effort cleanup. Process termination can bypass it, so correctness must not depend on `OnDeactivateAsync` always running.
+
+## Activation migration
+
+Migration moves an activation while preserving its grain identity. `ActivationMigrationManager` starts migration by creating a `MigrationContext`, asking registered migration participants to dehydrate state, and deactivating with the `Migrating` reason. The target creates the activation, rehydrates participants, runs activation, and waits until the activation reaches a stable state.
+
+```mermaid
+sequenceDiagram
+    participant Source as Source activation
+    participant Manager as ActivationMigrationManager
+    participant Target as Target silo
+    participant Directory as Grain directory
+
+    Manager->>Source: Begin migration
+    Source->>Source: OnDehydrate(MigrationContext)
+    Source->>Directory: Remove or transfer registration
+    Manager->>Target: AcceptMigratingGrains
+    Target->>Target: Create and OnRehydrate
+    Target->>Directory: Register target activation
+    Target->>Target: OnActivateAsync
+    Target-->>Manager: Stable activation
+```
+
+Migration state is not the same as persisted grain state. <xref:Orleans.Runtime.IGrainMigrationParticipant> is intended for runtime or application components whose in-memory state must accompany a live move. Participants write versionable data to the migration context and must tolerate rehydration on another silo.
+
+Source: [`ActivationMigrationManager`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Catalog/ActivationMigrationManager.cs) and [`ActivationDataMigrationTests`](https://github.com/dotnet/orleans/blob/main/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationDataMigrationTests.cs).
+
+## What initiates movement
+
+Migration is a mechanism, not a policy. Policies choose candidates:
+
+- explicit migration APIs can request a move;
+- the experimental activation rebalancer moves random activations to reduce resource imbalance;
+- the experimental activation repartitioner observes communication edges and moves activations to improve locality.
+
+Both cluster-wide policies are opt-in. See [placement and activation balancing](load-balancing.md) for their protocols and experimental warning identifiers.
+
+## Extension invariants
+
+Components participating in activation creation or migration should preserve these rules:
+
+- never expose a grain instance before activation completes;
+- execute grain lifecycle callbacks in the activation scheduling context;
+- do not accept new turns after deactivation begins;
+- unregister stale addresses even when cleanup fails;
+- keep migration payloads backward-compatible across rolling upgrades; and
+- assume source or target failure can interrupt migration.
+

--- a/docs/site/src/content/docs/implementation/activation-lifecycle.md
+++ b/docs/site/src/content/docs/implementation/activation-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 title: Activation lifecycle and migration
-description: Understand activation creation, activation, collection, deactivation, and migration in Orleans 10.
+description: Understand activation creation, activation, collection, deactivation, and migration in Orleans.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -96,4 +96,3 @@ Components participating in activation creation or migration should preserve the
 - unregister stale addresses even when cleanup fails;
 - keep migration payloads backward-compatible across rolling upgrades; and
 - assume source or target failure can interrupt migration.
-

--- a/docs/site/src/content/docs/implementation/cluster-management.md
+++ b/docs/site/src/content/docs/implementation/cluster-management.md
@@ -11,7 +11,7 @@ Cluster membership answers one question for the rest of the runtime: which silo 
 
 ## Identity, status, and views
 
-A silo identity includes its advertised endpoint and a generation value, so a restarted process at the same endpoint is a new identity. Its status progresses through `Created`, `Joining`, `Active`, and a terminating status (`ShuttingDown`, `Stopping`, or `Dead`).
+A silo identity includes its advertised endpoint and a generation value, so a restarted process at the same endpoint is a new identity. Its <xref:Orleans.Runtime.SiloStatus> progresses through `Created`, `Joining`, `Active`, and a terminating status (`ShuttingDown`, `Stopping`, or `Dead`).
 
 Each successful membership-table mutation advances a version. `MembershipTableManager` publishes immutable snapshots through `ClusterMembershipService`; consumers ignore older versions. Directory ownership, gateway discovery, and failure recovery therefore observe a monotonically ordered sequence of views even if notifications arrive out of order.
 
@@ -37,7 +37,7 @@ A starting silo writes its row, becomes `Joining`, and validates two-way connect
 
 The periodic `IAmAlive` value is not the peer heartbeat. It is a timestamp written to the membership row for diagnostics and startup disaster recovery. A sufficiently stale active row can be ignored during the joining connectivity check, allowing a cluster to recover after all processes were lost without cleanly declaring each other dead.
 
-## Failure detection and death votes
+## Failure detection and death votes <a name="the-membership-protocol"></a>
 
 Active silos monitor peers selected from the membership view. `ClusterHealthMonitor` sends probes over silo-to-silo messaging, tracks consecutive failures, and can use indirect probes to distinguish a failed target from an unhealthy observer. A failed monitor writes a timestamped vote into the target's membership row.
 
@@ -63,25 +63,25 @@ Declaring a member dead requires enough unexpired votes from distinct observers.
 
 Once a row is `Dead`, that identity never returns to `Active`. If the process was only partitioned, it terminates when it learns that the cluster declared it dead. Its host can restart it with a new generation.
 
-## Default settings
+## Default settings <a name="membership-protocol-configuration"></a>
 
-The defaults are defined by [`ClusterMembershipOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs):
+The defaults are defined by <xref:Orleans.Configuration.ClusterMembershipOptions>:
 
 | Option | Default | Protocol role |
 | --- | ---: | --- |
-| `NumProbedSilos` | 10 | Number of peers monitored by each silo |
-| `ProbeTimeout` | 5 seconds | Baseline direct probe timeout |
-| `NumMissedProbesLimit` | 3 | Failed probes before a death vote |
-| `NumVotesForDeathDeclaration` | 2 | Fresh votes required to mark a member dead |
-| `DeathVoteExpirationTimeout` | 2 minutes | Lifetime of a death vote |
-| `TableRefreshTimeout` | 1 minute | Fallback membership-table refresh period |
-| `IAmAliveTablePublishTimeout` | 30 seconds | Membership-row liveness timestamp period |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.NumProbedSilos?displayProperty=nameWithType> | 10 | Number of peers monitored by each silo |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.ProbeTimeout?displayProperty=nameWithType> | 5 seconds | Baseline direct probe timeout |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.NumMissedProbesLimit?displayProperty=nameWithType> | 3 | Failed probes before a death vote |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.NumVotesForDeathDeclaration?displayProperty=nameWithType> | 2 | Fresh votes required to mark a member dead |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.DeathVoteExpirationTimeout?displayProperty=nameWithType> | 2 minutes | Lifetime of a death vote |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.TableRefreshTimeout?displayProperty=nameWithType> | 1 minute | Fallback membership-table refresh period |
+| <xref:Orleans.Configuration.ClusterMembershipOptions.IAmAliveTablePublishTimeout?displayProperty=nameWithType> | 30 seconds | Membership-row liveness timestamp period |
 
 These values are protocol parameters, not independent timers: indirect probing, local health, scheduling delays, and table contention all affect observed detection time. Following [Lifeguard's local-health awareness principle](https://arxiv.org/abs/1707.00788), the runtime increases probe tolerance when `LocalSiloHealthMonitor` detects thread-pool delay, timer delay, or other local distress, reducing false accusations from an unhealthy observer.
 
-## Membership-table contract
+## Membership-table contract <a name="membership-table"></a>
 
-An `IMembershipTable` implementation is more than a list of endpoints. It must support:
+An <xref:Orleans.IMembershipTable> implementation is more than a list of endpoints. It must support:
 
 - insertion of a new silo row;
 - optimistic, conditional update of a silo row;

--- a/docs/site/src/content/docs/implementation/cluster-management.md
+++ b/docs/site/src/content/docs/implementation/cluster-management.md
@@ -77,7 +77,7 @@ The defaults are defined by [`ClusterMembershipOptions`](https://github.com/dotn
 | `TableRefreshTimeout` | 1 minute | Fallback membership-table refresh period |
 | `IAmAliveTablePublishTimeout` | 30 seconds | Membership-row liveness timestamp period |
 
-These values are protocol parameters, not independent timers: indirect probing, local health, scheduling delays, and table contention all affect observed detection time. The runtime increases probe tolerance when `LocalSiloHealthMonitor` detects thread-pool delay, timer delay, or other local distress, reducing false accusations from an unhealthy observer.
+These values are protocol parameters, not independent timers: indirect probing, local health, scheduling delays, and table contention all affect observed detection time. Following [Lifeguard's local-health awareness principle](https://arxiv.org/abs/1707.00788), the runtime increases probe tolerance when `LocalSiloHealthMonitor` detects thread-pool delay, timer delay, or other local distress, reducing false accusations from an unhealthy observer.
 
 ## Membership-table contract
 

--- a/docs/site/src/content/docs/implementation/cluster-management.md
+++ b/docs/site/src/content/docs/implementation/cluster-management.md
@@ -1,576 +1,116 @@
 ---
-title: Cluster management in Orleans
-description: Learn about cluster management in .NET Orleans.
-ms.date: 01/22/2026
+title: Cluster membership protocol
+description: Understand Orleans membership storage, failure detection, ordered views, and death-vote invariants.
+ms.date: 08/02/2026
 ms.topic: concept-article
-zone_pivot_groups: orleans-version
 ---
 
-# Cluster management in Orleans
+# Cluster membership protocol
 
-Orleans provides cluster management via a built-in membership protocol, sometimes referred to as **Cluster membership**. The goal of this protocol is for all silos (Orleans servers) to agree on the set of currently alive silos, detect failed silos, and allow new silos to join the cluster.
+Cluster membership answers one question for the rest of the runtime: which silo identities are members of the current view, and what is each member's status? Orleans combines a durable <xref:Orleans.IMembershipTable> with direct peer probes. The table provides coordination and ordered views; probes measure the communication path that Orleans actually uses.
 
-:::zone target="docs" pivot="orleans-9-0,orleans-10-0"
+## Identity, status, and views
 
-## Membership protocol configuration
+A silo identity includes its advertised endpoint and a generation value, so a restarted process at the same endpoint is a new identity. Its status progresses through `Created`, `Joining`, `Active`, and a terminating status (`ShuttingDown`, `Stopping`, or `Dead`).
 
-The membership protocol uses the following default configuration:
+Each successful membership-table mutation advances a version. `MembershipTableManager` publishes immutable snapshots through `ClusterMembershipService`; consumers ignore older versions. Directory ownership, gateway discovery, and failure recovery therefore observe a monotonically ordered sequence of views even if notifications arrive out of order.
 
-- Every silo is monitored by 10 other silos
-- 2 suspicions are required to declare a silo dead
-- Suspicions are valid for 3 minutes
-- Probes are sent every 10 seconds
-- 3 missed probes trigger a suspicion
+```mermaid
+flowchart LR
+    Table[(IMembershipTable)]
+    Manager[MembershipTableManager]
+    Service[ClusterMembershipService]
+    Agent[MembershipAgent]
+    Health[ClusterHealthMonitor]
+    Consumers[Directory, placement, gateways]
 
-With these defaults, typical failure detection time is approximately 15 seconds. In disaster recovery scenarios where silos crash without proper cleanup, the cluster uses the `IAmAlive` timestamp (updated every 30 seconds by default) to recover; silos that haven't updated their timestamp for several periods are ignored during startup connectivity checks. By skipping these unresponsive silos, new silos can start up and quickly clear the cluster of defunct silos by declaring them dead.
-
-### Configuration
-
-You can configure membership protocol settings using `ClusterMembershipOptions`:
-
-```csharp
-siloBuilder.Configure<ClusterMembershipOptions>(options =>
-{
-    // Number of silos each silo monitors (default: 10)
-    options.NumProbedSilos = 10;
-
-    // Number of suspicions required to declare a silo dead (default: 2)
-    options.NumVotesForDeathDeclaration = 2;
-
-    // Time window for suspicions to be valid (default: 180 seconds)
-    options.DeathVoteExpirationTimeout = TimeSpan.FromSeconds(180);
-
-    // Interval between probes (default: 10 seconds)
-    options.ProbeTimeout = TimeSpan.FromSeconds(10);
-
-    // Number of missed probes before suspecting a silo (default: 3)
-    options.NumMissedProbesLimit = 3;
-});
+    Agent -->|join and IAmAlive writes| Manager
+    Health -->|death votes| Manager
+    Manager <-->|versioned reads and writes| Table
+    Manager --> Service
+    Service --> Consumers
 ```
 
-### When to adjust settings
+## Joining
 
-In most cases, the default settings are appropriate. However, you might consider adjustments in these scenarios:
+A starting silo writes its row, becomes `Joining`, and validates two-way connectivity with active members before becoming `Active`. This prevents a partitioned process from silently joining one side of a cluster.
 
-- **High-latency networks**: Increase `ProbeTimeout` if your silos are distributed across regions with high network latency.
-- **Critical availability requirements**: Decrease `DeathVoteExpirationTimeout` for faster failure detection, but be cautious of false positives.
+The periodic `IAmAlive` value is not the peer heartbeat. It is a timestamp written to the membership row for diagnostics and startup disaster recovery. A sufficiently stale active row can be ignored during the joining connectivity check, allowing a cluster to recover after all processes were lost without cleanly declaring each other dead.
 
-:::zone-end
+## Failure detection and death votes
 
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0"
+Active silos monitor peers selected from the membership view. `ClusterHealthMonitor` sends probes over silo-to-silo messaging, tracks consecutive failures, and can use indirect probes to distinguish a failed target from an unhealthy observer. A failed monitor writes a timestamped vote into the target's membership row.
 
-## Membership protocol configuration
+```mermaid
+sequenceDiagram
+    participant A as Monitoring silo A
+    participant B as Target silo B
+    participant C as Indirect probe silo C
+    participant T as Membership table
 
-The membership protocol uses the following default configuration:
-
-- Every silo is monitored by 3 other silos
-- 2 suspicions are required to declare a silo dead
-- Suspicions are valid for 3 minutes
-- Probes are sent every 10 seconds
-- 3 missed probes trigger a suspicion
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-## Membership protocol configuration
-
-The membership protocol uses the following default configuration:
-
-- Every silo is monitored by 3 other silos
-- 2 suspicions are required to declare a silo dead
-- Suspicions are valid for 3 minutes
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0,orleans-3-x"
-
-The protocol relies on an external service to provide an abstraction of <xref:Orleans.IMembershipTable>. `IMembershipTable` is a flat, durable table used for two purposes. First, it serves as a rendezvous point for silos to find each other and for Orleans clients to find silos. Second, it stores the current membership view (list of alive silos) and helps coordinate agreement on this view.
-
-The following official implementations of `IMembershipTable` are currently available:
-
-* [ADO.NET](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.AdoNet) (PostgreSQL, MySQL/MariaDB, SQL Server, Oracle),
-* [AWS DynamoDB](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.DynamoDB),
-* [Apache Cassandra](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.Cassandra),
-* [Apache ZooKeeper](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.ZooKeeper),
-* [Azure Cosmos DB](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.Cosmos),
-* [Azure Table Storage](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.AzureStorage),
-* [HashiCorp Consul](../host/configuration-guide/clustering/consul.md),
-* [Redis](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.Redis),
-* and an in-memory implementation for development.
-
-### Configure Redis clustering
-
-Configure Redis as the clustering provider using the <xref:Microsoft.Extensions.Hosting.RedisClusteringISiloBuilderExtensions.UseRedisClustering*> extension method:
-
-```csharp
-using StackExchange.Redis;
-
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder.UseRedisClustering(options =>
-    {
-        options.ConfigurationOptions = new ConfigurationOptions
-        {
-            EndPoints = { "localhost:6379" },
-            AbortOnConnectFail = false
-        };
-    });
-});
+    A->>B: Probe
+    B--xA: No response
+    A->>C: Probe B indirectly
+    C->>B: Probe
+    B--xC: No response
+    C-->>A: Negative acknowledgement
+    A->>T: Read B and fresh votes
+    A->>T: Compare-and-swap vote/status + view version
+    T-->>A: New ordered membership view
 ```
 
-Alternatively, you can use a connection string:
+Declaring a member dead requires enough unexpired votes from distinct observers. The read-modify-write is protected by the membership table's version or ETag. A conflicting update causes the writer to reread and reevaluate; it must not overwrite a newer view.
 
-```csharp
-siloBuilder.UseRedisClustering("localhost:6379");
-```
+Once a row is `Dead`, that identity never returns to `Active`. If the process was only partitioned, it terminates when it learns that the cluster declared it dead. Its host can restart it with a new generation.
 
-The <xref:Orleans.Clustering.Redis.RedisClusteringOptions> class provides the following configuration options:
+## Default settings
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `ConfigurationOptions` | `ConfigurationOptions` | The StackExchange.Redis client configuration. Required. |
-| `EntryExpiry` | `TimeSpan?` | Optional expiration time for entries. Only set this for ephemeral environments like testing. Default is `null`. |
-| `CreateMultiplexer` | `Func<RedisClusteringOptions, Task<IConnectionMultiplexer>>` | Custom factory for creating the Redis connection multiplexer. |
-| `CreateRedisKey` | `Func<ClusterOptions, RedisKey>` | Custom function to generate the Redis key for the membership table. Default format is `{ServiceId}/members/{ClusterId}`. |
+The defaults are defined by [`ClusterMembershipOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Configuration/Options/ClusterMembershipOptions.cs):
 
-> [!IMPORTANT]
-> Implementations of the `IMembershipTable` interface must use a durable data store. For example, if you are using Redis, ensure that persistence is explicitly enabled. Volatile configurations may result in cluster unavailability.
+| Option | Default | Protocol role |
+| --- | ---: | --- |
+| `NumProbedSilos` | 10 | Number of peers monitored by each silo |
+| `ProbeTimeout` | 5 seconds | Baseline direct probe timeout |
+| `NumMissedProbesLimit` | 3 | Failed probes before a death vote |
+| `NumVotesForDeathDeclaration` | 2 | Fresh votes required to mark a member dead |
+| `DeathVoteExpirationTimeout` | 2 minutes | Lifetime of a death vote |
+| `TableRefreshTimeout` | 1 minute | Fallback membership-table refresh period |
+| `IAmAliveTablePublishTimeout` | 30 seconds | Membership-row liveness timestamp period |
 
-:::zone-end
+These values are protocol parameters, not independent timers: indirect probing, local health, scheduling delays, and table contention all affect observed detection time. The runtime increases probe tolerance when `LocalSiloHealthMonitor` detects thread-pool delay, timer delay, or other local distress, reducing false accusations from an unhealthy observer.
 
-:::zone target="docs" pivot="orleans-8-0,orleans-9-0,orleans-10-0"
+## Membership-table contract
 
-### Aspire integration for clustering
+An `IMembershipTable` implementation is more than a list of endpoints. It must support:
 
-When using [Aspire](../host/aspire-integration.md), you can configure Orleans clustering declaratively in your AppHost project. Aspire automatically injects the necessary configuration into your silo projects via environment variables.
+- insertion of a new silo row;
+- optimistic, conditional update of a silo row;
+- atomic advancement of the table version with a row mutation;
+- reads which return rows and the corresponding version;
+- periodic `IAmAlive` updates; and
+- durable availability appropriate for cluster coordination.
 
-#### Redis clustering with Aspire
+Table unavailability favors safety over liveness. Existing silos can continue processing calls, but they cannot durably admit a member or declare a failed member dead. A provider must not synthesize successful updates when its backing store is unavailable.
 
-**AppHost project (Program.cs):**
+Official providers adapt transactions, ETags, lightweight transactions, or compare-and-swap primitives to this contract. Provider selection and operational setup belong in the [deployment documentation](../deployment/index.md); the extension architecture is covered by [provider authoring](provider-authoring.md).
 
-```csharp
-var builder = DistributedApplication.CreateBuilder(args);
+## Protocol consumers
 
-var redis = builder.AddRedis("redis");
+Membership is deliberately separate from the services which consume it:
 
-var orleans = builder.AddOrleans("cluster")
-    .WithClustering(redis);
+- `LocalGrainDirectory` adjusts consistent-hash ownership after view changes.
+- the experimental distributed directory runs an explicit range-transfer protocol.
+- placement removes unavailable or overloaded candidates.
+- clients refresh the gateway list.
+- persistent-stream queue balancers redistribute queue responsibility.
+- activation balancing protocols stop exchanging work with failed members.
 
-builder.AddProject<Projects.MySilo>("silo")
-    .WithReference(orleans)
-    .WithReference(redis);
+This separation lets those services add stronger invariants without expanding the membership-table transaction.
 
-builder.Build().Run();
-```
+## Source and tests
 
-**Silo project (Program.cs):**
-
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.AddServiceDefaults();
-builder.AddKeyedRedisClient("redis");
-builder.UseOrleans();
-
-builder.Build().Run();
-```
-
-#### Azure Table Storage clustering with Aspire
-
-**AppHost project (Program.cs):**
-
-```csharp
-var builder = DistributedApplication.CreateBuilder(args);
-
-var storage = builder.AddAzureStorage("storage")
-    .RunAsEmulator();  // Use Azurite for local development
-var tables = storage.AddTables("clustering");
-
-var orleans = builder.AddOrleans("cluster")
-    .WithClustering(tables);
-
-builder.AddProject<Projects.MySilo>("silo")
-    .WithReference(orleans)
-    .WaitFor(storage);
-
-builder.Build().Run();
-```
-
-**Silo project (Program.cs):**
-
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.AddServiceDefaults();
-builder.AddKeyedAzureTableServiceClient("clustering");
-builder.UseOrleans();
-
-builder.Build().Run();
-```
-
-> [!TIP]
-> To use the Azurite emulator for local development, call `.RunAsEmulator()` on the Azure Storage resource. Without this call, Aspire expects a real Azure Storage connection.
-
-#### Azure Cosmos DB clustering with Aspire
-
-**AppHost project (Program.cs):**
-
-```csharp
-var builder = DistributedApplication.CreateBuilder(args);
-
-var cosmos = builder.AddAzureCosmosDB("cosmos")
-    .RunAsEmulator();  // Use emulator for local development
-var database = cosmos.AddCosmosDatabase("orleans");
-
-var orleans = builder.AddOrleans("cluster")
-    .WithClustering(database);
-
-builder.AddProject<Projects.MySilo>("silo")
-    .WithReference(orleans)
-    .WaitFor(cosmos);
-
-builder.Build().Run();
-```
-
-**Silo project (Program.cs):**
-
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.AddServiceDefaults();
-builder.AddKeyedAzureCosmosClient("cosmos");
-builder.UseOrleans();
-
-builder.Build().Run();
-```
-
-> [!NOTE]
-> Aspire's Cosmos DB integration for Orleans currently supports clustering only. For grain storage and reminders with Cosmos DB, you'll need to configure those providers manually in the silo project.
-
-> [!IMPORTANT]
-> You must call the appropriate `AddKeyed*` method (such as `AddKeyedRedisClient`, `AddKeyedAzureTableServiceClient`, or `AddKeyedAzureCosmosClient`) to register the backing resource in the dependency injection container. Orleans providers look up resources by their keyed service name—if you skip this step, Orleans won't be able to resolve the resource and will throw a dependency resolution error at runtime.
-
-For more information about Orleans and Aspire integration, see [Orleans and Aspire integration](../host/aspire-integration.md).
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0,orleans-3-x"
-
-### Configure Cassandra clustering
-
-Configure Apache Cassandra as the clustering provider using the <xref:Orleans.Clustering.Cassandra.Hosting.CassandraMembershipHostingExtensions.UseCassandraClustering*> extension method. Install the [Microsoft.Orleans.Clustering.Cassandra](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.Cassandra) NuGet package:
-
-```dotnetcli
-dotnet add package Microsoft.Orleans.Clustering.Cassandra
-```
-
-Configure Cassandra clustering with a connection string:
-
-```csharp
-using Orleans.Clustering.Cassandra.Hosting;
-
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder.UseCassandraClustering(
-        connectionString: "Contact Points=localhost;Port=9042",
-        keyspace: "orleans");
-});
-```
-
-Alternatively, use the options-based configuration for more control:
-
-```csharp
-siloBuilder.UseCassandraClustering(options =>
-{
-    options.ConfigureClient("Contact Points=cassandra-node1,cassandra-node2;Port=9042", "orleans");
-    options.UseCassandraTtl = true;
-    options.InitializeRetryMaxDelay = TimeSpan.FromSeconds(30);
-});
-```
-
-Or provide a custom session factory for advanced scenarios:
-
-```csharp
-using Cassandra;
-
-siloBuilder.UseCassandraClustering(async serviceProvider =>
-{
-    var cluster = Cluster.Builder()
-        .AddContactPoints("cassandra-node1", "cassandra-node2")
-        .WithPort(9042)
-        .WithCredentials("username", "password")
-        .WithQueryOptions(new QueryOptions().SetConsistencyLevel(ConsistencyLevel.Quorum))
-        .Build();
-
-    return await cluster.ConnectAsync("orleans");
-});
-```
-
-The <xref:Orleans.Clustering.Cassandra.Hosting.CassandraClusteringOptions> class provides the following configuration options:
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `UseCassandraTtl` | `bool` | `false` | When `true`, configures time-to-live for membership table rows in Cassandra, allowing defunct silo cleanup even if the cluster is no longer running. Uses `DefunctSiloExpiration` from `ClusterMembershipOptions`. |
-| `InitializeRetryMaxDelay` | <xref:System.TimeSpan> | 20 seconds | The maximum delay between retries when encountering contention during initialization. This is typically needed with large numbers of silos connecting simultaneously to multi-datacenter Cassandra clusters. |
-
-#### When to use Cassandra clustering
-
-Consider Cassandra for clustering when:
-
-- You already have a Cassandra infrastructure in your organization
-- You need a clustering provider that works across multiple data centers with tunable consistency
-- You require automatic defunct silo cleanup via Cassandra TTL even when the Orleans cluster isn't running
-- You need high write throughput for large clusters
-
-### Configure Azure Cosmos DB clustering
-
-Configure Azure Cosmos DB as the clustering provider using the <xref:Orleans.Hosting.HostingExtensions.UseCosmosClustering*> extension method. Install the [Microsoft.Orleans.Clustering.Cosmos](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.Cosmos) NuGet package:
-
-```dotnetcli
-dotnet add package Microsoft.Orleans.Clustering.Cosmos
-```
-
-Configure Cosmos DB clustering with a connection string:
-
-```csharp
-using Azure.Identity;
-
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder.UseCosmosClustering(options =>
-    {
-        options.ConfigureCosmosClient(
-            "https://myaccount.documents.azure.com:443/",
-            new DefaultAzureCredential());
-        options.DatabaseName = "Orleans";
-        options.ContainerName = "OrleansCluster";
-        options.IsResourceCreationEnabled = true;
-    });
-});
-```
-
-Alternatively, you can use a connection string:
-
-```csharp
-siloBuilder.UseCosmosClustering(options =>
-{
-    options.ConfigureCosmosClient("AccountEndpoint=https://myaccount.documents.azure.com:443/;AccountKey=...");
-});
-```
-
-The <xref:Orleans.Clustering.Cosmos.CosmosClusteringOptions> class inherits from `CosmosOptions` and provides the following configuration options:
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `DatabaseName` | `string` | `"Orleans"` | The name of the Cosmos DB database. |
-| `ContainerName` | `string` | `"OrleansCluster"` | The name of the container for cluster membership data. |
-| `IsResourceCreationEnabled` | `bool` | `false` | When `true`, automatically creates the database and container if they don't exist. |
-| `DatabaseThroughput` | `int?` | `null` | The provisioned throughput for the database. If `null`, uses serverless mode. |
-| `ContainerThroughputProperties` | `ThroughputProperties?` | `null` | The throughput properties for the container. |
-| `ClientOptions` | `CosmosClientOptions` | `new()` | The options passed to the Cosmos DB client. |
-| `CleanResourcesOnInitialization` | `bool` | `false` | Deletes the database on initialization. **Only for testing.** |
-
-#### When to use Cosmos DB clustering
-
-Consider Azure Cosmos DB for clustering when:
-
-- You're already using Azure Cosmos DB in your application
-- You need a globally distributed database with multi-region write capabilities
-- You want a fully managed, serverless option with automatic scaling
-- You need low-latency reads and writes with guaranteed SLAs
-
-For Orleans clients, use `UseCosmosGatewayListProvider` to configure gateway discovery:
-
-```csharp
-builder.UseOrleansClient(clientBuilder =>
-{
-    clientBuilder.UseCosmosGatewayListProvider(options =>
-    {
-        options.ConfigureCosmosClient(
-            "https://myaccount.documents.azure.com:443/",
-            new DefaultAzureCredential());
-    });
-});
-```
-
-In addition to `IMembershipTable`, each silo participates in a fully distributed peer-to-peer membership protocol that detects failed silos and reaches an agreement on the set of alive silos. The internal implementation of Orleans's membership protocol is described below.
-
-### The membership protocol
-
-1. Upon startup, every silo adds an entry for itself into a well-known, shared table using an implementation of <xref:Orleans.IMembershipTable>. Orleans uses a combination of silo identity (`ip:port:epoch`) and service deployment ID (cluster ID) as unique keys in the table. Epoch is simply the time in ticks when this silo started, ensuring `ip:port:epoch` is unique within a given Orleans deployment.
-
-1. Silos monitor each other directly via application probes ("are you alive" `heartbeats`). Probes are sent as direct messages from silo to silo over the same TCP sockets used for regular communication. This way, probes fully correlate with actual networking problems and server health. Every silo probes a configurable set of other silos. A silo picks whom to probe by calculating consistent hashes on other silos' identities, forming a virtual ring of all identities, and picking X successor silos on the ring. (This is a well-known distributed technique called [consistent hashing](https://en.wikipedia.org/wiki/Consistent_hashing) and is widely used in many distributed hash tables, like [Chord DHT](https://en.wikipedia.org/wiki/Chord_(peer-to-peer))).
-
-1. If a silo S doesn't receive Y probe replies from a monitored server P, it suspects P by writing its timestamped suspicion into P's row in the `IMembershipTable`.
-
-1. If P has more than Z suspicions within K seconds, S writes that P is dead into P's row and broadcasts a snapshot of the current membership table to all other silos. Silos refresh the table periodically, so the snapshot is an optimization to reduce the time it takes for all silos to learn about the new membership view.
-
-1. In more detail:
-
-   1. Suspicion is written to the `IMembershipTable`, in a special column in the row corresponding to P. When S suspects P, it writes: "at time TTT S suspected P".
-
-   1. One suspicion isn't enough to declare P dead. You need Z suspicions from different silos within a configurable time window T (typically 3 minutes) to declare P dead. The suspicion is written using optimistic concurrency control provided by the `IMembershipTable`.
-
-   1. The suspecting silo S reads P's row.
-
-   1. If `S` is the last suspecter (there have already been Z-1 suspecters within period T, as recorded in the suspicion column), S decides to declare P dead. In this case, S adds itself to the list of suspecters and also writes in P's Status column that P is Dead.
-
-   1. Otherwise, if S isn't the last suspecter, S just adds itself to the suspecter's column.
-
-   1. In either case, the write-back uses the version number or ETag read previously, serializing updates to this row. If the write fails due to a version/ETag mismatch, S retries (reads again and tries to write, unless P was already marked dead).
-
-   1. At a high level, this sequence of "read, local modify, write back" is a transaction. However, storage transactions aren't necessarily used. The "transaction" code executes locally on a server, and optimistic concurrency provided by the `IMembershipTable` ensures isolation and atomicity.
-
-1. Every silo periodically reads the entire membership table for its deployment. This way, silos learn about new silos joining and about other silos being declared dead.
-
-1. **Snapshot broadcast**: To reduce the frequency of periodic table reads, every time a silo writes to the table (suspicion, new join, etc.), it sends a snapshot of the current table state to all other silos. Since the membership table is consistent and monotonically versioned, each update produces a uniquely versioned snapshot that can be safely shared. This enables immediate propagation of membership changes without waiting for the periodic read cycle. The periodic read is still maintained as a fallback mechanism in case snapshot distribution fails.
-
-1. **Ordered membership views**: The membership protocol ensures all membership configurations are globally totally ordered. This ordering provides two key benefits:
-
-   1. **Guaranteed connectivity**: When a new silo joins the cluster, it must validate two-way connectivity to every other active silo. If any existing silo doesn't respond (potentially indicating a network connectivity problem), the new silo isn't allowed to join. This ensures full connectivity between all silos in the cluster at startup time. See the note about `IAmAlive` below for an exception in disaster recovery scenarios.
-
-   1. **Consistent directory updates**: Higher-level protocols, such as the distributed grain directory, rely on all silos having a consistent, monotonic view of membership. This enables smarter resolution of duplicate grain activations. For more details, see the [Grain directory](grain-directory.md) documentation.
-
-   **Implementation details**:
-
-   1. The `IMembershipTable` requires atomic updates to guarantee a global total order of changes:
-
-      - Implementations must update both the table entries (list of silos) and the version number atomically.
-      - Achieve this using database transactions (as in SQL Server) or atomic compare-and-swap operations using ETags (as in Azure Table Storage).
-      - The specific mechanism depends on the capabilities of the underlying storage system.
-
-   1. A special membership-version row in the table tracks changes:
-
-      - Every write to the table (suspicions, death declarations, joins) increments this version number.
-      - All writes are serialized through this row using atomic updates.
-      - The monotonically increasing version ensures a total ordering of all membership changes.
-
-   1. When silo S updates the status of silo P:
-
-      - S first reads the latest table state.
-      - In a single atomic operation, it updates both P's row and increments the version number.
-      - If the atomic update fails (for example, due to concurrent modifications), the operation retries with exponential backoff.
-
-    **Scalability considerations**:
-
-    Serializing all writes through the version row can impact scalability due to increased contention. The protocol has proven effective in production with up to 200 silos but might face challenges beyond a thousand silos. For very large deployments, other parts of Orleans (messaging, grain directory, hosting) remain scalable even if membership updates become a bottleneck.
-
-1. **Default configuration**: The default configuration has been hand-tuned during production usage in Azure. By default: every silo is monitored by three other silos, two suspicions are enough to declare a silo dead, and suspicions are only considered from the last three minutes (otherwise they are outdated). Probes are sent every ten seconds, and you need to miss three probes to suspect a silo.
-
-1. **Self-monitoring**: The fault detector incorporates ideas from Hashicorp's _Lifeguard_ research ([paper](https://arxiv.org/abs/1707.00788), [talk](https://www.youtube.com/watch?v=u-a7rVJ6jZY), [blog](https://www.hashicorp.com/blog/making-gossip-more-robust-with-lifeguard)) to improve cluster stability during catastrophic events where a large portion of the cluster experiences partial failure. The `LocalSiloHealthMonitor` component scores each silo's health using multiple heuristics:
-
-    - Active status in the membership table
-    - No suspicions from other silos
-    - Recent successful probe responses
-    - Recent probe requests received
-    - Thread pool responsiveness (work items executing within 1 second)
-    - Timer accuracy (firing within 3 seconds of schedule)
-
-    A silo's health score affects its probe timeouts: unhealthy silos (scoring 1-8) have increased timeouts compared to healthy silos (score 0). This provides two benefits:
-
-    - Gives more time for probes to succeed when the network or system is under stress.
-    - Makes it more likely that unhealthy silos are voted dead before they can incorrectly vote out healthy silos.
-
-    This is particularly valuable during scenarios like thread pool starvation, where slow nodes might otherwise incorrectly suspect healthy nodes simply because they cannot process responses quickly enough.
-
-1. **Indirect probing**: Another [Lifeguard](https://arxiv.org/abs/1707.00788)-inspired feature improving failure detection accuracy by reducing the chance that an unhealthy or partitioned silo incorrectly declares a healthy silo dead. When a monitoring silo has two probe attempts remaining for a target silo before casting a vote to declare it dead, it employs indirect probing:
-
-    - The monitoring silo randomly selects another silo as an intermediary and asks it to probe the target.
-    - The intermediary attempts to contact the target silo.
-    - If the target fails to respond within the timeout period, the intermediary sends a negative acknowledgment.
-    - If the monitoring silo receives a negative acknowledgment from the intermediary, and the intermediary declares itself healthy (through self-monitoring, described above), the monitoring silo casts a vote to declare the target dead.
-    - With the default configuration of two required votes, a negative acknowledgment from an indirect probe counts as both votes, allowing faster declaration of dead silos when multiple perspectives confirm the failure.
-
-1. **Enforcing perfect failure detection**: Once a silo is declared dead in the table, everyone considers it dead, even if it isn't truly dead (e.g., just temporarily partitioned or heartbeat messages were lost). Everyone stops communicating with it. Once the silo learns it's dead (by reading its new status from the table), it terminates its process. Consequently, an infrastructure must be in place to restart the silo as a new process (a new epoch number is generated upon start). When hosted in Azure, this happens automatically. Otherwise, another infrastructure is required, such as a Windows Service configured to auto-restart on failure or a Kubernetes deployment.
-
-1. **What happens if the table is inaccessible for some time**:
-
-    When the storage service is down, unavailable, or experiencing communication problems, the Orleans protocol does NOT mistakenly declare silos dead. Operational silos continue working without issues. However, Orleans won't be able to declare a silo dead (if it detects a dead silo via missed probes, it can't write this fact to the table) and won't be able to allow new silos to join. So, completeness suffers, but accuracy doesn't—partitioning from the table never causes Orleans to mistakenly declare a silo dead. Also, in a partial network partition (where some silos can access the table and others can't), Orleans might declare a silo dead, but it takes time for all other silos to learn about it. Detection might be delayed, but Orleans never wrongly kills a silo due to table unavailability.
-
-1. **`IAmAlive` writes for diagnostics and disaster recovery**:
-
-    In addition to heartbeats sent between silos, each silo periodically updates an "I Am Alive" timestamp in its table row. This serves two purposes:
-
-    1. **Diagnostics**: Provides system administrators a simple way to check cluster liveness and determine when a silo was last active. The timestamp is by default updated every 30 seconds.
-
-    1. **Disaster recovery**: If a silo hasn't updated its timestamp for several periods (configured via `NumMissedTableIAmAliveLimit`, default: 3), new silos ignore it during startup connectivity checks. This allows the cluster to recover from scenarios where silos crashed without proper cleanup.
-
-### Membership table
-
-As mentioned, `IMembershipTable` serves as a rendezvous point for silos to find each other and for Orleans clients to find silos. It also helps coordinate agreement on the membership view.
-
-The following listing contains implementation notes for some of the official implementations of the `IMembershipTable`:
-
-1. **[Azure Table Storage](/azure/storage/storage-dotnet-how-to-use-tables)**: In this implementation, the Azure deployment ID serves as the partition key, and the silo identity (`ip:port:epoch`) acts as the row key. Together, they guarantee a unique key per silo. For concurrency control, optimistic concurrency control based on [Azure Table ETags](/rest/api/storageservices/Update-Entity2) is used. Every time data is read from the table, the ETag for each read row is stored and used when trying to write back. The Azure Table service automatically assigns and checks ETags on every write. For multi-row transactions, the support for [batch transactions provided by Azure Table](/rest/api/storageservices/Performing-Entity-Group-Transactions) is utilized, guaranteeing serializable transactions over rows with the same partition key.
-
-1. **SQL Server**: In this implementation, the configured deployment ID distinguishes between deployments and which silos belong to which deployments. The silo identity is defined as a combination of `deploymentID, ip, port, epoch` in appropriate tables and columns. The relational backend uses optimistic concurrency control and transactions, similar to using ETags in the Azure Table implementation. The relational implementation expects the database engine to generate the ETag. For SQL Server 2000, the generated ETag is acquired from a call to `NEWID()`. On SQL Server 2005 and later, [ROWVERSION](/sql/t-sql/data-types/rowversion-transact-sql) is used. Orleans reads and writes relational ETags as opaque `VARBINARY(16)` tags and stores them in memory as [base64](https://en.wikipedia.org/wiki/Base64) encoded strings. Orleans supports multi-row inserts using `UNION ALL` (for Oracle, including `DUAL`), which is currently used to insert statistics data. The exact implementation and rationale for SQL Server is available at [CreateOrleansTables_SqlServer.sql](https://github.com/dotnet/orleans/blob/ba30bbb2155168fc4b9f190727220583b9a7ae4c/src/OrleansSQLUtils/CreateOrleansTables_SqlServer.sql).
-
-1. **[Apache ZooKeeper](https://zookeeper.apache.org/)**: In this implementation, the configured deployment ID is used as a root node, and the silo identity (`ip:port@epoch`) as its child node. Together, they guarantee a unique path per silo. For concurrency control, optimistic concurrency control based on the [node version](https://zookeeper.apache.org/doc/r3.4.6/zookeeperOver.html#Nodes+and+ephemeral+nodes) is used. Every time data is read from the deployment root node, the version for every read child silo node is stored and used when trying to write back. Each time a node's data changes, the ZooKeeper service atomically increases the version number. For multi-row transactions, the [multi method](https://zookeeper.apache.org/doc/r3.4.6/api/org/apache/zookeeper/ZooKeeper.html#multi(java.lang.Iterable)) is utilized, guaranteeing serializable transactions over silo nodes with the same parent deployment ID node.
-
-1. **[HashiCorp Consul](https://www.consul.io)**: Consul's key/value store is used to implement the membership table. See [Configure Consul clustering](../host/configuration-guide/clustering/consul.md) for details.
-
-1. **[AWS DynamoDB](https://aws.amazon.com/dynamodb/)**: In this implementation, the cluster Deployment ID is used as the Partition Key and Silo Identity (`ip-port-generation`) as the RangeKey, making the record unique. Optimistic concurrency is achieved using the `ETag` attribute by making conditional writes on DynamoDB. The implementation logic is quite similar to Azure Table Storage.
-
-1. **[Apache Cassandra](https://cassandra.apache.org/_/index.html)**: In this implementation, the composite of Service ID and Cluster ID serves as the partition key, and the silo identity (`ip:port:epoch`) as the row key. Together, they guarantee a unique row per silo. For concurrency control, optimistic concurrency control based on a static column version using a Lightweight Transaction is used. This version column is shared for all rows in the partition/cluster, providing a consistent incrementing version number for each cluster's membership table. There are no multi-row transactions in this implementation.
-
-1. **In-memory emulation for development setup**: A special system grain is used for this implementation. This grain lives on a designated primary silo, which is only used for a **development setup**. In any real production usage, a primary silo **isn't required**.
-
-### Design rationale
-
-A natural question might be why not rely completely on [Apache ZooKeeper](https://ZooKeeper.apache.org/) or [etcd](https://etcd.io/) for the cluster membership implementation, potentially using ZooKeeper's out-of-the-box support for group membership with ephemeral nodes? Why implement our membership protocol? There were primarily three reasons:
-
-1. **Deployment/Hosting in the cloud**:
-
-   Zookeeper isn't a hosted service. This means in a Cloud environment, Orleans customers would have to deploy, run, and manage their instance of a ZK cluster. This is an unnecessary burden that wasn't forced on customers. By using Azure Table, Orleans relies on a hosted, managed service, making customers' lives much simpler. _Basically, in the Cloud, use Cloud as a Platform, not Infrastructure._ On the other hand, when running on-premises and managing your servers, relying on ZK as an implementation of `IMembershipTable` is a viable option.
-
-1. **Direct failure detection**:
-
-   When using ZK's group membership with ephemeral nodes, failure detection occurs between the Orleans servers (ZK clients) and ZK servers. This might not necessarily correlate with actual network problems between Orleans servers. _The desire was that failure detection accurately reflects the intra-cluster state of communication._ Specifically, in this design, if an Orleans silo can't communicate with `IMembershipTable`, it isn't considered dead and can continue working. In contrast, if ZK group membership with ephemeral nodes were used, a disconnection from a ZK server might cause an Orleans silo (ZK client) to be declared dead, while it might be alive and fully functional.
-
-1. **Portability and flexibility**:
-
-   As part of Orleans's philosophy, Orleans doesn't force a strong dependence on any particular technology but rather provides a flexible design where different components can be easily switched with different implementations. This is exactly the purpose the `IMembershipTable` abstraction serves.
-
-### Properties of the membership protocol
-
-1. **Can handle any number of failures**:
-
-   This algorithm can handle any number of failures (f<=n), including full cluster restart. This contrasts with "traditional" [Paxos](https://en.wikipedia.org/wiki/Paxos_(computer_science))-based solutions, which require a quorum (usually a majority). Production situations have shown scenarios where more than half of the silos were down. This system stayed functional, while Paxos-based membership wouldn't be able to make progress.
-
-1. **Traffic to the table is very light**:
-
-   Actual probes go directly between servers, not to the table. Routing probes through the table would generate significant traffic and be less accurate from a failure detection perspective – if a silo couldn't reach the table, it would miss writing its "I am alive" heartbeat, and others would declare it dead.
-
-1. **Tunable accuracy versus completeness**:
-
-   While you can't achieve both perfect and accurate failure detection, you usually want the ability to trade off accuracy (not wanting to declare a live silo dead) with completeness (wanting to declare a dead silo dead as soon as possible). The configurable votes to declare dead and missed probes allow trading these two aspects. For more information, see [Yale University: Computer Science Failure Detectors](https://www.cs.yale.edu/homes/aspnes/pinewiki/FailureDetectors.html).
-
-1. **Scale**:
-
-   The protocol can handle thousands, probably even tens of thousands, of servers. This contrasts with traditional Paxos-based solutions, such as group communication protocols, which are known not to scale beyond tens of nodes.
-
-1. **Diagnostics**:
-
-   The table is also very convenient for diagnostics and troubleshooting. System administrators can instantaneously find the current list of alive silos in the table, as well as see the history of all killed silos and suspicions. This is especially useful when diagnosing problems.
-
-1. **Why is reliable persistent storage needed for the implementation of `IMembershipTable`**:
-
-   Persistent storage is used for `IMembershipTable` for two purposes. First, it serves as a rendezvous point for silos to find each other and for Orleans clients to find silos. Second, reliable storage helps coordinate agreement on the membership view. While failure detection occurs directly peer-to-peer between silos, the membership view is stored in reliable storage, and the concurrency control mechanism provided by this storage is used to reach an agreement on who is alive and who is dead. In a sense, this protocol outsources the hard problem of distributed consensus to the cloud. In doing so, the full power of the underlying cloud platform is utilized, using it truly as Platform as a Service (PaaS).
-
-1. **Direct `IAmAlive` writes into the table for diagnostics only**:
-
-   In addition to heartbeats sent between silos, each silo also periodically updates an "I Am Alive" column in its table row. This "I Am Alive" column is only used **for manual troubleshooting and diagnostics** and isn't used by the membership protocol itself. It's usually written at a much lower frequency (once every 5 minutes) and serves as a very useful tool for system administrators to check the liveness of the cluster or easily find out when the silo was last alive.
-
-### Acknowledgements
-
-Acknowledgments for the contribution of Alex Kogan to the design and implementation of the first version of this protocol. This work was done as part of a summer internship in Microsoft Research in the Summer of 2011.
-The implementation of ZooKeeper based `IMembershipTable` was done by [Shay Hazor](https://github.com/shayhatsor), the implementation of SQL `IMembershipTable` was done by [Veikko Eeva](https://github.com/veikkoeeva), the implementation of AWS DynamoDB `IMembershipTable` was done by [Gutemberg Ribeiro](https://github.com/galvesribeiro/), the implementation of Consul based `IMembershipTable` was done by [Paul North](https://github.com/PaulNorth), and finally the implementation of the Apache Cassandra `IMembershipTable` was adapted from `OrleansCassandraUtils` by [Arshia001](https://github.com/Arshia001).
-
-:::zone-end
+- [`MembershipAgent`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/MembershipService/MembershipAgent.cs) drives joining and active-state transitions.
+- [`MembershipTableManager`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs) coordinates table updates and death declarations.
+- [`ClusterHealthMonitor`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/MembershipService/ClusterHealthMonitor.cs) owns peer monitoring.
+- [`MembershipAgentTests`](https://github.com/dotnet/orleans/blob/main/test/Orleans.Core.Tests/Membership/MembershipAgentTests.cs) exercise startup connectivity.
+- [`MembershipTableManagerTests`](https://github.com/dotnet/orleans/blob/main/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs) cover vote expiry and status changes.

--- a/docs/site/src/content/docs/implementation/grain-directory.md
+++ b/docs/site/src/content/docs/implementation/grain-directory.md
@@ -13,7 +13,7 @@ Orleans uses `LocalGrainDirectory` by default. `DistributedGrainDirectory` is ex
 
 ## Default: `LocalGrainDirectory`
 
-`LocalGrainDirectory` partitions registrations over the membership ring. Hashing a grain identity selects the silo whose local `LocalGrainDirectoryPartition` is authoritative for that key. Each silo also keeps non-authoritative cache entries to avoid repeated remote lookups.
+`LocalGrainDirectory` partitions registrations over the membership ring. Hashing a grain identity selects the silo whose local `LocalGrainDirectoryPartition` is authoritative for that key. This follows the broad consistent-hashing distributed-hash-table model described by [Chord](https://pdos.csail.mit.edu/papers/chord:sigcomm01/chord_sigcomm.pdf), adapted to Orleans membership and activation semantics. Each silo also keeps non-authoritative cache entries to avoid repeated remote lookups.
 
 ```mermaid
 flowchart LR
@@ -63,7 +63,7 @@ siloBuilder.AddDistributedGrainDirectory();
 
 It is not the default. The experimental status allows its API and protocol to evolve.
 
-The implementation divides the hash ring into configurable ranges. `GrainDirectoryOptions.PartitionsPerSilo` defaults to **1**, not 30. A partition normally serves requests locally. During a membership view change, old and new owners coordinate range locks, snapshots, and ownership transfer.
+The implementation divides the hash ring into configurable ranges, analogous to the virtual-node partitioning described by [Dynamo](https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf). `GrainDirectoryOptions.PartitionsPerSilo` defaults to **1**, not 30. A partition normally serves requests locally. During a membership view change, old and new owners coordinate range locks, snapshots, and ownership transfer. The design applies the [virtually synchronous methodology for dynamic service replication](https://www.microsoft.com/en-us/research/publication/virtually-synchronous-methodology-for-dynamic-service-replication/) and has similarities to [Vertical Paxos and primary-backup replication](https://www.microsoft.com/en-us/research/publication/vertical-paxos-and-primary-backup-replication/).
 
 ```mermaid
 sequenceDiagram

--- a/docs/site/src/content/docs/implementation/grain-directory.md
+++ b/docs/site/src/content/docs/implementation/grain-directory.md
@@ -1,6 +1,6 @@
 ---
 title: Grain directory architecture
-description: Compare Orleans 10's default LocalGrainDirectory DHT with the experimental distributed directory.
+description: Compare the default LocalGrainDirectory DHT with the experimental distributed directory.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -9,7 +9,7 @@ ms.topic: concept-article
 
 The grain directory maps a grain identity to an activation address. It is on the critical path when a caller has no usable cached address and when the runtime creates, moves, or removes an activation. Placement chooses a silo; the directory coordinates which activation address is authoritative.
 
-Orleans 10 uses `LocalGrainDirectory` by default. The newer `DistributedGrainDirectory` is experimental and must be enabled explicitly.
+Orleans uses `LocalGrainDirectory` by default. `DistributedGrainDirectory` is experimental and must be enabled explicitly.
 
 ## Default: `LocalGrainDirectory`
 
@@ -61,7 +61,7 @@ siloBuilder.AddDistributedGrainDirectory();
 #pragma warning restore ORLEANSEXP003
 ```
 
-It is not the Orleans 10 default. The experimental status allows its API and protocol to evolve.
+It is not the default. The experimental status allows its API and protocol to evolve.
 
 The implementation divides the hash ring into configurable ranges. `GrainDirectoryOptions.PartitionsPerSilo` defaults to **1**, not 30. A partition normally serves requests locally. During a membership view change, old and new owners coordinate range locks, snapshots, and ownership transfer.
 
@@ -89,7 +89,7 @@ Source: [`AddDistributedGrainDirectory`](https://github.com/dotnet/orleans/blob/
 
 | Property | Default `LocalGrainDirectory` | Experimental `DistributedGrainDirectory` |
 | --- | --- | --- |
-| Orleans 10 status | Default | Opt-in, `ORLEANSEXP003` |
+| Status | Default | Opt-in, `ORLEANSEXP003` |
 | Ownership | Membership consistent-hash ring | Versioned ranges over membership views |
 | Normal lookup | Owner partition plus per-silo cache | Owner partition plus view coordination |
 | View change | Partition split/merge and cache repair | Sealed ranges and snapshot transfer |

--- a/docs/site/src/content/docs/implementation/grain-directory.md
+++ b/docs/site/src/content/docs/implementation/grain-directory.md
@@ -11,7 +11,7 @@ The grain directory maps a grain identity to an activation address. It is on the
 
 Orleans uses `LocalGrainDirectory` by default. `DistributedGrainDirectory` is experimental and must be enabled explicitly.
 
-## Default: `LocalGrainDirectory`
+## Default: `LocalGrainDirectory` <a name="overview-and-architecture"></a>
 
 `LocalGrainDirectory` partitions registrations over the membership ring. Hashing a grain identity selects the silo whose local `LocalGrainDirectoryPartition` is authoritative for that key. This follows the broad consistent-hashing distributed-hash-table model described by [Chord](https://pdos.csail.mit.edu/papers/chord:sigcomm01/chord_sigcomm.pdf), adapted to Orleans membership and activation semantics. Each silo also keeps non-authoritative cache entries to avoid repeated remote lookups.
 
@@ -51,20 +51,16 @@ The runtime resolves a directory per grain type. The unnamed default resolves to
 
 Custom directories own their consistency, availability, and cleanup behavior. They should define what concurrent registration means, how failed silos are removed, and whether stale reads are possible. The surrounding message router cannot turn an eventually consistent custom directory into a strongly consistent one.
 
-## Experimental: `DistributedGrainDirectory`
+## Experimental: `DistributedGrainDirectory` <a name="distributed-grain-directory"></a>
 
-`AddDistributedGrainDirectory()` opts into a view-synchronous directory marked with compiler warning **`ORLEANSEXP003`**:
-
-```csharp
-#pragma warning disable ORLEANSEXP003
-siloBuilder.AddDistributedGrainDirectory();
-#pragma warning restore ORLEANSEXP003
-```
+<xref:Orleans.Hosting.CoreHostingExtensions.AddDistributedGrainDirectory*?displayProperty=nameWithType> opts into a view-synchronous directory marked with compiler warning **`ORLEANSEXP003`**:
 
 It is not the default. The experimental status allows its API and protocol to evolve.
 
-The implementation divides the hash ring into configurable ranges, analogous to the virtual-node partitioning described by [Dynamo](https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf). `GrainDirectoryOptions.PartitionsPerSilo` defaults to **1**, not 30. A partition normally serves requests locally. During a membership view change, old and new owners coordinate range locks, snapshots, and ownership transfer. The design applies the [virtually synchronous methodology for dynamic service replication](https://www.microsoft.com/en-us/research/publication/virtually-synchronous-methodology-for-dynamic-service-replication/) and has similarities to [Vertical Paxos and primary-backup replication](https://www.microsoft.com/en-us/research/publication/vertical-paxos-and-primary-backup-replication/).
+<a name="partitioning-strategy"></a>
+The implementation divides the hash ring into configurable ranges, analogous to the virtual-node partitioning described by [Dynamo](https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf). <xref:Orleans.Configuration.GrainDirectoryOptions.PartitionsPerSilo?displayProperty=nameWithType> defaults to **1**, not 30. A partition normally serves requests locally. During a membership view change, old and new owners coordinate range locks, snapshots, and ownership transfer. The design applies the [virtually synchronous methodology for dynamic service replication](https://www.microsoft.com/en-us/research/publication/virtually-synchronous-methodology-for-dynamic-service-replication/) and has similarities to [Vertical Paxos and primary-backup replication](https://www.microsoft.com/en-us/research/publication/vertical-paxos-and-primary-backup-replication/).
 
+<a name="view-change-procedure"></a>
 ```mermaid
 sequenceDiagram
     participant Old as Previous range owner
@@ -81,9 +77,10 @@ sequenceDiagram
     Old->>Old: Delete transferred snapshot
 ```
 
+<a name="recovery-process"></a>
 Requests and responses carry view information. A range cannot serve a request under an incompatible ownership view. If an orderly transfer is impossible, the new owner recovers registrations by querying active silos rather than assuming the failed owner's state.
 
-Source: [`AddDistributedGrainDirectory`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs#L150-L180), [`DistributedGrainDirectory`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs), and [`GrainDirectoryOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs).
+API: <xref:Orleans.Hosting.CoreHostingExtensions.AddDistributedGrainDirectory*?displayProperty=nameWithType> and <xref:Orleans.Configuration.GrainDirectoryOptions>. Implementation: [hosting registration](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs) and [`DistributedGrainDirectory`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs).
 
 ## Tradeoffs
 
@@ -94,6 +91,6 @@ Source: [`AddDistributedGrainDirectory`](https://github.com/dotnet/orleans/blob/
 | Normal lookup | Owner partition plus per-silo cache | Owner partition plus view coordination |
 | View change | Partition split/merge and cache repair | Sealed ranges and snapshot transfer |
 | Recovery emphasis | Duplicate detection and invalidation | Explicit range recovery |
-| Configuration | Existing default behavior | `PartitionsPerSilo`, default 1 |
+| Configuration | Existing default behavior | <xref:Orleans.Configuration.GrainDirectoryOptions.PartitionsPerSilo?displayProperty=nameWithType>, default 1 |
 
 More partitions can improve ownership granularity but increase transfer and coordination work. This page documents the mechanism; any production rollout of an experimental component should include compatibility, failure, and load testing.

--- a/docs/site/src/content/docs/implementation/grain-directory.md
+++ b/docs/site/src/content/docs/implementation/grain-directory.md
@@ -1,78 +1,99 @@
 ---
-title: Grain Directory Implementation
-description: Explore the implementation of the grain directory in .NET Orleans.
-ms.date: 05/23/2025
+title: Grain directory architecture
+description: Compare Orleans 10's default LocalGrainDirectory DHT with the experimental distributed directory.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
-# Grain directory implementation
+# Grain directory architecture
 
-## Overview and architecture
+The grain directory maps a grain identity to an activation address. It is on the critical path when a caller has no usable cached address and when the runtime creates, moves, or removes an activation. Placement chooses a silo; the directory coordinates which activation address is authoritative.
 
-The grain directory in Orleans is a key-value store where the key is a grain identifier and the value is a registration entry pointing to an active silo that (potentially) hosts the grain.
+Orleans 10 uses `LocalGrainDirectory` by default. The newer `DistributedGrainDirectory` is experimental and must be enabled explicitly.
 
-While Orleans provides a default in-memory distributed directory implementation (described in this article), the grain directory system is designed to be pluggable. You can implement your own directory by implementing the `IGrainDirectory` interface and registering it with the silo's service collection. This allows for custom directory implementations that might use different storage backends or consistency models to better suit specific application requirements. Since the introduction of the new strong consistency directory, there's less need for external directory implementations, but the API remains for backward compatibility and flexibility. You can configure the grain directory on a per-grain-type basis.
+## Default: `LocalGrainDirectory`
 
-To optimize performance, Orleans caches directory lookups locally within each silo. This means potentially remote directory reads are only necessary when the local cache entry is missing or invalid. This caching mechanism reduces network overhead and latency associated with grain location lookups.
+`LocalGrainDirectory` partitions registrations over the membership ring. Hashing a grain identity selects the silo whose local `LocalGrainDirectoryPartition` is authoritative for that key. Each silo also keeps non-authoritative cache entries to avoid repeated remote lookups.
 
-Originally, Orleans implemented an eventually consistent directory structured as a distributed hash table. This was superseded by a strongly consistent directory in Orleans v9.0, based on the two-phase [Virtually Synchronous methodology](https://www.microsoft.com/en-us/research/publication/virtually-synchronous-methodology-for-dynamic-service-replication/). It's also structured as a distributed hash table but offers improved load balancing through virtual nodes. This article describes the latter, newer grain directory implementation.
+```mermaid
+flowchart LR
+    Caller[Calling silo]
+    Cache[Local address cache]
+    Ring[Membership hash ring]
+    Owner[Owning LocalGrainDirectory]
+    Partition[LocalGrainDirectoryPartition]
+    Activation[Target activation]
 
-## Distributed grain directory
+    Caller --> Cache
+    Cache -->|miss or invalid| Ring
+    Ring --> Owner
+    Owner --> Partition
+    Partition -->|activation address| Caller
+    Caller --> Activation
+```
 
-The distributed grain directory in Orleans offers strong consistency, even load balancing, high performance, and fault tolerance. The implementation follows a two-phase design based on the [Virtual Synchrony methodology](https://www.microsoft.com/en-us/research/publication/virtually-synchronous-methodology-for-dynamic-service-replication/) with similarities to [Vertical Paxos](https://www.microsoft.com/en-us/research/publication/vertical-paxos-and-primary-backup-replication/).
+The default directory preserves these invariants:
 
-Directory partitions have two modes of operation:
+- a directory key is derived from the grain identity, not its current location;
+- the membership view determines the authoritative owner;
+- local cache entries are hints and can be invalidated;
+- registration detects competing single-activation addresses;
+- a failed or deactivated silo's addresses are removed or rejected; and
+- partition ownership transfers as the membership ring changes.
 
-1. **Normal operation**: Partitions process requests locally without coordination with other hosts.
-1. **View change**: Hosts coordinate with each other to transfer ownership of directory ranges.
+Message forwarding and invalidation repair stale caches. Forwarding is bounded and is not an application-level retry policy.
 
-The directory leverages Orleans' strong consistency cluster membership system, where configurations called "views" have monotonically increasing version numbers. As silos join and leave the cluster, successive views are created, resulting in changes to range ownership.
+Source: [`LocalGrainDirectory`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectory.cs) and [`LocalGrainDirectoryPartition`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/GrainDirectory/LocalGrainDirectoryPartition.cs).
 
-All directory operations include view coordination:
+## Directory selection
 
-- Requests carry the caller's view number.
-- Responses include the partition's view number.
-- View number mismatches trigger synchronization.
-- Requests automatically retry on view changes.
+The runtime resolves a directory per grain type. The unnamed default resolves to `LocalGrainDirectory` unless the silo has explicitly replaced it. A named implementation of <xref:Orleans.GrainDirectory.IGrainDirectory> can be registered and selected using grain-type metadata.
 
-This ensures the correct owner of the directory partition processes all requests.
+Custom directories own their consistency, availability, and cleanup behavior. They should define what concurrent registration means, how failed silos are removed, and whether stale reads are possible. The surrounding message router cannot turn an eventually consistent custom directory into a strongly consistent one.
 
-### Partitioning strategy
+## Experimental: `DistributedGrainDirectory`
 
-The directory is partitioned using a consistent hash ring, with ranges assigned to the active silos in the cluster. Grain identifiers are hashed to find the silo owning the section of the ring corresponding to its hash.
+`AddDistributedGrainDirectory()` opts into a view-synchronous directory marked with compiler warning **`ORLEANSEXP003`**:
 
-Each active silo owns a pre-configured number of ranges, defaulting to 30 ranges per silo. This is similar to the scheme used by [Amazon Dynamo](https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf) and [Apache Cassandra](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/architecture/archDataDistributeVnodesUsing.html), where multiple "virtual nodes" (ranges) are created for each physical node (host).
+```csharp
+#pragma warning disable ORLEANSEXP003
+siloBuilder.AddDistributedGrainDirectory();
+#pragma warning restore ORLEANSEXP003
+```
 
-The size of a partition is determined by the distance between its hash and the hash of the next partition. It's possible for a range to be split among multiple silos during a view change. This adds complexity to the view change procedure, as each partition must potentially coordinate with multiple other partitions.
+It is not the Orleans 10 default. The experimental status allows its API and protocol to evolve.
 
-### View change procedure
+The implementation divides the hash ring into configurable ranges. `GrainDirectoryOptions.PartitionsPerSilo` defaults to **1**, not 30. A partition normally serves requests locally. During a membership view change, old and new owners coordinate range locks, snapshots, and ownership transfer.
 
-Directory partitions (implemented in `GrainDirectoryPartition`) use versioned range locks to prevent invalid access to ranges during view changes. Range locks are created during a view change and released when the view change completes. These locks are analogous to the 'wedges' used in the Virtual Synchrony methodology.
+```mermaid
+sequenceDiagram
+    participant Old as Previous range owner
+    participant New as New range owner
+    participant Clients as Directory callers
 
-When a view change occurs, a partition can either grow or shrink:
+    Old->>Old: Seal range for new view
+    Clients->>Old: Request with view number
+    Old-->>Clients: Synchronize or retry in newer view
+    New->>Old: Request range snapshot
+    Old-->>New: Registrations and version
+    New->>New: Install snapshot and open range
+    New-->>Old: Transfer complete
+    Old->>Old: Delete transferred snapshot
+```
 
-- If a new silo joins the cluster, existing partitions might shrink to make room.
-- If a silo leaves the cluster, remaining partitions might grow to take over the orphaned ranges.
+Requests and responses carry view information. A range cannot serve a request under an incompatible ownership view. If an orderly transfer is impossible, the new owner recovers registrations by querying active silos rather than assuming the failed owner's state.
 
-Directory registrations must transfer from the old owner to the new owner before requests can be served. The transfer process follows these steps:
+Source: [`AddDistributedGrainDirectory`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/CoreHostingExtensions.cs#L150-L180), [`DistributedGrainDirectory`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs), and [`GrainDirectoryOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Configuration/Options/GrainDirectoryOptions.cs).
 
-1. The previous owner seals the range and creates a snapshot of its directory entries.
-1. The new owner requests and applies the snapshot.
-1. The new owner begins servicing requests for the range.
-1. The previous owner is notified and deletes the snapshot.
+## Tradeoffs
 
-### Recovery process
+| Property | Default `LocalGrainDirectory` | Experimental `DistributedGrainDirectory` |
+| --- | --- | --- |
+| Orleans 10 status | Default | Opt-in, `ORLEANSEXP003` |
+| Ownership | Membership consistent-hash ring | Versioned ranges over membership views |
+| Normal lookup | Owner partition plus per-silo cache | Owner partition plus view coordination |
+| View change | Partition split/merge and cache repair | Sealed ranges and snapshot transfer |
+| Recovery emphasis | Duplicate detection and invalidation | Explicit range recovery |
+| Configuration | Existing default behavior | `PartitionsPerSilo`, default 1 |
 
-When a host crashes without properly handing off its directory partitions, the subsequent partition owners must perform recovery. This involves:
-
-1. Querying all active silos in the cluster for their grain registrations.
-1. Rebuilding the directory state for affected ranges.
-1. Ensuring no duplicate grain activations occur.
-
-Recovery is also necessary when cluster membership changes rapidly. While cluster membership guarantees monotonicity, it's possible for silos to miss intermediate membership views. In such cases:
-
-- Snapshot transfers are abandoned.
-- Recovery is performed instead of the normal partition-to-partition handover.
-- The system maintains consistency despite missing intermediate states.
-
-A future improvement to cluster membership might reduce or eliminate these scenarios by ensuring all silos see all views.
+More partitions can improve ownership granularity but increase transfer and coordination work. This page documents the mechanism; any production rollout of an experimental component should include compatibility, failure, and load testing.

--- a/docs/site/src/content/docs/implementation/index.md
+++ b/docs/site/src/content/docs/implementation/index.md
@@ -35,11 +35,11 @@ The pages in this track use Orleans source and tests as the specification. Inter
 | --- | --- |
 | Placement | <xref:Orleans.Runtime.ResourceOptimizedPlacement> |
 | Grain directory | `LocalGrainDirectory`, using the membership ring |
-| Experimental directory | Opt-in with `AddDistributedGrainDirectory`; warning `ORLEANSEXP003` |
-| Experimental directory partitions | `GrainDirectoryOptions.PartitionsPerSilo = 1` |
+| Experimental directory | Opt-in with <xref:Orleans.Hosting.CoreHostingExtensions.AddDistributedGrainDirectory*?displayProperty=nameWithType>; warning `ORLEANSEXP003` |
+| Experimental directory partitions | <xref:Orleans.Configuration.GrainDirectoryOptions.PartitionsPerSilo?displayProperty=nameWithType> defaults to 1 |
 | Membership probe timeout | 5 seconds |
 | Death-vote expiry | 2 minutes |
-| Response timeout | 30 seconds, or 30 minutes while a debugger is attached |
+| <xref:Orleans.Configuration.MessagingOptions.ResponseTimeout?displayProperty=nameWithType> | 30 seconds, or 30 minutes while a debugger is attached |
 | Automatic call retry after response timeout | None |
 
 Configuration values affect failure detection and resource use. This track explains their role in protocols, while the [hosting configuration guide](../host/configuration-guide/index.md) and [deployment guidance](../deployment/index.md) own operational recommendations.

--- a/docs/site/src/content/docs/implementation/index.md
+++ b/docs/site/src/content/docs/implementation/index.md
@@ -1,13 +1,13 @@
 ---
 title: Orleans runtime architecture
-description: An advanced guide to the protocols, invariants, and extension points inside the Orleans 10 runtime.
+description: An advanced guide to the protocols, invariants, and extension points inside the Orleans runtime.
 ms.date: 08/02/2026
 ms.topic: overview
 ---
 
 # Orleans runtime architecture
 
-The implementation track explains how Orleans 10 realizes the virtual actor model. It is intended for runtime contributors, provider authors, and operators who need to reason about failure, consistency, scheduling, and extensibility. For application programming guidance, start with the conceptual and task-oriented sections of this documentation instead.
+The implementation track explains how Orleans realizes the virtual actor model. It is intended for runtime contributors, provider authors, and operators who need to reason about failure, consistency, scheduling, and extensibility. For application programming guidance, start with the conceptual and task-oriented sections of this documentation instead.
 
 The pages in this track use Orleans source and tests as the specification. Internal types are named so that readers can follow an operation through the repository, but those types are not public compatibility contracts unless the page explicitly identifies an extension point.
 
@@ -29,9 +29,9 @@ The pages in this track use Orleans source and tests as the specification. Inter
 - [Provider authoring](provider-authoring.md) describes named providers, configuration binding, lifecycle participation, and validation.
 - [TestingHost architecture](testing.md) explains the in-process cluster harness and its substitutions for production services.
 
-## Orleans 10 defaults that shape the architecture
+## Defaults that shape the architecture
 
-| Concern | Orleans 10 default |
+| Concern | Default |
 | --- | --- |
 | Placement | <xref:Orleans.Runtime.ResourceOptimizedPlacement> |
 | Grain directory | `LocalGrainDirectory`, using the membership ring |

--- a/docs/site/src/content/docs/implementation/index.md
+++ b/docs/site/src/content/docs/implementation/index.md
@@ -1,36 +1,45 @@
 ---
-title: Implementation details
-description: Explore the various implementation details in .NET Orleans.
-ms.date: 05/23/2025
+title: Orleans runtime architecture
+description: An advanced guide to the protocols, invariants, and extension points inside the Orleans 10 runtime.
+ms.date: 08/02/2026
 ms.topic: overview
 ---
 
-# Implementation details overview
+# Orleans runtime architecture
 
-## [Orleans lifecycle](orleans-lifecycle.md)
+The implementation track explains how Orleans 10 realizes the virtual actor model. It is intended for runtime contributors, provider authors, and operators who need to reason about failure, consistency, scheduling, and extensibility. For application programming guidance, start with the conceptual and task-oriented sections of this documentation instead.
 
-Some Orleans behaviors are sufficiently complex that they need ordered startup and shutdown. To address this, Orleans introduced a general component lifecycle pattern.
+The pages in this track use Orleans source and tests as the specification. Internal types are named so that readers can follow an operation through the repository, but those types are not public compatibility contracts unless the page explicitly identifies an extension point.
 
-## [Messaging delivery guarantees](messaging-delivery-guarantees.md)
+## Runtime core
 
-Orleans messaging delivery guarantees are **at-most-once** by default. Optionally, if you configure retries upon timeout, Orleans provides at-least-once delivery instead.
+- [Runtime architecture](runtime-architecture.md) follows a call through client, messaging, placement, directory, activation, and scheduling components.
+- [Activation lifecycle and migration](activation-lifecycle.md) explains creation, activation, collection, deactivation, and state transfer.
+- [Cluster membership](cluster-management.md) describes the failure detector, membership table, ordered views, and death-vote protocol.
+- [Grain directory](grain-directory.md) distinguishes the default `LocalGrainDirectory` DHT from the experimental distributed directory.
+- [Scheduling and turn execution](scheduler.md) explains `WorkItemGroup`, continuations, interleaving, and single-threaded execution.
+- [Messaging and delivery semantics](messaging-delivery-guarantees.md) traces requests and explains why a timeout has an unknown outcome.
+- [Placement and activation balancing](load-balancing.md) covers the default resource-optimized policy and the opt-in movement protocols.
 
-## [Scheduler](scheduler.md)
+## Runtime services and extensibility
 
-The Orleans Scheduler is a component within the Orleans runtime responsible for executing application code and parts of the runtime code to ensure single-threaded execution semantics.
+- [Lifecycle implementation](orleans-lifecycle.md) describes ordered startup and shutdown.
+- [Serialization and code generation](serialization.md) covers generated codecs, proxies, manifests, wire identity, and custom components.
+- [Persistent streams](streams-implementation/index.md) explains pulling agents, queue ownership, caches, cursors, pub-sub, and recovery.
+- [Provider authoring](provider-authoring.md) describes named providers, configuration binding, lifecycle participation, and validation.
+- [TestingHost architecture](testing.md) explains the in-process cluster harness and its substitutions for production services.
 
-## [Cluster management](cluster-management.md)
+## Orleans 10 defaults that shape the architecture
 
-Orleans provides cluster management via a built-in membership protocol, sometimes referred to as Silo Membership. The goal of this protocol is for all silos (Orleans servers) to agree on the set of currently alive silos, detect failed silos, and allow new silos to join the cluster.
+| Concern | Orleans 10 default |
+| --- | --- |
+| Placement | <xref:Orleans.Runtime.ResourceOptimizedPlacement> |
+| Grain directory | `LocalGrainDirectory`, using the membership ring |
+| Experimental directory | Opt-in with `AddDistributedGrainDirectory`; warning `ORLEANSEXP003` |
+| Experimental directory partitions | `GrainDirectoryOptions.PartitionsPerSilo = 1` |
+| Membership probe timeout | 5 seconds |
+| Death-vote expiry | 2 minutes |
+| Response timeout | 30 seconds, or 30 minutes while a debugger is attached |
+| Automatic call retry after response timeout | None |
 
-## [Streams implementation](streams-implementation/index.md)
-
-This section provides a high-level overview of the Orleans Stream implementation. It describes concepts and details not visible at the application level.
-
-## [Load balancing](load-balancing.md)
-
-Load balancing, in a broad sense, is one of the pillars of the Orleans runtime.
-
-## [Unit testing](testing.md)
-
-This section shows how to unit test your grains to ensure they behave correctly.
+Configuration values affect failure detection and resource use. This track explains their role in protocols, while the [hosting configuration guide](../host/configuration-guide/index.md) and [deployment guidance](../deployment/index.md) own operational recommendations.

--- a/docs/site/src/content/docs/implementation/load-balancing.md
+++ b/docs/site/src/content/docs/implementation/load-balancing.md
@@ -13,7 +13,7 @@ The default placement strategy is <xref:Orleans.Runtime.ResourceOptimizedPlaceme
 
 ## Resource-optimized placement
 
-`ResourceOptimizedPlacementDirector` receives cluster-wide `SiloRuntimeStatistics` from `DeploymentLoadPublisher`. It excludes incompatible and overloaded silos, samples approximately the square root of the available candidates, normalizes their signals, adds jitter to avoid deterministic herding, and selects the lowest utilization score.
+`ResourceOptimizedPlacementDirector` receives cluster-wide `SiloRuntimeStatistics` from `DeploymentLoadPublisher`. It excludes incompatible and overloaded silos, applies a [power-of-multiple-choices load-balancing strategy](https://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf) by sampling approximately the square root of the available candidates, normalizes their signals, adds jitter to avoid deterministic herding, and selects the lowest utilization score.
 
 ```mermaid
 flowchart LR

--- a/docs/site/src/content/docs/implementation/load-balancing.md
+++ b/docs/site/src/content/docs/implementation/load-balancing.md
@@ -1,6 +1,6 @@
 ---
 title: Placement and activation balancing
-description: Understand Orleans 10 resource-optimized placement, load signals, activation rebalancing, and repartitioning.
+description: Understand Orleans resource-optimized placement, load signals, activation rebalancing, and repartitioning.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -9,7 +9,7 @@ ms.topic: concept-article
 
 Placement chooses a silo when Orleans needs a new activation. Balancing can later move existing activations. Those are separate decisions with different information and costs.
 
-The Orleans 10 default placement strategy is <xref:Orleans.Runtime.ResourceOptimizedPlacement>, not random placement.
+The default placement strategy is <xref:Orleans.Runtime.ResourceOptimizedPlacement>, not random placement.
 
 ## Resource-optimized placement
 

--- a/docs/site/src/content/docs/implementation/load-balancing.md
+++ b/docs/site/src/content/docs/implementation/load-balancing.md
@@ -1,20 +1,102 @@
 ---
-title: Load balancing
-description: Learn how .NET Orleans manages load balancing.
-ms.date: 05/23/2025
+title: Placement and activation balancing
+description: Understand Orleans 10 resource-optimized placement, load signals, activation rebalancing, and repartitioning.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
-# Load balancing
+# Placement and activation balancing
 
-Load balancing, in a broad sense, is one of the pillars of the Orleans runtime. The Orleans runtime tries to keep everything balanced, as balancing maximizes resource usage, avoids hotspots, leads to better performance, and helps with elasticity. Load balancing in Orleans applies in multiple places. Below is a non-exhaustive list of where the runtime performs balancing:
+Placement chooses a silo when Orleans needs a new activation. Balancing can later move existing activations. Those are separate decisions with different information and costs.
 
-1. The default actor placement strategy is random; new activations are placed randomly across silos. This results in balanced placement and prevents hotspots for most scenarios.
-1. A more advanced <xref:Orleans.Runtime.ActivationCountBasedPlacement> strategy tries to equalize the number of activations on all silos, resulting in a more even distribution across silos. This is especially important for elasticity.
-1. The grain directory service builds on top of a distributed hash table, which is inherently balanced. The directory service maps grains to activations. Each silo owns part of the global mapping table, and this table is globally partitioned in a balanced way across all silos using consistent hashing with virtual buckets.
-1. Clients connect to all gateways and spread their requests across them in a balanced way.
-1. The reminder service is a distributed, partitioned runtime service. The assignment of which silo is responsible for serving which reminder is balanced across all silos via consistent hashing, just like the grain directory.
-1. Performance-critical components within a silo are partitioned, and the work across them is locally balanced. This allows the silo runtime to fully utilize all available CPU cores and avoid in-silo bottlenecks. This applies to all local resources: allocation of work to threads, sockets, dispatch responsibilities, queues, etc.
-1. The <xref:Orleans.Streams.QueueBalancerBase> balances the responsibility of pulling events from persistence queues across silos in the cluster.
+The Orleans 10 default placement strategy is <xref:Orleans.Runtime.ResourceOptimizedPlacement>, not random placement.
 
-Balancing doesn't necessarily mean loss of locality. You can achieve balance while still maintaining good locality. For example, when balancing involves sharding/partitioning, you can partition responsibility for a certain logical task while maintaining locality within each partition. This applies to both local and distributed balancing.
+## Resource-optimized placement
+
+`ResourceOptimizedPlacementDirector` receives cluster-wide `SiloRuntimeStatistics` from `DeploymentLoadPublisher`. It excludes incompatible and overloaded silos, samples approximately the square root of the available candidates, normalizes their signals, adds jitter to avoid deterministic herding, and selects the lowest utilization score.
+
+```mermaid
+flowchart LR
+    Stats[SiloRuntimeStatistics]
+    Publisher[DeploymentLoadPublisher]
+    Director[ResourceOptimizedPlacementDirector]
+    Candidates[Compatible, non-overloaded silos]
+    Score[Weighted normalized score]
+    Target[Selected silo]
+
+    Stats --> Publisher
+    Publisher --> Director
+    Candidates --> Director
+    Director --> Score
+    Score --> Target
+```
+
+The default relative weights are:
+
+| Signal | Weight |
+| --- | ---: |
+| CPU usage | 40 |
+| Memory usage | 20 |
+| Available memory | 20 |
+| Maximum available memory | 5 |
+| Activation count | 15 |
+
+`LocalSiloPreferenceMargin` defaults to 5. If the local silo's score is within that margin of the best candidate, placement can preserve locality. If statistics are not yet available, the director falls back to a random compatible silo.
+
+Source: [`ResourceOptimizedPlacementDirector`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/ResourceOptimizedPlacementDirector.cs), [`ResourceOptimizedPlacementOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Configuration/Options/ResourceOptimizedPlacementOptions.cs), and the default registration in [`DefaultSiloServices`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs#L218-L241).
+
+## Placement resolution and extension
+
+`PlacementStrategyResolver` selects a grain-specific strategy when one is declared; otherwise it uses the default. `PlacementService` applies placement filters before calling the strategy's keyed <xref:Orleans.Runtime.IPlacementDirector>.
+
+A custom strategy consists of:
+
+1. a `PlacementStrategy` value associated with the grain type;
+1. an `IPlacementDirector` which chooses from compatible silos; and
+1. registration through `AddPlacementDirector<TStrategy, TDirector>()`.
+
+Placement filters are orthogonal constraints. They can remove candidates based on metadata or another policy before the director scores them. A director should use the candidates supplied by the placement context instead of reconstructing cluster membership.
+
+Source: [`PlacementService`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/PlacementService.cs), [`PlacementStrategyResolver`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/PlacementStrategyResolver.cs), and [`PlacementStrategyExtensions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/PlacementStrategyExtensions.cs).
+
+## Why initial placement is not enough
+
+Resource-optimized placement only affects new activations. Long-lived activations can become unbalanced after:
+
+- a silo joins or leaves;
+- traffic changes while the activation remains alive;
+- activation memory use diverges;
+- a placement constraint changes the candidate set; or
+- communicating grains are spread across silos.
+
+Moving an activation has a cost: dehydrate and rehydrate work, directory updates, cold caches, and a temporary interruption. Orleans therefore exposes opt-in protocols rather than continuously moving every activation.
+
+## Experimental activation rebalancer
+
+`AddActivationRebalancer()` enables the resource rebalancer and produces compiler warning **`ORLEANSEXP002`**. A worker observes cluster statistics in sessions, estimates imbalance using entropy, and asks source silos to migrate random activations toward underloaded silos. A monitor can wake or relocate the worker after failure.
+
+The protocol optimizes distribution of activation count and memory use. It does not inspect the communication graph, so a more balanced cluster can still have cross-silo hot paths.
+
+Source: [`ActivationRebalancerWorker`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/Rebalancing/ActivationRebalancerWorker.cs) and [`ActivationRebalancerOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Configuration/Options/ActivationRebalancerOptions.cs).
+
+## Experimental activation repartitioner
+
+`AddActivationRepartitioner()` enables communication-aware repartitioning and produces compiler warning **`ORLEANSEXP001`**. The repartitioner samples fully addressed request messages and constructs a weighted graph:
+
+- vertices represent migratable activations;
+- edge weights represent observed calls;
+- anchored or non-migratable grains constrain possible moves.
+
+Periodically, peer repartitioners exchange graph information and negotiate activation moves which improve locality while respecting an imbalance-tolerance rule. The default `RebalancerCompatibleRule` can incorporate the resource rebalancer's cluster-imbalance report.
+
+Source: [`ActivationRepartitioner`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs), [`RepartitionerMessageFilter`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/Repartitioning/RepartitionerMessageFilter.cs), and [`ActivationRepartitionerOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Configuration/Options/ActivationRepartitionerOptions.cs).
+
+## Choosing the mechanism
+
+| Mechanism | When it acts | Primary signal | Movement |
+| --- | --- | --- | --- |
+| Resource-optimized placement | Activation creation | CPU, memory, capacity, activation count | None |
+| Activation rebalancer | Opt-in balancing sessions | Cluster resource imbalance | Random eligible activations |
+| Activation repartitioner | Opt-in exchange rounds | Grain call graph and tolerance rule | Communication-aware activations |
+
+The experimental protocols use [activation migration](activation-lifecycle.md). Neither replaces capacity planning, admission control, or deployment health monitoring. Operational guidance belongs in the [deployment section](../deployment/index.md).

--- a/docs/site/src/content/docs/implementation/load-balancing.md
+++ b/docs/site/src/content/docs/implementation/load-balancing.md
@@ -13,7 +13,7 @@ The default placement strategy is <xref:Orleans.Runtime.ResourceOptimizedPlaceme
 
 ## Resource-optimized placement
 
-`ResourceOptimizedPlacementDirector` receives cluster-wide `SiloRuntimeStatistics` from `DeploymentLoadPublisher`. It excludes incompatible and overloaded silos, applies a [power-of-multiple-choices load-balancing strategy](https://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf) by sampling approximately the square root of the available candidates, normalizes their signals, adds jitter to avoid deterministic herding, and selects the lowest utilization score.
+`ResourceOptimizedPlacementDirector` receives cluster-wide <xref:Orleans.Runtime.SiloRuntimeStatistics> from `DeploymentLoadPublisher`. It excludes incompatible and overloaded silos, applies a [power-of-multiple-choices load-balancing strategy](https://www.eecs.harvard.edu/~michaelm/postscripts/handbook2001.pdf) by sampling approximately the square root of the available candidates, normalizes their signals, adds jitter to avoid deterministic herding, and selects the lowest utilization score.
 
 ```mermaid
 flowchart LR
@@ -35,29 +35,29 @@ The default relative weights are:
 
 | Signal | Weight |
 | --- | ---: |
-| CPU usage | 40 |
-| Memory usage | 20 |
-| Available memory | 20 |
-| Maximum available memory | 5 |
-| Activation count | 15 |
+| <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions.CpuUsageWeight?displayProperty=nameWithType> | 40 |
+| <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions.MemoryUsageWeight?displayProperty=nameWithType> | 20 |
+| <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions.AvailableMemoryWeight?displayProperty=nameWithType> | 20 |
+| <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions.MaxAvailableMemoryWeight?displayProperty=nameWithType> | 5 |
+| <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions.ActivationCountWeight?displayProperty=nameWithType> | 15 |
 
-`LocalSiloPreferenceMargin` defaults to 5. If the local silo's score is within that margin of the best candidate, placement can preserve locality. If statistics are not yet available, the director falls back to a random compatible silo.
+<xref:Orleans.Configuration.ResourceOptimizedPlacementOptions.LocalSiloPreferenceMargin?displayProperty=nameWithType> defaults to 5. If the local silo's score is within that margin of the best candidate, placement can preserve locality. If statistics are not yet available, the director falls back to a random compatible silo.
 
-Source: [`ResourceOptimizedPlacementDirector`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/ResourceOptimizedPlacementDirector.cs), [`ResourceOptimizedPlacementOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Configuration/Options/ResourceOptimizedPlacementOptions.cs), and the default registration in [`DefaultSiloServices`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs#L218-L241).
+Public options: <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions>. Implementation: [`ResourceOptimizedPlacementDirector`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/ResourceOptimizedPlacementDirector.cs) and the default registration in [`DefaultSiloServices`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs).
 
 ## Placement resolution and extension
 
-`PlacementStrategyResolver` selects a grain-specific strategy when one is declared; otherwise it uses the default. `PlacementService` applies placement filters before calling the strategy's keyed <xref:Orleans.Runtime.IPlacementDirector>.
+<xref:Orleans.Runtime.Placement.PlacementStrategyResolver> selects a grain-specific strategy when one is declared; otherwise it uses the default. `PlacementService` applies placement filters before calling the strategy's keyed <xref:Orleans.Runtime.Placement.IPlacementDirector>.
 
 A custom strategy consists of:
 
-1. a `PlacementStrategy` value associated with the grain type;
-1. an `IPlacementDirector` which chooses from compatible silos; and
-1. registration through `AddPlacementDirector<TStrategy, TDirector>()`.
+1. an <xref:Orleans.Runtime.PlacementStrategy> value associated with the grain type;
+1. an <xref:Orleans.Runtime.Placement.IPlacementDirector> which chooses from compatible silos; and
+1. registration through <xref:Orleans.Hosting.PlacementStrategyExtensions.AddPlacementDirector*?displayProperty=nameWithType>.
 
 Placement filters are orthogonal constraints. They can remove candidates based on metadata or another policy before the director scores them. A director should use the candidates supplied by the placement context instead of reconstructing cluster membership.
 
-Source: [`PlacementService`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/PlacementService.cs), [`PlacementStrategyResolver`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/PlacementStrategyResolver.cs), and [`PlacementStrategyExtensions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/PlacementStrategyExtensions.cs).
+API: <xref:Orleans.Runtime.Placement.PlacementStrategyResolver> and <xref:Orleans.Hosting.PlacementStrategyExtensions.AddPlacementDirector*?displayProperty=nameWithType>. Implementation: [`PlacementService`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/PlacementService.cs), [strategy resolution](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/PlacementStrategyResolver.cs), and [registration extensions](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/PlacementStrategyExtensions.cs).
 
 ## Why initial placement is not enough
 
@@ -73,15 +73,15 @@ Moving an activation has a cost: dehydrate and rehydrate work, directory updates
 
 ## Experimental activation rebalancer
 
-`AddActivationRebalancer()` enables the resource rebalancer and produces compiler warning **`ORLEANSEXP002`**. A worker observes cluster statistics in sessions, estimates imbalance using entropy, and asks source silos to migrate random activations toward underloaded silos. A monitor can wake or relocate the worker after failure.
+<xref:Orleans.Hosting.ActivationRebalancerExtensions.AddActivationRebalancer*?displayProperty=nameWithType> enables the resource rebalancer and produces compiler warning **`ORLEANSEXP002`**. A worker observes cluster statistics in sessions, estimates imbalance using entropy, and asks source silos to migrate random activations toward underloaded silos. A monitor can wake or relocate the worker after failure.
 
 The protocol optimizes distribution of activation count and memory use. It does not inspect the communication graph, so a more balanced cluster can still have cross-silo hot paths.
 
-Source: [`ActivationRebalancerWorker`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/Rebalancing/ActivationRebalancerWorker.cs) and [`ActivationRebalancerOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Configuration/Options/ActivationRebalancerOptions.cs).
+Public options: <xref:Orleans.Configuration.ActivationRebalancerOptions>. Implementation: [`ActivationRebalancerWorker`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/Rebalancing/ActivationRebalancerWorker.cs).
 
 ## Experimental activation repartitioner
 
-`AddActivationRepartitioner()` enables communication-aware repartitioning and produces compiler warning **`ORLEANSEXP001`**. The repartitioner samples fully addressed request messages and constructs a weighted graph:
+<xref:Orleans.Hosting.ActivationRepartitioningExtensions.AddActivationRepartitioner*?displayProperty=nameWithType> enables communication-aware repartitioning and produces compiler warning **`ORLEANSEXP001`**. The repartitioner samples fully addressed request messages and constructs a weighted graph:
 
 - vertices represent migratable activations;
 - edge weights represent observed calls;
@@ -89,7 +89,7 @@ Source: [`ActivationRebalancerWorker`](https://github.com/dotnet/orleans/blob/ma
 
 Periodically, peer repartitioners exchange graph information and negotiate activation moves which improve locality while respecting an imbalance-tolerance rule. The default `RebalancerCompatibleRule` can incorporate the resource rebalancer's cluster-imbalance report.
 
-Source: [`ActivationRepartitioner`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs), [`RepartitionerMessageFilter`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/Repartitioning/RepartitionerMessageFilter.cs), and [`ActivationRepartitionerOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Configuration/Options/ActivationRepartitionerOptions.cs).
+Public options: <xref:Orleans.Configuration.ActivationRepartitionerOptions>. Implementation: [`ActivationRepartitioner`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/Repartitioning/ActivationRepartitioner.cs) and [`RepartitionerMessageFilter`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/Repartitioning/RepartitionerMessageFilter.cs).
 
 ## Choosing the mechanism
 

--- a/docs/site/src/content/docs/implementation/messaging-delivery-guarantees.md
+++ b/docs/site/src/content/docs/implementation/messaging-delivery-guarantees.md
@@ -1,6 +1,6 @@
 ---
 title: Messaging pipeline and delivery semantics
-description: Trace Orleans 10 requests and understand routing, forwarding, response timeouts, retries, and unknown outcomes.
+description: Trace Orleans requests and understand routing, forwarding, response timeouts, retries, and unknown outcomes.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -39,7 +39,7 @@ Source: [`GrainReferenceRuntime`](https://github.com/dotnet/orleans/blob/main/sr
 
 A message can encounter a stale activation address because an activation deactivated, moved, or its silo failed. The runtime can reject, invalidate, forward, or reroute that same logical request while locating the current activation. Forwarding is bounded by silo messaging options.
 
-This internal address repair must not be confused with retrying an application call after its response timeout. Orleans 10 does **not** automatically resubmit a call because the caller's response timer elapsed.
+This internal address repair must not be confused with retrying an application call after its response timeout. Orleans does **not** automatically resubmit a call because the caller's response timer elapsed.
 
 Transport code can also retry a failed socket send. That repairs a transport attempt using the same message identity; it is not a new application invocation policy.
 

--- a/docs/site/src/content/docs/implementation/messaging-delivery-guarantees.md
+++ b/docs/site/src/content/docs/implementation/messaging-delivery-guarantees.md
@@ -1,27 +1,91 @@
 ---
-title: Messaging delivery guarantees
-description: Learn about messaging delivery guarantees in .NET Orleans.
-ms.date: 05/23/2025
+title: Messaging pipeline and delivery semantics
+description: Trace Orleans 10 requests and understand routing, forwarding, response timeouts, retries, and unknown outcomes.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
-# Messaging delivery guarantees
+# Messaging pipeline and delivery semantics
 
-Orleans messaging delivery guarantees are **at-most-once** by default. Optionally, if you configure retries upon timeout, Orleans provides at-least-once delivery instead.
+An Orleans call is an asynchronous request-response exchange. Generated code, routing, the grain directory, activation scheduling, and callbacks all participate. The API resembles a local method call, but failures retain distributed-system ambiguity.
 
-In more detail:
+## Request and response pipeline
 
-- Every message in Orleans has an automatic timeout (you can configure the exact timeout). If the reply doesn't arrive on time, the returned <xref:System.Threading.Tasks.Task> breaks with a timeout exception.
-- You can configure Orleans to perform automatic retries upon timeout. By default, it _does not_ perform automatic retries.
-- Your application code can also choose to implement retries upon timeout.
+```mermaid
+sequenceDiagram
+    participant App as Caller
+    participant Proxy as Generated proxy
+    participant Out as Runtime client
+    participant Net as MessageCenter
+    participant Act as Target activation
 
-If the Orleans system is configured not to perform automatic retries (the default setting) and your application doesn't resend messages, **Orleans provides at-most-once message delivery**. A message is either delivered once or not at all. **It's never delivered twice.**
+    App->>Proxy: Invoke method
+    Proxy->>Out: Generated invokable
+    Out->>Out: Outgoing filters and callback
+    Out->>Net: Address and send request
+    Net->>Net: Resolve, route, or forward
+    Net->>Act: Queue request
+    Act->>Act: Incoming filters and grain turn
+    Act-->>Net: Response or rejection
+    Net-->>Out: Correlate callback
+    Out-->>App: Complete Task
+```
 
-In a system with retries (either by the runtime or by the application), the message might arrive multiple times. Orleans currently doesn't durably store which messages have already arrived or suppress subsequent deliveries. (We believe this would be quite costly.) So, in a system with retries, Orleans does NOT guarantee at-most-once delivery.
+The source generator emits a proxy and an invokable request type. `GrainReferenceRuntime` runs outgoing call filters and submits the request through `IRuntimeClient`. `MessageFactory` creates the message and correlation identity. `MessageCenter` resolves the activation address and selects a local dispatch, silo connection, or client gateway. On the target, `InsideRuntimeClient` runs incoming filters and invokes the generated method dispatcher.
 
-**If you keep retrying potentially indefinitely**, **the message eventually arrives**, thus providing the at-least-once delivery guarantee. Note that "eventually arrives" is something the runtime needs to guarantee. It doesn't happen automatically just because you keep retrying. Orleans provides eventual delivery because grains never enter a permanent failure state, and a failed grain eventually reactivates on another silo.
+Source: [`GrainReferenceRuntime`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs), [`MessageFactory`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Messaging/MessageFactory.cs), [`MessageCenter`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Messaging/MessageCenter.cs), and [`InsideRuntimeClient`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Core/InsideRuntimeClient.cs).
 
-**To summarize**: In a system without retries, Orleans guarantees at-most-once message delivery. In a system with infinite retries, Orleans guarantees at-least-once (and _does not_ guarantee at-most-once).
+## Routing repair is not call retry
 
-> [!IMPORTANT]
-> The [Orleans technical report](https://research.microsoft.com/pubs/210931/Orleans-MSR-TR-2014-41.pdf) accidentally only mentioned the second option with automatic retries. It failed to mention that by default, with no retries, Orleans provides at-most-once delivery.
+A message can encounter a stale activation address because an activation deactivated, moved, or its silo failed. The runtime can reject, invalidate, forward, or reroute that same logical request while locating the current activation. Forwarding is bounded by silo messaging options.
+
+This internal address repair must not be confused with retrying an application call after its response timeout. Orleans 10 does **not** automatically resubmit a call because the caller's response timer elapsed.
+
+Transport code can also retry a failed socket send. That repairs a transport attempt using the same message identity; it is not a new application invocation policy.
+
+## Response timeout means unknown outcome
+
+`MessagingOptions.ResponseTimeout` defaults to 30 seconds, or 30 minutes when a debugger is attached. `CallbackData` completes the caller with <xref:System.TimeoutException> when no response reaches the callback in time.
+
+At that point, any of these can be true:
+
+- the request never reached the target;
+- the request is queued but has not started;
+- the grain method is still running;
+- the grain method completed and its response was lost or delayed; or
+- a response will arrive after the callback has already been removed.
+
+The timeout therefore reports an **unknown outcome**, not a failed execution. By default, `CancelRequestOnTimeout` is `false`. Enabling cancellation requests cooperative cancellation; it still cannot prove that no side effect occurred.
+
+Source: [`MessagingOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Configuration/Options/MessagingOptions.cs), [`CallbackData`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Runtime/CallbackData.cs), and [`TimeoutTests`](https://github.com/dotnet/orleans/blob/main/test/Orleans.Runtime.Internal.Tests/TimeoutTests.cs).
+
+## Delivery model
+
+Without an application retry, Orleans submits one logical request and does not intentionally invoke it again after a response timeout. This is commonly described as **at-most-once delivery**. It is not a durable exactly-once transaction:
+
+- a caller cannot distinguish non-delivery from completed execution after a timeout;
+- a process crash can erase volatile duplicate-tracking and callback state;
+- side effects can commit even when the response is not observed; and
+- one-way messages provide no completion result.
+
+If application code retries a timed-out call, both attempts can execute. Orleans does not durably deduplicate arbitrary requests. Retried operations should be naturally idempotent or carry an application operation identifier recorded atomically with the side effect.
+
+Repeated retry can approximate at-least-once delivery only while the cluster and target eventually recover. It does not imply exactly once, ordering across retries, or bounded completion time.
+
+## Rejections and expiration
+
+The runtime can return a rejection when it knows that it cannot process a request, for example because of invalid routing or overload. A rejection is stronger evidence than a timeout, but application code must still interpret the rejection type.
+
+Messages have expiration metadata derived from the response timeout. With `DropExpiredMessages = true` (the default), an expired request or response can be dropped instead of consuming work which can no longer complete the original callback.
+
+## Designing callers
+
+Choose semantics at the application boundary:
+
+- use idempotent commands for safe retry;
+- include operation IDs when duplicate side effects are unacceptable;
+- query durable state after an unknown outcome when possible;
+- use transactions or storage compare-and-swap for business invariants; and
+- do not use a longer timeout as a substitute for overload handling.
+
+Operational timeout and connection tuning belongs in the [hosting configuration guide](../host/configuration-guide/index.md).

--- a/docs/site/src/content/docs/implementation/messaging-delivery-guarantees.md
+++ b/docs/site/src/content/docs/implementation/messaging-delivery-guarantees.md
@@ -45,7 +45,7 @@ Transport code can also retry a failed socket send. That repairs a transport att
 
 ## Response timeout means unknown outcome
 
-`MessagingOptions.ResponseTimeout` defaults to 30 seconds, or 30 minutes when a debugger is attached. `CallbackData` completes the caller with <xref:System.TimeoutException> when no response reaches the callback in time.
+<xref:Orleans.Configuration.MessagingOptions.ResponseTimeout?displayProperty=nameWithType> defaults to 30 seconds, or 30 minutes when a debugger is attached. `CallbackData` completes the caller with <xref:System.TimeoutException> when no response reaches the callback in time.
 
 At that point, any of these can be true:
 
@@ -55,9 +55,9 @@ At that point, any of these can be true:
 - the grain method completed and its response was lost or delayed; or
 - a response will arrive after the callback has already been removed.
 
-The timeout therefore reports an **unknown outcome**, not a failed execution. By default, `CancelRequestOnTimeout` is `false`. Enabling cancellation requests cooperative cancellation; it still cannot prove that no side effect occurred.
+The timeout therefore reports an **unknown outcome**, not a failed execution. By default, <xref:Orleans.Configuration.MessagingOptions.CancelRequestOnTimeout?displayProperty=nameWithType> is `false`. Enabling cancellation requests cooperative cancellation; it still cannot prove that no side effect occurred.
 
-Source: [`MessagingOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Configuration/Options/MessagingOptions.cs), [`CallbackData`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Runtime/CallbackData.cs), and [`TimeoutTests`](https://github.com/dotnet/orleans/blob/main/test/Orleans.Runtime.Internal.Tests/TimeoutTests.cs).
+API: <xref:Orleans.Configuration.MessagingOptions>. Implementation: [messaging options](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Configuration/Options/MessagingOptions.cs), [`CallbackData`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Runtime/CallbackData.cs), and [`TimeoutTests`](https://github.com/dotnet/orleans/blob/main/test/Orleans.Runtime.Internal.Tests/TimeoutTests.cs).
 
 ## Delivery model
 
@@ -76,7 +76,7 @@ Repeated retry can approximate at-least-once delivery only while the cluster and
 
 The runtime can return a rejection when it knows that it cannot process a request, for example because of invalid routing or overload. A rejection is stronger evidence than a timeout, but application code must still interpret the rejection type.
 
-Messages have expiration metadata derived from the response timeout. With `DropExpiredMessages = true` (the default), an expired request or response can be dropped instead of consuming work which can no longer complete the original callback.
+Messages have expiration metadata derived from the response timeout. With <xref:Orleans.Configuration.MessagingOptions.DropExpiredMessages?displayProperty=nameWithType> set to `true` (the default), an expired request or response can be dropped instead of consuming work which can no longer complete the original callback.
 
 ## Designing callers
 

--- a/docs/site/src/content/docs/implementation/orleans-lifecycle.md
+++ b/docs/site/src/content/docs/implementation/orleans-lifecycle.md
@@ -9,11 +9,13 @@ ms.topic: concept-article
 
 Orleans composes many independently registered services into one silo or client. Some services must start only after a dependency is ready and stop before that dependency disappears. The lifecycle abstraction gives those components an ordered protocol without placing every dependency in a central start method.
 
-## Observable and observers
+## Observable and observers <a name="observable-lifecycle"></a>
+
+<a name="lifecycle-observer"></a>
 
 <xref:Orleans.ILifecycleObservable> accepts subscriptions at integer stages. During startup it visits stages in ascending order; during shutdown it visits them in descending order. Every observer at a stage completes before the lifecycle advances.
 
-<xref:Orleans.ILifecycleObserver> provides asynchronous `OnStart` and `OnStop` callbacks. <xref:Orleans.ILifecycleParticipant`1> is the discovery contract used by dependency injection: a participant receives the lifecycle and subscribes itself.
+<xref:Orleans.ILifecycleObserver> provides asynchronous <xref:Orleans.ILifecycleObserver.OnStart*> and <xref:Orleans.ILifecycleObserver.OnStop*> callbacks. <xref:Orleans.ILifecycleParticipant`1> is the discovery contract used by dependency injection: a participant receives the lifecycle and subscribes itself.
 
 ```mermaid
 sequenceDiagram
@@ -40,20 +42,20 @@ The reverse shutdown order is the key invariant. A service can continue using de
 
 ## Silo and client lifecycles
 
-`SiloLifecycleSubject` drives silo startup and shutdown. Membership, messaging, grain directory, activation collection, statistics, providers, and other runtime components participate at named `ServiceLifecycleStage` values.
+<xref:Orleans.Runtime.SiloLifecycleSubject> drives silo startup and shutdown. Membership, messaging, grain directory, activation collection, statistics, providers, and other runtime components participate at named <xref:Orleans.ServiceLifecycleStage> values.
 
-The client uses the same pattern for gateway discovery, connections, stream providers, and the outside runtime client. The generic `ILifecycleObservable` also lets providers compose a private lifecycle when the silo-specific interface is unnecessary.
+The client uses the same pattern for gateway discovery, connections, stream providers, and the outside runtime client. The generic <xref:Orleans.ILifecycleObservable> also lets providers compose a private lifecycle when the silo-specific interface is unnecessary.
 
 The host-facing stage list and configuration examples are documented in [silo lifecycle](../host/silo-lifecycle.md). This page focuses on the protocol rather than where application startup code should be registered.
 
-## Subscription rules
+## Subscription rules <a name="lifecycle-participation"></a>
 
 A lifecycle participant should:
 
 - subscribe during composition, before lifecycle start;
 - use a stable observer name for diagnostics;
 - select the latest stage whose prerequisites are guaranteed;
-- make `OnStop` safe after partial `OnStart`;
+- make <xref:Orleans.ILifecycleObserver.OnStop*> safe after a partial <xref:Orleans.ILifecycleObserver.OnStart*>;
 - honor the supplied cancellation token; and
 - release dependencies before their lower stage stops.
 
@@ -67,7 +69,7 @@ Cancellation bounds lifecycle observation; it cannot guarantee instantaneous cle
 
 ## Source
 
-- [`LifecycleSubject`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Lifecycle/LifecycleSubject.cs) implements stage traversal.
-- [`SiloLifecycleSubject`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Lifecycle/SiloLifecycleSubject.cs) is the silo lifecycle.
+- <xref:Orleans.LifecycleSubject> implements stage traversal; see its [implementation](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Lifecycle/LifecycleSubject.cs).
+- <xref:Orleans.Runtime.SiloLifecycleSubject> is the silo lifecycle; see its [implementation](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Lifecycle/SiloLifecycleSubject.cs).
 - [`DefaultSiloServices`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs) shows participant registration.
-- [`PersistentStreamProvider`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs#L218-L235) is a named-provider example with separate initialize and active stages.
+- <xref:Orleans.Providers.Streams.Common.PersistentStreamProvider> is a named-provider example with separate initialize and active stages; see its [lifecycle participation implementation](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs).

--- a/docs/site/src/content/docs/implementation/orleans-lifecycle.md
+++ b/docs/site/src/content/docs/implementation/orleans-lifecycle.md
@@ -1,149 +1,73 @@
 ---
-title: Orleans lifecycle
-description: Learn the various lifecycles of .NET Orleans apps.
-ms.date: 03/30/2025
+title: Lifecycle implementation
+description: Understand ordered startup and shutdown for Orleans runtime components.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
-# Orleans lifecycle overview
+# Lifecycle implementation
 
-Some Orleans behaviors are sufficiently complex that they require ordered startup and shutdown. Components with such behaviors include grains, silos, and clients. To address this, Orleans introduced a general component lifecycle pattern. This pattern consists of an observable lifecycle, responsible for signaling stages of a component's startup and shutdown, and lifecycle observers, responsible for performing startup or shutdown operations at specific stages.
+Orleans composes many independently registered services into one silo or client. Some services must start only after a dependency is ready and stop before that dependency disappears. The lifecycle abstraction gives those components an ordered protocol without placing every dependency in a central start method.
 
-For more information, see [Grain lifecycle](../grains/grain-lifecycle.md) and [Silo lifecycle](../host/silo-lifecycle.md).
+## Observable and observers
 
-## Observable lifecycle
+<xref:Orleans.ILifecycleObservable> accepts subscriptions at integer stages. During startup it visits stages in ascending order; during shutdown it visits them in descending order. Every observer at a stage completes before the lifecycle advances.
 
-Components needing ordered startup and shutdown can use an observable lifecycle. This allows other components to observe the lifecycle and receive notifications when a specific stage is reached during startup or shutdown.
+<xref:Orleans.ILifecycleObserver> provides asynchronous `OnStart` and `OnStop` callbacks. <xref:Orleans.ILifecycleParticipant`1> is the discovery contract used by dependency injection: a participant receives the lifecycle and subscribes itself.
 
-```csharp
-public interface ILifecycleObservable
-{
-    IDisposable Subscribe(
-        string observerName,
-        int stage,
-        ILifecycleObserver observer);
-}
+```mermaid
+sequenceDiagram
+    participant Host
+    participant Lifecycle
+    participant Membership
+    participant Runtime
+    participant Application
+
+    Host->>Lifecycle: Start
+    Lifecycle->>Membership: Low stage OnStart
+    Membership-->>Lifecycle: Ready
+    Lifecycle->>Runtime: Runtime stage OnStart
+    Runtime-->>Lifecycle: Ready
+    Lifecycle->>Application: Active stage OnStart
+    Application-->>Lifecycle: Ready
+    Host->>Lifecycle: Stop
+    Lifecycle->>Application: Active stage OnStop
+    Lifecycle->>Runtime: Runtime stage OnStop
+    Lifecycle->>Membership: Low stage OnStop
 ```
 
-The subscribe call registers an observer for notification when a stage is reached during startup or shutdown. The observer's name is used for reporting purposes. The stage indicates at which point in the startup/shutdown sequence the observer receives notification. Each lifecycle stage is observable. All observers are notified when the stage is reached during startup and shutdown. Stages start in ascending order and stop in descending order. The observer can unsubscribe by disposing of the returned disposable object.
+The reverse shutdown order is the key invariant. A service can continue using dependencies which started at earlier stages until its own stop callback completes.
 
-## Lifecycle observer
+## Silo and client lifecycles
 
-Components needing to participate in another component's lifecycle must provide hooks for their startup and shutdown behaviors and subscribe to a specific stage of an observable lifecycle.
+`SiloLifecycleSubject` drives silo startup and shutdown. Membership, messaging, grain directory, activation collection, statistics, providers, and other runtime components participate at named `ServiceLifecycleStage` values.
 
-```csharp
-public interface ILifecycleObserver
-{
-    Task OnStart(CancellationToken ct);
-    Task OnStop(CancellationToken ct);
-}
-```
+The client uses the same pattern for gateway discovery, connections, stream providers, and the outside runtime client. The generic `ILifecycleObservable` also lets providers compose a private lifecycle when the silo-specific interface is unnecessary.
 
-Both <xref:Orleans.ILifecycleObserver.OnStart*?displayProperty=nameWithType> and <xref:Orleans.ILifecycleObserver.OnStop*?displayProperty=nameWithType> are called when the subscribed stage is reached during startup or shutdown.
+The host-facing stage list and configuration examples are documented in [silo lifecycle](../host/silo-lifecycle.md). This page focuses on the protocol rather than where application startup code should be registered.
 
-## Utilities
+## Subscription rules
 
-For convenience, helper functions exist for common lifecycle usage patterns.
+A lifecycle participant should:
 
-### Extensions
+- subscribe during composition, before lifecycle start;
+- use a stable observer name for diagnostics;
+- select the latest stage whose prerequisites are guaranteed;
+- make `OnStop` safe after partial `OnStart`;
+- honor the supplied cancellation token; and
+- release dependencies before their lower stage stops.
 
-Extension functions are available for subscribing to an observable lifecycle that don't require the subscribing component to implement `ILifecycleObserver`. Instead, these allow components to pass in lambdas or member functions to be called at the subscribed stages.
+Avoid creating hidden ordering by resolving and starting another participant manually. Stage dependencies should remain visible in lifecycle subscriptions.
 
-```csharp
-IDisposable Subscribe(
-    this ILifecycleObservable observable,
-    string observerName,
-    int stage,
-    Func<CancellationToken, Task> onStart,
-    Func<CancellationToken, Task> onStop);
+## Failure behavior
 
-IDisposable Subscribe(
-    this ILifecycleObservable observable,
-    string observerName,
-    int stage,
-    Func<CancellationToken, Task> onStart);
-```
+Startup does not skip a failed observer and continue to a success-shaped state. The exception aborts lifecycle progress and the host reports startup failure. Shutdown attempts to unwind initialized stages under its cancellation deadline.
 
-Similar extension functions allow using generic type arguments instead of the observer name.
+Cancellation bounds lifecycle observation; it cannot guarantee instantaneous cleanup of external resources. Provider code should keep shutdown idempotent and should not swallow failures which leave durable ownership ambiguous.
 
-```csharp
-IDisposable Subscribe<TObserver>(
-    this ILifecycleObservable observable,
-    int stage,
-    Func<CancellationToken, Task> onStart,
-    Func<CancellationToken, Task> onStop);
+## Source
 
-IDisposable Subscribe<TObserver>(
-    this ILifecycleObservable observable,
-    int stage,
-    Func<CancellationToken, Task> onStart);
-```
-
-### Lifecycle participation
-
-Some extensibility points need a way to recognize which components are interested in participating in a lifecycle. A lifecycle participant marker interface serves this purpose. More details on its usage are covered when exploring silo and grain lifecycles.
-
-```csharp
-public interface ILifecycleParticipant<TLifecycleObservable>
-    where TLifecycleObservable : ILifecycleObservable
-{
-    void Participate(TLifecycleObservable lifecycle);
-}
-```
-
-## Example
-
-From the Orleans lifecycle tests, below is an example of a component that participates in an observable lifecycle at multiple stages.
-
-```csharp
-enum TestStages
-{
-    Down,
-    Initialize,
-    Configure,
-    Run,
-};
-
-class MultiStageObserver : ILifecycleParticipant<ILifecycleObservable>
-{
-    public Dictionary<TestStages,bool> Started { get; } = new();
-    public Dictionary<TestStages, bool> Stopped { get; } = new();
-
-    private Task OnStartStage(TestStages stage)
-    {
-        Started[stage] = true;
-
-        return Task.CompletedTask;
-    }
-
-    private Task OnStopStage(TestStages stage)
-    {
-        Stopped[stage] = true;
-
-        return Task.CompletedTask;
-    }
-
-    public void Participate(ILifecycleObservable lifecycle)
-    {
-        lifecycle.Subscribe<MultiStageObserver>(
-            (int)TestStages.Down,
-            _ => OnStartStage(TestStages.Down),
-            _ => OnStopStage(TestStages.Down));
-
-        lifecycle.Subscribe<MultiStageObserver>(
-            (int)TestStages.Initialize,
-            _ => OnStartStage(TestStages.Initialize),
-            _ => OnStopStage(TestStages.Initialize));
-
-        lifecycle.Subscribe<MultiStageObserver>(
-            (int)TestStages.Configure,
-            _ => OnStartStage(TestStages.Configure),
-            _ => OnStopStage(TestStages.Configure));
-
-        lifecycle.Subscribe<MultiStageObserver>(
-            (int)TestStages.Run,
-            _ => OnStartStage(TestStages.Run),
-            _ => OnStopStage(TestStages.Run));
-    }
-}
-```
+- [`LifecycleSubject`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Lifecycle/LifecycleSubject.cs) implements stage traversal.
+- [`SiloLifecycleSubject`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Lifecycle/SiloLifecycleSubject.cs) is the silo lifecycle.
+- [`DefaultSiloServices`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs) shows participant registration.
+- [`PersistentStreamProvider`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs#L218-L235) is a named-provider example with separate initialize and active stages.

--- a/docs/site/src/content/docs/implementation/provider-authoring.md
+++ b/docs/site/src/content/docs/implementation/provider-authoring.md
@@ -1,0 +1,105 @@
+---
+title: Provider authoring architecture
+description: Design Orleans 10 providers with named services, configuration binding, validation, lifecycle, and runtime extension contracts.
+ms.date: 08/02/2026
+ms.topic: concept-article
+---
+
+# Provider authoring architecture
+
+An Orleans provider adapts an external system or alternate runtime implementation to a defined contract. Storage, clustering, reminders, grain directories, and persistent streams have different data-plane interfaces, but their hosting architecture follows the same pattern:
+
+1. bind a named configuration section;
+1. register named services and options;
+1. validate configuration during host startup;
+1. participate in lifecycle when resources need initialization; and
+1. surface failures instead of silently degrading to another backend.
+
+## Configuration-driven provider builders
+
+<xref:Orleans.Providers.IProviderBuilder`1> is the bridge from Orleans configuration to a silo or client builder:
+
+```csharp
+public sealed class ExampleProviderBuilder : IProviderBuilder<ISiloBuilder>
+{
+    public void Configure(
+        ISiloBuilder builder,
+        string? name,
+        IConfigurationSection configurationSection)
+    {
+        builder.AddExampleProvider(
+            name ?? throw new ArgumentNullException(nameof(name)),
+            options => options.Bind(configurationSection));
+    }
+}
+```
+
+Provider packages associate a provider type string and category with a builder using assembly metadata. The host selects that builder from configuration, passes the provider name and section, and lets the builder call the same public registration API used by code-first configuration.
+
+The Azure Queue stream implementation is a current example: [`AzureQueueStreamProviderBuilder`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/AzureQueueStreamProviderBuilder.cs) implements builders for both `ISiloBuilder` and `IClientBuilder`.
+
+## Named-service composition
+
+Many provider kinds allow multiple instances. The provider name is therefore part of service identity, options identity, logging identity, and runtime lookup. `NamedServiceConfigurator` and its derived configurators register keyed components and named options without creating a private service provider.
+
+A registration extension should:
+
+- require a non-empty name when the provider category is named;
+- register options through `AddOptions<T>(name)` or an Orleans configurator;
+- register the contract and implementation under the same key;
+- use `TryAdd` only for truly shared defaults; and
+- include the name in validators and diagnostics.
+
+Resolving an unkeyed singleton for a named component can make the first provider's options leak into every other provider.
+
+## Separate control plane and data plane
+
+The provider builder and options are the control plane. The runtime contract is the data plane:
+
+| Provider kind | Data-plane contract |
+| --- | --- |
+| Cluster membership | <xref:Orleans.IMembershipTable> |
+| Grain storage | <xref:Orleans.Storage.IGrainStorage> |
+| Grain directory | <xref:Orleans.GrainDirectory.IGrainDirectory> |
+| Reminder table | <xref:Orleans.Runtime.IReminderTable> |
+| Persistent streams | <xref:Orleans.Streams.IQueueAdapterFactory> and its adapter components |
+
+Do not let configuration concerns weaken the data-plane contract. For example, a membership provider must preserve conditional updates and ordered versions regardless of whether credentials came from a connection string, a keyed SDK client, or managed identity.
+
+## Validation
+
+Options validation should fail before the silo joins the cluster or starts accepting traffic. Orleans providers commonly register an `IConfigurationValidator` so validation can include named options and service dependencies which ordinary data-annotation validation cannot express.
+
+Validate at least:
+
+- required endpoint, client, or credential source;
+- mutually exclusive configuration forms;
+- provider-specific naming and range constraints;
+- compatibility between paired components; and
+- capabilities required by the runtime contract.
+
+Avoid broad exception handling which turns an inaccessible backend into an empty result. An empty membership table, missing grain state, or empty stream queue has domain meaning and must not represent a swallowed infrastructure failure.
+
+## Lifecycle and ownership
+
+Providers which allocate clients, receivers, leases, or background agents should implement or register an <xref:Orleans.ILifecycleParticipant`1>. Initialize after required runtime services are ready and stop before those services disappear.
+
+Ownership must be explicit. If the application supplies a keyed SDK client, the provider generally should not dispose an object it does not own. If the provider creates receivers per queue, it should stop and dispose them when queue ownership moves.
+
+The persistent stream provider illustrates staged lifecycle composition: it creates the adapter during initialization, starts pulling agents at the active stage, then stops agents before closing. See [`PersistentStreamProvider.Participate`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs#L218-L235).
+
+## Testing a provider
+
+Contract tests should cover more than successful round trips:
+
+- concurrent conditional updates and stale version rejection;
+- duplicate registration or delivery behavior;
+- cancellation and timeout propagation;
+- startup validation;
+- backend unavailability without silent fallback;
+- resource cleanup after lifecycle stop;
+- multiple named instances with isolated options; and
+- rolling-upgrade compatibility of stored or transmitted data.
+
+Use [TestingHost architecture](testing.md) to understand which runtime services a test cluster substitutes. Provider tests which depend on a real backend should state those preconditions and should not treat an emulator's weaker consistency as proof of the production contract.
+

--- a/docs/site/src/content/docs/implementation/provider-authoring.md
+++ b/docs/site/src/content/docs/implementation/provider-authoring.md
@@ -7,7 +7,7 @@ ms.topic: concept-article
 
 # Provider authoring architecture
 
-An Orleans provider adapts an external system or alternate runtime implementation to a defined contract. Storage, clustering, reminders, grain directories, and persistent streams have different data-plane interfaces, but their hosting architecture follows the same pattern:
+An Orleans provider adapts an external system or alternate runtime implementation to a defined contract. Storage, clustering, reminders, grain directories, and persistent streams have different data-plane interfaces, but their hosting architecture follows the same pattern, built on the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options) and [dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection/overview):
 
 1. bind a named configuration section;
 1. register named services and options;

--- a/docs/site/src/content/docs/implementation/provider-authoring.md
+++ b/docs/site/src/content/docs/implementation/provider-authoring.md
@@ -19,35 +19,20 @@ An Orleans provider adapts an external system or alternate runtime implementatio
 
 <xref:Orleans.Providers.IProviderBuilder`1> is the bridge from Orleans configuration to a silo or client builder:
 
-```csharp
-public sealed class ExampleProviderBuilder : IProviderBuilder<ISiloBuilder>
-{
-    public void Configure(
-        ISiloBuilder builder,
-        string? name,
-        IConfigurationSection configurationSection)
-    {
-        builder.AddExampleProvider(
-            name ?? throw new ArgumentNullException(nameof(name)),
-            options => options.Bind(configurationSection));
-    }
-}
-```
-
 Provider packages associate a provider type string and category with a builder using assembly metadata. The host selects that builder from configuration, passes the provider name and section, and lets the builder call the same public registration API used by code-first configuration.
 
-The Azure Queue stream implementation demonstrates this pattern: [`AzureQueueStreamProviderBuilder`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/AzureQueueStreamProviderBuilder.cs) implements builders for both `ISiloBuilder` and `IClientBuilder`.
+The Azure Queue stream implementation demonstrates this pattern: <xref:Orleans.Hosting.AzureQueueStreamProviderBuilder> implements builders for both <xref:Orleans.Hosting.ISiloBuilder> and <xref:Orleans.Hosting.IClientBuilder>. See its [implementation](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/AzureQueueStreamProviderBuilder.cs).
 
 ## Named-service composition
 
-Many provider kinds allow multiple instances. The provider name is therefore part of service identity, options identity, logging identity, and runtime lookup. `NamedServiceConfigurator` and its derived configurators register keyed components and named options without creating a private service provider.
+Many provider kinds allow multiple instances. The provider name is therefore part of service identity, options identity, logging identity, and runtime lookup. <xref:Orleans.Hosting.NamedServiceConfigurator> and its derived configurators register keyed components and named options without creating a private service provider.
 
 A registration extension should:
 
 - require a non-empty name when the provider category is named;
 - register options through `AddOptions<T>(name)` or an Orleans configurator;
 - register the contract and implementation under the same key;
-- use `TryAdd` only for truly shared defaults; and
+- use <xref:Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAdd*> only for truly shared defaults; and
 - include the name in validators and diagnostics.
 
 Resolving an unkeyed singleton for a named component can make the first provider's options leak into every other provider.
@@ -61,14 +46,14 @@ The provider builder and options are the control plane. The runtime contract is 
 | Cluster membership | <xref:Orleans.IMembershipTable> |
 | Grain storage | <xref:Orleans.Storage.IGrainStorage> |
 | Grain directory | <xref:Orleans.GrainDirectory.IGrainDirectory> |
-| Reminder table | <xref:Orleans.Runtime.IReminderTable> |
+| Reminder table | <xref:Orleans.IReminderTable> |
 | Persistent streams | <xref:Orleans.Streams.IQueueAdapterFactory> and its adapter components |
 
 Do not let configuration concerns weaken the data-plane contract. For example, a membership provider must preserve conditional updates and ordered versions regardless of whether credentials came from a connection string, a keyed SDK client, or managed identity.
 
 ## Validation
 
-Options validation should fail before the silo joins the cluster or starts accepting traffic. Orleans providers commonly register an `IConfigurationValidator` so validation can include named options and service dependencies which ordinary data-annotation validation cannot express.
+Options validation should fail before the silo joins the cluster or starts accepting traffic. Orleans providers commonly register an <xref:Orleans.IConfigurationValidator> so validation can include named options and service dependencies which ordinary data-annotation validation cannot express.
 
 Validate at least:
 
@@ -86,7 +71,7 @@ Providers which allocate clients, receivers, leases, or background agents should
 
 Ownership must be explicit. If the application supplies a keyed SDK client, the provider generally should not dispose an object it does not own. If the provider creates receivers per queue, it should stop and dispose them when queue ownership moves.
 
-The persistent stream provider illustrates staged lifecycle composition: it creates the adapter during initialization, starts pulling agents at the active stage, then stops agents before closing. See [`PersistentStreamProvider.Participate`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs#L218-L235).
+The persistent stream provider illustrates staged lifecycle composition: it creates the adapter during initialization, starts pulling agents at the active stage, then stops agents before closing. See <xref:Orleans.Providers.Streams.Common.PersistentStreamProvider.Participate*?displayProperty=nameWithType> and its [implementation](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs).
 
 ## Testing a provider
 

--- a/docs/site/src/content/docs/implementation/provider-authoring.md
+++ b/docs/site/src/content/docs/implementation/provider-authoring.md
@@ -1,6 +1,6 @@
 ---
 title: Provider authoring architecture
-description: Design Orleans 10 providers with named services, configuration binding, validation, lifecycle, and runtime extension contracts.
+description: Design Orleans providers with named services, configuration binding, validation, lifecycle, and runtime extension contracts.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -36,7 +36,7 @@ public sealed class ExampleProviderBuilder : IProviderBuilder<ISiloBuilder>
 
 Provider packages associate a provider type string and category with a builder using assembly metadata. The host selects that builder from configuration, passes the provider name and section, and lets the builder call the same public registration API used by code-first configuration.
 
-The Azure Queue stream implementation is a current example: [`AzureQueueStreamProviderBuilder`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/AzureQueueStreamProviderBuilder.cs) implements builders for both `ISiloBuilder` and `IClientBuilder`.
+The Azure Queue stream implementation demonstrates this pattern: [`AzureQueueStreamProviderBuilder`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/AzureQueueStreamProviderBuilder.cs) implements builders for both `ISiloBuilder` and `IClientBuilder`.
 
 ## Named-service composition
 
@@ -102,4 +102,3 @@ Contract tests should cover more than successful round trips:
 - rolling-upgrade compatibility of stored or transmitted data.
 
 Use [TestingHost architecture](testing.md) to understand which runtime services a test cluster substitutes. Provider tests which depend on a real backend should state those preconditions and should not treat an emulator's weaker consistency as proof of the production contract.
-

--- a/docs/site/src/content/docs/implementation/runtime-architecture.md
+++ b/docs/site/src/content/docs/implementation/runtime-architecture.md
@@ -7,7 +7,7 @@ ms.topic: concept-article
 
 # Runtime architecture
 
-Orleans presents a location-transparent grain reference, but the runtime implements each call using several independently replaceable or failure-aware subsystems. The central invariant is that a grain identity is stable while its activation location is temporary.
+Orleans presents a location-transparent grain reference, an abstraction introduced in the [Orleans virtual actor research paper](https://www.microsoft.com/en-us/research/publication/orleans-distributed-virtual-actors-for-programmability-and-scalability/), but the runtime implements each call using several independently replaceable or failure-aware subsystems. The central invariant is that a grain identity is stable while its activation location is temporary.
 
 ```mermaid
 flowchart LR
@@ -27,7 +27,7 @@ flowchart LR
 
 ## Host composition
 
-A silo is a .NET Generic Host with Orleans services registered in dependency injection. `SiloHostedService` starts and stops the `Silo`; the `Silo` drives the ordered silo lifecycle. The default registration set composes:
+A silo is a [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) with Orleans services registered through [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection/overview). `SiloHostedService` starts and stops the `Silo`; the `Silo` drives the ordered silo lifecycle. The default registration set composes:
 
 - `MessageCenter` for network connections, routing, forwarding, gateways, and dispatch.
 - `MembershipTableManager`, `MembershipAgent`, `ClusterHealthMonitor`, and `ClusterMembershipService` for membership.

--- a/docs/site/src/content/docs/implementation/runtime-architecture.md
+++ b/docs/site/src/content/docs/implementation/runtime-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: Runtime architecture
-description: Follow an Orleans 10 call through the client, messaging, placement, directory, activation, and scheduler.
+description: Follow an Orleans call through the client, messaging, placement, directory, activation, and scheduler.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -37,7 +37,7 @@ A silo is a .NET Generic Host with Orleans services registered in dependency inj
 - `InsideRuntimeClient` for invoking local targets and producing responses.
 - `DeploymentLoadPublisher` and environment statistics for placement and overload decisions.
 
-See [`DefaultSiloServices`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs) for the current composition root and [`Silo`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Silo/Silo.cs) for lifecycle orchestration.
+See [`DefaultSiloServices`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs) for the composition root and [`Silo`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Silo/Silo.cs) for lifecycle orchestration.
 
 An external client has no activation catalog or placement service. `ClusterClient` starts an `OutsideRuntimeClient`, discovers gateways, maintains gateway connections, and sends requests through a client `MessageCenter`. A silo also embeds a runtime client, but its `InsideRuntimeClient` can dispatch directly to local activations and system targets.
 
@@ -89,5 +89,4 @@ Prefer supported extension points over replacing internal runtime types:
 - <xref:Orleans.Providers.IProviderBuilder`1> integrates configuration-driven providers.
 - lifecycle participants order provider startup and shutdown.
 
-Internal names and algorithms can change between releases. Public APIs, analyzer warnings, and documented wire identities are the compatibility boundaries.
-
+Internal names and algorithms are not compatibility guarantees. Public APIs, analyzer warnings, and documented wire identities are the compatibility boundaries.

--- a/docs/site/src/content/docs/implementation/runtime-architecture.md
+++ b/docs/site/src/content/docs/implementation/runtime-architecture.md
@@ -1,0 +1,93 @@
+---
+title: Runtime architecture
+description: Follow an Orleans 10 call through the client, messaging, placement, directory, activation, and scheduler.
+ms.date: 08/02/2026
+ms.topic: concept-article
+---
+
+# Runtime architecture
+
+Orleans presents a location-transparent grain reference, but the runtime implements each call using several independently replaceable or failure-aware subsystems. The central invariant is that a grain identity is stable while its activation location is temporary.
+
+```mermaid
+flowchart LR
+    App[Application code] --> Proxy[Generated grain proxy]
+    Proxy --> GRef[GrainReferenceRuntime]
+    GRef --> Client[OutsideRuntimeClient]
+    Client --> Gateway[Client gateway]
+    Gateway --> MC[MessageCenter]
+    MC --> Directory[Grain locator and directory]
+    Directory --> Placement[Placement service]
+    Placement --> Catalog[Catalog and ActivationData]
+    Catalog --> Scheduler[WorkItemGroup scheduler]
+    Scheduler --> Grain[Grain method]
+    Grain --> MC
+    MC --> Client
+```
+
+## Host composition
+
+A silo is a .NET Generic Host with Orleans services registered in dependency injection. `SiloHostedService` starts and stops the `Silo`; the `Silo` drives the ordered silo lifecycle. The default registration set composes:
+
+- `MessageCenter` for network connections, routing, forwarding, gateways, and dispatch.
+- `MembershipTableManager`, `MembershipAgent`, `ClusterHealthMonitor`, and `ClusterMembershipService` for membership.
+- `LocalGrainDirectory`, `GrainLocator`, and `CachedGrainLocator` for activation location.
+- `PlacementService` and keyed placement directors for new activation selection.
+- `ActivationDirectory`, `Catalog`, `ActivationData`, and `ActivationCollector` for local activation ownership.
+- `InsideRuntimeClient` for invoking local targets and producing responses.
+- `DeploymentLoadPublisher` and environment statistics for placement and overload decisions.
+
+See [`DefaultSiloServices`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs) for the current composition root and [`Silo`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Silo/Silo.cs) for lifecycle orchestration.
+
+An external client has no activation catalog or placement service. `ClusterClient` starts an `OutsideRuntimeClient`, discovers gateways, maintains gateway connections, and sends requests through a client `MessageCenter`. A silo also embeds a runtime client, but its `InsideRuntimeClient` can dispatch directly to local activations and system targets.
+
+## A request through the runtime
+
+1. The source generator emits a proxy method and an invokable request type for each grain interface method.
+1. The proxy passes the invokable to `GrainReferenceRuntime`. Outgoing call filters can inspect or replace the invocation.
+1. The runtime creates a `Message`, assigns its correlation identity and target grain, registers a response callback, and sends it through `MessageCenter`.
+1. A client sends through a gateway. A silo can route directly to the target silo when the activation address is known.
+1. The receiving `MessageCenter` resolves the activation address. A cache hit can avoid a directory round trip. A stale address can be invalidated and rerouted.
+1. If no activation exists, the directory and `PlacementService` coordinate creation on a compatible silo.
+1. `Catalog` creates an `ActivationData`; activation runs before queued application requests are dispatched.
+1. `ActivationData` places the request on the activation scheduler. Incoming call filters and the generated invoker execute the grain method.
+1. `InsideRuntimeClient` creates a response or rejection. The response follows the original correlation identity to the waiting callback.
+
+The relevant implementations are [`GrainReferenceRuntime`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs), [`OutsideRuntimeClient`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Runtime/OutsideRuntimeClient.cs), [`MessageCenter`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Messaging/MessageCenter.cs), [`Catalog`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Catalog/Catalog.cs), and [`InsideRuntimeClient`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Core/InsideRuntimeClient.cs).
+
+## System targets
+
+System targets are addressable runtime components which use Orleans messaging and single-threaded scheduling without virtual activation. The runtime constructs them at explicit silo addresses. Membership services, persistent stream pulling agents, and activation balancing protocols use system targets because they need the messaging and scheduling model but must not be location-transparent virtual actors.
+
+Unlike a grain, a system target:
+
+- has a concrete silo location;
+- is created and registered by runtime code;
+- is not activated by placement or grain-directory lookup; and
+- participates in runtime lifecycle rather than application grain lifecycle.
+
+## Consistency boundaries
+
+Orleans does not implement one global transaction across these subsystems. Each boundary has a narrower contract:
+
+- The membership table serializes membership updates into monotonically ordered views.
+- The directory coordinates a grain identity with an activation address and repairs stale registrations.
+- The activation scheduler serializes synchronous work items for one activation.
+- Messaging correlates a request with a response but cannot infer whether a timed-out request executed.
+- Persistence and streams define their own durability and acknowledgement points.
+
+Understanding those boundaries is essential when extending the runtime. A custom directory changes location consistency, not membership. A placement director chooses where a new activation starts, not how calls are scheduled. A stream adapter defines queue acknowledgement, not grain-call exactly-once semantics.
+
+## Public extension surfaces
+
+Prefer supported extension points over replacing internal runtime types:
+
+- <xref:Orleans.Runtime.IPlacementDirector> and placement filters customize candidate selection.
+- <xref:Orleans.GrainDirectory.IGrainDirectory> supplies a named grain directory.
+- serializer codecs, copiers, activators, and converters extend wire handling.
+- stream queue adapters, mappers, balancers, caches, and failure handlers extend persistent streams.
+- <xref:Orleans.Providers.IProviderBuilder`1> integrates configuration-driven providers.
+- lifecycle participants order provider startup and shutdown.
+
+Internal names and algorithms can change between releases. Public APIs, analyzer warnings, and documented wire identities are the compatibility boundaries.
+

--- a/docs/site/src/content/docs/implementation/runtime-architecture.md
+++ b/docs/site/src/content/docs/implementation/runtime-architecture.md
@@ -27,7 +27,7 @@ flowchart LR
 
 ## Host composition
 
-A silo is a [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) with Orleans services registered through [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection/overview). `SiloHostedService` starts and stops the `Silo`; the `Silo` drives the ordered silo lifecycle. The default registration set composes:
+A silo is a [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) with Orleans services registered through [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection/overview). `SiloHostedService` starts and stops <xref:Orleans.Runtime.Silo>, which drives the ordered silo lifecycle. The default registration set composes:
 
 - `MessageCenter` for network connections, routing, forwarding, gateways, and dispatch.
 - `MembershipTableManager`, `MembershipAgent`, `ClusterHealthMonitor`, and `ClusterMembershipService` for membership.
@@ -37,7 +37,7 @@ A silo is a [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensio
 - `InsideRuntimeClient` for invoking local targets and producing responses.
 - `DeploymentLoadPublisher` and environment statistics for placement and overload decisions.
 
-See [`DefaultSiloServices`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs) for the composition root and [`Silo`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Silo/Silo.cs) for lifecycle orchestration.
+See [`DefaultSiloServices`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs) for the composition root and <xref:Orleans.Runtime.Silo> plus its [implementation](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Silo/Silo.cs) for lifecycle orchestration.
 
 An external client has no activation catalog or placement service. `ClusterClient` starts an `OutsideRuntimeClient`, discovers gateways, maintains gateway connections, and sends requests through a client `MessageCenter`. A silo also embeds a runtime client, but its `InsideRuntimeClient` can dispatch directly to local activations and system targets.
 
@@ -82,7 +82,7 @@ Understanding those boundaries is essential when extending the runtime. A custom
 
 Prefer supported extension points over replacing internal runtime types:
 
-- <xref:Orleans.Runtime.IPlacementDirector> and placement filters customize candidate selection.
+- <xref:Orleans.Runtime.Placement.IPlacementDirector> and placement filters customize candidate selection.
 - <xref:Orleans.GrainDirectory.IGrainDirectory> supplies a named grain directory.
 - serializer codecs, copiers, activators, and converters extend wire handling.
 - stream queue adapters, mappers, balancers, caches, and failure handlers extend persistent streams.

--- a/docs/site/src/content/docs/implementation/scheduler.md
+++ b/docs/site/src/content/docs/implementation/scheduler.md
@@ -1,6 +1,6 @@
 ---
 title: Scheduling and turn execution
-description: Understand Orleans 10 activation scheduling, request admission, continuations, and interleaving.
+description: Understand Orleans activation scheduling, request admission, continuations, and interleaving.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---

--- a/docs/site/src/content/docs/implementation/scheduler.md
+++ b/docs/site/src/content/docs/implementation/scheduler.md
@@ -16,7 +16,7 @@ This distinction explains how reentrant calls can interleave without two pieces 
 
 ## `WorkItemGroup` and `ActivationTaskScheduler`
 
-Each activation owns a `WorkItemGroup` and an `ActivationTaskScheduler`. The task scheduler enqueues work into the group. The group implements a small state machine (`Waiting`, `Runnable`, and `Running`) and schedules itself onto the .NET thread pool.
+Each activation owns a `WorkItemGroup` and an `ActivationTaskScheduler`, which derives from the .NET <xref:System.Threading.Tasks.TaskScheduler> abstraction. The task scheduler enqueues work into the group. The group implements a small state machine (`Waiting`, `Runnable`, and `Running`) and schedules itself onto the [.NET managed thread pool](https://learn.microsoft.com/dotnet/standard/threading/the-managed-thread-pool).
 
 ```mermaid
 flowchart LR
@@ -82,6 +82,6 @@ Blocking a turn prevents every queued continuation and admitted request for that
 
 ## Fairness and diagnostics
 
-`WorkItemGroup` drains work subject to runtime scheduling limits so one busy activation does not permanently own a thread-pool worker. Long synchronous turns still delay other work and are reported by runtime scheduling diagnostics.
+`WorkItemGroup` drains work subject to runtime scheduling limits so one busy activation does not permanently own a thread-pool worker. Long synchronous turns still delay other work and are reported by runtime scheduling diagnostics. The [.NET diagnostics tools](https://learn.microsoft.com/dotnet/core/diagnostics/) provide the underlying runtime traces, counters, and dumps used alongside Orleans telemetry.
 
 Scheduling guarantees are local to an activation. They do not order calls across grains, create a distributed lock, or provide message exactly-once behavior.

--- a/docs/site/src/content/docs/implementation/scheduler.md
+++ b/docs/site/src/content/docs/implementation/scheduler.md
@@ -14,7 +14,9 @@ Orleans separates **request scheduling** from **task scheduling**:
 
 This distinction explains how reentrant calls can interleave without two pieces of grain code running in parallel on the same activation.
 
-## `WorkItemGroup` and `ActivationTaskScheduler`
+## `WorkItemGroup` and `ActivationTaskScheduler` <a name="task-scheduling"></a>
+
+<a name="task-scheduling-in-orleans"></a>
 
 Each activation owns a `WorkItemGroup` and an `ActivationTaskScheduler`, which derives from the .NET <xref:System.Threading.Tasks.TaskScheduler> abstraction. The task scheduler enqueues work into the group. The group implements a small state machine (`Waiting`, `Runnable`, and `Running`) and schedules itself onto the [.NET managed thread pool](https://learn.microsoft.com/dotnet/standard/threading/the-managed-thread-pool).
 
@@ -41,18 +43,9 @@ Source: [`WorkItemGroup`](https://github.com/dotnet/orleans/blob/main/src/Orlean
 
 ## Async methods become multiple turns
 
-An async grain method runs synchronously until it awaits incomplete work. Its continuation is later queued back to the same activation scheduler.
+An async grain method runs synchronously until it awaits incomplete work. Its continuation is later queued back to the same activation scheduler. Code before the incomplete await executes in one turn; code after it executes in a later turn.
 
-```csharp
-public async Task UpdateAsync()
-{
-    ApplyFirstChange();       // turn 1
-    await ReadDependency();   // yields
-    ApplySecondChange();      // a later turn
-}
-```
-
-For a non-reentrant activation, other application requests normally wait while this request is incomplete. For reentrant or selectively interleavable calls, another request can run during the await. It still runs as a separate synchronous turn; it does not execute in parallel with `ApplyFirstChange` or `ApplySecondChange`.
+For a non-reentrant activation, other application requests normally wait while this request is incomplete. For reentrant or selectively interleavable calls, another request can run during the await. It still runs as a separate synchronous turn; it does not execute in parallel with either portion of the awaiting method.
 
 Therefore, grain state is protected from parallel access by the scheduler but can still change across an `await` when interleaving is allowed. Code must recheck assumptions after awaits in reentrant grains.
 
@@ -63,8 +56,8 @@ Therefore, grain state is protected from parallel access by the scheduler but ca
 - the default non-reentrant model;
 - grain-wide reentrancy;
 - call-chain reentrancy;
-- `[AlwaysInterleave]`; and
-- predicate-based `[MayInterleave]`.
+- <xref:Orleans.Concurrency.AlwaysInterleaveAttribute>; and
+- predicate-based <xref:Orleans.Concurrency.MayInterleaveAttribute>.
 
 The user-facing rules are documented in [request scheduling](../grains/request-scheduling.md). Internally, request admission and task serialization remain separate layers.
 
@@ -78,7 +71,7 @@ This prevents a continuation or runtime callback from bypassing activation isola
 
 Blocking a turn prevents every queued continuation and admitted request for that activation from progressing. Sync-over-async can deadlock when the awaited completion needs the same activation scheduler.
 
-`Task.Run` executes outside the activation scheduler. It can be useful for isolated CPU work, but code running there must not directly access mutable grain state or assume `RuntimeContext.Current` is the activation. Return immutable results and apply them in a scheduled continuation.
+<xref:System.Threading.Tasks.Task.Run*> executes outside the activation scheduler. It can be useful for isolated CPU work, but code running there must not directly access mutable grain state or assume `RuntimeContext.Current` is the activation. Return immutable results and apply them in a scheduled continuation.
 
 ## Fairness and diagnostics
 

--- a/docs/site/src/content/docs/implementation/scheduler.md
+++ b/docs/site/src/content/docs/implementation/scheduler.md
@@ -1,79 +1,87 @@
 ---
-title: Scheduling overview
-description: Explore the scheduling overview in .NET Orleans.
-ms.date: 03/30/2025
+title: Scheduling and turn execution
+description: Understand Orleans 10 activation scheduling, request admission, continuations, and interleaving.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
-# Scheduling overview
+# Scheduling and turn execution
 
-Two forms of scheduling in Orleans are relevant to grains:
+Orleans separates **request scheduling** from **task scheduling**:
 
-1. **Request scheduling**: Scheduling incoming grain calls for execution according to rules discussed in [Request scheduling](../grains/request-scheduling.md).
-1. **Task scheduling**: Scheduling synchronous blocks of code to execute in a *single-threaded* manner.
+- request scheduling decides which incoming calls may make progress for an activation;
+- task scheduling executes each synchronous work item one at a time in that activation's context.
 
-All grain code executes on the grain's task scheduler, meaning requests also execute on the grain's task scheduler. Even if request scheduling rules allow multiple requests to execute *concurrently*, they won't execute *in parallel* because the grain's task scheduler always executes tasks one by one and never executes multiple tasks in parallel.
+This distinction explains how reentrant calls can interleave without two pieces of grain code running in parallel on the same activation.
 
-## Task scheduling
+## `WorkItemGroup` and `ActivationTaskScheduler`
 
-To better understand scheduling, consider the following grain, `MyGrain`. It has a method called `DelayExecution()` that logs a message, waits some time, then logs another message before returning.
+Each activation owns a `WorkItemGroup` and an `ActivationTaskScheduler`. The task scheduler enqueues work into the group. The group implements a small state machine (`Waiting`, `Runnable`, and `Running`) and schedules itself onto the .NET thread pool.
+
+```mermaid
+flowchart LR
+    Request[Admitted request]
+    Continuation[Async continuation]
+    Scheduler[ActivationTaskScheduler]
+    Queue[WorkItemGroup queue]
+    Pool[.NET thread pool]
+    Turn[One synchronous turn]
+
+    Request --> Scheduler
+    Continuation --> Scheduler
+    Scheduler --> Queue
+    Queue --> Pool
+    Pool --> Turn
+    Turn -->|more queued work| Pool
+```
+
+Only one thread can execute a `WorkItemGroup` at a time. That thread is not permanently assigned: different turns can run on different pool threads. The invariant is exclusive execution of the activation context, not thread affinity.
+
+Source: [`WorkItemGroup`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Scheduler/WorkItemGroup.cs) and [`ActivationTaskScheduler`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Scheduler/ActivationTaskScheduler.cs).
+
+## Async methods become multiple turns
+
+An async grain method runs synchronously until it awaits incomplete work. Its continuation is later queued back to the same activation scheduler.
 
 ```csharp
-public interface IMyGrain : IGrain
+public async Task UpdateAsync()
 {
-    Task DelayExecution();
-}
-
-public class MyGrain : Grain, IMyGrain
-{
-    private readonly ILogger<MyGrain> _logger;
-
-    public MyGrain(ILogger<MyGrain> logger) => _logger = logger;
-
-    public async Task DelayExecution()
-    {
-        _logger.LogInformation("Executing first task");
-
-        await Task.Delay(1_000);
-
-        _logger.LogInformation("Executing second task");
-    }
+    ApplyFirstChange();       // turn 1
+    await ReadDependency();   // yields
+    ApplySecondChange();      // a later turn
 }
 ```
 
-When this method executes, the method body executes in two parts:
+For a non-reentrant activation, other application requests normally wait while this request is incomplete. For reentrant or selectively interleavable calls, another request can run during the await. It still runs as a separate synchronous turn; it does not execute in parallel with `ApplyFirstChange` or `ApplySecondChange`.
 
-1. The first `_logger.LogInformation(...)` call and the call to `Task.Delay(1_000)`.
-1. The second `_logger.LogInformation(...)` call.
+Therefore, grain state is protected from parallel access by the scheduler but can still change across an `await` when interleaving is allowed. Code must recheck assumptions after awaits in reentrant grains.
 
-The second task isn't scheduled on the grain's task scheduler until the `Task.Delay(1_000)` call completes. At that point, it schedules the *continuation* of the grain method.
+## Request admission
 
-Here's a graphical representation of how a request is scheduled and executed as two tasks:
+`ActivationData` owns pending and running requests. It applies the grain's concurrency policy, dispatches eligible messages, and signals completion so that another request can progress. Policies include:
 
-:::image type="content" source="media/scheduler/scheduling-1.png" alt-text="Two-Task-based request execution example.":::
+- the default non-reentrant model;
+- grain-wide reentrancy;
+- call-chain reentrancy;
+- `[AlwaysInterleave]`; and
+- predicate-based `[MayInterleave]`.
 
-The description above isn't specific to Orleans; it describes how task scheduling works in .NET. The C# compiler converts asynchronous methods into an asynchronous state machine, and execution progresses through this state machine in discrete steps. Each step schedules on the current <xref:System.Threading.Tasks.TaskScheduler> (accessed via <xref:System.Threading.Tasks.TaskScheduler.Current?displayProperty=nameWithType>, defaulting to <xref:System.Threading.Tasks.TaskScheduler.Default?displayProperty=nameWithType>) or the current <xref:System.Threading.SynchronizationContext>. If a <xref:System.Threading.Tasks.TaskScheduler> is used, each step in the method represents a <xref:System.Threading.Tasks.Task> instance passed to that <xref:System.Threading.Tasks.TaskScheduler>. Therefore, a <xref:System.Threading.Tasks.Task> in .NET can represent two conceptual things:
+The user-facing rules are documented in [request scheduling](../grains/request-scheduling.md). Internally, request admission and task serialization remain separate layers.
 
-1. An asynchronous operation that can be awaited. The execution of the `DelayExecution()` method above is represented by a <xref:System.Threading.Tasks.Task> that can be awaited.
-1. A synchronous block of work. Each stage within the `DelayExecution()` method above is represented by a <xref:System.Threading.Tasks.Task>.
+## Runtime context and inline execution
 
-When `TaskScheduler.Default` is used, continuations schedule directly onto the .NET <xref:System.Threading.ThreadPool> and aren't wrapped in a <xref:System.Threading.Tasks.Task> object. The wrapping of continuations in <xref:System.Threading.Tasks.Task> instances occurs transparently, so developers rarely need to be aware of these implementation details.
+`ActivationTaskScheduler.TryExecuteTaskInline` permits inline execution only when the current `RuntimeContext` belongs to the same `WorkItemGroup` and the task was not already queued. Runtime helpers follow the same rule: execute inline in the matching grain context, otherwise enqueue.
 
-### Task scheduling in Orleans
+This prevents a continuation or runtime callback from bypassing activation isolation simply because it originated on a thread which is already processing Orleans work.
 
-Each grain activation has its own <xref:System.Threading.Tasks.TaskScheduler> instance responsible for enforcing the *single-threaded* execution model of grains. Internally, this <xref:System.Threading.Tasks.TaskScheduler> is implemented via `ActivationTaskScheduler` and `WorkItemGroup`. `WorkItemGroup` keeps enqueued tasks in a <xref:System.Collections.Generic.Queue`1> (where `T` is internally a <xref:System.Threading.Tasks.Task>) and implements <xref:System.Threading.IThreadPoolWorkItem>. To execute each currently enqueued <xref:System.Threading.Tasks.Task>, `WorkItemGroup` schedules *itself* on the .NET <xref:System.Threading.ThreadPool>. When the .NET <xref:System.Threading.ThreadPool> invokes the `WorkItemGroup`'s `IThreadPoolWorkItem.Execute()` method, the `WorkItemGroup` executes the enqueued <xref:System.Threading.Tasks.Task> instances one by one.
+## Blocking and escaping the scheduler
 
-Each grain has a scheduler that executes by scheduling itself on the .NET <xref:System.Threading.ThreadPool>:
+Blocking a turn prevents every queued continuation and admitted request for that activation from progressing. Sync-over-async can deadlock when the awaited completion needs the same activation scheduler.
 
-:::image type="content" source="media/scheduler/scheduling-2.png" alt-text="Orleans grains scheduling themselves on the .NET ThreadPool.":::
+`Task.Run` executes outside the activation scheduler. It can be useful for isolated CPU work, but code running there must not directly access mutable grain state or assume `RuntimeContext.Current` is the activation. Return immutable results and apply them in a scheduled continuation.
 
-Each scheduler contains a queue of tasks:
+## Fairness and diagnostics
 
-:::image type="content" source="media/scheduler/scheduling-3.png" alt-text="Scheduler queue of scheduled tasks.":::
+`WorkItemGroup` drains work subject to runtime scheduling limits so one busy activation does not permanently own a thread-pool worker. Long synchronous turns still delay other work and are reported by runtime scheduling diagnostics.
 
-The .NET <xref:System.Threading.ThreadPool> executes each work item enqueued to it. This includes *grain schedulers* as well as other work items, such as those scheduled via `Task.Run(...)`:
-
-:::image type="content" source="media/scheduler/scheduling-4.png" alt-text="Visualization of the all schedulers running in the .NET ThreadPool.":::
-
-> [!NOTE]
-> A grain's scheduler can only execute on one thread at a time, but it doesn't always execute on the same thread. The .NET <xref:System.Threading.ThreadPool> is free to use a different thread each time the grain's scheduler executes. The grain's scheduler ensures it only executes on one thread at a time, implementing the *single-threaded* execution model of grains.
+Scheduling guarantees are local to an activation. They do not order calls across grains, create a distributed lock, or provide message exactly-once behavior.

--- a/docs/site/src/content/docs/implementation/serialization.md
+++ b/docs/site/src/content/docs/implementation/serialization.md
@@ -1,0 +1,106 @@
+---
+title: Serialization and code generation internals
+description: Understand Orleans 10 generated codecs, RPC proxies, manifests, wire identity, and serialization extension points.
+ms.date: 08/02/2026
+ms.topic: concept-article
+---
+
+# Serialization and code generation internals
+
+Orleans serialization serves two related pipelines:
+
+- value serialization, deep copying, and activation for message and storage payloads;
+- RPC code generation for grain references, request objects, dispatch, and responses.
+
+Most application code uses generated components. Reflection-based discovery is deliberately not the default architecture: generated manifests make the participating types explicit and keep runtime dispatch compatible with trimming and ahead-of-time compilation.
+
+## Incremental generator pipeline
+
+The Orleans source generator is a Roslyn incremental generator. It discovers types marked with <xref:Orleans.GenerateSerializerAttribute> and interfaces marked directly or transitively with <xref:Orleans.GenerateMethodSerializersAttribute>. It also reads metadata emitted by referenced assemblies.
+
+```mermaid
+flowchart LR
+    Source[C# source and attributes]
+    Refs[Referenced assembly manifests]
+    Models[Serializable and proxy models]
+    Codecs[Field codecs, serializers, copiers, activators]
+    RPC[Proxy and invokable request types]
+    Manifest[Assembly type manifest provider]
+    Runtime[CodecProvider and GrainReferenceRuntime]
+
+    Source --> Models
+    Refs --> Models
+    Models --> Codecs
+    Models --> RPC
+    Models --> Manifest
+    Codecs --> Runtime
+    RPC --> Runtime
+    Manifest --> Runtime
+```
+
+Generated output includes serializers, field codecs, deep copiers, activators, grain proxies, invokable method objects, dispatch metadata, aliases, and a type-manifest provider. Diagnostics reject inaccessible types, ambiguous field identity, unsupported RPC shapes, and missing cross-assembly generation metadata before the application starts.
+
+Source: [`OrleansSourceGenerator`](https://github.com/dotnet/orleans/blob/main/src/Orleans.CodeGenerator/OrleansSourceGenerator.cs) and [`ReferenceAssemblyDataProvider`](https://github.com/dotnet/orleans/blob/main/src/Orleans.CodeGenerator/ReferenceAssemblyDataProvider.cs).
+
+## Field identity is the wire contract
+
+`[Id(n)]` identifies a serialized member within its declaring type. IDs are not field order and must remain stable as source is edited.
+
+```csharp
+[GenerateSerializer]
+public sealed class AccountSnapshot
+{
+    [Id(0)]
+    public string Owner { get; init; } = "";
+
+    [Id(1)]
+    public decimal Balance { get; init; }
+}
+```
+
+Adding a new ID is compatible with readers which tolerate an omitted field. Reusing or renumbering an existing ID changes the meaning of bytes on the wire and can corrupt rolling upgrades or persisted data.
+
+`GenerateSerializerAttribute.GenerateFieldIds` defaults to `None`. Automatic public-property IDs are available, but explicit IDs make compatibility review visible. Primary constructor parameters are included by default for records and excluded by default for other types.
+
+Aliases provide stable type identity when CLR names move. A type alias must remain unique in the manifest. Generic and compound aliases are resolved through the manifest's alias tree.
+
+## Writer and reader sessions
+
+The wire protocol uses writer and reader sessions to track references and type information across a payload. Reference tracking preserves object identity and cycles. A field codec writes field headers and values; the matching codec reads or skips fields it understands.
+
+Deep copying is a separate operation used when Orleans must preserve isolation without crossing a transport boundary. Immutable values can bypass copying; mutable values require a generated or custom copier. Declaring a mutable type immutable trades safety for speed and must be justified by the type's actual behavior.
+
+## RPC generation
+
+For each grain interface method, generated code captures arguments in an invokable object. The generated proxy submits that object through its proxy base. On the target, generated dispatch metadata invokes the concrete implementation and encodes the response.
+
+The request object is serializable like any other Orleans value. Stable method and interface metadata allow caller and target assemblies to evolve independently within the supported versioning rules. Outgoing and incoming call filters wrap the generated invocation; they do not replace serialization or dispatch.
+
+## Runtime manifest and type safety
+
+Each generated assembly carries a `TypeManifestProviderAttribute`. `ISerializerBuilder.AddAssembly` finds those providers and contributes their components to <xref:Orleans.Serialization.Configuration.TypeManifestOptions>.
+
+The manifest records:
+
+- activators, field codecs, serializers, copiers, and converters;
+- RPC interfaces, proxies, and implementations;
+- well-known numeric type IDs and aliases; and
+- explicitly allowed types and assemblies.
+
+`AllowAllTypes` defaults to `false`. This is a type-resolution boundary: receiving a formatted type name does not make every loadable CLR type valid input.
+
+Source: [`TypeManifestOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs), [`SerializerBuilderExtensions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Serialization/Hosting/SerializerBuilderExtensions.cs), and [`ServiceCollectionExtensions.AddSerializer`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs).
+
+## Extension points
+
+Use the registration APIs exposed by `ISerializerBuilder` for:
+
+- a field codec when a type needs custom wire encoding;
+- a deep copier when generated member-wise copy is unsuitable;
+- an activator when construction needs special handling;
+- a serializer when the type owns an external format; or
+- a converter which maps a type to a supported surrogate.
+
+Keep codec and copier behavior paired. A custom serializer which preserves a graph while its copier loses reference identity can produce different local and remote call behavior.
+
+Configuration examples belong in the [serialization configuration guide](../host/configuration-guide/serialization.md). Implementation behavior is exercised by [`GeneratedSerializerTests`](https://github.com/dotnet/orleans/blob/main/test/Orleans.Serialization.UnitTests/GeneratedSerializerTests.cs) and [`GeneratedSerializerBitwiseCompatibilityTests`](https://github.com/dotnet/orleans/blob/main/test/Orleans.Serialization.UnitTests/GeneratedSerializerBitwiseCompatibilityTests.cs).

--- a/docs/site/src/content/docs/implementation/serialization.md
+++ b/docs/site/src/content/docs/implementation/serialization.md
@@ -1,6 +1,6 @@
 ---
 title: Serialization and code generation internals
-description: Understand Orleans 10 generated codecs, RPC proxies, manifests, wire identity, and serialization extension points.
+description: Understand Orleans generated codecs, RPC proxies, manifests, wire identity, and serialization extension points.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---

--- a/docs/site/src/content/docs/implementation/serialization.md
+++ b/docs/site/src/content/docs/implementation/serialization.md
@@ -12,11 +12,11 @@ Orleans serialization serves two related pipelines:
 - value serialization, deep copying, and activation for message and storage payloads;
 - RPC code generation for grain references, request objects, dispatch, and responses.
 
-Most application code uses generated components. Reflection-based discovery is deliberately not the default architecture: generated manifests make the participating types explicit and keep runtime dispatch compatible with trimming and ahead-of-time compilation.
+Most application code uses generated components. Reflection-based discovery is deliberately not the default architecture: generated manifests make the participating types explicit and keep runtime dispatch compatible with [trimming](https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming) and ahead-of-time compilation.
 
 ## Incremental generator pipeline
 
-The Orleans source generator is a Roslyn incremental generator. It discovers types marked with <xref:Orleans.GenerateSerializerAttribute> and interfaces marked directly or transitively with <xref:Orleans.GenerateMethodSerializersAttribute>. It also reads metadata emitted by referenced assemblies.
+The Orleans source generator is a [Roslyn source generator](https://learn.microsoft.com/dotnet/csharp/roslyn-sdk/#source-generators) implemented using the incremental generator APIs. It discovers types marked with <xref:Orleans.GenerateSerializerAttribute> and interfaces marked directly or transitively with <xref:Orleans.GenerateMethodSerializersAttribute>. It also reads metadata emitted by referenced assemblies.
 
 ```mermaid
 flowchart LR

--- a/docs/site/src/content/docs/implementation/serialization.md
+++ b/docs/site/src/content/docs/implementation/serialization.md
@@ -44,23 +44,11 @@ Source: [`OrleansSourceGenerator`](https://github.com/dotnet/orleans/blob/main/s
 
 ## Field identity is the wire contract
 
-`[Id(n)]` identifies a serialized member within its declaring type. IDs are not field order and must remain stable as source is edited.
+<xref:Orleans.IdAttribute> identifies a serialized member within its declaring type. IDs are not field order and must remain stable as source is edited.
 
-```csharp
-[GenerateSerializer]
-public sealed class AccountSnapshot
-{
-    [Id(0)]
-    public string Owner { get; init; } = "";
+For example, `[Id(0)]` and `[Id(1)]` identify two different members. Adding a new ID is compatible with readers which tolerate an omitted field. Reusing or renumbering an existing ID changes the meaning of bytes on the wire and can corrupt rolling upgrades or persisted data.
 
-    [Id(1)]
-    public decimal Balance { get; init; }
-}
-```
-
-Adding a new ID is compatible with readers which tolerate an omitted field. Reusing or renumbering an existing ID changes the meaning of bytes on the wire and can corrupt rolling upgrades or persisted data.
-
-`GenerateSerializerAttribute.GenerateFieldIds` defaults to `None`. Automatic public-property IDs are available, but explicit IDs make compatibility review visible. Primary constructor parameters are included by default for records and excluded by default for other types.
+<xref:Orleans.GenerateSerializerAttribute.GenerateFieldIds?displayProperty=nameWithType> defaults to <xref:Orleans.GenerateFieldIds.None?displayProperty=nameWithType>. Automatic public-property IDs are available, but explicit IDs make compatibility review visible. Primary constructor parameters are included by default for records and excluded by default for other types.
 
 Aliases provide stable type identity when CLR names move. A type alias must remain unique in the manifest. Generic and compound aliases are resolved through the manifest's alias tree.
 
@@ -78,7 +66,7 @@ The request object is serializable like any other Orleans value. Stable method a
 
 ## Runtime manifest and type safety
 
-Each generated assembly carries a `TypeManifestProviderAttribute`. `ISerializerBuilder.AddAssembly` finds those providers and contributes their components to <xref:Orleans.Serialization.Configuration.TypeManifestOptions>.
+Each generated assembly carries a <xref:Orleans.Serialization.Configuration.TypeManifestProviderAttribute>. <xref:Orleans.Serialization.SerializerBuilderExtensions.AddAssembly*?displayProperty=nameWithType> finds those providers and contributes their components to <xref:Orleans.Serialization.Configuration.TypeManifestOptions>.
 
 The manifest records:
 
@@ -87,13 +75,13 @@ The manifest records:
 - well-known numeric type IDs and aliases; and
 - explicitly allowed types and assemblies.
 
-`AllowAllTypes` defaults to `false`. This is a type-resolution boundary: receiving a formatted type name does not make every loadable CLR type valid input.
+<xref:Orleans.Serialization.Configuration.TypeManifestOptions.AllowAllTypes?displayProperty=nameWithType> defaults to `false`. This is a type-resolution boundary: receiving a formatted type name does not make every loadable CLR type valid input.
 
-Source: [`TypeManifestOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs), [`SerializerBuilderExtensions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Serialization/Hosting/SerializerBuilderExtensions.cs), and [`ServiceCollectionExtensions.AddSerializer`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs).
+API: <xref:Orleans.Serialization.Configuration.TypeManifestOptions>, <xref:Orleans.Serialization.ISerializerBuilder>, and <xref:Orleans.Serialization.SerializerBuilderExtensions.AddAssembly*?displayProperty=nameWithType>. Implementation: [manifest options](https://github.com/dotnet/orleans/blob/main/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs), [serializer builder extensions](https://github.com/dotnet/orleans/blob/main/src/Orleans.Serialization/Hosting/SerializerBuilderExtensions.cs), and [serializer service registration](https://github.com/dotnet/orleans/blob/main/src/Orleans.Serialization/Hosting/ServiceCollectionExtensions.cs).
 
 ## Extension points
 
-Use the registration APIs exposed by `ISerializerBuilder` for:
+Use the registration APIs exposed by <xref:Orleans.Serialization.ISerializerBuilder> for:
 
 - a field codec when a type needs custom wire encoding;
 - a deep copier when generated member-wise copy is unsuitable;

--- a/docs/site/src/content/docs/implementation/snippets/testing/orleans-testing/Sample.OrleansTesting/Sample.OrleansTesting.csproj
+++ b/docs/site/src/content/docs/implementation/snippets/testing/orleans-testing/Sample.OrleansTesting/Sample.OrleansTesting.csproj
@@ -3,11 +3,12 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="10.2.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
+++ b/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
@@ -1,113 +1,100 @@
 ---
-title: Azure Queue streams overview
-description: Explore the streaming implementation with Azure Queue in .NET Orleans.
-ms.date: 05/23/2025
+title: Azure Queue stream implementation
+description: Understand the Orleans 10 Azure Queue adapter, receiver acknowledgement, queue mapping, and current configuration surfaces.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
-# Azure Queue streams overview
+# Azure Queue stream implementation
 
-Each stream provider (Azure Queues, EventHub, SMS, SQS, etc.) has its own queue-specific details and configuration. This section provides details about the usage, configuration, and implementation of **Orleans Azure Queue Streams**. This section isn't comprehensive. You can find more details in the streaming tests, which contain most configuration options, specifically [`AQClientStreamTests`](https://github.com/dotnet/orleans/blob/main/test/Extensions/Orleans.Azure.Tests/Streaming/AQClientStreamTests.cs) and [`AQSubscriptionMultiplicityTests`](https://github.com/dotnet/orleans/blob/main/test/Extensions/Orleans.Azure.Tests/Streaming/AQSubscriptionMultiplicityTests.cs), and the extension functions for <xref:Orleans.Hosting.IAzureQueueStreamConfigurator> and <xref:Orleans.Hosting.ISiloPersistentStreamConfigurator>.
+The `Microsoft.Orleans.Streaming.AzureStorage` package implements a persistent stream adapter over Azure Queue Storage. It uses the common [persistent stream pulling architecture](index.md) and supplies Azure-specific queue mapping, encoding, receive, delete, and configuration behavior.
 
-Orleans Azure Queue requires the [Microsoft.Orleans.Streaming.AzureStorage](https://www.nuget.org/packages/Microsoft.Orleans.Streaming.AzureStorage) NuGet package. In addition to the implementation, the package contains extension methods that simplify configuration at silo startup. The minimal configuration requires specifying the connection string, for example:
+## Current registration APIs
+
+Both silo and client builders expose `AddAzureQueueStreams`. The concise overload configures named `AzureQueueOptions`. Both configurator types can replace the queue data adapter; only the silo configurator exposes the cache and pulling-agent components which run on silos.
 
 ```csharp
-hostBuilder
-    .AddAzureQueueStreams("AzureQueueProvider", configurator =>
+using Azure.Storage.Queues;
+using Orleans.Configuration;
+
+siloBuilder.AddAzureQueueStreams(
+    "orders",
+    options => options.Configure(providerOptions =>
     {
-        configurator.ConfigureAzureQueue(
-            ob => ob.Configure(options =>
-            {
-                options.ConnectionString = "[PLACEHOLDER]";
-                options.QueueNames = new List<string> { "yourprefix-azurequeueprovider-0" };
-            }));
-    configurator.ConfigureCacheSize(1024);
-    configurator.ConfigurePullingAgent(ob => ob.Configure(options =>
-    {
-      options.GetQueueMsgsTimerPeriod = TimeSpan.FromMilliseconds(200);
+        providerOptions.QueueServiceClient =
+            new QueueServiceClient("UseDevelopmentStorage=true");
+        providerOptions.QueueNames =
+        [
+            "orders-0",
+            "orders-1"
+        ];
     }));
-  })
-  // a PubSubStore could be needed, as example Azure Table Storage
-  .AddAzureTableGrainStorage("PubSubStore", options => {
-    options.ConnectionString = "[PLACEHOLDER]";
-  })
 ```
 
-The pulling agents pull repeatedly until there are no more messages on a queue, then delay for a configurable period before continuing to pull. This process occurs for each queue. Internally, the pulling agents place messages in a cache (one cache per queue) for delivery to consumers but stop reading if the cache fills up. Messages are removed from the cache once consumers process them, so the read rate should be roughly throttled by the consumers' processing rate.
+Applications can instead supply a keyed `QueueServiceClient` through configuration-driven provider registration. Current configuration supports a service key, connection name, connection string, or queue-service URI. Older `ConfigureQueueServiceClient*` methods and the `ClientOptions` property are obsolete and should not be used in new code.
 
-By default, Orleans Azure Queue uses **8 queues** (see <xref:Orleans.Configuration.AzureQueueOptions>) and 8 related pulling agents, a delay of **100 ms** (see <xref:Orleans.Configuration.StreamPullingAgentOptions.GetQueueMsgsTimerPeriod?displayProperty=nameWithType>), and a cache size (<xref:Orleans.Streams.IQueueCache>) of **4096 messages** (see <xref:Orleans.Configuration.SimpleQueueCacheOptions.CacheSize?displayProperty=nameWithType>).
+Source: [`SiloBuilderExtensions`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs), [`AzureQueueStreamProviderBuilder`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/AzureQueueStreamProviderBuilder.cs), and [`AzureQueueOptions`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamOptions.cs).
 
-## Configuration
+## Adapter behavior
 
-The default configuration should fit a production environment, but for special needs, it's possible to configure the default behavior. For example, in a development machine, it's possible to reduce the number of polling agents to using just one queue. This can help to reduce CPU usage and resource pressure.
+`AzureQueueAdapter` is read-write and not rewindable. A producer encodes the stream identity, payload, request context, and sequence metadata using an `IAzureQueueDataAdapter`, then sends an Azure Queue message to the mapped queue.
 
-```csharp
-hostBuilder
-    .AddAzureQueueStreams<AzureQueueDataAdapterV2>(
-        "AzureQueueProvider",
-        optionsBuilder => optionsBuilder.Configure(
-            options =>
-            {
-                options.ConnectionString = "[PLACEHOLDER]";
-                options.QueueNames =
-                    new List<string>
-                    {
-                        "yourprefix-azurequeueprovider-0"
-                    };
-            }))
+Because Azure Queue Storage does not expose a durable arbitrary stream offset, a non-null rewind token is rejected. The default `AzureQueueDataAdapterV2` is the current encoding. Version 1 remains for compatibility with existing messages, not as the preferred format for new providers.
+
+Source: [`AzureQueueAdapter`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapter.cs) and [`IAzureQueueDataAdapter`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs).
+
+## Receive and acknowledgement
+
+`AzureQueueAdapterReceiver` asks Azure Queue Storage for up to 32 visible messages at a time. Receiving makes a message temporarily invisible; it does not delete it. The pulling agent decodes and delivers the batch through its cache and cursors. Only messages reported as delivered are deleted.
+
+```mermaid
+sequenceDiagram
+    participant Agent as Pulling agent
+    participant Receiver as AzureQueueAdapterReceiver
+    participant Queue as Azure Queue Storage
+    participant Consumer
+
+    Agent->>Receiver: GetQueueMessagesAsync
+    Receiver->>Queue: Receive visible messages
+    Queue-->>Receiver: Messages + pop receipts
+    Receiver-->>Agent: Batch containers
+    Agent->>Consumer: Deliver
+    Consumer-->>Agent: Completed
+    Agent->>Receiver: MessagesDeliveredAsync
+    Receiver->>Queue: Delete with pop receipt
 ```
 
-## Tuning
+If the receiver, agent, or silo fails before delete, the visibility timeout eventually expires and Azure can return the message again. Consumers must tolerate redelivery. If visibility expires while a message is still being processed, delete can fail because the pop receipt is no longer current.
 
-In a production system, you may need to tune the default configuration. When tuning some factors should be considered, and it's service-specific.
+Source: [`AzureQueueAdapterReceiver`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapterReceiver.cs).
 
-1. First, most of the settings are per queue, so for a large number of streams, the load on each queue can be reduced by configuring more queues.
-1. Since streams process messages in order per stream, the gating factor will be the number of events being sent on a single stream.
-1. A reasonable balance of **cache time** (<xref:Orleans.Configuration.StreamPullingAgentOptions.GetQueueMsgsTimerPeriod?displayProperty=nameWithType>) versus **visibility time** (<xref:Orleans.Configuration.AzureQueueOptions.MessageVisibilityTimeout?displayProperty=nameWithType>) is that the visibility should be configured **to double** the time messages **are expected** to be in the cache.
+## Queue mapping and defaults
 
-### Example
+When queue names are not supplied, provider configuration generates names from the Orleans service ID and provider name. The hash-ring queue mapper defaults to eight queues. Each owned queue has one pulling agent and one queue cache on its current silo.
 
-Assuming a system with these characteristics:
+Common persistent-stream defaults used by this provider are:
 
-- 100 streams,
-- 10 queues,
-- Each stream processing 60 messages per minute,
-- Each message takes around 30ms to process,
-- 1 minute worth of messages in cache (cache time).
+| Setting | Default |
+| --- | ---: |
+| Hash-ring queues | 8 |
+| Empty-poll period | 100 ms |
+| Simple cache capacity | 4,096 batch containers |
+| Maximum event delivery time | 1 minute |
+| Stream inactivity period | 30 minutes |
 
-So we can calculate some parameters of the system:
+The number of queues bounds pulling parallelism and ownership granularity. Changing queue names changes the physical partition set and must be treated as a data migration, not routine tuning.
 
-- Streams/queue: Even balancing of streams across queues would be an ideal 10 streams/queue (100 streams / 10 queues).
-But since streams won't always be evenly balanced over the queues, doubling (or even tripling) the ideal is safer than expecting ideal distribution.
-Hence **20 streams/queue** (10 streams/queue x 2 as safety factor) is probably reasonable.
+## Visibility and cache progress
 
-- Messages/minute: This means each queue will be expected to process up to **1200 messages/minute** (60 messages x 20 streams).
+Azure visibility and Orleans cache retention are different clocks:
 
-Then we can determine the visibility time to use:
+- visibility controls when an undeleted Azure message can be received again;
+- the queue cache controls how long the pulling agent retains a batch for active subscription cursors.
 
-- Visibility time: The cache time (1 minute) is configured to hold 1 minute of messages (so 1200 messages, as we calculated messages/minute above).
-We assumed that each message takes 30 ms to process, then we can expect messages to spend up to 36 seconds in the cache (0.030 sec x 1200 msg = 36 sec), so the visibility time - doubled for safety - would need be over 72 seconds (36 sec of time in cache x 2).
-Accordingly, if we define a bigger cache, that would require a longer visibility time.
+A visibility timeout which is shorter than worst-case delivery increases duplicate receive and stale pop-receipt risk. An excessively long timeout delays recovery after agent failure. Choose values from measured delivery latency and failure objectives; operational tuning belongs with the [stream provider guidance](../../streaming/stream-providers.md).
 
-Final considerations in a real-world system:
+## Extension and compatibility points
 
-- Since the order is only per stream, and a queue consumes many streams, messages will likely be processed across multiple streams in parallel (as an example: we have a grain for the stream, which can run in parallel). This means we'll burn through the cache in far less time, but we planned for the worse case: it will give the system room to continue to function well even under intermittent delays and transient errors.
+A custom `IAzureQueueDataAdapter` can change payload encoding while retaining the Azure transport. It must preserve stream identity, request context, and any sequence information needed by consumers. Encoding changes should be versioned so a rolling cluster can read messages produced by both versions.
 
-So we can configure Azure Queue Streams using:
-
-```csharp
-hostBuilder
-  .AddAzureQueueStreams("AzureQueueProvider", configurator => {
-    configurator.ConfigureAzureQueue(
-      ob => ob.Configure(options => {
-        options.ConnectionString = "[PLACEHOLDER]";
-        options.QueueNames = new List<string> {
-          "yourprefix-azurequeueprovider-1",
-          [...]
-          "yourprefix-azurequeueprovider-10",
-        };
-        options.MessageVisibilityTimeout = TimeSpan.FromSeconds(72);
-      }));
-    configurator.ConfigureCacheSize(1200);
-  })
-```
+Configuration binding behavior is tested by [`AzureQueueStreamProviderBuilderTests`](https://github.com/dotnet/orleans/blob/main/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueStreamProviderBuilderTests.cs). Adapter acknowledgement and cursor behavior are covered by [`AzureQueueAdapterTests`](https://github.com/dotnet/orleans/blob/main/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs).

--- a/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
+++ b/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
@@ -1,6 +1,6 @@
 ---
 title: Azure Queue stream implementation
-description: Understand the Orleans 10 Azure Queue adapter, receiver acknowledgement, queue mapping, and current configuration surfaces.
+description: Understand the Orleans Azure Queue adapter, receiver acknowledgement, queue mapping, and configuration surfaces.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -9,7 +9,7 @@ ms.topic: concept-article
 
 The `Microsoft.Orleans.Streaming.AzureStorage` package implements a persistent stream adapter over Azure Queue Storage. It uses the common [persistent stream pulling architecture](index.md) and supplies Azure-specific queue mapping, encoding, receive, delete, and configuration behavior.
 
-## Current registration APIs
+## Registration APIs
 
 Both silo and client builders expose `AddAzureQueueStreams`. The concise overload configures named `AzureQueueOptions`. Both configurator types can replace the queue data adapter; only the silo configurator exposes the cache and pulling-agent components which run on silos.
 
@@ -31,7 +31,7 @@ siloBuilder.AddAzureQueueStreams(
     }));
 ```
 
-Applications can instead supply a keyed `QueueServiceClient` through configuration-driven provider registration. Current configuration supports a service key, connection name, connection string, or queue-service URI. Older `ConfigureQueueServiceClient*` methods and the `ClientOptions` property are obsolete and should not be used in new code.
+Applications can instead supply a keyed `QueueServiceClient` through configuration-driven provider registration. Configuration supports a service key, connection name, connection string, or queue-service URI. The `ConfigureQueueServiceClient*` methods and `ClientOptions` property are obsolete and should not be used in new code.
 
 Source: [`SiloBuilderExtensions`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs), [`AzureQueueStreamProviderBuilder`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/AzureQueueStreamProviderBuilder.cs), and [`AzureQueueOptions`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamOptions.cs).
 
@@ -39,7 +39,7 @@ Source: [`SiloBuilderExtensions`](https://github.com/dotnet/orleans/blob/main/sr
 
 `AzureQueueAdapter` is read-write and not rewindable. A producer encodes the stream identity, payload, request context, and sequence metadata using an `IAzureQueueDataAdapter`, then sends an Azure Queue message to the mapped queue.
 
-Because Azure Queue Storage does not expose a durable arbitrary stream offset, a non-null rewind token is rejected. The default `AzureQueueDataAdapterV2` is the current encoding. Version 1 remains for compatibility with existing messages, not as the preferred format for new providers.
+Because Azure Queue Storage does not expose a durable arbitrary stream offset, a non-null rewind token is rejected. `AzureQueueDataAdapterV2` is the default encoding. Version 1 remains for compatibility with existing messages, not as the preferred format for new providers.
 
 Source: [`AzureQueueAdapter`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapter.cs) and [`IAzureQueueDataAdapter`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs).
 

--- a/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
+++ b/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
@@ -7,7 +7,7 @@ ms.topic: concept-article
 
 # Azure Queue stream implementation
 
-The `Microsoft.Orleans.Streaming.AzureStorage` package implements a persistent stream adapter over Azure Queue Storage. It uses the common [persistent stream pulling architecture](index.md) and supplies Azure-specific queue mapping, encoding, receive, delete, and configuration behavior.
+The [`Microsoft.Orleans.Streaming.AzureStorage`](https://www.nuget.org/packages/Microsoft.Orleans.Streaming.AzureStorage/) package implements a persistent stream adapter over Azure Queue Storage. It uses the common [persistent stream pulling architecture](index.md) and supplies Azure-specific queue mapping, encoding, receive, delete, and configuration behavior.
 
 ## Registration APIs
 
@@ -45,7 +45,7 @@ Source: [`AzureQueueAdapter`](https://github.com/dotnet/orleans/blob/main/src/Az
 
 ## Receive and acknowledgement
 
-`AzureQueueAdapterReceiver` asks Azure Queue Storage for up to 32 visible messages at a time. Receiving makes a message temporarily invisible; it does not delete it. The pulling agent decodes and delivers the batch through its cache and cursors. Only messages reported as delivered are deleted.
+`AzureQueueAdapterReceiver` asks Azure Queue Storage for up to 32 visible messages at a time. Azure Queue Storage's [Get Messages operation](https://learn.microsoft.com/rest/api/storageservices/get-messages) makes a received message temporarily invisible; it does not delete it. The pulling agent decodes and delivers the batch through its cache and cursors. Only messages reported as delivered are removed using the [Delete Message operation](https://learn.microsoft.com/rest/api/storageservices/delete-message2).
 
 ```mermaid
 sequenceDiagram

--- a/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
+++ b/docs/site/src/content/docs/implementation/streams-implementation/azure-queue-streams.md
@@ -9,37 +9,19 @@ ms.topic: concept-article
 
 The [`Microsoft.Orleans.Streaming.AzureStorage`](https://www.nuget.org/packages/Microsoft.Orleans.Streaming.AzureStorage/) package implements a persistent stream adapter over Azure Queue Storage. It uses the common [persistent stream pulling architecture](index.md) and supplies Azure-specific queue mapping, encoding, receive, delete, and configuration behavior.
 
-## Registration APIs
+## Registration APIs <a name="configuration"></a>
 
-Both silo and client builders expose `AddAzureQueueStreams`. The concise overload configures named `AzureQueueOptions`. Both configurator types can replace the queue data adapter; only the silo configurator exposes the cache and pulling-agent components which run on silos.
+Silo and client builders expose <xref:Orleans.Hosting.SiloBuilderExtensions.AddAzureQueueStreams*?displayProperty=nameWithType> and <xref:Orleans.Hosting.ClientBuilderExtensions.AddAzureQueueStreams*?displayProperty=nameWithType>, respectively. The concise overload configures named <xref:Orleans.Configuration.AzureQueueOptions>. Both configurator types can replace the queue data adapter; only the silo configurator exposes the cache and pulling-agent components which run on silos.
 
-```csharp
-using Azure.Storage.Queues;
-using Orleans.Configuration;
+Applications can instead supply a keyed <xref:Azure.Storage.Queues.QueueServiceClient> through configuration-driven provider registration. Configuration supports a service key, connection name, connection string, or queue-service URI. The <xref:Orleans.Configuration.AzureQueueOptions.ConfigureQueueServiceClient*> overloads and <xref:Orleans.Configuration.AzureQueueOptions.ClientOptions?displayProperty=nameWithType> property are obsolete and should not be used in new code.
 
-siloBuilder.AddAzureQueueStreams(
-    "orders",
-    options => options.Configure(providerOptions =>
-    {
-        providerOptions.QueueServiceClient =
-            new QueueServiceClient("UseDevelopmentStorage=true");
-        providerOptions.QueueNames =
-        [
-            "orders-0",
-            "orders-1"
-        ];
-    }));
-```
-
-Applications can instead supply a keyed `QueueServiceClient` through configuration-driven provider registration. Configuration supports a service key, connection name, connection string, or queue-service URI. The `ConfigureQueueServiceClient*` methods and `ClientOptions` property are obsolete and should not be used in new code.
-
-Source: [`SiloBuilderExtensions`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs), [`AzureQueueStreamProviderBuilder`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/AzureQueueStreamProviderBuilder.cs), and [`AzureQueueOptions`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamOptions.cs).
+API: <xref:Orleans.Hosting.SiloBuilderExtensions.AddAzureQueueStreams*?displayProperty=nameWithType>, <xref:Orleans.Hosting.ClientBuilderExtensions.AddAzureQueueStreams*?displayProperty=nameWithType>, <xref:Orleans.Hosting.AzureQueueStreamProviderBuilder>, and <xref:Orleans.Configuration.AzureQueueOptions>. Implementation: [silo registration](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/SiloBuilderExtensions.cs), [configuration-driven registration](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Hosting/AzureQueueStreamProviderBuilder.cs), and [queue options](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueStreamOptions.cs).
 
 ## Adapter behavior
 
 `AzureQueueAdapter` is read-write and not rewindable. A producer encodes the stream identity, payload, request context, and sequence metadata using an `IAzureQueueDataAdapter`, then sends an Azure Queue message to the mapped queue.
 
-Because Azure Queue Storage does not expose a durable arbitrary stream offset, a non-null rewind token is rejected. `AzureQueueDataAdapterV2` is the default encoding. Version 1 remains for compatibility with existing messages, not as the preferred format for new providers.
+Because Azure Queue Storage does not expose a durable arbitrary stream offset, a non-null rewind token is rejected. <xref:Orleans.Providers.Streams.AzureQueue.AzureQueueDataAdapterV2> is the default encoding. Version 1 remains for compatibility with existing messages, not as the preferred format for new providers.
 
 Source: [`AzureQueueAdapter`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/AzureQueueAdapter.cs) and [`IAzureQueueDataAdapter`](https://github.com/dotnet/orleans/blob/main/src/Azure/Orleans.Streaming.AzureStorage/Providers/Streams/AzureQueue/IAzureQueueDataAdapter.cs).
 
@@ -70,31 +52,31 @@ Source: [`AzureQueueAdapterReceiver`](https://github.com/dotnet/orleans/blob/mai
 
 ## Queue mapping and defaults
 
-When queue names are not supplied, provider configuration generates names from the Orleans service ID and provider name. The hash-ring queue mapper defaults to eight queues. Each owned queue has one pulling agent and one queue cache on its current silo.
+When <xref:Orleans.Configuration.AzureQueueOptions.QueueNames?displayProperty=nameWithType> is not supplied, provider configuration generates names from the Orleans service ID and provider name. The hash-ring queue mapper defaults to eight queues. Each owned queue has one pulling agent and one queue cache on its current silo.
 
 Common persistent-stream defaults used by this provider are:
 
 | Setting | Default |
 | --- | ---: |
-| Hash-ring queues | 8 |
-| Empty-poll period | 100 ms |
-| Simple cache capacity | 4,096 batch containers |
-| Maximum event delivery time | 1 minute |
-| Stream inactivity period | 30 minutes |
+| <xref:Orleans.Configuration.HashRingStreamQueueMapperOptions.TotalQueueCount?displayProperty=nameWithType> | 8 |
+| <xref:Orleans.Configuration.StreamPullingAgentOptions.GetQueueMsgsTimerPeriod?displayProperty=nameWithType> | 100 ms |
+| <xref:Orleans.Configuration.SimpleQueueCacheOptions.CacheSize?displayProperty=nameWithType> | 4,096 batch containers |
+| <xref:Orleans.Configuration.StreamPullingAgentOptions.MaxEventDeliveryTime?displayProperty=nameWithType> | 1 minute |
+| <xref:Orleans.Configuration.StreamPullingAgentOptions.StreamInactivityPeriod?displayProperty=nameWithType> | 30 minutes |
 
 The number of queues bounds pulling parallelism and ownership granularity. Changing queue names changes the physical partition set and must be treated as a data migration, not routine tuning.
 
-## Visibility and cache progress
+## Visibility and cache progress <a name="tuning"></a>
 
 Azure visibility and Orleans cache retention are different clocks:
 
 - visibility controls when an undeleted Azure message can be received again;
 - the queue cache controls how long the pulling agent retains a batch for active subscription cursors.
 
-A visibility timeout which is shorter than worst-case delivery increases duplicate receive and stale pop-receipt risk. An excessively long timeout delays recovery after agent failure. Choose values from measured delivery latency and failure objectives; operational tuning belongs with the [stream provider guidance](../../streaming/stream-providers.md).
+A <xref:Orleans.Configuration.AzureQueueOptions.MessageVisibilityTimeout?displayProperty=nameWithType> value which is shorter than worst-case delivery increases duplicate receive and stale pop-receipt risk. An excessively long timeout delays recovery after agent failure. Choose values from measured delivery latency and failure objectives; operational tuning belongs with the [stream provider guidance](../../streaming/stream-providers.md).
 
 ## Extension and compatibility points
 
-A custom `IAzureQueueDataAdapter` can change payload encoding while retaining the Azure transport. It must preserve stream identity, request context, and any sequence information needed by consumers. Encoding changes should be versioned so a rolling cluster can read messages produced by both versions.
+A custom <xref:Orleans.Streams.IQueueDataAdapter`2> can change payload encoding while retaining the Azure transport. It must preserve stream identity, request context, and any sequence information needed by consumers. Encoding changes should be versioned so a rolling cluster can read messages produced by both versions.
 
 Configuration binding behavior is tested by [`AzureQueueStreamProviderBuilderTests`](https://github.com/dotnet/orleans/blob/main/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueStreamProviderBuilderTests.cs). Adapter acknowledgement and cursor behavior are covered by [`AzureQueueAdapterTests`](https://github.com/dotnet/orleans/blob/main/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs).

--- a/docs/site/src/content/docs/implementation/streams-implementation/index.md
+++ b/docs/site/src/content/docs/implementation/streams-implementation/index.md
@@ -1,6 +1,6 @@
 ---
 title: Persistent stream pulling architecture
-description: Understand Orleans 10 persistent stream providers, queue balancing, pulling agents, caches, cursors, pub-sub, and recovery.
+description: Understand Orleans persistent stream providers, queue balancing, pulling agents, caches, cursors, pub-sub, and recovery.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---

--- a/docs/site/src/content/docs/implementation/streams-implementation/index.md
+++ b/docs/site/src/content/docs/implementation/streams-implementation/index.md
@@ -1,80 +1,127 @@
 ---
-title: Streams implementation details
-description: Learn the stream implementation details in .NET Orleans.
-ms.date: 07/03/2024
+title: Persistent stream pulling architecture
+description: Understand Orleans 10 persistent stream providers, queue balancing, pulling agents, caches, cursors, pub-sub, and recovery.
+ms.date: 08/02/2026
+ms.topic: concept-article
 ---
 
-# Orleans streams implementation details
+# Persistent stream pulling architecture
 
-This section provides a high-level overview of Orleans Stream implementation. It describes concepts and details that are not visible on the application level. If you only plan to use streams, you do not have to read this section.
+A persistent stream provider connects Orleans streams to a durable queue technology. Producers enqueue through an adapter. Silo-local pulling agents own queue partitions, read batches, cache them, discover subscriptions, and deliver events through ordinary Orleans calls.
 
-*Terminology*:
+This page describes the runtime mechanism. For stream APIs and provider selection, see the [streaming documentation](../../streaming/index.md).
 
-We refer by the word "queue" to any durable storage technology that can ingest stream events and allows either to pull events or provides a push-based mechanism to consume events. Usually, to provide scalability, those technologies provide sharded/partitioned queues. For example, Azure Queues allow you to create multiple queues, and Event Hubs have multiple hubs.
+```mermaid
+flowchart LR
+    Producer[Stream producer]
+    Adapter[IQueueAdapter]
+    Queue[(Durable queue)]
+    Balancer[IStreamQueueBalancer]
+    Manager[PersistentStreamPullingManager]
+    Agent[Pulling agent SystemTarget]
+    Cache[IQueueCache]
+    PubSub[Stream pub-sub]
+    Consumers[Grain/client consumers]
 
-## Persistent streams
-
-All Orleans persistent stream providers share a common implementation <xref:Orleans.Providers.Streams.Common.PersistentStreamProvider>. These generic stream providers need to be configured with a technology-specific <xref:Orleans.Streams.IQueueAdapterFactory>.
-
-For instance, for testing purposes, we have queue adapters that generate their test data rather than reading the data from a queue.
-The code below shows how we configure a persistent stream provider to use our custom (generator) queue adapter.
-It does this by configuring the persistent stream provider with a factory function used to create the adapter.
-
-```csharp
-hostBuilder.AddPersistentStreams(
-    StreamProviderName, GeneratorAdapterFactory.Create);
+    Producer --> Adapter
+    Adapter --> Queue
+    Balancer --> Manager
+    Manager --> Agent
+    Agent --> Queue
+    Agent --> Cache
+    Agent <--> PubSub
+    Cache --> Agent
+    Agent --> Consumers
 ```
 
-When a stream producer generates a new stream item and calls `stream.OnNext()`, the Orleans streaming runtime invokes the appropriate method on the <xref:Orleans.Streams.IQueueAdapter> of that stream provider which enqueues the item directly onto the appropriate queue.
+## Provider composition and lifecycle
 
-### Pulling agents
+`PersistentStreamProvider` is the common implementation. A provider-specific <xref:Orleans.Streams.IQueueAdapterFactory> creates:
 
-At the heart of the Persistent Stream Provider are the pulling agents.
-Pulling agents pull events from a set of durable queues and deliver them to the application code in grains that consumes them.
-One can think of the pulling agents as a distributed "micro-service" -- a partitioned, highly available, and elastic distributed component.
-The pulling agents run inside the same silos that host application grains and are fully managed by the Orleans Streaming Runtime.
+- an `IQueueAdapter` for enqueue and receive semantics;
+- an <xref:Orleans.Streams.IStreamQueueMapper> for stream-to-queue mapping;
+- an <xref:Orleans.Streams.IStreamQueueBalancer> for silo ownership;
+- an `IQueueAdapterCache` for per-agent caches; and
+- optional failure handlers, filters, and backoff providers.
 
-### `StreamQueueMapper` and `StreamQueueBalancer`
+During lifecycle initialization the provider resolves its named adapter factory and creates the adapter. At the active stage it initializes the pulling manager and starts agents. Shutdown stops agents before the provider closes.
 
-<span name="streamqueuemapper-and-streamqueuebalancer"></span>
+By default, pulling agents start automatically. Explicit grain-based and implicit subscriptions are both enabled.
 
-Pulling agents are parameterized with <xref:Orleans.Streams.IStreamQueueMapper> and <xref:Orleans.Streams.IStreamQueueBalancer>. The `IStreamQueueMapper` provides a list of all queues and is also responsible for mapping streams to queues. That way, the producer side of the Persistent Stream Provider knows into which queue to enqueue the message.
+Source: [`PersistentStreamProvider`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs) and [`PersistentStreamProviderOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/Options/PersistentStreamProviderOptions.cs).
 
-The `IStreamQueueBalancer` expresses the way queues are balanced across Orleans silos and agents. The goal is to assign queues to agents in a balanced way, to prevent bottlenecks and support elasticity. When a new silo is added to the Orleans cluster, queues are automatically rebalanced across the old and new silos. The `StreamQueueBalancer` allows customizing that process. Orleans has several built-in StreamQueueBalancers, to support different balancing scenarios (large and small number of queues) and different environments (Azure, on-prem, static).
+## Queue mapping and ownership
 
-Using the test generator example from above, the code below shows how one could configure the queue mapper and queue balancer.
+The queue mapper deterministically assigns a stream identity to a queue. All producers and consumers for a provider must use compatible mapping or events can be written to queues which no intended agent reads.
 
-```csharp
-hostBuilder
-    .AddPersistentStreams(StreamProviderName, GeneratorAdapterFactory.Create,
-        providerConfigurator =>
-        providerConfigurator.Configure<HashRingStreamQueueMapperOptions>(
-            ob => ob.Configure(options => options.TotalQueueCount = 8))
-      .UseDynamicClusterConfigDeploymentBalancer());
+The queue balancer assigns queues to silos and publishes sequenced ownership changes. `PersistentStreamPullingManager` is a silo-local system target which serializes those notifications, ignores stale sequences, and starts or stops one pulling agent per owned queue. When membership changes, queues move among managers; agents themselves are not virtual and do not migrate.
+
+Source: [`PersistentStreamPullingManager`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs).
+
+## Pulling-agent loop
+
+Each `PersistentStreamPullingAgent` is a system target with single-threaded Orleans scheduling. Its loop:
+
+1. asks the adapter receiver for a batch;
+1. adds batch containers to its queue cache;
+1. groups cached items by stream;
+1. resolves and caches pub-sub registrations;
+1. advances each subscription's cursor independently;
+1. sends events through Orleans messaging;
+1. records delivery progress and failure; and
+1. purges only data which the cache says is safe to remove.
+
+The default maximum adapter batch-container batch size is 1 and the empty-poll period is 100 ms. These defaults are runtime behavior, not a universal throughput recommendation.
+
+## Cache and cursor invariants
+
+An <xref:Orleans.Streams.IQueueCache> decouples queue reads from consumer delivery. Each subscription has an `IQueueCacheCursor`, so a slow consumer does not directly block a fast consumer at a later cursor.
+
+The cache tracks the earliest delivery progress across active subscriptions. Purging must not remove an item still needed by any cursor. `SimpleQueueCache` uses pressure buckets to stop or slow reads as lag grows instead of discarding undelivered events. Its default capacity is 4,096 batch containers.
+
+```mermaid
+flowchart TB
+    New[New queue batches] --> Cache[Queue cache]
+    Cache --> C1[Cursor A: fast]
+    Cache --> C2[Cursor B: slow]
+    C1 --> P1[Consumer A]
+    C2 --> P2[Consumer B]
+    C1 --> Progress[Earliest safe progress]
+    C2 --> Progress
+    Progress --> Purge[Purge or apply backpressure]
 ```
 
-The above code configures the <xref:Orleans.Providers.Streams.Generator.GeneratorAdapterFactory> to use a queue mapper with eight queues, and balances the queues across the cluster using the <xref:Orleans.Streams.StreamQueueBalancerType.DynamicClusterConfigDeploymentBalancer>.
+Cache capacity is not durability. The queue remains the durable boundary, subject to the adapter's acknowledgement contract.
 
-### Pulling protocol
+## Pub-sub handshake
 
-Every silo runs a set of pulling agents, every agent is pulling from one queue. Pulling agents themselves are implemented by an internal runtime component, called **SystemTarget**. SystemTargets are essentially runtime grains, are subject to single-threaded concurrency, can use regular grain messaging, and are as lightweight as grains. In contrast to grains, SystemTargets are not virtual: they are explicitly created (by the runtime) and are not location transparent. By implementing pulling agents as SystemTargets, the Orleans Streaming Runtime can rely on built-in Orleans features and can scale to a very large number of queues, since creating a new pulling agent is as cheap as creating a new grain.
+The agent registers as a producer for each stream and obtains subscription records from stream pub-sub. It holds a pin cursor while subscription handshakes complete so cache cleanup cannot pass the requested start token. New subscription notifications update the agent's local pub-sub cache.
 
-Every pulling agent runs a periodic timer that pulls from the queue by invoking the <xref:Orleans.Streams.IQueueAdapterReceiver.GetQueueMessagesAsync*?displayProperty=nameWithType> method. The returned messages are put in the internal per-agent data structure called <xref:Orleans.Streams.IQueueCache>. Every message is inspected to find out its destination stream. The agent uses the Pub-Sub to find out the list of stream consumers that subscribed to this stream. Once the consumer list is retrieved, the agent stores it locally (in its pub-sub cache) so it does not need to consult with Pub-Sub on every message. The agent also subscribes to the pub-sub to receive notification of any new consumers that subscribe to that stream. This handshake between the agent and the pub-sub guarantees **strong streaming subscription semantics**: once the consumer has subscribed to the stream it will see all events that were generated after it has subscribed. In addition, using <xref:Orleans.Streams.StreamSequenceToken> allows it to subscribe in the past.
+Sequence tokens allow a rewindable adapter to start from a supported historical position. An adapter which reports `IsRewindable = false` must reject unsupported tokens rather than pretending to honor them.
 
-### Queue cache
+## Delivery and failure semantics
 
-<xref:Orleans.Streams.IQueueCache> is an internal per-agent data structure that allows to decoupling dequeuing new events from the queue and delivering them to consumers. It also allows for decoupling delivery to different streams and different consumers.
+The agent normally awaits delivery before advancing a subscription cursor, creating per-subscription backpressure. When delivery fails, it invokes the configured `IStreamFailureHandler`. Depending on provider policy, an explicit subscription can be faulted and removed.
 
-Imagine a situation where one stream has 3 stream consumers and one of them is slow. If care is not taken, this slow consumer may impact the agent's progress, slowing the consumption of other consumers of that stream, and even slowing the dequeuing and delivery of events for other streams. To prevent that and allow maximum parallelism in the agent, we use `IQueueCache`.
+Persistent streams are not universally exactly once. Semantics depend on:
 
-`IQueueCache` buffers stream events and provides a way for the agent to deliver events to each consumer at its own pace. The per-consumer delivery is implemented by the internal component called <xref:Orleans.Streams.IQueueCacheCursor>, which tracks per-consumer progress. That way, each consumer receives events at its own pace: fast consumers receive events as quickly as they are dequeued from the queue, while slow consumers receive them later on. Once the message is delivered to all consumers, it can be deleted from the cache.
+- when the external queue considers a message acknowledged;
+- whether the adapter can redeliver after receiver or silo failure;
+- cache checkpoint behavior;
+- consumer idempotency; and
+- provider-specific sequence tokens.
 
-### Backpressure
+A queue message can be delivered again after ownership change or failure. Consumers which perform durable side effects should be idempotent.
 
-Backpressure in the Orleans Streaming Runtime applies in two places: **bringing stream events from the queue to the agent** and **delivering the events from the agent to stream consumers**.
+## Extension contracts
 
-The latter is provided by the built-in Orleans message delivery mechanism. Every stream event is delivered from the agent to consumers via the standard Orleans grain messaging, one at a time. That is, the agents send one event (or a limited size batch of events) to each stream consumer and await this call. The next event will not start being delivered until the Task for the previous event was resolved or broken. That way we naturally limit the per-consumer delivery rate to one message at a time.
+Provider authors should keep these responsibilities separate:
 
-When bringing stream events from the queue to the agent, Orleans Streaming provides a new special Backpressure mechanism. Since the agent decouples dequeuing of events from the queue and delivering them to consumers, a single slow consumer may fall behind so much that the `IQueueCache` will fill up. To prevent `IQueueCache` from growing indefinitely, we limit its size (the size limit is configurable). However, the agent never throws away undelivered events.
+- `IQueueAdapter` defines external queue reads/writes and rewindability.
+- `IQueueAdapterReceiver` defines receive, acknowledgement, and shutdown.
+- `IStreamQueueMapper` defines stable partition mapping.
+- `IStreamQueueBalancer` defines cluster ownership.
+- `IQueueCache` and cursors define buffering and safe purge.
+- `IStreamFailureHandler` defines delivery failure policy.
 
-Instead, when the cache starts to fill up, the agents slow the rate of dequeuing events from the queue. That way, we can "ride out" the slow delivery periods by adjusting the rate at which we consume from the queue ("backpressure") and get back into fast consumption rates later on. To detect the "slow delivery" valleys the `IQueueCache` uses an internal data structure of cache buckets that tracks the progress of delivery of events to individual stream consumers. This results in a very responsive and self-adjusting system.
+See [provider authoring](../provider-authoring.md) for hosting and validation patterns and [Azure Queue streams](azure-queue-streams.md) for a concrete adapter.

--- a/docs/site/src/content/docs/implementation/streams-implementation/index.md
+++ b/docs/site/src/content/docs/implementation/streams-implementation/index.md
@@ -34,23 +34,23 @@ flowchart LR
     Agent --> Consumers
 ```
 
-## Provider composition and lifecycle
+## Provider composition and lifecycle <a name="persistent-streams"></a>
 
-`PersistentStreamProvider` is the common implementation. A provider-specific <xref:Orleans.Streams.IQueueAdapterFactory> creates:
+<xref:Orleans.Providers.Streams.Common.PersistentStreamProvider> is the common implementation. A provider-specific <xref:Orleans.Streams.IQueueAdapterFactory> creates:
 
-- an `IQueueAdapter` for enqueue and receive semantics;
+- an <xref:Orleans.Streams.IQueueAdapter> for enqueue and receive semantics;
 - an <xref:Orleans.Streams.IStreamQueueMapper> for stream-to-queue mapping;
 - an <xref:Orleans.Streams.IStreamQueueBalancer> for silo ownership;
-- an `IQueueAdapterCache` for per-agent caches; and
+- an <xref:Orleans.Streams.IQueueAdapterCache> for per-agent caches; and
 - optional failure handlers, filters, and backoff providers.
 
 During lifecycle initialization the provider resolves its named adapter factory and creates the adapter. At the active stage it initializes the pulling manager and starts agents. Shutdown stops agents before the provider closes.
 
 By default, pulling agents start automatically. Explicit grain-based and implicit subscriptions are both enabled.
 
-Source: [`PersistentStreamProvider`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs) and [`PersistentStreamProviderOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/Options/PersistentStreamProviderOptions.cs).
+API: <xref:Orleans.Providers.Streams.Common.PersistentStreamProvider>. Implementation: [provider lifecycle](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs) and [provider options](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/Options/PersistentStreamProviderOptions.cs).
 
-## Queue mapping and ownership
+## Queue mapping and ownership <a name="streamqueuemapper-and-streamqueuebalancer"></a>
 
 The queue mapper deterministically assigns a stream identity to a queue. All producers and consumers for a provider must use compatible mapping or events can be written to queues which no intended agent reads.
 
@@ -58,7 +58,9 @@ The queue balancer assigns queues to silos and publishes sequenced ownership cha
 
 Source: [`PersistentStreamPullingManager`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingManager.cs).
 
-## Pulling-agent loop
+## Pulling-agent loop <a name="pulling-agents"></a>
+
+<a name="pulling-protocol"></a>
 
 Each `PersistentStreamPullingAgent` is a system target with single-threaded Orleans scheduling. Its loop:
 
@@ -73,11 +75,13 @@ Each `PersistentStreamPullingAgent` is a system target with single-threaded Orle
 
 The default maximum adapter batch-container batch size is 1 and the empty-poll period is 100 ms. These defaults are runtime behavior, not a universal throughput recommendation.
 
-## Cache and cursor invariants
+## Cache and cursor invariants <a name="queue-cache"></a>
 
-An <xref:Orleans.Streams.IQueueCache> decouples queue reads from consumer delivery. Each subscription has an `IQueueCacheCursor`, so a slow consumer does not directly block a fast consumer at a later cursor.
+<a name="backpressure"></a>
 
-The cache tracks the earliest delivery progress across active subscriptions. Purging must not remove an item still needed by any cursor. `SimpleQueueCache` uses pressure buckets to stop or slow reads as lag grows instead of discarding undelivered events. Its default capacity is 4,096 batch containers.
+An <xref:Orleans.Streams.IQueueCache> decouples queue reads from consumer delivery. Each subscription has an <xref:Orleans.Streams.IQueueCacheCursor>, so a slow consumer does not directly block a fast consumer at a later cursor.
+
+The cache tracks the earliest delivery progress across active subscriptions. Purging must not remove an item still needed by any cursor. <xref:Orleans.Providers.Streams.Common.SimpleQueueCache> uses pressure buckets to stop or slow reads as lag grows instead of discarding undelivered events. Its default capacity is 4,096 batch containers.
 
 ```mermaid
 flowchart TB
@@ -97,11 +101,11 @@ Cache capacity is not durability. The queue remains the durable boundary, subjec
 
 The agent registers as a producer for each stream and obtains subscription records from stream pub-sub. It holds a pin cursor while subscription handshakes complete so cache cleanup cannot pass the requested start token. New subscription notifications update the agent's local pub-sub cache.
 
-Sequence tokens allow a rewindable adapter to start from a supported historical position. An adapter which reports `IsRewindable = false` must reject unsupported tokens rather than pretending to honor them.
+Sequence tokens allow a rewindable adapter to start from a supported historical position. An adapter whose <xref:Orleans.Streams.IQueueAdapter.IsRewindable?displayProperty=nameWithType> property is `false` must reject unsupported tokens rather than pretending to honor them.
 
 ## Delivery and failure semantics
 
-The agent normally awaits delivery before advancing a subscription cursor, creating per-subscription backpressure. When delivery fails, it invokes the configured `IStreamFailureHandler`. Depending on provider policy, an explicit subscription can be faulted and removed.
+The agent normally awaits delivery before advancing a subscription cursor, creating per-subscription backpressure. When delivery fails, it invokes the configured <xref:Orleans.Streams.IStreamFailureHandler>. Depending on provider policy, an explicit subscription can be faulted and removed.
 
 Persistent streams are not universally exactly once. Semantics depend on:
 
@@ -117,11 +121,11 @@ A queue message can be delivered again after ownership change or failure. Consum
 
 Provider authors should keep these responsibilities separate:
 
-- `IQueueAdapter` defines external queue reads/writes and rewindability.
-- `IQueueAdapterReceiver` defines receive, acknowledgement, and shutdown.
-- `IStreamQueueMapper` defines stable partition mapping.
-- `IStreamQueueBalancer` defines cluster ownership.
-- `IQueueCache` and cursors define buffering and safe purge.
-- `IStreamFailureHandler` defines delivery failure policy.
+- <xref:Orleans.Streams.IQueueAdapter> defines external queue reads/writes and rewindability.
+- <xref:Orleans.Streams.IQueueAdapterReceiver> defines receive, acknowledgement, and shutdown.
+- <xref:Orleans.Streams.IStreamQueueMapper> defines stable partition mapping.
+- <xref:Orleans.Streams.IStreamQueueBalancer> defines cluster ownership.
+- <xref:Orleans.Streams.IQueueCache> and its cursors define buffering and safe purge.
+- <xref:Orleans.Streams.IStreamFailureHandler> defines delivery failure policy.
 
 See [provider authoring](../provider-authoring.md) for hosting and validation patterns and [Azure Queue streams](azure-queue-streams.md) for a concrete adapter.

--- a/docs/site/src/content/docs/implementation/testing.md
+++ b/docs/site/src/content/docs/implementation/testing.md
@@ -7,7 +7,7 @@ ms.topic: concept-article
 
 # TestingHost architecture
 
-`Microsoft.Orleans.TestingHost` composes real silo and client hosts with test-oriented discovery, transport, statistics, directory, and lifecycle controls. It is an integration harness, not a mock grain runtime. Grain activation, scheduling, serialization, messaging, placement, and most provider behavior execute through the same runtime components as a hosted cluster.
+The [`Microsoft.Orleans.TestingHost`](https://www.nuget.org/packages/Microsoft.Orleans.TestingHost/) package composes real silo and client hosts with test-oriented discovery, transport, statistics, directory, and lifecycle controls. It is an integration harness, not a mock grain runtime. Grain activation, scheduling, serialization, messaging, placement, and most provider behavior execute through the same runtime components as a hosted cluster.
 
 This page describes the harness internals. Test-fixture patterns and basic unit-testing guidance belong in task-oriented testing documentation.
 

--- a/docs/site/src/content/docs/implementation/testing.md
+++ b/docs/site/src/content/docs/implementation/testing.md
@@ -1,6 +1,6 @@
 ---
 title: TestingHost architecture
-description: Understand Orleans 10 in-process test clusters, substituted runtime services, builders, handles, and failure simulation.
+description: Understand Orleans in-process test clusters, substituted runtime services, builders, handles, and failure simulation.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -38,7 +38,7 @@ The processes are shared, but the hosts and dependency-injection containers are 
 
 Source: [`InProcessTestClusterBuilder`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestClusterBuilder.cs), [`InProcessTestCluster`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestCluster.cs), and [`InProcessSiloHandle`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcessSiloHandle.cs).
 
-## Current defaults
+## Defaults
 
 `InProcessTestClusterBuilder` defaults to:
 
@@ -72,17 +72,17 @@ Delegates run for each relevant host. A singleton registered by a silo delegate 
 
 `StartAdditionalSiloAsync()` and `StartSilosAsync(int)` create new hosts using the cluster's current options and configuration delegates. `StopSiloAsync`, `StopSilosAsync`, `StopAllSilosAsync`, `WaitForLivenessToStabilizeAsync`, and `WaitForClusterManifestToStabilizeAsync` coordinate membership and manifest transitions for failure and elasticity tests.
 
-The overloads which take `startAdditionalSiloOnNewPort` are obsolete. Current tests should use the parameterless `StartAdditionalSilo` methods or `StartSilosAsync(int)`. Lower-level `StartSiloAsync` overloads remain available when a test must supply an instance number or configuration overrides.
+The overloads which take `startAdditionalSiloOnNewPort` are obsolete. Tests should use the parameterless `StartAdditionalSilo` methods or `StartSilosAsync(int)`. Lower-level `StartSiloAsync` overloads remain available when a test must supply an instance number or configuration overrides.
 
 Stopping a host gracefully exercises shutdown. Disposing or terminating a handle without graceful membership update is a different failure mode and should be chosen deliberately when testing failure detection.
 
 ## `TestCluster` and custom silo creation
 
-`TestClusterBuilder` is the older, class-configurator-based harness. It still defaults to two silos, in-memory transport, generated cluster identity, test membership, client initialization, file logging, and homogeneous-silo assumptions. It also installs `ConfigureDistributedGrainDirectory`, so its silos opt into the experimental distributed grain directory instead of the production runtime's default `LocalGrainDirectory`.
+`TestClusterBuilder` is the class-configurator-based harness. It defaults to two silos, in-memory transport, generated cluster identity, test membership, client initialization, file logging, and homogeneous-silo assumptions. It also installs `ConfigureDistributedGrainDirectory`, so its silos opt into the experimental distributed grain directory instead of the production runtime's default `LocalGrainDirectory`.
 
 `ISiloConfigurator`, `IHostConfigurator`, and `IClientBuilderConfigurator` types are serializable configuration identities which can be applied to every host. Supplying a custom `CreateSiloAsync` switches the connection transport to TCP because the custom path cannot use the harness's in-memory transport.
 
-`TestCluster` remains valuable for suites built around `SiloHandle` and configurator types. It should not be described as using separate application domains; current hosts run in-process unless a custom silo creation path provides different isolation.
+`TestCluster` supports suites built around `SiloHandle` and configurator types. It does not use separate application domains; its hosts run in-process unless a custom silo creation path provides different isolation.
 
 Source: [`TestClusterBuilder`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestClusterBuilder.cs), [`TestCluster`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestCluster.cs), and [`TestClusterOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestClusterOptions.cs).
 

--- a/docs/site/src/content/docs/implementation/testing.md
+++ b/docs/site/src/content/docs/implementation/testing.md
@@ -1,261 +1,104 @@
 ---
-title: Unit testing
-description: Learn how to unit test with .NET Orleans.
-ms.date: 01/22/2026
-ms.topic: how-to
-zone_pivot_groups: orleans-version
+title: TestingHost architecture
+description: Understand Orleans 10 in-process test clusters, substituted runtime services, builders, handles, and failure simulation.
+ms.date: 08/02/2026
+ms.topic: concept-article
 ---
 
-# Unit testing with Orleans
+# TestingHost architecture
 
-This tutorial shows how to unit test your grains to ensure they behave correctly. There are two main ways to unit test your grains, and the method you choose depends on the type of functionality you're testing. Use the [Microsoft.Orleans.TestingHost](https://www.nuget.org/packages/Microsoft.Orleans.TestingHost) NuGet package to create test silos for your grains, or use a mocking framework like [Moq](https://github.com/moq/moq) to mock parts of the Orleans runtime your grain interacts with.
+`Microsoft.Orleans.TestingHost` composes real silo and client hosts with test-oriented discovery, transport, statistics, directory, and lifecycle controls. It is an integration harness, not a mock grain runtime. Grain activation, scheduling, serialization, messaging, placement, and most provider behavior execute through the same runtime components as a hosted cluster.
 
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0"
+This page describes the harness internals. Test-fixture patterns and basic unit-testing guidance belong in task-oriented testing documentation.
 
-## Use the `InProcessTestCluster` (recommended)
+## Cluster object model
 
-The `InProcessTestCluster` is the recommended testing infrastructure for Orleans. It provides a streamlined, delegate-based API for configuring test clusters, making it easier to share services between your tests and the cluster.
+```mermaid
+flowchart TB
+    Builder[InProcessTestClusterBuilder]
+    Options[InProcessTestClusterOptions]
+    Cluster[InProcessTestCluster]
+    Client[In-process ClusterClient]
+    S1[InProcessSiloHandle 1]
+    S2[InProcessSiloHandle 2]
+    Hosts[Independent Generic Hosts]
 
-### Key advantages
-
-The primary advantage of `InProcessTestCluster` over `TestCluster` is **ergonomics**:
-
-- **Delegate-based configuration**: Configure silos and clients using inline delegates instead of separate configuration classes
-- **Shared service instances**: Easily share mock services, test doubles, and other instances between your test code and the silo hosts
-- **Less boilerplate**: No need to create separate `ISiloConfigurator` or `IClientConfigurator` classes
-- **Simpler dependency injection**: Register services directly in the builder fluent API
-
-Both `InProcessTestCluster` and `TestCluster` use the same underlying in-process silo host by default, so memory usage and startup time are equivalent. The `TestCluster` API is designed to also support multi-process scenarios (for production-like simulation), which requires the class-based configuration approach, but by default it runs in-process just like `InProcessTestCluster`.
-
-### Basic usage
-
-```csharp
-using Orleans.TestingHost;
-using Xunit;
-
-public class HelloGrainTests : IAsyncLifetime
-{
-    private InProcessTestCluster _cluster = null!;
-
-    public async Task InitializeAsync()
-    {
-        var builder = new InProcessTestClusterBuilder();
-        _cluster = builder.Build();
-        await _cluster.DeployAsync();
-    }
-
-    public async Task DisposeAsync()
-    {
-        await _cluster.DisposeAsync();
-    }
-
-    [Fact]
-    public async Task SaysHello()
-    {
-        var grain = _cluster.Client.GetGrain<IHelloGrain>(0);
-        var result = await grain.SayHello("World");
-        Assert.Equal("Hello, World!", result);
-    }
-}
+    Builder --> Options
+    Builder --> Cluster
+    Cluster --> Client
+    Cluster --> S1
+    Cluster --> S2
+    S1 --> Hosts
+    S2 --> Hosts
 ```
 
-### Configure the test cluster
+`InProcessTestClusterBuilder` accumulates host, silo, and client delegates. `Build` passes its options to an `InProcessTestCluster`; the cluster retains that mutable options object. `DeployAsync` starts the configured silo hosts and initializes the client when requested. With client initialization enabled, it performs a best-effort initial membership-view check but can continue after warning that views have not stabilized. Each `InProcessSiloHandle` owns one Generic Host and exposes its service provider for test inspection.
 
-Use `InProcessTestClusterBuilder` to configure silos, clients, and services:
+The processes are shared, but the hosts and dependency-injection containers are not. Static process state can still leak between silos, which is one reason production code should not use static mutable state for silo-local behavior.
 
-```csharp
-var builder = new InProcessTestClusterBuilder(initialSilosCount: 2);
+Source: [`InProcessTestClusterBuilder`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestClusterBuilder.cs), [`InProcessTestCluster`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestCluster.cs), and [`InProcessSiloHandle`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcessSiloHandle.cs).
 
-// Configure silos
-builder.ConfigureSilo((options, siloBuilder) =>
-{
-    siloBuilder.AddMemoryGrainStorage("Default");
-    siloBuilder.AddMemoryGrainStorage("PubSubStore");
-});
+## Current defaults
 
-// Configure clients
-builder.ConfigureClient(clientBuilder =>
-{
-    // Client-specific configuration
-});
+`InProcessTestClusterBuilder` defaults to:
 
-// Configure both silos and clients (shared services)
-builder.ConfigureHost(hostBuilder =>
-{
-    hostBuilder.Services.AddSingleton<IMyService, MyService>();
-});
+| Setting | Default |
+| --- | --- |
+| Initial silos | 2 |
+| Cluster ID | Newly generated |
+| Service ID | Newly generated GUID |
+| Client initialization on deploy | `true` |
+| Test-cluster membership | `true` |
+| Test-cluster grain directory | `true` |
+| Gateway per silo | `true` |
+| Real environment statistics | `false` |
+| Connection transport | In-memory |
 
-var cluster = builder.Build();
-await cluster.DeployAsync();
-```
+Simulated environment statistics make resource-based tests deterministic, but they do not reproduce operating-system CPU or memory pressure. Opt into real statistics only when the test specifically needs those signals.
 
-### InProcessTestClusterOptions
+These defaults are defined in [`InProcTestClusterBuilder`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestClusterBuilder.cs) and [`InProcTestClusterOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestClusterOptions.cs).
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| <xref:Orleans.Configuration.ClusterOptions.ClusterId> | `string` | Auto-generated | Cluster identifier. |
-| <xref:Orleans.Configuration.ClusterOptions.ServiceId> | `string` | Auto-generated | Service identifier. |
-| `InitialSilosCount` | `int` | 1 | Number of silos to start initially. |
-| `InitializeClientOnDeploy` | `bool` | `true` | Whether to auto-initialize the client on deploy. |
-| `ConfigureFileLogging` | `bool` | `true` | Enable file logging for debugging. |
-| `UseRealEnvironmentStatistics` | `bool` | `false` | Use real memory/CPU statistics instead of simulated values. |
-| `GatewayPerSilo` | `bool` | `true` | Whether each silo hosts a gateway for client connections. |
+## Configuration layers
 
-### Share a test cluster between tests
+The builder separates three scopes:
 
-To improve test performance, share a single cluster across multiple test cases using xUnit fixtures:
+- `ConfigureHost` applies to both silo and client Generic Hosts and is useful for shared configuration or keyed SDK clients.
+- `ConfigureSilo` receives per-silo options and an `ISiloBuilder`.
+- `ConfigureClient` configures the cluster client.
 
-```csharp
-public class ClusterFixture : IAsyncLifetime
-{
-    public InProcessTestCluster Cluster { get; private set; } = null!;
+Delegates run for each relevant host. A singleton registered by a silo delegate is singleton within that silo's container, not across the cluster. A concrete instance captured by a delegate is shared because the test supplied the same object.
 
-    public async Task InitializeAsync()
-    {
-        var builder = new InProcessTestClusterBuilder();
-        builder.ConfigureSilo((options, siloBuilder) =>
-        {
-            siloBuilder.AddMemoryGrainStorageAsDefault();
-        });
-        
-        Cluster = builder.Build();
-        await Cluster.DeployAsync();
-    }
+## Dynamic topology
 
-    public async Task DisposeAsync()
-    {
-        await Cluster.DisposeAsync();
-    }
-}
+`StartAdditionalSiloAsync()` and `StartSilosAsync(int)` create new hosts using the cluster's current options and configuration delegates. `StopSiloAsync`, `StopSilosAsync`, `StopAllSilosAsync`, `WaitForLivenessToStabilizeAsync`, and `WaitForClusterManifestToStabilizeAsync` coordinate membership and manifest transitions for failure and elasticity tests.
 
-[CollectionDefinition(nameof(ClusterCollection))]
-public class ClusterCollection : ICollectionFixture<ClusterFixture>
-{
-}
+The overloads which take `startAdditionalSiloOnNewPort` are obsolete. Current tests should use the parameterless `StartAdditionalSilo` methods or `StartSilosAsync(int)`. Lower-level `StartSiloAsync` overloads remain available when a test must supply an instance number or configuration overrides.
 
-[Collection(nameof(ClusterCollection))]
-public class HelloGrainTests
-{
-    private readonly ClusterFixture _fixture;
+Stopping a host gracefully exercises shutdown. Disposing or terminating a handle without graceful membership update is a different failure mode and should be chosen deliberately when testing failure detection.
 
-    public HelloGrainTests(ClusterFixture fixture)
-    {
-        _fixture = fixture;
-    }
+## `TestCluster` and custom silo creation
 
-    [Fact]
-    public async Task SaysHello()
-    {
-        var grain = _fixture.Cluster.Client.GetGrain<IHelloGrain>(0);
-        var result = await grain.SayHello("World");
-        Assert.Equal("Hello, World!", result);
-    }
-}
-```
+`TestClusterBuilder` is the older, class-configurator-based harness. It still defaults to two silos, in-memory transport, generated cluster identity, test membership, client initialization, file logging, and homogeneous-silo assumptions. It also installs `ConfigureDistributedGrainDirectory`, so its silos opt into the experimental distributed grain directory instead of the production runtime's default `LocalGrainDirectory`.
 
-### Add and remove silos during tests
+`ISiloConfigurator`, `IHostConfigurator`, and `IClientBuilderConfigurator` types are serializable configuration identities which can be applied to every host. Supplying a custom `CreateSiloAsync` switches the connection transport to TCP because the custom path cannot use the harness's in-memory transport.
 
-The `InProcessTestCluster` supports dynamic silo management for testing cluster behavior:
+`TestCluster` remains valuable for suites built around `SiloHandle` and configurator types. It should not be described as using separate application domains; current hosts run in-process unless a custom silo creation path provides different isolation.
 
-```csharp
-// Start with 2 silos
-var builder = new InProcessTestClusterBuilder(initialSilosCount: 2);
-var cluster = builder.Build();
-await cluster.DeployAsync();
+Source: [`TestClusterBuilder`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestClusterBuilder.cs), [`TestCluster`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestCluster.cs), and [`TestClusterOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestClusterOptions.cs).
 
-// Add a third silo
-var newSilo = await cluster.StartSiloAsync();
+## Fidelity boundaries
 
-// Stop a silo
-await cluster.StopSiloAsync(newSilo);
+TestingHost deliberately substitutes infrastructure. Tests must account for those boundaries:
 
-// Restart all silos
-await cluster.RestartAsync();
-```
+- in-memory transport does not reproduce sockets, TLS, packet loss, or network buffers;
+- test membership does not prove a production membership provider's transaction behavior;
+- the test grain directory can bypass production directory edge cases;
+- simulated statistics do not reproduce load shedding;
+- one process shares thread-pool and static state; and
+- graceful stop does not model abrupt process or machine loss.
 
-:::zone-end
+Use the smallest substitution which keeps the invariant under test real. Directory, membership, transport, and provider contract tests often need their production component explicitly enabled.
 
-## Use the `TestCluster`
+## Test architecture in the repository
 
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0"
-
-The `TestCluster` uses a class-based configuration approach that requires implementing `ISiloConfigurator` and `IClientConfigurator` interfaces. This design supports multi-process testing scenarios where silos run in separate processes, which is useful for production-like simulation testing. However, by default `TestCluster` also runs in-process with equivalent performance to `InProcessTestCluster`.
-
-Choose `TestCluster` over `InProcessTestCluster` when:
-
-- You need multi-process testing for production simulation
-- You have existing tests using the `TestCluster` API
-- You need compatibility with Orleans 7.x or 8.x
-
-For new tests, `InProcessTestCluster` is recommended due to its simpler delegate-based configuration.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-8-0,orleans-7-0,orleans-3-x"
-:::zone-end
-
-The `Microsoft.Orleans.TestingHost` NuGet package contains <xref:Orleans.TestingHost.TestCluster>, which you can use to create an in-memory cluster (comprised of two silos by default) for testing grains.
-
-:::code source="snippets/testing/orleans-testing/Sample.OrleansTesting/HelloGrainTests.cs":::
-
-Due to the overhead of starting an in-memory cluster, you might want to create a `TestCluster` and reuse it among multiple test cases. For example, achieve this using xUnit's class or collection fixtures.
-
-To share a `TestCluster` between multiple test cases, first create a fixture type:
-
-:::code source="snippets/testing/orleans-testing/Sample.OrleansTesting/ClusterFixture.cs":::
-
-Next, create a collection fixture:
-
-:::code source="snippets/testing/orleans-testing/Sample.OrleansTesting/ClusterCollection.cs":::
-
-You can now reuse a `TestCluster` in your test cases:
-
-:::code source="snippets/testing/orleans-testing/Sample.OrleansTesting/HelloGrainTestsWithFixture.cs":::
-
-When all tests complete and the in-memory cluster silos stop, xUnit calls the <xref:System.IDisposable.Dispose> method of the `ClusterFixture` type. `TestCluster` also has a constructor accepting <xref:Orleans.TestingHost.TestClusterOptions> that you can use to configure the silos in the cluster.
-
-If you use Dependency Injection in your Silo to make services available to Grains, you can use this pattern as well:
-
-:::code source="snippets/testing/orleans-testing/Sample.OrleansTesting/ClusterFixtureWithConfig.cs"
-
-## Use mocks
-
-Orleans also allows mocking many parts of the system. For many scenarios, this is the easiest way to unit test grains. This approach has limitations (e.g., around scheduling reentrancy and serialization) and might require grains to include code used only by your unit tests. The [Orleans TestKit](https://github.com/OrleansContrib/OrleansTestKit) provides an alternative approach that sidesteps many of these limitations.
-
-For example, imagine the grain you're testing interacts with other grains. To mock those other grains, you also need to mock the <xref:Orleans.Grain.GrainFactory> member of the grain under test. By default, `GrainFactory` is a normal `protected` property, but most mocking frameworks require properties to be `public` and `virtual` to enable mocking. So, the first step is to make `GrainFactory` both `public` and `virtual`:
-
-```csharp
-public new virtual IGrainFactory GrainFactory
-{
-    get => base.GrainFactory;
-}
-```
-
-Now you can create your grain outside the Orleans runtime and use mocking to control the behavior of `GrainFactory`:
-
-```csharp
-using Xunit;
-using Moq;
-
-namespace Tests;
-
-public class WorkerGrainTests
-{
-    [Fact]
-    public async Task RecordsMessageInJournal()
-    {
-        var data = "Hello, World";
-        var journal = new Mock<IJournalGrain>();
-        var worker = new Mock<WorkerGrain>();
-        worker
-            .Setup(x => x.GrainFactory.GetGrain<IJournalGrain>(It.IsAny<Guid>()))
-            .Returns(journal.Object);
-
-        await worker.DoWork(data)
-
-        journal.Verify(x => x.Record(data), Times.Once());
-    }
-}
-```
-
-Here, create the grain under test, `WorkerGrain`, using Moq. This allows overriding the `GrainFactory`'s behavior so it returns a mocked `IJournalGrain`. You can then verify that `WorkerGrain` interacts with `IJournalGrain` as expected.
+Repository fixtures such as `BaseInProcessTestClusterFixture` wrap cluster setup and disposal, while specialized suites configure the component being exercised. For example, [`AQStreamingTests`](https://github.com/dotnet/orleans/blob/main/test/Extensions/Orleans.Azure.Tests/Streaming/AQStreamingTests.cs) uses `ConfigureHost`, `ConfigureSilo`, and `ConfigureClient` to combine real Azure Queue adapters with an in-process Orleans cluster.

--- a/docs/site/src/content/docs/implementation/testing.md
+++ b/docs/site/src/content/docs/implementation/testing.md
@@ -80,7 +80,7 @@ Stopping a host gracefully exercises shutdown. Disposing or terminating a handle
 
 `TestClusterBuilder` is the class-configurator-based harness. It defaults to two silos, in-memory transport, generated cluster identity, test membership, client initialization, file logging, and homogeneous-silo assumptions. It also installs `ConfigureDistributedGrainDirectory`, so its silos opt into the experimental distributed grain directory instead of the production runtime's default `LocalGrainDirectory`.
 
-`ISiloConfigurator`, `IHostConfigurator`, and `IClientBuilderConfigurator` types are serializable configuration identities which can be applied to every host. Supplying a custom `CreateSiloAsync` switches the connection transport to TCP because the custom path cannot use the harness's in-memory transport.
+`ISiloConfigurator`, `IHostConfigurator`, and `IClientBuilderConfigurator` types are serializable configuration identities which can be applied to every host. Assigning `TestClusterBuilder.CreateSiloAsync` sets `ConnectionTransport` to `TcpSocket`, so the built-in client uses its TCP transport instead of the harness's in-memory transport. The delegate bypasses `DefaultCreateSiloAsync` and cannot access the harness's private in-memory transport hub, so it must configure the custom silo host with a compatible transport.
 
 `TestCluster` supports suites built around `SiloHandle` and configurator types. It does not use separate application domains; its hosts run in-process unless a custom silo creation path provides different isolation.
 

--- a/docs/site/src/content/docs/implementation/testing.md
+++ b/docs/site/src/content/docs/implementation/testing.md
@@ -11,7 +11,7 @@ The [`Microsoft.Orleans.TestingHost`](https://www.nuget.org/packages/Microsoft.O
 
 This page describes the harness internals. Test-fixture patterns and basic unit-testing guidance belong in task-oriented testing documentation.
 
-## Cluster object model
+## Cluster object model <a name="use-the-inprocesstestcluster-recommended"></a>
 
 ```mermaid
 flowchart TB
@@ -32,61 +32,61 @@ flowchart TB
     S2 --> Hosts
 ```
 
-`InProcessTestClusterBuilder` accumulates host, silo, and client delegates. `Build` passes its options to an `InProcessTestCluster`; the cluster retains that mutable options object. `DeployAsync` starts the configured silo hosts and initializes the client when requested. With client initialization enabled, it performs a best-effort initial membership-view check but can continue after warning that views have not stabilized. Each `InProcessSiloHandle` owns one Generic Host and exposes its service provider for test inspection.
+<xref:Orleans.TestingHost.InProcessTestClusterBuilder> accumulates host, silo, and client delegates. <xref:Orleans.TestingHost.InProcessTestClusterBuilder.Build*> passes its options to an <xref:Orleans.TestingHost.InProcessTestCluster>; the cluster retains that mutable options object. <xref:Orleans.TestingHost.InProcessTestCluster.DeployAsync*> starts the configured silo hosts and initializes the client when requested. With client initialization enabled, it performs a best-effort initial membership-view check but can continue after warning that views have not stabilized. Each <xref:Orleans.TestingHost.InProcessSiloHandle> owns one Generic Host and exposes its service provider for test inspection.
 
 The processes are shared, but the hosts and dependency-injection containers are not. Static process state can still leak between silos, which is one reason production code should not use static mutable state for silo-local behavior.
 
-Source: [`InProcessTestClusterBuilder`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestClusterBuilder.cs), [`InProcessTestCluster`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestCluster.cs), and [`InProcessSiloHandle`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcessSiloHandle.cs).
+API: <xref:Orleans.TestingHost.InProcessTestClusterBuilder>, <xref:Orleans.TestingHost.InProcessTestCluster>, and <xref:Orleans.TestingHost.InProcessSiloHandle>. Implementation: [builder](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestClusterBuilder.cs), [cluster](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestCluster.cs), and [silo handle](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcessSiloHandle.cs).
 
 ## Defaults
 
-`InProcessTestClusterBuilder` defaults to:
+<xref:Orleans.TestingHost.InProcessTestClusterBuilder> defaults to:
 
 | Setting | Default |
 | --- | --- |
-| Initial silos | 2 |
-| Cluster ID | Newly generated |
-| Service ID | Newly generated GUID |
-| Client initialization on deploy | `true` |
+| <xref:Orleans.TestingHost.InProcessTestClusterOptions.InitialSilosCount?displayProperty=nameWithType> | 2 |
+| <xref:Orleans.TestingHost.InProcessTestClusterOptions.ClusterId?displayProperty=nameWithType> | Newly generated |
+| <xref:Orleans.TestingHost.InProcessTestClusterOptions.ServiceId?displayProperty=nameWithType> | Newly generated GUID |
+| <xref:Orleans.TestingHost.InProcessTestClusterOptions.InitializeClientOnDeploy?displayProperty=nameWithType> | `true` |
 | Test-cluster membership | `true` |
 | Test-cluster grain directory | `true` |
-| Gateway per silo | `true` |
-| Real environment statistics | `false` |
+| <xref:Orleans.TestingHost.InProcessTestClusterOptions.GatewayPerSilo?displayProperty=nameWithType> | `true` |
+| <xref:Orleans.TestingHost.InProcessTestClusterOptions.UseRealEnvironmentStatistics?displayProperty=nameWithType> | `false` |
 | Connection transport | In-memory |
 
 Simulated environment statistics make resource-based tests deterministic, but they do not reproduce operating-system CPU or memory pressure. Opt into real statistics only when the test specifically needs those signals.
 
-These defaults are defined in [`InProcTestClusterBuilder`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestClusterBuilder.cs) and [`InProcTestClusterOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestClusterOptions.cs).
+These defaults are defined by <xref:Orleans.TestingHost.InProcessTestClusterBuilder> and <xref:Orleans.TestingHost.InProcessTestClusterOptions>; see their [builder](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestClusterBuilder.cs) and [options](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/InProcTestClusterOptions.cs) implementations.
 
-## Configuration layers
+## Configuration layers <a name="configure-the-test-cluster"></a>
 
 The builder separates three scopes:
 
-- `ConfigureHost` applies to both silo and client Generic Hosts and is useful for shared configuration or keyed SDK clients.
-- `ConfigureSilo` receives per-silo options and an `ISiloBuilder`.
-- `ConfigureClient` configures the cluster client.
+- <xref:Orleans.TestingHost.InProcessTestClusterBuilder.ConfigureHost*> applies to both silo and client Generic Hosts and is useful for shared configuration or keyed SDK clients.
+- <xref:Orleans.TestingHost.InProcessTestClusterBuilder.ConfigureSilo*> receives per-silo options and an <xref:Orleans.Hosting.ISiloBuilder>.
+- <xref:Orleans.TestingHost.InProcessTestClusterBuilder.ConfigureClient*> configures the cluster client.
 
 Delegates run for each relevant host. A singleton registered by a silo delegate is singleton within that silo's container, not across the cluster. A concrete instance captured by a delegate is shared because the test supplied the same object.
 
-## Dynamic topology
+## Dynamic topology <a name="add-and-remove-silos-during-tests"></a>
 
-`StartAdditionalSiloAsync()` and `StartSilosAsync(int)` create new hosts using the cluster's current options and configuration delegates. `StopSiloAsync`, `StopSilosAsync`, `StopAllSilosAsync`, `WaitForLivenessToStabilizeAsync`, and `WaitForClusterManifestToStabilizeAsync` coordinate membership and manifest transitions for failure and elasticity tests.
+<xref:Orleans.TestingHost.InProcessTestCluster.StartAdditionalSiloAsync*> and <xref:Orleans.TestingHost.InProcessTestCluster.StartSilosAsync*> create new hosts using the cluster's current options and configuration delegates. <xref:Orleans.TestingHost.InProcessTestCluster.StopSiloAsync*>, <xref:Orleans.TestingHost.InProcessTestCluster.StopSilosAsync*>, <xref:Orleans.TestingHost.InProcessTestCluster.StopAllSilosAsync*>, <xref:Orleans.TestingHost.InProcessTestCluster.WaitForLivenessToStabilizeAsync*>, and <xref:Orleans.TestingHost.InProcessTestCluster.WaitForClusterManifestToStabilizeAsync*> coordinate membership and manifest transitions for failure and elasticity tests.
 
-The overloads which take `startAdditionalSiloOnNewPort` are obsolete. Tests should use the parameterless `StartAdditionalSilo` methods or `StartSilosAsync(int)`. Lower-level `StartSiloAsync` overloads remain available when a test must supply an instance number or configuration overrides.
+The overloads which take `startAdditionalSiloOnNewPort` are obsolete. Tests should use the parameterless <xref:Orleans.TestingHost.InProcessTestCluster.StartAdditionalSilo*> overloads or <xref:Orleans.TestingHost.InProcessTestCluster.StartSilosAsync*>. Lower-level <xref:Orleans.TestingHost.InProcessTestCluster.StartSiloAsync*> overloads remain available when a test must supply an instance number or configuration overrides.
 
 Stopping a host gracefully exercises shutdown. Disposing or terminating a handle without graceful membership update is a different failure mode and should be chosen deliberately when testing failure detection.
 
-## `TestCluster` and custom silo creation
+## Class-configurator test cluster and custom silo creation <a name="use-the-testcluster"></a>
 
-`TestClusterBuilder` is the class-configurator-based harness. It defaults to two silos, in-memory transport, generated cluster identity, test membership, client initialization, file logging, and homogeneous-silo assumptions. It also installs `ConfigureDistributedGrainDirectory`, so its silos opt into the experimental distributed grain directory instead of the production runtime's default `LocalGrainDirectory`.
+<xref:Orleans.TestingHost.TestClusterBuilder> is the class-configurator-based harness. It defaults to two silos, in-memory transport, generated cluster identity, test membership, client initialization, file logging, and homogeneous-silo assumptions. It also installs `ConfigureDistributedGrainDirectory`, so its silos opt into the experimental distributed grain directory instead of the production runtime's default `LocalGrainDirectory`.
 
-`ISiloConfigurator`, `IHostConfigurator`, and `IClientBuilderConfigurator` types are serializable configuration identities which can be applied to every host. Assigning `TestClusterBuilder.CreateSiloAsync` sets `ConnectionTransport` to `TcpSocket`, so the built-in client uses its TCP transport instead of the harness's in-memory transport. The delegate bypasses `DefaultCreateSiloAsync` and cannot access the harness's private in-memory transport hub, so it must configure the custom silo host with a compatible transport.
+<xref:Orleans.TestingHost.ISiloConfigurator>, <xref:Orleans.TestingHost.IHostConfigurator>, and <xref:Orleans.TestingHost.IClientBuilderConfigurator> are serializable configuration identities which can be applied to every host. Assigning <xref:Orleans.TestingHost.TestClusterBuilder.CreateSiloAsync?displayProperty=nameWithType> sets <xref:Orleans.TestingHost.TestClusterOptions.ConnectionTransport?displayProperty=nameWithType> to `TcpSocket`, so the built-in client uses its TCP transport instead of the harness's in-memory transport. The delegate bypasses <xref:Orleans.TestingHost.TestCluster.DefaultCreateSiloAsync*> and cannot access the harness's private in-memory transport hub, so it must configure the custom silo host with a compatible transport.
 
-`TestCluster` supports suites built around `SiloHandle` and configurator types. It does not use separate application domains; its hosts run in-process unless a custom silo creation path provides different isolation.
+<xref:Orleans.TestingHost.TestCluster> supports suites built around <xref:Orleans.TestingHost.SiloHandle> and configurator types. It does not use separate application domains; its hosts run in-process unless a custom silo creation path provides different isolation.
 
-Source: [`TestClusterBuilder`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestClusterBuilder.cs), [`TestCluster`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestCluster.cs), and [`TestClusterOptions`](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestClusterOptions.cs).
+API: <xref:Orleans.TestingHost.TestClusterBuilder>, <xref:Orleans.TestingHost.TestCluster>, and <xref:Orleans.TestingHost.TestClusterOptions>. Implementation: [builder](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestClusterBuilder.cs), [cluster](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestCluster.cs), and [options](https://github.com/dotnet/orleans/blob/main/src/Orleans.TestingHost/TestClusterOptions.cs).
 
-## Fidelity boundaries
+## Fidelity boundaries <a name="use-mocks"></a>
 
 TestingHost deliberately substitutes infrastructure. Tests must account for those boundaries:
 


### PR DESCRIPTION
Expands the Orleans 10 implementation track into an advanced, source-backed architecture guide. It documents runtime topology, activation migration, membership and directory protocols, scheduling and messaging semantics, resource-optimized placement, serialization, persistent streams, provider authoring, and TestingHost internals while correcting stale defaults and APIs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10332)