### PR TITLE
docs: modernize grain programming guidance

### DIFF
--- a/docs/site/src/content/docs/grains/cancellation-tokens.md
+++ b/docs/site/src/content/docs/grains/cancellation-tokens.md
@@ -7,7 +7,7 @@ ms.topic: concept-article
 
 # Cancel Orleans grain calls
 
-Orleans 10 supports <xref:System.Threading.CancellationToken> parameters on grain methods. Cancellation is cooperative: Orleans delivers a cancellation signal, and the grain implementation decides where it is safe to stop.
+Orleans supports <xref:System.Threading.CancellationToken> parameters on grain methods. Cancellation is cooperative: Orleans delivers a cancellation signal, and the grain implementation decides where it is safe to stop.
 
 ## Add cancellation to a contract
 
@@ -115,4 +115,4 @@ Cancellation callbacks registered from grain code execute in the grain's schedul
 
 Orleans treats a `CancellationToken` specially in generated request contracts. Adding or removing a token parameter is wire-compatible with callers compiled against the other form: a missing token is represented as `CancellationToken.None`, and an extra token from an older caller can be ignored. Making a newly added parameter optional also preserves C# source compatibility for common call sites.
 
-The older `GrainCancellationToken` API isn't needed for new Orleans 10 applications. Use the standard .NET token.
+The older `GrainCancellationToken` API isn't needed for new applications. Use the standard .NET token.

--- a/docs/site/src/content/docs/grains/cancellation-tokens.md
+++ b/docs/site/src/content/docs/grains/cancellation-tokens.md
@@ -1,527 +1,118 @@
 ---
-title: Use cancellation tokens in Orleans grains
-description: Learn how to implement cooperative cancellation in Orleans grain methods.
-ms.date: 01/21/2026
-zone_pivot_groups: orleans-version
+title: Cancel Orleans grain calls
+description: Use CancellationToken for cooperative cancellation of Orleans grain calls.
+ms.date: 08/02/2026
+ms.topic: concept-article
 ---
 
-# Use cancellation tokens in Orleans grains
+# Cancel Orleans grain calls
 
-:::zone target="docs" pivot="orleans-9-0,orleans-10-0,orleans-8-0,orleans-7-0,orleans-3-x"
+Orleans 10 supports <xref:System.Threading.CancellationToken> parameters on grain methods. Cancellation is cooperative: Orleans delivers a cancellation signal, and the grain implementation decides where it is safe to stop.
 
-Orleans supports cooperative cancellation in grain methods through the standard <xref:System.Threading.CancellationToken>. This feature lets you stop long-running operations early, cancel work that's no longer needed, and improve your application's responsiveness and resource utilization.
+## Add cancellation to a contract
 
-:::zone-end
-
-## Overview
-
-Orleans supports passing <xref:System.Threading.CancellationToken> instances to grain interface methods. This works for:
-
-- Regular grain methods that return <xref:System.Threading.Tasks.Task>, <xref:System.Threading.Tasks.Task`1>, etcetera
-- Streaming methods that return <xref:System.Collections.Generic.IAsyncEnumerable`1>
-- Both client-to-grain and grain-to-grain calls
-
-Cancellation is cooperative, meaning your grain implementation must observe the token and respond appropriately for it to be effective. If a cancellation token is not observed, the runtime will not automatically stop a method from executing. This behavior is consistent with the majority of libraries that support <xref:System.Threading.CancellationToken>. In other words, .NET uses cooperative cancellation. The major benefit of this approach is that cancellation can only occur at clearly identifiable points, not at any given instruction. This lets you run cleanup logic when cancellation is signalled.
-
-Before a grain call is made, the runtime checks if the provided <xref:System.Threading.CancellationToken> is already canceled. If so, it immediately throws an <xref:System.OperationCanceledException> without issuing the request. Similarly, if an enqueued request is canceled before a grain begins executing it, it is cancelled without being executed.
-
-While the grain call is executing, the runtime listens for cancellation, propagating the cancellation signal to the remote caller. Cancellation signals are only propagated while the call is active. Once the call completes (either normally or with an error), any subsequent cancellation signal will not be propagated to the remote caller even if it is still executing. These semantics are similar to how cancellation with remote calls works with other APIs such as <xref:System.Net.Http.HttpClient>, gRPC, or Azure API clients.
-
-## Basic usage
-
-Follow these steps to add cancellation support to your grain methods:
-
-### 1. Define the grain interface
-
-Add a <xref:System.Threading.CancellationToken> parameter as the last parameter in your grain interface method. Make it optional with a default value for better usability:
+Add at most one `CancellationToken` parameter. Put it last and make it optional when callers commonly don't need cancellation:
 
 ```csharp
-public interface IProcessingGrain : IGrainWithGuidKey
+public interface IImportGrain : IGrainWithGuidKey
 {
-    Task<string> ProcessDataAsync(string data, int chunks, CancellationToken cancellationToken = default);
+    Task<int> Import(
+        IReadOnlyList<string> records,
+        CancellationToken cancellationToken = default);
 }
 ```
 
-### 2. Implement the grain method
-
-In your grain implementation, regularly check the cancellation token during long-running operations:
+Observe the token in the implementation and pass it to cancellation-aware APIs:
 
 ```csharp
-public class ProcessingGrain : Grain, IProcessingGrain
+public sealed class ImportGrain : Grain, IImportGrain
 {
-    public async Task<string> ProcessDataAsync(string data, int chunks, CancellationToken cancellationToken = default)
+    public async Task<int> Import(
+        IReadOnlyList<string> records,
+        CancellationToken cancellationToken = default)
     {
-        // Check cancellation before starting work
-        cancellationToken.ThrowIfCancellationRequested();
+        var imported = 0;
 
-        var results = new List<string>();
-
-        for (int i = 0; i < chunks; i++)
+        foreach (string record in records)
         {
-            // Check cancellation before each chunk
             cancellationToken.ThrowIfCancellationRequested();
-
-            // Process each chunk
-            var chunkResult = await ProcessChunkAsync(data, i);
-            results.Add(chunkResult);
-
-            // Use cancellation token with async operations when possible
-            await Task.Delay(100, cancellationToken);
+            await SaveRecord(record, cancellationToken);
+            imported++;
         }
 
-        return string.Join(", ", results);
+        return imported;
     }
 
-    private async Task<string> ProcessChunkAsync(string data, int chunkIndex)
-    {
-        // Simulate processing work
-        await Task.Delay(50);
-        return $"{data}_chunk_{chunkIndex}";
-    }
+    private static Task SaveRecord(
+        string record,
+        CancellationToken cancellationToken) =>
+        Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken);
 }
 ```
 
-### 3. Call the grain with cancellation
+If a token is already canceled before the call is sent, Orleans doesn't issue the request. If cancellation arrives while the request is queued, Orleans can remove it before execution. Once execution starts, the grain method must observe the token.
 
-Create a <xref:System.Threading.CancellationTokenSource> and pass its token to the grain method:
+## Cancel a call
+
+Pass a token from a <xref:System.Threading.CancellationTokenSource>:
 
 ```csharp
-var grain = grainFactory.GetGrain<IProcessingGrain>(Guid.NewGuid());
+IImportGrain importer =
+    grainFactory.GetGrain<IImportGrain>(Guid.NewGuid());
 
-using var cts = new CancellationTokenSource();
-
-// Set a timeout for automatic cancellation
-cts.CancelAfter(TimeSpan.FromSeconds(30));
+using var cancellation = new CancellationTokenSource(
+    TimeSpan.FromSeconds(30));
 
 try
 {
-    var result = await grain.ProcessDataAsync("sample data", 20, cts.Token);
-    Console.WriteLine($"Result: {result}");
+    await importer.Import(records, cancellation.Token);
 }
 catch (OperationCanceledException)
+    when (cancellation.IsCancellationRequested)
 {
-    Console.WriteLine("Operation was canceled");
-}
-
-// Manual cancellation example
-var grain2 = grainFactory.GetGrain<IProcessingGrain>(Guid.NewGuid());
-using var cts2 = new CancellationTokenSource();
-
-// Start a long-running task
-var task = grain2.ProcessDataAsync("large dataset", 1000, cts2.Token);
-
-// Cancel after 5 seconds
-await Task.Delay(5000);
-cts2.Cancel();
-
-try
-{
-    await task;
-}
-catch (OperationCanceledException)
-{
-    Console.WriteLine("Long processing was canceled");
+    // The caller requested cancellation.
 }
 ```
 
-## Streaming with IAsyncEnumerable&lt;T&gt;
+Cancellation can cross client-to-grain and grain-to-grain calls. Delivery is best effort under network failure, and cancellation doesn't roll back side effects that completed before the grain observed the token.
 
-Cancellation is particularly useful for streaming scenarios where you might want to stop enumeration early. Orleans supports cancellation tokens in async enumerable grain methods.
+## Timeouts and cancellation
 
-```csharp
-using System.Runtime.CompilerServices;
+A response timeout and cancellation answer different questions:
 
-public interface IDataStreamGrain : IGrainWithGuidKey
-{
-    IAsyncEnumerable<DataPoint> StreamDataAsync(int count, CancellationToken cancellationToken = default);
-}
+- A **timeout** stops the caller from waiting after no response arrives in time.
+- **Cancellation** asks the callee to stop cooperatively.
 
-public class DataStreamGrain : Grain, IDataStreamGrain
-{
-    public async IAsyncEnumerable<DataPoint> StreamDataAsync(
-        int count,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        for (int i = 0; i < count; i++)
-        {
-            // Check cancellation before each yield
-            cancellationToken.ThrowIfCancellationRequested();
-            // Generate or fetch data
-            var dataPoint = await GenerateDataPointAsync(i, cancellationToken);
-            yield return dataPoint;
-
-            // Optional: add delay with cancellation support
-            await Task.Delay(100, cancellationToken);
-        }
-    }
-
-    private async Task<DataPoint> GenerateDataPointAsync(int index, CancellationToken cancellationToken)
-    {
-        // Simulate data generation
-        await Task.Delay(10, cancellationToken);
-        return new DataPoint { Index = index, Value = Random.Shared.NextDouble() };
-    }
-}
-
-public record DataPoint(int Index, double Value);
-```
-
-### Consuming the stream
-
-When you consume async enumerables, you have two approaches for passing cancellation tokens: [Direct method call with cancellation](#approach-1-direct-method-call-with-cancellation) and [WithCancellation extension method](#approach-2-withcancellation-extension-method).
-
-#### Approach 1: Direct method call with cancellation
-
-When the async enumerable method has an <xref:System.Runtime.CompilerServices.EnumeratorCancellationAttribute> parameter, pass the token directly:
+By default, a timed-out call isn't canceled. <xref:Orleans.Configuration.MessagingOptions.CancelRequestOnTimeout> defaults to `false`. Enable it explicitly when timed-out operations should receive a cancellation signal:
 
 ```csharp
-var grain = grainFactory.GetGrain<IDataStreamGrain>(Guid.NewGuid());
-
-using var cts = new CancellationTokenSource();
-cts.CancelAfter(TimeSpan.FromSeconds(10)); // Auto-cancel after 10 seconds
-
-try
-{
-    // The token is passed directly to the method and will be combined
-    // with any token passed to GetAsyncEnumerator() internally
-    await foreach (var dataPoint in grain.StreamDataAsync(1000, cts.Token))
-    {
-        Console.WriteLine($"Received: {dataPoint}");
-
-        // Process the data point
-        // Cancellation will stop the enumeration automatically
-    }
-}
-catch (OperationCanceledException)
-{
-    Console.WriteLine("Streaming was canceled");
-}
-```
-
-#### Approach 2: WithCancellation extension method
-
-For scenarios where you have an existing <xref:System.Collections.Generic.IAsyncEnumerable`1> instance or need to override the cancellation token, use the <xref:System.Threading.Tasks.TaskAsyncEnumerableExtensions.WithCancellation*> extension method:
-
-```csharp
-var grain = grainFactory.GetGrain<IDataStreamGrain>(Guid.NewGuid());
-var asyncEnumerable = grain.StreamDataAsync(1000);
-
-using var cts = new CancellationTokenSource();
-cts.CancelAfter(TimeSpan.FromSeconds(10));
-
-try
-{
-    // WithCancellation passes the token to GetAsyncEnumerator()
-    await foreach (var dataPoint in asyncEnumerable.WithCancellation(cts.Token))
-    {
-        Console.WriteLine($"Received: {dataPoint}");
-    }
-}
-catch (OperationCanceledException)
-{
-    Console.WriteLine("Streaming was canceled");
-}
-```
-
-## Backward compatibility
-
-One of the key advantages of Orleans's cancellation token support is its backward compatibility. You can modify your grain interfaces and implementations to include or remove <xref:System.Threading.CancellationToken> parameters without breaking existing clients or other grains that call these methods.
-
-- **Adding a <xref:System.Threading.CancellationToken>**: You can add a <xref:System.Threading.CancellationToken> parameter to an existing grain interface method. If an older client, compiled against the previous interface, calls this method without providing the token, the grain method will receive `CancellationToken.None` from the Orleans runtime. For C# source compatibility with existing grain *implementations* of the interface, it's recommended to define this new parameter as optional in the interface (for example, `CancellationToken cancellationToken = default`). New callers can provide a specific token.
-
-- **Removing a <xref:System.Threading.CancellationToken>**: If you remove a <xref:System.Threading.CancellationToken> parameter from a grain method, callers that were previously passing a token will still have their calls succeed. The Orleans runtime will simply ignore the extra token parameter that the caller is sending, and the grain method will execute without it. The caller might still observe its own token's cancellation and could potentially time out or throw an `OperationCanceledException` on the calling side if its token is canceled, but the grain method itself won't receive the token.
-
-This flexibility allows you to incrementally adopt cancellation in your Orleans applications without forcing a coordinated update across all components.
-
-## Configuration
-
-Configure cancellation behavior through <xref:Orleans.Configuration.SiloMessagingOptions> (for silos) and <xref:Orleans.Configuration.ClientMessagingOptions> (for clients):
-
-```csharp
-// In your silo configuration
 siloBuilder.Configure<SiloMessagingOptions>(options =>
 {
-    // Send cancellation signal when requests timeout (default: true)
     options.CancelRequestOnTimeout = true;
-
-    // Wait for callee to acknowledge cancellation (default: false)
-    // Setting this to true provides stronger cancellation guarantees but may impact performance
-    options.WaitForCancellationAcknowledgement = false;
 });
 
-// In your client configuration
 clientBuilder.Configure<ClientMessagingOptions>(options =>
 {
     options.CancelRequestOnTimeout = true;
-    options.WaitForCancellationAcknowledgement = false;
 });
 ```
 
-### Configuration options explained
+Even when enabled, the timeout doesn't prove that the operation stopped. The cancellation message can be delayed, the method might not observe its token, or side effects might already have completed.
 
-- **<xref:Orleans.Configuration.MessagingOptions.CancelRequestOnTimeout>**: When `true`, Orleans automatically sends a cancellation signal to the target grain if a request times out. This helps notify long-running operations that the caller is no longer waiting.
+`WaitForCancellationAcknowledgement` also defaults to `false`. Enabling it makes the caller wait for acknowledgement from the callee rather than completing local cancellation immediately. Use it only when that stronger coordination is worth the added latency and messaging.
 
-- **<xref:Orleans.Configuration.MessagingOptions.WaitForCancellationAcknowledgement>**: When `true`, the cancellation call waits for the target grain to acknowledge that it received the cancellation signal. This provides stronger guarantees but can impact performance in high-throughput scenarios.
+## Design cancellable operations
 
-## Diagnostics and troubleshooting
+- Check the token before expensive work and between independently safe units of work.
+- Pass the token to I/O and other asynchronous dependencies.
+- Leave state consistent at every cancellation point.
+- Re-throw <xref:System.OperationCanceledException> after cleanup so the caller can distinguish cancellation from failure.
+- Make externally visible operations idempotent when a caller might retry after an uncertain outcome.
 
-### Compiler diagnostics
+Cancellation callbacks registered from grain code execute in the grain's scheduling context. Keep callbacks short and avoid blocking.
 
-Orleans code generation enforces that only one <xref:System.Threading.CancellationToken> parameter is allowed per grain method. If you add more than one, you'll get a build error with diagnostic ID `ORLEANS0109`:
+## Contract evolution
 
-> The type `YourGrainInterface` contains method `YourMethod` which has multiple CancellationToken parameters. Only a single CancellationToken parameter is supported.
+Orleans treats a `CancellationToken` specially in generated request contracts. Adding or removing a token parameter is wire-compatible with callers compiled against the other form: a missing token is represented as `CancellationToken.None`, and an extra token from an older caller can be ignored. Making a newly added parameter optional also preserves C# source compatibility for common call sites.
 
-**Incorrect:**
-
-```csharp
-public interface IMyGrain : IGrainWithGuidKey
-{
-    // This will cause ORLEANS0109 error
-    Task ProcessAsync(CancellationToken token1, CancellationToken token2);
-}
-```
-
-**Correct:**
-
-```csharp
-public interface IMyGrain : IGrainWithGuidKey
-{
-    Task ProcessAsync(CancellationToken cancellationToken = default);
-}
-```
-
-### Monitoring cancellation activity
-
-Orleans provides metrics to help you monitor cancellation behavior in your application:
-
-- **`orleans-app-requests-canceled`**: Tracks the number of canceled requests.
-- Monitor this metric to understand cancellation patterns and identify potential issues.
-
-```csharp
-// Example: Custom logging for cancellation tracking
-public async Task MonitoredOperationAsync(CancellationToken cancellationToken = default)
-{
-    var stopwatch = Stopwatch.StartNew();
-
-    try
-    {
-        await DoWorkAsync(cancellationToken);
-        logger.LogInformation("Operation completed in {ElapsedMs}ms", stopwatch.ElapsedMilliseconds);
-    }
-    catch (OperationCanceledException)
-    {
-        logger.LogInformation("Operation canceled after {ElapsedMs}ms", stopwatch.ElapsedMilliseconds);
-        throw;
-    }
-}
-```
-
-## Performance considerations
-
-### Cancellation batching
-
-Orleans optimizes performance by batching cancellation requests when many cancellations occur simultaneously. This reduces network overhead and CPU load during high-cancellation scenarios, such as when a service shuts down or when many operations time out simultaneously.
-
-### Callback execution context
-
-Callbacks registered on a <xref:System.Threading.CancellationToken> within a grain execute on the grain's scheduler. This lets you safely perform operations in the context of the grain from cancellation callbacks.
-
-```csharp
-public async Task ExampleWithCancellationCallbackAsync(CancellationToken cancellationToken = default)
-{
-    // Register a callback that will run on the grain's scheduler
-    cancellationToken.Register(() =>
-    {
-        // This runs on the grain's execution context
-        // Safe to access grain state here
-        logger.LogInformation("Operation was canceled for grain {GrainId}", this.GetPrimaryKey());
-    });
-
-    // Continue with work...
-    await DoWorkAsync(cancellationToken);
-}
-```
-
-## Behavioral notes and limitations
-
-### Cooperative cancellation
-
-Cancellation in Orleans is cooperative, which means:
-
-- The grain method must actively check the <xref:System.Threading.CancellationToken> and respond to cancellation requests.
-- Simply passing a canceled token doesn't automatically stop a running operation.
-- For best results, check cancellation at regular intervals during long-running work.
-
-### Timeout integration
-
-When `CancelRequestOnTimeout` is enabled (default), Orleans automatically sends cancellation signals for timed-out requests:
-
-```csharp
-// If this call times out, Orleans sends a cancellation signal to the grain
-await grain.LongRunningOperationAsync(cancellationToken);
-```
-
-### Cross-silo cancellation
-
-Cancellation works across silo boundaries in distributed Orleans clusters:
-
-- Client-to-grain calls can be canceled regardless of which silo hosts the grain.
-- Grain-to-grain calls support cancellation even when grains are on different silos.
-- Network partitions might delay cancellation signal delivery.
-
-### Error handling patterns
-
-Handle cancellation gracefully with proper error handling patterns:
-
-```csharp
-public async Task<ProcessingResult> ProcessWithFallbackAsync(
-    string data,
-    CancellationToken cancellationToken = default)
-{
-    try
-    {
-        return await ProcessPrimaryAsync(data, cancellationToken);
-    }
-    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-    {
-        // Expected cancellation from our token - clean up and re-throw
-        await CleanupAsync();
-        throw;
-    }
-    catch (OperationCanceledException)
-    {
-        // Cancellation from a different token (unexpected) - treat as error
-        logger.LogWarning("Received unexpected cancellation");
-        throw;
-    }
-    catch (Exception ex)
-    {
-        // Unexpected error - try fallback if not canceled
-        if (cancellationToken.IsCancellationRequested)
-        {
-            throw new OperationCanceledException(cancellationToken);
-        }
-
-        logger.LogWarning(ex, "Primary processing failed, trying fallback");
-        return await ProcessFallbackAsync(data, cancellationToken);
-    }
-}
-```
-
-When handling `OperationCanceledException`, always check if the cancellation is from the expected token using the `when` clause. This pattern distinguishes between expected cancellation (from your operation's token) and unexpected cancellation (from other sources).
-
-### IAsyncEnumerable&lt;T&gt; behavior
-
-For streaming scenarios with <xref:System.Collections.Generic.IAsyncEnumerable`1>:
-
-- **Pre-enumeration cancellation**: If the token is canceled before enumeration starts, no items are yielded and an `OperationCanceledException` is thrown immediately.
-- **Mid-enumeration cancellation**: If canceled during enumeration, the stream stops at the next cancellation check point (typically the next `yield` or `await` operation).
-- **Exception propagation**: An `OperationCanceledException` is thrown to the consumer when cancellation occurs.
-- **Resource cleanup**: The async enumerator's `DisposeAsync()` method is called automatically by `await foreach` to clean up resources.
-- **Partial results**: Items yielded before cancellation are preserved and delivered to the consumer.
-
-#### Cancellation timing considerations
-
-The effectiveness of cancellation depends on how frequently the async iterator checks the cancellation token:
-
-```csharp
-public async IAsyncEnumerable<DataPoint> StreamDataAsync(
-    int count,
-    [EnumeratorCancellation] CancellationToken cancellationToken = default)
-{
-    for (int i = 0; i < count; i++)
-    {
-        // Good: Check before each item
-        cancellationToken.ThrowIfCancellationRequested();
-
-        var data = await ProcessItemAsync(i);
-
-        // Good: Check after long-running operations
-        cancellationToken.ThrowIfCancellationRequested();
-
-        yield return data;
-
-        // Good: Use cancellation-aware operations
-        await Task.Delay(100, cancellationToken);
-    }
-}
-```
-
-## Legacy: GrainCancellationToken and GrainCancellationTokenSource
-
-Prior to the direct support for `System.Threading.CancellationToken` in grain methods, Orleans provided a specific mechanism using <xref:Orleans.GrainCancellationToken> and <xref:Orleans.GrainCancellationTokenSource>. **This approach is now considered legacy, and `System.Threading.CancellationToken` is the recommended method for implementing cancellation in Orleans grains.**
-
-The following information is provided for context on older systems or for specific backward compatibility needs. For new development, see the <xref:System.Threading.CancellationToken> usage described earlier in this article.
-
-### Overview of GrainCancellationToken
-
-<xref:Orleans.GrainCancellationToken> is a wrapper around the standard <xref:System.Threading.CancellationToken>. It enables cooperative cancellation between threads, thread pool work items, or <xref:System.Threading.Tasks.Task> objects, and can be passed as a grain method argument.
-
-A <xref:Orleans.GrainCancellationTokenSource> provides a <xref:Orleans.GrainCancellationToken> through its `Token` property and sends a cancellation message when its <xref:Orleans.GrainCancellationTokenSource.Cancel*?displayProperty=nameWithType> method is called.
-
-### Using GrainCancellationToken
-
-To use the legacy <xref:Orleans.GrainCancellationToken>:
-
-1. Instantiate a <xref:Orleans.GrainCancellationTokenSource> object. This object manages and sends cancellation notifications to individual grain cancellation tokens.
-
-    ```csharp
-    var tcs = new GrainCancellationTokenSource();
-    ```
-
-1. Pass the token returned by the <xref:Orleans.GrainCancellationTokenSource.Token?displayProperty=nameWithType> property to each grain method that should listen for cancellation.
-
-    ```csharp
-    var waitTask = grain.LongIoWork(tcs.Token, TimeSpan.FromSeconds(10));
-    ```
-
-1. A cancellable grain operation needs to handle the underlying <xref:System.Threading.CancellationToken> property of <xref:Orleans.GrainCancellationToken> just like in any other .NET code.
-
-    ```csharp
-    public async Task LongIoWork(GrainCancellationToken tc, TimeSpan delay)
-    {
-        // Periodically check if cancellation has been requested
-        while (!tc.CancellationToken.IsCancellationRequested)
-        {
-            // Perform a portion of the work
-            await IoOperation(tc.CancellationToken);
-
-            // Example: tc.CancellationToken.ThrowIfCancellationRequested();
-        }
-        // Perform cleanup if necessary and then exit or throw OperationCanceledException
-    }
-    ```
-
-1. Call the `GrainCancellationTokenSource.Cancel()` method to initiate cancellation. This signals all <xref:Orleans.GrainCancellationToken> instances created from this source.
-
-    ```csharp
-    // Request cancellation
-    await tcs.Cancel();
-    ```
-
-1. Call the `GrainCancellationTokenSource.Dispose()` method when finished with the <xref:Orleans.GrainCancellationTokenSource> object to release its resources.
-
-    ```csharp
-    tcs.Dispose();
-    ```
-
-#### Important considerations for GrainCancellationToken
-
-- The `GrainCancellationTokenSource.Cancel()` method returns a <xref:System.Threading.Tasks.Task>. To ensure cancellation is robust against transient communication failures, you might need to retry the cancel call.
-- Callbacks registered on the underlying `System.Threading.CancellationToken` (accessed via `GrainCancellationToken.CancellationToken`) are subject to single-threaded execution guarantees within the grain activation where they were registered. This means they will run on the grain's task scheduler.
-- Each <xref:Orleans.GrainCancellationToken> can be passed through multiple method invocations if needed.
-
-## Related topics
-
-- <xref:System.Threading.CancellationToken>
-- <xref:System.OperationCanceledException>
-- <xref:System.Collections.Generic.IAsyncEnumerable`1>
-- <xref:System.Runtime.CompilerServices.EnumeratorCancellationAttribute>
-- <xref:Orleans.Configuration.SiloMessagingOptions>
-- <xref:Orleans.Configuration.ClientMessagingOptions>
-- [Cancellation in managed threads](../../standard/threading/cancellation-in-managed-threads.md)
-- [Task cancellation](../../standard/parallel-programming/task-cancellation.md)
-- [Async streams](/dotnet/csharp/language-reference/language-specification/statements#13953-await-foreach)
-- [Orleans timers and reminders](timers-and-reminders.md)
-- [Orleans streaming](../streaming/index.md)
-- [Orleans GitHub repository](<https://github.com/dotnet/orleans>)
+The older `GrainCancellationToken` API isn't needed for new Orleans 10 applications. Use the standard .NET token.

--- a/docs/site/src/content/docs/grains/code-generation.md
+++ b/docs/site/src/content/docs/grains/code-generation.md
@@ -1,13 +1,13 @@
 ---
 title: Orleans source generation
-description: Understand build-time code generation for grains and serialization in Orleans 10.
+description: Understand build-time code generation for grains and serialization in Orleans.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
 # Orleans source generation
 
-Orleans 10 generates grain proxies, method dispatch code, serializers, and copiers at build time. There is no runtime or initialization-time code generation workflow for application code.
+Orleans generates grain proxies, method dispatch code, serializers, and copiers at build time. There is no runtime or initialization-time code generation workflow for application code.
 
 ## Reference the SDK
 

--- a/docs/site/src/content/docs/grains/code-generation.md
+++ b/docs/site/src/content/docs/grains/code-generation.md
@@ -1,130 +1,61 @@
 ---
-title: Code generation
-description: Learn how to use code generation in .NET Orleans.
-ms.date: 05/23/2025
+title: Orleans source generation
+description: Understand build-time code generation for grains and serialization in Orleans 10.
+ms.date: 08/02/2026
 ms.topic: concept-article
-zone_pivot_groups: orleans-version
 ---
 
-# Orleans code generation
+# Orleans source generation
 
-:::zone target="docs" pivot="orleans-8-0,orleans-9-0,orleans-10-0"
+Orleans 10 generates grain proxies, method dispatch code, serializers, and copiers at build time. There is no runtime or initialization-time code generation workflow for application code.
 
-Before Orleans 7.0, source generation was more manual and required explicit developer intervention. Starting with Orleans 7.0, code generation is automatic and typically requires no intervention. However, cases still exist where influencing code generation might be desired, for example, to generate code for types not automatically generated or for types in another assembly.
+## Reference the SDK
 
-:::zone-end
+Use the package matching the project role:
 
-## Enable code generation
+- `Microsoft.Orleans.Client` for client applications.
+- `Microsoft.Orleans.Server` for silo applications.
+- `Microsoft.Orleans.Sdk` for class libraries containing grain contracts, implementations, or serializable types.
 
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
+These packages include the source generator and analyzers.
 
-Orleans generates C# source code for the app at build time. All projects, including the host, need the appropriate NuGet packages installed to enable code generation. The following packages are available:
+## Grain contracts
 
-- All clients should reference [Microsoft.Orleans.Client](https://nuget.org/packages/Microsoft.Orleans.Client).
-- All silos (servers) should reference [Microsoft.Orleans.Server](https://nuget.org/packages/Microsoft.Orleans.Server).
-- All other packages should reference [Microsoft.Orleans.Sdk](https://nuget.org/packages/Microsoft.Orleans.Sdk).
+The generator discovers grain interfaces and implementations from their Orleans base interfaces. It reports build diagnostics for unsupported signatures, inaccessible types, multiple cancellation token parameters, and other contract errors.
 
-Use the <xref:Orleans.GenerateSerializerAttribute> to specify that the type is intended for serialization and that Orleans should generate serialization code for it. For more information, see [Use Orleans serialization](../host/configuration-guide/serialization.md#use-orleans-serialization).
+Supported grain method return types are `Task`, `Task<T>`, `ValueTask`, and `ValueTask<T>`. The generator emits strongly typed references and invocation classes for those methods.
 
-:::zone-end
+## Serializable types
 
-:::zone target="docs" pivot="orleans-3-x"
+Mark application data crossing grain boundaries or stored by Orleans with <xref:Orleans.GenerateSerializerAttribute>. Give serialized members stable field IDs:
 
-The Orleans runtime uses generated code to ensure proper serialization of types used across the cluster and to generate boilerplate code. This boilerplate abstracts away implementation details of method dispatching, exception propagation, and other internal runtime concepts. Code generation can be performed either when building projects or when the application initializes.
+```csharp
+[GenerateSerializer]
+public sealed class PurchaseOrder
+{
+    [Id(0)]
+    public required string OrderId { get; init; }
 
-:::zone-end
+    [Id(1)]
+    public decimal Total { get; init; }
+}
+```
 
-### Build-time code generation
+IDs are part of the wire and storage contract. Don't reuse or renumber them after deployment. Use <xref:Orleans.AliasAttribute> when a stable serialized type alias is required independently of the CLR name.
 
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
+## Generate code for external types
 
-At build time, Orleans generates code for all types marked with <xref:Orleans.GenerateSerializerAttribute>. If a type isn't marked with <xref:Orleans.GenerateSerializerAttribute>, Orleans won't serialize it.
+When a project must generate serializers for accessible types declared elsewhere, use <xref:Orleans.GenerateCodeForDeclaringAssemblyAttribute>:
 
-If developing with F# or Visual Basic, code generation can also be used. For more information, see these samples:
+```csharp
+[assembly: GenerateCodeForDeclaringAssembly(
+    typeof(ExternalContract))]
+```
 
-- [Orleans F# sample app](/samples/dotnet/samples/orleans-fsharp-sample)
-- [Orleans Visual Basic sample app](/samples/dotnet/samples/orleans-vb-sample)
+Prefer owning serialization annotations with the type whenever possible. Generating for external declaring assemblies broadens the compatibility surface and can increase build output.
 
-These examples demonstrate using the <xref:Orleans.GenerateCodeForDeclaringAssemblyAttribute?displayProperty=nameWithType>, specifying types in the assembly for the source generator to inspect and generate source code.
+## Inspect diagnostics and output
 
-:::zone-end
+Treat Orleans analyzer and generator diagnostics as contract errors, not warnings to suppress. Generated files can be inspected through normal compiler-generated-file tooling when debugging, but application code should depend on the public interfaces rather than generated implementation names.
 
-:::zone target="docs" pivot="orleans-3-x"
-
-The preferred method for code generation is at build time. Enable build-time code generation using one of the following packages:
-
-- `Microsoft.Orleans.OrleansCodeGenerator.Build`: A package using Roslyn for code generation and .NET Reflection for analysis.
-- `Microsoft.Orleans.CodeGenerator.MSBuild`: A newer code generation package leveraging Roslyn for both code generation and analysis. It doesn't load application binaries, avoiding issues caused by clashing dependency versions and differing target frameworks. This code generator also improves support for incremental builds, resulting in shorter build times.
-
-Install one of these packages into all projects containing grains, grain interfaces, custom serializers, or types sent between grains. Installing a package injects a target into the project that generates code at build time.
-
-Both packages (`Microsoft.Orleans.CodeGenerator.MSBuild` and `Microsoft.Orleans.OrleansCodeGenerator.Build`) only support C# projects. Support other languages either by using the `Microsoft.Orleans.OrleansCodeGenerator` package (described below) or by creating a C# project acting as the target for code generated from assemblies written in other languages.
-
-Emit additional diagnostics at build time by specifying a value for `OrleansCodeGenLogLevel` in the target project's *.csproj* file. For example: `<OrleansCodeGenLogLevel>Trace</OrleansCodeGenLogLevel>`.
-
-:::zone-end
-
-### Initialization-time code generation
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-In Orleans 7+, nothing happens during initialization. Code generation occurs only at build time.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-Code generation can be performed during initialization on the client and silo by installing the `Microsoft.Orleans.OrleansCodeGenerator` package and using the <xref:Orleans.Hosting.ApplicationPartManagerCodeGenExtensions.WithCodeGeneration*?displayProperty=nameWithType> extension method:
-
-:::code language="csharp" source="snippets-v3/code-generation/CodeGeneration.cs" id="with_code_generation":::
-
-In the preceding example, `builder` can be an instance of either <xref:Orleans.Hosting.ISiloHostBuilder> or <xref:Orleans.IClientBuilder>. Pass an optional <xref:Microsoft.Extensions.Logging.ILoggerFactory> instance to `WithCodeGeneration` to enable logging during code generation, for example:
-
-:::code language="csharp" source="snippets-v3/code-generation/CodeGeneration.cs" id="with_code_generation_logging":::
-
-:::zone-end
-
-## Influence code generation
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-When applying <xref:Orleans.GenerateSerializerAttribute> to a type, the <xref:Orleans.IdAttribute> can also be applied to uniquely identify the member. Likewise, an alias can be applied using the <xref:Orleans.AliasAttribute>. For more information on influencing code generation, see [Use Orleans serialization](../host/configuration-guide/serialization.md#use-orleans-serialization).
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-During code generation, the generation of code for a specific type can be influenced. Orleans automatically generates code for grain interfaces, grain classes, grain state, and types passed as arguments in grain methods. If a type doesn't fit these criteria, use the following methods to guide code generation further.
-
-Adding <xref:System.SerializableAttribute> to a type instructs the code generator to generate a serializer for it.
-
-Adding [`[assembly: GenerateSerializer(Type)]`](xref:Orleans.CodeGeneration.GenerateSerializerAttribute) to a project instructs the code generator to treat that type as serializable. It causes an error if a serializer cannot be generated for that type (e.g., because the type isn't accessible). This error halts the build if code generation is enabled. This attribute also allows generating code for specific types from another assembly.
-
-[`[assembly: KnownType(Type)]`](xref:Orleans.CodeGeneration.KnownTypeAttribute) also instructs the code generator to include a specific type (which might be from a referenced assembly), but it doesn't cause an exception if the type is inaccessible.
-
-### Generate serializers for all subtypes
-
-Adding <xref:Orleans.CodeGeneration.KnownBaseTypeAttribute> to an interface or class instructs the code generator to generate serialization code for all types inheriting from or implementing that type.
-
-### Generate code for all types in another assembly
-
-Sometimes, generated code cannot be included in a particular assembly at build time. Examples include shared libraries not referencing Orleans, assemblies written in languages other than C#, and assemblies for which the source code isn't available. In these cases, place the generated code for those assemblies into a separate assembly referenced during initialization.
-
-To enable this for an assembly:
-
-1. Create a C# project.
-1. Install the `Microsoft.Orleans.CodeGenerator.MSBuild` or `Microsoft.Orleans.OrleansCodeGenerator.Build` package.
-1. Add a reference to the target assembly.
-1. Add `[assembly: KnownAssembly("OtherAssembly")]` at the top level of a C# file.
-
-The <xref:Orleans.CodeGeneration.KnownAssemblyAttribute> instructs the code generator to inspect the specified assembly and generate code for the types within it. This attribute can be used multiple times within a project.
-
-Then, add the generated assembly to the client/silo during initialization:
-
-:::code language="csharp" source="snippets-v3/code-generation/CodeGeneration.cs" id="add_application_part":::
-
-In the preceding example, `builder` can be an instance of either <xref:Orleans.Hosting.ISiloHostBuilder> or <xref:Orleans.IClientBuilder>.
-
-`KnownAssemblyAttribute` has an optional property, <xref:Orleans.CodeGeneration.KnownAssemblyAttribute.TreatTypesAsSerializable>. Set this to `true` to instruct the code generator to act as though all types within that assembly are marked as serializable.
-
-:::zone-end
+For serialization rules and version tolerance, see the Orleans serialization documentation. For the runtime invocation pipeline, see the advanced implementation documentation.

--- a/docs/site/src/content/docs/grains/external-tasks-and-grains.md
+++ b/docs/site/src/content/docs/grains/external-tasks-and-grains.md
@@ -1,144 +1,74 @@
 ---
-title: External tasks and grains
-description: Learn about external tasks and grains in .NET Orleans.
-ms.date: 03/31/2025
+title: External tasks and grain scheduling
+description: Safely use asynchronous libraries, CPU work, and blocking APIs from Orleans grains.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
-# External tasks and grains
+# External tasks and grain scheduling
 
-By design, any sub-tasks spawned from grain code (e.g., using `await`, `ContinueWith`, or `Task.Factory.StartNew`) dispatch on the same per-activation <xref:System.Threading.Tasks.TaskScheduler> as the parent task. Therefore, they inherit the same *single-threaded execution model* as the rest of the grain code. This is the main point behind the single-threaded execution of grain turn-based concurrency.
-
-In some cases, grain code might need to "break out" of the Orleans task scheduling model and "do something special," such as explicitly pointing a <xref:System.Threading.Tasks.Task> to a different task scheduler or the .NET <xref:System.Threading.ThreadPool>. An example is when grain code needs to execute a synchronous remote blocking call (like remote I/O). Executing that blocking call in the grain context blocks the grain and thus should never be done. Instead, the grain code can execute this piece of blocking code on a thread pool thread, join (`await`) the completion of that execution, and then proceed in the grain context. Escaping the Orleans scheduler is expected to be a very advanced and seldom-required usage scenario beyond typical usage patterns.
-
-## Task-based APIs
-
-1. `await`, <xref:System.Threading.Tasks.TaskFactory.StartNew*?displayProperty=nameWithType> (see below), <xref:System.Threading.Tasks.Task.ContinueWith*?displayProperty=nameWithType>, <xref:System.Threading.Tasks.Task.WhenAny*?displayProperty=nameWithType>, <xref:System.Threading.Tasks.Task.WhenAll*?displayProperty=nameWithType>, and <xref:System.Threading.Tasks.Task.Delay*?displayProperty=nameWithType> all respect the current task scheduler. This means using them in the default way, without passing a different <xref:System.Threading.Tasks.TaskScheduler>, causes them to execute in the grain context.
-
-1. Both <xref:System.Threading.Tasks.Task.Run*?displayProperty=nameWithType> and the `endMethod` delegate of <xref:System.Threading.Tasks.TaskFactory.FromAsync*?displayProperty=nameWithType> do *not* respect the current task scheduler. They both use the `TaskScheduler.Default` scheduler, the .NET thread pool task scheduler. Therefore, code inside `Task.Run` and the `endMethod` in `Task.Factory.FromAsync` *always* runs on the .NET thread pool, outside the single-threaded execution model for Orleans grains. However, any code after `await Task.Run` or `await Task.Factory.FromAsync` runs back under the scheduler active at the point the task was created, which is the grain's scheduler.
-
-1. <xref:System.Threading.Tasks.Task.ConfigureAwait*?displayProperty=nameWithType> with `false` is an explicit API to escape the current task scheduler. It causes the code after an awaited <xref:System.Threading.Tasks.Task> to execute on the <xref:System.Threading.Tasks.TaskScheduler.Default*?displayProperty=nameWithType> scheduler (the .NET thread pool), thus breaking the single-threaded execution of the grain.
-
-    > [!CAUTION]
-    > Generally, **never use `ConfigureAwait(false)` directly in grain code.**
-
-1. Methods with the signature `async void` should not be used with grains. They are intended for graphical user interface event handlers. An `async void` method can immediately crash the current process if it allows an exception to escape, with no way to handle the exception. This also applies to `List<T>.ForEach(async element => ...)` and any other method accepting an <xref:System.Action`1>, since the asynchronous delegate coerces into an `async void` delegate.
-
-### `Task.Factory.StartNew` and `async` delegates
-
-The usual recommendation for scheduling tasks in C# is using `Task.Run` instead of `Task.Factory.StartNew`. A quick web search for `Task.Factory.StartNew` suggests [it's dangerous](https://blog.stephencleary.com/2013/08/startnew-is-dangerous.html) and [favoring `Task.Run` is always recommended](https://devblogs.microsoft.com/pfxteam/task-run-vs-task-factory-startnew/). However, to stay within the grain's *single-threaded execution model*, `Task.Factory.StartNew` must be used. So, how to use it correctly? The danger with `Task.Factory.StartNew()` is its lack of native support for async delegates. This means code like `var notIntendedTask = Task.Factory.StartNew(SomeDelegateAsync)` is likely a bug. `notIntendedTask` is *not* a task completing when `SomeDelegateAsync` finishes. Instead, *always* unwrap the returned task: `var task = Task.Factory.StartNew(SomeDelegateAsync).Unwrap()`.
-
-#### Example: Multiple tasks and the task scheduler
-
-Below is sample code demonstrating using `TaskScheduler.Current`, `Task.Run`, and a special custom scheduler to escape the Orleans grain context and how to return to it.
+Normal `await` keeps grain code in the activation's turn-based scheduling model. The continuation resumes on the grain scheduler, so it can safely access grain state:
 
 ```csharp
-public async Task MyGrainMethod()
+public async Task Refresh()
 {
-    // Grab the grain's task scheduler
-    var orleansTS = TaskScheduler.Current;
-    await Task.Delay(10_000);
-
-    // Current task scheduler did not change, the code after await is still running
-    // in the same task scheduler.
-    Assert.AreEqual(orleansTS, TaskScheduler.Current);
-
-    Task t1 = Task.Run(() =>
-    {
-        // This code runs on the thread pool scheduler, not on Orleans task scheduler
-        Assert.AreNotEqual(orleansTS, TaskScheduler.Current);
-        Assert.AreEqual(TaskScheduler.Default, TaskScheduler.Current);
-    });
-
-    await t1;
-
-    // We are back to the Orleans task scheduler.
-    // Since await was executed in Orleans task scheduler context, we are now back
-    // to that context.
-    Assert.AreEqual(orleansTS, TaskScheduler.Current);
-
-    // Example of using Task.Factory.StartNew with a custom scheduler to escape from
-    // the Orleans scheduler
-    Task t2 = Task.Factory.StartNew(() =>
-    {
-        // This code runs on the MyCustomSchedulerThatIWroteMyself scheduler, not on
-        // the Orleans task scheduler
-        Assert.AreNotEqual(orleansTS, TaskScheduler.Current);
-        Assert.AreEqual(MyCustomSchedulerThatIWroteMyself, TaskScheduler.Current);
-    },
-    CancellationToken.None,
-    TaskCreationOptions.None,
-    scheduler: MyCustomSchedulerThatIWroteMyself);
-
-    await t2;
-
-    // We are back to Orleans task scheduler.
-    Assert.AreEqual(orleansTS, TaskScheduler.Current);
+    Item value = await repository.Load();
+    _cachedItem = value;
 }
 ```
 
-#### Example: Make a grain call from code running on a thread pool thread
+Async libraries don't need `Task.Run`. Await them directly.
 
-Another scenario involves grain code needing to "break out" of the grain's task scheduling model and run on a thread pool thread (or some other non-grain context) but still needing to call another grain. Grain calls can be made from non-grain contexts without extra ceremony.
+## Don't block the grain scheduler
 
-The following code demonstrates making a grain call from code running inside a grain but not in the grain context.
+Never wait synchronously on incomplete tasks using `.Result`, `.Wait()`, `WaitAll`, or `GetAwaiter().GetResult()`. Blocking can deadlock the activation and starve the .NET thread pool.
+
+Avoid `async void`, including async lambdas passed to APIs expecting `Action<T>`. Exceptions can't be observed through a returned task and can terminate the process.
+
+## Use Task.Run narrowly
+
+<xref:System.Threading.Tasks.Task.Run*> executes on the .NET thread pool outside the Orleans scheduler. Use it only for:
+
+- An unavoidable synchronous blocking API.
+- CPU-heavy work that doesn't access grain state.
+
+Capture immutable input, do the external work, then update grain state after awaiting:
 
 ```csharp
-public async Task MyGrainMethod()
+public async Task<int> Compress(byte[] input)
 {
-    // Grab the Orleans task scheduler
-    var orleansTS = TaskScheduler.Current;
-    var fooGrain = this.GrainFactory.GetGrain<IFooGrain>(0);
-    Task<int> t1 = Task.Run(async () =>
-    {
-        // This code runs on the thread pool scheduler,
-        // not on Orleans task scheduler
-        Assert.AreNotEqual(orleansTS, TaskScheduler.Current);
-        int res = await fooGrain.MakeGrainCall();
+    byte[] copy = input.ToArray();
 
-        // This code continues on the thread pool scheduler,
-        // not on the Orleans task scheduler
-        Assert.AreNotEqual(orleansTS, TaskScheduler.Current);
-        return res;
-    });
+    int size = await Task.Run(
+        () => CompressSynchronously(copy));
 
-    int result = await t1;
-
-    // We are back to the Orleans task scheduler.
-    // Since await was executed in the Orleans task scheduler context,
-    // we are now back to that context.
-    Assert.AreEqual(orleansTS, TaskScheduler.Current);
+    _lastCompressedSize = size;
+    return size;
 }
 ```
 
-## Work with libraries
+Don't read or mutate grain fields inside the `Task.Run` delegate. That code isn't protected by the grain scheduler.
 
-Some external libraries used by the code might use `ConfigureAwait(false)` internally. Using `ConfigureAwait(false)` is a good and correct practice in .NET [when implementing general-purpose libraries](https://devblogs.microsoft.com/dotnet/configureawait-faq/#when-should-i-use-configureawaitfalse). This isn't a problem in Orleans. As long as the grain code invoking the library method awaits the library call with a regular `await`, the grain code is correct. The result is exactly as desired: the library code runs continuations on the default scheduler (the value returned by `TaskScheduler.Default`, which doesn't guarantee continuations run on a <xref:System.Threading.ThreadPool> thread, as they are often inlined on the previous thread), while the grain code runs on the grain's scheduler.
+## ConfigureAwait
 
-Another frequently asked question is whether library calls need executing with `Task.Run`—that is, whether library code needs explicit offloading to the <xref:System.Threading.ThreadPool> (e.g., `await Task.Run(() => myLibrary.FooAsync())`). The answer is no. Offloading code to the <xref:System.Threading.ThreadPool> isn't necessary except when library code makes blocking synchronous calls. Usually, any well-written and correct .NET async library (methods returning <xref:System.Threading.Tasks.Task> and named with an `Async` suffix) doesn't make blocking calls. Thus, offloading anything to the <xref:System.Threading.ThreadPool> isn't needed unless the async library is suspected to be buggy or a synchronous blocking library is deliberately used.
+Don't use `ConfigureAwait(false)` directly in grain methods. It can resume the continuation outside the activation scheduler. General-purpose libraries can use `ConfigureAwait(false)` internally; grain code returns to its scheduler when it normally awaits the library's task.
 
-## Deadlocks
+## Start activation-scheduled work
 
-Since grains execute single-threaded, deadlocking a grain is possible by synchronously blocking in a way requiring multiple threads to unblock. This means code calling any of the following methods and properties can deadlock a grain if the provided tasks haven't completed by the time the method or property is invoked:
+`Task.Factory.StartNew` without an explicit scheduler uses `TaskScheduler.Current`, which is the Orleans scheduler in grain code. This is rarely needed; ordinary async methods are clearer.
 
-- `Task.Wait()`
-- `Task.Result`
-- `Task.WaitAny(...)`
-- `Task.WaitAll(...)`
-- `task.GetAwaiter().GetResult()`
+If an advanced integration passes an async delegate to `Task.Factory.StartNew`, unwrap the nested task:
 
-Avoid these methods in any high-concurrency service because they can lead to poor performance and instability. They starve the .NET <xref:System.Threading.ThreadPool> by blocking threads that could perform useful work and require the <xref:System.Threading.ThreadPool> to inject additional threads for completion. When executing grain code, these methods can cause the grain to deadlock, so avoid them in grain code as well.
+```csharp
+Task work = Task.Factory
+    .StartNew(WorkerAsync)
+    .Unwrap();
 
-If some *sync-over-async* work is unavoidable, moving that work to a separate scheduler is best. The simplest way is using `await Task.Run(() => task.Wait())`, for example. Note that avoiding *sync-over-async* work is strongly recommended, as it harms application scalability and performance.
+await work;
+```
 
-## Summary: Working with tasks in Orleans
+Don't start unobserved background work that outlives the request. Use [grain timers](timers-and-reminders.md), reminders, a durable job abstraction, or a hosted service depending on the required lifetime and reliability.
 
-| What are you trying to do? | How to do it |
-|--|--|
-| Run background work on .NET thread-pool threads. No grain code or grain calls are allowed. | `Task.Run` |
-| Run asynchronous worker task from grain code with Orleans turn-based concurrency guarantees ([see above](#taskfactorystartnew-and-async-delegates)). | `Task.Factory.StartNew(WorkerAsync).Unwrap()` (<xref:System.Threading.Tasks.TaskExtensions.Unwrap*>) |
-| Run synchronous worker task from grain code with Orleans turn-based concurrency guarantees. | `Task.Factory.StartNew(WorkerSync)` |
-| Timeouts for executing work items | `Task.Delay` + `Task.WhenAny` |
-| Call an asynchronous library method | `await` the library call |
-| Use `async`/`await` | The normal .NET Task-Async programming model. Supported & recommended |
-| `ConfigureAwait(false)` | Do not use inside grain code. Allowed only inside libraries. |
+## Reentrancy still applies
+
+Awaiting external work doesn't let another request run on a non-reentrant grain. Marking a grain reentrant or enabling interleaving can improve throughput while calls wait for I/O, but state can change between turns. See [Request scheduling](request-scheduling.md).

--- a/docs/site/src/content/docs/grains/grain-extensions.md
+++ b/docs/site/src/content/docs/grains/grain-extensions.md
@@ -1,161 +1,71 @@
 ---
 title: Grain extensions
-description: Learn how to extend an Orleans Grain.
-ms.date: 03/31/2025
+description: Add runtime-provided interfaces to Orleans grains.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
 # Grain extensions
 
-Grain extensions provide a way to add extra behavior to grains. By extending a grain with an interface deriving from <xref:Orleans.Runtime.IGrainExtension>, new methods and functionality can be added to the grain.
+Grain extensions attach an additional callable interface to grain activations. Orleans uses extensions internally for features such as cancellation and streaming. Applications can use them for infrastructure behavior that should be available across many grain types.
 
-This article presents two examples of grain extensions. The first example shows how to add a `Deactivate` method to all grains, usable for deactivating the grain. The second example shows how to add `GetState` and `SetState` methods to any grain, allowing manipulation of the grain's internal state.
+Extensions are an advanced integration mechanism. Prefer a normal grain interface when the behavior is part of the grain's domain contract.
 
-## Deactivate extension example
+## Define an extension
 
-This example demonstrates adding a `Deactivate` method to all grains automatically. Use the method to deactivate the grain; it accepts a string as a message parameter. Orleans grains already support this functionality via the <xref:Orleans.Core.Internal.IGrainManagementExtension> interface. Nevertheless, this example shows how this or similar functionality could be added.
-
-### Deactivate extension interface
-
-Start by defining an `IGrainDeactivateExtension` interface containing the `Deactivate` method. The interface must derive from `IGrainExtension`.
+The interface derives from <xref:Orleans.Runtime.IGrainExtension> and uses normal grain method return types:
 
 ```csharp
-public interface IGrainDeactivateExtension : IGrainExtension
+public interface IDiagnosticsExtension : IGrainExtension
 {
-    Task Deactivate(string msg);
+    ValueTask<string> GetStatus();
 }
-```
 
-### Deactivate extension implementation
-
-Next, implement the `GrainDeactivateExtension` class, providing the implementation for the `Deactivate` method.
-
-To access the target grain, retrieve the <xref:Orleans.Runtime.IGrainContext> from the constructor. It's injected via dependency injection when creating the extension.
-
-```csharp
-public sealed class GrainDeactivateExtension : IGrainDeactivateExtension
+public sealed class DiagnosticsExtension(
+    IGrainContext grainContext) : IDiagnosticsExtension
 {
-    private IGrainContext _context;
-
-    public GrainDeactivateExtension(IGrainContext context)
+    public ValueTask<string> GetStatus()
     {
-        _context = context;
-    }
-
-    public Task Deactivate(string msg)
-    {
-        var reason = new DeactivationReason(DeactivationReasonCode.ApplicationRequested, msg);
-        _context.Deactivate(reason);
-        return Task.CompletedTask;
+        return ValueTask.FromResult(
+            $"Active grain: {grainContext.GrainId}");
     }
 }
 ```
 
-### Deactivate extension registration and usage
+Orleans generates extension request and reference code at build time.
 
-Now that the interface and implementation are defined, register the extension when configuring the silo using the <xref:Orleans.Hosting.HostingGrainExtensions.AddGrainExtension*> method.
+## Register the extension
 
-```csharp
-siloBuilder.AddGrainExtension<IGrainDeactivateExtension, GrainDeactivateExtension>();
-```
-
-To use the extension on any grain, retrieve a reference to the extension and call its `Deactivate` method.
+Register a default implementation on the silo:
 
 ```csharp
-var grain = client.GetGrain<SomeExampleGrain>(someKey);
-var grainReferenceAsInterface = grain.AsReference<IGrainDeactivateExtension>();
-
-await grainReferenceAsInterface.Deactivate("Because, I said so...");
+siloBuilder.AddGrainExtension<
+    IDiagnosticsExtension,
+    DiagnosticsExtension>();
 ```
 
-## State manipulation extension example
+The implementation is created through dependency injection for the target grain context.
 
-This example demonstrates adding `GetState` and `SetState` methods to any grain through extensions, allowing manipulation of the grain's internal state.
+## Call the extension
 
-### State manipulation extension interface
-
-First, define the `IGrainStateAccessor<T>` interface containing the `GetState` and `SetState` methods. Again, this interface must derive from `IGrainExtension`.
+Cast an existing grain reference to the extension interface:
 
 ```csharp
-public interface IGrainStateAccessor<T> : IGrainExtension
-{
-    Task<T> GetState();
-    Task SetState(T state);
-}
+IUserGrain user =
+    grainFactory.GetGrain<IUserGrain>("user-42");
+
+IDiagnosticsExtension diagnostics =
+    user.AsReference<IDiagnosticsExtension>();
+
+string status = await diagnostics.GetStatus();
 ```
 
-Once access to the target grain is available, use the extension to manipulate its state. In this example, use an extension to access and modify a specific integer state value within the target grain.
+The extension reference keeps the same grain identity. It doesn't address a separate grain.
 
-### State manipulation extension implementation
+Incoming [grain call filters](interceptors.md) run for extension calls. Filters should not assume every `ImplementationMethod` belongs to the grain implementation class.
 
-The extension used is `IGrainStateAccessor<T>`, providing methods to get and set a state value of type `T`. To create the extension, implement the interface in a class taking a `getter` and a `setter` as arguments in its constructor.
+## Per-activation components
 
-```csharp
-public sealed class GrainStateAccessor<T> : IGrainStateAccessor<T>
-{
-    private readonly Func<T> _getter;
-    private readonly Action<T> _setter;
+Framework components can use <xref:Orleans.Runtime.IGrainContext> component APIs and `GetGrainExtension<T>()` to provide an activation-specific extension. Those APIs are intended for runtime integrations that control grain activation setup. Application code should normally use `AddGrainExtension` and constructor-injected dependencies instead of mutating a grain context during activation.
 
-    public GrainStateAccessor(Func<T> getter, Action<T> setter)
-    {
-        _getter = getter;
-        _setter = setter;
-    }
-
-    public Task<T> GetState()
-    {
-        return Task.FromResult(_getter.Invoke());
-    }
-
-    public Task SetState(T state)
-    {
-        _setter.Invoke(state);
-        return Task.CompletedTask;
-    }
-}
-```
-
-In the preceding implementation, the `GrainStateAccessor<T>` class takes `getter` and `setter` arguments in its constructor. These delegates read and modify the target grain's state. The `GetState()` method returns a <xref:System.Threading.Tasks.Task`1> wrapping the current value of the `T` state, while the `SetState(T state)` method sets the new value of the `T` state.
-
-### State manipulation extension registration and usage
-
-To use the extension to access and modify the target grain's state, register the extension and set its components in the target grain's <xref:Orleans.Grain.OnActivateAsync?displayProperty=nameWithType> method.
-
-```csharp
-public override Task OnActivateAsync()
-{
-    // Retrieve the IGrainStateAccessor<T> extension
-    var accessor = new GrainStateAccessor<int>(
-        getter: () => this.Value,
-        setter: value => this.Value = value);
-
-    // Set the extension as a component of the target grain's context
-    ((IGrainBase)this).GrainContext.SetComponent<IGrainStateAccessor<int>>(accessor);
-
-    return base.OnActivateAsync();
-}
-```
-
-In the preceding example, create a new instance of `GrainStateAccessor<int>` taking a `getter` and `setter` for an integer state value. The `getter` reads the `Value` property of the target grain, while the `setter` sets the new value of the `Value` property. Then, set this instance as a component of the target grain's context using the <xref:Orleans.Runtime.IGrainContext.SetComponent*?displayProperty=nameWithType> method.
-
-Once the extension is registered, use it to get and set the target grain's state by accessing it through a reference to the extension.
-
-```csharp
-// Get a reference to the IGrainStateAccessor<int> extension
-var accessor = grain.AsReference<IGrainStateAccessor<int>>();
-
-// Get the current value of the state
-var value = await accessor.GetState();
-
-// Set a new value of the state
-await accessor.SetState(10);
-```
-
-In the preceding example, get a reference to the `IGrainStateAccessor<int>` extension for a specific grain instance using the <xref:Orleans.GrainExtensions.AsReference*> method. Then, use this reference to call the `GetState()` and `SetState(T state)` methods to read and modify the state value of the target grain.
-
-## See also
-
-- [Develop a grain](index.md)
-- [Grain identity](grain-identity.md)
-- [Grain lifecycle overview](grain-lifecycle.md)
-- [Grain placement](grain-placement.md)
+Avoid exposing mutable grain state through a generic extension. Doing so bypasses the grain's domain invariants and couples infrastructure to implementation details.

--- a/docs/site/src/content/docs/grains/grain-identity.md
+++ b/docs/site/src/content/docs/grains/grain-identity.md
@@ -1,161 +1,88 @@
 ---
 title: Grain identity
-description: Learn about grain identities in .NET Orleans.
-ms.date: 03/31/2025
+description: Understand grain types, keys, and GrainId values in Orleans 10.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
 # Grain identity
 
-Grains in Orleans each have a single, unique, user-defined identifier consisting of two parts:
+Every grain has a stable logical identity made from:
 
-1. The grain _type_ name, uniquely identifying the grain class.
-1. The grain _key_, uniquely identifying a logical instance of that grain class.
+1. A **grain type**, which identifies the implementation.
+1. A **grain key**, which identifies one logical grain within that type.
 
-Orleans represents both grain type and key as human-readable strings. By convention, write the grain identity with the grain type and key separated by a `/` character. For example, `shoppingcart/bob65` represents the grain type named `shoppingcart` with the key `bob65`.
+Orleans represents the complete identity with <xref:Orleans.Runtime.GrainId>. A `GrainId` exposes `Type` and `Key`; it doesn't expose a `PrimaryKey` property. Application code normally uses typed [grain references](grain-references.md) and key helpers rather than constructing `GrainId` values directly.
 
-Constructing grain identities directly is uncommon. Instead, creating [grain references](./grain-references.md) using <xref:Orleans.IGrainFactory?displayProperty=nameWithType> is more common.
+## Choose a key type
 
-The following sections discuss grain type names and grain keys in more detail.
+Declare the key shape on the grain interface:
 
-## Grain type names
+| Interface | Key supplied to `GetGrain` |
+|---|---|
+| <xref:Orleans.IGrainWithStringKey> | `string` |
+| <xref:Orleans.IGrainWithGuidKey> | <xref:System.Guid> |
+| <xref:Orleans.IGrainWithIntegerKey> | `long` |
+| <xref:Orleans.IGrainWithGuidCompoundKey> | <xref:System.Guid> plus a string extension |
+| <xref:Orleans.IGrainWithIntegerCompoundKey> | `long` plus a string extension |
 
-Orleans creates a grain type name based on the grain implementation class. It removes the suffix "Grain" from the class name, if present, and converts the resulting string to its lowercase representation. For example, a class named `ShoppingCartGrain` receives the grain type name `shoppingcart`. It's recommended that grain type names and keys consist only of printable characters, such as alphanumeric characters (`a`-`z`, `A`-`Z`, and `0`-`9`) and symbols like `-`, `_`, `@`, and `=`. Other characters might not be supported and often require special treatment when printed in logs or appearing as identifiers in other systems, such as databases.
-
-Alternatively, use the <xref:Orleans.GrainTypeAttribute?displayProperty=nameWithType> attribute to customize the grain type name for the grain class it's attached to, as shown in the following example:
+Choose keys from the application's domain, such as a customer ID, device ID, or account number. Grain keys are scoped by grain type, so two different grain types can use the same key without referring to the same grain.
 
 ```csharp
-[GrainType("cart")]
-public class ShoppingCartGrain : IShoppingCartGrain
+public interface IDeviceGrain : IGrainWithStringKey
 {
-    // Add your grain implementation here
+    ValueTask<string> GetStatus();
 }
+
+IDeviceGrain device = grainFactory.GetGrain<IDeviceGrain>("device-17");
 ```
 
-In the preceding example, the grain class `ShoppingCartGrain` has the grain type name `cart`. Each grain can only have one grain type name.
+Use a fixed key such as `"default"` when the application intentionally addresses one logical grain of a type. This is a convention, not a separate singleton feature.
 
-For generic grains, include the generic arity in the grain type name. For example, consider the following `DictionaryGrain<K, V>` class:
+## Read the current grain's key
+
+Inside a grain, use the key helper matching its interface:
 
 ```csharp
-[GrainType("dict`2")]
-public class DictionaryGrain<K, V> : IDictionaryGrain<K, V>
+public sealed class DeviceGrain : Grain, IDeviceGrain
 {
-    // Add your grain implementation here
-}
-```
-
-The grain class has two generic parameters, so a backtick `` ` `` followed by the generic arity, 2, is added to the end of the grain type name `dict` to create the grain type name ``dict`2``. This is specified in the attribute on the grain class: ``[GrainType("dict`2")]``.
-
-## Grain keys
-
-For convenience, Orleans exposes methods allowing construction of grain keys from a <xref:System.Guid> or <xref:System.Int64>, in addition to a <xref:System.String>. The primary key is scoped to the grain type. Therefore, the complete identity of a grain forms from its type and key.
-
-The caller of the grain decides which scheme to use. The options are:
-
-- <xref:System.Guid?displayProperty=nameWithType>
-- <xref:System.Int64?displayProperty=nameWithType>
-- <xref:System.String?displayProperty=nameWithType>
-- <xref:System.Guid?displayProperty=nameWithType> and <xref:System.String?displayProperty=nameWithType>
-- <xref:System.Int64?displayProperty=nameWithType> and <xref:System.String?displayProperty=nameWithType>
-
-Because the underlying data is the same, the schemes can be used interchangeably: they are all encoded as strings.
-
-Situations requiring a singleton grain instance can use a well-known, fixed value such as `"default"`. This is merely a convention, but adhering to it clarifies at the caller site that a singleton grain is in use.
-
-### Using globally unique identifiers (GUIDs) as keys
-
-<xref:System.Guid?displayProperty=nameWithType> make useful keys when randomness and global uniqueness are desired, such as when creating a new job in a job processing system. Coordinating key allocation isn't needed, which could introduce a single point of failure or a system-side lock on a resource, potentially creating a bottleneck. The chance of GUID collisions is very low, making them a common choice when architecting systems needing random identifier allocation.
-
-Referencing a grain by GUID in client code:
-
-```csharp
-var grain = grainFactory.GetGrain<IExample>(Guid.NewGuid());
-```
-
-Retrieving the primary key from grain code:
-
-```csharp
-public override Task OnActivateAsync()
-{
-    Guid primaryKey = this.GetPrimaryKey();
-    return base.OnActivateAsync();
-}
-```
-
-### Using integers as keys
-
-A long integer is also available. This makes sense if the grain persists to a relational database, where numerical indexes are often preferred over GUIDs.
-
-Referencing a grain by a long integer in client code:
-
-```csharp
-var grain = grainFactory.GetGrain<IExample>(1);
-```
-
-Retrieving the primary key from grain code:
-
-```csharp
-public override Task OnActivateAsync()
-{
-    long primaryKey = this.GetPrimaryKeyLong();
-    return base.OnActivateAsync();
-}
-```
-
-### Using strings as keys
-
-A string key is also available.
-
-Referencing a grain by String in client code:
-
-```csharp
-var grain = grainFactory.GetGrain<IExample>("myGrainKey");
-```
-
-Retrieving the primary key from grain code:
-
-```csharp
-public override Task OnActivateAsync()
-{
-    string primaryKey = this.GetPrimaryKeyString();
-    return base.OnActivateAsync();
-}
-```
-
-### Using compound keys
-
-If the system doesn't fit well with either GUIDs or longs, opt for a compound primary key. This allows using a combination of a GUID or long and a string to reference a grain.
-
-Inherit the interface from <xref:Orleans.IGrainWithGuidCompoundKey> or <xref:Orleans.IGrainWithIntegerCompoundKey> like this:
-
-```csharp
-public interface IExampleGrain : Orleans.IGrainWithIntegerCompoundKey
-{
-    Task Hello();
-}
-```
-
-In client code, this adds a second argument to the <xref:Orleans.IGrainFactory.GetGrain*?displayProperty=nameWithType> method on the grain factory:
-
-```csharp
-var grain = grainFactory.GetGrain<IExample>(0, "a string!", null);
-```
-
-To access the compound key in the grain, call an overload of the <xref:Orleans.GrainExtensions.GetPrimaryKey*> method (such as <xref:Orleans.GrainExtensions.GetPrimaryKeyLong*>):
-
-```csharp
-public class ExampleGrain : Orleans.Grain, IExampleGrain
-{
-    public Task Hello()
+    public ValueTask<string> GetStatus()
     {
-        long primaryKey = this.GetPrimaryKeyLong(out string keyExtension);
-        Console.WriteLine($"Hello from {keyExtension}");
-
-        return Task.CompletedTask;
+        string deviceId = this.GetPrimaryKeyString();
+        return ValueTask.FromResult($"Device {deviceId} is online");
     }
 }
 ```
 
-## Why grains use logical identifiers
+Other helpers include `GetPrimaryKey()`, `GetPrimaryKeyLong()`, and overloads that return a compound key's string extension.
 
-In object-oriented environments like .NET, an object's identity is hard to distinguish from a reference to it. When an object is created using the `new` keyword, the returned reference represents all aspects of its identity except those mapping the object to some external entity it represents. Orleans is designed for distributed systems. In distributed systems, object references cannot represent instance identity because they are limited to a single process's address space. Orleans uses logical identifiers to avoid this limitation. Grains use logical identifiers so grain references remain valid across process lifetimes and are portable from one process to another. This allows them to be stored and later retrieved, or sent across a network to another process in the application, all while still referring to the same entity: the grain for which the reference was created.
+The runtime identity is also available from `this.GetGrainId()` or `((IGrainBase)this).GrainContext.GrainId`. Use that form for infrastructure code that needs the grain type and encoded key together.
+
+## Grain type names
+
+By convention, Orleans derives a grain type name from the implementation class. Use <xref:Orleans.GrainTypeAttribute> when the type name must be stable independently of the CLR class name:
+
+```csharp
+[GrainType("shopping-cart")]
+public sealed class ShoppingCartGrain : Grain, IShoppingCartGrain
+{
+}
+```
+
+Treat explicit grain type names as durable identifiers. Changing a deployed type name creates a different logical grain namespace and can disconnect existing references or persisted data from the new implementation.
+
+## Work with GrainId
+
+Advanced infrastructure can parse or create an untyped identity:
+
+```csharp
+GrainId grainId = GrainId.Create(
+    GrainType.Create("shopping-cart"),
+    IdSpan.Create("customer-42"));
+```
+
+Prefer `IGrainFactory.GetGrain<TGrainInterface>(key)` in application code. A typed reference carries both the logical identity and the interface used to call it, while a bare `GrainId` doesn't provide a callable contract.
+
+## Why identity is logical
+
+A grain identity isn't a process address. Orleans can activate the grain on any compatible silo, deactivate it when idle, and later recreate it elsewhere. References keep addressing the same logical grain throughout those changes. This location independence is what makes grain references safe to pass in calls and persist for later use.

--- a/docs/site/src/content/docs/grains/grain-identity.md
+++ b/docs/site/src/content/docs/grains/grain-identity.md
@@ -1,6 +1,6 @@
 ---
 title: Grain identity
-description: Understand grain types, keys, and GrainId values in Orleans 10.
+description: Understand grain types, keys, and GrainId values in Orleans.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---

--- a/docs/site/src/content/docs/grains/grain-lifecycle.md
+++ b/docs/site/src/content/docs/grains/grain-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 title: Grain activation and lifecycle
-description: Understand grain activation, deactivation, collection, lifecycle participation, and migration in Orleans 10.
+description: Understand grain activation, deactivation, collection, lifecycle participation, and migration in Orleans.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -145,6 +145,6 @@ public sealed class SessionGrain :
 
 Persistent-state components supplied by Orleans participate automatically. Migration isn't a replacement for durable storage: migrated state is still lost if the source process fails before transfer completes.
 
-Automatic activation repartitioning and rebalancing use migration to improve locality or cluster balance. Both are experimental in Orleans 10. See [Grain placement](grain-placement.md) for their status and configuration.
+Automatic activation repartitioning and rebalancing use migration to improve locality or cluster balance. Both are experimental. See [Grain placement](grain-placement.md) for their status and configuration.
 
 Use <xref:Orleans.Placement.ImmovableAttribute> to exclude a grain type from automatic migration. It doesn't block an explicit `MigrateOnIdle()` request.

--- a/docs/site/src/content/docs/grains/grain-lifecycle.md
+++ b/docs/site/src/content/docs/grains/grain-lifecycle.md
@@ -1,378 +1,150 @@
 ---
-title: Grain lifecycle overview
-description: Learn about grain lifecycles in .NET Orleans.
-ms.date: 01/21/2026
+title: Grain activation and lifecycle
+description: Understand grain activation, deactivation, collection, lifecycle participation, and migration in Orleans 10.
+ms.date: 08/02/2026
 ms.topic: concept-article
-zone_pivot_groups: orleans-version
 ---
 
-# Grain lifecycle overview
+# Grain activation and lifecycle
 
-:::zone target="docs" pivot="orleans-8-0,orleans-9-0,orleans-10-0"
+Orleans activates grains on demand and deactivates idle activations to reclaim resources. Activation is an implementation detail of a grain's stable logical identity: callers continue using the same grain reference across activation changes.
 
-Orleans grains use an observable lifecycle (see [Orleans Lifecycle](../implementation/orleans-lifecycle.md)) for ordered activation and deactivation. This allows grain logic, system components, and application logic to start and stop in an ordered manner during grain activation and collection.
+## Activation
 
-:::zone-end
+Orleans creates grain classes through dependency injection, establishes their grain context, loads configured persistent state, and then calls <xref:Orleans.Grain.OnActivateAsync*>.
 
-## Stages
-
-The predefined grain lifecycle stages are as follows:
+Override the cancellation-token overload:
 
 ```csharp
-public static class GrainLifecycleStage
+public sealed class DeviceGrain(
+    IDeviceConnectionFactory connectionFactory) : Grain, IDeviceGrain
 {
-    public const int First = int.MinValue;
-    public const int SetupState = 1_000;
-    public const int Activate = 2_000;
-    public const int Last = int.MaxValue;
-}
-```
+    private IDeviceConnection? _connection;
 
-- `First`: First stage in a grain's lifecycle.
-- `SetupState`: Set up grain state before activation. For stateful grains, this is the stage where Orleans loads <xref:Orleans.Core.IStorage`1.State?displayProperty=nameWithType> from storage if <xref:Orleans.Core.IStorage.RecordExists?displayProperty=nameWithType> is `true`.
-- `Activate`: Stage where Orleans calls <xref:Orleans.Grain.OnActivateAsync*?displayProperty=nameWithType> and <xref:Orleans.Grain.OnDeactivateAsync*?displayProperty=nameWithType>.
-- `Last`: Last stage in a grain's lifecycle.
-
-While Orleans uses the grain lifecycle during grain activation, grains aren't always deactivated during some error cases (such as silo crashes). Therefore, applications shouldn't rely on the grain lifecycle always executing during grain deactivations.
-
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0"
-
-## Memory-based activation shedding
-
-Memory-based activation shedding automatically deactivates grain activations when the silo is under memory pressure. This helps prevent out-of-memory conditions by intelligently removing grains from memory based on their activity patterns.
-
-### How it works
-
-When enabled, Orleans monitors memory usage and begins deactivating grains when usage exceeds the configured threshold:
-
-1. Orleans polls memory usage at a configurable interval (default: 5 seconds)
-2. When memory usage exceeds `MemoryUsageLimitPercentage`, Orleans begins deactivating grains
-3. Orleans prioritizes deactivating older and less-recently-used grains first
-4. Deactivation continues until memory usage falls below `MemoryUsageTargetPercentage`
-
-### Configuration
-
-Configure memory-based activation shedding using <xref:Orleans.Configuration.GrainCollectionOptions>:
-
-```csharp
-builder.Configure<GrainCollectionOptions>(options =>
-{
-    // Enable memory-based activation shedding
-    options.EnableActivationSheddingOnMemoryPressure = true;
-
-    // Memory usage percentage (0-100) at which grain collection triggers
-    options.MemoryUsageLimitPercentage = 80; // default: 80
-
-    // Target memory usage percentage to reach after collection
-    options.MemoryUsageTargetPercentage = 75; // default: 75
-
-    // How often to poll memory usage
-    options.MemoryUsagePollingPeriod = TimeSpan.FromSeconds(5); // default: 5s
-});
-```
-
-### GrainCollectionOptions properties
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `EnableActivationSheddingOnMemoryPressure` | `bool` | `false` | Enable automatic deactivation under memory pressure. |
-| `MemoryUsageLimitPercentage` | `int` | 80 | Memory usage percentage at which shedding begins. Valid range: 0-100. |
-| `MemoryUsageTargetPercentage` | `int` | 75 | Target memory usage percentage after shedding. Valid range: 0-100. |
-| `MemoryUsagePollingPeriod` | <xref:System.TimeSpan> | 5 seconds | How often to check memory usage. |
-| `CollectionAge` | <xref:System.TimeSpan> | 15 minutes | Minimum time a grain must be idle before eligible for collection. |
-| `CollectionQuantum` | <xref:System.TimeSpan> | 1 minute | How often idle grain collection runs. |
-
-### Best practices
-
-- **Set thresholds conservatively**: Leave headroom between `MemoryUsageTargetPercentage` and `MemoryUsageLimitPercentage` to avoid oscillation
-- **Monitor collection metrics**: Track grain deactivations to understand the impact on your workload
-- **Consider grain importance**: Critical grains can extend their lifetime using timers with `KeepAlive = true` or by receiving periodic calls
-- **Test under load**: Verify behavior under production-like memory conditions
-
-:::zone-end
-
-## Grain lifecycle participation
-
-Application logic can participate in a grain's lifecycle in two ways:
-
-:::zone target="docs" pivot="orleans-8-0,orleans-7-0"
-
-- The grain can participate in its own lifecycle.
-- Components can access the lifecycle via the grain activation context (see <xref:Orleans.Runtime.IGrainContext.ObservableLifecycle?displayProperty=nameWithType>).
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-- The grain can participate in its own lifecycle.
-- Components can access the lifecycle via the grain activation context (see <xref:Orleans.Runtime.IGrainActivationContext.ObservableLifecycle?displayProperty=nameWithType>).
-
-:::zone-end
-
-A grain always participates in its lifecycle, so application logic can be introduced by overriding the participate method.
-
-### Example participation
-
-```csharp
-public override void Participate(IGrainLifecycle lifecycle)
-{
-    base.Participate(lifecycle);
-    lifecycle.Subscribe(
-        this.GetType().FullName,
-        GrainLifecycleStage.SetupState,
-        OnSetupState);
-}
-```
-
-In the preceding example, <xref:Orleans.Grain`1> overrides the <xref:Orleans.Grain.Participate*?displayProperty=nameWithType> method to tell the lifecycle to call its `OnSetupState` method during the <xref:Orleans.Runtime.GrainLifecycleStage.SetupState?displayProperty=nameWithType> stage of the lifecycle.
-
-:::zone target="docs" pivot="orleans-8-0,orleans-7-0"
-
-Components created during a grain's construction can also participate in the lifecycle without adding any special grain logic. Since Orleans creates the grain's context (<xref:Orleans.Runtime.IGrainContext>), including its lifecycle (<xref:Orleans.Runtime.IGrainContext.ObservableLifecycle?displayProperty=nameWithType>), before creating the grain, any component injected into the grain by the container can participate in the grain's lifecycle.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-Components created during a grain's construction can also participate in the lifecycle without adding any special grain logic. Since Orleans creates the grain's activation context (<xref:Orleans.Runtime.IGrainActivationContext>), including its lifecycle (<xref:Orleans.Runtime.IGrainActivationContext.ObservableLifecycle?displayProperty=nameWithType>), before creating the grain, any component injected into the grain by the container can participate in the grain's lifecycle.
-
-:::zone-end
-
-### Example: Component participation
-
-The following component participates in the grain's lifecycle when created using its factory function `Create(...)`. This logic could exist in the component's constructor, but that risks adding the component to the lifecycle before it's fully constructed, which might not be safe.
-
-:::zone target="docs" pivot="orleans-8-0,orleans-7-0"
-
-```csharp
-public class MyComponent : ILifecycleParticipant<IGrainLifecycle>
-{
-    public static MyComponent Create(IGrainContext context)
+    public override async Task OnActivateAsync(
+        CancellationToken cancellationToken)
     {
-        var component = new MyComponent();
-        component.Participate(context.ObservableLifecycle);
-        return component;
-    }
+        _connection = await connectionFactory.ConnectAsync(
+            this.GetPrimaryKeyString(),
+            cancellationToken);
 
-    public void Participate(IGrainLifecycle lifecycle)
-    {
-        lifecycle.Subscribe<MyComponent>(GrainLifecycleStage.Activate, OnActivate);
-    }
-
-    private Task OnActivate(CancellationToken ct)
-    {
-        // Do stuff
+        await base.OnActivateAsync(cancellationToken);
     }
 }
 ```
 
-:::zone-end
+The parameterless `OnActivateAsync()` overload is obsolete. If activation fails, Orleans doesn't make that activation available for calls.
 
-:::zone target="docs" pivot="orleans-3-x"
+Avoid doing unnecessary work during activation. Activations can be recreated after collection, migration, silo restart, or failure.
+
+## Deactivation
+
+Orleans can deactivate an activation because it has been idle, the silo is stopping, the application requested deactivation, migration is occurring, or an error made the activation invalid.
 
 ```csharp
-public class MyComponent : ILifecycleParticipant<IGrainLifecycle>
+public override async Task OnDeactivateAsync(
+    DeactivationReason reason,
+    CancellationToken cancellationToken)
 {
-    public static MyComponent Create(IGrainActivationContext context)
+    if (_connection is not null)
     {
-        var component = new MyComponent();
-        component.Participate(context.ObservableLifecycle);
-        return component;
+        await _connection.DisposeAsync();
     }
 
-    public void Participate(IGrainLifecycle lifecycle)
-    {
-        lifecycle.Subscribe<MyComponent>(GrainLifecycleStage.Activate, OnActivate);
-    }
-
-    private Task OnActivate(CancellationToken ct)
-    {
-        // Do stuff
-    }
+    await base.OnDeactivateAsync(reason, cancellationToken);
 }
 ```
 
-:::zone-end
+Deactivation is best effort. `OnDeactivateAsync` doesn't run if the process terminates abruptly or in some failure cases. Persist important state as part of the operation that changes it, not only during deactivation.
 
-By registering the example component in the service container using its `Create(...)` factory function, any grain constructed with the component as a dependency has the component participate in its lifecycle without requiring any special logic in the grain itself.
+## Influence activation lifetime
 
-#### Register component in container
-
-:::zone target="docs" pivot="orleans-8-0,orleans-7-0"
+Call `DeactivateOnIdle()` to ask Orleans to deactivate the grain after the current request and queued work complete:
 
 ```csharp
-services.AddTransient<MyComponent>(sp =>
-    MyComponent.Create(sp.GetRequiredService<IGrainContext>());
-```
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-```csharp
-services.AddTransient<MyComponent>(sp =>
-    MyComponent.Create(sp.GetRequiredService<IGrainActivationContext>());
-```
-
-:::zone-end
-
-#### Grain with component as a dependency
-
-```csharp
-public class MyGrain : Grain, IMyGrain
+public Task Close()
 {
-    private readonly MyComponent _component;
-
-    public MyGrain(MyComponent component)
-    {
-        _component = component;
-    }
-}
-```
-
-:::zone target="docs" pivot="orleans-8-0,orleans-9-0,orleans-10-0"
-
-## Grain migration
-
-Grain migration allows grain activations to move from one silo to another while preserving their in-memory state. This enables load balancing and cluster optimization without losing grain state. The migration process involves:
-
-1. **Dehydration**: Serializing the grain's state on the source silo before deactivation
-2. **Transfer**: Sending the serialized state to the target silo
-3. **Rehydration**: Restoring the grain's state on the new activation before `OnActivateAsync` is called
-
-### When migration occurs
-
-Migration can occur in several scenarios:
-
-- **Application-initiated**: A grain can request migration by calling `this.MigrateOnIdle()`
-- **Activation repartitioner**: Automatically collocates frequently communicating grains to optimize call locality (experimental)
-- **Activation rebalancer**: Distributes activations to balance load across silos (experimental)
-
-### Implementing migration support
-
-Grains can participate in migration by implementing <xref:Orleans.Runtime.IGrainMigrationParticipant>:
-
-```csharp
-public interface IGrainMigrationParticipant
-{
-    void OnDehydrate(IDehydrationContext dehydrationContext);
-    void OnRehydrate(IRehydrationContext rehydrationContext);
-}
-```
-
-#### Option 1: Implement IGrainMigrationParticipant directly
-
-For grains with custom in-memory state that should be preserved during migration:
-
-```csharp
-public class MyMigratableGrain : Grain, IMyGrain, IGrainMigrationParticipant
-{
-    private int _cachedValue;
-    private string _sessionData;
-
-    public void OnDehydrate(IDehydrationContext dehydrationContext)
-    {
-        // Save state before migration
-        dehydrationContext.TryAddValue("cached", _cachedValue);
-        dehydrationContext.TryAddValue("session", _sessionData);
-    }
-
-    public void OnRehydrate(IRehydrationContext rehydrationContext)
-    {
-        // Restore state after migration
-        rehydrationContext.TryGetValue("cached", out _cachedValue);
-        rehydrationContext.TryGetValue("session", out _sessionData);
-    }
-}
-```
-
-#### Option 2: Use Grain&lt;TState&gt; or IPersistentState&lt;T&gt;
-
-Grains using <xref:Orleans.Grain`1> or <xref:Orleans.Runtime.IPersistentState`1> automatically support migration. Their state is serialized and restored without additional code:
-
-```csharp
-// Automatic migration support via Grain<TState>
-public class MyStatefulGrain : Grain<MyGrainState>, IMyGrain
-{
-    public Task UpdateValue(int value)
-    {
-        State.Value = value;
-        return WriteStateAsync();
-    }
-}
-
-// Automatic migration support via IPersistentState<T>
-public class MyOtherGrain : Grain, IMyGrain
-{
-    private readonly IPersistentState<MyGrainState> _state;
-
-    public MyOtherGrain(
-        [PersistentState("state", "storage")] IPersistentState<MyGrainState> state)
-    {
-        _state = state;
-    }
-}
-```
-
-### Triggering migration
-
-A grain can request migration to a new silo:
-
-```csharp
-public class MyGrain : Grain, IMyGrain
-{
-    public Task RequestMigration()
-    {
-        // Request migration when the grain becomes idle
-        this.MigrateOnIdle();
-        return Task.CompletedTask;
-    }
-}
-```
-
-You can also specify a preferred target silo using placement hints:
-
-```csharp
-public Task MigrateToSilo(SiloAddress targetSilo)
-{
-    RequestContext.Set(IPlacementDirector.PlacementHintKey, targetSilo);
-    this.MigrateOnIdle();
+    DeactivateOnIdle();
     return Task.CompletedTask;
 }
 ```
 
-### Preventing automatic migration
+Call `DelayDeactivation(TimeSpan)` to keep an otherwise idle activation eligible for a specified period. This is a hint, not a durability guarantee; failures and shutdown can still remove the activation.
 
-Use the <xref:Orleans.Placement.ImmovableAttribute> to prevent automatic migration by the repartitioner or rebalancer:
+Grain timers don't keep an activation alive by default. Set `GrainTimerCreationOptions.KeepAlive` only when timer activity should extend the activation lifetime.
+
+## Lifecycle stages and participants
+
+The grain lifecycle exposes ordered stages:
+
+| Stage | Purpose |
+|---|---|
+| `GrainLifecycleStage.First` | Earliest subscription point. |
+| `GrainLifecycleStage.SetupState` | State setup and loading. |
+| `GrainLifecycleStage.Activate` | Grain activation and deactivation callbacks. |
+| `GrainLifecycleStage.Last` | Latest subscription point. |
+
+Components that need ordered activation-scoped behavior can implement `ILifecycleParticipant<IGrainLifecycle>` and subscribe through <xref:Orleans.Runtime.IGrainContext.ObservableLifecycle>. `IGrainActivationContext` has been removed; use <xref:Orleans.Runtime.IGrainContext>.
 
 ```csharp
-// Prevent all automatic migration
-[Immovable]
-public class MyImmovableGrain : Grain, IMyGrain { }
+public sealed class CacheParticipant : ILifecycleParticipant<IGrainLifecycle>
+{
+    public void Participate(IGrainLifecycle lifecycle)
+    {
+        lifecycle.Subscribe<CacheParticipant>(
+            GrainLifecycleStage.Activate,
+            OnStart,
+            OnStop);
+    }
 
-// Prevent only repartitioner migration
-[Immovable(ImmovableKind.Repartitioner)]
-public class MyPartiallyImmovableGrain : Grain, IMyGrain { }
+    private Task OnStart(CancellationToken cancellationToken) =>
+        Task.CompletedTask;
+
+    private Task OnStop(CancellationToken cancellationToken) =>
+        Task.CompletedTask;
+}
 ```
 
-The `ImmovableKind` enum provides these options:
+Lifecycle participation is an advanced integration mechanism. Most grains should use `OnActivateAsync` and `OnDeactivateAsync`.
 
-| Value | Description |
-|-------|-------------|
-| `Repartitioner` | Won't be migrated by the activation repartitioner |
-| `Rebalancer` | Won't be migrated by the activation rebalancer |
-| `Any` | Won't be migrated by any automatic process (default) |
+## Grain migration
 
-> [!NOTE]
-> The `[Immovable]` attribute only prevents *automatic* migration. User-initiated migration via `MigrateOnIdle()` still works.
+Migration moves an activation to another silo while preserving migration-participating in-memory state. Call `MigrateOnIdle()` to request migration after the activation finishes its current work:
 
-### Non-migratable grain types
+```csharp
+public Task RequestMigration()
+{
+    MigrateOnIdle();
+    return Task.CompletedTask;
+}
+```
 
-The following grain types cannot be migrated:
+The request is advisory. Migration occurs only if placement selects another compatible silo. Orleans carries the current <xref:Orleans.Runtime.RequestContext> into the placement decision.
 
-- Client grains
-- System targets
-- Grain services
-- Stateless worker grains
+Implement <xref:Orleans.Runtime.IGrainMigrationParticipant> for custom activation state that must survive migration:
 
-:::zone-end
+```csharp
+public sealed class SessionGrain :
+    Grain,
+    ISessionGrain,
+    IGrainMigrationParticipant
+{
+    private int _sequence;
+
+    public void OnDehydrate(IDehydrationContext context)
+    {
+        context.TryAddValue("sequence", _sequence);
+    }
+
+    public void OnRehydrate(IRehydrationContext context)
+    {
+        context.TryGetValue("sequence", out _sequence);
+    }
+}
+```
+
+Persistent-state components supplied by Orleans participate automatically. Migration isn't a replacement for durable storage: migrated state is still lost if the source process fails before transfer completes.
+
+Automatic activation repartitioning and rebalancing use migration to improve locality or cluster balance. Both are experimental in Orleans 10. See [Grain placement](grain-placement.md) for their status and configuration.
+
+Use <xref:Orleans.Placement.ImmovableAttribute> to exclude a grain type from automatic migration. It doesn't block an explicit `MigrateOnIdle()` request.

--- a/docs/site/src/content/docs/grains/grain-placement-filtering.md
+++ b/docs/site/src/content/docs/grains/grain-placement-filtering.md
@@ -1,183 +1,107 @@
 ---
-title: Grain placement filtering
-description: Learn about grain placement filtering in Microsoft Orleans.
-
-ms.date: 01/22/2026
+title: Grain placement filters
+description: Filter Orleans 10 grain placement candidates using silo metadata.
+ms.date: 08/02/2026
+ms.topic: concept-article
 ---
 
-# Grain placement filtering
+# Grain placement filters
 
-Grain placement filtering in Orleans allows developers additional control over the placement of grains within a cluster. It works in conjunction with placement strategies, adding an additional layer of filtering to determine candidate silos for grain activation.
+> [!WARNING]
+> Placement filtering is experimental in Orleans 10. Its APIs are annotated with `Experimental("ORLEANSEXP004")` and can change in a future release.
 
-This filtering takes place before candidate silos are passed on to the configured placement method allowing for more flexibility and reuse of the filters.
+Placement first determines which silos are compatible with a grain type. Filters then reduce that candidate set, in order, before the grain's [placement strategy](grain-placement.md) selects a target.
 
-For example, the existing `PreferLocal` placement strategy is hard coded to fall back to `Random` placement if the local silo is unable to host the grain type. But by using filters, a `PreferLocalPlacementFilter` could be implemented to filter down to either the local silo or all compatible silos. Then any placement strategy (`Random`, <xref:Orleans.Runtime.ResourceOptimizedPlacement>, `ActivationCount`, etc.) could be configured for that grain type. This allows for any set of filters and any placement strategy to be configured for a grain type.
+Use filters for constraints and preferences such as availability zone, hardware capability, or deployment tier. Don't use them to encode per-request business routing that would make one grain identity behave like multiple independent entities.
 
-## How placement filtering works
+## Configure silo metadata
 
-Placement filtering operates as an additional step in the grain placement process. After all compatible silos for the grain type are identified, all placement filters configured for that grain type, if any, are applied to allow further refinement of the selection by eliminating silos that do not meet the defined criteria.
-
-### Ordering
-
-Filters running in different orders may result in different behavior so explicit ordering is required when two or more filters are defined on a type. This needs to be configured with the `order:` parameter, as the type metadata pulled at runtime may return the attributes on a type in a different order from how they appear in the source code. Ordering must have unique values so an explicit ordering can be determined.
-
-## Built-in filters
-
-Orleans provides various built-in filters for you to choose from. However, if you are unable to find one that suits your needs you can always [implement your own](#implement-placement-filters).
-
-### Silo metadata filters
-
-These filters work with [*Silo Metadata*](../host/configuration-guide/silo-metadata.md) to filter candidate silos. The filters compare metadata values between the **calling silo** (the silo making the placement request) and **candidate silos**. Only silos whose metadata values match the calling silo's values for the specified keys are considered for placement. This enables locality-aware placement where grains are placed on silos in the same zone, rack, or region as the caller.
-
-Before using these filters, configure metadata on your silos:
+Built-in filters compare metadata on the calling silo with metadata on candidate silos. Configure consistent keys and values on every participating silo:
 
 ```csharp
-// From environment variables (ORLEANS__METADATA__key=value)
-builder.UseSiloMetadata();
-
-// From IConfiguration
-builder.UseSiloMetadata(configuration.GetSection("Orleans:Metadata"));
-
-// From a dictionary
-builder.UseSiloMetadata(new Dictionary<string, string>
-{
-    ["zone"] = "us-east-1a",
-    ["tier"] = "premium",
-    ["rack"] = "rack-42"
-});
-```
-
-#### `RequiredMatchSiloMetadata`
-
-Filters candidate silos to only those that match all of the specified metadata keys with the calling silo. If no compatible silos match all of the keys, an empty set is returned and placement fails for the grain.
-
-Use required match filtering when a grain **must** be placed on a silo with specific metadata:
-
-```csharp
-// Grain will only be placed on silos where the "zone" metadata 
-// matches the calling silo's "zone" value
-[RequiredMatchSiloMetadataPlacementFilter(new[] { "zone" })]
-public class ZoneRestrictedGrain : Grain, IZoneRestrictedGrain
-{
-    // This grain will only activate on silos in the same zone as the caller
-}
-
-// Multiple metadata keys can be specified
-[RequiredMatchSiloMetadataPlacementFilter(new[] { "zone", "tier" })]
-public class ZoneAndTierGrain : Grain, IZoneAndTierGrain
-{
-    // Requires both zone AND tier to match the calling silo's values
-}
-```
-
-#### `PreferredMatchSiloMetadata`
-
-This filter attempts to select only silos that match all of the configured metadata keys with the values of the calling silo. However, instead of returning an empty set if there are no matches (as with required filtering), this falls back to partial matches. The first configured metadata key is dropped and a match is made against the remaining keys. This continues, dropping the initial keys, until a sufficient number of matches are made. If no compatible silos match *any* of the metadata keys, all candidate silos are returned.
-
-The `minCandidates` value configures how many candidates must be found to stop the filtering process. This value prevents a single silo or small number of silos from getting quickly overloaded if the match were that small.
-
-If `minCandidates` were not considered, there could be a scenario where there are a large number of silos but only one silo that best matches the configured metadata keys. All placements would be concentrated on that one silo despite having many more available that could host activations. The purpose of `minCandidates` is to allow for a balance between preferring only best matches and avoiding hot silos. It is often desirable to not focus activation (or do scheduling in general) on one target. Set it to a value larger than 1 to ensure a minimum candidate set size so that future placement decisions can avoid concentrating activations on one or a few hot silos. Note that this config is a minimum value; more candidates could be returned. If you prefer most specific matching only, set `minCandidates: 1` to always prefer best match. This might be preferable in specific use cases where there is low activation throughput and where there is a great penalty when moving to a less specific match from a more specific one. In general use, the default value of 2 should be used (and not need to be specified in the attribute).
-
-For example, if filtering on `[PreferredMatchSiloMetadataPlacementFilter(["cloud.availability-zone", "cloud.region"], minCandidates: 2)]` and there is only one matching silo on both `cloud.availability-zone` and `cloud.region`, then this scenario with `minCandidates: 2` would fail to match on both keys because only one silo matches both metadata keys and that's below the minimum configured size of 2. It would then fall back to matching only on `cloud.region`. If there were 2 or more silos that match only `cloud.region`, those would get returned. Otherwise, it would fall back to returning all of the candidates.
-
-```csharp
-// Prefer silos with matching "zone" and "rack" values, but allow fallback
-// minCandidates ensures at least 2 silos are considered even without matches
-[PreferredMatchSiloMetadataPlacementFilter(new[] { "zone", "rack" }, minCandidates: 2)]
-public class LocalityAwareGrain : Grain, ILocalityAwareGrain
-{
-    // Prefers silos in the same zone/rack as the caller, but can activate elsewhere
-}
-```
-
-### Access silo metadata at runtime
-
-Grains can access metadata for any silo using `ISiloMetadataCache`:
-
-```csharp
-public class MyGrain : Grain, IMyGrain
-{
-    private readonly ISiloMetadataCache _metadataCache;
-
-    public MyGrain(ISiloMetadataCache metadataCache)
+siloBuilder.UseSiloMetadata(
+    new Dictionary<string, string>
     {
-        _metadataCache = metadataCache;
-    }
-
-    public Task<string?> GetCurrentSiloZone()
-    {
-        var siloAddress = this.GetSiloAddress();
-        var metadata = _metadataCache.GetMetadata(siloAddress);
-        return Task.FromResult(metadata?.Metadata.GetValueOrDefault("zone"));
-    }
-}
+        ["zone"] = "west-1",
+        ["tier"] = "premium"
+    });
 ```
 
-## Implement placement filters
+External clients don't have silo metadata. Design filtered grain activation paths so the initiating placement request comes from a silo with the required metadata.
 
-To implement a custom placement filter in Orleans, follow these steps:
+## Require metadata matches
 
-1. **Implementation**
-   - Create marker Attribute derived from `PlacementFilterAttribute`
-   - Create Strategy derived from `PlacementFilterStrategy` to manage any configuration values
-   - Create Director derived from `IPlacementFilterDirector` which contains the filtering logic
-     - Define the filtering logic in the `Filter` method, which takes a list of candidate silos and returns a filtered list.
-
-2. **Register the Filter**
-   - Call `AddPlacementFilter` to register the Strategy and corresponding Director
-
-3. **Apply the Filter**
-   - Add the Attribute to a grain class to apply the filter
-
-Here is an example of a simple custom Placement Filter. It is similar in behavior to using `[PreferLocalPlacement]` without any filter, but this has the advantage of being able to specify any placement method. Whereas <xref:Orleans.Runtime.PreferLocalPlacement> falls back to Random placement if the local silo is unable to host a grain, this example has configured <xref:Orleans.Runtime.ActivationCountBasedPlacement>. Any other placement could similarly be used with this filter
+<xref:Orleans.Placement.RequiredMatchSiloMetadataPlacementFilterAttribute> keeps only candidates matching every configured key:
 
 ```csharp
-[AttributeUsage(
-    AttributeTargets.Class, AllowMultiple = false)]
-public class ExamplePreferLocalPlacementFilterAttribute(int order)
-    : PlacementFilterAttribute(
-        new ExamplePreferLocalPlacementFilterStrategy(order));
-```
-
-```csharp
-public class ExamplePreferLocalPlacementFilterStrategy(int order)
-    : PlacementFilterStrategy(order)
-    {
-        public ExamplePreferLocalPlacementFilterStrategy() : this(0) { }
-    }
-```
-
-```csharp
-internal class ExamplePreferLocalPlacementFilterDirector(
-    ILocalSiloDetails localSiloDetails)
-    : IPlacementFilterDirector
+#pragma warning disable ORLEANSEXP004
+[RequiredMatchSiloMetadataPlacementFilter(
+    ["zone", "tier"])]
+public sealed class PremiumZoneGrain :
+    Grain,
+    IPremiumZoneGrain
 {
-    public IEnumerable<SiloAddress> Filter(PlacementFilterStrategy filterStrategy, PlacementTarget target, IEnumerable<SiloAddress> silos)
-    {
-        var siloList = silos.ToList();
-        var localSilo = siloList.FirstOrDefault(s => s == localSiloDetails.SiloAddress);
-        if (localSilo is not null)
-        {
-            return [localSilo];
-        }
-        return siloList;
-    }
 }
+#pragma warning restore ORLEANSEXP004
 ```
 
-After implementing this filter, it can be registered and applied to grains.
+Placement fails if no compatible silo matches. Use this filter only for hard requirements.
+
+## Prefer metadata matches
+
+<xref:Orleans.Placement.PreferredMatchSiloMetadataPlacementFilterAttribute> prefers candidates matching the ordered keys and progressively falls back by dropping earlier keys:
 
 ```csharp
-builder.Services.AddPlacementFilter<
-    ExamplePreferLocalPlacementFilterStrategy,
-    ExamplePreferLocalPlacementFilterDirector>();
-```
-
-```csharp
-[ExamplePreferLocalPlacementFilter]
-[ActivationCountBasedPlacement]
-public class MyGrain() : Grain, IMyGrain
+#pragma warning disable ORLEANSEXP004
+[PreferredMatchSiloMetadataPlacementFilter(
+    ["rack", "zone"],
+    minCandidates: 2)]
+public sealed class LocalityGrain :
+    Grain,
+    ILocalityGrain
 {
-    // ...
 }
+#pragma warning restore ORLEANSEXP004
 ```
+
+`minCandidates` prevents a narrow preference from concentrating placements on too few silos. Its default is 2.
+
+## Combine and order filters
+
+When a grain class has multiple filters, give each a unique `order` value. Orleans applies lower values first. Attribute declaration order isn't a reliable ordering mechanism.
+
+```csharp
+#pragma warning disable ORLEANSEXP004
+[RequiredMatchSiloMetadataPlacementFilter(
+    ["tier"],
+    order: 0)]
+[PreferredMatchSiloMetadataPlacementFilter(
+    ["rack", "zone"],
+    minCandidates: 2,
+    order: 10)]
+public sealed class OrderedFilterGrain :
+    Grain,
+    IOrderedFilterGrain
+{
+}
+#pragma warning restore ORLEANSEXP004
+```
+
+The placement strategy sees only candidates that remain after every filter. A preferred filter can broaden only within the candidate set it receives; it can't restore candidates removed by an earlier required filter.
+
+## Read metadata from a grain
+
+Inject `ISiloMetadataCache` when grain logic needs silo metadata. Use `this.GetSiloAddress()` to identify the current activation's silo. Metadata reads don't influence placement retroactively.
+
+## Custom filters
+
+A custom filter consists of:
+
+1. A `PlacementFilterStrategy` carrying serializable configuration and a unique order.
+1. A `PlacementFilterAttribute` that attaches the strategy to a grain class.
+1. An `IPlacementFilterDirector` that returns a subset of candidate `SiloAddress` values.
+1. Registration using `AddPlacementFilter<TStrategy, TDirector>()`.
+
+Custom filters are part of the same `ORLEANSEXP004` API surface. Keep directors deterministic and fast, don't return silos outside the input candidate set, and define behavior for no matches. Prefer the built-in metadata filters unless custom logic is essential.
+
+During placement, read application request metadata from `PlacementTarget.RequestContextData`; the static <xref:Orleans.Runtime.RequestContext> isn't populated because no activation exists yet.

--- a/docs/site/src/content/docs/grains/grain-placement-filtering.md
+++ b/docs/site/src/content/docs/grains/grain-placement-filtering.md
@@ -1,6 +1,6 @@
 ---
 title: Grain placement filters
-description: Filter Orleans 10 grain placement candidates using silo metadata.
+description: Filter Orleans grain placement candidates using silo metadata.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -8,7 +8,7 @@ ms.topic: concept-article
 # Grain placement filters
 
 > [!WARNING]
-> Placement filtering is experimental in Orleans 10. Its APIs are annotated with `Experimental("ORLEANSEXP004")` and can change in a future release.
+> Placement filtering is experimental. Its APIs are annotated with `Experimental("ORLEANSEXP004")` and can change without notice.
 
 Placement first determines which silos are compatible with a grain type. Filters then reduce that candidate set, in order, before the grain's [placement strategy](grain-placement.md) selects a target.
 

--- a/docs/site/src/content/docs/grains/grain-placement-filtering.md
+++ b/docs/site/src/content/docs/grains/grain-placement-filtering.md
@@ -100,7 +100,16 @@ A custom filter consists of:
 1. A `PlacementFilterStrategy` carrying serializable configuration and a unique order.
 1. A `PlacementFilterAttribute` that attaches the strategy to a grain class.
 1. An `IPlacementFilterDirector` that returns a subset of candidate `SiloAddress` values.
-1. Registration using `AddPlacementFilter<TStrategy, TDirector>()`.
+1. Registration from the silo's service collection, including the strategy lifetime:
+
+    ```csharp
+    siloBuilder.Services.AddPlacementFilter<
+        ExamplePlacementFilterStrategy,
+        ExamplePlacementFilterDirector>(
+            ServiceLifetime.Transient);
+    ```
+
+    The `ServiceLifetime` argument controls the placement strategy lifetime. Orleans always registers the director as a keyed singleton.
 
 Custom filters are part of the same `ORLEANSEXP004` API surface. Keep directors deterministic and fast, don't return silos outside the input candidate set, and define behavior for no matches. Prefer the built-in metadata filters unless custom logic is essential.
 

--- a/docs/site/src/content/docs/grains/grain-placement.md
+++ b/docs/site/src/content/docs/grains/grain-placement.md
@@ -1,6 +1,6 @@
 ---
 title: Grain placement and migration
-description: Understand placement, resource-optimized defaults, and activation movement in Orleans 10.
+description: Understand placement, resource-optimized defaults, and activation movement in Orleans.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -11,7 +11,7 @@ When a grain isn't active, Orleans selects a compatible silo and creates an acti
 
 ## Default placement
 
-<xref:Orleans.Runtime.ResourceOptimizedPlacement> is the default Orleans 10 placement strategy. It uses sampled silo runtime statistics and a power-of-k-choices algorithm to balance new activations while avoiding overloaded silos. It considers CPU, memory, available memory, activation count, and a preference for the local silo.
+<xref:Orleans.Runtime.ResourceOptimizedPlacement> is the default placement strategy. It uses sampled silo runtime statistics and a power-of-k-choices algorithm to balance new activations while avoiding overloaded silos. It considers CPU, memory, available memory, activation count, and a preference for the local silo.
 
 Configure its weights through <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions>:
 
@@ -67,7 +67,7 @@ Per-grain attributes still take precedence.
 
 ## Placement filters
 
-Placement filters reduce the compatible candidate set before the placement strategy selects a silo. They can express requirements or preferences based on silo metadata. Placement filters are experimental in Orleans 10 and produce diagnostic `ORLEANSEXP004`.
+Placement filters reduce the compatible candidate set before the placement strategy selects a silo. They can express requirements or preferences based on silo metadata. Placement filters are experimental and produce diagnostic `ORLEANSEXP004`.
 
 See [Placement filters](grain-placement-filtering.md) for the built-in filters and experimental status.
 
@@ -100,7 +100,7 @@ The attribute doesn't prevent explicit `MigrateOnIdle()` calls.
 
 ## Experimental automatic movement
 
-Orleans 10 includes two opt-in experimental services:
+Orleans includes two opt-in experimental services:
 
 | Feature | Goal | Diagnostic |
 |---|---|---|

--- a/docs/site/src/content/docs/grains/grain-placement.md
+++ b/docs/site/src/content/docs/grains/grain-placement.md
@@ -1,68 +1,19 @@
 ---
-title: Grain placement
-description: Learn about grain placement in .NET Orleans.
-ms.date: 01/22/2026
+title: Grain placement and migration
+description: Understand placement, resource-optimized defaults, and activation movement in Orleans 10.
+ms.date: 08/02/2026
 ms.topic: concept-article
-zone_pivot_groups: orleans-version
 ---
 
-# Grain placement
+# Grain placement and migration
 
-Orleans ensures that when a grain call is made, an instance of that grain is available in memory on some server in the cluster to handle the request. If the grain isn't currently active in the cluster, Orleans picks a server to activate the grain on. This process is called _grain placement_. Placement is also one way Orleans balances load: placing busy grains evenly helps distribute the workload across the cluster.
+When a grain isn't active, Orleans selects a compatible silo and creates an activation there. This process is **placement**. Callers continue using location-transparent grain references, so placement doesn't change application call sites.
 
-The placement process in Orleans is fully configurable. Choose from out-of-the-box placement policies such as random, prefer-local, and load-based, or configure custom logic. This allows full flexibility in deciding where grains are created. For example, place grains on a server close to resources they need to operate on or close to other grains they communicate with.
+## Default placement
 
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0"
+<xref:Orleans.Runtime.ResourceOptimizedPlacement> is the default Orleans 10 placement strategy. It uses sampled silo runtime statistics and a power-of-k-choices algorithm to balance new activations while avoiding overloaded silos. It considers CPU, memory, available memory, activation count, and a preference for the local silo.
 
-> [!NOTE]
-> Starting in Orleans 9.2, the default placement strategy changed from **random placement** to **resource-optimized placement**. This provides better load distribution based on CPU and memory utilization across silos. If you require the previous random placement behavior, explicitly configure it as described in [Configure the default placement strategy](#configure-the-default-placement-strategy).
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-8-0,orleans-7-0,orleans-3-x"
-
-By default, Orleans picks a random compatible server.
-
-:::zone-end
-
-Configure the placement strategy Orleans uses globally or per grain class.
-
-## Resource-optimized placement (default)
-
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0"
-
-> [!NOTE]
-> Starting in Orleans 9.2, resource-optimized placement is the **default** placement strategy. You don't need to explicitly configure it unless you want to customize the options.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-8-0"
-
-To use resource-optimized placement, add the <xref:Orleans.Placement.ResourceOptimizedPlacementAttribute> to your grain class.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-7-0,orleans-3-x"
-
-Resource-optimized placement is not available in this version of Orleans. Consider upgrading to Orleans 8.1 or later to use this feature.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0,orleans-8-0"
-
-The resource-optimized placement strategy attempts to optimize cluster resources by balancing grain activations across silos based on available memory and CPU usage. It assigns weights to runtime statistics to prioritize different resources and calculates a normalized score for each silo. The silo with the lowest score is chosen for placing the upcoming activation. Normalization ensures each property contributes proportionally to the overall score. Adjust weights via <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions> based on specific requirements and priorities for different resources.
-
-Additionally, this placement strategy exposes an option to build a stronger *preference* for the local silo (the one receiving the request to make a new placement) to be picked as the target for the activation. Control this via the `LocalSiloPreferenceMargin` property, part of the options.
-
-Also, an [*online*](https://en.wikipedia.org/wiki/Online_algorithm), [*adaptive*](https://en.wikipedia.org/wiki/Adaptive_algorithm) algorithm provides a smoothing effect avoiding rapid signal drops by transforming the signal into a polynomial-like decay process. This is especially important for CPU usage and contributes overall to avoiding resource saturation on silos, particularly newly joined ones.
-
-This algorithm is based on [*Resource-based placement with cooperative dual-mode Kalman filtering*](https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/).
-
-Configure this placement strategy by adding the <xref:Orleans.Placement.ResourceOptimizedPlacementAttribute> to the grain class.
-
-### Resource-optimized placement options
-
-Configure the resource-optimized placement strategy using <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions>:
+Configure its weights through <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions>:
 
 ```csharp
 siloBuilder.Configure<ResourceOptimizedPlacementOptions>(options =>
@@ -70,395 +21,108 @@ siloBuilder.Configure<ResourceOptimizedPlacementOptions>(options =>
     options.CpuUsageWeight = 40;
     options.MemoryUsageWeight = 20;
     options.AvailableMemoryWeight = 20;
-    options.MaxAvailableMemoryWeight = 5;
     options.ActivationCountWeight = 15;
     options.LocalSiloPreferenceMargin = 5;
 });
 ```
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `CpuUsageWeight` | `int` | 40 | The importance of CPU usage. Higher values favor silos with lower CPU usage. Valid range: 0-100. |
-| `MemoryUsageWeight` | `int` | 20 | The importance of memory usage. Higher values favor silos with lower memory usage. Valid range: 0-100. |
-| `AvailableMemoryWeight` | `int` | 20 | The importance of available memory. Higher values favor silos with more available memory. Valid range: 0-100. |
-| `MaxAvailableMemoryWeight` | `int` | 5 | The importance of maximum available memory. Higher values favor silos with higher physical memory capacity. Useful in clusters with unevenly distributed resources. Valid range: 0-100. |
-| `ActivationCountWeight` | `int` | 15 | The importance of activation count. Higher values favor silos with fewer active grains. Valid range: 0-100. |
-| `LocalSiloPreferenceMargin` | `int` | 5 | Margin for preferring the local silo. When set to 0, always selects the silo with lowest utilization. When set to 100, always prefers the local silo (equivalent to <xref:Orleans.Runtime.PreferLocalPlacement>). Recommended: 5-10. Valid range: 0-100. |
+Weights are relative and don't need to total 100. Keep defaults until measurements show a workload-specific reason to change them.
 
-> [!NOTE]
-> The weight values don't need to sum to 100. Orleans normalizes them automatically, so they represent relative importance rather than absolute percentages.
+## Per-grain strategies
 
-:::zone-end
+Apply a placement attribute to a grain implementation when its requirements differ from the default:
 
-## Random placement
-
-Orleans randomly selects a server from the compatible servers in the cluster. To configure this placement strategy, add the <xref:Orleans.Placement.RandomPlacementAttribute> to the grain class.
-
-## Local placement
-
-If the local server is compatible, Orleans selects the local server; otherwise, it selects a random server. Configure this placement strategy by adding the <xref:Orleans.Placement.PreferLocalPlacementAttribute> to the grain class.
-
-## Hash-based placement
-
-Orleans hashes the grain ID to a non-negative integer and applies a modulo operation with the number of compatible servers. It then selects the corresponding server from the list of compatible servers ordered by server address. Note that this placement isn't guaranteed to remain stable as cluster membership changes. Specifically, adding, removing, or restarting servers can alter the server selected for a given grain ID. Because grains placed using this strategy register in the grain directory, this change in placement decision as membership changes typically doesn't have a noticeable effect.
-
-Configure this placement strategy by adding the <xref:Orleans.Placement.HashBasedPlacementAttribute> to the grain class.
-
-## Activation-count-based placement
-
-This placement strategy attempts to place new grain activations on the least heavily loaded server based on the number of recently busy grains. It includes a mechanism where all servers periodically publish their total activation count to all other servers. The placement director then selects a server predicted to have the fewest activations by examining the most recently reported activation count and predicting the current count based on recent activations made by the placement director on the current server. The director selects several servers randomly when making this prediction to avoid multiple separate servers overloading the same server. By default, two servers are selected randomly, but this value can be configured via <xref:Orleans.Configuration.ActivationCountBasedPlacementOptions>.
-
-This algorithm is based on the thesis [*The Power of Two Choices in Randomized Load Balancing* by Michael David Mitzenmacher](https://www.eecs.harvard.edu/~michaelm/postscripts/mythesis.pdf). It's also used in Nginx for distributed load balancing, as described in the article [*NGINX and the "Power of Two Choices" Load-Balancing Algorithm*](https://www.nginx.com/blog/nginx-power-of-two-choices-load-balancing-algorithm/).
-
-Configure this placement strategy by adding the <xref:Orleans.Placement.ActivationCountBasedPlacementAttribute> to the grain class.
-
-## Stateless worker placement
-
-Stateless worker placement is a special placement strategy used by [*stateless worker* grains](stateless-worker-grains.md). This placement operates almost identically to <xref:Orleans.Runtime.PreferLocalPlacement>, except each server can have multiple activations of the same grain, and the grain isn't registered in the grain directory since there's no need.
-
-Configure this placement strategy by adding the <xref:Orleans.Concurrency.StatelessWorkerAttribute> to the grain class.
-
-## Silo-role-based placement
-
-This is a deterministic placement strategy placing grains on silos with a specific role. Configure this placement strategy by adding the <xref:Orleans.Placement.SiloRoleBasedPlacementAttribute> to the grain class.
-
-## Choose a placement strategy
-
-Choosing the appropriate grain placement strategy, beyond the defaults Orleans provides, requires monitoring and evaluation. The choice should be based on the app's size and complexity, workload characteristics, and deployment environment.
-
-Random placement relies on the [Law of Large Numbers](https://en.wikipedia.org/wiki/Law_of_large_numbers), so it's usually a good default for unpredictable loads spread across many grains (10,000 or more).
-
-Activation-count-based placement also has a random element, relying on the Power of Two Choices principle. This is a commonly used algorithm for distributed load balancing and is used in popular load balancers. Silos frequently publish runtime statistics to other silos in the cluster, including:
-
-- Available memory, total physical memory, and memory usage.
-- CPU usage.
-- Total activation count and recent active activation count.
-  - A sliding window of activations active in the last few seconds, sometimes referred to as the activation working set.
-
-From these statistics, only activation counts are currently used to determine the load on a given silo.
-
-Ultimately, experiment with different strategies and monitor performance metrics to determine the best fit. Selecting the right grain placement strategy optimizes the performance, scalability, and cost-effectiveness of Orleans apps.
-
-## Configure the default placement strategy
-
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0"
-
-Starting in Orleans 9.2, Orleans uses resource-optimized placement by default. Override the default placement strategy by registering an implementation of <xref:Orleans.Runtime.PlacementStrategy> during configuration.
-
-To revert to the previous random placement behavior:
+| Attribute | Behavior |
+|---|---|
+| <xref:Orleans.Placement.ResourceOptimizedPlacementAttribute> | Explicitly selects the default resource-aware strategy. |
+| <xref:Orleans.Placement.RandomPlacementAttribute> | Chooses a random compatible silo. |
+| <xref:Orleans.Placement.PreferLocalPlacementAttribute> | Uses the local compatible silo when possible. |
+| <xref:Orleans.Placement.HashBasedPlacementAttribute> | Maps the grain ID across the current compatible silo set. |
+| <xref:Orleans.Placement.ActivationCountBasedPlacementAttribute> | Favors sampled silos with fewer activations. |
+| <xref:Orleans.Placement.SiloRoleBasedPlacementAttribute> | Restricts placement by silo role. |
+| <xref:Orleans.Concurrency.StatelessWorkerAttribute> | Uses local, scalable worker-pool placement. |
 
 ```csharp
-siloBuilder.Services.AddSingleton<PlacementStrategy, RandomPlacement>();
-```
-
-To use a custom placement strategy:
-
-```csharp
-siloBuilder.Services.AddSingleton<PlacementStrategy, MyPlacementStrategy>();
-```
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-8-0,orleans-7-0"
-
-Orleans uses random placement unless the default is overridden. Override the default placement strategy by registering an implementation of <xref:Orleans.Runtime.PlacementStrategy> during configuration:
-
-```csharp
-siloBuilder.Services.AddSingleton<PlacementStrategy, MyPlacementStrategy>();
-```
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-Orleans uses random placement unless the default is overridden. Override the default placement strategy by registering an implementation of <xref:Orleans.Runtime.PlacementStrategy> during configuration:
-
-```csharp
-siloBuilder.ConfigureServices(services =>
-    services.AddSingleton<PlacementStrategy, MyPlacementStrategy>());
-```
-
-:::zone-end
-
-## Configure the placement strategy for a grain
-
-Configure the placement strategy for a grain type by adding the appropriate attribute to the grain class. Relevant attributes are specified in the [placement strategies](#random-placement) sections above.
-
-## Sample custom placement strategy
-
-First, define a class implementing the <xref:Orleans.Runtime.Placement.IPlacementDirector> interface, requiring a single method. In this example, assume a function `GetSiloNumber` is defined that returns a silo number given the <xref:System.Guid> of the grain about to be created.
-
-```csharp
-public class SamplePlacementStrategyFixedSiloDirector : IPlacementDirector
+[PreferLocalPlacement]
+public sealed class GatewayCacheGrain :
+    Grain,
+    IGatewayCacheGrain
 {
-    public Task<SiloAddress> OnAddActivation(
-        PlacementStrategy strategy,
-        PlacementTarget target,
-        IPlacementContext context)
-    {
-        var silos = context.GetCompatibleSilos(target).OrderBy(s => s).ToArray();
-        int silo = GetSiloNumber(target.GrainIdentity.PrimaryKey, silos.Length);
+}
+```
 
-        return Task.FromResult(silos[silo]);
-    }
+Placement happens when creating an activation. Changing cluster membership or a strategy doesn't move existing activations by itself.
+
+## Override the cluster default
+
+Register a different default strategy only when all unannotated grains should use it:
+
+```csharp
+siloBuilder.Services.AddSingleton<
+    PlacementStrategy,
+    RandomPlacement>();
+```
+
+Per-grain attributes still take precedence.
+
+## Placement filters
+
+Placement filters reduce the compatible candidate set before the placement strategy selects a silo. They can express requirements or preferences based on silo metadata. Placement filters are experimental in Orleans 10 and produce diagnostic `ORLEANSEXP004`.
+
+See [Placement filters](grain-placement-filtering.md) for the built-in filters and experimental status.
+
+## Request migration
+
+A grain can ask Orleans to move its activation after current work completes:
+
+```csharp
+public Task Move()
+{
+    MigrateOnIdle();
+    return Task.CompletedTask;
 }
 ```
 
-Then, define two classes to allow assigning grain classes to the strategy:
+Migration is advisory and occurs only if placement chooses another compatible silo. Custom activation state must participate in dehydration and rehydration; see [Grain activation and lifecycle](grain-lifecycle.md#grain-migration).
+
+Use <xref:Orleans.Placement.ImmovableAttribute> to exclude a grain class from automatic movement:
 
 ```csharp
-[Serializable]
-public sealed class SamplePlacementStrategy : PlacementStrategy
+[Immovable]
+public sealed class HardwareSessionGrain :
+    Grain,
+    IHardwareSessionGrain
 {
-}
-
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-public sealed class SamplePlacementStrategyAttribute : PlacementAttribute
-{
-    public SamplePlacementStrategyAttribute() :
-        base(new SamplePlacementStrategy())
-    {
-    }
 }
 ```
 
-Then, tag any grain classes intended to use this strategy with the attribute:
+The attribute doesn't prevent explicit `MigrateOnIdle()` calls.
 
-```csharp
-[SamplePlacementStrategy]
-public class MyGrain : Grain, IMyGrain
-{
-    // ...
-}
-```
+## Experimental automatic movement
 
-Finally, register the strategy when building the <xref:Orleans.Hosting.ISiloHost>:
+Orleans 10 includes two opt-in experimental services:
 
-```csharp
-private static async Task<ISiloHost> StartSilo()
-{
-    var builder = new HostBuilder(c =>
-    {
-        // normal configuration methods omitted for brevity
-        c.ConfigureServices(ConfigureServices);
-    });
+| Feature | Goal | Diagnostic |
+|---|---|---|
+| Activation repartitioner | Improve grain-to-grain call locality. | `ORLEANSEXP001` |
+| Activation rebalancer | Balance activation count and memory pressure across silos. | `ORLEANSEXP002` |
 
-    var host = builder.Build();
-    await host.StartAsync();
-
-    return host;
-}
-
-private static void ConfigureServices(IServiceCollection services)
-{
-    services.AddPlacementDirector<SamplePlacementStrategy, SamplePlacementStrategyFixedSiloDirector>();
-}
-```
-
-For a second simple example showing further use of the placement context, refer to `PreferLocalPlacementDirector` in the [Orleans source repository](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/PreferLocalPlacementDirector.cs).
-
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0"
-
-## Placement filtering
-
-Placement filtering allows you to filter which silos are eligible for grain placement before the placement strategy selects a target. This works in conjunction with placement strategies and enables scenarios like:
-
-- **Zone-aware placement**: Place grains on silos in the same availability zone
-- **Tiered deployments**: Direct certain grains to premium or standard tier silos
-- **Hardware affinity**: Place compute-intensive grains on silos with specific capabilities
-
-Orleans provides built-in filters based on [silo metadata](../host/configuration-guide/silo-metadata.md), including required-match and preferred-match filtering. You can also implement custom placement filters.
-
-For detailed information on configuring silo metadata, using built-in filters, and implementing custom filters, see [Grain placement filtering](grain-placement-filtering.md).
-
-:::zone-end
-
-## Activation repartitioning
-
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0"
-
-Activation repartitioning is a feature that automatically optimizes grain call locality by migrating grain activations to be closer to the grains they communicate with most frequently. This feature can significantly improve performance by reducing network hops for inter-grain communication.
-
-> [!WARNING]
-> Activation repartitioning is an experimental feature. Use the `#pragma warning disable ORLEANSEXP001` directive or add `<NoWarn>ORLEANSEXP001</NoWarn>` to your project file to suppress the experimental warning.
-
-### How it works
-
-The repartitioner monitors grain-to-grain communication patterns and builds a graph of "edges" representing how frequently grains communicate. Periodically, it analyzes this graph to identify opportunities to improve locality by migrating grains to silos where their communication partners are located, while maintaining an approximately equal distribution of activations across silos.
-
-Key characteristics:
-
-- **Probabilistic tracking**: Uses a probabilistic data structure to track the heaviest communication links while conserving memory
-- **Balanced distribution**: Attempts to keep activation counts balanced across silos
-- **Recovery period**: After migrating grains, a silo waits before participating in another repartitioning round to allow the system to stabilize
-- **Anchoring filter**: Identifies well-partitioned grains (those already close to their communication partners) and avoids migrating them
-
-### Enable activation repartitioning
-
-Enable activation repartitioning using the `AddActivationRepartitioner` extension method:
+Enable them independently:
 
 ```csharp
 #pragma warning disable ORLEANSEXP001
 siloBuilder.AddActivationRepartitioner();
 #pragma warning restore ORLEANSEXP001
-```
 
-### Configuration options
-
-Configure the repartitioner using <xref:Orleans.Configuration.ActivationRepartitionerOptions>:
-
-```csharp
-#pragma warning disable ORLEANSEXP001
-siloBuilder.AddActivationRepartitioner();
-siloBuilder.Configure<ActivationRepartitionerOptions>(options =>
-{
-    options.MaxEdgeCount = 10_000;
-    options.MinRoundPeriod = TimeSpan.FromMinutes(1);
-    options.MaxRoundPeriod = TimeSpan.FromMinutes(2);
-    options.RecoveryPeriod = TimeSpan.FromMinutes(1);
-    options.AnchoringFilterEnabled = true;
-});
-#pragma warning restore ORLEANSEXP001
-```
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `MaxEdgeCount` | `int` | 10,000 | Maximum number of edges (grain communication links) to track. Higher values improve accuracy but use more memory. Values under 100 are not recommended. |
-| `MaxUnprocessedEdges` | `int` | 100,000 | Maximum number of unprocessed edges to buffer. Oldest edges are discarded when exceeded. |
-| `MinRoundPeriod` | <xref:System.TimeSpan> | 1 minute | Minimum time between repartitioning rounds. |
-| `MaxRoundPeriod` | <xref:System.TimeSpan> | 2 minutes | Maximum time between repartitioning rounds. Actual timing is random between min and max. For optimal results, aim for ~10 seconds multiplied by the maximum silo count. |
-| `RecoveryPeriod` | <xref:System.TimeSpan> | 1 minute | Time a silo waits after a repartitioning round before participating in another. Must be less than or equal to `MinRoundPeriod`. |
-| `AnchoringFilterEnabled` | `bool` | `true` | Enables tracking of well-partitioned grains to avoid unnecessarily migrating them. Reduces accuracy slightly but improves effectiveness. |
-| `ProbabilisticFilteringMaxAllowedErrorRate` | `double` | 0.01 | Maximum error rate for the probabilistic filter (0.1% to 1% range). Only applies when `AnchoringFilterEnabled` is `true`. |
-
-### Performance considerations
-
-- **Convergence time**: The repartitioner gradually improves locality over multiple rounds. If the system isn't converging fast enough, consider increasing `MaxEdgeCount`.
-- **Memory usage**: Higher `MaxEdgeCount` values consume more memory. The probabilistic data structure helps limit memory usage while maintaining reasonable accuracy.
-- **Cluster stability**: Avoid very short `RecoveryPeriod` values to prevent excessive grain migration.
-- **Workload patterns**: Works best with workloads that have stable communication patterns. Highly dynamic workloads may see less benefit.
-
-### When to use activation repartitioning
-
-Consider enabling activation repartitioning when:
-
-- Your grains have predictable communication patterns (grain A frequently calls grain B)
-- You have a multi-silo cluster where network latency between silos is significant
-- Benchmarking shows improved throughput with the feature enabled
-
-Avoid activation repartitioning when:
-
-- Grains communicate with many different grains randomly
-- Your cluster is small (2-3 silos) where migration overhead may outweigh benefits
-- Your grains frequently deactivate and reactivate, preventing stable patterns from emerging
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-8-0"
-
-Activation repartitioning was introduced as an experimental feature in Orleans 8.2. For the latest documentation on this feature, see the Orleans 9.0+ documentation.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-7-0,orleans-3-x"
-
-Activation repartitioning is available in Orleans 8.2 and later.
-
-:::zone-end
-
-## Activation rebalancing
-
-:::zone target="docs" pivot="orleans-10-0"
-
-Activation rebalancing is a cluster-wide feature that automatically redistributes grain activations across silos to optimize both **memory usage** and **activation count** balance. Unlike activation repartitioning (which optimizes for communication locality), the rebalancer focuses on keeping silos evenly loaded in terms of resource consumption.
-
-> [!WARNING]
-> Activation rebalancing is an experimental feature. Use the `#pragma warning disable ORLEANSEXP002` directive or add `<NoWarn>ORLEANSEXP002</NoWarn>` to your project file to suppress the experimental warning.
-
-### How it works
-
-The activation rebalancer runs as a singleton grain that coordinates rebalancing across the cluster:
-
-1. **Statistics collection**: Each silo periodically publishes its memory usage and activation count to the rebalancer.
-2. **Entropy calculation**: The rebalancer calculates the current "entropy" of the cluster—a measure of how evenly distributed resources are. Maximum entropy means perfect balance.
-3. **Migration decisions**: When entropy is below the target, the rebalancer identifies "heavy" silos (high memory/activation count) and "light" silos, then instructs heavy silos to migrate activations to light silos.
-4. **Session-based execution**: Rebalancing runs in sessions with multiple cycles. A session ends when the cluster reaches acceptable balance or when no further improvement is detected.
-
-The algorithm considers both memory consumption and activation counts, using the harmonic mean of memory usage to compute ideal activation distribution. This means silos with less available memory receive fewer activations.
-
-### Enable activation rebalancing
-
-Enable activation rebalancing using the `AddActivationRebalancer` extension method:
-
-```csharp
 #pragma warning disable ORLEANSEXP002
 siloBuilder.AddActivationRebalancer();
 #pragma warning restore ORLEANSEXP002
 ```
 
-### Configuration options
+Both features migrate eligible activations and can operate together. They add cluster coordination and state-transfer costs, so benchmark representative workloads before production use. Stateless workers, system targets, grain services, client objects, and immovable activations aren't candidates.
 
-Configure the rebalancer using <xref:Orleans.Configuration.ActivationRebalancerOptions>:
+## Custom placement
 
-```csharp
-#pragma warning disable ORLEANSEXP002
-siloBuilder.AddActivationRebalancer();
-siloBuilder.Configure<ActivationRebalancerOptions>(options =>
-{
-    options.RebalancerDueTime = TimeSpan.FromSeconds(60);
-    options.SessionCyclePeriod = TimeSpan.FromSeconds(15);
-    options.MaxStagnantCycles = 3;
-});
-#pragma warning restore ORLEANSEXP002
-```
+Custom placement strategies and directors are advanced runtime extensions. Implement them only when built-in strategies plus placement filters can't express the requirement. A director must handle membership changes, empty candidate sets, overloaded silos, and deterministic testing.
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `RebalancerDueTime` | <xref:System.TimeSpan> | 60 seconds | Initial delay before the first rebalancing session starts after the cluster stabilizes. |
-| `SessionCyclePeriod` | <xref:System.TimeSpan> | 15 seconds | Time between rebalancing cycles within a session. Must be at least twice the statistics publishing interval. |
-| `MaxStagnantCycles` | `int` | 3 | Maximum consecutive cycles without improvement before a session ends. |
-| `EntropyQuantum` | `double` | 0.0001 | Minimum entropy change considered an improvement. Smaller values make the rebalancer more sensitive. |
-| `AllowedEntropyDeviation` | `double` | 0.0001 | Base threshold for acceptable deviation from maximum entropy. When deviation is below this threshold, the cluster is considered balanced. |
-| `ScaleAllowedEntropyDeviation` | `bool` | `true` | Whether to dynamically scale the allowed deviation based on cluster size and activation count. |
-| `CycleNumberWeight` | `double` | 0.1 | Weight factor for cycle number in migration rate calculation. Higher values accelerate migration in later cycles. |
-| `SiloNumberWeight` | `double` | 0.1 | Weight factor for silo count in migration rate calculation. Higher values migrate more activations in larger clusters. |
-| `ActivationMigrationCountLimit` | `int` | int.MaxValue | Maximum number of activations to migrate in a single cycle. Use to throttle migration rate. |
-
-### Requirements
-
-- **Minimum cluster size**: Requires at least 2 silos to function.
-- **Memory statistics**: Each silo must report valid (non-zero) memory usage. If any silo reports zero memory, rebalancing cycles are skipped.
-- **Grain migratability**: Grains marked with `[Immovable]` or `[Immovable(ImmovableKind.Rebalancer)]` are excluded from rebalancing.
-
-### When to use activation rebalancing
-
-Consider enabling activation rebalancing when:
-
-- Your cluster has silos with uneven resource utilization (some silos running hot while others are underutilized)
-- You have long-running grain activations that may accumulate unevenly over time
-- Your workload patterns cause activation imbalances that placement strategies alone can't address
-
-Avoid activation rebalancing when:
-
-- Your cluster is small (2-3 silos) where the overhead may outweigh benefits
-- Grains have very short lifetimes and deactivate quickly
-- You're already using activation repartitioning and want to avoid conflicting migrations—though the two features can coexist, as the repartitioner adjusts its behavior based on rebalancer reports
-
-### Comparison with activation repartitioning
-
-| Feature | Activation Rebalancing | Activation Repartitioning |
-|---------|------------------------|---------------------------|
-| **Optimizes for** | Memory and activation count balance | Communication locality |
-| **Scope** | Cluster-wide coordination | Pairwise silo coordination |
-| **Experimental ID** | `ORLEANSEXP002` | `ORLEANSEXP001` |
-| **Migration trigger** | Resource imbalance | Communication patterns |
-
-Both features can be enabled simultaneously. The repartitioner automatically adjusts its tolerance based on the cluster imbalance reported by the rebalancer.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-9-0,orleans-8-0,orleans-7-0,orleans-3-x"
-
-Activation rebalancing is available in Orleans 10.0 and later.
-
-:::zone-end
+For implementation details and examples, inspect the built-in directors under [`src/Orleans.Runtime/Placement`](https://github.com/dotnet/orleans/tree/main/src/Orleans.Runtime/Placement).

--- a/docs/site/src/content/docs/grains/grain-references.md
+++ b/docs/site/src/content/docs/grains/grain-references.md
@@ -1,6 +1,6 @@
 ---
 title: Grain references
-description: Create, use, and reason about grain references in Orleans 10.
+description: Create, use, and reason about grain references in Orleans.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---

--- a/docs/site/src/content/docs/grains/grain-references.md
+++ b/docs/site/src/content/docs/grains/grain-references.md
@@ -1,227 +1,102 @@
 ---
 title: Grain references
-description: Learn about grain references in .NET Orleans.
-ms.date: 05/23/2025
+description: Create, use, and reason about grain references in Orleans 10.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
 # Grain references
 
-Before calling a method on a grain, you first need a reference to that grain. A grain reference is a proxy object implementing the same grain interface as the corresponding grain class. It encapsulates the logical identity (type and unique key) of the target grain. You use grain references to make calls to the target grain. Each grain reference points to a single grain (a single instance of the grain class), but you can create multiple independent references to the same grain.
+A grain reference is a generated proxy that implements a grain interface and addresses one logical grain. It contains the grain's [identity](grain-identity.md) and the interface used to call it, but it doesn't contain the activation's network location.
 
-Since a grain reference represents the logical identity of the target grain, it's independent of the grain's physical location and remains valid even after a complete system restart. You can use grain references like any other .NET object. You can pass it to a method, use it as a method return value, and even save it to persistent storage.
+References remain valid when Orleans deactivates, recreates, or migrates the target activation. Getting a reference is a local operation and doesn't activate the grain.
 
-You can obtain a grain reference by passing the identity of a grain to the <xref:Orleans.IGrainFactory.GetGrain``1(System.Type,System.Guid)?displayProperty=nameWithType> method, where `T` is the grain interface and `key` is the unique key of the grain within its type.
+## Get a reference
 
-The following examples show how to obtain a grain reference for the `IPlayerGrain` interface defined previously.
-
-From within a grain class:
-
-```csharp
-// This would typically be read from an HTTP request parameter or elsewhere.
-Guid playerId = Guid.NewGuid();
-IPlayerGrain player = GrainFactory.GetGrain<IPlayerGrain>(playerId);
-```
-
-From Orleans client code:
-
-```csharp
-// This would typically be read from an HTTP request parameter or elsewhere.
-Guid playerId = Guid.NewGuid();
-IPlayerGrain player = client.GetGrain<IPlayerGrain>(playerId);
-```
-
-Grain references contain three pieces of information:
-
-1. The grain _type_, which uniquely identifies the grain class.
-1. The grain _key_, which uniquely identifies a logical instance of that grain class.
-1. The _interface_ which the grain reference must implement.
-
-> [!NOTE]
-> The grain _type_ and _key_ form the [grain identity](grain-identity.md).
-
-Notice that the preceding calls to <xref:Orleans.IGrainFactory.GetGrain*?displayProperty=nameWithType> accepted only two of these three things:
-
-- The _interface_ implemented by the grain reference, `IPlayerGrain`.
-- The grain _key_, which is the value of `playerId`.
-
-Despite stating that a grain reference contains a grain _type_, _key_, and _interface_, the examples only provided Orleans with the _key_ and _interface_. This is because Orleans maintains a mapping between grain interfaces and grain types. When you ask the grain factory for `IShoppingCartGrain`, Orleans consults its mapping to find the corresponding grain type so it can create the reference. This works when there's only one implementation of a grain interface. However, if there are multiple implementations, you need to disambiguate them in the <xref:Orleans.IGrainFactory.GetGrain*> call. For more information, see the next section, [Disambiguating grain type resolution](#disambiguating-grain-type-resolution).
-
-> [!NOTE]
-> Orleans generates grain reference implementation types for each grain interface in your application during compilation. These grain reference implementations inherit from the <xref:Orleans.Runtime.GrainReference?displayProperty=nameWithType> class. <xref:Orleans.IGrainFactory.GetGrain*> returns instances of the generated <xref:Orleans.Runtime.GrainReference?displayProperty=nameWithType> implementation corresponding to the requested grain interface.
-
-## Disambiguating grain type resolution
-
-When multiple implementations of a grain interface exist, such as in the following example, Orleans attempts to determine the intended implementation when creating a grain reference. Consider the following example, where there are two implementations of the `ICounterGrain` interface:
+Use <xref:Orleans.IGrainFactory.GetGrain*> from a client, hosted service, or grain:
 
 ```csharp
 public interface ICounterGrain : IGrainWithStringKey
 {
-    ValueTask<int> UpdateCount();
+    ValueTask<int> Add(int amount);
 }
 
-public class UpCounterGrain : ICounterGrain
-{
-    private int _count;
+ICounterGrain counter =
+    grainFactory.GetGrain<ICounterGrain>("orders-processed");
 
-    public ValueTask<string> UpdateCount() => new(++_count); // Increment count
-}
-
-public class DownCounterGrain : ICounterGrain
-{
-    private int _count;
-
-    public ValueTask<string> UpdateCount() => new(--_count); // Decrement count
-}
+int value = await counter.Add(1);
 ```
 
-The following call to <xref:Orleans.IGrainFactory.GetGrain*> throws an exception because Orleans doesn't know how to unambiguously map `ICounterGrain` to one of the grain classes.
+Within a class deriving from <xref:Orleans.Grain>, use its `GrainFactory` property. In other services, inject <xref:Orleans.IGrainFactory> or <xref:Orleans.IClusterClient>.
 
-```csharp
-// This will throw an exception: there is no unambiguous mapping from ICounterGrain to a grain class.
-ICounterGrain myCounter = grainFactory.GetGrain<ICounterGrain>("my-counter");
-```
+Grain references are serializable. They can be passed as grain method arguments, returned from calls, and included in persistent state.
 
-An <xref:System.ArgumentException?displayProperty=nameWithType> is thrown with the following message:
+## Interface-to-type resolution
 
-```Output
-Unable to identify a single appropriate grain type for interface ICounterGrain. Candidates: upcounter (UpCounterGrain), downcounter (DownCounterGrain)
-```
+The interface and key are usually enough for Orleans to identify the grain type. If exactly one grain class implements the interface, Orleans maps the interface to that class.
 
-The error message tells you which grain implementations Orleans found that match the requested grain interface type, `ICounterGrain`. It shows the grain type names (`upcounter` and `downcounter`) and the grain classes (`UpCounterGrain` and `DownCounterGrain`).
-
-> [!NOTE]
-> The grain type names in the preceding error message, `upcounter` and `downcounter`, are derived from the grain class names, `UpCounterGrain` and `DownCounterGrain` respectively. This is the default behavior in Orleans and it can be customized by adding a `[GrainType(string)]` attribute to the grain class. For example:
->
-> ```csharp
-> [GrainType("up")]
-> public class UpCounterGrain : IUpCounterGrain { /* as above */ }
-> ```
-
-There are several ways to resolve this ambiguity, detailed in the following subsections.
-
-### Disambiguating grain types using unique marker interfaces
-
-The clearest way to disambiguate these grains is to give them unique grain interfaces. For example, if you add the interface `IUpCounterGrain` to the `UpCounterGrain` class and add the interface `IDownCounterGrain` to the `DownCounterGrain` class, as in the following example, you can resolve the correct grain reference by passing `IUpCounterGrain` or `IDownCounterGrain` to the <xref:Orleans.IGrainFactory.GetGrain*> call instead of the ambiguous `ICounterGrain` type.
+When multiple classes implement the same interface, prefer distinct marker interfaces:
 
 ```csharp
 public interface ICounterGrain : IGrainWithStringKey
 {
-    ValueTask<int> UpdateCount();
+    ValueTask<int> Add(int amount);
 }
 
-// Define unique interfaces for our implementations
-public interface IUpCounterGrain : ICounterGrain, IGrainWithStringKey {}
-public interface IDownCounterGrain : ICounterGrain, IGrainWithStringKey {}
+public interface IUpCounterGrain : ICounterGrain;
 
-public class UpCounterGrain : IUpCounterGrain
+public interface IDownCounterGrain : ICounterGrain;
+
+public sealed class UpCounterGrain : Grain, IUpCounterGrain
 {
-    private int _count;
+    private int _value;
 
-    public ValueTask<string> UpdateCount() => new(++_count); // Increment count
+    public ValueTask<int> Add(int amount) =>
+        ValueTask.FromResult(_value += amount);
 }
 
-public class DownCounterGrain : IDownCounterGrain
+public sealed class DownCounterGrain : Grain, IDownCounterGrain
 {
-    private int _count;
+    private int _value;
 
-    public ValueTask<string> UpdateCount() => new(--_count); // Decrement count
-}
-```
-
-To create a reference to either grain, consider the following code:
-
-```csharp
-// Get a reference to an UpCounterGrain.
-ICounterGrain myUpCounter = grainFactory.GetGrain<IUpCounterGrain>("my-counter");
-
-// Get a reference to a DownCounterGrain.
-ICounterGrain myDownCounter = grainFactory.GetGrain<IDownCounterGrain>("my-counter");
-```
-
-> [!NOTE]
-> In the preceding example, you created two grain references with the same key but different grain types. The first, stored in the `myUpCounter` variable, references the grain with the ID `upcounter/my-counter`. The second, stored in the `myDownCounter` variable, references the grain with the ID `downcounter/my-counter`. The combination of grain _type_ and grain _key_ uniquely identifies a grain. Therefore, `myUpCounter` and `myDownCounter` refer to different grains.
-
-#### Disambiguating grain types by providing a grain class prefix
-
-You can provide a grain class name prefix to <xref:Orleans.IGrainFactory.GetGrain*?displayProperty=nameWithType>, for example:
-
-```csharp
-ICounterGrain myUpCounter = grainFactory.GetGrain<ICounterGrain>("my-counter", grainClassNamePrefix: "Up");
-ICounterGrain myDownCounter = grainFactory.GetGrain<ICounterGrain>("my-counter", grainClassNamePrefix: "Down");
-```
-
-### Specifying the default grain implementation using the naming convention
-
-When disambiguating multiple implementations of the same grain interface, Orleans selects an implementation using the convention of stripping a leading 'I' from the interface name. For example, if the interface name is `ICounterGrain` and there are two implementations, `CounterGrain` and `DownCounterGrain`, Orleans chooses `CounterGrain` when asked for a reference to `ICounterGrain`, as in the following example:
-
-```csharp
-/// This will refer to an instance of CounterGrain, since that matches the convention.
-ICounterGrain myUpCounter = grainFactory.GetGrain<ICounterGrain>("my-counter");
-```
-
-### Specifying the default grain type using an attribute
-
-You can add the <xref:Orleans.Metadata.DefaultGrainTypeAttribute?displayProperty=nameWithType> attribute to a grain interface to specify the grain type of the default implementation for that interface, as shown in the following example:
-
-```csharp
-[DefaultGrainType("up-counter")]
-public interface ICounterGrain : IGrainWithStringKey
-{
-    ValueTask<int> UpdateCount();
-}
-
-[GrainType("up-counter")]
-public class UpCounterGrain : ICounterGrain
-{
-    private int _count;
-
-    public ValueTask<string> UpdateCount() => new(++_count); // Increment count
-}
-
-[GrainType("down-counter")]
-public class DownCounterGrain : ICounterGrain
-{
-    private int _count;
-
-    public ValueTask<string> UpdateCount() => new(--_count); // Decrement count
+    public ValueTask<int> Add(int amount) =>
+        ValueTask.FromResult(_value -= amount);
 }
 ```
 
 ```csharp
-/// This will refer to an instance of UpCounterGrain, due to the [DefaultGrainType("up-counter"')] attribute
-ICounterGrain myUpCounter = grainFactory.GetGrain<ICounterGrain>("my-counter");
+IUpCounterGrain up =
+    grainFactory.GetGrain<IUpCounterGrain>("counter");
+
+IDownCounterGrain down =
+    grainFactory.GetGrain<IDownCounterGrain>("counter");
 ```
 
-### Disambiguating grain types by providing the resolved grain ID
+The two references have the same key but different grain types, so they address different logical grains.
 
-Some overloads of <xref:Orleans.IGrainFactory.GetGrain*?displayProperty=nameWithType> accept an argument of type <xref:Orleans.Runtime.GrainId?displayProperty=nameWithType>. When using these overloads, Orleans doesn't need to map from an interface type to a grain type, so there's no ambiguity to resolve. For example:
+For compatibility scenarios, <xref:Orleans.Metadata.DefaultGrainTypeAttribute> can select the default implementation for an interface, and `GetGrain` overloads accepting a grain class name prefix can disambiguate implementations. Explicit marker interfaces are usually clearer and safer to refactor.
+
+## Cast a reference to another supported interface
+
+If the same grain implementation supports another grain interface or extension interface, use <xref:Orleans.GrainExtensions.AsReference*>:
 
 ```csharp
-public interface ICounterGrain : IGrainWithStringKey
-{
-    ValueTask<int> UpdateCount();
-}
-
-[GrainType("up-counter")]
-public class UpCounterGrain : ICounterGrain
-{
-    private int _count;
-
-    public ValueTask<string> UpdateCount() => new(++_count); // Increment count
-}
-
-[GrainType("down-counter")]
-public class DownCounterGrain : ICounterGrain
-{
-    private int _count;
-
-    public ValueTask<string> UpdateCount() => new(--_count); // Decrement count
-}
+IUserGrain user = grainFactory.GetGrain<IUserGrain>("user-42");
+IUserProfileGrain profile = user.AsReference<IUserProfileGrain>();
 ```
+
+This doesn't create a different grain. It creates another typed proxy for the same grain identity. The target grain type must support the requested interface.
+
+Within a grain, pass a reference to itself instead of passing `this`:
 
 ```csharp
-// This will refer to an instance of UpCounterGrain, since "up-counter" was specified as the grain type
-// and the UpCounterGrain uses [GrainType("up-counter")] to specify its grain type.
-ICounterGrain myUpCounter = grainFactory.GetGrain<ICounterGrain>(GrainId.Create("up-counter", "my-counter"));
+IUserGrain self = this.AsReference<IUserGrain>();
 ```
+
+## Reference equality and storage
+
+Multiple proxy objects can refer to the same grain. Compare logical identity when identity matters rather than relying on CLR object identity. Persist references only when retaining the interface relationship is useful; persist domain keys when the application should resolve the current interface at use time.
+
+## Advanced: resolve from GrainId
+
+Some `GetGrain` overloads accept <xref:Orleans.Runtime.GrainId>. These are intended for framework and infrastructure code that already has a resolved grain type and encoded key. Most application code should use a typed key overload because it preserves compile-time key and interface checks.

--- a/docs/site/src/content/docs/grains/grainservices.md
+++ b/docs/site/src/content/docs/grains/grainservices.md
@@ -1,176 +1,110 @@
 ---
-title: Create a GrainService
-description: Learn how to create a GrainService in .NET Orleans.
-ms.date: 01/21/2026
+title: Grain services
+description: Implement silo-resident partitioned services for Orleans grains.
+ms.date: 08/02/2026
 ms.topic: how-to
-zone_pivot_groups: orleans-version
 ---
 
 # Grain services
 
-:::zone target="docs" pivot="orleans-8-0,orleans-9-0,orleans-10-0"
+A grain service is a silo-resident, remotely callable service that supports grain functionality. Orleans starts one instance on every silo and keeps it for the silo lifetime. A `GrainServiceClient<T>` maps a calling grain to the service instance responsible for it.
 
-Grain services are remotely accessible, partitioned services for supporting grain functionality. Each instance of a grain service is responsible for some set of grains. Those grains can get a reference to the grain service currently responsible for servicing them by using a `GrainServiceClient`.
+Reminders are an example of this pattern. Most application workloads should use regular grains or hosted services; use grain services when a framework-level capability must be partitioned across every silo.
 
-:::zone-end
+## Define and implement the service
 
-Grain services exist to support cases where responsibility for servicing grains should be distributed around the Orleans cluster. For example, Orleans Reminders are implemented using grain services: each silo handles reminder operations for a subset of grains and notifies those grains when their reminders fire.
-
-You configure grain services on silos. They initialize when the silo starts, before the silo completes initialization. They aren't collected when idle; instead, their lifetimes extend for the lifetime of the silo itself.
-
-## Create a grain service
-
-A <xref:Orleans.Runtime.GrainService> is a special grain: it has no stable identity and runs in every silo from startup to shutdown. Implementing an <xref:Orleans.Services.IGrainService> interface involves several steps.
-
-1. Define the grain service communication interface. Build the interface of a `GrainService` using the same principles you use for building a grain interface.
-
-    ```csharp
-    public interface IDataService : IGrainService
-    {
-        Task MyMethod();
-    }
-    ```
-
-1. Create the `DataService` grain service. It's helpful to know that you can also inject an <xref:Orleans.IGrainFactory> so you can make grain calls from your `GrainService`.
-
-    :::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-    ```csharp
-    [Reentrant]
-    public class DataService : GrainService, IDataService
-    {
-        readonly IGrainFactory _grainFactory;
-
-        public DataService(
-            IServiceProvider services,
-            GrainId id,
-            Silo silo,
-            ILoggerFactory loggerFactory,
-            IGrainFactory grainFactory)
-            : base(id, silo, loggerFactory)
-        {
-            _grainFactory = grainFactory;
-        }
-
-        public override Task Init(IServiceProvider serviceProvider) =>
-            base.Init(serviceProvider);
-
-        public override Task Start() => base.Start();
-
-        public override Task Stop() => base.Stop();
-
-        public Task MyMethod()
-        {
-            // TODO: custom logic here.
-            return Task.CompletedTask;
-        }
-    }
-    ```
-
-    :::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-:::code language="csharp" source="snippets-v3/grainservices/GrainServices.cs" id="data_service":::
-
-:::zone-end
-
-1. Create an interface for the <xref:Orleans.Runtime.Services.GrainServiceClient`1>`GrainServiceClient` that other grains will use to connect to the `GrainService`.
-
-    ```csharp
-    public interface IDataServiceClient : IGrainServiceClient<IDataService>, IDataService
-    {
-    }
-    ```
-
-1. Create the grain service client. Clients typically act as proxies for the grain services they target, so you usually add a method for each method on the target service. These methods need to get a reference to the target grain service so they can call into it. The `GrainServiceClient<T>` base class provides several overloads of the `GetGrainService` method that can return a grain reference corresponding to a <xref:Orleans.Runtime.GrainId>, a numeric hash (`uint`), or a <xref:Orleans.Runtime.SiloAddress>. The latter two overloads are for advanced cases where you want to use a different mechanism to map responsibility to hosts or address a host directly. In the sample code below, we define a property, `GrainService`, which returns the `IDataService` for the grain calling the `DataServiceClient`. To do that, we use the `GetGrainService(GrainId)` overload in conjunction with the `CurrentGrainReference` property.
-
-    ```csharp
-    public class DataServiceClient : GrainServiceClient<IDataService>, IDataServiceClient
-    {
-        public DataServiceClient(IServiceProvider serviceProvider)
-            : base(serviceProvider)
-        {
-        }
-
-        // For convenience when implementing methods, you can define a property which gets the IDataService
-        // corresponding to the grain which is calling the DataServiceClient.
-        private IDataService GrainService => GetGrainService(CurrentGrainReference.GrainId);
-
-        public Task MyMethod() => GrainService.MyMethod();
-    }
-    ```
-
-1. Inject the grain service client into the other grains that need it. The `GrainServiceClient` isn't guaranteed to access the `GrainService` on the local silo. Your command could potentially be sent to the `GrainService` on any silo in the cluster.
-
-    ```csharp
-    public class MyNormalGrain: Grain<NormalGrainState>, INormalGrain
-    {
-        readonly IDataServiceClient _dataServiceClient;
-
-        public MyNormalGrain(
-            IGrainActivationContext grainActivationContext,
-            IDataServiceClient dataServiceClient) =>
-                _dataServiceClient = dataServiceClient;
-    }
-    ```
-
-1. Configure the grain service and grain service client in the silo. You need to do this so the silo starts the `GrainService`.
-
-    :::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-    ```csharp
-    builder.UseOrleans(siloBuilder =>
-    {
-        siloBuilder.Services
-            .AddGrainService<DataService>()
-            .AddSingleton<IDataServiceClient, DataServiceClient>();
-    });
-    ```
-
-    :::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-:::code language="csharp" source="snippets-v3/grainservices/GrainServices.cs" id="configure_grain_service":::
-
-:::zone-end
-
-## Additional notes
-
-There's an extension method, <xref:Orleans.Hosting.GrainServicesSiloBuilderExtensions.AddGrainService*?displayProperty=nameWithType>, used to register grain services.
+The service interface derives from <xref:Orleans.Services.IGrainService>:
 
 ```csharp
-services.AddSingleton<IGrainService>(
-    serviceProvider => GrainServiceFactory(grainServiceType, serviceProvider));
-```
-
-The silo fetches `IGrainService` types from the service provider when starting (see _orleans/src/Orleans.Runtime/Silo/Silo.cs_):
-
-```csharp
-var grainServices = this.Services.GetServices<IGrainService>();
-```
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-The [Microsoft.Orleans.Runtime](https://www.nuget.org/packages/Microsoft.Orleans.Runtime) NuGet package should be referenced by the `GrainService` project.
-:::zone-end
-:::zone target="docs" pivot="orleans-3-x"
-The [Microsoft.Orleans.OrleansRuntime](https://www.nuget.org/packages/Microsoft.Orleans.OrleansRuntime) NuGet package should be referenced by the `GrainService` project.
-:::zone-end
-
-For this to work, you must register both the service and its client. The code looks something like this:
-
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.UseOrleans(siloBuilder =>
+public interface IIndexService : IGrainService
 {
-    siloBuilder.AddGrainService<DataService>();  // Register GrainService
-});
-
-// Register Client of GrainService
-builder.Services.AddSingleton<IDataServiceClient, DataServiceClient>();
-
-using var host = builder.Build();
-await host.RunAsync();
+    Task Add(string key);
+}
 ```
+
+Derive the implementation from <xref:Orleans.Runtime.GrainService>:
+
+```csharp
+[Reentrant]
+public sealed class IndexService :
+    GrainService,
+    IIndexService
+{
+    public IndexService(
+        GrainId id,
+        Silo silo,
+        ILoggerFactory loggerFactory)
+        : base(id, silo, loggerFactory)
+    {
+    }
+
+    public Task Add(string key)
+    {
+        return Task.CompletedTask;
+    }
+}
+```
+
+Override `Init`, `Start`, `StartInBackground`, and `Stop` only when the service needs work at those lifecycle points. Grain services aren't ordinary grains: they don't have a stable application identity, aren't collected when idle, and don't migrate.
+
+## Create the grain-facing client
+
+Define a client interface and proxy:
+
+```csharp
+public interface IIndexServiceClient :
+    IGrainServiceClient<IIndexService>
+{
+    Task Add(string key);
+}
+
+public sealed class IndexServiceClient :
+    GrainServiceClient<IIndexService>,
+    IIndexServiceClient
+{
+    public IndexServiceClient(IServiceProvider services)
+        : base(services)
+    {
+    }
+
+    public Task Add(string key)
+    {
+        IIndexService service =
+            GetGrainService(CurrentGrainReference.GrainId);
+
+        return service.Add(key);
+    }
+}
+```
+
+`GetGrainService(GrainId)` consistently maps the calling grain to a service partition. Other overloads support explicit silo or hash routing for advanced implementations.
+
+## Register and consume the service
+
+Register both the service and its client:
+
+```csharp
+siloBuilder.AddGrainService<IndexService>();
+siloBuilder.Services.AddSingleton<
+    IIndexServiceClient,
+    IndexServiceClient>();
+```
+
+Inject the client into a normal grain:
+
+```csharp
+public sealed class DocumentGrain(
+    IIndexServiceClient indexService) :
+    Grain,
+    IDocumentGrain
+{
+    public Task Index()
+    {
+        return indexService.Add(this.GetPrimaryKeyString());
+    }
+}
+```
+
+The client can route to a remote silo; don't assume calls stay local.
+
+For a compiled implementation used by Orleans tests, see [`TestGrainService.cs`](https://github.com/dotnet/orleans/blob/main/test/Orleans.Runtime.Tests/GrainServiceTests/TestGrainService.cs).

--- a/docs/site/src/content/docs/grains/index.md
+++ b/docs/site/src/content/docs/grains/index.md
@@ -1,6 +1,6 @@
 ---
 title: Develop Orleans grains
-description: Define grain contracts, implement grains, and call them in Orleans 10.
+description: Define grain contracts, implement grains, and call them in Orleans.
 ms.date: 08/02/2026
 ms.topic: article
 ---
@@ -35,7 +35,7 @@ public sealed record Receipt(
     [property: Id(0)] string OrderId);
 ```
 
-Orleans 10 supports these grain method return types:
+Orleans supports these grain method return types:
 
 - <xref:System.Threading.Tasks.Task>
 - <xref:System.Threading.Tasks.Task`1>

--- a/docs/site/src/content/docs/grains/index.md
+++ b/docs/site/src/content/docs/grains/index.md
@@ -1,371 +1,154 @@
 ---
-title: Develop a grain
-description: Learn how to develop a grain in .NET Orleans.
-ms.date: 05/23/2025
+title: Develop Orleans grains
+description: Define grain contracts, implement grains, and call them in Orleans 10.
+ms.date: 08/02/2026
 ms.topic: article
 ---
 
-# Develop a grain
+# Develop Orleans grains
 
-Before writing code to implement a grain class, create a new Class Library project targeting .NET Standard or .NET Core (preferred), or .NET Framework 4.6.1 or higher (if you cannot use .NET Standard or .NET Core due to dependencies). You can define grain interfaces and grain classes in the same Class Library project or in two different projects for better separation of interfaces from implementation. In either case, the projects need to reference the [Microsoft.Orleans.Sdk](https://www.nuget.org/packages/Microsoft.Orleans.Sdk) NuGet package.
+A grain is an application object with a stable logical identity. Orleans activates it on demand, routes calls to its current activation, and removes idle activations from memory. Application code works with grain references instead of constructing grain classes or locating activations.
 
-For more thorough instructions, see the [Project Setup](../tutorials-and-samples/tutorial-1.md#project-setup) section of [Tutorial One – Orleans Basics](../tutorials-and-samples/tutorial-1.md).
+## Define a grain contract
 
-## Grain interfaces and classes
-
-Grains interact with each other and are called from outside by invoking methods declared as part of their respective grain interfaces. A grain class implements one or more previously declared grain interfaces. All methods of a grain interface must return a <xref:System.Threading.Tasks.Task> (for `void` methods), a <xref:System.Threading.Tasks.Task`1>, or a <xref:System.Threading.Tasks.ValueTask`1> (for methods returning values of type `T`).
-
-The following is an excerpt from the Orleans Presence Service sample:
+A grain interface derives from one of the grain key interfaces and declares asynchronous methods:
 
 ```csharp
-public interface IPlayerGrain : IGrainWithGuidKey
+public interface IShoppingCartGrain : IGrainWithStringKey
 {
-    Task<IGameGrain> GetCurrentGame(CancellationToken cancellationToken = default);
+    ValueTask AddItem(CartItem item);
 
-    Task JoinGame(IGameGrain game, CancellationToken cancellationToken = default);
+    ValueTask<IReadOnlyList<CartItem>> GetItems();
 
-    Task LeaveGame(IGameGrain game, CancellationToken cancellationToken = default);
-}
+    Task Checkout();
 
-public class PlayerGrain : Grain, IPlayerGrain
-{
-    private IGameGrain _currentGame;
-
-    // Game the player is currently in. May be null.
-    public Task<IGameGrain> GetCurrentGame(CancellationToken cancellationToken = default)
-    {
-       return Task.FromResult(_currentGame);
-    }
-
-    // Game grain calls this method to notify that the player has joined the game.
-    public Task JoinGame(IGameGrain game, CancellationToken cancellationToken = default)
-    {
-       _currentGame = game;
-
-       Console.WriteLine(
-           $"Player {GetPrimaryKey()} joined game {game.GetPrimaryKey()}");
-
-       return Task.CompletedTask;
-    }
-
-   // Game grain calls this method to notify that the player has left the game.
-   public Task LeaveGame(IGameGrain game, CancellationToken cancellationToken = default)
-   {
-       _currentGame = null;
-
-       Console.WriteLine(
-           $"Player {GetPrimaryKey()} left game {game.GetPrimaryKey()}");
-
-       return Task.CompletedTask;
-   }
-}
-```
-
-## Response timeout for grain methods
-
-The Orleans runtime allows you to enforce a response timeout per grain method. If a grain method doesn't complete within the timeout, the runtime throws a <xref:System.TimeoutException>. To impose a response timeout, add the <xref:Orleans.ResponseTimeoutAttribute> to the interface's grain method definition. It's crucial to add the attribute to the interface method definition, not the method implementation in the grain class, as both the client and the silo need to be aware of the timeout.
-
-Extending the previous `PlayerGrain` implementation, the following example shows how to impose a response timeout on the `LeaveGame` method:
-
-```csharp
-public interface IPlayerGrain : IGrainWithGuidKey
-{
-    Task<IGameGrain> GetCurrentGame(CancellationToken cancellationToken = default);
-
-    Task JoinGame(IGameGrain game, CancellationToken cancellationToken = default);
-
-    [ResponseTimeout("00:00:05")] // 5s timeout
-    Task LeaveGame(IGameGrain game, CancellationToken cancellationToken = default);
-}
-```
-
-The preceding code sets a response timeout of five seconds on the `LeaveGame` method. When leaving a game, if it takes longer than five seconds a <xref:System.TimeoutException> is thrown.
-
-You can also specify the timeout using <xref:System.TimeSpan> constructor parameters:
-
-```csharp
-public interface IDataProcessingGrain : IGrainWithGuidKey
-{
-    // 2 minute timeout using hours, minutes, seconds
-    [ResponseTimeout(0, 2, 0)]
-    Task<ProcessingResult> ProcessLargeDatasetAsync(Dataset data, CancellationToken cancellationToken = default);
-
-    // 500ms timeout using TimeSpan.FromMilliseconds equivalent
-    [ResponseTimeout("00:00:00.500")]
-    Task<HealthStatus> GetHealthAsync(CancellationToken cancellationToken = default);
-}
-```
-
-### Configure response timeout
-
-Similar to individual grain method response timeouts, you can configure a default response timeout for all grain methods. Calls to grain methods time out if a response isn't received within the specified period. By default, this period is **30 seconds**. You can configure the default response timeout:
-
-- By configuring <xref:Orleans.Configuration.MessagingOptions.ResponseTimeout> on <xref:Orleans.Configuration.ClientMessagingOptions>, on an external client.
-- By configuring <xref:Orleans.Configuration.MessagingOptions.ResponseTimeout> on <xref:Orleans.Configuration.SiloMessagingOptions>, on a server.
-
-For more information on configuring Orleans, see [Client configuration](../host/configuration-guide/client-configuration.md) or [Server configuration](../host/configuration-guide/server-configuration.md).
-
-### Timeout best practices
-
-Consider the following when configuring timeouts:
-
-- **Per-method timeouts override global settings**: A <xref:Orleans.ResponseTimeoutAttribute> on a grain method takes precedence over the global <xref:Orleans.ResponseTimeoutAttribute> configuration.
-- **Set realistic timeouts**: Base timeouts on expected execution time plus reasonable network latency. Timeouts that are too short cause unnecessary failures; timeouts that are too long delay error detection.
-- **Long-running operations**: For operations that may take significant time, consider using Orleans [Reminders](timers-and-reminders.md) instead of extending timeouts indefinitely.
-- **Testing**: Test timeout behavior in your integration tests to ensure your application handles <xref:System.TimeoutException> gracefully.
-
-## Return values from grain methods
-
-Define a grain method that returns a value of type `T` in a grain interface as returning a <xref:System.Threading.Tasks.Task`1>.
-For grain methods not marked with the `async` keyword, when the return value is available, you usually return it using the following statement:
-
-```csharp
-public Task<SomeType> GrainMethod1()
-{
-    return Task.FromResult(GetSomeType());
-}
-```
-
-Define a grain method that returns no value (effectively a void method) in a grain interface as returning a <xref:System.Threading.Tasks.Task>. The returned <xref:System.Threading.Tasks.Task> indicates the asynchronous execution and completion of the method. For grain methods not marked with the `async` keyword, when a "void" method completes its execution, it needs to return the special value <xref:System.Threading.Tasks.Task.CompletedTask?displayProperty=nameWithType>:
-
-```csharp
-public Task GrainMethod2()
-{
-    return Task.CompletedTask;
-}
-```
-
-A grain method marked as `async` returns the value directly:
-
-```csharp
-public async Task<SomeType> GrainMethod3()
-{
-    return await GetSomeTypeAsync();
-}
-```
-
-A `void` grain method marked as `async` that returns no value simply returns at the end of its execution:
-
-```csharp
-public async Task GrainMethod4()
-{
-    return;
-}
-```
-
-If a grain method receives the return value from another asynchronous method call (to a grain or not) and doesn't need to perform error handling for that call, it can simply return the <xref:System.Threading.Tasks.Task> it receives from that asynchronous call:
-
-```csharp
-public Task<SomeType> GrainMethod5()
-{
-    Task<SomeType> task = CallToAnotherGrain();
-
-    return task;
-}
-```
-
-Similarly, a `void` grain method can return a <xref:System.Threading.Tasks.Task> returned to it by another call instead of awaiting it.
-
-```csharp
-public Task GrainMethod6()
-{
-    Task task = CallToAsyncAPI();
-    return task;
-}
-```
-
-<xref:System.Threading.Tasks.ValueTask`1> can be used instead of <xref:System.Threading.Tasks.Task`1>.
-
-## IAsyncEnumerable return values
-
-Orleans supports returning <xref:System.Collections.Generic.IAsyncEnumerable`1> from grain methods, enabling efficient streaming of data from a grain to a caller without loading the entire result set into memory. This is useful for scenarios like:
-
-- Returning large collections of data progressively
-- Streaming real-time updates
-- Processing results as they become available
-
-### Define a streaming grain interface
-
-```csharp
-public interface IDataGrain : IGrainWithStringKey
-{
-    // Returns a streaming sequence of items
-    IAsyncEnumerable<DataItem> GetAllItemsAsync();
-
-    // Can also include CancellationToken for cancellation support
-    IAsyncEnumerable<DataItem> GetItemsAsync(CancellationToken cancellationToken = default);
-}
-```
-
-### Implement the streaming method
-
-Use the `yield return` statement or return an <xref:System.Collections.Generic.IAsyncEnumerable`1> directly:
-
-```csharp
-public class DataGrain : Grain, IDataGrain
-{
-    public async IAsyncEnumerable<DataItem> GetAllItemsAsync()
-    {
-        for (int i = 0; i < 1000; i++)
-        {
-            // Simulate async data retrieval
-            var item = await FetchItemAsync(i);
-            yield return item;
-        }
-    }
-
-    public async IAsyncEnumerable<DataItem> GetItemsAsync(
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        int id = 0;
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            var item = await FetchItemAsync(id++);
-            yield return item;
-        }
-    }
-
-    private Task<DataItem> FetchItemAsync(int id) =>
-        Task.FromResult(new DataItem { Id = id });
+    Task<Receipt> GetReceipt();
 }
 
 [GenerateSerializer]
-public class DataItem
+public sealed record CartItem(
+    [property: Id(0)] string ProductId,
+    [property: Id(1)] int Quantity);
+
+[GenerateSerializer]
+public sealed record Receipt(
+    [property: Id(0)] string OrderId);
+```
+
+Orleans 10 supports these grain method return types:
+
+- <xref:System.Threading.Tasks.Task>
+- <xref:System.Threading.Tasks.Task`1>
+- <xref:System.Threading.Tasks.ValueTask>
+- <xref:System.Threading.Tasks.ValueTask`1>
+
+Use `Task` or `ValueTask` for methods without a result, and their generic forms for methods returning a result. Don't use `void`, `async void`, or synchronous return types in grain contracts. A <xref:System.Threading.CancellationToken> can be included as a method parameter for cooperative cancellation.
+
+Arguments, return values, and exceptions cross process boundaries. Make application data serializable by Orleans, normally using <xref:Orleans.GenerateSerializerAttribute> and stable <xref:Orleans.IdAttribute> values. Grain references are already serializable and can be passed in calls or stored as part of grain state.
+
+## Implement the contract
+
+A grain class usually derives from <xref:Orleans.Grain> and implements one or more grain interfaces:
+
+```csharp
+public sealed class ShoppingCartGrain : Grain, IShoppingCartGrain
 {
-    [Id(0)]
-    public int Id { get; set; }
+    private readonly List<CartItem> _items = [];
+
+    public ValueTask AddItem(CartItem item)
+    {
+        _items.Add(item);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<IReadOnlyList<CartItem>> GetItems() =>
+        ValueTask.FromResult<IReadOnlyList<CartItem>>(_items.ToArray());
+
+    public Task Checkout() => Task.CompletedTask;
+
+    public Task<Receipt> GetReceipt() =>
+        Task.FromResult(new Receipt($"order-{this.GetPrimaryKeyString()}"));
 }
 ```
 
-### Consume the streaming method
+Orleans creates grain classes through dependency injection. Constructor injection is available for application services, and <xref:Orleans.IGrainFactory> is available through the `GrainFactory` property on <xref:Orleans.Grain>.
+
+> [!IMPORTANT]
+> A grain activation processes one turn at a time. Don't block on tasks using `.Result`, `.Wait()`, or `GetAwaiter().GetResult()`. Use `await` so Orleans can resume the request on the activation scheduler.
+
+## Get and call a grain reference
+
+Use <xref:Orleans.IGrainFactory.GetGrain*> with the interface and key:
 
 ```csharp
-var grain = client.GetGrain<IDataGrain>("mydata");
+IShoppingCartGrain cart =
+    grainFactory.GetGrain<IShoppingCartGrain>("customer-42");
 
-await foreach (var item in grain.GetAllItemsAsync())
+await cart.AddItem(new CartItem("SKU-123", 2));
+IReadOnlyList<CartItem> items = await cart.GetItems();
+```
+
+Getting a reference doesn't create or activate a grain. The first call that needs an activation causes Orleans to place and activate it. The reference remains valid if the activation moves, deactivates, or is recreated on another silo.
+
+## Understand call completion
+
+A regular grain call completes in one of these ways:
+
+- The method returns successfully, optionally with a result.
+- The method throws, and the exception is propagated to the caller.
+- The caller cancels the call and observes <xref:System.OperationCanceledException>.
+- The caller doesn't receive a response before its response timeout and observes <xref:System.TimeoutException>.
+- Messaging or cluster failures prevent the call from completing.
+
+A timeout tells the caller that no response arrived in time. It doesn't prove that the grain method didn't run or won't finish. `CancelRequestOnTimeout` defaults to `false`; when enabled, Orleans sends a best-effort cancellation signal after a timeout, and the grain must still cooperate by observing a cancellation token.
+
+Distributed calls can be retried by application code or infrastructure after an uncertain outcome. Design operations to be idempotent when duplicate execution would be harmful. A common pattern is to include an operation ID and persist completed IDs with the state change.
+
+Configure a per-method timeout on the interface:
+
+```csharp
+public interface IReportGrain : IGrainWithGuidKey
 {
-    Console.WriteLine($"Received item: {item.Id}");
-
-    // Process each item as it arrives
-    await ProcessItemAsync(item);
+    [ResponseTimeout("00:00:10")]
+    Task<Report> Generate(CancellationToken cancellationToken = default);
 }
 ```
 
-### Configure batch size
+Global defaults are configured through <xref:Orleans.Configuration.ClientMessagingOptions> and <xref:Orleans.Configuration.SiloMessagingOptions>. See [Cancellation tokens](cancellation-tokens.md) for cancellation semantics and configuration.
 
-Orleans batches multiple elements together to reduce network round trips. You can configure the batch size using the `WithBatchSize` extension method:
+## Activation and deactivation
+
+Override the current lifecycle methods when a grain needs activation-scoped setup or cleanup:
 
 ```csharp
-// Request up to 50 elements per batch instead of the default 100
-await foreach (var item in grain.GetAllItemsAsync().WithBatchSize(50))
+public override Task OnActivateAsync(CancellationToken cancellationToken)
 {
-    await ProcessItemAsync(item);
+    return base.OnActivateAsync(cancellationToken);
+}
+
+public override Task OnDeactivateAsync(
+    DeactivationReason reason,
+    CancellationToken cancellationToken)
+{
+    return base.OnDeactivateAsync(reason, cancellationToken);
 }
 ```
 
-### IAsyncEnumerable vs Orleans Streams
+The parameterless `OnActivateAsync()` overload is obsolete. Deactivation callbacks are best effort and don't run after process termination or some failures, so don't rely on them to persist critical state.
 
-| Feature | IAsyncEnumerable | Orleans Streams |
-|---------|------------------|-----------------|
-| **Use case** | Request-response streaming | Pub-sub messaging |
-| **Lifetime** | Scoped to single call | Persistent subscriptions |
-| **Direction** | Grain to caller only | Any producer to any subscriber |
-| **Backpressure** | Built-in | Provider-dependent |
-| **Persistence** | No | Optional (provider-dependent) |
+See [Grain lifecycle](grain-lifecycle.md) for collection, lifecycle participation, and migration.
 
-Use <xref:System.Collections.Generic.IAsyncEnumerable`1> when:
+## Choose basic or advanced features
 
-- You need a simple request-response pattern with streaming results
-- The caller initiates the data flow and consumes all results
-- You want automatic backpressure and cancellation support
+Most grains only need a contract, an implementation, a stable key, and regular request-response calls. Add specialized behavior only when the workload requires it:
 
-Use [Orleans Streams](../streaming/index.md) when:
-
-- You need pub-sub messaging with multiple subscribers
-- Subscriptions should survive grain deactivation
-- You need persistent or durable streams
-
-## Grain references
-
-A grain reference is a proxy object implementing the same grain interface as the corresponding grain class. It encapsulates the logical identity (type and unique key) of the target grain. You use grain references to make calls to the target grain. Each grain reference points to a single grain (a single instance of the grain class), but you can create multiple independent references to the same grain.
-
-Since a grain reference represents the logical identity of the target grain, it's independent of the grain's physical location and remains valid even after a complete system restart. You can use grain references like any other .NET object. You can pass it to a method, use it as a method return value, etc., and even save it to persistent storage.
-
-You can obtain a grain reference by passing the identity of a grain to the <xref:Orleans.IGrainFactory.GetGrain``1(System.Type,System.Guid)?displayProperty=nameWithType> method, where `T` is the grain interface and `key` is the unique key of the grain within its type.
-
-The following examples show how to obtain a grain reference for the `IPlayerGrain` interface defined previously.
-
-From inside a grain class:
-
-```csharp
-IPlayerGrain player = GrainFactory.GetGrain<IPlayerGrain>(playerId);
-```
-
-From Orleans client code.
-
-```csharp
-IPlayerGrain player = client.GetGrain<IPlayerGrain>(playerId);
-```
-
-For more information about grain references, see the [grain reference article](grain-references.md).
-
-### Grain method invocation
-
-The Orleans programming model is based on [asynchronous programming](../../csharp/asynchronous-programming/index.md). Using the grain reference from the previous example, here's how you perform a grain method invocation:
-
-```csharp
-// Invoking a grain method asynchronously
-Task joinGameTask = player.JoinGame(this, GrainCancellationToken);
-
-// The await keyword effectively makes the remainder of the
-// method execute asynchronously at a later point
-// (upon completion of the Task being awaited) without blocking the thread.
-await joinGameTask;
-
-// The next line will execute later, after joinGameTask has completed.
-players.Add(playerId);
-```
-
-You can join two or more `Tasks`. The join operation creates a new <xref:System.Threading.Tasks.Task> that resolves when all its constituent `Tasks` complete. This pattern is useful when a grain needs to start multiple computations and wait for all of them to complete before proceeding. For example, a front-end grain generating a web page made of many parts might make multiple back-end calls (one for each part) and receive a <xref:System.Threading.Tasks.Task> for each result. The grain would then await the join of all these `Tasks`. When the joined <xref:System.Threading.Tasks.Task> resolves, the individual `Tasks` have completed, and all the data required to format the web page has been received.
-
-Example:
-
-```csharp
-List<Task> tasks = new List<Task>();
-Message notification = CreateNewMessage(text);
-
-foreach (ISubscriber subscriber in subscribers)
-{
-    tasks.Add(subscriber.Notify(notification));
-}
-
-// WhenAll joins a collection of tasks, and returns a joined
-// Task that will be resolved when all of the individual notification Tasks are resolved.
-Task joinedTask = Task.WhenAll(tasks);
-
-await joinedTask;
-
-// Execution of the rest of the method will continue
-// asynchronously after joinedTask is resolve.
-```
-
-### Error propagation
-
-When a grain method throws an exception, Orleans propagates that exception up the calling stack, across hosts as necessary. For this to work as intended, exceptions must be serializable by Orleans, and hosts handling the exception must have the exception type available. If an exception type isn't available, Orleans throws the exception as an instance of <xref:Orleans.Serialization.UnavailableExceptionFallbackException?displayProperty=nameWithType>, preserving the message, type, and stack trace of the original exception.
-
-Exceptions thrown from grain methods don't cause the grain to be deactivated unless the exception inherits from <xref:Orleans.Storage.InconsistentStateException?displayProperty=nameWithType>. Storage operations throw <xref:Orleans.Storage.InconsistentStateException> when they discover that the grain's in-memory state is inconsistent with the state in the database. Aside from the special handling of <xref:Orleans.Storage.InconsistentStateException>, this behavior is similar to throwing an exception from any .NET object: exceptions don't cause an object to be destroyed.
-
-### Virtual methods
-
-A grain class can optionally override the <xref:Orleans.Grain.OnActivateAsync*> and <xref:Orleans.Grain.OnDeactivateAsync*> virtual methods. The Orleans runtime invokes these methods upon activation and deactivation of each grain of the class. This gives your grain code a chance to perform additional initialization and cleanup operations. An exception thrown by <xref:Orleans.Grain.OnActivateAsync*> fails the activation process.
-
-While <xref:Orleans.Grain.OnActivateAsync*> (if overridden) is always called as part of the grain activation process, <xref:Orleans.Grain.OnDeactivateAsync*> isn't guaranteed to be called in all situations (for example, in case of a server failure or other abnormal events). Because of this, your applications shouldn't rely on <xref:Orleans.Grain.OnDeactivateAsync*> for performing critical operations, such as persisting state changes. Use it only for best-effort operations.
-
-## See also
-
-- [Grain extensions](grain-extensions.md)
-- [Grain identity](grain-identity.md)
-- [Grain references](grain-references.md)
-- [Grain persistence](grain-persistence/index.md)
-- [Grain lifecycle overview](grain-lifecycle.md)
+- [Request scheduling and reentrancy](request-scheduling.md)
+- [Timers and reminders](timers-and-reminders.md)
+- [Observers](observers.md)
 - [Grain placement](grain-placement.md)
+- [Stateless worker grains](stateless-worker-grains.md)
+- [Grain call filters](interceptors.md)
+- [Grain extensions](grain-extensions.md)
+- [Grain services](grainservices.md)
+
+The [Orleans runtime implementation](../implementation/index.md) documentation describes internal scheduling, messaging, and lifecycle components. Those details aren't required for basic grain development.

--- a/docs/site/src/content/docs/grains/interceptors.md
+++ b/docs/site/src/content/docs/grains/interceptors.md
@@ -1,228 +1,69 @@
 ---
 title: Grain call filters
-description: Learn about grain call filters in .NET Orleans.
-ms.date: 01/21/2026
+description: Intercept incoming and outgoing Orleans grain calls.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
 # Grain call filters
 
-Grain call filters provide a way to intercept grain calls. Filters can execute code both before and after a grain call. You can install multiple filters simultaneously. Filters are asynchronous and can modify <xref:Orleans.Runtime.RequestContext>, arguments, and the return value of the method being invoked. Filters can also inspect the <xref:System.Reflection.MethodInfo> of the method being invoked on the grain class and can be used to throw or handle exceptions.
+Grain call filters run around Orleans calls. Use them for cross-cutting behavior such as authorization, telemetry, request metadata, and deliberate exception translation.
 
-Some example uses of grain call filters are:
+- <xref:Orleans.IIncomingGrainCallFilter> runs on the target silo before and after a grain or extension method.
+- <xref:Orleans.IOutgoingGrainCallFilter> runs on a client or silo that sends a call.
 
-- **Authorization**: A filter can inspect the method being invoked and the arguments, or authorization information in the <xref:Orleans.Runtime.RequestContext>, to determine whether to allow the call to proceed.
-- **Logging/Telemetry**: A filter can log information and capture timing data and other statistics about method invocation.
-- **Error Handling**: A filter can intercept exceptions thrown by a method invocation and transform them into other exceptions or handle the exceptions as they pass through the filter.
+Filters form an asynchronous pipeline. A filter must call and await `context.Invoke()` to continue to the next filter and eventually the target method.
 
-Filters come in two types:
+## Incoming filters
 
-- Incoming call filters
-- Outgoing call filters
-
-Incoming call filters are executed when receiving a call. Outgoing call filters are executed when making a call.
-
-## Incoming call filters
-
-Incoming grain call filters implement the <xref:Orleans.IIncomingGrainCallFilter> interface, which has one method:
-
-```csharp
-public interface IIncomingGrainCallFilter
-{
-    Task Invoke(IIncomingGrainCallContext context);
-}
-```
-
-The <xref:Orleans.IIncomingGrainCallContext> argument passed to the `Invoke` method has the following shape:
-
-```csharp
-public interface IIncomingGrainCallContext
-{
-    /// <summary>
-    /// Gets the grain being invoked.
-    /// </summary>
-    IAddressable Grain { get; }
-
-    /// <summary>
-    /// Gets the <see cref="MethodInfo"/> for the interface method being invoked.
-    /// </summary>
-    MethodInfo InterfaceMethod { get; }
-
-    /// <summary>
-    /// Gets the <see cref="MethodInfo"/> for the implementation method being invoked.
-    /// </summary>
-    MethodInfo ImplementationMethod { get; }
-
-    /// <summary>
-    /// Gets the arguments for this method invocation.
-    /// </summary>
-    object[] Arguments { get; }
-
-    /// <summary>
-    /// Invokes the request.
-    /// </summary>
-    Task Invoke();
-
-    /// <summary>
-    /// Gets or sets the result.
-    /// </summary>
-    object Result { get; set; }
-}
-```
-
-The `IIncomingGrainCallFilter.Invoke(IIncomingGrainCallContext)` method must `await` or return the result of `IIncomingGrainCallContext.Invoke()` to execute the next configured filter and eventually the grain method itself. You can modify the `Result` property after awaiting the `Invoke()` method. The `ImplementationMethod` property returns the <xref:System.Reflection.MethodInfo> of the implementation class. You can access the <xref:System.Reflection.MethodInfo> of the interface method using the `InterfaceMethod` property. Grain call filters are called for all method calls to a grain, including calls to grain extensions (implementations of `IGrainExtension`) installed in the grain. For example, Orleans uses grain extensions to implement Streams and Cancellation Tokens. Therefore, expect that the value of `ImplementationMethod` isn't always a method in the grain class itself.
-
-## Configure incoming grain call filters
-
-You can register implementations of <xref:Orleans.IIncomingGrainCallFilter> either as silo-wide filters via Dependency Injection or as grain-level filters by having a grain implement `IIncomingGrainCallFilter` directly.
-
-### Silo-wide grain call filters
-
-You can register a delegate as a silo-wide grain call filter using Dependency Injection like this:
-
-:::code language="csharp" source="snippets/interceptors/Configuration.cs" id="silo_delegate_filter":::
-
-Similarly, you can register a class as a grain call filter using the <xref:Orleans.Hosting.GrainCallFilterSiloBuilderExtensions.AddIncomingGrainCallFilter*> helper method. Here's an example of a grain call filter that logs the results of every grain method:
+The following compiled documentation sample logs completion and failure:
 
 :::code language="csharp" source="snippets/interceptors/LoggingFilters.cs" id="logging_incoming_filter":::
 
-This filter can then be registered using the `AddIncomingGrainCallFilter` extension method:
+Register it for the silo:
 
 :::code language="csharp" source="snippets/interceptors/Configuration.cs" id="register_incoming_filter":::
 
-Alternatively, the filter can be registered without the extension method:
+A grain class can also implement `IIncomingGrainCallFilter` to filter calls to that grain only. Silo-wide incoming filters run in registration order, followed by the grain-level filter, and then the target method.
 
-:::code language="csharp" source="snippets/interceptors/Configuration.cs" id="register_incoming_filter_di":::
+## Outgoing filters
 
-### Per-grain grain call filters
-
-A grain class can register itself as a grain call filter and filter any calls made to it by implementing `IIncomingGrainCallFilter` like this:
-
-:::code language="csharp" source="snippets/interceptors/GrainFilters.cs" id="per_grain_filter":::
-
-In the preceding example, all calls to the `GetFavoriteNumber` method return `38` instead of `7` because the filter altered the return value.
-
-Another use case for filters is access control, as shown in this example:
-
-:::code language="csharp" source="snippets/interceptors/GrainFilters.cs" id="access_control_attribute":::
-
-:::code language="csharp" source="snippets/interceptors/GrainFilters.cs" id="access_control_grain":::
-
-In the preceding example, the `SpecialAdminOnlyOperation` method can only be called if `"isAdmin"` is set to `true` in the <xref:Orleans.Runtime.RequestContext>. In this way, you can use grain call filters for authorization. In this example, it's the caller's responsibility to ensure the `"isAdmin"` value is set correctly and that authentication is performed correctly. Note that the `[AdminOnly]` attribute is specified on the grain class method. This is because the `ImplementationMethod` property returns the <xref:System.Reflection.MethodInfo> of the implementation, not the interface. The filter could also check the `InterfaceMethod` property.
-
-## Grain call filter ordering
-
-Grain call filters follow a defined order:
-
-1. `IIncomingGrainCallFilter` implementations configured in the dependency injection container, in the order in which they are registered.
-1. Grain-level filter, if the grain implements `IIncomingGrainCallFilter`.
-1. Grain method implementation or grain extension method implementation.
-
-Each call to `IIncomingGrainCallContext.Invoke()` encapsulates the next defined filter, allowing each filter a chance to execute code before and after the next filter in the chain and, eventually, the grain method itself.
-
-## Outgoing call filters
-
-Outgoing grain call filters are similar to incoming grain call filters. The major difference is that they are invoked on the caller (client) rather than the callee (grain).
-
-Outgoing grain call filters implement the `IOutgoingGrainCallFilter` interface, which has one method:
-
-```csharp
-public interface IOutgoingGrainCallFilter
-{
-    Task Invoke(IOutgoingGrainCallContext context);
-}
-```
-
-The <xref:Orleans.IOutgoingGrainCallContext> argument passed to the `Invoke` method has the following shape:
-
-```csharp
-public interface IOutgoingGrainCallContext
-{
-    /// <summary>
-    /// Gets the grain being invoked.
-    /// </summary>
-    IAddressable Grain { get; }
-
-    /// <summary>
-    /// Gets the <see cref="MethodInfo"/> for the interface method being invoked.
-    /// </summary>
-    MethodInfo InterfaceMethod { get; }
-
-    /// <summary>
-    /// Gets the arguments for this method invocation.
-    /// </summary>
-    object[] Arguments { get; }
-
-    /// <summary>
-    /// Invokes the request.
-    /// </summary>
-    Task Invoke();
-
-    /// <summary>
-    /// Gets or sets the result.
-    /// </summary>
-    object Result { get; set; }
-}
-```
-
-The `IOutgoingGrainCallFilter.Invoke(IOutgoingGrainCallContext)` method must `await` or return the result of `IOutgoingGrainCallContext.Invoke()` to execute the next configured filter and eventually the grain method itself. You can modify the `Result` property after awaiting the `Invoke()` method. You can access the <xref:System.Reflection.MethodInfo> of the interface method being called using the `InterfaceMethod` property. Outgoing grain call filters are invoked for all method calls to a grain, including calls to system methods made by Orleans.
-
-## Configure outgoing grain call filters
-
-You can register implementations of `IOutgoingGrainCallFilter` on both silos and clients using Dependency Injection.
-
-Register a delegate as a call filter like this:
-
-:::code language="csharp" source="snippets/interceptors/Configuration.cs" id="outgoing_delegate_filter":::
-
-In the above code, `builder` may be either an instance of <xref:Orleans.Hosting.ISiloBuilder> or <xref:Orleans.IClientBuilder>.
-
-Similarly, you can register a class as an outgoing grain call filter. Here's an example of a grain call filter that logs the results of every grain method:
+Outgoing filters use the same pipeline pattern:
 
 :::code language="csharp" source="snippets/interceptors/LoggingFilters.cs" id="logging_outgoing_filter":::
 
-This filter can then be registered using the `AddOutgoingGrainCallFilter` extension method:
+Register outgoing filters on silos or clients:
 
 :::code language="csharp" source="snippets/interceptors/Configuration.cs" id="register_outgoing_filter":::
 
-Alternatively, the filter can be registered without the extension method:
+## Inspect and modify calls
 
-:::code language="csharp" source="snippets/interceptors/Configuration.cs" id="register_outgoing_filter_di":::
+<xref:Orleans.IGrainCallContext> exposes:
 
-As with the delegate call filter example, `builder` may be an instance of either <xref:Orleans.Hosting.ISiloBuilder> or <xref:Orleans.IClientBuilder>.
+- `SourceId` and `TargetId`.
+- `InterfaceType`, `InterfaceName`, and `MethodName`.
+- `InterfaceMethod`.
+- `Request`, an <xref:Orleans.Serialization.Invocation.IInvokable>.
+- `Result` and `Response`.
 
-## Use cases
+Incoming contexts also expose `TargetContext` and `ImplementationMethod`; outgoing contexts expose `SourceContext`.
 
-### Exception conversion
+Use `context.Request.GetArgumentCount()`, `GetArgument(index)`, and `SetArgument(index, value)` to inspect or replace arguments. Current contexts and `IInvokable` don't expose an `Arguments` array.
 
-When an exception thrown from the server is deserialized on the client, you might sometimes get the following exception instead of the actual one: `TypeLoadException: Could not find Whatever.dll.`
+The compiled delegate example demonstrates request context and result modification:
 
-This happens if the assembly containing the exception isn't available to the client. For example, say you use Entity Framework in your grain implementations; an `EntityException` might be thrown. The client, on the other hand, doesn't (and shouldn't) reference `EntityFramework.dll` since it doesn't know the underlying data access layer.
+:::code language="csharp" source="snippets/interceptors/Configuration.cs" id="silo_delegate_filter":::
 
-When the client tries to deserialize the `EntityException`, it fails due to the missing DLL. As a consequence, a <xref:System.TypeLoadException> is thrown, hiding the original `EntityException`.
+Changing arguments or results can violate interface expectations. Preserve declared types and apply transformations only to methods whose contract explicitly permits them.
 
-One might argue this is acceptable since the client would never handle the `EntityException`; otherwise, it would need to reference `EntityFramework.dll`.
+## Exceptions
 
-But what if the client wants at least to log the exception? The problem is that the original error message is lost. One way to work around this issue is to intercept server-side exceptions and replace them with plain exceptions of type <xref:System.Exception> if the exception type is presumably unknown on the client-side.
+Code before `context.Invoke()` runs on the way into the call. Code after it runs on successful return. Use `try`, `catch`, and `finally` around the awaited call to observe or transform failures.
 
-However, keep one important thing in mind: you only want to replace an exception **if the caller is the grain client**. You don't want to replace an exception if the caller is another grain (or the Orleans infrastructure making grain calls, for example,, on the `GrainBasedReminderTable` grain).
+If a filter catches an exception and doesn't rethrow, the exception is handled. Only replace exceptions when callers understand the replacement contract. Orleans already preserves unavailable remote exception details using `UnavailableExceptionFallbackException`, so broad exception conversion is rarely necessary.
 
-On the server-side, you can do this with a silo-level interceptor:
+## Scope and ordering
 
-:::code language="csharp" source="snippets/interceptors/ExceptionConversion.cs" id="exception_conversion_filter":::
+Incoming filters also observe grain extension calls. Outgoing filters can observe Orleans system calls in addition to application calls. Filter by interface or method when behavior isn't intended globally.
 
-This filter can then be registered on the silo:
-
-:::code language="csharp" source="snippets/interceptors/Configuration.cs" id="register_exception_filter":::
-
-Enable the filter for calls made by the client by adding an outgoing call filter:
-
-:::code language="csharp" source="snippets/interceptors/Configuration.cs" id="client_exception_filter":::
-
-This way, the client tells the server it wants to use exception conversion.
-
-### Call grains from interceptors
-
-You can make grain calls from an interceptor by injecting <xref:Orleans.IGrainFactory> into the interceptor class:
-
-:::code language="csharp" source="snippets/interceptors/GrainFactoryInjection.cs" id="grain_factory_injection":::
+Keep filters asynchronous, fast, and free of blocking calls. A filter adds latency to every call in its scope and can become a cluster-wide bottleneck.

--- a/docs/site/src/content/docs/grains/observers.md
+++ b/docs/site/src/content/docs/grains/observers.md
@@ -1,211 +1,121 @@
 ---
-title: Observers
-description: Learn about observers in .NET Orleans.
-ms.date: 03/03/2026
+title: Orleans observers
+description: Send asynchronous notifications from grains to clients or other grains.
+ms.date: 08/02/2026
 ms.topic: concept-article
-zone_pivot_groups: orleans-version
-ai-usage: ai-assisted
 ---
 
-# Observers
+# Orleans observers
 
-Sometimes, a simple message/response pattern isn't enough, and the client needs to receive asynchronous notifications. For example, a user might want notification when a friend publishes a new instant message.
+Observers let grains call an object hosted by an Orleans client or another grain. They are useful for live, best-effort notifications while the receiver is connected.
 
-Client observers are a mechanism allowing asynchronous notification of clients. Observer interfaces must inherit from <xref:Orleans.IGrainObserver>, and all methods must return either `void`, <xref:System.Threading.Tasks.Task>, <xref:System.Threading.Tasks.Task`1>, <xref:System.Threading.Tasks.ValueTask>, or <xref:System.Threading.Tasks.ValueTask`1>. We don't recommend a return type of `void` because it might encourage using `async void` in the implementation. This is a dangerous pattern, as it can cause application crashes if an exception is thrown from the method. Instead, for best-effort notification scenarios, consider applying the <xref:Orleans.Concurrency.OneWayAttribute> to the observer's interface method. This causes the receiver not to send a response for the method invocation and makes the method return immediately at the call site, without waiting for a response from the observer. A grain calls a method on an observer by invoking it like any grain interface method. The Orleans runtime ensures the delivery of requests and responses. A common use case for observers is enlisting a client to receive notifications when an event occurs in the Orleans application. A grain publishing such notifications should provide an API to add or remove observers. Additionally, it's usually convenient to expose a method allowing cancellation of an existing subscription.
+Observers aren't durable subscriptions. A client can disconnect without notice, and a recreated observer has a different identity. Use an Orleans stream or another durable messaging mechanism when subscriptions or delivery must survive failures.
 
-You can use a utility class like <xref:Orleans.Utilities.ObserverManager`1> to simplify the development of observed grain types. Unlike grains, which Orleans automatically reactivates as needed after failure, clients aren't fault-tolerant: a client that fails might never recover. For this reason, the `ObserverManager<T>` utility removes subscriptions after a configured duration. Active clients should resubscribe on a timer to keep their subscriptions active.
+## Define an observer
 
-To subscribe to a notification, the client must first create a local object implementing the observer interface. It then calls the <xref:Orleans.IGrainFactory.CreateObjectReference*> method on the grain factory to turn the object into a grain reference. You can then pass this reference to the subscription method on the notifying grain. When the observer is no longer needed, call <xref:Orleans.IGrainFactory.DeleteObjectReference*> to clean up the reference and avoid a memory leak in the client process.
-
-Other grains can also use this model to receive asynchronous notifications. Grains can implement <xref:Orleans.IGrainObserver> interfaces. Unlike the client subscription case, the subscribing grain simply implements the observer interface and passes in a reference to itself (for example, `this.AsReference<IMyGrainObserverInterface>()`). There's no need for <xref:Orleans.IGrainFactory.CreateObjectReference*> because grains are already addressable.
-
-## Code example
-
-Let's assume you have a grain that periodically sends messages to clients. For simplicity, the message in our example is a string. First, define the interface on the client that receives the message.
-
-The interface looks like this:
+Observer interfaces derive from <xref:Orleans.IGrainObserver>:
 
 ```csharp
-public interface IChat : IGrainObserver
+public interface IChatObserver : IGrainObserver
 {
-    Task ReceiveMessage(string message);
+    Task ReceiveMessage(string room, string message);
 }
-```
 
-The only special requirement is that the interface must inherit from <xref:Orleans.IGrainObserver>.
-Now, any client wanting to observe these messages should implement a class that implements `IChat`.
-
-The simplest case looks something like this:
-
-```csharp
-public class Chat : IChat
+public sealed class ChatObserver : IChatObserver
 {
-    public Task ReceiveMessage(string message)
+    public Task ReceiveMessage(string room, string message)
     {
-        Console.WriteLine(message);
+        Console.WriteLine($"[{room}] {message}");
         return Task.CompletedTask;
     }
 }
 ```
 
-On the server, you should next have a grain that sends these chat messages to clients. The grain should also provide a mechanism for clients to subscribe and unsubscribe from notifications. For subscriptions, the grain can use an instance of the utility class [ObserverManager\<IChat>](<xref:Orleans.Utilities.ObserverManager`1>).
+Use asynchronous return types. Avoid `async void`. Apply <xref:Orleans.Concurrency.OneWayAttribute> only when notifications are deliberately best effort and the publisher doesn't need exceptions or completion.
 
-> [!NOTE]
-> <xref:Orleans.Utilities.ObserverManager`1> is part of Orleans since version 7.0. For older versions, the following [implementation](https://github.com/dotnet/orleans/blob/e997335d2d689bb39e67f6bcf6fd70862a22c02f/test/Grains/TestGrains/ObserverManager.cs#L12) can be copied.
+## Create and remove a client observer reference
+
+Convert the local object into an addressable reference:
 
 ```csharp
-class HelloGrain : Grain, IHello
-{
-    private readonly ObserverManager<IChat> _subsManager;
+var observer = new ChatObserver();
+IChatObserver observerReference =
+    grainFactory.CreateObjectReference<IChatObserver>(observer);
 
-    public HelloGrain(ILogger<HelloGrain> logger)
+IChatRoomGrain room =
+    grainFactory.GetGrain<IChatRoomGrain>("general");
+
+await room.Subscribe(observerReference);
+```
+
+Keep a strong reference to the local observer for as long as it should receive calls. When finished, unsubscribe and delete the object reference:
+
+```csharp
+await room.Unsubscribe(observerReference);
+grainFactory.DeleteObjectReference<IChatObserver>(observerReference);
+```
+
+Deleting the reference releases the client-side registration. Failing to delete long-lived registrations can leak resources.
+
+## Manage subscriptions in a grain
+
+<xref:Orleans.Utilities.ObserverManager`1> tracks observers, expires stale entries, and removes observers whose notifications fail:
+
+```csharp
+public sealed class ChatRoomGrain : Grain, IChatRoomGrain
+{
+    private readonly ObserverManager<IChatObserver> _observers;
+
+    public ChatRoomGrain(ILogger<ChatRoomGrain> logger)
     {
-        _subsManager =
-            new ObserverManager<IChat>(
-                TimeSpan.FromMinutes(5), logger);
+        _observers = new(
+            TimeSpan.FromMinutes(5),
+            logger);
     }
 
-    // Clients call this to subscribe.
-    public Task Subscribe(IChat observer)
+    public Task Subscribe(IChatObserver observer)
     {
-        _subsManager.Subscribe(observer, observer);
-
+        _observers.Subscribe(observer, observer);
         return Task.CompletedTask;
     }
 
-    //Clients use this to unsubscribe and no longer receive messages.
-    public Task UnSubscribe(IChat observer)
+    public Task Unsubscribe(IChatObserver observer)
     {
-        _subsManager.Unsubscribe(observer);
-
+        _observers.Unsubscribe(observer);
         return Task.CompletedTask;
     }
-}
-```
 
-To send a message to clients, use the <xref:Orleans.Utilities.ObserverManager`2.Notify*> method of the [ObserverManager\<IChat>](<xref:Orleans.Utilities.ObserverManager`1>) instance. The method takes an `Action<T>` method or lambda expression (where `T` is of type `IChat` here). You can call any method on the interface to send it to clients. In our case, we only have one method, `ReceiveMessage`, and our sending code on the server looks like this:
-
-```csharp
-public Task SendUpdateMessage(string message)
-{
-    _subsManager.Notify(s => s.ReceiveMessage(message));
-
-    return Task.CompletedTask;
-}
-```
-
-Now, our server has a method to send messages to observer clients and two methods for subscribing/unsubscribing. The client has implemented a class capable of observing the grain messages. The final step is to create an observer reference on the client using our previously implemented `Chat` class and let it receive messages after subscribing.
-
-The code looks like this:
-
-```csharp
-//First create the grain reference
-var friend = _grainFactory.GetGrain<IHello>(0);
-Chat c = new Chat();
-
-//Create a reference for chat, usable for subscribing to the observable grain.
-var obj = _grainFactory.CreateObjectReference<IChat>(c);
-
-//Subscribe the instance to receive messages.
-await friend.Subscribe(obj);
-```
-
-Now, whenever our grain on the server calls the `SendUpdateMessage` method, all subscribed clients receive the message. In our client code, the `Chat` instance in the variable `c` receives the message and outputs it to the console.
-
-When the observer is no longer needed, unsubscribe from the grain and delete the object reference:
-
-```csharp
-// Unsubscribe the observer when it's no longer needed.
-await friend.Unsubscribe(obj);
-
-// Delete the object reference to free resources and avoid a memory leak.
-_grainFactory.DeleteObjectReference<IChat>(obj);
-```
-
-> [!IMPORTANT]
-> The client holds observer instances passed to <xref:Orleans.IGrainFactory.CreateObjectReference*> in its internal object manager by using a <xref:System.WeakReference`1>, so the observer instance itself might be garbage collected if no other references exist, but the object reference registration stays active until you delete it.
->
-> Always call <xref:Orleans.IGrainFactory.DeleteObjectReference*> when you no longer need an observer to remove that registration. Without it, a reference remains in the client's internal object manager, causing a memory leak that can eventually crash the client process.
-
-You should maintain a reference for each observer you don't want collected.
-
-> [!NOTE]
-> Observers are inherently unreliable because a client hosting an observer might fail, and observers created after recovery have different (randomized) identities. <xref:Orleans.Utilities.ObserverManager`1> relies on periodic resubscription by observers, as discussed above, so it can remove inactive observers.
-
-## Execution model
-
-Implementations of <xref:Orleans.IGrainObserver> are registered via a call to <xref:Orleans.IGrainFactory.CreateObjectReference*?displayProperty=nameWithType>. Each call to that method creates a new reference pointing to that implementation. Orleans executes requests sent to each of these references one by one, to completion. Observers are non-reentrant; therefore, Orleans doesn't interleave concurrent requests to an observer. If multiple observers receive requests concurrently, those requests can execute in parallel. Attributes such as <xref:Orleans.Concurrency.AlwaysInterleaveAttribute> or <xref:Orleans.Concurrency.ReentrantAttribute> don't affect the execution of observer methods; you cannot customize the execution model.
-
-## CancellationToken support
-
-:::zone target="docs" pivot="orleans-9-0,orleans-10-0"
-
-Starting with Orleans 9.0, observer interface methods fully support <xref:System.Threading.CancellationToken> parameters. This allows grains to signal cancellation to observers, enabling long-running observer operations to be stopped gracefully.
-
-### Define an observer interface with CancellationToken
-
-Add a <xref:System.Threading.CancellationToken> parameter as the last parameter in your observer interface method:
-
-```csharp
-public interface IDataObserver : IGrainObserver
-{
-    Task OnDataReceivedAsync(DataPayload data, CancellationToken cancellationToken = default);
-}
-```
-
-### Implement the observer with cancellation support
-
-```csharp
-public class DataObserver : IDataObserver
-{
-    public async Task OnDataReceivedAsync(DataPayload data, CancellationToken cancellationToken = default)
+    public Task Publish(string message)
     {
-        // Check cancellation before processing
-        cancellationToken.ThrowIfCancellationRequested();
-
-        // Process data with cancellation-aware operations
-        await ProcessDataAsync(data, cancellationToken);
-    }
-
-    private async Task ProcessDataAsync(DataPayload data, CancellationToken cancellationToken)
-    {
-        // Use cancellation token with async operations
-        await Task.Delay(100, cancellationToken);
-        Console.WriteLine($"Processed: {data.Id}");
+        return _observers.Notify(
+            observer => observer.ReceiveMessage(
+                this.GetPrimaryKeyString(),
+                message));
     }
 }
 ```
 
-### Notify observers with cancellation
+The current API is `Notify`, including the overload that accepts `Func<TObserver, Task>`. There is no `NotifyAsync` method.
 
-When notifying observers, you can pass a cancellation token to enable cooperative cancellation:
+Subscriptions expire lazily after `ExpirationDuration`. Clients should renew before expiry. A notification exception causes `ObserverManager` to remove that observer; it doesn't fail the entire publish operation.
+
+Use <xref:Orleans.Utilities.ObserverManager`2> when the subscription identity should differ from the observer reference.
+
+## Grain observers
+
+A grain can implement an observer interface and pass a reference to itself:
 
 ```csharp
-public async Task SendDataToObserversAsync(DataPayload data, CancellationToken cancellationToken = default)
-{
-    // Create a linked token source to combine the grain's token with a timeout
-    using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-    cts.CancelAfter(TimeSpan.FromSeconds(30)); // Timeout for observer notifications
+IChatObserver observer =
+    this.AsReference<IChatObserver>();
 
-    await _subsManager.NotifyAsync(
-        observer => observer.OnDataReceivedAsync(data, cts.Token));
-}
+await room.Subscribe(observer);
 ```
 
-For more information about using cancellation tokens in Orleans, see [Use cancellation tokens in Orleans grains](cancellation-tokens.md).
+Don't call `CreateObjectReference` for a grain. Grains are already addressable.
 
-:::zone-end
+## Execution and cancellation
 
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0"
+Calls to one client observer reference execute sequentially and aren't reentrant. Different observer references can execute concurrently.
 
-CancellationToken support for observers was introduced in Orleans 9.0. For earlier versions, you can use <xref:Orleans.GrainCancellationToken> as a workaround, but direct <xref:System.Threading.CancellationToken> support in observer methods isn't available.
-
-For full CancellationToken support, consider upgrading to Orleans 9.0 or later.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-CancellationToken support for observers is available in Orleans 9.0 and later. Orleans 3.x uses the legacy <xref:Orleans.GrainCancellationToken> mechanism for cancellation.
-
-:::zone-end
+Observer methods can accept a <xref:System.Threading.CancellationToken> parameter. Cancellation remains cooperative and doesn't make observer delivery durable.

--- a/docs/site/src/content/docs/grains/oneway.md
+++ b/docs/site/src/content/docs/grains/oneway.md
@@ -1,24 +1,37 @@
 ---
-title: One-way requests
-description: Learn about one-way requests in .NET Orleans.
-ms.date: 05/23/2025
+title: One-way grain calls
+description: Use one-way requests for best-effort Orleans notifications.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
-# One-way requests
+# One-way grain calls
 
-Grains perform asynchronous request execution, requiring all grain interface methods to return an asynchronous type, like <xref:System.Threading.Tasks.Task>. Awaiting the completion of a task returned from a grain call notifies the caller that the request has finished, allowing the caller to handle any exceptions or receive return values. Orleans also supports *one-way requests*, enabling callers to notify a grain about an event without expecting exceptions or completion signals.
+A regular grain call returns a task that completes when Orleans receives the method's response. The task carries a return value or exception and tells the caller that the request finished.
 
-One-way requests return to the caller immediately and don't signal failure or completion. A one-way request doesn't even guarantee the callee received the request. The primary benefit of one-way requests is that they save messaging costs associated with sending a response back to the caller and can therefore improve performance in some specialized cases. One-way requests are an advanced performance feature. Use them with care and only when you determine that a one-way request is beneficial. We recommend preferring regular bidirectional requests, which signal completion and propagate errors back to callers.
-
-You can make a request one-way by marking the grain interface method with the <xref:Orleans.Concurrency.OneWayAttribute>, like this:
+A method marked with <xref:Orleans.Concurrency.OneWayAttribute> returns to the caller after Orleans accepts the request for sending. The caller receives no completion signal, result, or exception:
 
 ```csharp
-public interface IOneWayGrain : IGrainWithGuidKey
+public interface IAuditGrain : IGrainWithStringKey
 {
     [OneWay]
-    Task Notify(MyData data);
+    ValueTask Record(AuditEntry entry);
 }
 ```
 
-One-way requests must return either <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.ValueTask>. They must not return generic variants of those types (<xref:System.Threading.Tasks.Task`1> and <xref:System.Threading.Tasks.ValueTask`1>).
+One-way methods must return <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.ValueTask>, not their generic forms.
+
+## Delivery semantics
+
+One-way calls are best effort:
+
+- Completion of the returned task doesn't mean the target received or processed the request.
+- Exceptions thrown by the target aren't returned to the caller.
+- The caller can't distinguish successful processing from message loss or target failure.
+- Cancellation and response timeout semantics don't provide useful completion guarantees because there is no response.
+
+Use one-way calls only for notifications that are safe to lose and where the result isn't needed. Telemetry hints, cache invalidation hints, or redundant status signals can fit this model.
+
+Don't use one-way calls for state changes that require confirmation, financial operations, workflow transitions, or any operation the caller might need to retry. Prefer a regular request-response call, a durable queue, or an Orleans streaming provider when delivery and recovery matter.
+
+One-way calls can reduce response-message overhead, but treat them as an advanced optimization. Measure before replacing regular calls.

--- a/docs/site/src/content/docs/grains/request-context.md
+++ b/docs/site/src/content/docs/grains/request-context.md
@@ -1,142 +1,68 @@
 ---
 title: Request context
-description: Learn about request context in .NET Orleans.
-ms.date: 05/23/2025
+description: Flow application metadata with Orleans grain calls.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
 # Request context
 
-The <xref:Orleans.Runtime.RequestContext> is an Orleans feature allowing application metadata, such as a trace ID, to flow with requests. You can add application metadata on the client; it flows with Orleans requests to the receiving grain. The feature is implemented by a public static class, <xref:Orleans.Runtime.RequestContext>, in the Orleans namespace. This class exposes two simple methods:
+<xref:Orleans.Runtime.RequestContext> carries application metadata with an Orleans request. Typical values include correlation IDs, tenant IDs, and authorization context established by trusted application code.
 
 ```csharp
-void Set(string key, object value)
+RequestContext.Set("trace-id", Guid.NewGuid().ToString("N"));
+
+IOrderGrain order = grainFactory.GetGrain<IOrderGrain>("order-42");
+await order.Submit();
 ```
 
-Use the preceding API to store a value in the request context. The value can be any serializable type.
+The receiving grain reads the value:
 
 ```csharp
-object Get(string key)
-```
-
-Use the preceding API to retrieve a value from the current request context.
-
-The backing storage for <xref:Orleans.Runtime.RequestContext> is async-local. When a caller (client-side or within Orleans) sends a request, the contents of the caller's <xref:Orleans.Runtime.RequestContext> are included with the Orleans message for the request. When the grain code receives the request, that metadata is accessible from the local <xref:Orleans.Runtime.RequestContext>. If the grain code doesn't modify the <xref:Orleans.Runtime.RequestContext>, then any grain it requests receives the same metadata, and so on.
-
-Application metadata is also maintained when you schedule a future computation using <xref:System.Threading.Tasks.TaskFactory.StartNew*> or <xref:System.Threading.Tasks.Task.ContinueWith*>. In both cases, the continuation executes with the same metadata as the scheduling code had when the computation was scheduled. That is, the system copies the current metadata and passes it to the continuation, so the continuation won't see changes made after the call to <xref:System.Threading.Tasks.TaskFactory.StartNew*> or <xref:System.Threading.Tasks.Task.ContinueWith*>.
-
-> [!IMPORTANT]
-> Application metadata doesn't flow back with responses. Code that runs as a result of receiving a response (either within a <xref:System.Threading.Tasks.Task.ContinueWith*> continuation or after a call to <xref:System.Threading.Tasks.Task.Wait*> or <xref:System.Threading.Tasks.Task`1.Result>) still runs within the current context set by the original request.
-
-For example, to set a trace ID in the client to a new <xref:System.Guid?displayProperty=nameWithType>, call:
-
-```csharp
-RequestContext.Set("TraceId", Guid.NewGuid());
-```
-
-Within grain code (or other code running within Orleans on a scheduler thread), you could use the trace ID of the original client request, for instance, when writing a log:
-
-```csharp
-Logger.LogInformation(
-    "Currently processing external request {TraceId}",
-    RequestContext.Get("TraceId"));
-```
-
-While you can send any serializable `object` as application metadata, it's worth mentioning that large or complex objects might add noticeable overhead to message serialization time. For this reason, we recommend using simple types (strings, GUIDs, or numeric types).
-
-## Example grain code
-
-To help illustrate the use of request context, consider the following example grain code:
-
-```csharp
-using GrainInterfaces;
-using Microsoft.Extensions.Logging;
-
-namespace Grains;
-
-public class HelloGrain(ILogger<HelloGrain> logger) : Grain, IHelloGrain
+public sealed class OrderGrain(
+    ILogger<OrderGrain> logger) : Grain, IOrderGrain
 {
-    ValueTask<string> IHelloGrain.SayHello(string greeting)
+    public Task Submit()
     {
-        _logger.LogInformation("""
-            SayHello message received: greeting = "{Greeting}"
-            """,
-            greeting);
+        string? traceId = RequestContext.Get("trace-id") as string;
+        logger.LogInformation(
+            "Submitting order with trace ID {TraceId}",
+            traceId);
 
-        var traceId = RequestContext.Get("TraceId") as string
-            ?? "No trace ID";
-
-        return ValueTask.FromResult($"""
-            TraceID: {traceId}
-            Client said: "{greeting}", so HelloGrain says: Hello!
-            """);
-    }
-}
-
-public interface IHelloGrain : IGrainWithStringKey
-{
-    ValueTask<string> SayHello(string greeting);
-}
-```
-
-The `SayHello` method logs the incoming `greeting` parameter and then retrieves the trace ID from the request context. If no trace ID is found, the grain logs "No trace ID".
-
-## Example client code
-
-The client can set the trace ID in the request context before calling the `SayHello` method on the `HelloGrain`. The following client code demonstrates how to set a trace ID in the request context and call the `SayHello` method on the `HelloGrain`:
-
-```csharp
-﻿using GrainInterfaces;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-
-using var host = Host.CreateDefaultBuilder(args)
-    .UseOrleansClient(clientBuilder =>
-        clientBuilder.UseLocalhostClustering())
-    .Build();
-
-await host.StartAsync();
-
-var client = host.Services.GetRequiredService<IClusterClient>();
-
-var grain = client.GetGrain<IHelloGrain>("friend");
-
-var id = "example-id-set-by-client";
-
-RequestContext.Set("TraceId", id);
-
-var message = await friend.SayHello("Good morning!");
-
-Console.WriteLine(message);
-// Output:
-//   TraceID: example-id-set-by-client
-//   Client said: "Good morning!", so HelloGrain says: Hello!
-```
-
-In this example, the client sets the trace ID to "example-id-set-by-client" before calling the `SayHello` method on the `HelloGrain`. The grain retrieves the trace ID from the request context and logs it.
-
-## Example placement access code
-
-The <xref:Orleans.Runtime.RequestContext> data can be accessed during placement or placement filtering through the <xref:Orleans.Runtime.Placement.PlacementTarget> `RequestContextData`. The static <xref:Orleans.Runtime.RequestContext> is not populated at this time as there is not yet an activation of the grain. The following placement filter code demonstrates how to get <xref:Orleans.Runtime.RequestContext> data while handling placement:
-
-```csharp
-internal sealed class ExamplePlacementFilterDirector(ILogger<ExamplePlacementFilterDirector> logger)
-    : IPlacementFilterDirector
-{
-    public IEnumerable<SiloAddress> Filter(
-        PlacementFilterStrategy filterStrategy,
-        PlacementTarget target,
-        IEnumerable<SiloAddress> silos)
-    {
-        if (target.RequestContextData.TryGetValue("somekey", out var somevalue) 
-            && somevalue is string somestring)
-        {
-            logger.LogInformation("Read {Value} for {Key} from the RequestContext", somestring, "somekey");
-            // somestring is available for the filtering logic
-        }
-        return silos;
+        return Task.CompletedTask;
     }
 }
 ```
 
-In this example, the "somekey" value is read from the <xref:Orleans.Runtime.Placement.PlacementTarget> `RequestContextData` during the placement filtering.
+Values must be serializable by Orleans. Keep them small because Orleans includes them in request messages.
+
+## Propagation
+
+Request context uses async-local storage. When code sends a grain call, Orleans copies the current entries into the outgoing request. The receiving grain sees those entries, and calls it makes propagate its current context onward.
+
+Changes made by a callee don't flow back in the response. Treat request context as downstream metadata, not as a return channel.
+
+Use the static API to manage entries:
+
+```csharp
+object? value = RequestContext.Get("tenant-id");
+RequestContext.Set("tenant-id", "tenant-17");
+bool removed = RequestContext.Remove("tenant-id");
+RequestContext.Clear();
+```
+
+Set context as close as possible to the operation that needs it, and restore or clear values before unrelated operations execute in the same asynchronous flow.
+
+## Security
+
+Request context is caller-provided data. Don't trust a role, user ID, or tenant ID merely because it arrived in `RequestContext`. Establish authentication at a trusted boundary and use call filters or application authorization logic to validate access.
+
+## Placement and migration
+
+Placement occurs before a new activation exists, so the static `RequestContext` isn't populated inside placement directors and filters. Read <xref:Orleans.Runtime.Placement.PlacementTarget.RequestContextData> instead.
+
+When a grain requests migration using `MigrateOnIdle()`, Orleans captures the current request context and makes it available to placement. This allows an application to provide placement hints, but custom placement logic remains an advanced runtime extension.
+
+## Call-chain reentrancy
+
+<xref:Orleans.Runtime.RequestContext.AllowCallChainReentrancy> and `SuppressCallChainReentrancy` use request metadata internally to control scheduling for a call chain. Use their scoped return values with `using`; don't set Orleans-reserved context keys directly. See [Request scheduling](request-scheduling.md#call-chain-reentrancy).

--- a/docs/site/src/content/docs/grains/request-scheduling.md
+++ b/docs/site/src/content/docs/grains/request-scheduling.md
@@ -1,302 +1,124 @@
 ---
-title: Request scheduling
-description: Learn about request scheduling in .NET Orleans.
-ms.date: 03/09/2026
+title: Grain request scheduling
+description: Understand Orleans turn-based execution, interleaving, and reentrancy.
+ms.date: 08/02/2026
 ms.topic: concept-article
-ai-usage: ai-assisted
 ---
 
-# Request scheduling
+# Grain request scheduling
 
-Grain activations have a *single-threaded* execution model. By default, they process each request from beginning to completion before the next request can begin processing. In some circumstances, it might be desirable for an activation to process other requests while one request waits for an asynchronous operation to complete. For this and other reasons, Orleans gives you some control over the request interleaving behavior, as described in the [Reentrancy](#reentrancy) section. What follows is an example of non-reentrant request scheduling, which is the default behavior in Orleans.
+Each grain activation executes one turn at a time. Orleans runs a request until it completes or reaches an incomplete `await`, then later schedules its continuation as another turn. Two turns never execute in parallel on the same activation.
 
-Consider the following `PingGrain` definition:
+By default, an activation doesn't start a different request while the current request is incomplete. This non-reentrant model makes mutable grain state easier to reason about:
 
 ```csharp
-public interface IPingGrain : IGrainWithStringKey
+public sealed class CounterGrain : Grain, ICounterGrain
 {
-    Task Ping();
-    Task CallOther(IPingGrain other);
-}
+    private int _value;
 
-public class PingGrain : Grain, IPingGrain
-{
-    private readonly ILogger<PingGrain> _logger;
-
-    public PingGrain(ILogger<PingGrain> logger) => _logger = logger;
-
-    public Task Ping() => Task.CompletedTask;
-
-    public async Task CallOther(IPingGrain other)
+    public async ValueTask<int> AddAfterDelay(int amount)
     {
-        _logger.LogInformation("1");
-        await other.Ping();
-        _logger.LogInformation("2");
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+        _value += amount;
+        return _value;
     }
 }
 ```
 
-Two grains of type `PingGrain` are involved in our example, *A* and *B*. A caller invokes the following call:
+Although the method yields at `await`, another request doesn't observe or change `_value` before this request completes.
 
-```csharp
-var a = grainFactory.GetGrain("A");
-var b = grainFactory.GetGrain("B");
-await a.CallOther(b);
-```
+## Avoid blocking
 
-:::image type="content" source="grain-persistence/media/reentrancy-scheduling-diagram.png" alt-text="Reentrancy scheduling diagram." lightbox="grain-persistence/media/reentrancy-scheduling-diagram.png":::
+Never synchronously block on incomplete tasks from grain code. `.Result`, `.Wait()`, `WaitAll`, and `GetAwaiter().GetResult()` can deadlock an activation and consume thread-pool threads. Use `await`.
 
-The flow of execution is as follows:
+Normal `await` resumes grain code on the activation scheduler. Don't use `ConfigureAwait(false)` in grain methods because the continuation can escape the grain scheduler. General-purpose libraries can use it internally; grain code returns to the grain scheduler when it awaits the library normally.
 
-1. The call arrives at *A*, which logs `"1"` and then issues a call to *B*.
-1. *B* returns immediately from `Ping()` back to *A*.
-1. *A* logs `"2"` and returns back to the original caller.
+## Interleaving and reentrancy
 
-While *A* awaits the call to *B*, it can't process any incoming requests. As a result, if *A* and *B* were to call each other simultaneously, they might *deadlock* while waiting for those calls to complete. Here's an example, based on the client issuing the following call:
+Interleaving lets Orleans start or resume another request while an earlier request is incomplete. The activation is still single-threaded, but turns from different requests can alternate. Re-check assumptions about mutable state after every `await`.
 
-```csharp
-var a = grainFactory.GetGrain("A");
-var b = grainFactory.GetGrain("B");
+| Mechanism | Scope |
+|---|---|
+| <xref:Orleans.Concurrency.ReentrantAttribute> | All requests to the grain class can interleave. |
+| <xref:Orleans.Concurrency.AlwaysInterleaveAttribute> | The marked interface method can interleave with any request. |
+| <xref:Orleans.Concurrency.ReadOnlyAttribute> | Marked read-only methods can interleave with other read-only methods. |
+| <xref:Orleans.Concurrency.MayInterleaveAttribute> | A predicate inspects each request. |
+| <xref:Orleans.Runtime.RequestContext.AllowCallChainReentrancy> | A scoped call chain can call back into an activation already in that chain. |
 
-// A calls B at the same time as B calls A.
-// This might deadlock, depending on the non-deterministic timing of events.
-await Task.WhenAll(a.CallOther(b), b.CallOther(a));
-```
-
-## Case 1: The calls don't deadlock
-
-:::image type="content" source="grain-persistence/media/reentrancy-scheduling-diagram-01.png" alt-text="Reentrancy scheduling diagram without deadlock." lightbox="grain-persistence/media/reentrancy-scheduling-diagram-01.png":::
-
-In this example:
-
-1. The `Ping()` call from *A* arrives at *B* before the `CallOther(a)` call arrives at *B*.
-1. Therefore, *B* processes the `Ping()` call before the `CallOther(a)` call.
-1. Because *B* processes the `Ping()` call, *A* is able to return back to the caller.
-1. When *B* issues its `Ping()` call to *A*, *A* is still busy logging its message (`"2"`), so the call has to wait for a short duration, but it's soon able to be processed.
-1. *A* processes the `Ping()` call and returns to *B*, which returns to the original caller.
-
-Consider a less fortunate series of events where the same code results in a *deadlock* due to slightly different timing.
-
-## Case 2: The calls deadlock
-
-:::image type="content" source="grain-persistence/media/reentrancy-scheduling-diagram-02.png" alt-text="Reentrancy scheduling diagram with deadlock." lightbox="grain-persistence/media/reentrancy-scheduling-diagram-02.png":::
-
-In this example:
-
-1. The `CallOther` calls arrive at their respective grains and are processed simultaneously.
-1. Both grains log `"1"` and proceed to `await other.Ping()`.
-1. Since both grains are still *busy* (processing the `CallOther` request, which hasn't finished yet), the `Ping()` requests wait.
-1. After a while, Orleans determines that the call has **timed out**, and each `Ping()` call results in an exception being thrown.
-1. The `CallOther` method body doesn't handle the exception, and it bubbles up to the original caller.
-
-The following section describes how to prevent deadlocks by allowing multiple requests to interleave their execution.
-
-## Reentrancy
-
-> [!WARNING]
-> Reentrancy is an advanced feature that requires a solid understanding of concurrency concepts. Incorrect use can lead to race conditions, state corruption, or subtle bugs that are difficult to diagnose. Ensure you understand the implications before enabling reentrancy on your grains.
-
-Orleans defaults to a safe execution flow where the internal state of a grain isn't modified concurrently by multiple requests. Concurrent modification complicates logic and places a greater burden on you, the developer. This protection against concurrency bugs has a cost, primarily *liveness*: certain call patterns can lead to deadlocks, as discussed previously. One way to avoid deadlocks is to ensure grain calls never form a cycle. Often, it's difficult to write code that is cycle-free and guaranteed not to deadlock. Waiting for each request to run from beginning to completion before processing the next can also hurt performance. For example, by default, if a grain method performs an asynchronous request to a database service, the grain pauses request execution until the database response arrives.
-
-Each of these cases is discussed in the following sections. For these reasons, Orleans provides options to allow some or all requests to execute *concurrently*, interleaving their execution. In Orleans, we refer to such concerns as *reentrancy* or *interleaving*. By executing requests concurrently, grains performing asynchronous operations can process more requests in a shorter period.
-
-Multiple requests may be interleaved in the following cases:
-
-- The grain class is marked with <xref:Orleans.Concurrency.ReentrantAttribute>.
-- The interface method is marked with <xref:Orleans.Concurrency.AlwaysInterleaveAttribute>.
-- The grain's <xref:Orleans.Concurrency.MayInterleaveAttribute> predicate returns `true`.
-
-The following table summarizes all available reentrancy options:
-
-| Option | Scope | Description |
-|--------|-------|-------------|
-| <xref:Orleans.Concurrency.ReentrantAttribute> | Grain class | All methods in the grain can freely interleave with each other. |
-| <xref:Orleans.Concurrency.AlwaysInterleaveAttribute> | Interface method | The marked method always interleaves with any other request, and any other request can interleave with it. |
-| <xref:Orleans.Concurrency.ReadOnlyAttribute> | Interface method | The method doesn't modify grain state and can run concurrently with other <xref:Orleans.Concurrency.ReadOnlyAttribute> methods. |
-| <xref:Orleans.Concurrency.MayInterleaveAttribute> | Grain class | A predicate method determines on a per-call basis whether a specific request should interleave. |
-| <xref:Orleans.Runtime.RequestContext.AllowCallChainReentrancy> | Call site | Allows reentrancy for the duration of the call chain scoped to callers further down the chain, giving fine-grained control over where reentrancy is enabled. |
-
-With reentrancy, the following case becomes a valid execution, removing the possibility of the deadlock described above.
-
-### Case 3: The grain or method is reentrant
-
-:::image type="content" source="grain-persistence/media/reentrancy-scheduling-diagram-03.png" alt-text="Re-entrancy scheduling diagram with re-entrant grain or method." lightbox="grain-persistence/media/reentrancy-scheduling-diagram-03.png":::
-
-In this example, grains *A* and *B* can call each other simultaneously without potential request scheduling deadlocks because both grains are *reentrant*. The following sections provide more details on reentrancy.
+Use the narrowest mechanism that solves the problem. Reentrancy can improve throughput for I/O-heavy grains and prevent cyclic call deadlocks, but it also allows state to change between turns.
 
 ### Reentrant grains
 
-You can mark <xref:Orleans.Grain> implementation classes with the <xref:Orleans.Concurrency.ReentrantAttribute> to indicate that different requests can be freely interleaved.
-
-In other words, a reentrant activation might start processing another request while a previous request hasn't finished. Execution is still limited to a single thread, so the activation executes one turn at a time, and each turn executes on behalf of only one of the activation's requests.
-
-Reentrant grain code never runs multiple pieces of grain code in parallel (execution is always single-threaded), but reentrant grains **might** see the execution of code for different requests interleaving. That is, the continuation turns from different requests might interleave.
-
-For example, as shown in the following pseudo-code, consider that `Foo` and `Bar` are two methods of the same grain class:
-
 ```csharp
-Task Foo()
+[Reentrant]
+public sealed class CatalogGrain : Grain, ICatalogGrain
 {
-    await task1;    // line 1
-    return Do2();   // line 2
-}
-
-Task Bar()
-{
-    await task2;   // line 3
-    return Do2();  // line 4
-}
-```
-
-If this grain is marked <xref:Orleans.Concurrency.ReentrantAttribute>, the execution of `Foo` and `Bar` might interleave.
-
-For example, the following order of execution is possible:
-
-Line 1, line 3, line 2 and line 4.
-That is, the turns from different requests interleave.
-
-If the grain wasn't re-entrant, the only possible executions would be: line 1, line 2, line 3, line 4 OR: line 3, line 4, line 1, line 2 (a new request can't start before the previous one finished).
-
-The main tradeoff when choosing between reentrant and non-reentrant grains is the code complexity required to make interleaving work correctly and the difficulty of reasoning about it.
-
-In a trivial case where grains are stateless and the logic is simple, using fewer reentrant grains (but not too few, ensuring all hardware threads are utilized) should generally be slightly more efficient.
-
-If the code is more complex, using a larger number of non-reentrant grains, even if slightly less efficient overall, might save you significant trouble in debugging non-obvious interleaving issues.
-
-In the end, the answer depends on the specifics of the application.
-
-### Interleaving methods
-
-Grain interface methods marked with <xref:Orleans.Concurrency.AlwaysInterleaveAttribute> always interleave any other request and can always be interleaved by any other request, even requests for non-<xref:Orleans.Concurrency.AlwaysInterleaveAttribute> methods.
-
-Consider the following example:
-
-```csharp
-public interface ISlowpokeGrain : IGrainWithIntegerKey
-{
-    Task GoSlow();
-
-    [AlwaysInterleave]
-    Task GoFast();
-}
-
-public class SlowpokeGrain : Grain, ISlowpokeGrain
-{
-    public async Task GoSlow()
+    public async ValueTask<Product> GetProduct(string productId)
     {
-        await Task.Delay(TimeSpan.FromSeconds(10));
-    }
-
-    public async Task GoFast()
-    {
-        await Task.Delay(TimeSpan.FromSeconds(10));
+        return await LoadProduct(productId);
     }
 }
 ```
 
-Consider the call flow initiated by the following client request:
+Code in different requests doesn't run simultaneously, but multiple incomplete calls can make progress by alternating turns.
+
+### Method-level interleaving
 
 ```csharp
-var slowpoke = client.GetGrain<ISlowpokeGrain>(0);
-
-// A. This will take around 20 seconds.
-await Task.WhenAll(slowpoke.GoSlow(), slowpoke.GoSlow());
-
-// B. This will take around 10 seconds.
-await Task.WhenAll(slowpoke.GoFast(), slowpoke.GoFast(), slowpoke.GoFast());
-```
-
-Calls to `GoSlow` aren't interleaved, so the total execution time of the two `GoSlow` calls is around 20 seconds. On the other hand, `GoFast` is marked <xref:Orleans.Concurrency.AlwaysInterleaveAttribute>. The three calls to it execute concurrently, completing in approximately 10 seconds total instead of requiring at least 30 seconds.
-
-### Readonly methods
-
-When a grain method doesn't modify the grain state, it's safe to execute concurrently with other requests. The <xref:Orleans.Concurrency.ReadOnlyAttribute> indicates that a method doesn't modify the grain's state. Marking methods as <xref:Orleans.Concurrency.ReadOnlyAttribute> allows Orleans to process your request concurrently with other <xref:Orleans.Concurrency.ReadOnlyAttribute> requests, which can significantly improve your app's performance. Consider the following example:
-
-```csharp
-public interface IMyGrain : IGrainWithIntegerKey
+public interface IStatusGrain : IGrainWithStringKey
 {
-    Task<int> IncrementCount(int incrementBy);
+    Task Update(Status status);
 
     [ReadOnly]
-    Task<int> GetCount();
+    ValueTask<Status> Get();
+
+    [AlwaysInterleave]
+    ValueTask Ping();
 }
 ```
 
-The `GetCount` method doesn't modify the grain state, so it's marked <xref:Orleans.Concurrency.ReadOnlyAttribute>. Callers awaiting this method invocation aren't blocked by other <xref:Orleans.Concurrency.ReadOnlyAttribute> requests to the grain, and the method returns immediately.
+`ReadOnly` is a scheduling promise. Don't mutate grain state from a read-only method.
 
-### Call chain reentrancy
+### Predicate-based interleaving
 
-If a grain calls a method on another grain, which then calls back into the original grain, the call results in a deadlock unless the call is reentrant. You can enable reentrancy on a per-call-site basis using *call chain reentrancy*. To enable call chain reentrancy, call the <xref:Orleans.Runtime.RequestContext.AllowCallChainReentrancy> method. This method returns a value allowing reentrance from any caller further down the call chain until the value is disposed. This includes reentrance from the grain calling the method itself. Consider the following example:
+`MayInterleave` names a predicate that accepts <xref:Orleans.Serialization.Invocation.IInvokable>. Use its accessor methods; there is no `Arguments` property:
 
 ```csharp
-public interface IChatRoomGrain : IGrainWithStringKey
+[MayInterleave(nameof(CanInterleave))]
+public sealed class WorkGrain : Grain, IWorkGrain
 {
-    ValueTask OnJoinRoom(IUserGrain user);
-}
-
-public interface IUserGrain : IGrainWithStringKey
-{
-    ValueTask JoinRoom(string roomName);
-    ValueTask<string> GetDisplayName();
-}
-
-public class ChatRoomGrain : Grain<List<(string DisplayName, IUserGrain User)>>, IChatRoomGrain
-{
-    public async ValueTask OnJoinRoom(IUserGrain user)
+    public static bool CanInterleave(IInvokable request)
     {
-        var displayName = await user.GetDisplayName();
-        State.Add((displayName, user));
-        await WriteStateAsync();
+        return request.GetArgumentCount() == 1
+            && request.GetArgument(0) is WorkItem { IsReadOnly: true };
     }
-}
 
-public class UserGrain : Grain, IUserGrain
-{
-    public ValueTask<string> GetDisplayName() => new(this.GetPrimaryKeyString());
-    public async ValueTask JoinRoom(string roomName)
-    {
-        // This prevents the call below from triggering a deadlock.
-        using var scope = RequestContext.AllowCallChainReentrancy();
-        var roomGrain = GrainFactory.GetGrain<IChatRoomGrain>(roomName);
-        await roomGrain.OnJoinRoom(this.AsReference<IUserGrain>());
-    }
+    public Task Process(WorkItem item) => Task.CompletedTask;
 }
 ```
 
-In the preceding example, `UserGrain.JoinRoom(roomName)` calls `ChatRoomGrain.OnJoinRoom(user)`, which tries to call back into `UserGrain.GetDisplayName()` to get the user's display name. Since this call chain involves a cycle, it results in a deadlock if `UserGrain` doesn't allow reentrance using one of the supported mechanisms discussed in this article. In this instance, we use <xref:Orleans.Runtime.RequestContext.AllowCallChainReentrancy>, which allows only `roomGrain` to call back into `UserGrain`. This gives you fine-grained control over where and how reentrancy is enabled.
+Keep predicates deterministic, fast, and side-effect free.
 
-If you were to prevent the deadlock by annotating the `GetDisplayName()` method declaration on `IUserGrain` with <xref:Orleans.Concurrency.AlwaysInterleaveAttribute> instead, you would allow *any* grain to interleave a `GetDisplayName` call with any other method. By using `AllowCallChainReentrancy`, you allow *only* `roomGrain` to call methods on the `UserGrain`, and only until `scope` is disposed.
+### Call-chain reentrancy
 
-#### Suppress call chain reentrancy
-
-You can also *suppress* call chain reentrance using the <xref:Orleans.Runtime.RequestContext.SuppressCallChainReentrancy> method. This has limited usefulness for end developers but is important for internal use by libraries extending Orleans grain functionality, such as [streaming](../streaming/index.md) and [broadcast channels](../streaming/broadcast-channel.md), to ensure developers retain full control over when call chain reentrancy is enabled.
-
-### Reentrancy using a predicate
-
-Grain classes can specify a predicate to determine interleaving on a call-by-call basis by inspecting the request. The `[MayInterleave(string methodName)]` attribute provides this functionality. The argument to the attribute is the name of a static method within the grain class. This method accepts an <xref:Orleans.CodeGeneration.InvokeMethodRequest> object and returns a `bool` indicating whether the request should be interleaved.
-
-Here's an example that allows interleaving if the request argument type has the `[Interleave]` attribute:
+Use call-chain reentrancy when a known call path must call back into the initiating activation:
 
 ```csharp
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
-public sealed class InterleaveAttribute : Attribute { }
-
-// Specify the may-interleave predicate.
-[MayInterleave(nameof(ArgHasInterleaveAttribute))]
-public class MyGrain : Grain, IMyGrain
+public async Task JoinRoom(string roomName)
 {
-    public static bool ArgHasInterleaveAttribute(IInvokable req)
-    {
-        // Returning true indicates that this call should be interleaved with other calls.
-        // Returning false indicates the opposite.
-        return req.Arguments.Length == 1
-            && req.Arguments[0]?.GetType()
-                    .GetCustomAttribute<InterleaveAttribute>() != null;
-    }
+    using var scope = RequestContext.AllowCallChainReentrancy();
 
-    public Task Process(object payload)
-    {
-        // Process the object.
-    }
+    IChatRoomGrain room =
+        GrainFactory.GetGrain<IChatRoomGrain>(roomName);
+
+    await room.Join(this.AsReference<IUserGrain>());
 }
 ```
+
+The scope permits callbacks associated with that call chain until it is disposed. It is narrower than marking the entire grain reentrant.
+
+## Timers and external work
+
+Grain timer callbacks participate in scheduling. Callbacks don't interleave by default; configure `GrainTimerCreationOptions.Interleave` when intentional.
+
+Use <xref:System.Threading.Tasks.Task.Run*> only to isolate unavoidable synchronous blocking or CPU work from the Orleans scheduler. Don't access grain state from the thread-pool delegate. Await it and update grain state after execution resumes on the activation scheduler. See [External tasks and grains](external-tasks-and-grains.md).

--- a/docs/site/src/content/docs/grains/stateless-worker-grains.md
+++ b/docs/site/src/content/docs/grains/stateless-worker-grains.md
@@ -1,6 +1,6 @@
 ---
 title: Stateless worker grains
-description: Scale location-transparent worker pools with Orleans 10.
+description: Scale location-transparent worker pools with Orleans.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---

--- a/docs/site/src/content/docs/grains/stateless-worker-grains.md
+++ b/docs/site/src/content/docs/grains/stateless-worker-grains.md
@@ -1,65 +1,64 @@
 ---
 title: Stateless worker grains
-description: Learn how to use stateless worker grains in .NET Orleans.
-ms.date: 05/23/2025
+description: Scale location-transparent worker pools with Orleans 10.
+ms.date: 08/02/2026
 ms.topic: concept-article
 ---
 
 # Stateless worker grains
 
-By default, the Orleans runtime creates no more than one activation of a grain within the cluster. This is the most intuitive expression of the Virtual Actor model, where each grain corresponds to an entity with a unique type/identity. However, sometimes an application needs to perform functional stateless operations not tied to a particular entity in the system. For example, if a client sends requests with compressed payloads that need decompression before routing to the target grain for processing, such decompression/routing logic isn't tied to a specific entity and can easily scale out.
+A normal grain identity has at most one activation in the cluster. A stateless worker identity can have multiple activations, allowing Orleans to scale independent work across compatible silos.
 
-When you apply the <xref:Orleans.Concurrency.StatelessWorkerAttribute> to a grain class, it indicates to the Orleans runtime that grains of that class should be treated as stateless worker grains. Stateless worker grains have the following properties that make their execution very different from normal grain classes:
-
-1. The Orleans runtime can and does create multiple activations of a stateless worker grain on different silos in the cluster.
-1. Stateless worker grains execute requests locally as long as the silo is compatible, therefore incurring no networking or serialization costs. If the local silo isn't compatible, requests are forwarded to a compatible silo.
-1. The Orleans Runtime automatically creates additional activations of a stateless worker grain if the existing ones are busy. The maximum number of activations per silo is limited by default by the number of CPU cores on the machine, unless you specify it explicitly using the optional `maxLocalWorkers` argument.
-1. Because of points 2 and 3, stateless worker grain activations aren't individually addressable. Two subsequent requests to a stateless worker grain might be processed by different activations.
-
-Stateless worker grains provide a straightforward way to create an auto-managed pool of grain activations that automatically scales up and down based on the actual load. The runtime always scans for available stateless worker grain activations in the same order. Because of this, it always dispatches requests to the first idle local activation it finds and only proceeds to the last one if all previous activations are busy. If all activations are busy and the activation limit hasn't been reached, it creates one more activation at the end of the list and dispatches the request to it. This means that when the rate of requests to a stateless worker grain increases and existing activations are all busy, the runtime expands the pool of activations up to the limit. Conversely, when the load drops and a smaller number of activations can handle it, the activations at the tail of the list won't receive requests. They become idle and are eventually deactivated by the standard activation collection process. Thus, the pool of activations eventually shrinks to match the load.
-
-The following example defines a stateless worker grain class `MyStatelessWorkerGrain` with the default maximum activation number limit.
+Apply <xref:Orleans.Concurrency.StatelessWorkerAttribute> to the implementation:
 
 ```csharp
+public interface IImageWorker : IGrainWithStringKey
+{
+    Task<byte[]> Resize(byte[] image, int width);
+}
+
 [StatelessWorker]
-public class MyStatelessWorkerGrain : Grain, IMyStatelessWorkerGrain
+public sealed class ImageWorkerGrain : Grain, IImageWorker
 {
-    // ...
+    public Task<byte[]> Resize(byte[] image, int width)
+    {
+        return Task.FromResult(image);
+    }
 }
 ```
 
-Making a call to a stateless worker grain is the same as calling any other grain. The only difference is that in most cases, you use a single grain ID, for example, `0` or <xref:System.Guid.Empty?displayProperty=nameWithType>. You can use multiple grain IDs if having multiple stateless worker grain pools (one per ID) is desirable.
+Call it like any other grain:
 
 ```csharp
-var worker = GrainFactory.GetGrain<IMyStatelessWorkerGrain>(0);
-await worker.Process(args);
+IImageWorker worker =
+    grainFactory.GetGrain<IImageWorker>("default");
+
+byte[] resized = await worker.Resize(image, width: 320);
 ```
 
-This example defines a stateless worker grain class with no more than one activation per silo.
+The key identifies a worker pool, not an individual activation. Consecutive calls to the same reference can run on different activations.
+
+## Scaling behavior
+
+Orleans prefers a local compatible activation. If all local activations are busy and the per-silo limit hasn't been reached, Orleans can create another. The default maximum is `Environment.ProcessorCount` activations per silo.
+
+Set a limit explicitly:
 
 ```csharp
-[StatelessWorker(1)] // max 1 activation per silo
-public class MyLonelyWorkerGrain : ILonelyWorkerGrain
+[StatelessWorker(maxLocalWorkers: 4)]
+public sealed class ImageWorkerGrain : Grain, IImageWorker
 {
-    //...
 }
 ```
 
-Note that <xref:Orleans.Concurrency.StatelessWorkerAttribute> doesn't change the reentrancy of the target grain class. Like any other grain, stateless worker grains are non-reentrant by default. You can explicitly make them reentrant by adding a <xref:Orleans.Concurrency.ReentrantAttribute> to the grain class.
+Idle workers are removed by default. The two-argument attribute constructor can disable idle-worker removal for specialized workloads.
 
-## State
+## State and concurrency
 
-The "stateless" part of "stateless worker" doesn't mean a stateless worker cannot have state or is limited only to executing functional operations. Like any other grain, a stateless worker grain can load and keep in memory any state it needs. However, because multiple activations of a stateless worker grain can be created on the same and different silos in the cluster, there's no easy mechanism to coordinate state held by different activations.
+"Stateless" means activations aren't individually addressable and no single activation owns authoritative state for the key. A worker can keep caches or other local state, but that state isn't coordinated with other activations and can disappear at any time.
 
-Several useful patterns involve stateless workers holding state.
+Stateless workers are non-reentrant by default. Add <xref:Orleans.Concurrency.ReentrantAttribute> only if their implementation is safe for request interleaving.
 
-### Scaled-out hot cache items
+Good uses include CPU-bound transformations, local pre-aggregation, protocol adaptation, and replicated read caches. Don't use stateless workers for entity state that requires single-writer consistency.
 
-For hot cache items experiencing high throughput, holding each item in a stateless worker grain provides these benefits:
-
-1. It automatically scales out within a silo and across all silos in the cluster.
-1. It makes the data always locally available on the silo that received the client request via its client gateway, allowing requests to be answered without an extra network hop to another silo.
-
-### Reduce-style aggregation
-
-In some scenarios, applications need to calculate certain metrics across all grains of a particular type in the cluster and report the aggregates periodically. Examples include reporting the number of players per game map or the average duration of a VoIP call. If each of the many thousands or millions of grains reported their metrics to a single global aggregator, the aggregator would immediately become overloaded and unable to process the flood of reports. The alternative approach is to turn this task into a two-step (or more) reduce-style aggregation. The first layer of aggregation involves the reporting grains sending their metrics to a stateless worker pre-aggregation grain. The Orleans runtime automatically creates multiple activations of the stateless worker grain on each silo. Since Orleans processes all such calls locally without remote calls or message serialization, the cost of this aggregation is significantly less than in a remote case. Now, each pre-aggregation stateless worker grain activation, independently or in coordination with other local activations, can send its aggregated report to the global final aggregator (or to another reduction layer if necessary) without overloading it.
+Stateless worker activations don't participate in grain migration.

--- a/docs/site/src/content/docs/grains/timers-and-reminders.md
+++ b/docs/site/src/content/docs/grains/timers-and-reminders.md
@@ -1,6 +1,6 @@
 ---
 title: Grain timers and reminders
-description: Schedule activation-scoped and durable periodic work in Orleans 10.
+description: Schedule activation-scoped and durable periodic work in Orleans.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---

--- a/docs/site/src/content/docs/grains/timers-and-reminders.md
+++ b/docs/site/src/content/docs/grains/timers-and-reminders.md
@@ -1,342 +1,122 @@
 ---
-title: Timers and reminders
-description: Learn how to use timers and reminders in .NET Orleans.
-ms.date: 01/20/2026
+title: Grain timers and reminders
+description: Schedule activation-scoped and durable periodic work in Orleans 10.
+ms.date: 08/02/2026
 ms.topic: concept-article
-ms.custom: sfi-ropc-nochange
-zone_pivot_groups: orleans-version
 ---
 
-# Timers and reminders
+# Grain timers and reminders
 
-The Orleans runtime provides two mechanisms, timers and reminders, that enable you to specify periodic behavior for grains.
+Orleans provides two mechanisms for periodic grain work:
 
-## Timers
+- **Grain timers** belong to one activation. They stop when that activation deactivates or its silo fails.
+- **Reminders** belong to a logical grain. Their definitions are stored and can reactivate the grain after deactivation or cluster restart.
 
-Use **timers** to create periodic grain behavior that isn't required to span multiple activations (instantiations of the grain). A timer is identical to the standard .NET <xref:System.Threading.Timer?displayProperty=fullName> class. Additionally, timers are subject to single-threaded execution guarantees within the grain activation they operate on.
+Use a timer for frequent, activation-scoped work. Use a reminder when the schedule must survive activation changes and occasional missed ticks are acceptable.
 
-Each activation can have zero or more timers associated with it. The runtime executes each timer routine within the runtime context of its associated activation.
+## Grain timers
 
-## Timer usage
-
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0,orleans-8-0"
-
-To start a timer, use the <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> method, which returns an <xref:Orleans.Runtime.IGrainTimer> reference:
+Register timers with <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*>. `RegisterTimer` is obsolete.
 
 ```csharp
-protected IGrainTimer RegisterGrainTimer<TState>(
-    Func<TState, CancellationToken, Task> callback, // function invoked when the timer ticks
-    TState state,                                   // object to pass to callback
-    GrainTimerCreationOptions options)              // timer creation options
-```
-
-- `callback`: The callback function that receives the state and a <xref:System.Threading.CancellationToken> that is canceled when the timer is disposed or the grain deactivates.
-- `state`: The state object passed to the callback.
-- `options`: A <xref:Orleans.Runtime.GrainTimerCreationOptions> instance that configures timer behavior.
-
-To cancel the timer, dispose of it.
-
-A timer stops triggering if the grain deactivates or when a fault occurs and its silo crashes.
-
-### GrainTimerCreationOptions
-
-The <xref:Orleans.Runtime.GrainTimerCreationOptions> structure provides the following properties:
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| <xref:Orleans.Runtime.GrainTimerCreationOptions.DueTime> | <xref:System.TimeSpan> | *Required* | The amount of time to delay before invoking the callback. Use `TimeSpan.Zero` to start immediately, or `Timeout.InfiniteTimeSpan` to prevent the timer from starting. |
-| <xref:Orleans.Runtime.GrainTimerCreationOptions.Period> | <xref:System.TimeSpan> | *Required* | The time interval between invocations of the callback. Use `Timeout.InfiniteTimeSpan` to disable periodic signaling (one-shot timer). |
-| <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave> | `bool` | `false` | When `true`, timer callbacks can interleave with other timers and grain calls. When `false`, callbacks are treated like grain calls and don't interleave (unless the grain is reentrant). |
-| <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive> | `bool` | `false` | When `true`, timer callbacks extend the grain activation's lifetime, preventing idle collection. When `false`, timer callbacks don't prevent grain collection. |
-
-### Example: Creating a grain timer
-
-:::code language="csharp" source="./snippets/timers/TimerExamples.cs" id="grain_timer_example":::
-
-***Important considerations:***
-
-- When activation collection is enabled, executing a timer callback doesn't change the activation's state from idle to in-use by default. Set <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive> to `true` if you want timer callbacks to prevent deactivation.
-- The period passed to <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> is the amount of time passing from the moment the <xref:System.Threading.Tasks.Task> returned by `callback` resolves to the moment the next invocation of `callback` should occur. This not only prevents successive calls to `callback` from overlapping but also means the time `callback` takes to complete affects the frequency at which `callback` is invoked. This is an important deviation from the semantics of <xref:System.Threading.Timer?displayProperty=fullName>.
-- Each invocation of `callback` is delivered to an activation on a separate turn and never runs concurrently with other turns on the same activation.
-- Callbacks don't interleave by default. You can enable interleaving by setting <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave> to `true`.
-- You can update grain timers using the <xref:Orleans.Runtime.IGrainTimer.Change*> method on the returned <xref:Orleans.Runtime.IGrainTimer> instance.
-- Callbacks can keep the grain active, preventing collection if the timer period is relatively short. Enable this by setting <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive> to `true`.
-- Callbacks can receive a <xref:System.Threading.CancellationToken> that is canceled when the timer is disposed or the grain starts to deactivate.
-- Callbacks can dispose of the grain timer that fired them.
-- Callbacks are subject to grain call filters.
-- Callbacks are visible in distributed tracing when distributed tracing is enabled.
-- POCO grains (grain classes that don't inherit from <xref:Orleans.Grain>) can register grain timers using the <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> extension method.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-7-0,orleans-3-x"
-
-> [!IMPORTANT]
-> The `RegisterTimer` API is obsolete starting in Orleans 8.2. If you're upgrading to Orleans 8.0 or later, migrate to the new <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> API. See the [migration section](#migrate-from-registertimer-to-registergraintimer) for details.
-
-To start a timer, use the `Grain.RegisterTimer` method, which returns an <xref:System.IDisposable> reference:
-
-```csharp
-protected IDisposable RegisterTimer(
-    Func<object, Task> asyncCallback, // function invoked when the timer ticks
-    object state,                     // object to pass to asyncCallback
-    TimeSpan dueTime,                 // time to wait before the first timer tick
-    TimeSpan period)                  // the period of the timer
-```
-
-To cancel the timer, dispose of it.
-
-A timer stops triggering if the grain deactivates or when a fault occurs and its silo crashes.
-
-***Important considerations:***
-
-- When activation collection is enabled, executing a timer callback doesn't change the activation's state from idle to in-use. This means you can't use a timer to postpone the deactivation of otherwise idle activations.
-- The period passed to `Grain.RegisterTimer` is the amount of time passing from the moment the <xref:System.Threading.Tasks.Task> returned by `asyncCallback` resolves to the moment the next invocation of `asyncCallback` should occur. This not only prevents successive calls to `asyncCallback` from overlapping but also means the time `asyncCallback` takes to complete affects the frequency at which `asyncCallback` is invoked. This is an important deviation from the semantics of <xref:System.Threading.Timer?displayProperty=fullName>.
-- Each invocation of `asyncCallback` is delivered to an activation on a separate turn and never runs concurrently with other turns on the same activation.
-- Timer callbacks can interleave with other grain calls and timers.
-
-:::zone-end
-
-## Migrate from RegisterTimer to RegisterGrainTimer
-
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0,orleans-8-0"
-
-If you're upgrading from Orleans 7.x to Orleans 8.x or later, you should migrate from the obsolete `RegisterTimer` API to the new <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> API.
-
-### Key differences
-
-| Aspect | `RegisterTimer` (Orleans 7.x) | <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> (Orleans 8.x+) |
-|--------|-------------------------------|-------------------------------------|
-| **Interleaving** | Callbacks interleave by default | Callbacks do **not** interleave by default |
-| **Return type** | <xref:System.IDisposable> | <xref:Orleans.Runtime.IGrainTimer> |
-| **Callback signature** | `Func<object, Task>` | `Func<TState, CancellationToken, Task>` (receives <xref:System.Threading.CancellationToken>) |
-| **State type** | `object` (untyped) | `TState` (strongly typed) |
-| **CancellationToken** | Not supported | Supported via <xref:System.Threading.CancellationToken>, canceled on disposal or deactivation |
-| **Updatable** | No | Yes, via <xref:Orleans.Runtime.IGrainTimer.Change*> method |
-| **KeepAlive option** | Not supported | Supported via <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive>, prevents grain collection |
-| **Call filters** | Not subject to filters | Subject to grain call filters |
-| **Distributed tracing** | Not visible | Visible in distributed tracing |
-
-### Migration example
-
-**Before (Orleans 7.x):**
-
-```csharp
-public class MyGrain : Grain, IMyGrain
+public sealed class CacheGrain : Grain, ICacheGrain
 {
-    private IDisposable? _timer;
+    private IGrainTimer? _timer;
 
-    public override Task OnActivateAsync()
+    public override Task OnActivateAsync(
+        CancellationToken cancellationToken)
     {
-        _timer = RegisterTimer(
-            DoWorkAsync,
-            null,
-            TimeSpan.FromSeconds(5),
-            TimeSpan.FromSeconds(10));
+        _timer = this.RegisterGrainTimer(
+            Refresh,
+            new GrainTimerCreationOptions
+            {
+                DueTime = TimeSpan.Zero,
+                Period = TimeSpan.FromMinutes(1)
+            });
 
-        return base.OnActivateAsync();
+        return base.OnActivateAsync(cancellationToken);
     }
 
-    private Task DoWorkAsync(object state)
+    private Task Refresh(CancellationToken cancellationToken)
     {
-        // Timer work - this interleaves with other calls
         return Task.CompletedTask;
     }
 }
 ```
 
-**After (Orleans 8.x+):**
+`RegisterGrainTimer` returns <xref:Orleans.Runtime.IGrainTimer>. Dispose it to stop the timer, or call <xref:Orleans.Runtime.IGrainTimer.Change*> to change its due time and period.
 
-:::code language="csharp" source="./snippets/timers/TimerExamples.cs" id="migrate_after":::
+### Timer behavior
 
-> [!WARNING]
-> The default interleaving behavior changed in Orleans 8.2. The old `RegisterTimer` API allowed timer callbacks to interleave with other grain calls by default. The new <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> API does **not** interleave by default. If your grain logic depends on interleaving behavior, set <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave> to `true` to preserve the old behavior.
+<xref:Orleans.Runtime.GrainTimerCreationOptions> controls scheduling:
 
-:::zone-end
+| Property | Default | Behavior |
+|---|---:|---|
+| `DueTime` | Required | Delay before the first callback. |
+| `Period` | Required | Delay from callback completion until the next callback. |
+| `Interleave` | `false` | Whether callbacks can interleave with other grain requests. |
+| `KeepAlive` | `false` | Whether timer activity extends activation lifetime. |
 
-:::zone target="docs" pivot="orleans-7-0,orleans-3-x"
+A timer callback never overlaps itself. Orleans waits for the callback task to complete before measuring the next period. Exceptions are logged, and later ticks continue.
 
-This section applies to Orleans 8.0 and later. Select the **Orleans 8.0**, **Orleans 9.0**, or **Orleans 10.0** pivot to view migration guidance.
-
-:::zone-end
+The callback token is canceled when the timer is disposed or the grain begins deactivating. Timer callbacks execute as grain turns, participate in call filters and tracing, and don't interleave with other requests unless configured or allowed by the grain's reentrancy settings.
 
 ## Reminders
 
-Reminders are similar to timers, with a few important differences:
-
-- Reminders are persistent and continue to trigger in almost all situations (including partial or full cluster restarts) unless explicitly canceled.
-- Reminder "definitions" are written to storage. However, each specific occurrence with its specific time isn't stored. This has the side effect that if the cluster is down when a specific reminder tick is due, it will be missed, and only the next tick of the reminder occurs.
-- Reminders are associated with a grain, not any specific activation.
-- If a grain has no activation associated with it when a reminder ticks, Orleans creates the grain activation. If an activation becomes idle and is deactivated, a reminder associated with the same grain reactivates the grain when it ticks next.
-- Reminder delivery occurs via message and is subject to the same interleaving semantics as all other grain methods.
-- You shouldn't use reminders for high-frequency timers; their period should be measured in minutes, hours, or days.
-
-## Configuration
-
-Since reminders are persistent, they rely on storage to function. You must specify which storage backing to use before the reminder subsystem can function. Do this by configuring one of the reminder providers via `Use{X}ReminderService` extension methods, where `X` is the name of the provider (for example, <xref:Orleans.Hosting.AzureStorageReminderSiloBuilderExtensions.UseAzureTableReminderService*>).
-
-Azure Table configuration:
-
-:::code language="csharp" source="./snippets/timers/ReminderConfiguration.cs" id="configure_azure_table":::
-
-SQL:
-
-:::code language="csharp" source="./snippets/timers/ReminderConfiguration.cs" id="configure_adonet":::
-
- If you just want a placeholder implementation of reminders to work without needing to set up an Azure account or SQL database, this provides a development-only implementation of the reminder system:
-
-:::code language="csharp" source="./snippets/timers/ReminderConfiguration.cs" id="configure_inmemory":::
-
-Redis:
-
-:::code language="csharp" source="./snippets/timers/ReminderConfiguration.cs" id="configure_redis":::
-
-The <xref:Orleans.Configuration.RedisReminderTableOptions> class provides the following configuration options:
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `ConfigurationOptions` | `ConfigurationOptions` | The StackExchange.Redis client configuration. Required. |
-| `EntryExpiry` | `TimeSpan?` | Optional expiration time for reminder entries. Only set this for ephemeral environments like testing. Default is `null`. |
-| `CreateMultiplexer` | `Func<RedisReminderTableOptions, Task<IConnectionMultiplexer>>` | Custom factory for creating the Redis connection multiplexer. |
-
-Azure Cosmos DB:
-
-Install the [Microsoft.Orleans.Reminders.Cosmos](https://www.nuget.org/packages/Microsoft.Orleans.Reminders.Cosmos) NuGet package and configure with `UseCosmosReminderService`:
-
-:::code language="csharp" source="./snippets/timers/ReminderConfiguration.cs" id="configure_cosmos":::
-
-The <xref:Orleans.Reminders.Cosmos.CosmosReminderTableOptions> class provides the following configuration options:
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `DatabaseName` | `string` | `"Orleans"` | The name of the Cosmos DB database. |
-| `ContainerName` | `string` | `"OrleansReminders"` | The name of the container for reminder data. |
-| `IsResourceCreationEnabled` | `bool` | `false` | When `true`, automatically creates the database and container if they don't exist. |
-| `DatabaseThroughput` | `int?` | `null` | The provisioned throughput for the database. If `null`, uses serverless mode. |
-| `ContainerThroughputProperties` | `ThroughputProperties?` | `null` | The throughput properties for the container. |
-| `ClientOptions` | `CosmosClientOptions` | `new()` | The options passed to the Cosmos DB client. |
-
-> [!IMPORTANT]
-> If you have a heterogenous cluster, where the silos handle different grain types (implement different interfaces), every silo must add the configuration for Reminders, even if the silo itself doesn't handle any reminders.
-
-### Aspire integration for reminders
-
-:::zone target="docs" pivot="orleans-8-0,orleans-9-0,orleans-10-0"
-
-When using [Aspire](../host/aspire-integration.md), you can configure Orleans reminders declaratively in your AppHost project. Aspire automatically injects the necessary configuration into your silo projects via environment variables.
-
-#### Redis reminders with Aspire
-
-**AppHost project (Program.cs):**
-
-:::code language="csharp" source="../host/snippets/aspire/AppHost/AppHostExamples.cs" id="reminders_redis_apphost":::
-
-**Silo project (Program.cs):**
-
-:::code language="csharp" source="../host/snippets/aspire/Silo/SiloProgram.cs" id="reminders_redis_silo":::
-
-#### Azure Table Storage reminders with Aspire
-
-**AppHost project (Program.cs):**
-
-:::code language="csharp" source="../host/snippets/aspire/AppHost/AppHostExamples.cs" id="reminders_azure_table_apphost":::
-
-**Silo project (Program.cs):**
-
-:::code language="csharp" source="../host/snippets/aspire/Silo/SiloProgram.cs" id="reminders_azure_table_silo":::
-
-> [!TIP]
-> During local development, Aspire automatically uses the Azurite emulator for Azure Storage. In production, configure a real Azure Storage account in your AppHost.
-
-#### In-memory reminders for development with Aspire
-
-For local development, you can use in-memory reminders that don't require external storage:
-
-**AppHost project (Program.cs):**
-
-:::code language="csharp" source="../host/snippets/aspire/AppHost/AppHostExamples.cs" id="reminders_inmemory_apphost":::
-
-**Silo project (Program.cs):**
-
-:::code language="csharp" source="../host/snippets/aspire/Silo/SiloProgram.cs" id="reminders_inmemory_silo":::
-
-> [!WARNING]
-> In-memory reminders are lost when the silo restarts. Only use `WithMemoryReminders()` for local development and testing. For production, always use a persistent reminder storage provider like Redis, Azure Table Storage, or SQL.
-
-> [!IMPORTANT]
-> You must call the appropriate `AddKeyed*` method (such as `AddKeyedRedisClient` or `AddKeyedAzureTableClient`) to register the backing resource in the dependency injection container. Orleans providers look up resources by their keyed service name—if you skip this step, Orleans won't be able to resolve the resource and will throw a dependency resolution error at runtime.
-
-For more information about Orleans and Aspire integration, see [Orleans and Aspire integration](../host/aspire-integration.md).
-
-:::zone-end
-
-## Reminder usage
-
-A grain using reminders must implement the <xref:Orleans.IRemindable.ReceiveReminder*?displayProperty=nameWithType> method.
+A grain receiving reminders implements <xref:Orleans.IRemindable>:
 
 ```csharp
-Task IRemindable.ReceiveReminder(string reminderName, TickStatus status)
+public sealed class ReportGrain :
+    Grain,
+    IReportGrain,
+    IRemindable
 {
-    Console.WriteLine("Thanks for reminding me-- I almost forgot!");
-    return Task.CompletedTask;
+    public Task ReceiveReminder(
+        string reminderName,
+        TickStatus status)
+    {
+        return GenerateReport();
+    }
+
+    private Task GenerateReport() => Task.CompletedTask;
 }
 ```
 
- To start a reminder, use the <xref:Orleans.Grain.RegisterOrUpdateReminder*?displayProperty=nameWithType> method, which returns an <xref:Orleans.Runtime.IGrainReminder> object:
+Register or update a reminder from the grain:
 
 ```csharp
-protected Task<IGrainReminder> RegisterOrUpdateReminder(
-    string reminderName,
-    TimeSpan dueTime,
-    TimeSpan period)
+IGrainReminder reminder = await this.RegisterOrUpdateReminder(
+    "daily-report",
+    dueTime: TimeSpan.FromMinutes(1),
+    period: TimeSpan.FromDays(1));
 ```
 
-- `reminderName`: is a string that must uniquely identify the reminder within the scope of the contextual grain.
-- `dueTime`: specifies a quantity of time to wait before issuing the first-timer tick.
-- `period`: specifies the period of the timer.
-
-Since reminders survive the lifetime of any single activation, you must explicitly cancel them (as opposed to disposing of them). Cancel a reminder by calling <xref:Orleans.Grain.UnregisterReminder*?displayProperty=nameWithType>:
+Cancel it explicitly:
 
 ```csharp
-protected Task UnregisterReminder(IGrainReminder reminder)
+IGrainReminder? reminder =
+    await this.GetReminder("daily-report");
+
+if (reminder is not null)
+{
+    await this.UnregisterReminder(reminder);
+}
 ```
 
-The `reminder` is the handle object returned by <xref:Orleans.Grain.RegisterOrUpdateReminder*?displayProperty=nameWithType>.
+Store the reminder name, not the `IGrainReminder` handle, across activations. Handles aren't guaranteed to remain valid beyond the activation that retrieved them.
 
-Instances of `IGrainReminder` aren't guaranteed to be valid beyond the lifespan of an activation. If you wish to identify a reminder persistently, use a string containing the reminder's name.
+### Reminder behavior
 
-If you only have the reminder's name and need the corresponding `IGrainReminder` instance, call the <xref:Orleans.Grain.GetReminder*?displayProperty=nameWithType> method:
+Reminder definitions are durable, but individual tick messages aren't. If the cluster is unavailable at a scheduled time, that occurrence can be missed. The next scheduled tick still occurs. Reminder delivery follows normal grain request scheduling and can activate an inactive grain.
 
-```csharp
-protected Task<IGrainReminder> GetReminder(string reminderName)
-```
+Reminders are intended for periods measured in minutes, hours, or days, not high-frequency scheduling. A common pattern is for a reminder to wake a grain and create a finer-grained local timer.
 
-## Decide which to use
+## Configure reminder storage
 
-We recommend using timers in the following circumstances:
+Every silo must configure a reminder provider. Production deployments should use a durable provider such as Azure Table, ADO.NET, Redis, or Cosmos DB. In-memory reminders are suitable only for local development and tests because definitions are lost when the cluster stops.
 
-- If it doesn't matter (or is desirable) that the timer stops functioning when the activation deactivates or failures occur.
-- The timer's resolution is small (e.g., reasonably expressible in seconds or minutes).
-- You can start the timer callback from <xref:Orleans.Grain.OnActivateAsync?displayProperty=nameWithType> or when a grain method is invoked.
+The provider-specific configuration is covered by each reminder provider package. For a compiled in-repository configuration example, see the [reminder configuration snippets](https://github.com/dotnet/orleans/tree/main/docs/site/src/content/docs/grains/snippets/timers).
 
-We recommend using reminders in the following circumstances:
+## POCO grains
 
-- When the periodic behavior needs to survive activation and any failures.
-- Performing infrequent tasks (e.g., reasonably expressible in minutes, hours, or days).
-
-## Combine timers and reminders
-
-You might consider using a combination of reminders and timers to accomplish your goal. For example, if you need a timer with a small resolution that must survive across activations, you can use a reminder running every five minutes. Its purpose would be to wake up a grain that restarts a local timer possibly lost due to deactivation.
-
-## POCO grain registrations
-
-To register a timer or reminder with [a POCO grain](../migration-guide.md#poco-grains-and-igrainbase), implement the <xref:Orleans.IGrainBase> interface and inject <xref:Orleans.Timers.ITimerRegistry> or <xref:Orleans.Timers.IReminderRegistry> into the grain's constructor.
-
-:::code source="./snippets/timers/PingGrain.cs":::
-
-The preceding code does the following:
-
-- Defines a POCO grain implementing <xref:Orleans.IGrainBase>, `IPingGrain`, and <xref:System.IDisposable>.
-- Registers a timer invoked every 10 seconds, starting 3 seconds after registration.
-- When `Ping` is called, registers a reminder invoked every hour, starting immediately after registration.
-- The `Dispose` method cancels the reminder if it's registered.
+Grains implementing <xref:Orleans.IGrainBase> directly can use the same extension APIs. Inject <xref:Orleans.Timers.ITimerRegistry> or <xref:Orleans.Timers.IReminderRegistry> when lower-level registration is required.


### PR DESCRIPTION
Modernizes the grain programming documentation around Orleans 10 APIs and behavior. It covers contracts, activation and lifecycle, identity and calls, scheduling, timers and reminders, observers, placement and migration, filters, extensions, and grain services while removing legacy version narratives and correcting current defaults and experimental diagnostics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10334)