### PR TITLE
docs: modernize hosting and configuration guidance

### DIFF
--- a/docs/site/src/content/docs/host/aspire-integration.md
+++ b/docs/site/src/content/docs/host/aspire-integration.md
@@ -7,9 +7,9 @@ ms.topic: how-to
 
 # Orleans and Aspire integration
 
-The `Aspire.Hosting.Orleans` package models an Orleans cluster and its backing services in an Aspire AppHost. Aspire supplies cluster identity, endpoints, provider configuration, service discovery, dependency ordering, and observability context to silo and client projects.
+The `Aspire.Hosting.Orleans` package models an Orleans cluster and its backing services in an Aspire AppHost. [Aspire](https://aspire.dev/get-started/what-is-aspire/) supplies cluster identity, endpoints, provider configuration, service discovery, dependency ordering, and observability context to silo and client projects.
 
-Use Aspire when you want a repeatable local distributed environment or already use an AppHost to describe deployment resources. Aspire orchestrates Orleans; it doesn't replace Orleans clustering, storage, reminder, or stream providers.
+Use Aspire when you want a repeatable local distributed environment or already use an AppHost to describe deployment resources. Aspire orchestrates Orleans; it doesn't replace Orleans clustering, storage, reminder, or stream providers. See [Install the Aspire CLI](https://aspire.dev/get-started/install-cli/) for the supported toolchain.
 
 ## Add Orleans to the AppHost
 

--- a/docs/site/src/content/docs/host/aspire-integration.md
+++ b/docs/site/src/content/docs/host/aspire-integration.md
@@ -7,11 +7,18 @@ ms.topic: how-to
 
 # Orleans and Aspire integration
 
+## Overview
+
+<a id="prerequisites"></a>
+
 The `Aspire.Hosting.Orleans` package models an Orleans cluster and its backing services in an Aspire AppHost. [Aspire](https://aspire.dev/get-started/what-is-aspire/) supplies cluster identity, endpoints, provider configuration, service discovery, dependency ordering, and observability context to silo and client projects.
 
 Use Aspire when you want a repeatable local distributed environment or already use an AppHost to describe deployment resources. Aspire orchestrates Orleans; it doesn't replace Orleans clustering, storage, reminder, or stream providers. See [Install the Aspire CLI](https://aspire.dev/get-started/install-cli/) for the supported toolchain.
 
-## Add Orleans to the AppHost
+## Configure the AppHost
+
+<a id="required-packages"></a>
+<a id="apphost-project"></a>
 
 Reference `Aspire.Hosting.Orleans` and the Aspire integrations for the resources you use:
 
@@ -19,19 +26,26 @@ Reference `Aspire.Hosting.Orleans` and the Aspire integrations for the resources
 
 Define a clustering resource and an Orleans resource, then reference Orleans from the silo project:
 
+<a id="basic-orleans-cluster-with-redis-clustering"></a>
+
 :::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="basic_orleans_cluster":::
 
 `.WithReplicas(3)` starts three local silo replicas. `.WaitFor(redis)` prevents the silo project from starting before Redis is ready.
 
 Add only the capabilities the application needs:
 
+<a id="orleans-with-grain-storage-and-reminders"></a>
+
 :::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="orleans_with_storage_reminders":::
 
 The named grain storage resources correspond to named Orleans providers such as `Default` and `PubSubStore`.
 
-## Configure the silo project
+## Configure the Orleans silo project
 
-Register the keyed Aspire client for every backing resource consumed by Orleans, then call parameterless `UseOrleans()`:
+<a id="orleans-silo-project"></a>
+<a id="service-defaults-pattern"></a>
+
+Register the keyed Aspire client for every backing resource consumed by Orleans, then call parameterless <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*>:
 
 :::code language="csharp" source="snippets/aspire/Silo/SiloProgram.cs" id="silo_basic_config":::
 
@@ -40,21 +54,29 @@ The AppHost injects the `Orleans` configuration hierarchy. Orleans binds cluster
 > [!IMPORTANT]
 > Resource references inject configuration, but the application project must register the matching keyed service client. For example, use `AddKeyedRedisClient`, `AddKeyedAzureTableServiceClient`, or the matching Aspire integration method for the resource type and name.
 
-Use the `UseOrleans` delegate only for configuration that the AppHost doesn't model, such as application-specific options or custom services.
+Use the <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> delegate only for configuration that the AppHost doesn't model, such as application-specific options or custom services.
 
-## Configure a separate client
+## Configure the Orleans client project
+
+<a id="orleans-client-project-if-separate-from-silo"></a>
+
+<a id="separate-silo-and-client-projects"></a>
 
 Create a client-only view of the Orleans resource with `.AsClient()`:
 
 :::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="separate_silo_and_client":::
 
-In the client project, register the keyed resource client and call parameterless `UseOrleansClient()`:
+In the client project, register the keyed resource client and call parameterless <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*>:
 
 :::code language="csharp" source="snippets/aspire/Client/ClientProgram.cs" id="client_basic_config":::
 
 The client receives the same cluster identity and clustering provider settings as the silos, but doesn't receive silo hosting capabilities.
 
-## Use Azure resources
+## Azure Storage with Aspire
+
+<a id="development-vs-production-configuration"></a>
+<a id="local-development-using-emulators"></a>
+<a id="production-using-managed-services"></a>
 
 This compiled example uses Azurite for local Azure Storage development:
 
@@ -68,11 +90,18 @@ Register the matching Azure Tables client in the silo:
 
 The same principle applies to Redis and databases: the AppHost resource can launch a local container during development and bind to a managed service in deployment.
 
-## Understand generated configuration
+## AppHost extension methods reference
 
-`AddOrleans` produces standard Orleans configuration. The application projects still call `UseOrleans` or `UseOrleansClient`, and Orleans validates the resulting provider configuration at startup. You can inspect injected environment variables in the Aspire dashboard when diagnosing a missing provider, keyed resource, or endpoint.
+`AddOrleans` produces standard Orleans configuration. The application projects still call <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> or <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*>, and Orleans validates the resulting provider configuration at startup. You can inspect injected environment variables in the Aspire dashboard when diagnosing a missing provider, keyed resource, or endpoint.
 
 Common AppHost operations include:
+
+<a id="core-methods"></a>
+<a id="clustering"></a>
+<a id="grain-storage"></a>
+<a id="reminders"></a>
+<a id="streaming"></a>
+<a id="grain-directory"></a>
 
 | Operation | Purpose |
 |---|---|
@@ -87,11 +116,15 @@ Common AppHost operations include:
 
 Consult the [Aspire Orleans integration reference](https://aspire.dev/integrations/frameworks/orleans/) for resource types and overloads supported by your Aspire version.
 
-## Production considerations
+## Best practices
+
+<a id="opentelemetry-configuration"></a>
+<a id="health-checks"></a>
+<a id="see-also"></a>
 
 - Treat the AppHost as a resource model, not as a substitute for durable services.
 - Use managed identities or workload identities instead of embedding secrets.
-- Keep `ServiceId` stable and isolate environments with `ClusterId`.
+- Keep <xref:Orleans.Configuration.ClusterOptions.ServiceId> stable and isolate environments with <xref:Orleans.Configuration.ClusterOptions.ClusterId>.
 - Run multiple silo replicas across failure domains.
 - Configure readiness, telemetry export, and graceful termination in each application project.
 - Match keyed service names exactly between the AppHost and application projects.

--- a/docs/site/src/content/docs/host/aspire-integration.md
+++ b/docs/site/src/content/docs/host/aspire-integration.md
@@ -1,212 +1,97 @@
 ---
 title: Orleans and Aspire integration
-description: Learn how to integrate Orleans with Aspire for cloud-native development.
-ms.date: 01/21/2026
-ms.topic: concept-article
-zone_pivot_groups: orleans-version
+description: Model and run Orleans 10 applications with Aspire.
+ms.date: 08/02/2026
+ms.topic: how-to
 ---
 
 # Orleans and Aspire integration
 
-:::zone target="docs" pivot="orleans-8-0,orleans-9-0,orleans-10-0"
+The `Aspire.Hosting.Orleans` package models an Orleans cluster and its backing services in an Aspire AppHost. Aspire supplies cluster identity, endpoints, provider configuration, service discovery, dependency ordering, and observability context to silo and client projects.
 
-[Aspire](https://aspire.dev/get-started/what-is-aspire/) provides a streamlined approach to building cloud-native applications with built-in support for Orleans. Starting with Orleans 8.0, you can use Aspire to orchestrate your Orleans cluster, manage backing resources (like Redis or Azure Storage), and automatically configure service discovery, observability, and health checks.
+Use Aspire when you want a repeatable local distributed environment or already use an AppHost to describe deployment resources. Aspire orchestrates Orleans; it doesn't replace Orleans clustering, storage, reminder, or stream providers.
 
-## Overview
+## Add Orleans to the AppHost
 
-Orleans integration with Aspire uses the `Aspire.Hosting.Orleans` package in your AppHost project. This package provides extension methods to:
-
-- Define Orleans as a distributed resource
-- Configure clustering providers (Redis, Azure Storage, ADO.NET)
-- Configure grain storage providers
-- Configure reminder providers
-- Configure grain directory providers
-- Model silo and client relationships
-
-## Prerequisites
-
-Before using Orleans with Aspire, ensure you have:
-
-- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
-- [Aspire CLI](https://aspire.dev/get-started/install-cli/)
-- An IDE with Aspire support (Visual Studio 2022 17.9+, VS Code with C# Dev Kit, or JetBrains Rider)
-
-## Required packages
-
-Your solution needs the following package references:
-
-### AppHost project
+Reference `Aspire.Hosting.Orleans` and the Aspire integrations for the resources you use:
 
 :::code language="xml" source="snippets/aspire/AppHost/AppHost.csproj" id="apphost_packages":::
 
-### Orleans silo project
-
-:::code language="xml" source="snippets/aspire/Silo/Silo.csproj" id="silo_packages":::
-
-### Orleans client project (if separate from silo)
-
-:::code language="xml" source="snippets/aspire/Client/Client.csproj" id="client_packages":::
-
-## Configure the AppHost
-
-The AppHost project orchestrates your Orleans cluster and its dependencies.
-
-### Basic Orleans cluster with Redis clustering
+Define a clustering resource and an Orleans resource, then reference Orleans from the silo project:
 
 :::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="basic_orleans_cluster":::
 
-### Orleans with grain storage and reminders
+`.WithReplicas(3)` starts three local silo replicas. `.WaitFor(redis)` prevents the silo project from starting before Redis is ready.
+
+Add only the capabilities the application needs:
 
 :::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="orleans_with_storage_reminders":::
 
-### Separate silo and client projects
+The named grain storage resources correspond to named Orleans providers such as `Default` and `PubSubStore`.
 
-When your Orleans client runs in a separate process (such as a web frontend), use the `.AsClient()` method:
+## Configure the silo project
 
-:::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="separate_silo_and_client":::
-
-## Configure the Orleans silo project
-
-In your Orleans silo project, configure Orleans to use the Aspire-provided resources:
+Register the keyed Aspire client for every backing resource consumed by Orleans, then call parameterless `UseOrleans()`:
 
 :::code language="csharp" source="snippets/aspire/Silo/SiloProgram.cs" id="silo_basic_config":::
 
-> [!TIP]
-> When using Aspire, the parameterless <xref:Microsoft.Extensions.Hosting.GenericHostExtensions.UseOrleans*> is typically all you need. Aspire injects Orleans configuration (cluster ID, service ID, endpoints, and provider settings) via environment variables that Orleans reads automatically. You only need the delegate overload `UseOrleans(siloBuilder => {...})` when you require additional manual configuration beyond what Aspire provides.
+The AppHost injects the `Orleans` configuration hierarchy. Orleans 10 binds cluster identity, endpoints, clustering, reminders, streaming, grain storage, and grain directory configuration from it.
 
 > [!IMPORTANT]
-> You must call the appropriate `AddKeyed*` method (such as `AddKeyedRedisClient`, `AddKeyedAzureTableClient`, or `AddKeyedAzureBlobClient`) to register the backing resource in the dependency injection container. Orleans providers look up resources by their keyed service name—if you skip this step, Orleans won't be able to resolve the resource and will throw a dependency resolution error at runtime. This applies to all Aspire-managed resources used with Orleans.
+> Resource references inject configuration, but the application project must register the matching keyed service client. For example, use `AddKeyedRedisClient`, `AddKeyedAzureTableServiceClient`, or the matching Aspire integration method for the resource type and name.
 
-### Configure with explicit connection string
+Use the `UseOrleans` delegate only for configuration that the AppHost doesn't model, such as application-specific options or custom services.
 
-If you need explicit control over the connection string, you can read it from configuration:
+## Configure a separate client
 
-:::code language="csharp" source="snippets/aspire/Silo/SiloProgram.cs" id="silo_explicit_connection":::
+Create a client-only view of the Orleans resource with `.AsClient()`:
 
-## Configure the Orleans client project
+:::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="separate_silo_and_client":::
 
-For separate client projects, configure the Orleans client similarly:
+In the client project, register the keyed resource client and call parameterless `UseOrleansClient()`:
 
 :::code language="csharp" source="snippets/aspire/Client/ClientProgram.cs" id="client_basic_config":::
 
-## AppHost extension methods reference
+The client receives the same cluster identity and clustering provider settings as the silos, but doesn't receive silo hosting capabilities.
 
-The `Aspire.Hosting.Orleans` package provides these extension methods:
+## Use Azure resources
 
-### Core methods
-
-| Method | Description |
-|--------|-------------|
-| `builder.AddOrleans(name)` | Adds an Orleans resource to the distributed application with the specified name. |
-| `.WithClusterId(id)` | Sets the Orleans ClusterId. Accepts a string or `ParameterResource`. If not specified, a unique ID is generated automatically. |
-| `.WithServiceId(id)` | Sets the Orleans ServiceId. Accepts a string or `ParameterResource`. If not specified, a unique ID is generated automatically. |
-| `.AsClient()` | Returns a client-only reference to the Orleans resource (doesn't include silo capabilities). |
-| `project.WithReference(orleans)` | Adds the Orleans resource reference to a project, enabling configuration injection. |
-
-> [!NOTE]
-> When you configure a backing resource using `.WithClustering(resource)`, `.WithGrainStorage(name, resource)`, or similar methods, the Orleans resource automatically includes a reference to that backing resource. You don't need to call `.WithReference()` separately for each backing resource—only `.WithReference(orleans)` is required. However, you should use `.WaitFor()` on the backing resource to ensure it's ready before the silo starts.
-
-### Clustering
-
-| Method | Description |
-|--------|-------------|
-| `.WithClustering(resource)` | Configures Orleans clustering to use the specified resource (Redis, Azure Storage, Cosmos DB, etc.). |
-| `.WithDevelopmentClustering()` | Configures in-memory, single-host clustering for local development only. Not suitable for production. |
-
-### Grain storage
-
-| Method | Description |
-|--------|-------------|
-| `.WithGrainStorage(name, resource)` | Configures a named grain storage provider using the specified resource. |
-| `.WithMemoryGrainStorage(name)` | Configures in-memory grain storage for the specified name. Data is lost on silo restart. |
-
-### Reminders
-
-| Method | Description |
-|--------|-------------|
-| `.WithReminders(resource)` | Configures the Orleans reminder service using the specified resource. |
-| `.WithMemoryReminders()` | Configures in-memory reminders for development. Reminders are lost on silo restart. |
-
-### Streaming
-
-| Method | Description |
-|--------|-------------|
-| `.WithStreaming(name, resource)` | Configures a named stream provider using the specified resource (e.g., Azure Queue Storage). |
-| `.WithMemoryStreaming(name)` | Configures in-memory streaming for development. |
-| `.WithBroadcastChannel(name)` | Configures a broadcast channel provider with the specified name. |
-
-### Grain directory
-
-| Method | Description |
-|--------|-------------|
-| `.WithGrainDirectory(name, resource)` | Configures a named grain directory using the specified resource. |
-
-## Service defaults pattern
-
-Aspire uses a ServiceDefaults project pattern to share common configuration across all projects. For Orleans, this typically includes:
-
-### OpenTelemetry configuration
-
-:::code language="csharp" source="snippets/aspire/ServiceDefaults/Extensions.cs" id="service_defaults":::
-
-## Azure Storage with Aspire
-
-You can use Azure Storage resources for Orleans clustering and persistence:
+This compiled example uses Azurite for local Azure Storage development:
 
 :::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="azure_storage_aspire":::
 
-## Development vs. production configuration
+Register the matching Azure Tables client in the silo:
 
-Aspire makes it easy to switch between development and production configurations:
+:::code language="csharp" source="snippets/aspire/Silo/SiloProgram.cs" id="silo_azure_config":::
 
-### Local development (using emulators)
+`.RunAsEmulator()` is a local-development choice. For production, bind the Azure Storage resource to a real account and configure identity and access in the deployment environment. Don't copy emulator configuration into a production AppHost.
 
-:::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="local_development":::
+The same principle applies to Redis and databases: the AppHost resource can launch a local container during development and bind to a managed service in deployment.
 
-### Production (using managed services)
+## Understand generated configuration
 
-:::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="production_config":::
+`AddOrleans` produces standard Orleans configuration. The application projects still call `UseOrleans` or `UseOrleansClient`, and Orleans validates the resulting provider configuration at startup. You can inspect injected environment variables in the Aspire dashboard when diagnosing a missing provider, keyed resource, or endpoint.
 
-## Health checks
+Common AppHost operations include:
 
-Aspire automatically configures health check endpoints. You can add Orleans-specific health checks:
+| Operation | Purpose |
+|---|---|
+| `AddOrleans(name)` | Define an Orleans cluster resource. |
+| `WithClustering(resource)` | Select the membership and gateway provider. |
+| `WithGrainStorage(name, resource)` | Add named grain storage. |
+| `WithReminders(resource)` | Add a durable reminder provider. |
+| `WithStreaming(name, resource)` | Add a named stream provider. |
+| `WithGrainDirectory(name, resource)` | Add a named grain directory. |
+| `AsClient()` | Reference the cluster from a client-only project. |
+| `WithReference(orleans)` | Inject Orleans configuration into a project. |
 
-:::code language="csharp" source="snippets/aspire/Silo/SiloProgram.cs" id="health_checks":::
+Consult the current [Aspire Orleans integration reference](https://aspire.dev/integrations/frameworks/orleans/) for resource types and overloads supported by your Aspire version.
 
-## Best practices
+## Production considerations
 
-1. **Use ServiceDefaults**: Share common configuration (OpenTelemetry, health checks) across all projects using a ServiceDefaults project.
-
-2. **Wait for dependencies**: Always use `.WaitFor()` to ensure backing resources (Redis, databases) are ready before Orleans silos start.
-
-3. **Configure replicas**: Use `.WithReplicas()` to run multiple silo instances for fault tolerance and scalability.
-
-4. **Separate client projects**: For web frontends, use `.AsClient()` to configure Orleans client-only mode.
-
-5. **Use emulators for development**: Aspire can run Redis, Azure Storage (Azurite), and other dependencies locally using containers.
-
-6. **Enable distributed tracing**: Configure OpenTelemetry with Orleans source names to trace grain calls across the cluster.
-
-## See also
-
-- [Aspire overview](https://aspire.dev/get-started/what-is-aspire/)
-- [Aspire setup and tooling](https://aspire.dev/get-started/install-cli/)
-- [Orleans configuration guide](configuration-guide/index.md)
-- [Orleans Redis providers](../grains/grain-persistence/index.md#redis-grain-persistence)
-- [Orleans Azure Storage providers](../grains/grain-persistence/azure-storage.md)
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-7-0"
-
-Aspire integration was introduced in Orleans 8.0. For Orleans 7.0, you can still deploy to Aspire-orchestrated environments, but the dedicated `Aspire.Hosting.Orleans` package and its extension methods are not available.
-
-Consider upgrading to Orleans 8.0 or later to take advantage of the Aspire integration features.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-Aspire integration is available in Orleans 8.0 and later. Orleans 3.x does not support Aspire.
-
-:::zone-end
+- Treat the AppHost as a resource model, not as a substitute for durable services.
+- Use managed identities or workload identities instead of embedding secrets.
+- Keep `ServiceId` stable and isolate environments with `ClusterId`.
+- Run multiple silo replicas across failure domains.
+- Configure readiness, telemetry export, and graceful termination in each application project.
+- Match keyed service names exactly between the AppHost and application projects.

--- a/docs/site/src/content/docs/host/aspire-integration.md
+++ b/docs/site/src/content/docs/host/aspire-integration.md
@@ -1,6 +1,6 @@
 ---
 title: Orleans and Aspire integration
-description: Model and run Orleans 10 applications with Aspire.
+description: Model and run Orleans applications with Aspire.
 ms.date: 08/02/2026
 ms.topic: how-to
 ---
@@ -35,7 +35,7 @@ Register the keyed Aspire client for every backing resource consumed by Orleans,
 
 :::code language="csharp" source="snippets/aspire/Silo/SiloProgram.cs" id="silo_basic_config":::
 
-The AppHost injects the `Orleans` configuration hierarchy. Orleans 10 binds cluster identity, endpoints, clustering, reminders, streaming, grain storage, and grain directory configuration from it.
+The AppHost injects the `Orleans` configuration hierarchy. Orleans binds cluster identity, endpoints, clustering, reminders, streaming, grain storage, and grain directory configuration from it.
 
 > [!IMPORTANT]
 > Resource references inject configuration, but the application project must register the matching keyed service client. For example, use `AddKeyedRedisClient`, `AddKeyedAzureTableServiceClient`, or the matching Aspire integration method for the resource type and name.
@@ -85,7 +85,7 @@ Common AppHost operations include:
 | `AsClient()` | Reference the cluster from a client-only project. |
 | `WithReference(orleans)` | Inject Orleans configuration into a project. |
 
-Consult the current [Aspire Orleans integration reference](https://aspire.dev/integrations/frameworks/orleans/) for resource types and overloads supported by your Aspire version.
+Consult the [Aspire Orleans integration reference](https://aspire.dev/integrations/frameworks/orleans/) for resource types and overloads supported by your Aspire version.
 
 ## Production considerations
 

--- a/docs/site/src/content/docs/host/client.md
+++ b/docs/site/src/content/docs/host/client.md
@@ -60,7 +60,7 @@ After startup, Orleans refreshes gateways and reconnects as cluster membership c
 
 External client code isn't governed by the grain turn-based concurrency model. Multiple threads can use <xref:Orleans.IClusterClient> and grain references concurrently. Protect mutable client-side state using normal .NET synchronization.
 
-Grain calls return <xref:System.Threading.Tasks.Task>, <xref:System.Threading.Tasks.Task`1>, <xref:System.Threading.Tasks.ValueTask>, or <xref:System.Threading.Tasks.ValueTask`1> according to the [grain interface rules](../grains/index.md#grain-interfaces-and-classes). Always await calls rather than blocking threads.
+Grain calls return <xref:System.Threading.Tasks.Task>, <xref:System.Threading.Tasks.Task`1>, <xref:System.Threading.Tasks.ValueTask>, or <xref:System.Threading.Tasks.ValueTask`1> according to the [grain interface rules](../grains/index.md). Always await calls rather than blocking threads.
 
 ## Receive notifications
 

--- a/docs/site/src/content/docs/host/client.md
+++ b/docs/site/src/content/docs/host/client.md
@@ -1,250 +1,101 @@
 ---
 title: Orleans clients
-description: Learn how to write .NET Orleans clients.
-ms.date: 01/21/2026
+description: Choose and host an Orleans 10 client.
+ms.date: 08/02/2026
 ms.topic: concept-article
-zone_pivot_groups: orleans-version
-ms.custom: sfi-ropc-nochange
 ---
 
 # Orleans clients
 
-A client allows non-grain code to interact with an Orleans cluster. Clients enable application code to communicate with grains and streams hosted in a cluster. There are two ways to obtain a client, depending on where you host the client code: in the same process as a silo or in a separate process. This article discusses both options, starting with the recommended approach: co-hosting client code in the same process as grain code.
+An Orleans client lets application code call grains, use streams, and access other cluster services. Orleans provides a client automatically inside every silo, or you can host an external client in a separate process.
 
-## Co-hosted clients
+## Choose a hosting model
 
-If you host client code in the same process as grain code, you can directly obtain the client from the hosting application's dependency injection container. In this case, the client communicates directly with the silo it's attached to and can take advantage of the silo's extra knowledge about the cluster.
+| Model | Prefer it when | Tradeoff |
+|---|---|---|
+| Co-hosted client | HTTP endpoints, background workers, and grains can share a process. | Simplest topology and fastest calls, but client workload shares silo CPU and memory. |
+| External client | Frontends and silos need independent scaling, deployment, security, or resource isolation. | Adds gateways, network hops, and another process to operate. |
 
-This approach provides several benefits, including reduced network and CPU overhead, decreased latency, and increased throughput and reliability. The client uses the silo's knowledge of the cluster topology and state and doesn't need a separate gateway. This avoids a network hop and a serialization/deserialization round trip, thereby increasing reliability by minimizing the number of required nodes between the client and the grain. If the grain is a [stateless worker grain](../grains/stateless-worker-grains.md) or happens to be activated on the same silo where the client is hosted, no serialization or network communication is needed at all, allowing the client to achieve additional performance and reliability gains. Co-hosting client and grain code also simplifies deployment and application topology by eliminating the need to deploy and monitor two distinct application binaries.
+Start with a co-hosted client unless isolation is a requirement.
 
-There are also drawbacks to this approach, primarily that the grain code is no longer isolated from the client process. Therefore, issues in client code, such as blocking I/O or lock contention causing thread starvation, can affect grain code performance. Even without such code defects, *noisy neighbor* effects can occur simply because client code executes on the same processor as grain code, putting additional strain on the CPU cache and increasing contention for local resources. Additionally, identifying the source of these issues becomes more difficult because monitoring systems cannot distinguish logically between client code and grain code.
+## Use the co-hosted client
 
-Despite these drawbacks, co-hosting client code with grain code is a popular option and the recommended approach for most applications. The aforementioned drawbacks are often minimal in practice for the following reasons:
-
-- Client code is often very *thin* (e.g., translating incoming HTTP requests into grain calls). Therefore, *noisy neighbor* effects are minimal and comparable in cost to the otherwise required gateway.
-- If a performance issue arises, your typical workflow likely involves tools such as CPU profilers and debuggers. These tools remain effective in quickly identifying the source of the issue, even with both client and grain code executing in the same process. In other words, while metrics become coarser and less able to precisely identify the issue's source, more detailed tools are still effective.
-
-### Obtain a client from a host
-
-If you host using the [.NET Generic Host](../../core/extensions/generic-host.md), the client is automatically available in the host's [dependency injection](../../core/extensions/dependency-injection/overview.md) container. You can inject it into services such as [ASP.NET controllers](/aspnet/core/mvc/controllers/actions) or <xref:Microsoft.Extensions.Hosting.IHostedService> implementations.
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-Alternatively, you can obtain a client interface like <xref:Orleans.IGrainFactory> or <xref:Orleans.IClusterClient> from <xref:Orleans.Hosting.ISiloHost>:
-
-:::zone-end
+`UseOrleans` registers `IClusterClient` and `IGrainFactory` in the host service provider:
 
 ```csharp
-var client = host.Services.GetService<IClusterClient>();
-await client.GetGrain<IMyGrain>(0).Ping();
+var builder = WebApplication.CreateBuilder(args);
+
+builder.UseOrleans(siloBuilder =>
+{
+    // Configure the silo and its providers.
+});
+
+var app = builder.Build();
+
+app.MapPost("/players/{id}/games/{gameId}",
+    async (Guid id, Guid gameId, IClusterClient client) =>
+    {
+        var player = client.GetGrain<IPlayerGrain>(id);
+        await player.JoinGame(gameId);
+        return Results.Accepted();
+    });
+
+await app.RunAsync();
 ```
 
-## External clients
+Calls from a co-hosted client use the silo's cluster knowledge and don't require a gateway. If the target activation is local, Orleans can also avoid a network hop.
 
-Client code can run outside the Orleans cluster where grain code is hosted. In this case, an external client acts as a connector or conduit to the cluster and all the application's grains. Typically, you use clients on frontend web servers to connect to an Orleans cluster serving as a middle tier, with grains executing business logic.
+## Use an external client
 
-In a typical setup, a frontend web server:
-
-- Receives a web request.
-- Performs necessary authentication and authorization validation.
-- Decides which grain(s) should process the request.
-- Uses the [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client) NuGet package to make one or more method calls to the grain(s).
-- Handles successful completion or failures of the grain calls and any returned values.
-- Sends a response to the web request.
-
-### Initialize a grain client
-
-Before you can use a grain client to make calls to grains hosted in an Orleans cluster, you need to configure, initialize, and connect it to the cluster.
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-Provide configuration via <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*> and several supplemental option classes containing a hierarchy of configuration properties for programmatically configuring a client. For more information, see [Client configuration](configuration-guide/client-configuration.md).
-
-Consider the following example of a client configuration:
-
-### [Microsoft Entra ID (recommended)](#tab/entra-id)
-
-Using a `TokenCredential` with a service URI is the recommended approach. This pattern avoids storing secrets in configuration and leverages Microsoft Entra ID for secure authentication.
-
-<xref:Azure.Identity.DefaultAzureCredential> provides a credential chain that works seamlessly across local development and production environments. During development, it uses your Azure CLI or Visual Studio credentials. In production on Azure, it automatically uses the managed identity assigned to your resource.
-
-[!INCLUDE [credential-chain-guidance](../includes/credential-chain-guidance.md)]
+Install [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client), then add the client to the Generic Host:
 
 ```csharp
-using Azure.Identity;
+var builder = WebApplication.CreateBuilder(args);
 
-var builder = Host.CreateApplicationBuilder(args);
 builder.UseOrleansClient(clientBuilder =>
 {
     clientBuilder.Configure<ClusterOptions>(options =>
     {
-        options.ClusterId = "my-first-cluster";
-        options.ServiceId = "MyOrleansService";
+        options.ServiceId = "game";
+        options.ClusterId = "game-production";
     });
 
-    clientBuilder.UseAzureStorageClustering(options =>
-    {
-        options.ConfigureTableServiceClient(
-            new Uri("https://<your-storage-account>.table.core.windows.net"),
-            new DefaultAzureCredential());
-    });
+    // Configure the same clustering provider used by the silos.
 });
 
-using var host = builder.Build();
-await host.StartAsync();
+var app = builder.Build();
+await app.RunAsync();
 ```
 
-### [Connection string](#tab/connection-string)
+The client connects during host startup and is available from dependency injection afterward. Register hosted services that use Orleans after `UseOrleansClient` so the host starts them after the client:
 
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleansClient(clientBuilder =>
-{
-    clientBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "my-first-cluster";
-        options.ServiceId = "MyOrleansService";
-    });
+:::code language="csharp" source="snippets/ClusterClientHostedService.cs":::
 
-    clientBuilder.UseAzureStorageClustering(
-        options => options.ConfigureTableServiceClient(connectionString));
-});
+See [Client configuration](configuration-guide/client-configuration.md) for clustering and gateway settings.
 
-using var host = builder.Build();
-await host.StartAsync();
-```
+## Connection resiliency
 
----
+Orleans includes a default connection retry filter. During initial startup it retries eligible connection failures with linear backoff, up to 15 retries. If those retries are exhausted, the host fails to start instead of appearing healthy without a cluster connection.
 
-When you start the `host`, the client is configured and available through its constructed service provider instance.
+You can replace the default with `UseConnectionRetryFilter` or an `IClientConnectionRetryFilter`. Custom policies should:
 
-:::zone-end
+- Retry only transient failures.
+- Apply a finite attempt or time limit.
+- Honor the supplied cancellation token.
+- Let startup fail when the cluster or configuration is persistently unavailable.
 
-:::zone target="docs" pivot="orleans-3-x"
+After startup, Orleans refreshes gateways and reconnects as cluster membership changes. A transient failure can still surface from an individual grain call. The grain reference remains valid, but retry the operation only if the application can safely tolerate duplicate execution.
 
-Provide configuration via <xref:Orleans.ClientBuilder> and several supplemental option classes containing a hierarchy of configuration properties for programmatically configuring a client. For more information, see [Client configuration](configuration-guide/client-configuration.md).
+## Make concurrent calls
 
-Example of a client configuration:
+External client code isn't governed by the grain turn-based concurrency model. Multiple threads can use `IClusterClient` and grain references concurrently. Protect mutable client-side state using normal .NET synchronization.
 
-:::code language="csharp" source="snippets-v3/client/ClientExamples.cs" id="client_config":::
+Grain calls return `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>` according to the grain interface. Always await calls rather than blocking threads.
 
-Finally, you need to call the `Connect()` method on the constructed client object to connect it to the Orleans cluster. It's an asynchronous method returning a <xref:System.Threading.Tasks.Task>, so you need to wait for its completion using `await` or `.Wait()`.
+## Receive messages from grains
 
-:::code language="csharp" source="snippets-v3/client/ClientExamples.cs" id="client_connect":::
+Use [grain observers](../grains/observers.md) for best-effort, one-way callbacks to client objects. Add application-level acknowledgement or recovery when delivery matters. Use [streams](../streaming/index.md) when the stream provider's subscription and delivery model better fits the workflow.
 
-:::zone-end
+## Client lifetime
 
-### Make calls to grains
-
-Making calls to grains from a client is no different from [making such calls from within grain code](../grains/index.md). Use the same <xref:Orleans.IGrainFactory.GetGrain``1(System.Type,System.Guid)?displayProperty=nameWithType> method (where `T` is the target grain interface) in both cases [to obtain grain references](../grains/grain-references.md). The difference lies in which factory object invokes <xref:Orleans.IGrainFactory.GetGrain*?displayProperty=nameWithType>. In client code, you do this through the connected client object, as the following example shows:
-
-```csharp
-IPlayerGrain player = client.GetGrain<IPlayerGrain>(playerId);
-Task joinGameTask = player.JoinGame(game)
-
-await joinGameTask;
-```
-
-A call to a grain method returns a <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.Task`1>, as required by the [grain interface rules](../grains/index.md). The client can use the `await` keyword to asynchronously await the returned <xref:System.Threading.Tasks.Task> without blocking the thread, or in some cases, use the `Wait()` method to block the current thread of execution.
-
-The major difference between making calls to grains from client code and from within another grain is the single-threaded execution model of grains. The Orleans runtime constrains grains to be single-threaded, while clients can be multi-threaded. Orleans doesn't provide any such guarantee on the client-side, so it's up to the client to manage its concurrency using appropriate synchronization constructs for its environment—locks, events, `Tasks`, etc.
-
-### Receive notifications
-
-Sometimes, a simple request-response pattern isn't sufficient, and the client needs to receive asynchronous notifications. For example, a user might want notification when someone they follow publishes a new message.
-
-Using [Observers](../grains/observers.md) is one mechanism enabling exposure of client-side objects as grain-like targets to be invoked by grains. Calls to observers don't provide any indication of success or failure, as they are sent as one-way, best-effort messages. Therefore, it's the responsibility of your application code to build a higher-level reliability mechanism on top of observers where necessary.
-
-Another mechanism for delivering asynchronous messages to clients is [Streams](../streaming/index.md). Streams expose indications of success or failure for individual message delivery, enabling reliable communication back to the client.
-
-### Client connectivity
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-There are two scenarios in which a cluster client can experience connectivity issues:
-
-- When the client attempts to connect to a silo.
-- When making calls on grain references obtained from a connected cluster client.
-
-In the first case, the client attempts to connect to a silo. If the client cannot connect to any silo, it throws an exception indicating what went wrong. You can register an <xref:Orleans.IClientConnectionRetryFilter> to handle the exception and decide whether to retry. If you provide no retry filter, or if the retry filter returns `false`, the client gives up permanently.
-
-:::code source="snippets/ClientConnectRetryFilter.cs":::
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-There are two scenarios in which a cluster client can experience connectivity issues:
-
-- When the <xref:Orleans.IClusterClient.Connect?displayProperty=nameWithType> method is called initially.
-- When making calls on grain references obtained from a connected cluster client.
-
-In the first case, the `Connect` method throws an exception indicating what went wrong. This is typically (but not necessarily) a <xref:Orleans.Runtime.SiloUnavailableException>. If this happens, the cluster client instance is unusable and should be disposed of. You can optionally provide a retry filter function to the `Connect` method, which could, for instance, wait for a specified duration before making another attempt. If you provide no retry filter, or if the retry filter returns `false`, the client gives up permanently.
-
-If `Connect` returns successfully, the cluster client is guaranteed to be usable until disposed. This means that even if the client experiences connection issues, it attempts to recover indefinitely. You can configure the exact recovery behavior on a <xref:Orleans.Configuration.GatewayOptions> object provided by the <xref:Orleans.ClientBuilder>, e.g.:
-
-:::code language="csharp" source="snippets-v3/client/ClientExamples.cs" id="gateway_options":::
-
-:::zone-end
-
-In the second case, where a connection issue occurs during a grain call, a <xref:Orleans.Runtime.SiloUnavailableException> is thrown on the client-side. You could handle this like so:
-
-:::code source="snippets/Program.cs" id="siloexc":::
-
-The grain reference isn't invalidated in this situation; you could retry the call on the same reference later when a connection might have been re-established.
-
-### Dependency injection
-
-The recommended way to create an external client in a program using the .NET Generic Host is to inject an <xref:Orleans.IClusterClient> singleton instance via dependency injection. This instance can then be accepted as a constructor parameter in hosted services, ASP.NET controllers, etc.
-
-> [!NOTE]
-> When co-hosting an Orleans silo in the same process that will be connecting to it, it is *not* necessary to manually create a client; Orleans will automatically provide one and manage its lifetime appropriately.
-
-When connecting to a cluster in a different process (on a different machine), a common pattern is to create a hosted service like this:
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-:::code source="snippets/ClusterClientHostedService.cs":::
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-:::code language="csharp" source="snippets-v3/client/ClusterClientHostedService.cs" id="cluster_client_hosted_service":::
-
-:::zone-end
-
-Register the service like this:
-
-```csharp
-await Host.CreateDefaultBuilder(args)
-    .UseOrleansClient(builder =>
-    {
-        builder.UseLocalhostClustering();
-    })
-    .ConfigureServices(services =>
-    {
-        services.AddHostedService<ClusterClientHostedService>();
-    })
-    .RunConsoleAsync();
-```
-
-### Example
-
-Here's an extended version of the previous example showing a client application that connects to Orleans, finds the player account, subscribes for updates to the game session the player is part of using an observer, and prints notifications until the program is manually terminated.
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-:::code source="snippets/ExampleExternalProgram.cs" id="program":::
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-:::code language="csharp" source="snippets-v3/client/ExternalClientExample.cs" id="external_client_example":::
-
-:::zone-end
+Let the Generic Host own client startup and shutdown. Don't create a client per request, cache a second client in a static field, or dispose the dependency-injected singleton. When the host receives a termination signal, it closes the client as part of normal shutdown.

--- a/docs/site/src/content/docs/host/client.md
+++ b/docs/site/src/content/docs/host/client.md
@@ -18,66 +18,36 @@ An Orleans client lets application code call grains, use streams, and access oth
 
 Start with a co-hosted client unless isolation is a requirement.
 
-## Use the co-hosted client
+## Co-hosted clients
 
-`UseOrleans` registers `IClusterClient` and `IGrainFactory` in the host service provider:
+<a id="obtain-a-client-from-a-host"></a>
 
-```csharp
-var builder = WebApplication.CreateBuilder(args);
+<xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> registers <xref:Orleans.IClusterClient> and <xref:Orleans.IGrainFactory> in the host service provider:
 
-builder.UseOrleans(siloBuilder =>
-{
-    // Configure the silo and its providers.
-});
-
-var app = builder.Build();
-
-app.MapPost("/players/{id}/games/{gameId}",
-    async (Guid id, Guid gameId, IClusterClient client) =>
-    {
-        var player = client.GetGrain<IPlayerGrain>(id);
-        await player.JoinGame(gameId);
-        return Results.Accepted();
-    });
-
-await app.RunAsync();
-```
+:::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="local_silo_and_client":::
 
 Calls from a co-hosted client use the silo's cluster knowledge and don't require a gateway. If the target activation is local, Orleans can also avoid a network hop.
 
-## Use an external client
+## External clients
 
-Install [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client), then add the client to the [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host):
+<a id="initialize-a-grain-client"></a>
+<a id="example"></a>
 
-```csharp
-var builder = WebApplication.CreateBuilder(args);
+Install [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client), then add the client to the [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) with <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*>:
 
-builder.UseOrleansClient(clientBuilder =>
-{
-    clientBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ServiceId = "game";
-        options.ClusterId = "game-production";
-    });
+:::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="external_client":::
 
-    // Configure the same clustering provider used by the silos.
-});
-
-var app = builder.Build();
-await app.RunAsync();
-```
-
-The client connects during host startup and is available from [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection) afterward. Register hosted services that use Orleans after `UseOrleansClient` so the host starts them after the client:
+The client connects during host startup and is available from [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection) afterward. Register hosted services that use Orleans after <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*> so the host starts them after the client:
 
 :::code language="csharp" source="snippets/ClusterClientHostedService.cs":::
 
 See [Client configuration](configuration-guide/client-configuration.md) for clustering and gateway settings.
 
-## Connection resiliency
+## Client connectivity
 
 Orleans includes a default connection retry filter. During initial startup it retries eligible connection failures with linear backoff, up to 15 retries. If those retries are exhausted, the host fails to start instead of appearing healthy without a cluster connection.
 
-You can replace the default with `UseConnectionRetryFilter` or an `IClientConnectionRetryFilter`. Custom policies should:
+You can replace the default with <xref:Orleans.Hosting.ClientBuilderExtensions.UseConnectionRetryFilter*> or <xref:Orleans.IClientConnectionRetryFilter>. Custom policies should:
 
 - Retry only transient failures.
 - Apply a finite attempt or time limit.
@@ -86,16 +56,16 @@ You can replace the default with `UseConnectionRetryFilter` or an `IClientConnec
 
 After startup, Orleans refreshes gateways and reconnects as cluster membership changes. A transient failure can still surface from an individual grain call. The grain reference remains valid, but retry the operation only if the application can safely tolerate duplicate execution.
 
-## Make concurrent calls
+## Make calls to grains
 
-External client code isn't governed by the grain turn-based concurrency model. Multiple threads can use `IClusterClient` and grain references concurrently. Protect mutable client-side state using normal .NET synchronization.
+External client code isn't governed by the grain turn-based concurrency model. Multiple threads can use <xref:Orleans.IClusterClient> and grain references concurrently. Protect mutable client-side state using normal .NET synchronization.
 
-Grain calls return `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>` according to the [grain interface rules](../grains/index.md#grain-interfaces-and-classes). Always await calls rather than blocking threads.
+Grain calls return <xref:System.Threading.Tasks.Task>, <xref:System.Threading.Tasks.Task`1>, <xref:System.Threading.Tasks.ValueTask>, or <xref:System.Threading.Tasks.ValueTask`1> according to the [grain interface rules](../grains/index.md#grain-interfaces-and-classes). Always await calls rather than blocking threads.
 
-## Receive messages from grains
+## Receive notifications
 
 Use [grain observers](../grains/observers.md) for best-effort, one-way callbacks to client objects. Add application-level acknowledgement or recovery when delivery matters. Use [streams](../streaming/index.md) when the stream provider's subscription and delivery model better fits the workflow.
 
-## Client lifetime
+## Dependency injection
 
 Let the Generic Host own client startup and shutdown. Don't create a client per request, cache a second client in a static field, or dispose the dependency-injected singleton. When the host receives a termination signal, it closes the client as part of normal shutdown.

--- a/docs/site/src/content/docs/host/client.md
+++ b/docs/site/src/content/docs/host/client.md
@@ -1,6 +1,6 @@
 ---
 title: Orleans clients
-description: Choose and host an Orleans 10 client.
+description: Choose and host an Orleans client.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---

--- a/docs/site/src/content/docs/host/client.md
+++ b/docs/site/src/content/docs/host/client.md
@@ -47,7 +47,7 @@ Calls from a co-hosted client use the silo's cluster knowledge and don't require
 
 ## Use an external client
 
-Install [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client), then add the client to the Generic Host:
+Install [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client), then add the client to the [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host):
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
@@ -67,7 +67,7 @@ var app = builder.Build();
 await app.RunAsync();
 ```
 
-The client connects during host startup and is available from dependency injection afterward. Register hosted services that use Orleans after `UseOrleansClient` so the host starts them after the client:
+The client connects during host startup and is available from [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection) afterward. Register hosted services that use Orleans after `UseOrleansClient` so the host starts them after the client:
 
 :::code language="csharp" source="snippets/ClusterClientHostedService.cs":::
 
@@ -90,7 +90,7 @@ After startup, Orleans refreshes gateways and reconnects as cluster membership c
 
 External client code isn't governed by the grain turn-based concurrency model. Multiple threads can use `IClusterClient` and grain references concurrently. Protect mutable client-side state using normal .NET synchronization.
 
-Grain calls return `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>` according to the grain interface. Always await calls rather than blocking threads.
+Grain calls return `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>` according to the [grain interface rules](../grains/index.md#grain-interfaces-and-classes). Always await calls rather than blocking threads.
 
 ## Receive messages from grains
 

--- a/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
@@ -1,216 +1,87 @@
 ---
-title: Activation collection
-description: Learn about activation collection in .NET Orleans.
-ms.date: 05/23/2025
+title: Activation collection and resource management
+description: Manage idle Orleans 10 activations and memory pressure.
+ms.date: 08/02/2026
 ms.topic: concept-article
-zone_pivot_groups: orleans-version
 ---
 
-# Activation collection
+# Activation collection and resource management
 
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-This article applies to: ✔️ Orleans 7.x and later versions
-:::zone-end
-:::zone target="docs" pivot="orleans-3-x"
-This article applies to: ✔️ Orleans 3.x and earlier versions
-:::zone-end
+A grain activation is the in-memory instance that currently represents a grain identity. Orleans creates activations on demand and deactivates idle ones so a silo doesn't retain every grain it has ever served.
 
-A *grain activation* is an in-memory instance of a grain class that the Orleans runtime automatically creates on an as-needed basis as a temporary physical embodiment of a grain.
+Activation collection is separate from .NET garbage collection. Orleans first deactivates the grain and removes runtime references; .NET GC can then reclaim the managed objects.
 
-Activation collection is the process of removing unused grain activations from memory. It's conceptually similar to how garbage collection works in .NET. However, activation collection only considers how long a particular grain activation has been idle. Memory usage isn't used as a factor.
+## Idle activation collection
 
-## How activation collection works
+An activation becomes eligible for collection after it has been idle for `GrainCollectionOptions.CollectionAge`. The default is 15 minutes. Orleans scans on the `CollectionQuantum`, which defaults to one minute, so deactivation isn't scheduled at an exact instant.
 
-The general process of activation collection involves the Orleans runtime in a silo periodically scanning for grain activations that haven't been used for the configured period (Collection Age Limit). Once a grain activation has been idle for that long, it gets deactivated. The deactivation process begins with the runtime calling the grain's <xref:Orleans.Grain.OnDeactivateAsync> method and completes by removing references to the grain activation object from all silo data structures, allowing the .NET GC to reclaim the memory.
+Incoming grain calls, reminders, and stream events count as activity. Outgoing calls and arbitrary application I/O don't keep an activation active for collection purposes. Timers don't keep an activation active by default, but a timer created with `GrainTimerCreationOptions.KeepAlive` resets activation idleness after each callback.
 
-As a result, without burdening your application code, only recently used grain activations stay in memory. Activations no longer in use are automatically removed, and the runtime reclaims the system resources they used.
+Configure a global age and targeted overrides:
 
-**What counts as "being active" for grain activation collection:**
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="activation_collection":::
 
-- Receiving a method call.
-- Receiving a reminder.
-- Receiving an event via streaming.
+Prefer type-specific changes over a cluster-wide increase. Longer ages trade memory for fewer activation and state-load operations.
 
-**What does NOT count as "being active" for grain activation collection:**
+## Request deactivation behavior
 
-- Performing a call (to another grain or an Orleans client).
-- Timer events.
-- Arbitrary I/O operations or external calls not involving the Orleans framework.
-
-**Collection age limit**
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-The time after which an idle grain activation becomes subject to collection is called the Collection Age Limit. The default Collection Age Limit is 15 minutes, but you can change it globally or for individual grain classes.
-:::zone-end
-:::zone target="docs" pivot="orleans-3-x"
-The time after which an idle grain activation becomes subject to collection is called the Collection Age Limit. The default Collection Age Limit is 2 hours, but you can change it globally or for individual grain classes.
-:::zone-end
-
-## Explicit control of activation collection
-
-### Delay activation collection
-
-A grain activation can delay its collection by calling the <xref:Orleans.Grain.DelayDeactivation*> method:
+Call `DeactivateOnIdle()` when the current activation should deactivate after its current turn:
 
 ```csharp
-protected void DelayDeactivation(TimeSpan timeSpan)
+this.DeactivateOnIdle();
 ```
 
-This call ensures this activation isn't deactivated for at least the specified time duration. It takes priority over activation collection settings specified in the configuration but doesn't cancel them. Therefore, this call provides another hook to **delay deactivation beyond what's specified in the activation collection settings**. You can't use this call to expedite activation collection.
+Queued calls are forwarded to a new or existing activation.
 
-A positive `timeSpan` value means "prevent collection of this activation for that time."
-
-A negative `timeSpan` value means "cancel the previous setting of the `DelayDeactivation` call and make this activation behave based on the regular activation collection settings."
-
-**Scenarios:**
-
-1. Activation collection settings specify an age limit of 10 minutes, and the grain calls `DelayDeactivation(TimeSpan.FromMinutes(20))`. This causes the activation not to be collected for at least 20 minutes.
-
-1. Activation collection settings specify an age limit of 10 minutes, and the grain calls `DelayDeactivation(TimeSpan.FromMinutes(5))`. The activation will be collected after 10 minutes if no further calls are made.
-
-1. Activation collection settings specify an age limit of 10 minutes, and the grain calls `DelayDeactivation(TimeSpan.FromMinutes(5))`. After 7 minutes, another call arrives for this grain. The activation will be collected after 17 minutes from time zero if no further calls are made.
-
-1. Activation collection settings specify an age limit of 10 minutes, and the grain calls `DelayDeactivation(TimeSpan.FromMinutes(20))`. After 7 minutes, another call arrives for this grain. The activation will be collected after 20 minutes from time zero if no further calls are made.
-
-`DelayDeactivation` doesn't 100% guarantee the grain activation won't be deactivated before the specified time expires. Certain failure cases might cause 'premature' deactivation of grains. This means `DelayDeactivation` **cannot be used as a means to 'pin' a grain activation in memory forever or to a specific silo**. `DelayDeactivation` is merely an optimization mechanism that can help reduce the aggregate cost of a grain being deactivated and reactivated over time. In most cases, you shouldn't need to use `DelayDeactivation` at all.
-
-### Expedite activation collection
-
-A grain activation can also instruct the runtime to deactivate it the next time it becomes idle by calling the <xref:Orleans.Grain.DeactivateOnIdle> method:
+Call `DelayDeactivation(duration)` to keep an activation from idle collection for at least a period:
 
 ```csharp
-protected void DeactivateOnIdle()
+this.DelayDeactivation(TimeSpan.FromMinutes(30));
 ```
 
-A grain activation is considered idle if it isn't processing any messages at the moment. If you call <xref:Orleans.GrainBaseExtensions.DeactivateOnIdle*> while a grain is processing a message, it deactivates as soon as the processing of the current message finishes. If any requests are queued for the grain, they'll be forwarded to the next activation.
+A negative duration cancels the previous delay. Delaying deactivation is an optimization, not a durability or placement guarantee. Failures, shutdown, migration, and resource pressure can still remove an activation.
 
-<xref:Orleans.GrainBaseExtensions.DeactivateOnIdle*> takes priority over any activation collection settings specified in the configuration or `DelayDeactivation`.
-
-> [!NOTE]
-> This setting only applies to the specific grain activation from which it was called; it doesn't apply to other activations of this grain type.
-
-## Configuration
-
-Configure activation collection using <xref:Orleans.Configuration.GrainCollectionOptions>:
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
+Apply `[KeepAlive]` to a grain implementation only when the activation should be exempt from normal idle collection:
 
 ```csharp
-siloBuilder.Configure<GrainCollectionOptions>(options =>
-{
-    // Set the value of CollectionAge to 10 minutes for all grain
-    options.CollectionAge = TimeSpan.FromMinutes(10);
-
-    // Override the value of CollectionAge to 5 minutes for MyGrainImplementation
-    options.ClassSpecificCollectionAge[typeof(MyGrainImplementation).FullName] =
-        TimeSpan.FromMinutes(5);
-});
-```
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-```csharp
-mySiloHostBuilder.Configure<GrainCollectionOptions>(options =>
-{
-    // Set the value of CollectionAge to 10 minutes for all grain
-    options.CollectionAge = TimeSpan.FromMinutes(10);
-
-    // Override the value of CollectionAge to 5 minutes for MyGrainImplementation
-    options.ClassSpecificCollectionAge[typeof(MyGrainImplementation).FullName] =
-        TimeSpan.FromMinutes(5);
-});
-```
-
-:::zone-end
-
-## Memory-based activation shedding
-
-Memory-based activation shedding automatically deactivates grain activations when memory pressure exceeds configured thresholds. This helps prevent out-of-memory conditions by proactively freeing memory when the silo is under memory pressure.
-
-When enabled, the silo monitors memory usage and begins collecting grain activations when memory usage exceeds the configured limit. Collection continues until memory usage falls below the target percentage.
-
-### Enable memory-based activation shedding
-
-Configure memory-based activation shedding using <xref:Orleans.Configuration.GrainCollectionOptions>:
-
-```csharp
-siloBuilder.Configure<GrainCollectionOptions>(options =>
-{
-    // Enable memory-based activation shedding
-    options.EnableActivationSheddingOnMemoryPressure = true;
-
-    // Trigger collection when memory usage exceeds 80% (default)
-    options.MemoryUsageLimitPercentage = 80;
-
-    // Stop collection when memory usage drops below 75% (default)
-    options.MemoryUsageTargetPercentage = 75;
-
-    // Poll memory usage every 5 seconds (default)
-    options.MemoryUsagePollingPeriod = TimeSpan.FromSeconds(5);
-});
-```
-
-### Configuration options
-
-The following table describes the memory-based activation shedding configuration options:
-
-| Property | Default | Description |
-|----------|---------|-------------|
-| `EnableActivationSheddingOnMemoryPressure` | `false` | When `true`, enables automatic grain deactivation when memory pressure exceeds the configured limit. |
-| `MemoryUsageLimitPercentage` | `80` | The memory usage percentage (0–100) at which grain collection is triggered. Must be greater than 0 and less than or equal to 100. |
-| `MemoryUsageTargetPercentage` | `75` | The target memory usage percentage (0–100) to reach after grain collection. Must be greater than 0, less than or equal to 100, and less than `MemoryUsageLimitPercentage`. |
-| `MemoryUsagePollingPeriod` | `5 seconds` | The interval at which memory usage is polled. |
-
-### How it works
-
-When memory-based activation shedding is enabled:
-
-1. The silo periodically polls memory usage at the configured interval.
-2. When memory usage exceeds `MemoryUsageLimitPercentage`, the silo begins deactivating idle grain activations.
-3. Grains are deactivated starting with the least recently used activations.
-4. Collection continues until memory usage drops below `MemoryUsageTargetPercentage`.
-5. The standard grain lifecycle methods (<xref:Orleans.Grain.OnDeactivateAsync*>) are called during deactivation.
-
-This feature works in conjunction with standard activation collection. Grains that have called `DelayDeactivation` or have the `[KeepAlive]` attribute are still respected, though they may be deactivated if memory pressure is severe enough.
-
-## Keep alive
-
-To keep a grain alive indefinitely, apply the <xref:Orleans.KeepAliveAttribute?displayProperty=fullName> to the grain implementation. The `KeepAlive` attribute instructs the Orleans runtime to avoid collecting the grain by the idle activation collector. Avoiding collection is useful for grains used infrequently but that you want to keep alive to avoid potential creation overhead upon the next invocation.
-
-```csharp
-public interface IPlayerGrain : IGrainWithGuidKey
-{
-    Task<IGameGrain> GetCurrentGame();
-    Task JoinGame(IGameGrain game);
-    Task LeaveGame(IGameGrain game);
-}
-
 [KeepAlive]
-public class PlayerGrain : Grain, IPlayerGrain
+public sealed class ReferenceDataGrain : Grain, IReferenceDataGrain
 {
-    private IGameGrain _currentGame;
-
-    public Task<IGameGrain> GetCurrentGame()
-    {
-       return Task.FromResult(_currentGame);
-    }
-
-    public Task JoinGame(IGameGrain game)
-    {
-       // Omitted for brevity.
-
-       return Task.CompletedTask;
-    }
-
-   public Task LeaveGame(IGameGrain game)
-   {
-       // Omitted for brevity.
-
-       return Task.CompletedTask;
-   }
+    // ...
 }
 ```
 
-The preceding code prevents the idle activation collector from collecting the `PlayerGrain`.
+Keep-alive activations still consume memory and aren't a substitute for durable state.
+
+## Memory-pressure activation shedding
+
+Orleans can shed activations when process memory exceeds a configured percentage:
+
+The defaults are:
+
+| Option | Default |
+|---|---:|
+| `EnableActivationSheddingOnMemoryPressure` | `false` |
+| `MemoryUsageLimitPercentage` | `80` |
+| `MemoryUsageTargetPercentage` | `75` |
+| `MemoryUsagePollingPeriod` | 5 seconds |
+
+When enabled, Orleans estimates how many activations to deactivate to move from the limit toward the target, prioritizing older activations. Memory pressure can override normal keep-alive timing because protecting the process is more important than preserving an optimization.
+
+Set container or process memory limits before tuning percentage thresholds. Leave enough space between target, limit, and the platform's hard limit for deactivation callbacks, state writes, and GC to complete.
+
+## Activation and deactivation timeouts
+
+`GrainCollectionOptions.ActivationTimeout` and `DeactivationTimeout` both default to 30 seconds. These are runtime safety bounds, not goals. Keep `OnActivateAsync`, `OnDeactivateAsync`, state access, and dependency calls cancellable and normally much faster.
+
+## Tune from measurements
+
+Track at least:
+
+- Activation count and activation/deactivation rate by grain type.
+- State-load and state-write latency.
+- Process working set, managed heap size, and allocation rate.
+- Time in GC and pause duration.
+- Memory-pressure shedding events and deactivation failures.
+
+If activation churn is high but memory is healthy, increase the age for the affected type. If memory stays high, reduce retained application state, shorten selected ages, scale out, or enable memory-pressure shedding. Configure [server GC](configuring-garbage-collection.md) for the silo process.

--- a/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
@@ -11,11 +11,13 @@ A grain activation is the in-memory instance that currently represents a grain i
 
 Activation collection is separate from .NET garbage collection. Orleans first deactivates the grain and removes runtime references; .NET GC can then reclaim the managed objects.
 
-## Idle activation collection
+## How activation collection works
 
-An activation becomes eligible for collection after it has been idle for `GrainCollectionOptions.CollectionAge`. The default is 15 minutes. Orleans scans on the `CollectionQuantum`, which defaults to one minute, so deactivation isn't scheduled at an exact instant.
+An activation becomes eligible for collection after it has been idle for <xref:Orleans.Configuration.GrainCollectionOptions.CollectionAge>. The default is 15 minutes. Orleans scans on <xref:Orleans.Configuration.GrainCollectionOptions.CollectionQuantum>, which defaults to one minute, so deactivation isn't scheduled at an exact instant.
 
-Incoming grain calls, reminders, and stream events count as activity. Outgoing calls and arbitrary application I/O don't keep an activation active for collection purposes. Timers don't keep an activation active by default, but a timer created with `GrainTimerCreationOptions.KeepAlive` resets activation idleness after each callback.
+Incoming grain calls, reminders, and stream events count as activity. Outgoing calls and arbitrary application I/O don't keep an activation active for collection purposes. Timers don't keep an activation active by default, but a timer created with <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive> resets activation idleness after each callback.
+
+## Configuration
 
 Configure a global age and targeted overrides:
 
@@ -23,48 +25,50 @@ Configure a global age and targeted overrides:
 
 Prefer type-specific changes over a cluster-wide increase. Longer ages trade memory for fewer activation and state-load operations.
 
-## Request deactivation behavior
+## Explicit control of activation collection
 
-Call `DeactivateOnIdle()` when the current activation should deactivate after its current turn:
+### Expedite activation collection
 
-```csharp
-this.DeactivateOnIdle();
-```
+Call <xref:Orleans.Grain.DeactivateOnIdle*> when the current activation should deactivate after its current turn:
+
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="deactivate_on_idle":::
 
 Queued calls are forwarded to a new or existing activation.
 
-Call `DelayDeactivation(duration)` to keep an activation from idle collection for at least a period:
+### Delay activation collection
 
-```csharp
-this.DelayDeactivation(TimeSpan.FromMinutes(30));
-```
+Call <xref:Orleans.Grain.DelayDeactivation*> to keep an activation from idle collection for at least a period:
+
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="delay_deactivation":::
 
 A negative duration cancels the previous delay. Delaying deactivation is an optimization, not a durability or placement guarantee. Failures, shutdown, migration, and resource pressure can still remove an activation.
 
-Apply `[KeepAlive]` to a grain implementation only when the activation should be exempt from normal idle collection:
+### Keep alive
 
-```csharp
-[KeepAlive]
-public sealed class ReferenceDataGrain : Grain, IReferenceDataGrain
-{
-    // ...
-}
-```
+Apply <xref:Orleans.KeepAliveAttribute> to a grain implementation only when the activation should be exempt from normal idle collection:
+
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="keep_alive_grain":::
 
 Keep-alive activations still consume memory and aren't a substitute for durable state.
 
-## Memory-pressure activation shedding
+## Memory-based activation shedding
+
+<a id="enable-memory-based-activation-shedding"></a>
 
 Orleans can shed activations when process memory exceeds a configured percentage:
 
 The defaults are:
 
+### Configuration options
+
 | Option | Default |
 |---|---:|
-| `EnableActivationSheddingOnMemoryPressure` | `false` |
-| `MemoryUsageLimitPercentage` | `80` |
-| `MemoryUsageTargetPercentage` | `75` |
-| `MemoryUsagePollingPeriod` | 5 seconds |
+| <xref:Orleans.Configuration.GrainCollectionOptions.EnableActivationSheddingOnMemoryPressure> | `false` |
+| <xref:Orleans.Configuration.GrainCollectionOptions.MemoryUsageLimitPercentage> | `80` |
+| <xref:Orleans.Configuration.GrainCollectionOptions.MemoryUsageTargetPercentage> | `75` |
+| <xref:Orleans.Configuration.GrainCollectionOptions.MemoryUsagePollingPeriod> | 5 seconds |
+
+### How it works
 
 When enabled, Orleans estimates how many activations to deactivate to move from the limit toward the target, prioritizing older activations. Memory pressure can override normal keep-alive timing because protecting the process is more important than preserving an optimization.
 
@@ -72,7 +76,7 @@ Set container or process memory limits before tuning percentage thresholds. Leav
 
 ## Activation and deactivation timeouts
 
-`GrainCollectionOptions.ActivationTimeout` and `DeactivationTimeout` both default to 30 seconds. These are runtime safety bounds, not goals. Keep `OnActivateAsync`, `OnDeactivateAsync`, state access, and dependency calls cancellable and normally much faster.
+<xref:Orleans.Configuration.GrainCollectionOptions.ActivationTimeout> and <xref:Orleans.Configuration.GrainCollectionOptions.DeactivationTimeout> both default to 30 seconds. These are runtime safety bounds, not goals. Keep <xref:Orleans.Grain.OnActivateAsync*> and <xref:Orleans.Grain.OnDeactivateAsync*>, state access, and dependency calls cancellable and normally much faster.
 
 ## Tune from measurements
 

--- a/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/activation-collection.md
@@ -1,6 +1,6 @@
 ---
 title: Activation collection and resource management
-description: Manage idle Orleans 10 activations and memory pressure.
+description: Manage idle Orleans activations and memory pressure.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---

--- a/docs/site/src/content/docs/host/configuration-guide/adonet-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/adonet-configuration.md
@@ -1,48 +1,70 @@
 ---
 title: ADO.NET database configuration
-description: Learn about ADO.NET database configurations in .NET Orleans.
-ms.date: 05/23/2025
-ms.topic: how-to
+description: Find Orleans 10 ADO.NET schema scripts and provider invariants.
+ms.date: 08/02/2026
+ms.topic: reference
 ---
 
 # ADO.NET database configuration
 
-The following sections contain links to SQL scripts for configuring your database and the corresponding ADO.NET invariant used to configure ADO.NET providers in Orleans. Customize these scripts as needed for your deployment. Before executing scripts for Clustering, Persistence, or Reminders, you need to create the main tables using the Main scripts.
+Orleans keeps its current ADO.NET schema scripts beside each provider's source. Run the main script before the capability scripts. Use scripts from the same Orleans release as the packages deployed by the application.
+
+## Driver invariants
+
+| Database | Driver package | Orleans invariant |
+|---|---|---|
+| SQL Server | [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient/) | `Microsoft.Data.SqlClient` |
+| PostgreSQL | [Npgsql](https://www.nuget.org/packages/Npgsql/) | `Npgsql` |
+| MySQL/MariaDB | [MySql.Data](https://www.nuget.org/packages/MySql.Data/) | `MySql.Data.MySqlClient` |
+| Oracle | [Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) | `Oracle.DataAccess.Client` |
+
+> [!IMPORTANT]
+> Orleans 10 uses `Microsoft.Data.SqlClient`, not `System.Data.SqlClient`, for SQL Server.
 
 ## Main scripts
 
-| Database | Script | NuGet package| ADO.NET invariant |
-|--|--|--|--|
-| SQL Server | [SQLServer-Main.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/SQLServer-Main.sql) | [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) | `System.Data.SqlClient` |
-| MySQL / MariaDB | [MySQL-Main.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/MySQL-Main.sql) | [MySql.Data](https://www.nuget.org/packages/MySql.Data/) | `MySql.Data.MySqlClient` |
-| PostgreSQL | [PostgreSQL-Main.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/PostgreSQL-Main.sql) | [Npgsql](https://www.nuget.org/packages/Npgsql/) | `Npgsql` |
-| Oracle | [Oracle-Main.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/Oracle-Main.sql) | [ODP.net](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) | `Oracle.DataAccess.Client` |
+- [SQL Server](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/SQLServer-Main.sql)
+- [PostgreSQL](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/PostgreSQL-Main.sql)
+- [MySQL/MariaDB](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/MySQL-Main.sql)
+- [Oracle](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/Oracle-Main.sql)
+- [SQLite](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/Sqlite-Main.sql) for supported local persistence scenarios
 
-## Clustering
+## Clustering scripts
 
-| Database | Script | NuGet package| ADO.NET invariant |
-|--|--|--|--|
-| SQL Server | [SQLServer-Clustering.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql) | [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) | `System.Data.SqlClient` |
-| MySQL / MariaDB | [MySQL-Clustering.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/MySQL-Clustering.sql) | [MySql.Data](https://www.nuget.org/packages/MySql.Data/) | `MySql.Data.MySqlClient` |
-| PostgreSQL | [PostgreSQL-Clustering.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/PostgreSQL-Clustering.sql) | [Npgsql](https://www.nuget.org/packages/Npgsql/) | `Npgsql` |
-| Oracle | [Oracle-Clustering.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/Oracle-Clustering.sql) | [ODP.net](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) | `Oracle.DataAccess.Client` |
+- [SQL Server](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql)
+- [PostgreSQL](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/PostgreSQL-Clustering.sql)
+- [MySQL/MariaDB](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/MySQL-Clustering.sql)
+- [Oracle](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/Oracle-Clustering.sql)
 
-## Persistence
+## Grain storage scripts
 
-| Database | Script | NuGet package| ADO.NET invariant |
-|--|--|--|--|
-| SQL Server* | [SQLServer-Persistence.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql) | [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) | `System.Data.SqlClient` |
-| MySQL / MariaDB | [MySQL-Persistence.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/MySQL-Persistence.sql) | [MySql.Data](https://www.nuget.org/packages/MySql.Data/) | `MySql.Data.MySqlClient` |
-| PostgreSQL | [PostgreSQL-Persistence.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/PostgreSQL-Persistence.sql) | [Npgsql](https://www.nuget.org/packages/Npgsql/) | `Npgsql` |
-| Oracle | [Oracle-Persistence.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/Oracle-Persistence.sql) | [ODP.net](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) | `Oracle.DataAccess.Client` |
+- [SQL Server](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql)
+- [PostgreSQL](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/PostgreSQL-Persistence.sql)
+- [MySQL/MariaDB](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/MySQL-Persistence.sql)
+- [Oracle](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/Oracle-Persistence.sql)
+- [SQLite](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/Sqlite-Persistence.sql)
 
-\* If you're using Orleans v3.x use this script template: <https://github.com/dotnet/orleans/blob/3.x/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql>
+## Reminder scripts
 
-## Reminders
+- [SQL Server](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Reminders.AdoNet/SQLServer-Reminders.sql)
+- [PostgreSQL](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Reminders.AdoNet/PostgreSQL-Reminders.sql)
+- [MySQL/MariaDB](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Reminders.AdoNet/MySQL-Reminders.sql)
+- [Oracle](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Reminders.AdoNet/Oracle-Reminders.sql)
 
-| Database | Script | NuGet package| ADO.NET invariant |
-|--|--|--|--|
-| SQL Server | [SQLServer-Reminders.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Reminders.AdoNet/SQLServer-Reminders.sql) | [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient/) | `System.Data.SqlClient` |
-| MySQL / MariaDB | [MySQL-Reminders.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Reminders.AdoNet/MySQL-Reminders.sql) | [MySql.Data](https://www.nuget.org/packages/MySql.Data/) | `MySql.Data.MySqlClient` |
-| PostgreSQL | [PostgreSQL-Reminders.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Reminders.AdoNet/PostgreSQL-Reminders.sql) | [Npgsql](https://www.nuget.org/packages/Npgsql/) | `Npgsql` |
-| Oracle | [Oracle-Reminders.sql](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Reminders.AdoNet/Oracle-Reminders.sql) | [ODP.net](https://www.nuget.org/packages/Oracle.ManagedDataAccess/) | `Oracle.DataAccess.Client` |
+## Grain directory scripts
+
+- [SQL Server](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.GrainDirectory.AdoNet/SQLServer-GrainDirectory.sql)
+- [PostgreSQL](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.GrainDirectory.AdoNet/PostgreSQL-GrainDirectory.sql)
+- [MySQL/MariaDB](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.GrainDirectory.AdoNet/MySQL-GrainDirectory.sql)
+
+Not every capability supports every database. The presence of a script in the provider directory is the authoritative support signal for that Orleans release.
+
+## Apply and upgrade schemas
+
+1. Back up application data according to the database recovery policy.
+2. Apply the main script for a new database.
+3. Apply the script for each configured Orleans capability.
+4. Review and apply scripts under the provider's `Migrations` directory when upgrading from an older schema.
+5. Validate with a staging cluster using the same driver and database engine version.
+
+See [Configure ADO.NET providers](configuring-ado-dot-net-providers.md) for host configuration.

--- a/docs/site/src/content/docs/host/configuration-guide/adonet-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/adonet-configuration.md
@@ -29,14 +29,14 @@ Orleans keeps its ADO.NET schema scripts beside each provider's source. Run the 
 - [Oracle](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/Oracle-Main.sql)
 - [SQLite](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Shared/Sqlite-Main.sql) for supported local persistence scenarios
 
-## Clustering scripts
+## Clustering
 
 - [SQL Server](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql)
 - [PostgreSQL](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/PostgreSQL-Clustering.sql)
 - [MySQL/MariaDB](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/MySQL-Clustering.sql)
 - [Oracle](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Clustering.AdoNet/Oracle-Clustering.sql)
 
-## Grain storage scripts
+## Persistence
 
 - [SQL Server](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql)
 - [PostgreSQL](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/PostgreSQL-Persistence.sql)
@@ -44,7 +44,7 @@ Orleans keeps its ADO.NET schema scripts beside each provider's source. Run the 
 - [Oracle](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/Oracle-Persistence.sql)
 - [SQLite](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Persistence.AdoNet/Sqlite-Persistence.sql)
 
-## Reminder scripts
+## Reminders
 
 - [SQL Server](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Reminders.AdoNet/SQLServer-Reminders.sql)
 - [PostgreSQL](https://github.com/dotnet/orleans/blob/main/src/AdoNet/Orleans.Reminders.AdoNet/PostgreSQL-Reminders.sql)

--- a/docs/site/src/content/docs/host/configuration-guide/adonet-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/adonet-configuration.md
@@ -1,13 +1,13 @@
 ---
 title: ADO.NET database configuration
-description: Find Orleans 10 ADO.NET schema scripts and provider invariants.
+description: Find Orleans ADO.NET schema scripts and provider invariants.
 ms.date: 08/02/2026
 ms.topic: reference
 ---
 
 # ADO.NET database configuration
 
-Orleans keeps its current ADO.NET schema scripts beside each provider's source. Run the main script before the capability scripts. Use scripts from the same Orleans release as the packages deployed by the application.
+Orleans keeps its ADO.NET schema scripts beside each provider's source. Run the main script before the capability scripts. Use scripts from the same Orleans release as the packages deployed by the application.
 
 ## Driver invariants
 
@@ -19,7 +19,7 @@ Orleans keeps its current ADO.NET schema scripts beside each provider's source. 
 | Oracle | [Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/) | `Oracle.DataAccess.Client` |
 
 > [!IMPORTANT]
-> Orleans 10 uses `Microsoft.Data.SqlClient`, not `System.Data.SqlClient`, for SQL Server.
+> Use `Microsoft.Data.SqlClient`, not `System.Data.SqlClient`, for SQL Server.
 
 ## Main scripts
 

--- a/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
@@ -1,170 +1,47 @@
 ---
 title: Client configuration
-description: Learn about client configurations in .NET Orleans.
-ms.date: 01/21/2026
+description: Configure an Orleans 10 external client.
+ms.date: 08/02/2026
 ms.topic: how-to
-zone_pivot_groups: orleans-version
-ms.custom: sfi-ropc-nochange
 ---
 
 # Client configuration
 
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
+An external client runs outside a silo process and reaches the cluster through silo gateways. Install [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client), call `UseOrleansClient`, and configure the same cluster identity and clustering provider as the silos:
 
-Configure a client for connecting to a cluster of silos and sending requests to grains programmatically via an <xref:Microsoft.Extensions.Hosting.IHostBuilder> and several supplemental option classes. Like silo options, client option classes follow the [Options pattern in .NET](../../../core/extensions/options.md).
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="external_client":::
 
-:::zone-end
+The host starts Orleans before later registered hosted services and stops it with the rest of the application. Resolve `IClusterClient` or `IGrainFactory` from dependency injection; don't build a second client singleton manually.
 
-:::zone target="docs" pivot="orleans-3-x"
+## Required settings
 
-Configure a client for connecting to a cluster of silos and sending requests to grains programmatically via an <xref:Orleans.ClientBuilder> and several supplemental option classes. Like silo options, client option classes follow the [Options pattern in .NET](../../../core/extensions/options.md).
+- `ServiceId` identifies the logical Orleans application and should remain stable.
+- `ClusterId` identifies one deployment of that service. Use a different value to isolate environments or parallel deployments.
+- The client clustering provider discovers gateway-enabled silos. Its settings must point to the same membership data as the silos.
 
-:::zone-end
+Common production clustering packages include Azure Table Storage, ADO.NET, Redis, Azure Cosmos DB, DynamoDB, Consul, and ZooKeeper. Static and localhost clustering are intended for development. Kubernetes hosting is a silo integration, not a client clustering provider.
 
-> [!TIP]
-> If you just want to start a local silo and a local client for development purposes, see [Local development configuration](local-development-configuration.md).
-
-:::zone target="docs" pivot="orleans-8-0,orleans-9-0,orleans-10-0"
-
-> [!TIP]
-> If you're using [Aspire](../aspire-integration.md), client configuration is handled automatically. Aspire injects <xref:Orleans.Configuration.ClusterOptions.ClusterId>, <xref:Orleans.Configuration.ClusterOptions.ServiceId>, and clustering provider settings via environment variables, so you can use the simpler parameterless <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*> method. See [Orleans and Aspire integration](../aspire-integration.md) for the recommended approach.
-
-:::zone-end
-
-Add the [Microsoft.Orleans.Clustering.AzureStorage](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.AzureStorage) NuGet package to your client project.
-
-There are several key aspects of client configuration:
-
-- Orleans clustering information
-- Clustering provider
-- Application parts
-
-Example of a client configuration:
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-### [Microsoft Entra ID (recommended)](#tab/entra-id)
-
-Using a `TokenCredential` with a service URI is the recommended approach. This pattern avoids storing secrets in configuration and leverages Microsoft Entra ID for secure authentication.
-
-<xref:Azure.Identity.DefaultAzureCredential> provides a credential chain that works seamlessly across local development and production environments. During development, it uses your Azure CLI or Visual Studio credentials. In production on Azure, it automatically uses the managed identity assigned to your resource.
-
-[!INCLUDE [credential-chain-guidance](../../includes/credential-chain-guidance.md)]
+When Aspire supplies the Orleans resource, register the corresponding keyed service client and use the parameterless form:
 
 ```csharp
-using Azure.Identity;
-
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleansClient(clientBuilder =>
-{
-    clientBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "my-first-cluster";
-        options.ServiceId = "MyOrleansService";
-    })
-    .UseAzureStorageClustering(options =>
-    {
-        options.ConfigureTableServiceClient(
-            new Uri("https://<your-storage-account>.table.core.windows.net"),
-            new DefaultAzureCredential());
-    });
-});
-
-using var host = builder.Build();
-await host.StartAsync();
+builder.AddKeyedRedisClient("orleans-redis");
+builder.UseOrleansClient();
 ```
 
-### [Connection string](#tab/connection-string)
+## Connection resiliency
 
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleansClient(clientBuilder =>
-{
-    clientBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "my-first-cluster";
-        options.ServiceId = "MyOrleansService";
-    })
-    .UseAzureStorageClustering(
-        options => options.ConfigureTableServiceClient(
-            builder.Configuration["ORLEANS_AZURE_STORAGE_CONNECTION_STRING"]));
-});
+Orleans registers a default `IClientConnectionRetryFilter`. It retries eligible initial connection failures with linear backoff, up to 15 retries. Host startup fails if the client still can't connect, the host is stopping, or the failure isn't considered retryable.
 
-using var host = builder.Build();
-await host.StartAsync();
-```
+Override the policy only when the application has different startup requirements:
 
----
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="client_retry":::
 
-:::zone-end
+Bound every custom retry policy and honor the cancellation token so deployments can fail fast and shutdown isn't delayed indefinitely.
 
-:::zone target="docs" pivot="orleans-3-x"
+Initial connection retries don't make grain calls idempotent. A call can fail after the target started processing it, so retry application operations only when their semantics tolerate duplicates. Grain references remain usable after transient connectivity failures.
 
-:::code language="csharp" source="snippets-v3/client-config/Configuration.cs" id="full_client_config":::
+## Gateway behavior
 
-:::zone-end
+Configure gateway refresh and connection behavior through <xref:Orleans.Configuration.GatewayOptions> or `Orleans:Gateway`. Orleans refreshes the gateway list from the clustering provider and reconnects as gateways become unavailable. Expose gateway endpoints only to client networks that require them; silo-to-silo traffic uses a separate endpoint.
 
-Let's break down the steps used in this sample:
-
-## Orleans clustering information
-
-```csharp
-    .Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "orleans-docker";
-        options.ServiceId = "AspNetSampleApp";
-    })
-```
-
-Here, we set two things:
-
-- The <xref:Orleans.Configuration.ClusterOptions.ClusterId?displayProperty=nameWithType> to `"my-first-cluster"`: This is a unique ID for the Orleans cluster. All clients and silos using this ID can directly talk to each other. Some might choose to use a different <xref:Orleans.Configuration.ClusterOptions.ClusterId> for each deployment, for example.
-- The <xref:Orleans.Configuration.ClusterOptions.ServiceId?displayProperty=nameWithType> to `"AspNetSampleApp"`: This is a unique ID for your application, used by some providers (e.g., persistence providers). This ID should remain stable across deployments.
-
-## Clustering provider
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-### [Microsoft Entra ID (recommended)](#tab/entra-id)
-
-[!INCLUDE [credential-chain-guidance](../../includes/credential-chain-guidance.md)]
-
-```csharp
-clientBuilder.UseAzureStorageClustering(options =>
-{
-    options.ConfigureTableServiceClient(
-        new Uri("https://<your-storage-account>.table.core.windows.net"),
-        new DefaultAzureCredential());
-});
-```
-
-### [Connection string](#tab/connection-string)
-
-```csharp
-.UseAzureStorageClustering(
-    options => options.ConfigureTableServiceClient(connectionString));
-```
-
----
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-:::code language="csharp" source="snippets-v3/client-config/Configuration.cs" id="azure_clustering":::
-
-:::zone-end
-
-The client discovers all available gateways in the cluster using this provider. Several providers are available; here, we use the Azure Table provider.
-
-For more information, see [Server configuration](server-configuration.md).
-
-:::zone target="docs" pivot="orleans-3-x"
-
-## Application parts
-
-:::code language="csharp" source="snippets-v3/client-config/Configuration.cs" id="application_parts":::
-
-For more information, see [Server configuration](server-configuration.md).
-
-:::zone-end
+For a co-hosted client, use `UseOrleans` instead. The silo's client communicates directly with the cluster and doesn't require a gateway hop.

--- a/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
@@ -7,30 +7,29 @@ ms.topic: how-to
 
 # Client configuration
 
-An external client runs outside a silo process and reaches the cluster through silo gateways. Install [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client), call `UseOrleansClient`, and configure the same cluster identity and clustering provider as the silos:
+An external client runs outside a silo process and reaches the cluster through silo gateways. Install [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client), call <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*>, and configure the same cluster identity and clustering provider as the silos:
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="external_client":::
 
-Client settings participate in the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options). The host starts Orleans before later registered hosted services and stops it with the rest of the application. Resolve `IClusterClient` or `IGrainFactory` from [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection); don't build a second client singleton manually.
+Client settings participate in the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options). The host starts Orleans before later registered hosted services and stops it with the rest of the application. Resolve <xref:Orleans.IClusterClient> or <xref:Orleans.IGrainFactory> from [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection); don't build a second client singleton manually.
 
-## Required settings
+## Orleans clustering information
 
-- `ServiceId` identifies the logical Orleans application and should remain stable.
-- `ClusterId` identifies one deployment of that service. Use a different value to isolate environments or parallel deployments.
+- <xref:Orleans.Configuration.ClusterOptions.ServiceId> identifies the logical Orleans application and should remain stable.
+- <xref:Orleans.Configuration.ClusterOptions.ClusterId> identifies one deployment of that service. Use a different value to isolate environments or parallel deployments.
 - The client clustering provider discovers gateway-enabled silos. Its settings must point to the same membership data as the silos.
 
-Common production [clustering packages](server-configuration.md#choose-a-clustering-provider) include Azure Table Storage, ADO.NET, Redis, Azure Cosmos DB, DynamoDB, Consul, and ZooKeeper. Static and localhost clustering are intended for development. Kubernetes hosting is a silo integration, not a client clustering provider.
+### Clustering provider
+
+Common production [clustering packages](server-configuration.md#clustering-provider) include Azure Table Storage, ADO.NET, Redis, Azure Cosmos DB, DynamoDB, Consul, and ZooKeeper. Static and localhost clustering are intended for development. Kubernetes hosting is a silo integration, not a client clustering provider.
 
 When Aspire supplies the Orleans resource, register the corresponding keyed service client and use the parameterless form:
 
-```csharp
-builder.AddKeyedRedisClient("orleans-redis");
-builder.UseOrleansClient();
-```
+:::code language="csharp" source="../snippets/aspire/Client/ClientProgram.cs" id="client_basic_config":::
 
 ## Connection resiliency
 
-Orleans registers a default `IClientConnectionRetryFilter`. It retries eligible initial connection failures with linear backoff, up to 15 retries. Host startup fails if the client still can't connect, the host is stopping, or the failure isn't considered retryable.
+Orleans registers a default <xref:Orleans.IClientConnectionRetryFilter>. It retries eligible initial connection failures with linear backoff, up to 15 retries. Host startup fails if the client still can't connect, the host is stopping, or the failure isn't considered retryable.
 
 Override the policy only when the application has different startup requirements:
 
@@ -44,4 +43,4 @@ Initial connection retries don't make grain calls idempotent. A call can fail af
 
 Configure gateway refresh and connection behavior through <xref:Orleans.Configuration.GatewayOptions> or `Orleans:Gateway`. Orleans refreshes the gateway list from the clustering provider and reconnects as gateways become unavailable. Expose gateway endpoints only to client networks that require them; silo-to-silo traffic uses a separate endpoint.
 
-For a co-hosted client, use `UseOrleans` instead. The silo's client communicates directly with the cluster and doesn't require a gateway hop.
+For a co-hosted client, use <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> instead. The silo's client communicates directly with the cluster and doesn't require a gateway hop.

--- a/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
@@ -11,7 +11,7 @@ An external client runs outside a silo process and reaches the cluster through s
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="external_client":::
 
-The host starts Orleans before later registered hosted services and stops it with the rest of the application. Resolve `IClusterClient` or `IGrainFactory` from dependency injection; don't build a second client singleton manually.
+Client settings participate in the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options). The host starts Orleans before later registered hosted services and stops it with the rest of the application. Resolve `IClusterClient` or `IGrainFactory` from [.NET dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection); don't build a second client singleton manually.
 
 ## Required settings
 
@@ -19,7 +19,7 @@ The host starts Orleans before later registered hosted services and stops it wit
 - `ClusterId` identifies one deployment of that service. Use a different value to isolate environments or parallel deployments.
 - The client clustering provider discovers gateway-enabled silos. Its settings must point to the same membership data as the silos.
 
-Common production clustering packages include Azure Table Storage, ADO.NET, Redis, Azure Cosmos DB, DynamoDB, Consul, and ZooKeeper. Static and localhost clustering are intended for development. Kubernetes hosting is a silo integration, not a client clustering provider.
+Common production [clustering packages](server-configuration.md#choose-a-clustering-provider) include Azure Table Storage, ADO.NET, Redis, Azure Cosmos DB, DynamoDB, Consul, and ZooKeeper. Static and localhost clustering are intended for development. Kubernetes hosting is a silo integration, not a client clustering provider.
 
 When Aspire supplies the Orleans resource, register the corresponding keyed service client and use the parameterless form:
 

--- a/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/client-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Client configuration
-description: Configure an Orleans 10 external client.
+description: Configure an Orleans external client.
 ms.date: 08/02/2026
 ms.topic: how-to
 ---

--- a/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
+++ b/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
@@ -38,16 +38,7 @@ Use `Microsoft.Data.SqlClient` for SQL Server:
 
 Configure an external client with the same clustering database:
 
-```csharp
-builder.UseOrleansClient(clientBuilder =>
-{
-    clientBuilder.UseAdoNetClustering(options =>
-    {
-        options.Invariant = "Microsoft.Data.SqlClient";
-        options.ConnectionString = connectionString;
-    });
-});
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="adonet_client":::
 
 > [!IMPORTANT]
 > `System.Data.SqlClient` isn't the SQL Server invariant. Reference the `Microsoft.Data.SqlClient` package and use the `Microsoft.Data.SqlClient` invariant.
@@ -99,7 +90,7 @@ Store connection strings in a secret provider or deployment environment, not in 
 
 ## Operational guidance
 
-- Keep `ServiceId` stable so Orleans reads the expected application rows.
+- Keep <xref:Orleans.Configuration.ClusterOptions.ServiceId> stable so Orleans reads the expected application rows.
 - Size connection pools for the total number of silo and client processes.
 - Encrypt connections and use least-privilege database identities.
 - Monitor database latency, throttling, deadlocks, and pool exhaustion.

--- a/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
+++ b/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
@@ -1,142 +1,109 @@
 ---
 title: Configure ADO.NET providers
-description: Learn how to configure ADO.NET providers in .NET Orleans.
-ms.date: 01/21/2026
+description: Configure Orleans 10 clustering, reminders, storage, and grain directories with ADO.NET.
+ms.date: 08/02/2026
 ms.topic: how-to
-zone_pivot_groups: orleans-version
 ---
 
 # Configure ADO.NET providers
 
-Any reliable deployment of Orleans requires persistent storage to keep system state, specifically the Orleans cluster membership table and reminders. One available option is using a SQL database via ADO.NET providers.
+Orleans ADO.NET providers use a relational database for one or more runtime capabilities:
 
-To use ADO.NET for persistence, clustering, or reminders, you need to configure the ADO.NET providers as part of the silo configuration and, for clustering, also as part of the client configurations.
+| Capability | Package | Configure on |
+|---|---|---|
+| Clustering | `Microsoft.Orleans.Clustering.AdoNet` | Silos and external clients |
+| Grain storage | `Microsoft.Orleans.Persistence.AdoNet` | Silos |
+| Reminders | `Microsoft.Orleans.Reminders.AdoNet` | Silos |
+| Grain directory | `Microsoft.Orleans.GrainDirectory.AdoNet` | Silos |
 
-:::zone pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
+Install only the packages for the capabilities the application uses. Also reference the database driver package.
 
-The silo configuration code should look like this:
+## Prepare the database
 
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
+Run the main script for the database first, followed by each capability script. For example, SQL Server clustering and persistence require:
 
-var invariant = "Microsoft.Data.SqlClient";
-var connectionString = "Data Source=(localdb)\\MSSQLLocalDB;" +
-    "Initial Catalog=Orleans;Integrated Security=True;" +
-    "Pooling=False;Max Pool Size=200;" +
-    "MultipleActiveResultSets=True";
+1. `src/AdoNet/Shared/SQLServer-Main.sql`
+2. `src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql`
+3. `src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql`
 
-builder.UseOrleans(siloBuilder =>
-{
-    // Use ADO.NET for clustering
-    siloBuilder.UseAdoNetClustering(options =>
-    {
-        options.Invariant = invariant;
-        options.ConnectionString = connectionString;
-    });
-    // Use ADO.NET for reminder service
-    siloBuilder.UseAdoNetReminderService(options =>
-    {
-        options.Invariant = invariant;
-        options.ConnectionString = connectionString;
-    });
-    // Use ADO.NET for persistence
-    siloBuilder.AddAdoNetGrainStorage("GrainStorageForTest", options =>
-    {
-        options.Invariant = invariant;
-        options.ConnectionString = connectionString;
-    });
-});
-```
+See [ADO.NET database configuration](adonet-configuration.md) for links to every current script and invariant.
 
-The client configuration code should look like this:
+Apply schema changes as a controlled deployment step. Don't grant silos schema-owner permissions solely so they can create tables at runtime.
+
+## Configure SQL Server
+
+Orleans 10 uses `Microsoft.Data.SqlClient` for SQL Server:
+
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="adonet_silo":::
+
+Configure an external client with the same clustering database:
 
 ```csharp
-var builder = Host.CreateApplicationBuilder(args);
-
-var invariant = "Microsoft.Data.SqlClient";
-var connectionString = "Data Source=(localdb)\\MSSQLLocalDB;" +
-    "Initial Catalog=Orleans;Integrated Security=True;" +
-    "Pooling=False;Max Pool Size=200;" +
-    "MultipleActiveResultSets=True";
-
 builder.UseOrleansClient(clientBuilder =>
 {
-    // Use ADO.NET for clustering
     clientBuilder.UseAdoNetClustering(options =>
     {
-        options.Invariant = invariant;
+        options.Invariant = "Microsoft.Data.SqlClient";
         options.ConnectionString = connectionString;
     });
 });
 ```
 
-> [!NOTE]
-> Starting with Orleans 10.0, use `Microsoft.Data.SqlClient` instead of `System.Data.SqlClient` for the ADO.NET invariant.
+> [!IMPORTANT]
+> `System.Data.SqlClient` isn't the SQL Server invariant for Orleans 10. Reference the `Microsoft.Data.SqlClient` package and use the `Microsoft.Data.SqlClient` invariant.
 
-:::zone-end
+## Configure another database
 
-:::zone pivot="orleans-3-x"
+The Orleans configuration shape is the same for PostgreSQL, MySQL/MariaDB, and Oracle. Change the driver package, invariant, connection string, and SQL scripts together:
 
-The silo configuration code should look like this:
+| Database | Driver package | Invariant |
+|---|---|---|
+| SQL Server | `Microsoft.Data.SqlClient` | `Microsoft.Data.SqlClient` |
+| PostgreSQL | `Npgsql` | `Npgsql` |
+| MySQL/MariaDB | `MySql.Data` | `MySql.Data.MySqlClient` |
+| Oracle | `Oracle.ManagedDataAccess.Core` | `Oracle.DataAccess.Client` |
 
-```csharp
-var siloHostBuilder = new SiloHostBuilder();
+Orleans also recognizes `MySqlConnector` for the MySqlConnector driver. Verify that the selected capability has a script for the chosen database.
 
-var invariant = "System.Data.SqlClient";
-var connectionString = "Data Source=(localdb)\\MSSQLLocalDB;" +
-    "Initial Catalog=Orleans;Integrated Security=True;" +
-    "Pooling=False;Max Pool Size=200;" +
-    "Asynchronous Processing=True;MultipleActiveResultSets=True";
+## Configure declaratively
 
-// Use ADO.NET for clustering
-siloHostBuilder.UseAdoNetClustering(options =>
+Installed ADO.NET provider packages register `AdoNet` for declarative configuration. For example:
+
+```json
 {
-    options.Invariant = invariant;
-    options.ConnectionString = connectionString;
-});
-// Use ADO.NET for reminder service
-siloHostBuilder.UseAdoNetReminderService(options =>
-{
-    options.Invariant = invariant;
-    options.ConnectionString = connectionString;
-});
-// Use ADO.NET for persistence
-siloHostBuilder.AddAdoNetGrainStorage("GrainStorageForTest", options =>
-{
-    options.Invariant = invariant;
-    options.ConnectionString = connectionString;
-});
+  "Orleans": {
+    "ServiceId": "orders",
+    "ClusterId": "orders-production",
+    "Clustering": {
+      "ProviderType": "AdoNet",
+      "Invariant": "Microsoft.Data.SqlClient",
+      "ConnectionString": "..."
+    },
+    "Reminders": {
+      "ProviderType": "AdoNet",
+      "Invariant": "Microsoft.Data.SqlClient",
+      "ConnectionString": "..."
+    },
+    "GrainStorage": {
+      "Default": {
+        "ProviderType": "AdoNet",
+        "Invariant": "Microsoft.Data.SqlClient",
+        "ConnectionString": "..."
+      }
+    }
+  }
+}
 ```
 
-The client configuration code should look like this:
+Store connection strings in a secret provider or deployment environment, not in a committed settings file.
 
-```csharp
-var clientBuilder = new ClientBuilder();
+## Operational guidance
 
-var invariant = "System.Data.SqlClient";
-var connectionString = "Data Source=(localdb)\\MSSQLLocalDB;" +
-    "Initial Catalog=Orleans;Integrated Security=True;" +
-    "Pooling=False;Max Pool Size=200;" +
-    "Asynchronous Processing=True;MultipleActiveResultSets=True";
-
-// Use ADO.NET for clustering
-clientBuilder.UseAdoNetClustering(options =>
-{
-    options.Invariant = invariant;
-    options.ConnectionString = connectionString;
-});
-```
-
-:::zone-end
+- Keep `ServiceId` stable so Orleans reads the expected application rows.
+- Size connection pools for the total number of silo and client processes.
+- Encrypt connections and use least-privilege database identities.
+- Monitor database latency, throttling, deadlocks, and pool exhaustion.
+- Test database failover and rolling deployment behavior under load.
+- Back up grain state according to application recovery objectives; membership rows are transient and don't replace state backups.
 
 [!INCLUDE [managed-identities](../../../includes/managed-identities.md)]
-
-Set the `ConnectionString` to a valid ADO.NET Server connection string.
-
-To use ADO.NET providers for persistence, reminders, or clustering, you need scripts to create database artifacts. All servers hosting Orleans silos must have access to the database defined by these scripts. You can find scripts for popular providers in [ADO.NET Database configuration](adonet-configuration.md). Lack of access to the target database is a common mistake developers make.
-
-You also need to install the `*.AdoNet` NuGet package for the features you configure. We split ADO.NET NuGets into per-feature packages:
-
-- `Microsoft.Orleans.Clustering.AdoNet`: for clustering.
-- `Microsoft.Orleans.Persistence.AdoNet`: for persistence.
-- `Microsoft.Orleans.Reminders.AdoNet`: for reminders.

--- a/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
+++ b/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
@@ -1,6 +1,6 @@
 ---
 title: Configure ADO.NET providers
-description: Configure Orleans 10 clustering, reminders, storage, and grain directories with ADO.NET.
+description: Configure Orleans clustering, reminders, storage, and grain directories with ADO.NET.
 ms.date: 08/02/2026
 ms.topic: how-to
 ---
@@ -26,13 +26,13 @@ Run the main script for the database first, followed by each capability script. 
 2. `src/AdoNet/Orleans.Clustering.AdoNet/SQLServer-Clustering.sql`
 3. `src/AdoNet/Orleans.Persistence.AdoNet/SQLServer-Persistence.sql`
 
-See [ADO.NET database configuration](adonet-configuration.md) for links to every current script and invariant.
+See [ADO.NET database configuration](adonet-configuration.md) for schema script and invariant links.
 
 Apply schema changes as a controlled deployment step. Don't grant silos schema-owner permissions solely so they can create tables at runtime.
 
 ## Configure SQL Server
 
-Orleans 10 uses `Microsoft.Data.SqlClient` for SQL Server:
+Use `Microsoft.Data.SqlClient` for SQL Server:
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="adonet_silo":::
 
@@ -50,7 +50,7 @@ builder.UseOrleansClient(clientBuilder =>
 ```
 
 > [!IMPORTANT]
-> `System.Data.SqlClient` isn't the SQL Server invariant for Orleans 10. Reference the `Microsoft.Data.SqlClient` package and use the `Microsoft.Data.SqlClient` invariant.
+> `System.Data.SqlClient` isn't the SQL Server invariant. Reference the `Microsoft.Data.SqlClient` package and use the `Microsoft.Data.SqlClient` invariant.
 
 ## Configure another database
 

--- a/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
+++ b/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
@@ -11,10 +11,10 @@ Orleans ADO.NET providers use a relational database for one or more runtime capa
 
 | Capability | Package | Configure on |
 |---|---|---|
-| Clustering | `Microsoft.Orleans.Clustering.AdoNet` | Silos and external clients |
-| Grain storage | `Microsoft.Orleans.Persistence.AdoNet` | Silos |
-| Reminders | `Microsoft.Orleans.Reminders.AdoNet` | Silos |
-| Grain directory | `Microsoft.Orleans.GrainDirectory.AdoNet` | Silos |
+| Clustering | [`Microsoft.Orleans.Clustering.AdoNet`](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.AdoNet) | Silos and external clients |
+| Grain storage | [`Microsoft.Orleans.Persistence.AdoNet`](https://www.nuget.org/packages/Microsoft.Orleans.Persistence.AdoNet) | Silos |
+| Reminders | [`Microsoft.Orleans.Reminders.AdoNet`](https://www.nuget.org/packages/Microsoft.Orleans.Reminders.AdoNet) | Silos |
+| Grain directory | [`Microsoft.Orleans.GrainDirectory.AdoNet`](https://www.nuget.org/packages/Microsoft.Orleans.GrainDirectory.AdoNet) | Silos |
 
 Install only the packages for the capabilities the application uses. Also reference the database driver package.
 

--- a/docs/site/src/content/docs/host/configuration-guide/configuring-garbage-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/configuring-garbage-collection.md
@@ -1,39 +1,37 @@
 ---
 title: Configure .NET garbage collection
-description: Learn how to configure .NET garbage collection in .NET Orleans.
-ms.date: 05/23/2025
+description: Configure .NET garbage collection for Orleans 10 silos.
+ms.date: 08/02/2026
 ms.topic: how-to
 ---
 
 # Configure .NET garbage collection
 
-For good performance, it's important to configure .NET garbage collection correctly for the silo process. Based on the team's findings, the best combination of settings is `gcServer=true` and `gcConcurrent=true`. You can configure these values in your C# project (_.csproj_) or an _app.config_ file. For more information, see [Flavors of garbage collection](../../../core/runtime-config/garbage-collector.md#flavors-of-garbage-collection).
-
-## .NET Core and .NET 5+
-
-This method isn't supported for SDK-style projects compiling against the full .NET Framework.
+Orleans silos are long-running, highly concurrent server processes. Enable server garbage collection in the silo project:
 
 ```xml
 <PropertyGroup>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
-    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+  <ServerGarbageCollection>true</ServerGarbageCollection>
+  <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
 </PropertyGroup>
 ```
 
-## .NET Framework
+Server GC creates heaps and collection threads based on the processors available to the process. It is effective only when more than one processor is available.
 
-SDK-style projects compiling against the full .NET Framework should still use this configuration style. Consider an example _app.config_ XML file:
+## Containers and CPU limits
 
-``` xml
-<configuration>
-    <runtime>
-        <gcServer enabled="true"/>
-        <gcConcurrent enabled="true"/>
-    </runtime>
-</configuration>
-```
+.NET considers container CPU and memory limits when configuring the GC. Give the silo more than one CPU when you expect server GC to provide parallel collection, and load-test using the same limits as production.
 
-However, this isn't as easy if a silo runs as part of an Azure Worker Role, which defaults to using workstation GC. A relevant blog post discusses how to set the same configuration for an Azure Worker Role; see [Server garbage collection mode in Azure](/archive/blogs/cclayton/server-garbage-collection-mode-in-microsoft-azure).
+Don't size a silo solely from average managed-heap usage. Include native memory, socket buffers, serialization buffers, provider SDKs, telemetry, and temporary allocation bursts. Leave headroom below the container or operating-system memory limit so the runtime can collect before the process is terminated.
 
-> [!IMPORTANT]
-> Server garbage collection is available only on multiprocessor computers. Therefore, even if you configure garbage collection via the application _.csproj_ file or the scripts in the referred blog post, you won't get the benefits of `gcServer=true` if the silo runs on a (virtual) machine with a single core. For more information, see [GCSettings.IsServerGC remarks](/dotnet/api/system.runtime.gcsettings.isservergc#remarks).
+## Coordinate with Orleans activation management
+
+.NET GC reclaims unreachable managed objects. Orleans [activation collection](activation-collection.md) decides when idle grain activations become unreachable. Configure both layers:
+
+- Use server GC for process-level managed memory throughput.
+- Keep activation collection defaults unless workload measurements indicate a different idle age.
+- Consider memory-pressure activation shedding to reduce active grain count before the process reaches its memory limit.
+
+Monitor allocation rate, heap size, pause duration, time in GC, process working set, and activation count together. A GC setting can't compensate for unbounded activation growth or retained application objects.
+
+For runtime configuration details, see [.NET garbage collection configuration](../../../core/runtime-config/garbage-collector.md) and <xref:System.Runtime.GCSettings.IsServerGC>.

--- a/docs/site/src/content/docs/host/configuration-guide/configuring-garbage-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/configuring-garbage-collection.md
@@ -16,7 +16,7 @@ Orleans silos are long-running, highly concurrent server processes. Enable serve
 </PropertyGroup>
 ```
 
-Server GC creates heaps and collection threads based on the processors available to the process. It is effective only when more than one processor is available.
+[Server GC](https://learn.microsoft.com/dotnet/standard/garbage-collection/workstation-server-gc) creates heaps and collection threads based on the processors available to the process. It is effective only when more than one processor is available.
 
 ## Containers and CPU limits
 
@@ -34,4 +34,4 @@ Don't size a silo solely from average managed-heap usage. Include native memory,
 
 Monitor allocation rate, heap size, pause duration, time in GC, process working set, and activation count together. A GC setting can't compensate for unbounded activation growth or retained application objects.
 
-For runtime configuration details, see [.NET garbage collection configuration](../../../core/runtime-config/garbage-collector.md) and <xref:System.Runtime.GCSettings.IsServerGC>.
+For runtime configuration details, see [.NET garbage collection configuration](https://learn.microsoft.com/dotnet/core/runtime-config/garbage-collector) and <xref:System.Runtime.GCSettings.IsServerGC>.

--- a/docs/site/src/content/docs/host/configuration-guide/configuring-garbage-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/configuring-garbage-collection.md
@@ -9,12 +9,7 @@ ms.topic: how-to
 
 Orleans silos are long-running, highly concurrent server processes. Enable server garbage collection in the silo project:
 
-```xml
-<PropertyGroup>
-  <ServerGarbageCollection>true</ServerGarbageCollection>
-  <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
-</PropertyGroup>
-```
+:::code language="xml" source="../snippets/hosting/Hosting.csproj" id="server_gc":::
 
 [Server GC](https://learn.microsoft.com/dotnet/standard/garbage-collection/workstation-server-gc) creates heaps and collection threads based on the processors available to the process. It is effective only when more than one processor is available.
 

--- a/docs/site/src/content/docs/host/configuration-guide/configuring-garbage-collection.md
+++ b/docs/site/src/content/docs/host/configuration-guide/configuring-garbage-collection.md
@@ -1,6 +1,6 @@
 ---
 title: Configure .NET garbage collection
-description: Configure .NET garbage collection for Orleans 10 silos.
+description: Configure .NET garbage collection for Orleans silos.
 ms.date: 08/02/2026
 ms.topic: how-to
 ---

--- a/docs/site/src/content/docs/host/configuration-guide/index.md
+++ b/docs/site/src/content/docs/host/configuration-guide/index.md
@@ -1,32 +1,113 @@
 ---
 title: Orleans configuration guide
-description: Explore a guide on how to configure .NET Orleans.
-ms.date: 01/21/2026
+description: Configure Orleans 10 silos, clients, providers, and endpoints.
+ms.date: 08/02/2026
 ms.topic: overview
-zone_pivot_groups: orleans-version
 ---
 
 # Orleans configuration guide
 
-In this configuration guide, you learn the key configuration parameters and how to use them for most typical usage scenarios. You can use Orleans in various configurations fitting different scenarios, such as local single-node deployment for development and testing, server clustering, containerized deployments on Kubernetes or Azure Container Apps, and more.
+Orleans uses the [.NET Generic Host](../../../core/extensions/generic-host.md), dependency injection, and the [.NET options pattern](../../../core/extensions/options.md). Start with one of these hosting models:
 
-This guide provides instructions for the key configuration parameters necessary to run Orleans in one of the target scenarios. Other configuration parameters primarily help you fine-tune Orleans for better performance.
+| Model | Use it when | Entry point |
+|---|---|---|
+| Silo with co-hosted client | The process hosts grains and also calls grains. This is the default for most services. | `builder.UseOrleans(...)` |
+| External client | A separate process, such as a web frontend, calls a remote Orleans cluster but doesn't host grains. | `builder.UseOrleansClient(...)` |
+| Aspire-orchestrated application | Aspire creates backing resources and injects Orleans configuration and service references. | `builder.AddOrleans(...)` in the AppHost, then parameterless `UseOrleans()` or `UseOrleansClient()` |
 
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
+For a first local process, see [Local development configuration](local-development-configuration.md). For production, configure silos and external clients with the same cluster identity and clustering provider:
 
-Configure silos and clients programmatically via <xref:Microsoft.Extensions.Hosting.GenericHostExtensions.UseOrleans(Microsoft.Extensions.Hosting.IHostBuilder,System.Action{Microsoft.Extensions.Hosting.HostBuilderContext,Orleans.Hosting.ISiloBuilder})> and <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*>, respectively. You do this using several supplemental option classes. Option classes in Orleans follow the [Options pattern in .NET](../../../core/extensions/options.md) and can be loaded from files, environment variables, or any other valid configuration provider.
+- [Server configuration](server-configuration.md)
+- [Client configuration](client-configuration.md)
+- [Typical configurations](typical-configurations.md)
+- [Orleans and Aspire integration](../aspire-integration.md)
 
-:::zone-end
+## Programmatic configuration
 
-:::zone target="docs" pivot="orleans-3-x"
+Configure Orleans through `ISiloBuilder` or `IClientBuilder`:
 
-Configure silos and clients programmatically via <xref:Orleans.Hosting.SiloHostBuilder> and <xref:Orleans.ClientBuilder>, respectively. You do this using several supplemental option classes. Option classes in Orleans follow the [Options pattern in .NET](../../../core/extensions/options.md) and can be loaded from files, environment variables, or any other valid configuration provider.
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
 
-:::zone-end
+builder.UseOrleans(siloBuilder =>
+{
+    siloBuilder.Configure<ClusterOptions>(options =>
+    {
+        options.ServiceId = "orders";
+        options.ClusterId = "orders-production";
+    });
 
-If you want to configure a silo and a client for local development, see the [Local development configuration](local-development-configuration.md) section. The [Server configuration](server-configuration.md) and [Client configuration](client-configuration.md) sections cover configuring silos and clients, respectively.
+    // Add clustering, storage, reminders, and other providers here.
+});
 
-The section on [Typical configurations](typical-configurations.md) provides a summary of a few common configurations. You can find a list of important core options that you can configure in [List of options classes](list-of-options-classes.md).
+await builder.Build().RunAsync();
+```
 
-> [!IMPORTANT]
-> Make sure you properly configure .NET garbage collection as detailed in [Configure .NET garbage collection](configuring-garbage-collection.md).
+Provider extension methods validate configuration when the host starts. Prefer programmatic configuration when credentials require SDK objects such as `TokenCredential`, when configuration is computed, or when compile-time discoverability is important.
+
+## Declarative configuration
+
+Orleans 10 automatically binds the `Orleans` configuration section when `UseOrleans()` or `UseOrleansClient()` is called. The following sections are recognized:
+
+| Path | Applies to | Purpose |
+|---|---|---|
+| `Orleans` | Silo and client | `ClusterOptions`, including `ServiceId` and `ClusterId` |
+| `Orleans:Name` | Silo | Silo name |
+| `Orleans:Messaging` | Silo and client | `SiloMessagingOptions` or `ClientMessagingOptions` |
+| `Orleans:Gateway` | Client | Gateway refresh and connection behavior |
+| `Orleans:Endpoints` | Silo | Advertised and listening endpoints |
+| `Orleans:Clustering` | Silo and client | One clustering provider |
+| `Orleans:Reminders` | Silo | One reminder provider |
+| `Orleans:BroadcastChannel:{name}` | Silo and client | Named broadcast-channel providers |
+| `Orleans:Streaming:{name}` | Silo and client | Named stream providers |
+| `Orleans:GrainStorage:{name}` | Silo | Named grain storage providers |
+| `Orleans:GrainDirectory:{name}` | Silo | Named grain directory providers |
+
+A provider section selects a registered provider with `ProviderType`. Install the provider's NuGet package so its configuration builder is discoverable:
+
+```json
+{
+  "Orleans": {
+    "ServiceId": "orders",
+    "ClusterId": "orders-production",
+    "Clustering": {
+      "ProviderType": "Redis",
+      "ConnectionString": "redis.example.com:6380,ssl=true"
+    },
+    "Endpoints": {
+      "AdvertisedIPAddress": "10.0.0.12",
+      "SiloPort": 11111,
+      "GatewayPort": 30000,
+      "SiloListeningEndpoint": "0.0.0.0:11111",
+      "GatewayListeningEndpoint": "0.0.0.0:30000"
+    },
+    "GrainStorage": {
+      "Default": {
+        "ProviderType": "Redis",
+        "ConnectionString": "redis.example.com:6380,ssl=true"
+      }
+    }
+  }
+}
+```
+
+Environment variables use double underscores, for example `Orleans__ClusterId` and `Orleans__Endpoints__SiloPort`.
+
+> [!NOTE]
+> Declarative provider names come from the installed provider assemblies. If Orleans reports an unknown `ProviderType`, verify that the corresponding package is referenced and use the provider name documented by that package.
+
+## Configuration precedence
+
+The Generic Host combines configuration providers in its normal order. Programmatic options configuration also participates in the options pipeline, so avoid configuring the same value in multiple places unless the override is intentional. Keep service and cluster identity stable and inject environment-specific endpoints, credentials, and provider connection details at deployment time.
+
+## Production checklist
+
+- Use a durable, shared clustering provider; don't use development or static clustering for a production cluster.
+- Give every silo and client the same `ServiceId`, `ClusterId`, and clustering provider settings.
+- Advertise addresses reachable by other silos and clients, especially behind NAT, containers, or load balancers.
+- Use durable reminder and grain storage providers when the application depends on those features.
+- Configure [server garbage collection](configuring-garbage-collection.md).
+- Allow the Generic Host to perform [graceful shutdown](shutting-down-orleans.md).
+- Validate provider connectivity and credentials before rollout.
+
+For option types and API entry points, see [Core configuration options](list-of-options-classes.md) and the [`Orleans.Configuration` API reference](xref:Orleans.Configuration).

--- a/docs/site/src/content/docs/host/configuration-guide/index.md
+++ b/docs/site/src/content/docs/host/configuration-guide/index.md
@@ -24,36 +24,19 @@ For a first local process, see [Local development configuration](local-developme
 
 ## Programmatic configuration
 
-Configure Orleans through `ISiloBuilder` or `IClientBuilder`:
+Configure Orleans through <xref:Orleans.Hosting.ISiloBuilder> or <xref:Orleans.Hosting.IClientBuilder>. Provider extension methods validate configuration when the host starts. Prefer programmatic configuration when credentials require SDK objects such as <xref:Azure.Core.TokenCredential>, when configuration is computed, or when compile-time discoverability is important.
 
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ServiceId = "orders";
-        options.ClusterId = "orders-production";
-    });
-
-    // Add clustering, storage, reminders, and other providers here.
-});
-
-await builder.Build().RunAsync();
-```
-
-Provider extension methods validate configuration when the host starts. Prefer programmatic configuration when credentials require SDK objects such as `TokenCredential`, when configuration is computed, or when compile-time discoverability is important.
+See [Server configuration](server-configuration.md) and [Client configuration](client-configuration.md) for compiled examples.
 
 ## Declarative configuration
 
-Orleans automatically binds the `Orleans` configuration section when `UseOrleans()` or `UseOrleansClient()` is called. The following sections are recognized:
+Orleans automatically binds the `Orleans` configuration section when <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> or <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*> is called. The following sections are recognized:
 
 | Path | Applies to | Purpose |
 |---|---|---|
-| `Orleans` | Silo and client | `ClusterOptions`, including `ServiceId` and `ClusterId` |
+| `Orleans` | Silo and client | <xref:Orleans.Configuration.ClusterOptions>, including <xref:Orleans.Configuration.ClusterOptions.ServiceId> and <xref:Orleans.Configuration.ClusterOptions.ClusterId> |
 | `Orleans:Name` | Silo | Silo name |
-| `Orleans:Messaging` | Silo and client | `SiloMessagingOptions` or `ClientMessagingOptions` |
+| `Orleans:Messaging` | Silo and client | <xref:Orleans.Configuration.SiloMessagingOptions> or <xref:Orleans.Configuration.ClientMessagingOptions> |
 | `Orleans:Gateway` | Client | Gateway refresh and connection behavior |
 | `Orleans:Endpoints` | Silo | Advertised and listening endpoints |
 | `Orleans:Clustering` | Silo and client | One clustering provider |
@@ -63,33 +46,7 @@ Orleans automatically binds the `Orleans` configuration section when `UseOrleans
 | `Orleans:GrainStorage:{name}` | Silo | Named grain storage providers |
 | `Orleans:GrainDirectory:{name}` | Silo | Named grain directory providers |
 
-A provider section selects a registered provider with `ProviderType`. Install the provider's NuGet package so its configuration builder is discoverable:
-
-```json
-{
-  "Orleans": {
-    "ServiceId": "orders",
-    "ClusterId": "orders-production",
-    "Clustering": {
-      "ProviderType": "Redis",
-      "ConnectionString": "redis.example.com:6380,ssl=true"
-    },
-    "Endpoints": {
-      "AdvertisedIPAddress": "10.0.0.12",
-      "SiloPort": 11111,
-      "GatewayPort": 30000,
-      "SiloListeningEndpoint": "0.0.0.0:11111",
-      "GatewayListeningEndpoint": "0.0.0.0:30000"
-    },
-    "GrainStorage": {
-      "Default": {
-        "ProviderType": "Redis",
-        "ConnectionString": "redis.example.com:6380,ssl=true"
-      }
-    }
-  }
-}
-```
+A provider section selects a registered provider with `ProviderType`. Install the provider's NuGet package so its configuration builder is discoverable. See [Server configuration](server-configuration.md#clustering-provider) for the provider catalog and [Typical configurations](typical-configurations.md) for deployment-oriented examples.
 
 Environment variables use double underscores, for example `Orleans__ClusterId` and `Orleans__Endpoints__SiloPort`.
 
@@ -103,11 +60,11 @@ The Generic Host combines [.NET configuration providers](https://learn.microsoft
 ## Production checklist
 
 - Use a durable, shared clustering provider; don't use development or static clustering for a production cluster.
-- Give every silo and client the same `ServiceId`, `ClusterId`, and clustering provider settings.
+- Give every silo and client the same <xref:Orleans.Configuration.ClusterOptions.ServiceId>, <xref:Orleans.Configuration.ClusterOptions.ClusterId>, and clustering provider settings.
 - Advertise addresses reachable by other silos and clients, especially behind NAT, containers, or load balancers.
 - Use durable reminder and grain storage providers when the application depends on those features.
 - Configure [server garbage collection](configuring-garbage-collection.md).
 - Allow the Generic Host to perform [graceful shutdown](shutting-down-orleans.md).
 - Validate provider connectivity and credentials before rollout.
 
-For option types and API entry points, see [Core configuration options](list-of-options-classes.md) and the [`Orleans.Configuration` API reference](xref:Orleans.Configuration).
+For option types and API entry points, see [Core configuration options](list-of-options-classes.md) and <xref:Orleans.Configuration>.

--- a/docs/site/src/content/docs/host/configuration-guide/index.md
+++ b/docs/site/src/content/docs/host/configuration-guide/index.md
@@ -1,6 +1,6 @@
 ---
 title: Orleans configuration guide
-description: Configure Orleans 10 silos, clients, providers, and endpoints.
+description: Configure Orleans silos, clients, providers, and endpoints.
 ms.date: 08/02/2026
 ms.topic: overview
 ---
@@ -47,7 +47,7 @@ Provider extension methods validate configuration when the host starts. Prefer p
 
 ## Declarative configuration
 
-Orleans 10 automatically binds the `Orleans` configuration section when `UseOrleans()` or `UseOrleansClient()` is called. The following sections are recognized:
+Orleans automatically binds the `Orleans` configuration section when `UseOrleans()` or `UseOrleansClient()` is called. The following sections are recognized:
 
 | Path | Applies to | Purpose |
 |---|---|---|

--- a/docs/site/src/content/docs/host/configuration-guide/index.md
+++ b/docs/site/src/content/docs/host/configuration-guide/index.md
@@ -7,7 +7,7 @@ ms.topic: overview
 
 # Orleans configuration guide
 
-Orleans uses the [.NET Generic Host](../../../core/extensions/generic-host.md), dependency injection, and the [.NET options pattern](../../../core/extensions/options.md). Start with one of these hosting models:
+Orleans uses the [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host), [dependency injection](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection), and the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options). Start with one of these hosting models:
 
 | Model | Use it when | Entry point |
 |---|---|---|
@@ -98,7 +98,7 @@ Environment variables use double underscores, for example `Orleans__ClusterId` a
 
 ## Configuration precedence
 
-The Generic Host combines configuration providers in its normal order. Programmatic options configuration also participates in the options pipeline, so avoid configuring the same value in multiple places unless the override is intentional. Keep service and cluster identity stable and inject environment-specific endpoints, credentials, and provider connection details at deployment time.
+The Generic Host combines [.NET configuration providers](https://learn.microsoft.com/dotnet/core/extensions/configuration-providers) in its normal order. Programmatic options configuration also participates in the options pipeline, so avoid configuring the same value in multiple places unless the override is intentional. Keep service and cluster identity stable and inject environment-specific endpoints, credentials, and provider connection details at deployment time.
 
 ## Production checklist
 

--- a/docs/site/src/content/docs/host/configuration-guide/list-of-options-classes.md
+++ b/docs/site/src/content/docs/host/configuration-guide/list-of-options-classes.md
@@ -1,91 +1,60 @@
 ---
-title: List of options classes
-description: Explore a listing of options classes in .NET Orleans.
-ms.date: 01/21/2026
+title: Core Orleans configuration options
+description: Find the Orleans 10 option types used for common hosting tasks.
+ms.date: 08/02/2026
 ms.topic: reference
-zone_pivot_groups: orleans-version
 ---
 
-# List of options classes
+# Core Orleans configuration options
 
-All options classes used to configure Orleans are found in the `Orleans.Configuration` namespace. Many also have helper methods in the `Orleans.Hosting` namespace.
+Orleans options use the [.NET options pattern](../../../core/extensions/options.md). Configure them with `ISiloBuilder.Configure<TOptions>` or `IClientBuilder.Configure<TOptions>`. Orleans also automatically binds the specific sections listed in [Declarative configuration](index.md#declarative-configuration); other option types require explicit binding.
 
-:::zone pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
+This page is a curated starting point, not an exhaustive property catalog. The [`Orleans.Configuration` API reference](https://learn.microsoft.com/dotnet/api/orleans.configuration) and provider package APIs are the source of truth for the installed Orleans version.
 
-## Common core options for client and silo builders
+## Shared identity and messaging
 
-| Option type | Used for |
-|--|--|
-| <xref:Orleans.Configuration.ClusterOptions> | Setting the <xref:Orleans.Configuration.ClusterOptions.ClusterId> and the <xref:Orleans.Configuration.ClusterOptions.ServiceId> |
-| <xref:Orleans.Configuration.NetworkingOptions> | Setting timeout values for sockets and opened connections |
-| <xref:Orleans.Configuration.SerializationProviderOptions> | Setting the serialization providers |
-| <xref:Orleans.Configuration.TypeManagementOptions> | Setting the refresh period of the Type Map (see Heterogeneous silos and Versioning) |
+| Option type | Use it for |
+|---|---|
+| <xref:Orleans.Configuration.ClusterOptions> | `ServiceId` and `ClusterId` shared by silos and clients |
+| <xref:Orleans.Configuration.ClientMessagingOptions> | External client messaging and connections |
+| <xref:Orleans.Configuration.SiloMessagingOptions> | Silo messaging, response timeouts, and connection behavior |
+| <xref:Orleans.Configuration.GatewayOptions> | Client gateway refresh and preferred gateway behavior |
+| <xref:Orleans.Configuration.NetworkingOptions> | Shared socket and connection settings |
 
-## <xref:Orleans.IClientBuilder>-specific options
+## Silo hosting
 
-| Option type                                    | Used for                              |
-|------------------------------------------------|---------------------------------------|
-| <xref:Orleans.Configuration.ClientMessagingOptions> | Setting the number of connections to keep open, and specify what network interface to use |
-| <xref:Orleans.Configuration.StatisticsOptions> | Settings related to statistics output |
-| <xref:Orleans.Configuration.GatewayOptions> | Setting the refresh period of the list of available gateways |
-| <xref:Orleans.Configuration.StaticGatewayListProviderOptions> | Setting URIs a client will use to connect to cluster |
+| Option type | Use it for |
+|---|---|
+| <xref:Orleans.Configuration.EndpointOptions> | Advertised silo/gateway ports and listening endpoints |
+| <xref:Orleans.Configuration.SiloOptions> | Silo name |
+| <xref:Orleans.Configuration.ClusterMembershipOptions> | Membership probing, failure detection, and initial connectivity validation |
+| <xref:Orleans.Configuration.GrainCollectionOptions> | Idle activation collection and memory-pressure shedding |
+| <xref:Orleans.Configuration.GrainDirectoryOptions> | Built-in grain directory cache and partition behavior |
+| <xref:Orleans.Configuration.LoadSheddingOptions> | Request rejection under host load |
+| <xref:Orleans.Configuration.SchedulingOptions> | Grain scheduling limits and diagnostics |
+| <xref:Orleans.Configuration.ProcessExitHandlingOptions> | Process-exit behavior |
+| <xref:Orleans.Configuration.GrainTypeOptions> | Grain classes and interfaces supported by the process |
 
-## <xref:Orleans.Hosting.ISiloBuilder>-specific options
+## Feature-specific options
 
-| Option type                                           | Used for                        |
-|-------------------------------------------------------|---------------------------------|
-| <xref:Orleans.Configuration.ClusterMembershipOptions> | Settings for cluster membership |
-| <xref:Orleans.Configuration.ConsistentRingOptions> | Configuration options for consistent hashing algorithm, used to balance resource allocations across the cluster. |
-| <xref:Orleans.Configuration.EndpointOptions> | Setting the Silo endpoint options |
-| <xref:Orleans.Configuration.GrainCollectionOptions> | Options for grain garbage collection |
-| <xref:Orleans.Configuration.GrainVersioningOptions> | Governs grain implementation selection in heterogeneous deployments |
-| <xref:Orleans.Configuration.LoadSheddingOptions> | Settings for load shedding configuration. |
-| <xref:Orleans.Configuration.PerformanceTuningOptions> | Performance tuning options (networking, number of threads) |
-| <xref:Orleans.Configuration.ProcessExitHandlingOptions> | Configure silo behavior on process exit |
-| <xref:Orleans.Configuration.SchedulingOptions> | Configuring scheduler behavior |
-| <xref:Orleans.Configuration.SiloMessagingOptions> | Configuring global messaging options that are silo related. |
-| <xref:Orleans.Configuration.SiloOptions> | Setting the name of the Silo |
-| <xref:Orleans.Configuration.StatisticsOptions> | Setting related to statistics output |
-| <xref:Orleans.Configuration.TelemetryOptions> | Setting telemetry consumer settings |
+Storage, clustering, reminders, streaming, serialization, dashboards, and third-party integrations define options in their own packages. Start with the provider's builder method, such as `UseRedisClustering`, `AddAzureBlobGrainStorage`, or `UseAdoNetReminderService`, then follow the linked options type in IntelliSense or API reference.
 
-:::zone-end
+Named providers are normally configured using their builder methods:
 
-:::zone pivot="orleans-3-x"
+```csharp
+siloBuilder.AddRedisGrainStorage("hot-state", options =>
+{
+    options.ConfigurationOptions = redisConfiguration;
+});
+```
 
-## Common core options for <xref:Orleans.IClientBuilder> and <xref:Orleans.Hosting.ISiloHostBuilder>
+Declarative named providers use `Orleans:{capability}:{name}` and a `ProviderType`; see [Declarative configuration](index.md#declarative-configuration).
 
-| Option type | Used for |
-|--|--|
-| <xref:Orleans.Configuration.ClusterOptions> | Setting the <xref:Orleans.Configuration.ClusterOptions.ClusterId> and the <xref:Orleans.Configuration.ClusterOptions.ServiceId> |
-| <xref:Orleans.Configuration.NetworkingOptions> | Setting timeout values for sockets and opened connections |
-| <xref:Orleans.Configuration.SerializationProviderOptions> | Setting the serialization providers |
-| <xref:Orleans.Configuration.TypeManagementOptions> | Setting the refresh period of the Type Map (see Heterogeneous silos and Versioning) |
+## Find an option
 
-## <xref:Orleans.IClientBuilder>-specific options
+1. Start from the hosting extension method for the feature.
+2. Follow its options delegate type in IntelliSense.
+3. Check the installed package's API reference for defaults and validation.
+4. Inspect startup validation errors; Orleans validates required provider settings before the silo or client becomes ready.
 
-| Option type                                    | Used for                              |
-|------------------------------------------------|---------------------------------------|
-| <xref:Orleans.Configuration.ClientMessagingOptions> | Setting the number of connections to keep open, and specify what network interface to use |
-| <xref:Orleans.Configuration.StatisticsOptions> | Settings related to statistics output |
-| <xref:Orleans.Configuration.GatewayOptions> | Setting the refresh period of the list of available gateways |
-| <xref:Orleans.Configuration.StaticGatewayListProviderOptions> | Setting URIs a client will use to connect to cluster |
-
-## <xref:Orleans.Hosting.ISiloHostBuilder>-specific options
-
-| Option type                                           | Used for                        |
-|-------------------------------------------------------|---------------------------------|
-| <xref:Orleans.Configuration.ClusterMembershipOptions> | Settings for cluster membership |
-| <xref:Orleans.Configuration.ConsistentRingOptions> | Configuration options for consistent hashing algorithm, used to balance resource allocations across the cluster. |
-| <xref:Orleans.Configuration.EndpointOptions> | Setting the Silo endpoint options |
-| <xref:Orleans.Configuration.GrainCollectionOptions> | Options for grain garbage collection |
-| <xref:Orleans.Configuration.GrainVersioningOptions> | Governs grain implementation selection in heterogeneous deployments |
-| <xref:Orleans.Configuration.LoadSheddingOptions> | Settings for load shedding configuration. Must have a registered implementation of <xref:Orleans.Statistics.IHostEnvironmentStatistics> such as through <xref:Orleans.Statistics.ClientBuilderExtensions.UsePerfCounterEnvironmentStatistics*?displayProperty=nameWithType> or <xref:Orleans.Statistics.SiloHostBuilderExtensions.UsePerfCounterEnvironmentStatistics*?displayProperty=nameWithType> (Windows only) for `LoadShedding` to function. |
-| <xref:Orleans.Configuration.PerformanceTuningOptions> | Performance tuning options (networking, number of threads) |
-| <xref:Orleans.Configuration.ProcessExitHandlingOptions> | Configure silo behavior on process exit |
-| <xref:Orleans.Configuration.SchedulingOptions> | Configuring scheduler behavior |
-| <xref:Orleans.Configuration.SiloMessagingOptions> | Configuring global messaging options that are silo related. |
-| <xref:Orleans.Configuration.SiloOptions> | Setting the name of the Silo |
-| <xref:Orleans.Configuration.StatisticsOptions> | Setting related to statistics output |
-| <xref:Orleans.Configuration.TelemetryOptions> | Setting telemetry consumer settings |
-
-:::zone-end
+Avoid copying all available properties into configuration. Leave defaults in place unless a deployment requirement or measurement justifies an override. This reduces version drift and makes intentional tuning visible.

--- a/docs/site/src/content/docs/host/configuration-guide/list-of-options-classes.md
+++ b/docs/site/src/content/docs/host/configuration-guide/list-of-options-classes.md
@@ -7,24 +7,33 @@ ms.topic: reference
 
 # Core Orleans configuration options
 
-Orleans options use the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options). Configure them with `ISiloBuilder.Configure<TOptions>` or `IClientBuilder.Configure<TOptions>`. Orleans also automatically binds the specific sections listed in [Declarative configuration](index.md#declarative-configuration); other option types require explicit binding.
+Orleans options use the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options). Configure them with <xref:Orleans.Hosting.SiloBuilderExtensions.Configure*> or <xref:Orleans.Hosting.ClientBuilderExtensions.Configure*>. Orleans also automatically binds the specific sections listed in [Declarative configuration](index.md#declarative-configuration); other option types require explicit binding.
 
-This page is a curated starting point, not an exhaustive property catalog. The [`Orleans.Configuration` API reference](https://learn.microsoft.com/dotnet/api/orleans.configuration) and provider package APIs are the source of truth for the installed Orleans version.
+This page is a curated starting point, not an exhaustive property catalog. <xref:Orleans.Configuration> and provider package APIs are the source of truth for the installed Orleans version.
 
-## Shared identity and messaging
+## Common core options for client and silo builders
 
 | Option type | Use it for |
 |---|---|
-| <xref:Orleans.Configuration.ClusterOptions> | `ServiceId` and `ClusterId` shared by silos and clients |
-| <xref:Orleans.Configuration.ClientMessagingOptions> | External client messaging and connections |
-| <xref:Orleans.Configuration.SiloMessagingOptions> | Silo messaging, response timeouts, and connection behavior |
-| <xref:Orleans.Configuration.GatewayOptions> | Client gateway refresh and preferred gateway behavior |
+| <xref:Orleans.Configuration.ClusterOptions> | <xref:Orleans.Configuration.ClusterOptions.ServiceId> and <xref:Orleans.Configuration.ClusterOptions.ClusterId> shared by silos and clients |
 | <xref:Orleans.Configuration.NetworkingOptions> | Shared socket and connection settings |
 
-## Silo hosting
+<a id="iclientbuilder-specific-options"></a>
+
+## <xref:Orleans.Hosting.IClientBuilder>-specific options
 
 | Option type | Use it for |
 |---|---|
+| <xref:Orleans.Configuration.ClientMessagingOptions> | External client messaging and connections |
+| <xref:Orleans.Configuration.GatewayOptions> | Client gateway refresh and preferred gateway behavior |
+
+<a id="isilobuilder-specific-options"></a>
+
+## <xref:Orleans.Hosting.ISiloBuilder>-specific options
+
+| Option type | Use it for |
+|---|---|
+| <xref:Orleans.Configuration.SiloMessagingOptions> | Silo messaging, response timeouts, and connection behavior |
 | <xref:Orleans.Configuration.EndpointOptions> | Advertised silo/gateway ports and listening endpoints |
 | <xref:Orleans.Configuration.SiloOptions> | Silo name |
 | <xref:Orleans.Configuration.ClusterMembershipOptions> | Membership probing, failure detection, and initial connectivity validation |
@@ -37,16 +46,11 @@ This page is a curated starting point, not an exhaustive property catalog. The [
 
 ## Feature-specific options
 
-Storage, clustering, reminders, streaming, serialization, dashboards, and third-party integrations define options in their own packages. Start with the provider's builder method, such as `UseRedisClustering`, `AddAzureBlobGrainStorage`, or `UseAdoNetReminderService`, then follow the linked options type in IntelliSense or API reference.
+Storage, clustering, reminders, streaming, serialization, dashboards, and third-party integrations define options in their own packages. Start with the provider's builder method, such as <xref:Microsoft.Extensions.Hosting.RedisClusteringISiloBuilderExtensions.UseRedisClustering*>, <xref:Orleans.Hosting.AzureBlobSiloBuilderExtensions.AddAzureBlobGrainStorage*>, or <xref:Orleans.Hosting.SiloBuilderReminderExtensions.UseAdoNetReminderService*>, then follow the linked options type in IntelliSense or API reference.
 
 Named providers are normally configured using their builder methods:
 
-```csharp
-siloBuilder.AddRedisGrainStorage("hot-state", options =>
-{
-    options.ConfigurationOptions = redisConfiguration;
-});
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="named_providers":::
 
 Declarative named providers use `Orleans:{capability}:{name}` and a `ProviderType`; see [Declarative configuration](index.md#declarative-configuration).
 

--- a/docs/site/src/content/docs/host/configuration-guide/list-of-options-classes.md
+++ b/docs/site/src/content/docs/host/configuration-guide/list-of-options-classes.md
@@ -7,7 +7,7 @@ ms.topic: reference
 
 # Core Orleans configuration options
 
-Orleans options use the [.NET options pattern](../../../core/extensions/options.md). Configure them with `ISiloBuilder.Configure<TOptions>` or `IClientBuilder.Configure<TOptions>`. Orleans also automatically binds the specific sections listed in [Declarative configuration](index.md#declarative-configuration); other option types require explicit binding.
+Orleans options use the [.NET options pattern](https://learn.microsoft.com/dotnet/core/extensions/options). Configure them with `ISiloBuilder.Configure<TOptions>` or `IClientBuilder.Configure<TOptions>`. Orleans also automatically binds the specific sections listed in [Declarative configuration](index.md#declarative-configuration); other option types require explicit binding.
 
 This page is a curated starting point, not an exhaustive property catalog. The [`Orleans.Configuration` API reference](https://learn.microsoft.com/dotnet/api/orleans.configuration) and provider package APIs are the source of truth for the installed Orleans version.
 

--- a/docs/site/src/content/docs/host/configuration-guide/list-of-options-classes.md
+++ b/docs/site/src/content/docs/host/configuration-guide/list-of-options-classes.md
@@ -1,6 +1,6 @@
 ---
 title: Core Orleans configuration options
-description: Find the Orleans 10 option types used for common hosting tasks.
+description: Find the Orleans option types used for common hosting tasks.
 ms.date: 08/02/2026
 ms.topic: reference
 ---

--- a/docs/site/src/content/docs/host/configuration-guide/local-development-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/local-development-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Local development configuration
-description: Configure an Orleans 10 application for local development.
+description: Configure an Orleans application for local development.
 ms.date: 08/02/2026
 ms.topic: how-to
 ---

--- a/docs/site/src/content/docs/host/configuration-guide/local-development-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/local-development-configuration.md
@@ -1,116 +1,43 @@
 ---
 title: Local development configuration
-description: Learn how to configure .NET Orleans for local development.
-ms.date: 05/23/2025
+description: Configure an Orleans 10 application for local development.
+ms.date: 08/02/2026
 ms.topic: how-to
-zone_pivot_groups: orleans-version
 ---
 
 # Local development configuration
 
-For a working sample application targeting Orleans 7.0, see [Orleans: Hello World](https://github.com/dotnet/samples/tree/main/orleans/HelloWorld). The sample hosts the client and silo in .NET console applications that work on different platforms, while the grains and interfaces target .NET Standard 2.0.
+For the shortest development loop, host grains and the calling code in one process and use localhost clustering:
 
-> [!TIP]
-> For older versions of Orleans, please see [Orleans sample projects](https://github.com/dotnet/samples/tree/main/orleans).
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="local_silo_and_client":::
 
-## Silo configuration
+`UseOrleans` registers a co-hosted `IClusterClient`, so controllers, endpoints, hosted services, and other dependency-injected components can call grains without a separate client process.
 
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
+`UseLocalhostClustering` configures loopback networking and development clustering. Memory storage and memory reminders are also development-only: their data is lost when the process stops.
 
-We recommend using the [Microsoft.Extensions.Hosting](https://www.nuget.org/packages/Microsoft.Extensions.Hosting) NuGet package to configure and run the silo. Also, when developing an Orleans silo, you need the [Microsoft.Orleans.Server](https://www.nuget.org/packages/Microsoft.Orleans.Server) NuGet package. For local Orleans silo development, configure localhost clustering, which uses the loopback address. To use localhost clustering, call the <xref:Orleans.Hosting.CoreHostingExtensions.UseLocalhostClustering*> extension method. Consider this example _Program.cs_ file for the silo host:
+## Run a separate local client
 
-```csharp
-using Microsoft.Extensions.Hosting;
+Use a separate process when the production architecture requires client and silo isolation:
 
-await Host.CreateDefaultBuilder(args)
-    .UseOrleans(siloBuilder =>
-    {
-        siloBuilder.UseLocalhostClustering();
-    })
-    .RunConsoleAsync();
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="local_external_client":::
 
-The preceding code does the following:
+The client and silo must use matching gateway ports, `ServiceId`, and `ClusterId`. `UseLocalhostClustering` supplies matching defaults when both run on the same machine.
 
-- Creates a default host builder.
-- Calls the <xref:Microsoft.Extensions.Hosting.GenericHostExtensions.UseOrleans*> extension method to configure the silo.
-- Calls the `UseLocalhostClustering` extension method on the given <xref:Orleans.Hosting.ISiloBuilder> to configure the silo to use localhost clustering.
-- Chains the `RunConsoleAsync` method to run the silo as a console application.
+## Run multiple local silos
 
-:::zone-end
+`UseLocalhostClustering` is optimized for a single local silo. To exercise membership changes or failover, use one of these approaches:
 
-:::zone target="docs" pivot="orleans-3-x"
+- Use [Aspire](../aspire-integration.md) with a containerized Redis or other supported clustering resource and multiple silo replicas.
+- Configure a shared development clustering primary and assign each silo unique silo and gateway ports.
+- Run the same production clustering provider against a local container or emulator.
 
-For local development, refer to the example below showing how to configure a silo for this case. It configures and starts a silo listening on the `loopback` address, using `11111` and `30000` as the silo and gateway ports, respectively.
+Aspire is usually the easiest option because it allocates endpoints, starts dependencies, injects configuration, and displays logs for every replica.
 
-Add the `Microsoft.Orleans.Server` NuGet meta-package to your project.
+> [!IMPORTANT]
+> Don't deploy localhost, static, development, memory, or emulator-backed providers as production infrastructure. They don't provide the durability and availability expected from a multi-node deployment.
 
-```dotnetcli
-dotnet add package Microsoft.Orleans.Server
-```
+## Choose local backing services
 
-You need to configure <xref:Orleans.Configuration.ClusterOptions> via <xref:Orleans.Hosting.ISiloBuilder> `Configure` method, specify that you want `LocalhostClustering` as your clustering choice with this silo being the primary, and then configure silo endpoints.
+Use in-memory providers for fast unit-level iteration. Use containers or emulators when you need to test provider behavior, serialization formats, schema setup, or restart durability. Keep the same provider package and configuration shape that production uses whenever practical.
 
-The <xref:Orleans.Hosting.SiloHostBuilderExtensions.ConfigureApplicationParts*> call explicitly adds the assembly containing grain classes to the application setup. It also adds any referenced assembly due to the <xref:Orleans.ApplicationPartManagerExtensions.WithReferences*> extension. After completing these steps, build the silo host and start the silo.
-
-You can create an empty console application project targeting .NET Framework 4.6.1 or higher for hosting a silo.
-
-Here's an example of how you can start a local silo:
-
-:::code language="csharp" source="snippets-v3/local-dev/LocalDevelopment.cs" id="silo_localhost":::
-
-:::zone-end
-
-## Client configuration
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-We recommend using the [Microsoft.Extensions.Hosting](https://www.nuget.org/packages/Microsoft.Extensions.Hosting) NuGet package to configure and run clients (in addition to the silo). You also need the [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client) NuGet package. To use localhost clustering on the consuming client, call the <xref:Orleans.Hosting.ClientBuilderExtensions.UseLocalhostClustering*> extension method. Consider this example _Program.cs_ file for the client host:
-
-```csharp
-using Microsoft.Extensions.Hosting;
-
-using IHost host = Host.CreateDefaultBuilder(args)
-    .UseOrleansClient(client =>
-    {
-        client.UseLocalhostClustering();
-    })
-    .UseConsoleLifetime()
-    .Build();
-
-await host.StartAsync();
-```
-
-The preceding code does the following:
-
-- Creates a default host builder.
-- Calls the <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*> extension method to configure the client.
-- Calls the `UseLocalhostClustering` extension method on the given <xref:Orleans.Hosting.IClientBuilder> to configure the client to use localhost clustering.
-- Calls the `UseConsoleLifetime` extension method to configure the client to use the console lifetime.
-- Calls the `StartAsync` method on the `host` variable to start the client.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-For local development, refer to the example below showing how to configure a client for this case. It configures a client that connects to a `loopback` silo.
-
-Add the `Microsoft.Orleans.Client` NuGet meta-package to your project. After you become comfortable with the API, you can pick and choose the exact packages included in `Microsoft.Orleans.Client` that you need and reference them instead.
-
-```powershell
-Install-Package Microsoft.Orleans.Client
-```
-
-Configure <xref:Orleans.ClientBuilder> with a cluster ID matching the one specified for the local silo. Specify static clustering as your clustering choice, pointing it to the silo's gateway port.
-
-The `ConfigureApplicationParts` call explicitly adds the assembly containing grain interfaces to the application setup.
-
-After completing these steps, build the client and call its `Connect()` method to connect to the cluster.
-
-You can create an empty console application project targeting .NET Framework 4.6.1 or higher for running a client, or reuse the console application project created for hosting the silo.
-
-Here's an example of how a client can connect to a local silo:
-
-:::code language="csharp" source="snippets-v3/local-dev/LocalDevelopment.cs" id="client_localhost":::
-
-:::zone-end
+For integration tests that create in-process clusters, use `Microsoft.Orleans.TestingHost` and `TestClusterBuilder` instead of manually assigning ports.

--- a/docs/site/src/content/docs/host/configuration-guide/local-development-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/local-development-configuration.md
@@ -40,4 +40,4 @@ Aspire is usually the easiest option because it allocates endpoints, starts depe
 
 Use in-memory providers for fast unit-level iteration. Use containers or emulators when you need to test provider behavior, serialization formats, schema setup, or restart durability. Keep the same provider package and configuration shape that production uses whenever practical.
 
-For integration tests that create in-process clusters, use `Microsoft.Orleans.TestingHost` and `TestClusterBuilder` instead of manually assigning ports.
+For integration tests that create in-process clusters, use the [`Microsoft.Orleans.TestingHost`](https://www.nuget.org/packages/Microsoft.Orleans.TestingHost) package and `TestClusterBuilder` instead of manually assigning ports. For complete applications, see the [Orleans samples](https://github.com/dotnet/orleans/tree/main/samples).

--- a/docs/site/src/content/docs/host/configuration-guide/local-development-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/local-development-configuration.md
@@ -7,25 +7,27 @@ ms.topic: how-to
 
 # Local development configuration
 
+## Silo configuration
+
 For the shortest development loop, host grains and the calling code in one process and use localhost clustering:
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="local_silo_and_client":::
 
-`UseOrleans` registers a co-hosted `IClusterClient`, so controllers, endpoints, hosted services, and other dependency-injected components can call grains without a separate client process.
+<xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> registers a co-hosted <xref:Orleans.IClusterClient>, so controllers, endpoints, hosted services, and other dependency-injected components can call grains without a separate client process.
 
-`UseLocalhostClustering` configures loopback networking and development clustering. Memory storage and memory reminders are also development-only: their data is lost when the process stops.
+<xref:Orleans.Hosting.CoreHostingExtensions.UseLocalhostClustering*> configures loopback networking and development clustering. Memory storage and memory reminders are also development-only: their data is lost when the process stops.
 
-## Run a separate local client
+## Client configuration
 
 Use a separate process when the production architecture requires client and silo isolation:
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="local_external_client":::
 
-The client and silo must use matching gateway ports, `ServiceId`, and `ClusterId`. `UseLocalhostClustering` supplies matching defaults when both run on the same machine.
+The client and silo must use matching gateway ports, <xref:Orleans.Configuration.ClusterOptions.ServiceId>, and <xref:Orleans.Configuration.ClusterOptions.ClusterId>. <xref:Orleans.Hosting.ClientBuilderExtensions.UseLocalhostClustering*> supplies matching defaults when both run on the same machine.
 
 ## Run multiple local silos
 
-`UseLocalhostClustering` is optimized for a single local silo. To exercise membership changes or failover, use one of these approaches:
+<xref:Orleans.Hosting.CoreHostingExtensions.UseLocalhostClustering*> is optimized for a single local silo. To exercise membership changes or failover, use one of these approaches:
 
 - Use [Aspire](../aspire-integration.md) with a containerized Redis or other supported clustering resource and multiple silo replicas.
 - Configure a shared development clustering primary and assign each silo unique silo and gateway ports.
@@ -40,4 +42,4 @@ Aspire is usually the easiest option because it allocates endpoints, starts depe
 
 Use in-memory providers for fast unit-level iteration. Use containers or emulators when you need to test provider behavior, serialization formats, schema setup, or restart durability. Keep the same provider package and configuration shape that production uses whenever practical.
 
-For integration tests that create in-process clusters, use the [`Microsoft.Orleans.TestingHost`](https://www.nuget.org/packages/Microsoft.Orleans.TestingHost) package and `TestClusterBuilder` instead of manually assigning ports. For complete applications, see the [Orleans samples](https://github.com/dotnet/orleans/tree/main/samples).
+For integration tests that create in-process clusters, use the [`Microsoft.Orleans.TestingHost`](https://www.nuget.org/packages/Microsoft.Orleans.TestingHost) package and <xref:Orleans.TestingHost.TestClusterBuilder> instead of manually assigning ports. For complete applications, see the [Orleans samples](https://github.com/dotnet/orleans/tree/main/samples).

--- a/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
@@ -7,7 +7,7 @@ ms.topic: how-to
 
 # Server configuration
 
-Install [Microsoft.Orleans.Server](https://www.nuget.org/packages/Microsoft.Orleans.Server) and add Orleans to a .NET Generic Host:
+Install [Microsoft.Orleans.Server](https://www.nuget.org/packages/Microsoft.Orleans.Server) and add Orleans to a [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host):
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="redis_silo":::
 
@@ -19,17 +19,17 @@ Every silo and external client must use the same `ServiceId`, `ClusterId`, and c
 
 | Backend | Typical package or integration | Notes |
 |---|---|---|
-| Azure Table Storage | `Microsoft.Orleans.Clustering.AzureStorage` | Supports Microsoft Entra credentials and connection strings. |
-| ADO.NET | `Microsoft.Orleans.Clustering.AdoNet` | Supports SQL Server, PostgreSQL, MySQL/MariaDB, and Oracle. |
-| Redis | `Microsoft.Orleans.Clustering.Redis` | Can share a managed or self-hosted Redis service. |
-| Azure Cosmos DB | `Microsoft.Orleans.Clustering.Cosmos` | Uses a Cosmos DB container for membership. |
-| DynamoDB | `Microsoft.Orleans.Clustering.DynamoDB` | Common for AWS deployments. |
-| Consul | `Microsoft.Orleans.Clustering.Consul` | Uses Consul key/value storage. |
-| ZooKeeper | `Microsoft.Orleans.Clustering.ZooKeeper` | Uses a ZooKeeper ensemble. |
+| Azure Table Storage | [`Microsoft.Orleans.Clustering.AzureStorage`](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.AzureStorage) | Supports Microsoft Entra credentials and connection strings. |
+| ADO.NET | [`Microsoft.Orleans.Clustering.AdoNet`](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.AdoNet) | Supports SQL Server, PostgreSQL, MySQL/MariaDB, and Oracle. |
+| Redis | [`Microsoft.Orleans.Clustering.Redis`](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.Redis) | Can share a managed or self-hosted Redis service. |
+| Azure Cosmos DB | [`Microsoft.Orleans.Clustering.Cosmos`](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.Cosmos) | Uses a Cosmos DB container for membership. |
+| DynamoDB | [`Microsoft.Orleans.Clustering.DynamoDB`](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.DynamoDB) | Common for AWS deployments. |
+| Consul | [`Microsoft.Orleans.Clustering.Consul`](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.Consul) | Uses Consul key/value storage. |
+| ZooKeeper | [`Microsoft.Orleans.Clustering.ZooKeeper`](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.ZooKeeper) | Uses a ZooKeeper ensemble. |
 
 Use `UseLocalhostClustering`, development clustering, or static gateways only for local development and tests.
 
-`Microsoft.Orleans.Hosting.Kubernetes` configures a silo from its pod environment through `UseKubernetesHosting`; it is not a clustering provider. Kubernetes deployments still need one of the shared clustering providers above.
+[`Microsoft.Orleans.Hosting.Kubernetes`](https://www.nuget.org/packages/Microsoft.Orleans.Hosting.Kubernetes) configures a silo from its pod environment through `UseKubernetesHosting`; it is not a clustering provider. Kubernetes deployments still need one of the shared clustering providers above.
 
 Clustering stores membership, not grain state. Configure grain storage and reminders separately when the application uses them. Provider packages expose `Use...Clustering`, `Add...GrainStorage`, and `Use...ReminderService` methods and can also participate in [declarative configuration](index.md#declarative-configuration).
 

--- a/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
@@ -24,7 +24,7 @@ Every silo and external client must use the same `ServiceId`, `ClusterId`, and c
 | Redis | `Microsoft.Orleans.Clustering.Redis` | Can share a managed or self-hosted Redis service. |
 | Azure Cosmos DB | `Microsoft.Orleans.Clustering.Cosmos` | Uses a Cosmos DB container for membership. |
 | DynamoDB | `Microsoft.Orleans.Clustering.DynamoDB` | Common for AWS deployments. |
-| Consul | `Microsoft.Orleans.Clustering.Consul` | Uses Consul sessions and key/value storage. |
+| Consul | `Microsoft.Orleans.Clustering.Consul` | Uses Consul key/value storage. |
 | ZooKeeper | `Microsoft.Orleans.Clustering.ZooKeeper` | Uses a ZooKeeper ensemble. |
 
 Use `UseLocalhostClustering`, development clustering, or static gateways only for local development and tests.

--- a/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
@@ -1,246 +1,94 @@
 ---
 title: Server configuration
-description: Learn how to configure .NET Orleans server settings.
-ms.date: 01/21/2026
+description: Configure Orleans 10 silos, providers, and network endpoints.
+ms.date: 08/02/2026
 ms.topic: how-to
-zone_pivot_groups: orleans-version
-ms.custom: sfi-ropc-nochange
 ---
 
 # Server configuration
 
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
+Install [Microsoft.Orleans.Server](https://www.nuget.org/packages/Microsoft.Orleans.Server) and add Orleans to a .NET Generic Host:
 
-Configure a silo programmatically using the <xref:Microsoft.Extensions.Hosting.GenericHostExtensions.UseOrleans(Microsoft.Extensions.Hosting.IHostBuilder,System.Action{Microsoft.Extensions.Hosting.HostBuilderContext,Orleans.Hosting.ISiloBuilder})> extension method and several supplemental option classes. Option classes in Orleans follow the [Options pattern in .NET](../../../core/extensions/options.md) and can be loaded from files, environment variables, or any other valid configuration provider.
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="redis_silo":::
 
-There are several key aspects of silo configuration:
+`UseOrleans` hosts a silo and registers a co-hosted `IClusterClient`. Use `UseOrleansClient` only in a process that doesn't host grains.
 
-- Clustering provider
-- (Optional) Orleans clustering information
-- (Optional) Endpoints for silo-to-silo and client-to-silo communications
+## Choose a clustering provider
 
-> [!TIP]
-> If you're using [Aspire](../aspire-integration.md) (Orleans 8.0+), most of this configuration is handled automatically. Aspire injects <xref:Orleans.Configuration.ClusterOptions.ClusterId>, <xref:Orleans.Configuration.ClusterOptions.ServiceId>, and endpoint configuration via environment variables, so you can use the simpler parameterless <xref:Microsoft.Extensions.Hosting.GenericHostExtensions.UseOrleans*> method. See [Orleans and Aspire integration](../aspire-integration.md) for the recommended approach.
+Every silo and external client must use the same `ServiceId`, `ClusterId`, and clustering backend. Install the package for the deployment platform:
 
-This example shows a silo configuration defining cluster information and using Azure Table Storage for clustering:
+| Backend | Typical package or integration | Notes |
+|---|---|---|
+| Azure Table Storage | `Microsoft.Orleans.Clustering.AzureStorage` | Supports Microsoft Entra credentials and connection strings. |
+| ADO.NET | `Microsoft.Orleans.Clustering.AdoNet` | Supports SQL Server, PostgreSQL, MySQL/MariaDB, and Oracle. |
+| Redis | `Microsoft.Orleans.Clustering.Redis` | Can share a managed or self-hosted Redis service. |
+| Azure Cosmos DB | `Microsoft.Orleans.Clustering.Cosmos` | Uses a Cosmos DB container for membership. |
+| DynamoDB | `Microsoft.Orleans.Clustering.DynamoDB` | Common for AWS deployments. |
+| Consul | `Microsoft.Orleans.Clustering.Consul` | Uses Consul sessions and key/value storage. |
+| ZooKeeper | `Microsoft.Orleans.Clustering.ZooKeeper` | Uses a ZooKeeper ensemble. |
 
-### [Microsoft Entra ID (recommended)](#tab/entra-id)
+Use `UseLocalhostClustering`, development clustering, or static gateways only for local development and tests.
 
-Using a `TokenCredential` with a service URI is the recommended approach. This pattern avoids storing secrets in configuration and leverages Microsoft Entra ID for secure authentication.
+`Microsoft.Orleans.Hosting.Kubernetes` configures a silo from its pod environment through `UseKubernetesHosting`; it is not a clustering provider. Kubernetes deployments still need one of the shared clustering providers above.
 
-<xref:Azure.Identity.DefaultAzureCredential> provides a credential chain that works seamlessly across local development and production environments. During development, it uses your Azure CLI or Visual Studio credentials. In production on Azure, it automatically uses the managed identity assigned to your resource.
+Clustering stores membership, not grain state. Configure grain storage and reminders separately when the application uses them. Provider packages expose `Use...Clustering`, `Add...GrainStorage`, and `Use...ReminderService` methods and can also participate in [declarative configuration](index.md#declarative-configuration).
 
-[!INCLUDE [credential-chain-guidance](../../includes/credential-chain-guidance.md)]
+## Cluster identity
+
+`ServiceId` identifies the logical application and namespaces provider data. Keep it stable for the lifetime of the application. `ClusterId` identifies a specific cluster, such as `orders-production` or `orders-green`. All participants in one cluster must agree on both values.
+
+## Configure endpoints
+
+A silo has two advertised endpoints:
+
+- The silo endpoint is used for silo-to-silo traffic. Its default port is `11111`.
+- The gateway endpoint is used by external clients. Its default port is `30000`; set it to `0` to disable the gateway.
+
+Orleans must also know the IP address to advertise. If `AdvertisedIPAddress` isn't configured, Orleans selects a local address and falls back to loopback if necessary. The listening endpoints default to the advertised address and corresponding advertised port; Orleans does **not** listen on every interface unless you configure wildcard listening endpoints.
+
+For a directly reachable host, the helper configures advertised ports and an address:
 
 ```csharp
-using Azure.Identity;
-
-using IHost host = Host.CreateDefaultBuilder(args)
-    .UseOrleans(siloBuilder =>
-    {
-        siloBuilder.UseAzureStorageClustering(options =>
-        {
-            options.ConfigureTableServiceClient(
-                new Uri("https://<your-storage-account>.table.core.windows.net"),
-                new DefaultAzureCredential());
-        });
-    })
-    .UseConsoleLifetime()
-    .Build();
+siloBuilder.ConfigureEndpoints(
+    advertisedIP: IPAddress.Parse("10.0.0.12"),
+    siloPort: 11_111,
+    gatewayPort: 30_000,
+    listenOnAnyHostAddress: true);
 ```
 
-### [Connection string](#tab/connection-string)
+For containers, NAT, or port forwarding, configure advertised and listening endpoints independently:
 
-> [!WARNING]
-> Connection strings contain secrets and should be avoided in production. Use Microsoft Entra ID authentication whenever possible.
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="advertised_and_listening_endpoints":::
+
+This silo listens on ports `40000` and `50000` but publishes `172.16.0.42:11111` and `172.16.0.42:30000`. Ensure membership data never contains an address that peers can't route to.
+
+## Configure providers and options
+
+Use named providers when grain types need different stores:
 
 ```csharp
-using IHost host = Host.CreateDefaultBuilder(args)
-    .UseOrleans(builder =>
-    {
-        builder.UseAzureStorageClustering(
-            options => options.ConfigureTableServiceClient(connectionString));
-    })
-    .UseConsoleLifetime()
-    .Build();
+siloBuilder
+    .AddRedisGrainStorage("hot-state", options => { /* ... */ })
+    .AddAdoNetGrainStorage("archive", options => { /* ... */ })
+    .UseRedisReminderService(options => { /* ... */ });
 ```
 
----
-
-> [!TIP]
-> When developing for Orleans, you can call <xref:Orleans.Hosting.CoreHostingExtensions.UseLocalhostClustering(Orleans.Hosting.ISiloBuilder,System.Int32,System.Int32,System.Net.IPEndPoint,System.String,System.String)> to configure a local cluster. In production environments, you should use a clustering provider that is suitable for your deployment.
-
-## Clustering provider
-
-### [Microsoft Entra ID (recommended)](#tab/entra-id)
-
-[!INCLUDE [credential-chain-guidance](../../includes/credential-chain-guidance.md)]
+Configure runtime behavior with the options pattern:
 
 ```csharp
-siloBuilder.UseAzureStorageClustering(options =>
+siloBuilder.Configure<ClusterMembershipOptions>(options =>
 {
-    options.ConfigureTableServiceClient(
-        new Uri("https://<your-storage-account>.table.core.windows.net"),
-        new DefaultAzureCredential());
+    options.ValidateInitialConnectivity = true;
 });
 ```
 
-### [Connection string](#tab/connection-string)
+Prefer defaults until measurements or deployment requirements justify a change. See [Core configuration options](list-of-options-classes.md) rather than copying every property into application configuration.
 
-```csharp
-siloBuilder.UseAzureStorageClustering(
-    options => options.ConfigureTableServiceClient(connectionString))
-```
+## Production guidance
 
----
-
-Usually, you deploy a service built on Orleans on a cluster of nodes, either on dedicated hardware or in the cloud. For development and basic testing, you can deploy Orleans in a single-node configuration. When deployed to a cluster of nodes, Orleans internally implements protocols to discover and maintain membership of Orleans silos in the cluster, including detecting node failures and automatic reconfiguration.
-
-For reliable cluster membership management, Orleans uses Azure Table, SQL Server, or Apache ZooKeeper for node synchronization.
-
-In this sample, we use Azure Table as the membership provider.
-
-## Orleans clustering information
-
-To optionally configure clustering, use <xref:Orleans.Configuration.ClusterOptions> as the type parameter for the <xref:Orleans.Hosting.SiloBuilderExtensions.Configure*> method on the <xref:Orleans.Hosting.ISiloBuilder> instance.
-
-```csharp
-siloBuilder.Configure<ClusterOptions>(options =>
-{
-    options.ClusterId = "my-first-cluster";
-    options.ServiceId = "SampleApp";
-})
-```
-
-Here, you specify two options:
-
-- Set the <xref:Orleans.Configuration.ClusterOptions.ClusterId> to `"my-first-cluster"`: This is a unique ID for the Orleans cluster. All clients and silos using this ID can talk directly to each other. You can choose to use a different <xref:Orleans.Configuration.ClusterOptions.ClusterId> for different deployments, though.
-- Set the <xref:Orleans.Configuration.ClusterOptions.ServiceId> to `"SampleApp"`: This is a unique ID for your application used by some providers, such as persistence providers. **This ID should remain stable and not change across deployments**.
-
-By default, Orleans uses `"default"` for both <xref:Orleans.Configuration.ClusterOptions.ServiceId> and <xref:Orleans.Configuration.ClusterOptions.ClusterId>. These values don't need changing in most cases. <xref:Orleans.Configuration.ClusterOptions.ServiceId> is more significant and distinguishes different logical services, allowing them to share backend storage systems without interference. <xref:Orleans.Configuration.ClusterOptions.ClusterId> determines which hosts connect to form a cluster.
-
-Within each cluster, all hosts must use the same <xref:Orleans.Configuration.ClusterOptions.ServiceId>. However, multiple clusters can share a <xref:Orleans.Configuration.ClusterOptions.ServiceId>. This enables blue/green deployment scenarios where you start a new deployment (cluster) before shutting down another. This is typical for systems hosted in Azure App Service.
-
-The more common case is that <xref:Orleans.Configuration.ClusterOptions.ServiceId> and <xref:Orleans.Configuration.ClusterOptions.ClusterId> remain fixed for the application's lifetime, and you use a rolling deployment strategy. This is typical for systems hosted in Kubernetes and Service Fabric.
-
-## Endpoints
-
-By default, Orleans listens on all interfaces on port `11111` for silo-to-silo communication and port `30000` for client-to-silo communication. To override this behavior, call <xref:Orleans.Hosting.EndpointOptionsExtensions.ConfigureEndpoints(Orleans.Hosting.ISiloBuilder,System.Int32,System.Int32,System.Net.Sockets.AddressFamily,System.Boolean)> and pass in the port numbers you want to use.
-
-```csharp
-siloBuilder.ConfigureEndpoints(siloPort: 17_256, gatewayPort: 34_512)
-```
-
-In the preceding code:
-
-- The silo port is set to `17_256`.
-- The gateway port is set to `34_512`.
-
-An Orleans silo has two typical types of endpoint configuration:
-
-- Silo-to-silo endpoints: Used for communication between silos in the same cluster.
-- Client-to-silo (or gateway) endpoints: Used for communication between clients and silos in the same cluster.
-
-This method should suffice in most cases, but you can customize it further if needed. Here's an example of using an external IP address with port forwarding:
-
-```csharp
-siloBuilder.Configure<EndpointOptions>(options =>
-{
-    // Port to use for silo-to-silo
-    options.SiloPort = 11_111;
-    // Port to use for the gateway
-    options.GatewayPort = 30_000;
-    // IP Address to advertise in the cluster
-    options.AdvertisedIPAddress = IPAddress.Parse("172.16.0.42");
-    // The socket used for client-to-silo will bind to this endpoint
-    options.GatewayListeningEndpoint = new IPEndPoint(IPAddress.Any, 40_000);
-    // The socket used by the gateway will bind to this endpoint
-    options.SiloListeningEndpoint = new IPEndPoint(IPAddress.Any, 50_000);
-})
-```
-
-Internally, the silo listens on `0.0.0.0:40000` and `0.0.0.0:50000`, but the value published in the membership provider is `172.16.0.42:11111` and `172.16.0.42:30000`.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-Configure a silo programmatically via <xref:Orleans.Hosting.SiloHostBuilder> and several supplemental option classes. Option classes in Orleans follow the [Options pattern in .NET](../../../core/extensions/options.md) and can be loaded from files, environment variables, or any other valid configuration provider.
-
-There are several key aspects of silo configuration:
-
-- Orleans clustering information
-- Clustering provider
-- Endpoints for silo-to-silo and client-to-silo communications
-- Application parts
-
-This example shows a silo configuration defining cluster information, using Azure clustering, and configuring application parts:
-
-:::code language="csharp" source="snippets-v3/server-config/Configuration.cs" id="full_silo_config":::
-
-Let's break down the steps used in this sample:
-
-## Clustering provider
-
-:::code language="csharp" source="snippets-v3/server-config/Configuration.cs" id="azure_clustering":::
-
-Usually, you deploy a service built on Orleans on a cluster of nodes, either on dedicated hardware or in the cloud. For development and basic testing, you can deploy Orleans in a single-node configuration. When deployed to a cluster of nodes, Orleans internally implements protocols to discover and maintain membership of Orleans silos in the cluster, including detecting node failures and automatic reconfiguration.
-
-For reliable cluster membership management, Orleans uses Azure Table, SQL Server, or Apache ZooKeeper for node synchronization.
-
-In this sample, we use Azure Table as the membership provider.
-
-## Orleans clustering information
-
-:::code language="csharp" source="snippets-v3/server-config/Configuration.cs" id="cluster_options":::
-
-Here, we do two things:
-
-- Set the <xref:Orleans.Configuration.ClusterOptions.ClusterId> to `"my-first-cluster"`: This is a unique ID for the Orleans cluster. All clients and silos using this ID can talk directly to each other. You can choose to use a different <xref:Orleans.Configuration.ClusterOptions.ClusterId> for different deployments, though.
-- Set the <xref:Orleans.Configuration.ClusterOptions.ServiceId> to `"AspNetSampleApp"`: This is a unique ID for your application used by some providers, such as persistence providers. **This ID should remain stable and not change across deployments**.
-
-By default, Orleans uses `"default"` for both <xref:Orleans.Configuration.ClusterOptions.ServiceId> and <xref:Orleans.Configuration.ClusterOptions.ClusterId>. These values don't need changing in most cases. <xref:Orleans.Configuration.ClusterOptions.ServiceId> is more significant and distinguishes different logical services, allowing them to share backend storage systems without interference. <xref:Orleans.Configuration.ClusterOptions.ClusterId> determines which hosts connect to form a cluster.
-
-Within each cluster, all hosts must use the same <xref:Orleans.Configuration.ClusterOptions.ServiceId>. However, multiple clusters can share a <xref:Orleans.Configuration.ClusterOptions.ServiceId>. This enables blue/green deployment scenarios where you start a new deployment (cluster) before shutting down another. This is typical for systems hosted in Azure App Service.
-
-The more common case is that <xref:Orleans.Configuration.ClusterOptions.ServiceId> and <xref:Orleans.Configuration.ClusterOptions.ClusterId> remain fixed for the application's lifetime, and you use a rolling deployment strategy. This is typical for systems hosted in Kubernetes and Service Fabric.
-
-## Endpoints
-
-:::code language="csharp" source="snippets-v3/server-config/Configuration.cs" id="configure_endpoints":::
-
-An Orleans silo has two typical types of endpoint configuration:
-
-- Silo-to-silo endpoints: Used for communication between silos in the same cluster.
-- Client-to-silo endpoints (or gateway): Used for communication between clients and silos in the same cluster.
-
-In the sample, we use the helper method `.ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)`, which sets the port for silo-to-silo communication to `11111` and the gateway port to `30000`. This method detects which interface to listen on.
-
-This method should suffice in most cases, but you can customize it further if needed. Here's an example of using an external IP address with port forwarding:
-
-:::code language="csharp" source="snippets-v3/server-config/Configuration.cs" id="endpoint_options":::
-
-Internally, the silo listens on `0.0.0.0:40000` and `0.0.0.0:50000`, but the value published in the membership provider is `172.16.0.42:11111` and `172.16.0.42:30000`.
-
-## Application parts
-
-:::code language="csharp" source="snippets-v3/server-config/Configuration.cs" id="application_parts":::
-
-Although this step isn't technically required (if not configured, Orleans scans all assemblies in the current folder), we encourage you to configure it. This step helps Orleans load user assemblies and types. These assemblies are referred to as Application Parts. Orleans discovers all Grains, Grain Interfaces, and Serializers using Application Parts.
-
-Configure Application Parts using <xref:Orleans.ApplicationParts.IApplicationPartManager>, accessible via the `ConfigureApplicationParts` extension method on <xref:Orleans.IClientBuilder> and <xref:Orleans.Hosting.ISiloHostBuilder>. The `ConfigureApplicationParts` method accepts a delegate, `Action<IApplicationPartManager>`.
-
-The following extension methods on <xref:Orleans.ApplicationParts.IApplicationPartManager> support common uses:
-
-- <xref:Orleans.ApplicationPartManagerExtensions.AddApplicationPart*>: Add a single assembly using this extension method.
-- <xref:Orleans.ApplicationPartManagerExtensions.AddFromAppDomain*>: Adds all assemblies currently loaded in the `AppDomain`.
-- <xref:Orleans.ApplicationPartManagerExtensions.AddFromApplicationBaseDirectory*>: Loads and adds all assemblies in the current base path (see <xref:System.AppDomain.BaseDirectory?displayProperty=nameWithType>).
-
-Supplement assemblies added by the above methods using the following extension methods on their return type, <xref:Orleans.ApplicationParts.IApplicationPartManagerWithAssemblies>:
-
-- <xref:Orleans.ApplicationPartManagerExtensions.WithReferences*>: Adds all referenced assemblies from the added parts. This immediately loads any transitively referenced assemblies. Assembly loading errors are ignored.
-- <xref:Orleans.Hosting.ApplicationPartManagerCodeGenExtensions.WithCodeGeneration*>: Generates support code for the added parts and adds it to the part manager. Note that this requires installing the `Microsoft.Orleans.OrleansCodeGenerator` package and is commonly referred to as runtime code generation.
-
-Type discovery requires the provided Application Parts to include specific attributes. Adding the build-time code generation package (`Microsoft.Orleans.CodeGenerator.MSBuild` or `Microsoft.Orleans.OrleansCodeGenerator.Build`) to each project containing Grains, Grain Interfaces, or Serializers is the recommended approach to ensure these attributes are present. Build-time code generation only supports C#. For F#, Visual Basic, and other .NET languages, you can generate code during configuration time via the <xref:Orleans.Hosting.ApplicationPartManagerCodeGenExtensions.WithCodeGeneration*> method described above. Find more info regarding code generation in [the corresponding section](../../grains/code-generation.md).
-
-:::zone-end
+- Use workload identity, managed identity, or another short-lived credential mechanism where the provider supports it.
+- Keep connection strings and credentials outside source control.
+- Run at least three silos across failure domains when availability requirements demand quorum-like failure tolerance.
+- Configure readiness so traffic starts only after host startup completes.
+- Let the Generic Host receive termination signals and complete [graceful shutdown](shutting-down-orleans.md).
+- Use server GC and size CPU/memory limits from load tests.

--- a/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Server configuration
-description: Configure Orleans 10 silos, providers, and network endpoints.
+description: Configure Orleans silos, providers, and network endpoints.
 ms.date: 08/02/2026
 ms.topic: how-to
 ---

--- a/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/server-configuration.md
@@ -11,11 +11,11 @@ Install [Microsoft.Orleans.Server](https://www.nuget.org/packages/Microsoft.Orle
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="redis_silo":::
 
-`UseOrleans` hosts a silo and registers a co-hosted `IClusterClient`. Use `UseOrleansClient` only in a process that doesn't host grains.
+<xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> hosts a silo and registers a co-hosted <xref:Orleans.IClusterClient>. Use <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*> only in a process that doesn't host grains.
 
-## Choose a clustering provider
+## Clustering provider
 
-Every silo and external client must use the same `ServiceId`, `ClusterId`, and clustering backend. Install the package for the deployment platform:
+Every silo and external client must use the same <xref:Orleans.Configuration.ClusterOptions.ServiceId>, <xref:Orleans.Configuration.ClusterOptions.ClusterId>, and clustering backend. Install the package for the deployment platform:
 
 | Backend | Typical package or integration | Notes |
 |---|---|---|
@@ -27,34 +27,28 @@ Every silo and external client must use the same `ServiceId`, `ClusterId`, and c
 | Consul | [`Microsoft.Orleans.Clustering.Consul`](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.Consul) | Uses Consul key/value storage. |
 | ZooKeeper | [`Microsoft.Orleans.Clustering.ZooKeeper`](https://www.nuget.org/packages/Microsoft.Orleans.Clustering.ZooKeeper) | Uses a ZooKeeper ensemble. |
 
-Use `UseLocalhostClustering`, development clustering, or static gateways only for local development and tests.
+Use <xref:Orleans.Hosting.CoreHostingExtensions.UseLocalhostClustering*>, development clustering, or static gateways only for local development and tests.
 
-[`Microsoft.Orleans.Hosting.Kubernetes`](https://www.nuget.org/packages/Microsoft.Orleans.Hosting.Kubernetes) configures a silo from its pod environment through `UseKubernetesHosting`; it is not a clustering provider. Kubernetes deployments still need one of the shared clustering providers above.
+[`Microsoft.Orleans.Hosting.Kubernetes`](https://www.nuget.org/packages/Microsoft.Orleans.Hosting.Kubernetes) configures a silo from its pod environment through <xref:Orleans.Hosting.KubernetesHostingExtensions.UseKubernetesHosting*>; it is not a clustering provider. Kubernetes deployments still need one of the shared clustering providers above.
 
 Clustering stores membership, not grain state. Configure grain storage and reminders separately when the application uses them. Provider packages expose `Use...Clustering`, `Add...GrainStorage`, and `Use...ReminderService` methods and can also participate in [declarative configuration](index.md#declarative-configuration).
 
-## Cluster identity
+## Orleans clustering information
 
-`ServiceId` identifies the logical application and namespaces provider data. Keep it stable for the lifetime of the application. `ClusterId` identifies a specific cluster, such as `orders-production` or `orders-green`. All participants in one cluster must agree on both values.
+<xref:Orleans.Configuration.ClusterOptions.ServiceId> identifies the logical application and namespaces provider data. Keep it stable for the lifetime of the application. <xref:Orleans.Configuration.ClusterOptions.ClusterId> identifies a specific cluster, such as `orders-production` or `orders-green`. All participants in one cluster must agree on both values.
 
-## Configure endpoints
+## Endpoints
 
 A silo has two advertised endpoints:
 
 - The silo endpoint is used for silo-to-silo traffic. Its default port is `11111`.
 - The gateway endpoint is used by external clients. Its default port is `30000`; set it to `0` to disable the gateway.
 
-Orleans must also know the IP address to advertise. If `AdvertisedIPAddress` isn't configured, Orleans selects a local address and falls back to loopback if necessary. The listening endpoints default to the advertised address and corresponding advertised port; Orleans does **not** listen on every interface unless you configure wildcard listening endpoints.
+Orleans must also know the IP address to advertise. If <xref:Orleans.Configuration.EndpointOptions.AdvertisedIPAddress> isn't configured, Orleans selects a local address and falls back to loopback if necessary. The listening endpoints default to the advertised address and corresponding advertised port; Orleans does **not** listen on every interface unless you configure wildcard listening endpoints.
 
 For a directly reachable host, the helper configures advertised ports and an address:
 
-```csharp
-siloBuilder.ConfigureEndpoints(
-    advertisedIP: IPAddress.Parse("10.0.0.12"),
-    siloPort: 11_111,
-    gatewayPort: 30_000,
-    listenOnAnyHostAddress: true);
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="direct_endpoints":::
 
 For containers, NAT, or port forwarding, configure advertised and listening endpoints independently:
 
@@ -66,21 +60,11 @@ This silo listens on ports `40000` and `50000` but publishes `172.16.0.42:11111`
 
 Use named providers when grain types need different stores:
 
-```csharp
-siloBuilder
-    .AddRedisGrainStorage("hot-state", options => { /* ... */ })
-    .AddAdoNetGrainStorage("archive", options => { /* ... */ })
-    .UseRedisReminderService(options => { /* ... */ });
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="named_providers":::
 
 Configure runtime behavior with the options pattern:
 
-```csharp
-siloBuilder.Configure<ClusterMembershipOptions>(options =>
-{
-    options.ValidateInitialConnectivity = true;
-});
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="membership_options":::
 
 Prefer defaults until measurements or deployment requirements justify a change. See [Core configuration options](list-of-options-classes.md) rather than copying every property into application configuration.
 

--- a/docs/site/src/content/docs/host/configuration-guide/shutting-down-orleans.md
+++ b/docs/site/src/content/docs/host/configuration-guide/shutting-down-orleans.md
@@ -1,38 +1,72 @@
 ---
 title: Shut down Orleans silos
-description: Learn how to shut down .NET Orleans silos.
-ms.date: 05/23/2025
+description: Gracefully stop Orleans 10 silos with the .NET Generic Host.
+ms.date: 08/02/2026
 ms.topic: how-to
 ---
 
 # Shut down Orleans silos
 
-This article explains how to gracefully shut down an Orleans silo before the app exits. This applies to apps running as console apps or container apps. Various termination signals can cause an app to shut down, such as <kbd>Ctrl</kbd>+<kbd>C</kbd> (or `SIGTERM`). The following sections explain how to handle these signals.
+Orleans is an `IHostedService` inside the .NET Generic Host. When the host stops, Orleans leaves the cluster, closes gateways and networking, deactivates grains, and stops providers in reverse lifecycle order.
 
-## Graceful silo shutdown
+## Let the Generic Host own shutdown
 
-The following code shows how to gracefully shut down an Orleans silo console app. Consider the following example code:
+Use `RunAsync` or `RunConsoleAsync` and don't terminate the process directly:
 
 ```csharp
-using Microsoft.Extensions.Hosting;
-using Orleans;
-using Orleans.Hosting;
+var builder = Host.CreateApplicationBuilder(args);
 
-await Host.CreateDefaultBuilder(args)
-    .UseOrleans(siloBuilder =>
-    {
-        // Use the siloBuilder instance to configure the Orleans silo.
-    })
-    .RunConsoleAsync();
+builder.UseOrleans(siloBuilder =>
+{
+    // Configure Orleans.
+});
+
+await builder.Build().RunAsync();
 ```
 
-The preceding code relies on the [Microsoft.Extensions.Hosting](https://www.nuget.org/packages/Microsoft.Extensions.Hosting) and [Microsoft.Orleans.Server](https://www.nuget.org/packages/Microsoft.Orleans.Server) NuGet packages. The <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.RunConsoleAsync*> extension method extends <xref:Microsoft.Extensions.Hosting.IHostBuilder> to help manage the app's lifetime accordingly, listening for process termination signals and shutting down the silo gracefully.
+The console lifetime handles <kbd>Ctrl</kbd>+<kbd>C</kbd>, `SIGINT`, and `SIGTERM`. ASP.NET Core hosts use the same host lifetime model.
 
-Internally, the `RunConsoleAsync` method calls <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.UseConsoleLifetime*>, which ensures the app shuts down gracefully. Orleans is hosted within the .NET Generic Host, so it shuts down when the host application does, regardless of the lifetime model used.
+In tests or embedded hosts, call `StopAsync` and dispose the host:
 
-For more information on host shutdown, see [.NET Generic Host: Host shutdown](../../../core/extensions/generic-host.md#host-shutdown).
+```csharp
+await host.StopAsync(cancellationToken);
+host.Dispose();
+```
 
-## See also
+Don't call `Environment.Exit`, kill the process from application code, or dispose Orleans services independently of the host.
 
-- [.NET Generic Host](../../../core/extensions/generic-host.md)
-- [Orleans silo lifecycle overview](../silo-lifecycle.md)
+## Configure a shutdown budget
+
+The host cancellation token bounds every hosted service, including Orleans lifecycle participants and grain deactivation. Configure <xref:Microsoft.Extensions.Hosting.HostOptions.ShutdownTimeout> for the expected workload:
+
+```csharp
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(45);
+});
+```
+
+Set the orchestrator's termination grace period longer than the host shutdown timeout. Include time for:
+
+- Load balancers and readiness probes to stop sending new traffic.
+- Gateway and membership changes to propagate.
+- Grain deactivation callbacks and state writes.
+- Stream, reminder, storage, and telemetry providers to flush and stop.
+
+If the external grace period expires first, the process is killed and graceful shutdown can't complete.
+
+## Make application code shutdown-safe
+
+- Honor cancellation tokens in hosted services, startup tasks, lifecycle participants, and provider calls.
+- Keep `OnDeactivateAsync` bounded; persist important state during normal operation rather than relying only on shutdown.
+- Stop accepting new application work before the termination deadline.
+- Make recovery safe after abrupt termination, because crashes and node loss remain possible.
+- Avoid synchronous blocking and unbounded retries in shutdown callbacks.
+
+Grains can move or reactivate elsewhere after a silo leaves. Don't use graceful shutdown as an application-wide drain barrier unless the application separately coordinates that behavior.
+
+## Containers and orchestrators
+
+Configure readiness to fail before sending the termination signal when the platform supports a pre-stop phase. Send a normal termination signal, allow the host timeout to elapse, and reserve forceful termination for hung processes.
+
+For ordered Orleans callbacks, see [Orleans silo lifecycle](../silo-lifecycle.md).

--- a/docs/site/src/content/docs/host/configuration-guide/shutting-down-orleans.md
+++ b/docs/site/src/content/docs/host/configuration-guide/shutting-down-orleans.md
@@ -7,44 +7,27 @@ ms.topic: how-to
 
 # Shut down Orleans silos
 
-Orleans is an `IHostedService` inside the [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host). When the host stops, Orleans leaves the cluster, closes gateways and networking, deactivates grains, and stops providers in reverse lifecycle order.
+Orleans is an <xref:Microsoft.Extensions.Hosting.IHostedService> inside the [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host). When the host stops, Orleans leaves the cluster, closes gateways and networking, deactivates grains, and stops providers in reverse lifecycle order.
 
-## Let the Generic Host own shutdown
+## Graceful silo shutdown
 
-Use `RunAsync` or `RunConsoleAsync` and don't terminate the process directly:
+Use <xref:Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync*> or <xref:Microsoft.Extensions.Hosting.HostingHostBuilderExtensions.RunConsoleAsync*> and don't terminate the process directly:
 
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.UseOrleans(siloBuilder =>
-{
-    // Configure Orleans.
-});
-
-await builder.Build().RunAsync();
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="run_silo":::
 
 The console lifetime handles <kbd>Ctrl</kbd>+<kbd>C</kbd>, `SIGINT`, and `SIGTERM`. ASP.NET Core hosts use the same host lifetime model. For details, see [.NET Generic Host shutdown](https://learn.microsoft.com/dotnet/core/extensions/generic-host#host-shutdown).
 
-In tests or embedded hosts, call `StopAsync` and dispose the host:
+In tests or embedded hosts, call <xref:Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.StopAsync*> and dispose the host:
 
-```csharp
-await host.StopAsync(cancellationToken);
-host.Dispose();
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="stop_host":::
 
-Don't call `Environment.Exit`, kill the process from application code, or dispose Orleans services independently of the host.
+Don't call <xref:System.Environment.Exit*>, kill the process from application code, or dispose Orleans services independently of the host.
 
 ## Configure a shutdown budget
 
 The host cancellation token bounds every hosted service, including Orleans lifecycle participants and grain deactivation. Configure <xref:Microsoft.Extensions.Hosting.HostOptions.ShutdownTimeout> for the expected workload:
 
-```csharp
-builder.Services.Configure<HostOptions>(options =>
-{
-    options.ShutdownTimeout = TimeSpan.FromSeconds(45);
-});
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="shutdown_timeout":::
 
 Set the orchestrator's termination grace period longer than the host shutdown timeout. Include time for:
 
@@ -58,7 +41,7 @@ If the external grace period expires first, the process is killed and graceful s
 ## Make application code shutdown-safe
 
 - Honor cancellation tokens in hosted services, startup tasks, lifecycle participants, and provider calls.
-- Keep `OnDeactivateAsync` bounded; persist important state during normal operation rather than relying only on shutdown.
+- Keep <xref:Orleans.Grain.OnDeactivateAsync*> bounded; persist important state during normal operation rather than relying only on shutdown.
 - Stop accepting new application work before the termination deadline.
 - Make recovery safe after abrupt termination, because crashes and node loss remain possible.
 - Avoid synchronous blocking and unbounded retries in shutdown callbacks.
@@ -68,5 +51,7 @@ Grains can move or reactivate elsewhere after a silo leaves. Don't use graceful 
 ## Containers and orchestrators
 
 Configure readiness to fail before sending the termination signal when the platform supports a pre-stop phase. Send a normal termination signal, allow the host timeout to elapse, and reserve forceful termination for hung processes.
+
+## See also
 
 For ordered Orleans callbacks, see [Orleans silo lifecycle](../silo-lifecycle.md).

--- a/docs/site/src/content/docs/host/configuration-guide/shutting-down-orleans.md
+++ b/docs/site/src/content/docs/host/configuration-guide/shutting-down-orleans.md
@@ -1,6 +1,6 @@
 ---
 title: Shut down Orleans silos
-description: Gracefully stop Orleans 10 silos with the .NET Generic Host.
+description: Gracefully stop Orleans silos with the .NET Generic Host.
 ms.date: 08/02/2026
 ms.topic: how-to
 ---

--- a/docs/site/src/content/docs/host/configuration-guide/shutting-down-orleans.md
+++ b/docs/site/src/content/docs/host/configuration-guide/shutting-down-orleans.md
@@ -7,7 +7,7 @@ ms.topic: how-to
 
 # Shut down Orleans silos
 
-Orleans is an `IHostedService` inside the .NET Generic Host. When the host stops, Orleans leaves the cluster, closes gateways and networking, deactivates grains, and stops providers in reverse lifecycle order.
+Orleans is an `IHostedService` inside the [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host). When the host stops, Orleans leaves the cluster, closes gateways and networking, deactivates grains, and stops providers in reverse lifecycle order.
 
 ## Let the Generic Host own shutdown
 
@@ -24,7 +24,7 @@ builder.UseOrleans(siloBuilder =>
 await builder.Build().RunAsync();
 ```
 
-The console lifetime handles <kbd>Ctrl</kbd>+<kbd>C</kbd>, `SIGINT`, and `SIGTERM`. ASP.NET Core hosts use the same host lifetime model.
+The console lifetime handles <kbd>Ctrl</kbd>+<kbd>C</kbd>, `SIGINT`, and `SIGTERM`. ASP.NET Core hosts use the same host lifetime model. For details, see [.NET Generic Host shutdown](https://learn.microsoft.com/dotnet/core/extensions/generic-host#host-shutdown).
 
 In tests or embedded hosts, call `StopAsync` and dispose the host:
 

--- a/docs/site/src/content/docs/host/configuration-guide/silo-metadata.md
+++ b/docs/site/src/content/docs/host/configuration-guide/silo-metadata.md
@@ -60,14 +60,7 @@ Metadata is fixed for the lifetime of a silo instance. Restart the silo to publi
 
 Inject `ISiloMetadataCache` into a silo service or Orleans component:
 
-```csharp
-var metadata = siloMetadataCache.GetSiloMetadata(siloAddress);
-
-if (metadata.Metadata.TryGetValue("role", out var role))
-{
-    logger.LogInformation("Silo {Silo} has role {Role}", siloAddress, role);
-}
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="read_silo_metadata":::
 
 The cache follows cluster membership and fetches metadata from active silos. `GetSiloMetadata` returns the locally cached value, so it doesn't add a remote call to the request path.
 

--- a/docs/site/src/content/docs/host/configuration-guide/silo-metadata.md
+++ b/docs/site/src/content/docs/host/configuration-guide/silo-metadata.md
@@ -1,118 +1,82 @@
 ---
 title: Silo metadata
-description: Learn about silo metadata in .NET Orleans.
-ms.date: 01/21/2026
+description: Annotate Orleans 10 silos for placement and application decisions.
+ms.date: 08/02/2026
+ms.topic: how-to
 ---
 
 # Silo metadata
 
-Silo metadata is a feature in Orleans that allows developers to assign custom metadata to silos within a cluster. This metadata provides a flexible mechanism for annotating silos with descriptive information or specific capabilities.
+Silo metadata is an immutable string-to-string map published by each silo. Use it to describe placement-relevant capabilities such as region, hardware, role, or reservation type.
 
-This feature is particularly useful in scenarios where different silos have distinct roles, hardware configurations, or other unique characteristics. For example, silos can be tagged based on their region, compute power, or specialized responsibilities within the system.
+Metadata supports [grain placement filtering](../../grains/grain-placement-filtering.md). Don't put credentials, frequently changing health data, or large payloads in it.
 
-Silo metadata lays the groundwork for additional Orleans features, such as [Grain placement filtering](../../grains/grain-placement-filtering.md).
+## Configure metadata
 
-## Key concepts
-
-Silo metadata introduces a way to attach key-value pairs to silos within an Orleans cluster. This feature allows developers to configure silo-specific characteristics that can be leveraged by Orleans components.
-
-Silo metadata is represented as an **immutable** dictionary of key-value pairs:
-
-- **Keys**: Strings that identify the metadata (for example, `"cloud.region"`, `"compute.reservation.type"`).
-- **Values**: Strings that describe the corresponding property (for example, `"us-east1"`, `"spot"`).
-
-## Configuration
-
-Silo metadata in Orleans is configured using two methods, either .NET configuration or directly in code.
-
-### Configure Silo metadata with configuration
-
-Silo metadata can be defined in the app's configuration, such as _appsettings.json_, environment variables, or any other available configuration source.
-
-#### Example: _appsettings.json_ configuration
+`UseSiloMetadata()` reads `Orleans:Metadata`:
 
 ```json
 {
   "Orleans": {
     "Metadata": {
-      "cloud.region": "us-east1",
-      "compute.reservation.type": "spot",
-      "role": "worker"
+      "cloud.region": "westus3",
+      "hardware.accelerator": "gpu",
+      "role": "recommendations"
     }
   }
 }
 ```
 
-The preceding configuration defines metadata for a Silo, tagging it with:
-
-- `cloud.region`: `"us-east1"`
-- `compute.reservation.type`: `"spot"`
-- `role`: `"worker"`
-
-To apply this configuration, use the following setup in your silo host builder:
-
 ```csharp
-Host.CreateApplicationBuilder(args).UseOrleans(siloBuilder =>
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.UseOrleans(siloBuilder =>
 {
-    // Configuration section Orleans:Metadata is used by default
     siloBuilder.UseSiloMetadata();
 });
 ```
 
-Alternatively, an explicit `IConfiguration` or `IConfigurationSection` can be passed in to control where in configuration the metadata is pulled from.
+Environment variables can set deployment-specific values, for example:
 
-### Configuring silo metadata in code
+```text
+Orleans__Metadata__cloud.region=westus3
+Orleans__Metadata__role=recommendations
+```
 
-For scenarios requiring programmatic metadata configuration, developers can add metadata directly in the Silo host builder.
-
-#### Example: Direct Code Configuration
+You can also supply values programmatically:
 
 ```csharp
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleans(siloBuilder =>
+siloBuilder.UseSiloMetadata(new Dictionary<string, string>
 {
-    siloBuilder.UseSiloMetadata(new Dictionary<string, string>
-    {
-        ["cloud.region"] = "us-east1",
-        ["compute.reservation.type"] = "spot",
-        ["role"] = "worker"
-    });
+    ["cloud.region"] = region,
+    ["hardware.accelerator"] = hasGpu ? "gpu" : "none",
+    ["role"] = "recommendations"
 });
 ```
 
-The preceding example achieves the same result as the JSON configuration but allows metadata values to be computed or loaded dynamically during silo initialization.
+Metadata is fixed for the lifetime of a silo instance. Restart the silo to publish changed values.
 
-### Merge configurations
+## Read metadata
 
-If both .NET configuration and direct code configuration are used, the direct configuration overrides any conflicting metadata values from the .NET configuration. This allows developers to set defaults with configuration files and dynamically adjust specific metadata during runtime.
-
-## Usage
-
-Developers can retrieve metadata through the `ISiloMetadataCache` interface. This interface allows for querying metadata for individual silos across the cluster. Metadata will always be returned from a local cache of metadata that gets updated in the background as cluster membership changes.
-
-### Access metadata for a specific silo
-
-The `ISiloMetadataCache` provides a method to retrieve the metadata for a specific silo by its unique identifier (<xref:Orleans.Runtime.SiloAddress>). The `ISoloMetadataCache` implementation is registered in the `UseSiloMetadata` method and can be injected as a dependency.
-
-#### Example: Access metadata for a Silo
+Inject `ISiloMetadataCache` into a silo service or Orleans component:
 
 ```csharp
-var siloMetadata = siloMetadataCache.GetSiloMetadata(siloAddress);
+var metadata = siloMetadataCache.GetSiloMetadata(siloAddress);
 
-if (siloMetadata.Metadata.TryGetValue("role", out var role))
+if (metadata.Metadata.TryGetValue("role", out var role))
 {
-    Console.WriteLine($"Silo Role for {siloAddress}: {role}");
-    // Execute role-specific logic
+    logger.LogInformation("Silo {Silo} has role {Role}", siloAddress, role);
 }
 ```
 
-In the preceding example:
+The cache follows cluster membership and fetches metadata from active silos. `GetSiloMetadata` returns the locally cached value, so it doesn't add a remote call to the request path.
 
-- `GetSiloMetadata(siloAddress)` retrieves the metadata for the specified silo.
-- Metadata keys like `"role"` can be used to influence application logic.
+## Define a metadata contract
 
-## Internal implementation
+- Use stable, namespaced keys such as `cloud.region` or `hardware.accelerator`.
+- Treat key names and values as an application contract.
+- Define behavior for missing or unknown values during rolling deployments.
+- Keep values low-cardinality when they feed placement or telemetry.
+- Ensure enough silos match every required placement filter.
 
-Internally, the `SiloMetadataCache` monitors changes in cluster membership on `MembershipTableManager` and keeps a local cache of metadata in sync with membership changes. Metadata is immutable for a given Silo, so it's retrieved once and cached until that Silo leaves the cluster. Cached metadata for clusters that are `Dead` or have left the membership table will be cleared out of the local cache.
-
-Each silo hosts an `ISystemTarget` that provides that silo's metadata. Calls to `SiloMetadataCache : ISiloMetadataCache` return a result from the local cache.
+Metadata complements heterogeneous silo configuration: use `GrainTypeOptions.Classes` when a silo cannot host a grain class, and metadata placement filters when it can host the class but should be selected based on capability.

--- a/docs/site/src/content/docs/host/configuration-guide/silo-metadata.md
+++ b/docs/site/src/content/docs/host/configuration-guide/silo-metadata.md
@@ -7,13 +7,19 @@ ms.topic: how-to
 
 # Silo metadata
 
+<a id="key-concepts"></a>
+
 Silo metadata is an immutable string-to-string map published by each silo. Use it to describe placement-relevant capabilities such as region, hardware, role, or reservation type.
 
 Metadata supports [grain placement filtering](../../grains/grain-placement-filtering.md). Don't put credentials, frequently changing health data, or large payloads in it.
 
-## Configure metadata
+## Configuration
 
-`UseSiloMetadata()` reads `Orleans:Metadata`:
+### Configure silo metadata with configuration
+
+<a id="example-appsettingsjson-configuration"></a>
+
+<xref:Orleans.Runtime.MembershipService.SiloMetadata.SiloMetadataHostingExtensions.UseSiloMetadata*> reads `Orleans:Metadata`:
 
 ```json
 {
@@ -27,14 +33,7 @@ Metadata supports [grain placement filtering](../../grains/grain-placement-filte
 }
 ```
 
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder.UseSiloMetadata();
-});
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="silo_metadata_from_configuration":::
 
 Environment variables can set deployment-specific values, for example:
 
@@ -43,26 +42,27 @@ Orleans__Metadata__cloud.region=westus3
 Orleans__Metadata__role=recommendations
 ```
 
+### Configuring silo metadata in code
+
+<a id="example-direct-code-configuration"></a>
+
 You can also supply values programmatically:
 
-```csharp
-siloBuilder.UseSiloMetadata(new Dictionary<string, string>
-{
-    ["cloud.region"] = region,
-    ["hardware.accelerator"] = hasGpu ? "gpu" : "none",
-    ["role"] = "recommendations"
-});
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="configure_silo_metadata":::
 
 Metadata is fixed for the lifetime of a silo instance. Restart the silo to publish changed values.
 
-## Read metadata
+## Usage
 
-Inject `ISiloMetadataCache` into a silo service or Orleans component:
+### Access metadata for a specific silo
+
+<a id="example-access-metadata-for-a-silo"></a>
+
+Inject <xref:Orleans.Runtime.MembershipService.SiloMetadata.ISiloMetadataCache> into a silo service or Orleans component:
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="read_silo_metadata":::
 
-The cache follows cluster membership and fetches metadata from active silos. `GetSiloMetadata` returns the locally cached value, so it doesn't add a remote call to the request path.
+The cache follows cluster membership and fetches metadata from active silos. <xref:Orleans.Runtime.MembershipService.SiloMetadata.ISiloMetadataCache.GetSiloMetadata*> returns the locally cached value, so it doesn't add a remote call to the request path.
 
 ## Define a metadata contract
 
@@ -72,4 +72,4 @@ The cache follows cluster membership and fetches metadata from active silos. `Ge
 - Keep values low-cardinality when they feed placement or telemetry.
 - Ensure enough silos match every required placement filter.
 
-Metadata complements heterogeneous silo configuration: use `GrainTypeOptions.Classes` when a silo cannot host a grain class, and metadata placement filters when it can host the class but should be selected based on capability.
+Metadata complements heterogeneous silo configuration: use <xref:Orleans.Configuration.GrainTypeOptions.Classes> when a silo cannot host a grain class, and metadata placement filters when it can host the class but should be selected based on capability.

--- a/docs/site/src/content/docs/host/configuration-guide/silo-metadata.md
+++ b/docs/site/src/content/docs/host/configuration-guide/silo-metadata.md
@@ -1,6 +1,6 @@
 ---
 title: Silo metadata
-description: Annotate Orleans 10 silos for placement and application decisions.
+description: Annotate Orleans silos for placement and application decisions.
 ms.date: 08/02/2026
 ms.topic: how-to
 ---

--- a/docs/site/src/content/docs/host/configuration-guide/startup-tasks.md
+++ b/docs/site/src/content/docs/host/configuration-guide/startup-tasks.md
@@ -7,7 +7,7 @@ ms.topic: how-to
 
 # Background services and startup tasks
 
-Use standard .NET hosted services for application initialization and background work. Orleans participates in the same Generic Host, so registration order can ensure Orleans is ready before a hosted service starts.
+Use standard [.NET hosted services](https://learn.microsoft.com/dotnet/core/extensions/workers) for application initialization and background work. Orleans participates in the same Generic Host, so registration order can ensure Orleans is ready before a hosted service starts.
 
 ## Run continuous background work
 

--- a/docs/site/src/content/docs/host/configuration-guide/startup-tasks.md
+++ b/docs/site/src/content/docs/host/configuration-guide/startup-tasks.md
@@ -1,177 +1,83 @@
 ---
-title: Background Services and Startup Tasks
-description: Learn how to configure and manage background services and startup tasks in .NET Orleans.
-ms.date: 05/23/2025
+title: Background services and startup tasks
+description: Run application initialization and background work with Orleans 10.
+ms.date: 08/02/2026
+ms.topic: how-to
 ---
 
 # Background services and startup tasks
 
-When building Orleans applications, you often need to perform background operations or initialize components when the application starts.
+Use standard .NET hosted services for application initialization and background work. Orleans participates in the same Generic Host, so registration order can ensure Orleans is ready before a hosted service starts.
 
-Use startup tasks to perform initialization work when a silo starts, either before or after it begins accepting requests. Common use cases include:
+## Run continuous background work
 
-- Initializing grain state or preloading data
-- Setting up external service connections
-- Performing database migrations
-- Validating configuration
-- Warming up caches
-
-## Using `BackgroundService` (Recommended)
-
-The recommended approach is to use .NET [`BackgroundService` or `IHostedService`](/aspnet/core/fundamentals/host/hosted-services). See the [Background tasks with hosted services in ASP.NET Core](/aspnet/core/fundamentals/host/hosted-services) documentation for more information.
-
-Here's an example that pings a grain every 5 seconds:
+Register Orleans first, then the `BackgroundService`:
 
 ```csharp
-public class GrainPingService : BackgroundService
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.UseOrleans(siloBuilder =>
 {
-    private readonly IGrainFactory _grainFactory;
-    private readonly ILogger<GrainPingService> _logger;
-
-    public GrainPingService(
-        IGrainFactory grainFactory,
-        ILogger<GrainPingService> logger)
-    {
-        _grainFactory = grainFactory;
-        _logger = logger;
-    }
-
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-    {
-        try
-        {
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                try
-                {
-                    _logger.LogInformation("Pinging grain...");
-                    var grain = _grainFactory.GetGrain<IMyGrain>("ping-target");
-                    await grain.Ping();
-                }
-                catch (Exception ex) when (ex is not OperationCanceledException)
-                {
-                    // Log the error but continue running
-                    _logger.LogError(ex, "Failed to ping grain. Will retry in 5 seconds.");
-                }
-
-                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
-            }
-        }
-        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-        {
-            // Ignore cancellation during shutdown.
-        }
-        finally
-        {
-            _logger.LogInformation("Grain ping service is shutting down.");
-        }
-    }
-}
-```
-
-Registration order is significant because services added to the host builder start one by one in the order they are registered. Register the background service as follows:
-
-```csharp
-var builder = WebApplication.CreateBuilder(args);
-
-// Configure Orleans first
-builder.UseOrleans(siloBuilder => 
-{
-    // Orleans configuration...
+    // Configure Orleans.
 });
 
-// Register the background service after calling 'UseOrleans' to make it start once Orleans has started.
 builder.Services.AddHostedService<GrainPingService>();
 
-var app = builder.Build();
+await builder.Build().RunAsync();
 ```
 
-The background service starts automatically when the application starts and gracefully shuts down when the application stops.
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="background_service":::
 
-## Using `IHostedService`
+Honor `stoppingToken` so the service doesn't delay silo shutdown. Use `IHostedService` directly for one-time startup and shutdown work.
 
-For simpler scenarios where you don't need continuous background operation, implement `IHostedService` directly:
+## Run a required Orleans startup task
 
-```csharp
-public class GrainInitializerService : IHostedService
-{
-    private readonly IGrainFactory _grainFactory;
-    private readonly ILogger<GrainInitializerService> _logger;
-
-    public GrainInitializerService(
-        IGrainFactory grainFactory,
-        ILogger<GrainInitializerService> logger)
-    {
-        _grainFactory = grainFactory;
-        _logger = logger;
-    }
-
-    public async Task StartAsync(CancellationToken cancellationToken)
-    {
-        _logger.LogInformation("Initializing grains...");
-        var grain = _grainFactory.GetGrain<IMyGrain>("initializer");
-        await grain.Initialize();
-    }
-
-    public Task StopAsync(CancellationToken cancellationToken)
-    {
-        return Task.CompletedTask;
-    }
-}
-```
-
-Register it the same way:
-
-```csharp
-builder.Services.AddHostedService<GrainInitializerService>();
-```
-
-## Orleans startup tasks
-
-> [!NOTE]
-> While startup tasks are still supported, we recommend using `BackgroundService` or `IHostedService` instead, as they are the standard .NET hosting mechanism for running background tasks.
-
-> [!WARNING]
-> Any exceptions thrown from a startup task are reported in the silo log and stop the silo. This fail-fast approach helps detect configuration and bootstrap issues during testing rather than causing unexpected problems later. However, it can also mean that transient failures in a startup task cause host unavailability.
-
-If you need to use the built-in startup task system, configure them as follows:
-
-### Register a delegate
-
-Register a delegate as a startup task using the appropriate <xref:Orleans.Hosting.SiloBuilderStartupExtensions.AddStartupTask*> extension method on <xref:Orleans.Hosting.ISiloBuilder>.
+Use `AddStartupTask` when initialization must complete at an Orleans lifecycle stage before startup can continue:
 
 ```csharp
 siloBuilder.AddStartupTask(
-    async (IServiceProvider services, CancellationToken cancellation) =>
+    async (services, cancellationToken) =>
     {
         var grainFactory = services.GetRequiredService<IGrainFactory>();
-        var grain = grainFactory.GetGrain<IMyGrain>("startup-task-grain");
-        await grain.Initialize();
-    });
+        var grain = grainFactory.GetGrain<IInitializerGrain>("application");
+        await grain.Initialize(cancellationToken);
+    },
+    ServiceLifecycleStage.Active);
 ```
 
-### Register an `IStartupTask` implementation
+The default stage is `ServiceLifecycleStage.Active`. An exception fails silo startup. This is appropriate for mandatory validation or initialization, but not for optional work that can retry after the host becomes ready.
 
-Implement the <xref:Orleans.Runtime.IStartupTask> interface and register it as a startup task using the <xref:Orleans.Hosting.SiloBuilderStartupExtensions.AddStartupTask*> extension method on <xref:Orleans.Hosting.ISiloBuilder>.
+For reusable tasks, implement `IStartupTask`:
 
 ```csharp
-public class CallGrainStartupTask : IStartupTask
+public sealed class ValidateDependenciesTask : IStartupTask
 {
-    private readonly IGrainFactory _grainFactory;
+    private readonly IDependencyValidator _validator;
 
-    public CallGrainStartupTask(IGrainFactory grainFactory) =>
-        _grainFactory = grainFactory;
-
-    public async Task Execute(CancellationToken cancellationToken)
+    public ValidateDependenciesTask(IDependencyValidator validator)
     {
-        var grain = _grainFactory.GetGrain<IMyGrain>("startup-task-grain");
-        await grain.Initialize();
+        _validator = validator;
     }
+
+    public Task Execute(CancellationToken cancellationToken) =>
+        _validator.ValidateAsync(cancellationToken);
 }
 ```
 
-Register the startup task as follows:
-
 ```csharp
-siloBuilder.AddStartupTask<CallGrainStartupTask>();
+siloBuilder.AddStartupTask<ValidateDependenciesTask>(
+    ServiceLifecycleStage.ApplicationServices);
 ```
+
+## Choose the right mechanism
+
+| Requirement | Mechanism |
+|---|---|
+| Continuous loop or scheduled application work | `BackgroundService` |
+| One-time host startup and shutdown work | `IHostedService` |
+| Mandatory initialization at a specific Orleans stage | `AddStartupTask` |
+| Start and stop callbacks integrated with an Orleans subsystem | `ILifecycleParticipant<ISiloLifecycle>` |
+
+Don't use a startup task for long-running loops, database migrations that multiple replicas could race to apply, or work that needs unbounded retries. Coordinate migrations externally or make them safely single-writer.
+
+See [Orleans silo lifecycle](../silo-lifecycle.md) for lifecycle stage selection.

--- a/docs/site/src/content/docs/host/configuration-guide/startup-tasks.md
+++ b/docs/site/src/content/docs/host/configuration-guide/startup-tasks.md
@@ -9,74 +9,48 @@ ms.topic: how-to
 
 Use standard [.NET hosted services](https://learn.microsoft.com/dotnet/core/extensions/workers) for application initialization and background work. Orleans participates in the same Generic Host, so registration order can ensure Orleans is ready before a hosted service starts.
 
-## Run continuous background work
+<a id="using-backgroundservice-recommended"></a>
 
-Register Orleans first, then the `BackgroundService`:
+## Using <xref:Microsoft.Extensions.Hosting.BackgroundService> (Recommended)
 
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
+Register Orleans first, then the <xref:Microsoft.Extensions.Hosting.BackgroundService>:
 
-builder.UseOrleans(siloBuilder =>
-{
-    // Configure Orleans.
-});
-
-builder.Services.AddHostedService<GrainPingService>();
-
-await builder.Build().RunAsync();
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="register_background_service":::
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="background_service":::
 
-Honor `stoppingToken` so the service doesn't delay silo shutdown. Use `IHostedService` directly for one-time startup and shutdown work.
+Honor `stoppingToken` so the service doesn't delay silo shutdown. Use <xref:Microsoft.Extensions.Hosting.IHostedService> directly for one-time startup and shutdown work.
 
-## Run a required Orleans startup task
+## Orleans startup tasks
 
-Use `AddStartupTask` when initialization must complete at an Orleans lifecycle stage before startup can continue:
+### Register a delegate
 
-```csharp
-siloBuilder.AddStartupTask(
-    async (services, cancellationToken) =>
-    {
-        var grainFactory = services.GetRequiredService<IGrainFactory>();
-        var grain = grainFactory.GetGrain<IInitializerGrain>("application");
-        await grain.Initialize(cancellationToken);
-    },
-    ServiceLifecycleStage.Active);
-```
+Use <xref:Orleans.Hosting.SiloBuilderStartupExtensions.AddStartupTask*> when initialization must complete at an Orleans lifecycle stage before startup can continue:
 
-The default stage is `ServiceLifecycleStage.Active`. An exception fails silo startup. This is appropriate for mandatory validation or initialization, but not for optional work that can retry after the host becomes ready.
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="register_startup_task":::
 
-For reusable tasks, implement `IStartupTask`:
+The default stage is <xref:Orleans.ServiceLifecycleStage.Active>. An exception fails silo startup. This is appropriate for mandatory validation or initialization, but not for optional work that can retry after the host becomes ready.
 
-```csharp
-public sealed class ValidateDependenciesTask : IStartupTask
-{
-    private readonly IDependencyValidator _validator;
+<a id="register-an-istartuptask-implementation"></a>
 
-    public ValidateDependenciesTask(IDependencyValidator validator)
-    {
-        _validator = validator;
-    }
+### Register an <xref:Orleans.Runtime.IStartupTask> implementation
 
-    public Task Execute(CancellationToken cancellationToken) =>
-        _validator.ValidateAsync(cancellationToken);
-}
-```
+For reusable tasks, implement <xref:Orleans.Runtime.IStartupTask>:
 
-```csharp
-siloBuilder.AddStartupTask<ValidateDependenciesTask>(
-    ServiceLifecycleStage.ApplicationServices);
-```
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="validate_dependencies_task":::
+
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="register_validate_dependencies_task":::
 
 ## Choose the right mechanism
 
+<a id="using-ihostedservice"></a>
+
 | Requirement | Mechanism |
 |---|---|
-| Continuous loop or scheduled application work | `BackgroundService` |
-| One-time host startup and shutdown work | `IHostedService` |
-| Mandatory initialization at a specific Orleans stage | `AddStartupTask` |
-| Start and stop callbacks integrated with an Orleans subsystem | `ILifecycleParticipant<ISiloLifecycle>` |
+| Continuous loop or scheduled application work | <xref:Microsoft.Extensions.Hosting.BackgroundService> |
+| One-time host startup and shutdown work | <xref:Microsoft.Extensions.Hosting.IHostedService> |
+| Mandatory initialization at a specific Orleans stage | <xref:Orleans.Hosting.SiloBuilderStartupExtensions.AddStartupTask*> |
+| Start and stop callbacks integrated with an Orleans subsystem | <xref:Orleans.ILifecycleParticipant`1> with <xref:Orleans.Runtime.ISiloLifecycle> |
 
 Don't use a startup task for long-running loops, database migrations that multiple replicas could race to apply, or work that needs unbounded retries. Coordinate migrations externally or make them safely single-writer.
 

--- a/docs/site/src/content/docs/host/configuration-guide/startup-tasks.md
+++ b/docs/site/src/content/docs/host/configuration-guide/startup-tasks.md
@@ -1,6 +1,6 @@
 ---
 title: Background services and startup tasks
-description: Run application initialization and background work with Orleans 10.
+description: Run application initialization and background work with Orleans.
 ms.date: 08/02/2026
 ms.topic: how-to
 ---

--- a/docs/site/src/content/docs/host/configuration-guide/typical-configurations.md
+++ b/docs/site/src/content/docs/host/configuration-guide/typical-configurations.md
@@ -1,553 +1,66 @@
 ---
-title: Typical configurations
-description: Learn about typical configurations in .NET Orleans.
-ms.date: 01/21/2026
-ms.topic: reference
-zone_pivot_groups: orleans-version
-ms.custom: sfi-ropc-nochange
+title: Typical Orleans configurations
+description: Choose a local, Aspire, or production Orleans 10 configuration.
+ms.date: 08/02/2026
+ms.topic: concept-article
 ---
 
-# Typical configurations
+# Typical Orleans configurations
 
-Below are examples of typical configurations you can use for development and production deployments.
+Choose the smallest hosting model that matches the deployment.
 
-:::zone target="docs" pivot="orleans-8-0,orleans-9-0,orleans-10-0"
+| Scenario | Hosting model | Clustering | State and reminders |
+|---|---|---|---|
+| One-process development | Co-hosted silo and client | `UseLocalhostClustering` | Memory providers |
+| Local distributed development | Aspire with multiple silo replicas | Local container or emulator | Local container or emulator |
+| Production service with HTTP/API entry points | Co-host ASP.NET Core and Orleans in each silo when resource isolation isn't required | Platform-appropriate durable provider | Durable providers |
+| Isolated frontend and worker tier | External Orleans client in frontend; silo-only worker tier | Same durable provider and cluster identity in both tiers | Durable providers on silos |
 
-## Recommended: Aspire configuration
+## Single-process development
 
-[Aspire](../aspire-integration.md) is the recommended approach for configuring Orleans applications. Aspire provides declarative resource management, automatic service discovery, built-in observability, and simplified deployment—eliminating most manual configuration.
+:::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="local_silo_and_client":::
 
-### Production configuration with Redis
+This is intentionally disposable. See [Local development configuration](local-development-configuration.md) before adding more local silos.
 
-This configuration uses Redis for clustering, grain storage, and reminders with multiple silo replicas:
+## Aspire development and deployment modeling
 
-**AppHost project (Program.cs):**
+The compiled AppHost examples define Orleans resources and their dependencies:
 
-```csharp
-var builder = DistributedApplication.CreateBuilder(args);
+:::code language="csharp" source="../snippets/aspire/AppHost/AppHostExamples.cs" id="orleans_with_storage_reminders":::
 
-var redis = builder.AddRedis("redis");
+The silo registers the Aspire service clients and lets Orleans consume injected configuration:
 
-var orleans = builder.AddOrleans("cluster")
-    .WithClustering(redis)
-    .WithGrainStorage("Default", redis)
-    .WithReminders(redis);
+:::code language="csharp" source="../snippets/aspire/Silo/SiloProgram.cs" id="silo_basic_config":::
 
-// Add Orleans silo with 3 replicas for production
-builder.AddProject<Projects.MySilo>("silo")
-    .WithReference(orleans)
-    .WithReference(redis)
-    .WithReplicas(3);
+Use `.WithReplicas(...)` to model multiple silos. Local Redis containers and Azurite are useful development dependencies, but production deployments must bind those resources to managed or otherwise durable services. Don't call `.RunAsEmulator()` in a production AppHost configuration.
 
-// Add a separate client project (e.g., an API)
-builder.AddProject<Projects.MyApi>("api")
-    .WithReference(orleans.AsClient())
-    .WithReference(redis);
+## Production configuration
 
-builder.Build().Run();
-```
+A production configuration should make these choices explicit:
 
-**Silo project (Program.cs):**
+1. Pick a durable clustering provider supported by the platform.
+2. Set stable `ServiceId` and environment/deployment-specific `ClusterId` values.
+3. Configure advertised addresses that every silo and client can route to.
+4. Add durable storage, reminders, streams, and grain directories only for features the application uses.
+5. Supply credentials through the deployment environment, preferably using workload identity.
+6. Configure health/readiness, telemetry, graceful termination, CPU, memory, and server GC.
 
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
+For example, an Azure deployment can use Azure Table Storage for clustering and reminders and Azure Blob or Table Storage for grain state. An AWS deployment can use DynamoDB. A database-centered deployment can use ADO.NET. Redis, Cosmos DB, Consul, and ZooKeeper providers are also available for the capabilities their packages implement. Kubernetes deployments can use the separate Kubernetes hosting integration with one of these clustering providers.
 
-builder.AddServiceDefaults();
-builder.AddKeyedRedisClient("redis");
-builder.UseOrleans();
+The provider used for clustering doesn't need to match the grain storage or reminder provider. Select each based on durability, latency, operational ownership, and cost.
 
-builder.Build().Run();
-```
+## Separate external client
 
-**Client project (Program.cs):**
+Use an external client when the frontend and silo tier need separate scaling, security boundaries, deployments, or resource isolation. Configure `UseOrleansClient` with exactly the same service identity, cluster identity, and clustering backend as the silo tier. The client reaches gateway endpoints, so expose and secure those routes separately from silo-to-silo endpoints.
 
-```csharp
-var builder = WebApplication.CreateBuilder(args);
+## Avoid development configuration in production
 
-builder.AddServiceDefaults();
-builder.AddKeyedRedisClient("redis");
-builder.UseOrleansClient();
+Don't use any of the following in production:
 
-var app = builder.Build();
-// ... configure API endpoints
-app.Run();
-```
+- `UseLocalhostClustering`, development clustering, or static gateway lists.
+- Memory grain storage or memory reminders when data must survive.
+- Azurite or other emulator endpoints.
+- Loopback or wildcard addresses as advertised endpoints.
+- Unbounded custom client connection retries.
 
-> [!TIP]
-> Use `WithReplicas(n)` to run multiple silo instances for high availability. Use `orleans.AsClient()` when a project only needs to call grains, not host them.
-
-### Production configuration with Azure Storage
-
-This configuration uses Azure Table Storage for clustering and Azure Blob Storage for grain storage:
-
-**AppHost project (Program.cs):**
-
-```csharp
-var builder = DistributedApplication.CreateBuilder(args);
-
-var storage = builder.AddAzureStorage("storage")
-    .RunAsEmulator();  // Use Azurite for local development
-var tables = storage.AddTables("clustering");
-var blobs = storage.AddBlobs("grainstate");
-
-var orleans = builder.AddOrleans("cluster")
-    .WithClustering(tables)
-    .WithGrainStorage("Default", blobs);
-
-builder.AddProject<Projects.MySilo>("silo")
-    .WithReference(orleans)
-    .WaitFor(storage)
-    .WithReplicas(3);
-
-builder.Build().Run();
-```
-
-**Silo project (Program.cs):**
-
-```csharp
-var builder = Host.CreateApplicationBuilder(args);
-
-builder.AddServiceDefaults();
-builder.AddKeyedAzureTableServiceClient("clustering");
-builder.AddKeyedAzureBlobServiceClient("grainstate");
-builder.UseOrleans();
-
-builder.Build().Run();
-```
-
-> [!TIP]
-> To use the Azurite emulator for local development, call `.RunAsEmulator()` on the Azure Storage resource as shown above. Without this call, Aspire expects a real Azure Storage connection. In production deployments, remove `.RunAsEmulator()` and configure your Azure Storage account connection.
-
-> [!IMPORTANT]
-> You must call the appropriate `AddKeyed*` method (such as `AddKeyedRedisClient`, `AddKeyedAzureTableServiceClient`, or `AddKeyedAzureBlobServiceClient`) to register the backing resource in the dependency injection container. Orleans providers look up resources by their keyed service name—if you skip this step, Orleans won't be able to resolve the resource and will throw a dependency resolution error at runtime.
-
-For comprehensive documentation on Orleans and Aspire integration, see [Orleans and Aspire integration](../aspire-integration.md).
-
-:::zone-end
-
-## Local development
-
-For more information, see [Local development configuration](local-development-configuration.md).
-
-:::zone target="docs" pivot="orleans-8-0,orleans-9-0,orleans-10-0"
-
-## Traditional configurations (without Aspire)
-
-The following sections describe traditional Orleans configurations that don't use Aspire. These are useful when Aspire isn't available or when you need fine-grained control over Orleans configuration.
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-## Reliable production deployment using Azure
-
-For a reliable production deployment using Azure, use the Azure Table option for cluster membership. This configuration is typical for deployments to on-premises servers, containers, or Azure virtual machine instances.
-
-### [Microsoft Entra ID (recommended)](#tab/entra-id)
-
-Using a `TokenCredential` with a service URI is the recommended approach. This pattern avoids storing secrets in configuration and leverages Microsoft Entra ID for secure authentication.
-
-<xref:Azure.Identity.DefaultAzureCredential> provides a credential chain that works seamlessly across local development and production environments. During development, it uses your Azure CLI or Visual Studio credentials. In production on Azure, it automatically uses the managed identity assigned to your resource.
-
-[!INCLUDE [credential-chain-guidance](../../includes/credential-chain-guidance.md)]
-
-Silo configuration:
-
-```csharp
-using Azure.Identity;
-
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .UseAzureStorageClustering(options =>
-    {
-        options.ConfigureTableServiceClient(
-            new Uri("https://<your-storage-account>.table.core.windows.net"),
-            new DefaultAzureCredential());
-    })
-    .ConfigureEndpoints(siloPort: 11_111, gatewayPort: 30_000);
-});
-
-builder.Logging.SetMinimumLevel(LogLevel.Information).AddConsole();
-
-using var host = builder.Build();
-```
-
-Client configuration:
-
-```csharp
-using Azure.Identity;
-
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleansClient(clientBuilder =>
-{
-    clientBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .UseAzureStorageClustering(options =>
-    {
-        options.ConfigureTableServiceClient(
-            new Uri("https://<your-storage-account>.table.core.windows.net"),
-            new DefaultAzureCredential());
-    });
-});
-
-using var host = builder.Build();
-```
-
-### [Connection string](#tab/connection-string)
-
-> [!WARNING]
-> Connection strings contain secrets and should be avoided in production. Use Microsoft Entra ID authentication whenever possible.
-
-The format of the `DataConnection` string is a semicolon-separated list of `Key=Value` pairs. The following options are supported:
-
-| Key                        | Value                               |
-|----------------------------|-------------------------------------|
-| `DefaultEndpointsProtocol` | `https`                             |
-| `AccountName`              | `<Azure storage account>`           |
-| `AccountKey`               | `<Azure table storage account key>` |
-
-The following is an example of a `DataConnection` string for Azure Table storage:
-
-```
-"DefaultEndpointsProtocol=https;AccountName=<Azure storage account>;AccountKey=<Azure table storage account key>"
-```
-
-Silo configuration:
-
-```csharp
-const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .UseAzureStorageClustering(
-        options => options.ConfigureTableServiceClient(connectionString))
-    .ConfigureEndpoints(siloPort: 11_111, gatewayPort: 30_000);
-});
-
-builder.Logging.SetMinimumLevel(LogLevel.Information).AddConsole();
-
-using var host = builder.Build();
-```
-
-Client configuration:
-
-```csharp
-const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleansClient(clientBuilder =>
-{
-    clientBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .UseAzureStorageClustering(
-        options => options.ConfigureTableServiceClient(connectionString));
-});
-
-using var host = builder.Build();
-```
-
----
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-## Reliable production deployment using Azure
-
-For a reliable production deployment using Azure, use the Azure Table option for cluster membership. This configuration is typical for deployments to on-premises servers, containers, or Azure virtual machine instances.
-
-The format of the `DataConnection` string is a semicolon-separated list of `Key=Value` pairs. The following options are supported:
-
-| Key                        | Value                               |
-|----------------------------|-------------------------------------|
-| `DefaultEndpointsProtocol` | `https`                             |
-| `AccountName`              | `<Azure storage account>`           |
-| `AccountKey`               | `<Azure table storage account key>` |
-
-The following is an example of a `DataConnection` string for Azure Table storage:
-
-```
-"DefaultEndpointsProtocol=https;AccountName=<Azure storage account>;AccountKey=<Azure table storage account key>"
-```
-
-Silo configuration:
-
-```csharp
-const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-var silo = new SiloHostBuilder()
-    .Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .UseAzureStorageClustering(
-        options => options.ConnectionString = connectionString)
-    .ConfigureEndpoints(siloPort: 11_111, gatewayPort: 30_000)
-    .ConfigureLogging(builder => builder.SetMinimumLevel(LogLevel.Information).AddConsole())
-    .Build();
-```
-
-Client configuration:
-
-```csharp
-const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-
-var client = new ClientBuilder()
-    .Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .UseAzureStorageClustering(
-        options => options.ConnectionString = connectionString)
-    .Build();
-```
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-7-0,orleans-8-0,orleans-9-0,orleans-10-0"
-
-## Reliable production deployment using SQL Server
-
-For a reliable production deployment using SQL Server, supply a SQL Server connection string.
-
-> [!NOTE]
-> Starting with Orleans 10.0, ADO.NET providers require the `Microsoft.Data.SqlClient` package instead of `System.Data.SqlClient`. Use the invariant `Microsoft.Data.SqlClient` in Orleans 10.0 and later.
-
-### Orleans 10.0+
-
-```csharp
-const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .UseAdoNetClustering(options =>
-    {
-        options.ConnectionString = connectionString;
-        options.Invariant = "Microsoft.Data.SqlClient"; // Orleans 10.0+
-    })
-    .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000);
-});
-
-builder.Logging.SetMinimumLevel(LogLevel.Information).AddConsole();
-
-using var host = builder.Build();
-```
-
-### Orleans 7.0-9.x
-
-```csharp
-const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .UseAdoNetClustering(options =>
-    {
-        options.ConnectionString = connectionString;
-        options.Invariant = "System.Data.SqlClient";
-    })
-    .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000);
-});
-
-builder.Logging.SetMinimumLevel(LogLevel.Information).AddConsole();
-
-using var host = builder.Build();
-```
-
-Client configuration:
-
-```csharp
-const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleansClient(clientBuilder =>
-{
-    clientBuilder.Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .UseAdoNetClustering(options =>
-    {
-        options.ConnectionString = connectionString;
-        // Use "Microsoft.Data.SqlClient" for Orleans 10.0+
-        // Use "System.Data.SqlClient" for Orleans 7.0-9.x
-        options.Invariant = "Microsoft.Data.SqlClient";
-    });
-});
-
-using var host = builder.Build();
-```
-
-## Unreliable deployment on a cluster of dedicated servers
-
-For testing on a cluster of dedicated servers where reliability isn't a concern, you can leverage `MembershipTableGrain` and avoid dependency on Azure Table. You just need to designate one of the nodes as primary.
-
-On the silos:
-
-```csharp
-var primarySiloEndpoint = new IPEndPoint(PRIMARY_SILO_IP_ADDRESS, 11_111);
-
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleans(siloBuilder =>
-{
-    siloBuilder
-        .UseDevelopmentClustering(primarySiloEndpoint)
-        .Configure<ClusterOptions>(options =>
-        {
-            options.ClusterId = "Cluster42";
-            options.ServiceId = "MyAwesomeService";
-        })
-        .ConfigureEndpoints(siloPort: 11_111, gatewayPort: 30_000);
-});
-builder.Logging.AddConsole();
-
-using var host = builder.Build();
-await host.RunAsync();
-```
-
-On the clients:
-
-```csharp
-var gateways = new IPEndPoint[]
-{
-    new IPEndPoint(PRIMARY_SILO_IP_ADDRESS, 30_000),
-    new IPEndPoint(OTHER_SILO__IP_ADDRESS_1, 30_000),
-    // ...
-    new IPEndPoint(OTHER_SILO__IP_ADDRESS_N, 30_000),
-};
-
-var builder = Host.CreateApplicationBuilder(args);
-builder.UseOrleansClient(clientBuilder =>
-{
-    clientBuilder.UseStaticClustering(gateways)
-        .Configure<ClusterOptions>(options =>
-        {
-            options.ClusterId = "Cluster42";
-            options.ServiceId = "MyAwesomeService";
-        });
-});
-
-using var host = builder.Build();
-await host.StartAsync();
-```
-
-:::zone-end
-
-:::zone target="docs" pivot="orleans-3-x"
-
-## Reliable production deployment using SQL Server
-
-For a reliable production deployment using SQL Server, supply a SQL Server connection string.
-
-Silo configuration:
-
-```csharp
-const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-var silo = new SiloHostBuilder()
-    .Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .UseAdoNetClustering(options =>
-    {
-      options.ConnectionString = connectionString;
-      options.Invariant = "System.Data.SqlClient";
-    })
-    .ConfigureEndpoints(siloPort: 11111, gatewayPort: 30000)
-    .ConfigureLogging(builder => builder.SetMinimumLevel(LogLevel.Information).AddConsole())
-    .Build();
-```
-
-Client configuration:
-
-```csharp
-const string connectionString = "YOUR_CONNECTION_STRING_HERE";
-
-var client = new ClientBuilder()
-    .Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .UseAdoNetClustering(options =>
-    {
-      options.ConnectionString = connectionString;
-      options.Invariant = "System.Data.SqlClient";
-    })
-    .Build();
-```
-
-## Unreliable deployment on a cluster of dedicated servers
-
-For testing on a cluster of dedicated servers where reliability isn't a concern, you can leverage `MembershipTableGrain` and avoid dependency on Azure Table. You just need to designate one of the nodes as primary.
-
-On the silos:
-
-```csharp
-var primarySiloEndpoint = new IPEndPoint(PRIMARY_SILO_IP_ADDRESS, 11_111);
-var silo = new SiloHostBuilder()
-    .UseDevelopmentClustering(primarySiloEndpoint)
-    .Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .ConfigureEndpoints(siloPort: 11_111, gatewayPort: 30_000)
-    .ConfigureLogging(logging => logging.AddConsole())
-    .Build();
-```
-
-On the clients:
-
-```csharp
-var gateways = new IPEndPoint[]
-{
-    new IPEndPoint(PRIMARY_SILO_IP_ADDRESS, 30_000),
-    new IPEndPoint(OTHER_SILO__IP_ADDRESS_1, 30_000),
-    // ...
-    new IPEndPoint(OTHER_SILO__IP_ADDRESS_N, 30_000),
-};
-
-var client = new ClientBuilder()
-    .UseStaticClustering(gateways)
-    .Configure<ClusterOptions>(options =>
-    {
-        options.ClusterId = "Cluster42";
-        options.ServiceId = "MyAwesomeService";
-    })
-    .Build();
-```
-
-:::zone-end
+See [Server configuration](server-configuration.md), [Client configuration](client-configuration.md), and [Orleans and Aspire integration](../aspire-integration.md) for implementation details.

--- a/docs/site/src/content/docs/host/configuration-guide/typical-configurations.md
+++ b/docs/site/src/content/docs/host/configuration-guide/typical-configurations.md
@@ -1,6 +1,6 @@
 ---
 title: Typical Orleans configurations
-description: Choose a local, Aspire, or production Orleans 10 configuration.
+description: Choose a local, Aspire, or production Orleans configuration.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---

--- a/docs/site/src/content/docs/host/configuration-guide/typical-configurations.md
+++ b/docs/site/src/content/docs/host/configuration-guide/typical-configurations.md
@@ -11,18 +11,18 @@ Choose the smallest hosting model that matches the deployment.
 
 | Scenario | Hosting model | Clustering | State and reminders |
 |---|---|---|---|
-| One-process development | Co-hosted silo and client | `UseLocalhostClustering` | Memory providers |
+| One-process development | Co-hosted silo and client | <xref:Orleans.Hosting.CoreHostingExtensions.UseLocalhostClustering*> | Memory providers |
 | Local distributed development | Aspire with multiple silo replicas | Local container or emulator | Local container or emulator |
 | Production service with HTTP/API entry points | Co-host ASP.NET Core and Orleans in each silo when resource isolation isn't required | Platform-appropriate durable provider | Durable providers |
 | Isolated frontend and worker tier | External Orleans client in frontend; silo-only worker tier | Same durable provider and cluster identity in both tiers | Durable providers on silos |
 
-## Single-process development
+## Local development
 
 :::code language="csharp" source="../snippets/hosting/HostingExamples.cs" id="local_silo_and_client":::
 
 This is intentionally disposable. See [Local development configuration](local-development-configuration.md) before adding more local silos.
 
-## Aspire development and deployment modeling
+## Recommended: Aspire configuration
 
 The compiled AppHost examples define Orleans resources and their dependencies:
 
@@ -36,10 +36,16 @@ Use `.WithReplicas(...)` to model multiple silos. Local Redis containers and Azu
 
 ## Production configuration
 
+<a id="production-configuration-with-redis"></a>
+<a id="production-configuration-with-azure-storage"></a>
+<a id="reliable-production-deployment-using-azure"></a>
+<a id="reliable-production-deployment-using-sql-server"></a>
+<a id="traditional-configurations-without-aspire"></a>
+
 A production configuration should make these choices explicit:
 
 1. Pick a durable clustering provider supported by the platform.
-2. Set stable `ServiceId` and environment/deployment-specific `ClusterId` values.
+2. Set stable <xref:Orleans.Configuration.ClusterOptions.ServiceId> and environment/deployment-specific <xref:Orleans.Configuration.ClusterOptions.ClusterId> values.
 3. Configure advertised addresses that every silo and client can route to.
 4. Add durable storage, reminders, streams, and grain directories only for features the application uses.
 5. Supply credentials through the deployment environment, preferably using workload identity.
@@ -51,13 +57,13 @@ The provider used for clustering doesn't need to match the grain storage or remi
 
 ## Separate external client
 
-Use an external client when the frontend and silo tier need separate scaling, security boundaries, deployments, or resource isolation. Configure `UseOrleansClient` with exactly the same service identity, cluster identity, and clustering backend as the silo tier. The client reaches gateway endpoints, so expose and secure those routes separately from silo-to-silo endpoints.
+Use an external client when the frontend and silo tier need separate scaling, security boundaries, deployments, or resource isolation. Configure <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*> with exactly the same service identity, cluster identity, and clustering backend as the silo tier. The client reaches gateway endpoints, so expose and secure those routes separately from silo-to-silo endpoints.
 
 ## Avoid development configuration in production
 
 Don't use any of the following in production:
 
-- `UseLocalhostClustering`, development clustering, or static gateway lists.
+- <xref:Orleans.Hosting.CoreHostingExtensions.UseLocalhostClustering*>, development clustering, or static gateway lists.
 - Memory grain storage or memory reminders when data must survive.
 - Azurite or other emulator endpoints.
 - Loopback or wildcard addresses as advertised endpoints.

--- a/docs/site/src/content/docs/host/grain-directory.md
+++ b/docs/site/src/content/docs/host/grain-directory.md
@@ -1,188 +1,90 @@
 ---
-title: Grain directory
-description: Learn about the grain directory in .NET Orleans.
-ms.date: 01/22/2026
+title: Orleans grain directories
+description: Choose and configure grain directories in Orleans 10.
+ms.date: 08/02/2026
 ms.topic: concept-article
-ms.custom: sfi-ropc-nochange
-zone_pivot_groups: orleans-version
 ---
 
-# Orleans grain directory
+# Orleans grain directories
 
-Grains have stable logical identities. They can activate (instantiate) and deactivate many times over the application's life, but at most one activation of a grain exists at any point in time. Each time a grain activates, it might be placed on a different silo in the cluster. When a grain activates in the cluster, it registers itself in the _grain directory_. This ensures subsequent invocations of that grain are delivered to that activation and prevents the creation of other activations (instances) of that grain. The grain directory is responsible for maintaining a mapping between a grain identity and the location (which silo) of its current activation.
+A grain directory maps a grain identity to the silo that currently hosts its activation. Orleans consults the directory when routing calls and coordinating single-activation grain placement.
 
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0"
+## Start with the default directory
 
-Orleans provides several grain directory implementations:
+Orleans 10 uses the built-in `LocalGrainDirectory` by default. Despite its name, the directory is distributed across the cluster using a consistent-hash ring. It requires no external service and is the right starting point for most applications.
 
-| Directory | Package | Description |
-|-----------|---------|-------------|
-| **Distributed In-Cluster** (default) | Built-in | Eventually consistent, partitioned across silos using a distributed hash table. Allows occasional duplicate activations during cluster instability. |
-| **Strongly-Consistent In-Cluster** | Built-in | Strongly consistent distributed hash table with versioned range locks. Prevents duplicate activations but requires more coordination. |
-| **ADO.NET** | `Microsoft.Orleans.GrainDirectory.AdoNet` | Database-backed directory supporting SQL Server, PostgreSQL, MySQL, and Oracle. |
-| **Azure Table Storage** | `Microsoft.Orleans.GrainDirectory.AzureStorage` | Azure Table-backed directory for persistent grain locations. |
-| **Redis** | `Microsoft.Orleans.GrainDirectory.Redis` | Redis-backed directory for high-performance persistent lookups. |
+The default directory is eventually consistent during membership changes. A brief duplicate activation is possible during failures; Orleans resolves the conflict and deactivates the duplicate. Grain state and operations should therefore tolerate activation races and retries.
 
-:::zone-end
+## Choose another directory
 
-:::zone target="docs" pivot="orleans-8-0,orleans-7-0,orleans-3-x"
+Use a pluggable directory for grain types that need different operational characteristics:
 
-By default, Orleans uses a built-in distributed in-cluster directory. This directory is eventually consistent and partitioned across all silos in the cluster in the form of a distributed hash table.
+| Directory | Package | Consider it when |
+|---|---|---|
+| Redis | `Microsoft.Orleans.GrainDirectory.Redis` | A shared Redis service already meets latency and availability requirements. |
+| Azure Table Storage | `Microsoft.Orleans.GrainDirectory.AzureStorage` | Azure Table is the preferred shared backing service. |
+| ADO.NET | `Microsoft.Orleans.GrainDirectory.AdoNet` | Grain locations should use an existing supported relational database. |
+| Custom | Application or third-party package | The application has a backend-specific requirement not met by built-in providers. |
 
-Starting with version 3.2.0, Orleans also supports pluggable grain directory implementations.
+External directories add network calls and another availability dependency. Apply them selectively and load-test activation-heavy workloads.
 
-Two such plugins are included in the 3.2.0 release:
+## Configure a named directory
 
-- An Azure Table implementation: [Microsoft.Orleans.GrainDirectory.AzureStorage](https://www.nuget.org/packages/Microsoft.Orleans.GrainDirectory.AzureStorage)
-- A Redis store implementation: [Microsoft.Orleans.GrainDirectory.Redis](https://www.nuget.org/packages/Microsoft.Orleans.GrainDirectory.Redis)
+Register the provider under a name and select it on the grain implementation:
 
-:::zone-end
-
-You can configure which grain directory implementation to use on a per-grain type basis, and you can even inject your implementation.
-
-## Which grain directory should you use?
-
-We recommend always starting with the default directory (the built-in distributed in-cluster directory). Although it's eventually consistent and allows occasional duplicate activations when the cluster is unstable, the built-in directory is self-sufficient, has no external dependencies, requires no configuration, and has been used successfully in production since the beginning.
-
-When you have some experience with Orleans and have a use case requiring a stronger single-activation guarantee, or if you want to minimize the number of grains deactivated when a silo shuts down, consider using a storage-based grain directory implementation, such as the Redis implementation. Try using it for one or a few grain types first, starting with those that are long-lived, have significant state, or have an expensive initialization process.
-
-:::zone target="docs" pivot="orleans-10-0,orleans-9-0"
-
-## Strongly-consistent in-cluster directory
-
-[!INCLUDE [orleans-10-preview](../includes/orleans-10-preview.md)]
-
-Orleans also provides a strongly-consistent grain directory using a distributed hash table with virtual nodes (similar to Amazon Dynamo and Apache Cassandra). Unlike the default eventually-consistent directory, this implementation prevents duplicate grain activations even during cluster instability.
-
-### Key features
-
-- **Strong consistency**: Uses versioned range locks during view changes to ensure consistency
-- **Virtual nodes**: Each silo manages 30 virtual nodes (partitions) on the hash ring for better distribution
-- **Automatic recovery**: Recovers automatically when silos crash without completing handoff
-- **Two-phase operation**: Operates in normal phase and view-change phase for safe membership transitions
-
-### Configuration
-
-To use the strongly-consistent directory, explicitly add it using `AddDistributedGrainDirectory`:
+:::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="named_grain_directory":::
 
 ```csharp
-// Use as the default grain directory
-builder.AddDistributedGrainDirectory();
-
-// Or add as a named directory
-builder.AddDistributedGrainDirectory("MyDistributedDirectory");
-```
-
-### When to use
-
-Use the strongly-consistent directory when you need to prevent duplicate grain activations during cluster membership changes. The default eventually-consistent directory is suitable for most scenarios where occasional duplicate activations are acceptable.
-
-Consider external storage-backed directories (Redis, Azure Table, ADO.NET) when:
-
-- You need grain registrations to persist across full cluster restarts
-- You have very large clusters where memory usage is a concern
-
-## ADO.NET grain directory
-
-The ADO.NET-based grain directory stores grain locations in a relational database. This provides persistent grain location storage that survives cluster restarts.
-
-### Supported databases
-
-- SQL Server
-- PostgreSQL
-- MySQL / MariaDB
-- Oracle
-
-### Installation
-
-Install the NuGet package:
-
-```dotnetcli
-dotnet add package Microsoft.Orleans.GrainDirectory.AdoNet
-```
-
-### Configuration
-
-Configure the ADO.NET grain directory as the default or as a named directory:
-
-```csharp
-// Use as the default grain directory
-builder.UseAdoNetGrainDirectoryAsDefault(options =>
-{
-    options.Invariant = "System.Data.SqlClient"; // or "Npgsql", "MySql.Data.MySqlClient"
-    options.ConnectionString = "Server=localhost;Database=Orleans;...";
-});
-
-// Or add as a named directory
-builder.AddAdoNetGrainDirectory("MyAdoNetDirectory", options =>
-{
-    options.Invariant = "Npgsql";
-    options.ConnectionString = "Host=localhost;Database=Orleans;...";
-});
-```
-
-### AdoNetGrainDirectoryOptions
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `Invariant` | `string` | **Required.** The ADO.NET provider invariant name (e.g., `System.Data.SqlClient`, `Npgsql`, `MySql.Data.MySqlClient`). |
-| `ConnectionString` | `string` | **Required.** The database connection string. This value is redacted in logs. |
-
-### Database setup
-
-Before using the ADO.NET grain directory, you must create the required database tables. Run the appropriate SQL script for your database:
-
-- SQL Server: [CreateOrleansTables_SqlServer.sql](https://github.com/dotnet/orleans/tree/main/src/AdoNet/Shared)
-- PostgreSQL: [CreateOrleansTables_PostgreSql.sql](https://github.com/dotnet/orleans/tree/main/src/AdoNet/Shared)
-- MySQL: [CreateOrleansTables_MySql.sql](https://github.com/dotnet/orleans/tree/main/src/AdoNet/Shared)
-
-:::zone-end
-
-## Configuration
-
-By default, you don't need to do anything; Orleans automatically uses the in-cluster grain directory and partitions it across the cluster. If you want to use a non-default grain directory configuration, you need to specify the name of the directory plugin to use. You can do this via an attribute on the grain class and by configuring the directory plugin with that name using dependency injection during silo configuration.
-
-### Grain configuration
-
-Specify the grain directory plugin name using the <xref:Orleans.GrainDirectory.GrainDirectoryAttribute>:
-
-```csharp
-[GrainDirectory(GrainDirectoryName = "my-grain-directory")]
-public class MyGrain : Grain, IMyGrain
+[GrainDirectory("durable-directory")]
+public sealed class ShoppingCartGrain : Grain, IShoppingCartGrain
 {
     // ...
 }
 ```
 
-#### Silo configuration
+Grain types without `GrainDirectoryAttribute` continue to use the default directory. You can register multiple named providers for different grain types.
 
-Here's how you configure the Redis grain directory implementation:
+To replace the default for all unannotated grain types, use the provider's `Use...GrainDirectoryAsDefault` extension, for example `UseRedisGrainDirectoryAsDefault`, `UseAzureTableGrainDirectoryAsDefault`, or `UseAdoNetGrainDirectoryAsDefault`.
 
-```csharp
-siloBuilder.AddRedisGrainDirectory(
-    "my-grain-directory",
-    options => options.ConfigurationOptions = redisConfiguration);
+Named directories can also be configured under `Orleans:GrainDirectory:{name}` with an installed declarative provider:
+
+```json
+{
+  "Orleans": {
+    "GrainDirectory": {
+      "durable-directory": {
+        "ProviderType": "Redis",
+        "ConnectionString": "redis.example.com:6380,ssl=true"
+      }
+    }
+  }
+}
 ```
 
-Configure the Azure grain directory like this:
+## Experimental distributed grain directory
+
+Orleans 10 includes `AddDistributedGrainDirectory`, a strongly consistent in-cluster directory based on partitioned ranges and membership views.
+
+> [!CAUTION]
+> `AddDistributedGrainDirectory` is experimental and emits diagnostic `ORLEANSEXP003`. Its API and behavior can change or be removed. It is not the Orleans 10 default.
 
 ```csharp
-siloBuilder.AddAzureTableGrainDirectory(
-    "my-grain-directory",
-    options => options.ConnectionString = azureConnectionString);
+#pragma warning disable ORLEANSEXP003
+siloBuilder.AddDistributedGrainDirectory();
+#pragma warning restore ORLEANSEXP003
 ```
 
-You can configure multiple directories with different names for use with different grain classes:
+The experimental directory defaults to one partition per silo (`GrainDirectoryOptions.PartitionsPerSilo = 1`). Change this only after testing with the expected cluster size and workload.
 
-```csharp
-siloBuilder
-    .AddRedisGrainDirectory(
-        "redis-directory-1",
-        options => options.ConfigurationOptions = redisConfiguration1)
-    .AddRedisGrainDirectory(
-        "redis-directory-2",
-        options => options.ConfigurationOptions = redisConfiguration2)
-    .AddAzureTableGrainDirectory(
-        "azure-directory",
-        options => options.ConnectionString = azureConnectionString);
-```
+Evaluate it when stronger coordination during membership changes is worth adopting an experimental feature. Keep a rollout and rollback plan, and don't describe it as a drop-in production default.
+
+## Operational guidance
+
+- Keep directory backend latency low; activation and first-call latency depend on it.
+- Provision external directories for the aggregate cluster workload and failure bursts.
+- Don't use the grain directory as application state storage.
+- Keep grain activation and deactivation idempotent.
+- Test silo loss, rolling upgrades, and full-cluster restarts.
+- Monitor duplicate-activation, directory, membership, and provider errors.
+
+For architectural background, see [Grain directory implementation](../implementation/grain-directory.md).

--- a/docs/site/src/content/docs/host/grain-directory.md
+++ b/docs/site/src/content/docs/host/grain-directory.md
@@ -21,9 +21,9 @@ Use a pluggable directory for grain types that need different operational charac
 
 | Directory | Package | Consider it when |
 |---|---|---|
-| Redis | `Microsoft.Orleans.GrainDirectory.Redis` | A shared Redis service already meets latency and availability requirements. |
-| Azure Table Storage | `Microsoft.Orleans.GrainDirectory.AzureStorage` | Azure Table is the preferred shared backing service. |
-| ADO.NET | `Microsoft.Orleans.GrainDirectory.AdoNet` | Grain locations should use an existing supported relational database. |
+| Redis | [`Microsoft.Orleans.GrainDirectory.Redis`](https://www.nuget.org/packages/Microsoft.Orleans.GrainDirectory.Redis) | A shared Redis service already meets latency and availability requirements. |
+| Azure Table Storage | [`Microsoft.Orleans.GrainDirectory.AzureStorage`](https://www.nuget.org/packages/Microsoft.Orleans.GrainDirectory.AzureStorage) | Azure Table is the preferred shared backing service. |
+| ADO.NET | [`Microsoft.Orleans.GrainDirectory.AdoNet`](https://www.nuget.org/packages/Microsoft.Orleans.GrainDirectory.AdoNet) | Grain locations should use an existing supported relational database. |
 | Custom | Application or third-party package | The application has a backend-specific requirement not met by built-in providers. |
 
 External directories add network calls and another availability dependency. Apply them selectively and load-test activation-heavy workloads.

--- a/docs/site/src/content/docs/host/grain-directory.md
+++ b/docs/site/src/content/docs/host/grain-directory.md
@@ -1,6 +1,6 @@
 ---
 title: Orleans grain directories
-description: Choose and configure grain directories in Orleans 10.
+description: Choose and configure Orleans grain directories.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -11,7 +11,7 @@ A grain directory maps a grain identity to the silo that currently hosts its act
 
 ## Start with the default directory
 
-Orleans 10 uses the built-in `LocalGrainDirectory` by default. Despite its name, the directory is distributed across the cluster using a consistent-hash ring. It requires no external service and is the right starting point for most applications.
+Orleans uses the built-in `LocalGrainDirectory` by default. Despite its name, the directory is distributed across the cluster using a consistent-hash ring. It requires no external service and is the right starting point for most applications.
 
 The default directory is eventually consistent during membership changes. A brief duplicate activation is possible during failures; Orleans resolves the conflict and deactivates the duplicate. Grain state and operations should therefore tolerate activation races and retries.
 
@@ -63,10 +63,10 @@ Named directories can also be configured under `Orleans:GrainDirectory:{name}` w
 
 ## Experimental distributed grain directory
 
-Orleans 10 includes `AddDistributedGrainDirectory`, a strongly consistent in-cluster directory based on partitioned ranges and membership views.
+`AddDistributedGrainDirectory` adds a strongly consistent in-cluster directory based on partitioned ranges and membership views.
 
 > [!CAUTION]
-> `AddDistributedGrainDirectory` is experimental and emits diagnostic `ORLEANSEXP003`. Its API and behavior can change or be removed. It is not the Orleans 10 default.
+> `AddDistributedGrainDirectory` is experimental and emits diagnostic `ORLEANSEXP003`. Its API and behavior can change or be removed. It is not the default grain directory.
 
 ```csharp
 #pragma warning disable ORLEANSEXP003

--- a/docs/site/src/content/docs/host/grain-directory.md
+++ b/docs/site/src/content/docs/host/grain-directory.md
@@ -15,9 +15,15 @@ Orleans uses the built-in `LocalGrainDirectory` by default. Despite its name, th
 
 The default directory is eventually consistent during membership changes. A brief duplicate activation is possible during failures; Orleans resolves the conflict and deactivates the duplicate. Grain state and operations should therefore tolerate activation races and retries.
 
-## Choose another directory
+## Which grain directory should you use?
 
 Use a pluggable directory for grain types that need different operational characteristics:
+
+<a id="adonet-grain-directory"></a>
+<a id="supported-databases"></a>
+<a id="installation"></a>
+<a id="adonetgraindirectoryoptions"></a>
+<a id="database-setup"></a>
 
 | Directory | Package | Consider it when |
 |---|---|---|
@@ -28,23 +34,20 @@ Use a pluggable directory for grain types that need different operational charac
 
 External directories add network calls and another availability dependency. Apply them selectively and load-test activation-heavy workloads.
 
-## Configure a named directory
+## Configuration
+
+<a id="grain-configuration"></a>
+<a id="silo-configuration"></a>
 
 Register the provider under a name and select it on the grain implementation:
 
 :::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="named_grain_directory":::
 
-```csharp
-[GrainDirectory("durable-directory")]
-public sealed class ShoppingCartGrain : Grain, IShoppingCartGrain
-{
-    // ...
-}
-```
+:::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="grain_directory_attribute":::
 
-Grain types without `GrainDirectoryAttribute` continue to use the default directory. You can register multiple named providers for different grain types.
+Grain types without <xref:Orleans.GrainDirectory.GrainDirectoryAttribute> continue to use the default directory. You can register multiple named providers for different grain types.
 
-To replace the default for all unannotated grain types, use the provider's `Use...GrainDirectoryAsDefault` extension, for example `UseRedisGrainDirectoryAsDefault`, `UseAzureTableGrainDirectoryAsDefault`, or `UseAdoNetGrainDirectoryAsDefault`.
+To replace the default for all unannotated grain types, use the provider's `Use...GrainDirectoryAsDefault` extension, for example <xref:Orleans.Hosting.RedisGrainDirectoryExtensions.UseRedisGrainDirectoryAsDefault*>, <xref:Orleans.Hosting.AzureTableGrainDirectorySiloBuilderExtensions.UseAzureTableGrainDirectoryAsDefault*>, or <xref:Orleans.Hosting.AdoNetGrainDirectorySiloBuilderExtensions.UseAdoNetGrainDirectoryAsDefault*>.
 
 Named directories can also be configured under `Orleans:GrainDirectory:{name}` with an installed declarative provider:
 
@@ -61,20 +64,19 @@ Named directories can also be configured under `Orleans:GrainDirectory:{name}` w
 }
 ```
 
-## Experimental distributed grain directory
+## Strongly-consistent in-cluster directory
 
-`AddDistributedGrainDirectory` adds a strongly consistent in-cluster directory based on partitioned ranges and membership views.
+<a id="key-features"></a>
+<a id="when-to-use"></a>
+
+<xref:Orleans.Hosting.CoreHostingExtensions.AddDistributedGrainDirectory*> adds a strongly consistent in-cluster directory based on partitioned ranges and membership views.
 
 > [!CAUTION]
-> `AddDistributedGrainDirectory` is experimental and emits diagnostic `ORLEANSEXP003`. Its API and behavior can change or be removed. It is not the default grain directory.
+> <xref:Orleans.Hosting.CoreHostingExtensions.AddDistributedGrainDirectory*> is experimental and emits diagnostic `ORLEANSEXP003`. Its API and behavior can change or be removed. It is not the default grain directory.
 
-```csharp
-#pragma warning disable ORLEANSEXP003
-siloBuilder.AddDistributedGrainDirectory();
-#pragma warning restore ORLEANSEXP003
-```
+:::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="distributed_grain_directory":::
 
-The experimental directory defaults to one partition per silo (`GrainDirectoryOptions.PartitionsPerSilo = 1`). Change this only after testing with the expected cluster size and workload.
+The experimental directory defaults to one partition per silo (<xref:Orleans.Configuration.GrainDirectoryOptions.PartitionsPerSilo> = `1`). Change this only after testing with the expected cluster size and workload.
 
 Evaluate it when stronger coordination during membership changes is worth adopting an experimental feature. Keep a rollout and rollback plan, and don't describe it as a drop-in production default.
 

--- a/docs/site/src/content/docs/host/heterogeneous-silos.md
+++ b/docs/site/src/content/docs/host/heterogeneous-silos.md
@@ -63,6 +63,6 @@ Clients obtain cluster type information after connecting. Handle deployments so 
 - A request fails when no active silo supports its target grain type.
 - Every silo that supports one grain type must use a compatible implementation and contract.
 - Stateless worker grains should be consistently available across the cluster rather than split into incompatible heterogeneous sets.
-- Implicit stream subscriptions require compatible grain availability; use explicit subscriptions when heterogeneous deployment makes ownership ambiguous.
+- Implicit stream subscriptions require compatible grain availability; use [explicit subscriptions](../streaming/streams-programming-apis.md) when heterogeneous deployment makes ownership ambiguous.
 
 Test topology changes with production-like role counts, especially the loss and replacement of the last silo supporting a type.

--- a/docs/site/src/content/docs/host/heterogeneous-silos.md
+++ b/docs/site/src/content/docs/host/heterogeneous-silos.md
@@ -1,6 +1,6 @@
 ---
 title: Heterogeneous Orleans silos
-description: Host different Orleans 10 grain types on different silos.
+description: Host different Orleans grain types on different silos.
 ms.date: 08/02/2026
 ms.topic: how-to
 ---

--- a/docs/site/src/content/docs/host/heterogeneous-silos.md
+++ b/docs/site/src/content/docs/host/heterogeneous-silos.md
@@ -1,59 +1,68 @@
 ---
-title: Heterogeneous silos overview
-description: Learn an overview of heterogeneous silos in .NET Orleans.
-ms.date: 05/23/2025
-ms.topic: overview
+title: Heterogeneous Orleans silos
+description: Host different Orleans 10 grain types on different silos.
+ms.date: 08/02/2026
+ms.topic: how-to
 ---
 
-# Heterogeneous silos overview
+# Heterogeneous Orleans silos
 
-On a given cluster, silos can support different sets of grain types:
+Silos in one cluster can host different sets of grain classes. This lets you isolate workloads, use specialized hardware, or deploy grain implementations independently while retaining one Orleans cluster.
 
-:::image type="content" source="media/heterogeneous.png" alt-text="Heterogeneous silos overview diagram.":::
+:::image type="content" source="media/heterogeneous.png" alt-text="A cluster whose silos support different grain type sets.":::
 
-In this example, the cluster supports grains of type `A`, `B`, `C`, `D`, and `E`:
+All silos and clients should reference the interfaces and serialization contracts they can exchange. A silo should reference only the grain implementation assemblies it can host.
 
-- Grain types `A` and `B` can be placed on Silo 1 and 2.
-- Grain type `C` can be placed on Silo 1, 2, or 3.
-- Grain type `D` can only be placed on Silo 3.
-- Grain type `E` can only be placed on Silo 4.
+## Prefer assembly boundaries
 
-All silos should reference the interfaces of all grain types in the cluster, but grain classes should only be referenced by the silos that host them. The client doesn't know which silo supports a given grain type.
+The simplest model is to put specialized grain classes in separate projects and reference each implementation project only from the silo host that should run it. Orleans discovers supported grain classes from generated type metadata.
 
-> [!IMPORTANT]
-> A given grain type implementation must be the same on each silo that supports it.
+For example:
 
-The following scenario is _not_ valid:
+- General-purpose silos reference `Orders.Grains`.
+- GPU silos reference `Recommendations.Grains`.
+- Clients reference `Orders.Contracts` and `Recommendations.Contracts`, but neither implementation assembly.
 
-On Silo 1 and 2:
+The same grain implementation must be compatible across every silo that advertises support for that grain type.
 
-```csharp
-public class C: Grain, IMyGrainInterface
-{
-   public Task SomeMethod() { /* ... */ }
-}
-```
+## Configure supported grain classes explicitly
 
-On Silo 3:
+When one binary can run in several roles, configure <xref:Orleans.Configuration.GrainTypeOptions.Classes>:
+
+:::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="configure_grain_types":::
+
+`GrainTypeOptions.Classes` is a set of `Type` values. Use it to include the exact grain classes the process can host or remove discovered classes that a role must not host:
 
 ```csharp
-public class C: Grain, IMyGrainInterface, IMyOtherGrainInterface
+siloBuilder.Configure<GrainTypeOptions>(options =>
 {
-   public Task SomeMethod() { /* ... */ }
-   public Task SomeOtherMethod() { /* ... */ }
-}
+    options.Classes.Remove(typeof(RecommendationGrain));
+});
 ```
 
-## Configuration
+Don't use obsolete grain-class exclusion option names from earlier Orleans versions.
 
-No configuration is needed; you can deploy different binaries on each silo in your cluster. However, if necessary, you can change the interval at which silos and clients check for changes in supported types using the <xref:Orleans.Configuration.TypeManagementOptions.TypeMapRefreshInterval?displayProperty=nameWithType> property.
+## Direct placement by capability
 
-For testing purposes, you can use the <xref:Orleans.Configuration.GrainClassOptions.ExcludedGrainTypes?displayProperty=nameWithType> property, which is a list of names of the types you want to exclude on specific silos.
+Use [silo metadata](configuration-guide/silo-metadata.md) and [grain placement filtering](../grains/grain-placement-filtering.md) when many silos load the same grain implementation but only some meet a placement requirement such as region, hardware, tenant, or reservation type.
+
+Use heterogeneous grain type registration when a silo cannot host the implementation at all. Use placement filtering when it can host the type but placement should prefer or require metadata.
+
+## Deployment rules
+
+- Keep `ServiceId`, `ClusterId`, clustering, and protocol configuration consistent across all roles.
+- Deploy at least one healthy silo for every supported grain type before clients invoke it.
+- Maintain capacity and redundancy independently for each specialized grain set.
+- Roll out contract changes before implementations that require them.
+- Avoid removing the last silo for a grain type while requests or durable work still target it.
+
+Clients obtain cluster type information after connecting. Handle deployments so clients don't depend on a grain type before supporting silos are available.
 
 ## Limitations
 
-- Connected clients aren't notified if the set of supported grain types changes. In the previous example:
-  - If Silo 4 leaves the cluster, the client still tries to make calls to grains of type `E`. It fails at runtime with an <xref:Orleans.Runtime.OrleansException>.
-  - If the client connected to the cluster before Silo 4 joined, the client cannot make calls to grains of type `E`. It fails with an <xref:System.ArgumentException>.
-- Stateless grains aren't supported in heterogeneous deployments: all silos in the cluster must support the same set of stateless grains.
-- <xref:Orleans.ImplicitStreamSubscriptionAttribute> isn't supported; thus, you can only use [Explicit subscriptions](../streaming/streams-programming-apis.md) in Orleans Streams with heterogeneous silos.
+- A request fails when no active silo supports its target grain type.
+- Every silo that supports one grain type must use a compatible implementation and contract.
+- Stateless worker grains should be consistently available across the cluster rather than split into incompatible heterogeneous sets.
+- Implicit stream subscriptions require compatible grain availability; use explicit subscriptions when heterogeneous deployment makes ownership ambiguous.
+
+Test topology changes with production-like role counts, especially the loss and replacement of the last silo supporting a type.

--- a/docs/site/src/content/docs/host/heterogeneous-silos.md
+++ b/docs/site/src/content/docs/host/heterogeneous-silos.md
@@ -25,20 +25,15 @@ For example:
 
 The same grain implementation must be compatible across every silo that advertises support for that grain type.
 
-## Configure supported grain classes explicitly
+## Configuration
 
 When one binary can run in several roles, configure <xref:Orleans.Configuration.GrainTypeOptions.Classes>:
 
 :::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="configure_grain_types":::
 
-`GrainTypeOptions.Classes` is a set of `Type` values. Use it to include the exact grain classes the process can host or remove discovered classes that a role must not host:
+<xref:Orleans.Configuration.GrainTypeOptions.Classes> is a set of <xref:System.Type> values. Use it to include the exact grain classes the process can host or remove discovered classes that a role must not host:
 
-```csharp
-siloBuilder.Configure<GrainTypeOptions>(options =>
-{
-    options.Classes.Remove(typeof(RecommendationGrain));
-});
-```
+:::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="exclude_grain_type":::
 
 Don't use obsolete grain-class exclusion option names from earlier Orleans versions.
 
@@ -50,7 +45,7 @@ Use heterogeneous grain type registration when a silo cannot host the implementa
 
 ## Deployment rules
 
-- Keep `ServiceId`, `ClusterId`, clustering, and protocol configuration consistent across all roles.
+- Keep <xref:Orleans.Configuration.ClusterOptions.ServiceId>, <xref:Orleans.Configuration.ClusterOptions.ClusterId>, clustering, and protocol configuration consistent across all roles.
 - Deploy at least one healthy silo for every supported grain type before clients invoke it.
 - Maintain capacity and redundancy independently for each specialized grain set.
 - Roll out contract changes before implementations that require them.

--- a/docs/site/src/content/docs/host/silo-lifecycle.md
+++ b/docs/site/src/content/docs/host/silo-lifecycle.md
@@ -66,4 +66,4 @@ Fail startup when a required dependency can't initialize. For optional or contin
 
 The `Orleans.Runtime.SiloLifecycleSubject` logger reports participants, timing, and errors by stage. Enable `Information` logs while diagnosing startup ordering or slow shutdown. Lifecycle callbacks should log the external operation they are waiting for and honor cancellation.
 
-For a simpler one-time callback, see [Background services and startup tasks](configuration-guide/startup-tasks.md). For host termination behavior, see [Shut down Orleans silos](configuration-guide/shutting-down-orleans.md).
+For implementation details, see [Orleans lifecycle](../implementation/orleans-lifecycle.md). For a simpler one-time callback, see [Background services and startup tasks](configuration-guide/startup-tasks.md). For host termination behavior, see [Shut down Orleans silos](configuration-guide/shutting-down-orleans.md).

--- a/docs/site/src/content/docs/host/silo-lifecycle.md
+++ b/docs/site/src/content/docs/host/silo-lifecycle.md
@@ -9,61 +9,58 @@ ms.topic: concept-article
 
 Orleans starts and stops runtime components through an ordered observable lifecycle. Startup advances from the lowest stage to the highest. Shutdown runs the same stages in reverse.
 
-Most application code should use .NET `IHostedService` or `BackgroundService`. Implement `ILifecycleParticipant<ISiloLifecycle>` only when a component must run at a precise point inside the Orleans runtime lifecycle.
+Most application code should use <xref:Microsoft.Extensions.Hosting.IHostedService> or <xref:Microsoft.Extensions.Hosting.BackgroundService>. Implement <xref:Orleans.ILifecycleParticipant`1> with <xref:Orleans.Runtime.ISiloLifecycle> only when a component must run at a precise point inside the Orleans runtime lifecycle.
 
-## Lifecycle stages
+## Stages
 
 <xref:Orleans.ServiceLifecycleStage> defines these stages:
 
 | Stage | Value | Purpose |
 |---|---:|---|
-| `First` | `int.MinValue` | Earliest lifecycle stage |
-| `RuntimeInitialize` | `2000` | Initialize the runtime |
-| `RuntimeServices` | `4000` | Start core networking and runtime services |
-| `RuntimeStorageServices` | `6000` | Initialize runtime storage services |
-| `RuntimeGrainServices` | `8000` | Start grain-facing runtime services |
-| `AfterRuntimeGrainServices` | `8100` | Run after grain runtime services |
-| `ApplicationServices` | `10000` | Start application-level services |
-| `ValidateInitialConnectivity` | `19900` | Validate connectivity before becoming active |
-| `GrainDirectoryShutdown` | `19997` | Coordinate grain-directory shutdown |
-| `GrainDeactivation` | `19998` | Deactivate grains during shutdown |
-| `BecomeActive` | `19999` | Internal transition immediately before active |
-| `Active` | `20000` | Silo is active and accepts workload |
-| `Last` | `int.MaxValue` | Final lifecycle stage |
+| <xref:Orleans.ServiceLifecycleStage.First> | `int.MinValue` | Earliest lifecycle stage |
+| <xref:Orleans.ServiceLifecycleStage.RuntimeInitialize> | `2000` | Initialize the runtime |
+| <xref:Orleans.ServiceLifecycleStage.RuntimeServices> | `4000` | Start core networking and runtime services |
+| <xref:Orleans.ServiceLifecycleStage.RuntimeStorageServices> | `6000` | Initialize runtime storage services |
+| <xref:Orleans.ServiceLifecycleStage.RuntimeGrainServices> | `8000` | Start grain-facing runtime services |
+| <xref:Orleans.ServiceLifecycleStage.AfterRuntimeGrainServices> | `8100` | Run after grain runtime services |
+| <xref:Orleans.ServiceLifecycleStage.ApplicationServices> | `10000` | Start application-level services |
+| <xref:Orleans.ServiceLifecycleStage.ValidateInitialConnectivity> | `19900` | Validate connectivity before becoming active |
+| <xref:Orleans.ServiceLifecycleStage.GrainDirectoryShutdown> | `19997` | Coordinate grain-directory shutdown |
+| <xref:Orleans.ServiceLifecycleStage.GrainDeactivation> | `19998` | Deactivate grains during shutdown |
+| <xref:Orleans.ServiceLifecycleStage.BecomeActive> | `19999` | Internal transition immediately before active |
+| <xref:Orleans.ServiceLifecycleStage.Active> | `20000` | Silo is active and accepts workload |
+| <xref:Orleans.ServiceLifecycleStage.Last> | `int.MaxValue` | Final lifecycle stage |
 
 Some constants intentionally share or closely bracket values because their startup and shutdown semantics differ. Treat the named constants as ordering contracts; don't copy their numeric values into application code.
 
 > [!IMPORTANT]
-> `BecomeActive` is reserved for the membership and gateway transition. Application components normally use `ApplicationServices` or `Active`.
+> <xref:Orleans.ServiceLifecycleStage.BecomeActive> is reserved for the membership and gateway transition. Application components normally use <xref:Orleans.ServiceLifecycleStage.ApplicationServices> or <xref:Orleans.ServiceLifecycleStage.Active>.
 
-## Participate in the lifecycle
+## Silo lifecycle participation
 
-Register a singleton that implements `ILifecycleParticipant<ISiloLifecycle>`:
+Register a singleton that implements <xref:Orleans.ILifecycleParticipant`1> for <xref:Orleans.Runtime.ISiloLifecycle>:
+
+<a id="example"></a>
 
 :::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="lifecycle_participant":::
 
-```csharp
-siloBuilder.Services.AddSingleton<CacheLifecycleParticipant>();
-siloBuilder.Services.AddSingleton<
-    ILifecycleParticipant<ISiloLifecycle>>(
-    services => services.GetRequiredService<CacheLifecycleParticipant>());
-```
+:::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="register_lifecycle_participant":::
 
 The start callback must complete before Orleans advances to the next stage. On shutdown, the stop callback receives the host shutdown cancellation token.
 
-`ISiloLifecycle.HighestCompletedStage` and `LowestStoppedStage` expose lifecycle progress for diagnostics.
+<xref:Orleans.Runtime.ISiloLifecycle.HighestCompletedStage> and <xref:Orleans.Runtime.ISiloLifecycle.LowestStoppedStage> expose lifecycle progress for diagnostics.
 
 ## Choose a stage
 
-- Use `ApplicationServices` for dependencies that must start after core Orleans services and stop before them.
-- Use `Active` when work requires an active silo and grain calls.
+- Use <xref:Orleans.ServiceLifecycleStage.ApplicationServices> for dependencies that must start after core Orleans services and stop before them.
+- Use <xref:Orleans.ServiceLifecycleStage.Active> when work requires an active silo and grain calls.
 - Avoid runtime stages unless implementing infrastructure that depends on a specific Orleans subsystem.
-- Don't subscribe application code at `BecomeActive`, `GrainDeactivation`, or `GrainDirectoryShutdown`.
+- Don't subscribe application code at <xref:Orleans.ServiceLifecycleStage.BecomeActive>, <xref:Orleans.ServiceLifecycleStage.GrainDeactivation>, or <xref:Orleans.ServiceLifecycleStage.GrainDirectoryShutdown>.
 
 Fail startup when a required dependency can't initialize. For optional or continuously retrying work, start a hosted background service after Orleans instead of blocking a lifecycle stage indefinitely.
 
-## Diagnostics
+## Logging
 
-The `Orleans.Runtime.SiloLifecycleSubject` logger reports participants, timing, and errors by stage. Enable `Information` logs while diagnosing startup ordering or slow shutdown. Lifecycle callbacks should log the external operation they are waiting for and honor cancellation.
+The `Orleans.Runtime.SiloLifecycleSubject` logger category reports participants, timing, and errors by stage. Set <xref:Microsoft.Extensions.Logging.LogLevel> to `Information` while diagnosing startup ordering or slow shutdown. Lifecycle callbacks should log the external operation they are waiting for and honor cancellation.
 
 For implementation details, see [Orleans lifecycle](../implementation/orleans-lifecycle.md). For a simpler one-time callback, see [Background services and startup tasks](configuration-guide/startup-tasks.md). For host termination behavior, see [Shut down Orleans silos](configuration-guide/shutting-down-orleans.md).

--- a/docs/site/src/content/docs/host/silo-lifecycle.md
+++ b/docs/site/src/content/docs/host/silo-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 title: Orleans silo lifecycle
-description: Participate in Orleans 10 silo startup and shutdown.
+description: Participate in Orleans silo startup and shutdown.
 ms.date: 08/02/2026
 ms.topic: concept-article
 ---
@@ -13,7 +13,7 @@ Most application code should use .NET `IHostedService` or `BackgroundService`. I
 
 ## Lifecycle stages
 
-The current <xref:Orleans.ServiceLifecycleStage> values are:
+<xref:Orleans.ServiceLifecycleStage> defines these stages:
 
 | Stage | Value | Purpose |
 |---|---:|---|
@@ -29,7 +29,7 @@ The current <xref:Orleans.ServiceLifecycleStage> values are:
 | `GrainDeactivation` | `19998` | Deactivate grains during shutdown |
 | `BecomeActive` | `19999` | Internal transition immediately before active |
 | `Active` | `20000` | Silo is active and accepts workload |
-| `Last` | `int.MaxValue` | Latest lifecycle stage |
+| `Last` | `int.MaxValue` | Final lifecycle stage |
 
 Some constants intentionally share or closely bracket values because their startup and shutdown semantics differ. Treat the named constants as ordering contracts; don't copy their numeric values into application code.
 

--- a/docs/site/src/content/docs/host/silo-lifecycle.md
+++ b/docs/site/src/content/docs/host/silo-lifecycle.md
@@ -1,129 +1,69 @@
 ---
-title: Orleans silo lifecycles
-description: Learn about .NET Orleans silo lifecycles.
-ms.date: 01/22/2026
-ms.topic: overview
+title: Orleans silo lifecycle
+description: Participate in Orleans 10 silo startup and shutdown.
+ms.date: 08/02/2026
+ms.topic: concept-article
 ---
 
-# Orleans silo lifecycle overview
+# Orleans silo lifecycle
 
-Orleans silos use an observable lifecycle for the ordered startup and shutdown of Orleans systems and application layer components. For more information on the implementation details, see [Orleans lifecycle](../implementation/orleans-lifecycle.md).
+Orleans starts and stops runtime components through an ordered observable lifecycle. Startup advances from the lowest stage to the highest. Shutdown runs the same stages in reverse.
 
-## Stages
+Most application code should use .NET `IHostedService` or `BackgroundService`. Implement `ILifecycleParticipant<ISiloLifecycle>` only when a component must run at a precise point inside the Orleans runtime lifecycle.
 
-Orleans silo and cluster clients use a common set of service lifecycle stages:
+## Lifecycle stages
 
-```csharp
-public static class ServiceLifecycleStage
-{
-    public const int First = int.MinValue;
-    public const int RuntimeInitialize = 2_000;
-    public const int RuntimeServices = 4_000;
-    public const int RuntimeStorageServices = 6_000;
-    public const int RuntimeGrainServices = 8_000;
-    public const int ApplicationServices = 10_000;
-    public const int BecomeActive = Active - 1;
-    public const int Active = 20_000;
-    public const int Last = int.MaxValue;
-}
-```
+The current <xref:Orleans.ServiceLifecycleStage> values are:
 
-- <xref:Orleans.ServiceLifecycleStage.First?displayProperty=nameWithType>: The first stage in the service's lifecycle.
-- <xref:Orleans.ServiceLifecycleStage.RuntimeInitialize?displayProperty=nameWithType>: Initialization of the runtime environment, where the silo initializes threading.
-- <xref:Orleans.ServiceLifecycleStage.RuntimeServices?displayProperty=nameWithType>: Start of runtime services, where the silo initializes networking and various agents.
-- <xref:Orleans.ServiceLifecycleStage.RuntimeStorageServices?displayProperty=nameWithType>: Initialization of runtime storage.
-- <xref:Orleans.ServiceLifecycleStage.RuntimeGrainServices?displayProperty=nameWithType>: Starting of runtime services for grains. This includes grain type management, membership service, and grain directory.
-- <xref:Orleans.ServiceLifecycleStage.ApplicationServices?displayProperty=nameWithType>: Application layer services.
-- <xref:Orleans.ServiceLifecycleStage.BecomeActive?displayProperty=nameWithType>: The silo joins the cluster.
-- <xref:Orleans.ServiceLifecycleStage.Active?displayProperty=nameWithType>: The silo is active in the cluster and ready to accept workload.
-- <xref:Orleans.ServiceLifecycleStage.Last?displayProperty=nameWithType>: The last stage in the service's lifecycle.
+| Stage | Value | Purpose |
+|---|---:|---|
+| `First` | `int.MinValue` | Earliest lifecycle stage |
+| `RuntimeInitialize` | `2000` | Initialize the runtime |
+| `RuntimeServices` | `4000` | Start core networking and runtime services |
+| `RuntimeStorageServices` | `6000` | Initialize runtime storage services |
+| `RuntimeGrainServices` | `8000` | Start grain-facing runtime services |
+| `AfterRuntimeGrainServices` | `8100` | Run after grain runtime services |
+| `ApplicationServices` | `10000` | Start application-level services |
+| `ValidateInitialConnectivity` | `19900` | Validate connectivity before becoming active |
+| `GrainDirectoryShutdown` | `19997` | Coordinate grain-directory shutdown |
+| `GrainDeactivation` | `19998` | Deactivate grains during shutdown |
+| `BecomeActive` | `19999` | Internal transition immediately before active |
+| `Active` | `20000` | Silo is active and accepts workload |
+| `Last` | `int.MaxValue` | Latest lifecycle stage |
 
-## Logging
+Some constants intentionally share or closely bracket values because their startup and shutdown semantics differ. Treat the named constants as ordering contracts; don't copy their numeric values into application code.
 
-Due to the inversion of control, where participants join the lifecycle rather than the lifecycle having a centralized set of initialization steps, it's not always clear from the code what the startup/shutdown order is. To help address this, Orleans adds logging before silo startup to report which components participate at each stage. These logs are recorded at the _Information_ log level on the <xref:Orleans.Runtime.SiloLifecycleSubject?displayProperty=fullName> logger. For instance:
+> [!IMPORTANT]
+> `BecomeActive` is reserved for the membership and gateway transition. Application components normally use `ApplicationServices` or `Active`.
 
-```Output
-Information, Orleans.Runtime.SiloLifecycleSubject, "Stage 2000: Orleans.Statistics.PerfCounterEnvironmentStatistics, Orleans.Runtime.InsideRuntimeClient, Orleans.Runtime.Silo"
+## Participate in the lifecycle
 
-Information, Orleans.Runtime.SiloLifecycleSubject, "Stage 4000: Orleans.Runtime.Silo"
+Register a singleton that implements `ILifecycleParticipant<ISiloLifecycle>`:
 
-Information, Orleans.Runtime.SiloLifecycleSubject, "Stage 10000: Orleans.Runtime.Versions.GrainVersionStore, Orleans.Storage.AzureTableGrainStorage-Default, Orleans.Storage.AzureTableGrainStorage-PubSubStore"
-```
-
-Additionally, Orleans similarly logs timing and error information for each component by stage. For instance:
-
-```Output
-Information, Orleans.Runtime.SiloLifecycleSubject, "Lifecycle observer Orleans.Runtime.InsideRuntimeClient started in stage 2000 which took 33 Milliseconds."
-
-Information, Orleans.Runtime.SiloLifecycleSubject, "Lifecycle observer Orleans.Statistics.PerfCounterEnvironmentStatistics started in stage 2000 which took 17 Milliseconds."
-```
-
-## Silo lifecycle participation
-
-Your application logic can participate in the silo's lifecycle by registering a participating service in the silo's service container. Register the service as an <xref:Orleans.ILifecycleParticipant`1>, where `T` is <xref:Orleans.Runtime.ISiloLifecycle>.
+:::code language="csharp" source="snippets/hosting/HostingExamples.cs" id="lifecycle_participant":::
 
 ```csharp
-public interface ISiloLifecycle : ILifecycleObservable
-{
-}
-
-public interface ILifecycleParticipant<TLifecycleObservable>
-    where TLifecycleObservable : ILifecycleObservable
-{
-    void Participate(TLifecycleObservable lifecycle);
-}
+siloBuilder.Services.AddSingleton<CacheLifecycleParticipant>();
+siloBuilder.Services.AddSingleton<
+    ILifecycleParticipant<ISiloLifecycle>>(
+    services => services.GetRequiredService<CacheLifecycleParticipant>());
 ```
 
-When the silo starts, all participants (`ILifecycleParticipant<ISiloLifecycle>`) in the container can participate by having their <xref:Orleans.ILifecycleParticipant`1.Participate*?displayProperty=nameWithType> behavior called. Once all have had the opportunity to participate, the silo's observable lifecycle starts all stages in order.
+The start callback must complete before Orleans advances to the next stage. On shutdown, the stop callback receives the host shutdown cancellation token.
 
-### Example
+`ISiloLifecycle.HighestCompletedStage` and `LowestStoppedStage` expose lifecycle progress for diagnostics.
 
-With the introduction of the silo lifecycle, bootstrap providers, which previously allowed you to inject logic at the provider initialization phase, are no longer necessary. You can now inject application logic at any stage of silo startup. Nonetheless, we added a 'startup task' facade to aid the transition for developers who used bootstrap providers. As an example of how you can develop components that participate in the silo's lifecycle, let's look at the startup task facade.
+## Choose a stage
 
-The startup task only needs to inherit from `ILifecycleParticipant<ISiloLifecycle>` and subscribe the application logic to the silo lifecycle at the specified stage.
+- Use `ApplicationServices` for dependencies that must start after core Orleans services and stop before them.
+- Use `Active` when work requires an active silo and grain calls.
+- Avoid runtime stages unless implementing infrastructure that depends on a specific Orleans subsystem.
+- Don't subscribe application code at `BecomeActive`, `GrainDeactivation`, or `GrainDirectoryShutdown`.
 
-```csharp
-class StartupTask : ILifecycleParticipant<ISiloLifecycle>
-{
-    private readonly IServiceProvider _serviceProvider;
-    private readonly Func<IServiceProvider, CancellationToken, Task> _startupTask;
-    private readonly int _stage;
+Fail startup when a required dependency can't initialize. For optional or continuously retrying work, start a hosted background service after Orleans instead of blocking a lifecycle stage indefinitely.
 
-    public StartupTask(
-        IServiceProvider serviceProvider,
-        Func<IServiceProvider, CancellationToken, Task> startupTask,
-        int stage)
-    {
-        _serviceProvider = serviceProvider;
-        _startupTask = startupTask;
-        _stage = stage;
-    }
+## Diagnostics
 
-    public void Participate(ISiloLifecycle lifecycle)
-    {
-        lifecycle.Subscribe<StartupTask>(
-            _stage,
-            cancellation => _startupTask(_serviceProvider, cancellation));
-    }
-}
-```
+The `Orleans.Runtime.SiloLifecycleSubject` logger reports participants, timing, and errors by stage. Enable `Information` logs while diagnosing startup ordering or slow shutdown. Lifecycle callbacks should log the external operation they are waiting for and honor cancellation.
 
-From the preceding implementation, you can see that in the `Participate(...)` call, it subscribes to the silo lifecycle at the configured stage, passing the application callback rather than its initialization logic. Components needing initialization at a given stage would provide their callback, but the pattern remains the same. Now that you have a `StartupTask` ensuring the application's hook is called at the configured stage, you need to ensure the `StartupTask` participates in the silo lifecycle.
-
-For this, register it in the container using the <xref:Orleans.Hosting.SiloBuilderStartupExtensions.AddStartupTask*> extension method on the silo builder:
-
-```csharp
-siloBuilder.AddStartupTask(
-    async (serviceProvider, cancellationToken) =>
-    {
-        var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
-        logger.LogInformation("Silo is starting up...");
-
-        // Perform initialization logic, such as warming caches or validating configuration
-        var config = serviceProvider.GetRequiredService<IConfiguration>();
-        await ValidateExternalDependenciesAsync(config, cancellationToken);
-    },
-    ServiceLifecycleStage.Active);
-```
-
-By registering the `StartupTask` in the silo's service container as the marker interface `ILifecycleParticipant<ISiloLifecycle>`, you signal to the silo that this component needs to participate in the silo lifecycle.
+For a simpler one-time callback, see [Background services and startup tasks](configuration-guide/startup-tasks.md). For host termination behavior, see [Shut down Orleans silos](configuration-guide/shutting-down-orleans.md).

--- a/docs/site/src/content/docs/host/snippets/Client.csproj
+++ b/docs/site/src/content/docs/host/snippets/Client.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
@@ -10,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Orleans.Client" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="10.2.2" />
   </ItemGroup>
 
 </Project>

--- a/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHost.csproj
+++ b/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,14 +9,14 @@
 
   <!-- <apphost_packages> -->
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.3" />
-    <PackageReference Include="Aspire.Hosting.Orleans" Version="13.1.3" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.1.3" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Orleans" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.6" />
   </ItemGroup>
   <!-- </apphost_packages> -->
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.1.3" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.4.6" />
   </ItemGroup>
 
   <!-- Project references removed - Silo and Client are library projects

--- a/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHost.csproj
+++ b/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHost.csproj
@@ -3,6 +3,7 @@
   <Sdk Name="Aspire.AppHost.Sdk" Version="13.4.6" />
 
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>

--- a/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHostExamples.cs
+++ b/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHostExamples.cs
@@ -90,11 +90,10 @@ public static class AppHostExamples
             .RunAsEmulator();  // Use Azurite emulator for local development
 
         var tables = storage.AddTables("orleans-tables");
-        var blobs = storage.AddBlobs("orleans-blobs");
 
         var orleans = builder.AddOrleans("cluster")
             .WithClustering(tables)
-            .WithGrainStorage("Default", blobs)
+            .WithGrainStorage("Default", tables)
             .WithReminders(tables);
 
         builder.AddProject<Projects.Silo>("silo")

--- a/docs/site/src/content/docs/host/snippets/aspire/Client/Client.csproj
+++ b/docs/site/src/content/docs/host/snippets/aspire/Client/Client.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <!-- <client_packages> -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Client" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.2.2" />
     <PackageReference Include="Aspire.StackExchange.Redis" Version="13.4.6" />
   </ItemGroup>
   <!-- </client_packages> -->

--- a/docs/site/src/content/docs/host/snippets/aspire/ServiceDefaults/ServiceDefaults.csproj
+++ b/docs/site/src/content/docs/host/snippets/aspire/ServiceDefaults/ServiceDefaults.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Extensions.Hosting</RootNamespace>
   </PropertyGroup>

--- a/docs/site/src/content/docs/host/snippets/aspire/SharedContracts/SharedContracts.csproj
+++ b/docs/site/src/content/docs/host/snippets/aspire/SharedContracts/SharedContracts.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.2.2" />
   </ItemGroup>
 
 </Project>

--- a/docs/site/src/content/docs/host/snippets/aspire/Silo/Silo.csproj
+++ b/docs/site/src/content/docs/host/snippets/aspire/Silo/Silo.csproj
@@ -8,6 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.1" />
     <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AzureStorage" Version="10.2.1" />
     <PackageReference Include="Aspire.StackExchange.Redis" Version="13.4.6" />
   </ItemGroup>
   <!-- </silo_packages> -->

--- a/docs/site/src/content/docs/host/snippets/aspire/Silo/Silo.csproj
+++ b/docs/site/src/content/docs/host/snippets/aspire/Silo/Silo.csproj
@@ -1,23 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <!-- <silo_packages> -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Reminders.AzureStorage" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AzureStorage" Version="10.2.2" />
     <PackageReference Include="Aspire.StackExchange.Redis" Version="13.4.6" />
   </ItemGroup>
   <!-- </silo_packages> -->
 
   <ItemGroup>
     <PackageReference Include="Aspire.Azure.Data.Tables" Version="13.4.6" />
-    <PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="10.2.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
   </ItemGroup>
 

--- a/docs/site/src/content/docs/host/snippets/aspire/Silo/SiloProgram.cs
+++ b/docs/site/src/content/docs/host/snippets/aspire/Silo/SiloProgram.cs
@@ -56,6 +56,19 @@ public static class SiloProgram
     }
     // </silo_explicit_connection>
 
+    // <silo_azure_config>
+    public static void AzureStorageConfiguration(string[] args)
+    {
+        var builder = Host.CreateApplicationBuilder(args);
+
+        builder.AddServiceDefaults();
+        builder.AddKeyedAzureTableServiceClient("orleans-tables");
+        builder.UseOrleans();
+
+        builder.Build().Run();
+    }
+    // </silo_azure_config>
+
     // <health_checks>
     public static void ConfigureHealthChecks(IHostApplicationBuilder builder)
     {
@@ -84,7 +97,7 @@ public static class SiloProgram
         var builder = Host.CreateApplicationBuilder(args);
 
         builder.AddServiceDefaults();
-        builder.AddKeyedAzureTableClient("reminders");
+        builder.AddKeyedAzureTableServiceClient("reminders");
         builder.UseOrleans();
 
         builder.Build().Run();

--- a/docs/site/src/content/docs/host/snippets/hosting/Hosting.csproj
+++ b/docs/site/src/content/docs/host/snippets/hosting/Hosting.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.Redis" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.GrainDirectory.Redis" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AdoNet" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="10.2.1" />
+  </ItemGroup>
+
+</Project>

--- a/docs/site/src/content/docs/host/snippets/hosting/Hosting.csproj
+++ b/docs/site/src/content/docs/host/snippets/hosting/Hosting.csproj
@@ -1,7 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
+    <!-- <server_gc> -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <!-- </server_gc> -->
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,15 +14,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Client" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Reminders.Redis" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.GrainDirectory.Redis" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Clustering.AdoNet" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="10.2.1" />
-    <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="10.2.1" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.Redis" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.GrainDirectory.Redis" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AdoNet" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="10.2.2" />
   </ItemGroup>
 
 </Project>

--- a/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
+++ b/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
@@ -1,0 +1,311 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Orleans.Configuration;
+using Orleans.GrainDirectory;
+using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.Runtime.Messaging;
+using StackExchange.Redis;
+
+namespace Hosting;
+
+public static class HostingExamples
+{
+    public static async Task LocalSiloAndClient(string[] args)
+    {
+        // <local_silo_and_client>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.UseOrleans(siloBuilder =>
+        {
+            siloBuilder.UseLocalhostClustering();
+            siloBuilder.AddMemoryGrainStorageAsDefault();
+            siloBuilder.UseInMemoryReminderService();
+        });
+
+        var app = builder.Build();
+
+        app.MapGet("/hello/{name}", async (string name, IClusterClient client) =>
+            await client.GetGrain<IHelloGrain>(name).SayHello());
+
+        await app.RunAsync();
+        // </local_silo_and_client>
+    }
+
+    public static async Task LocalExternalClient(string[] args)
+    {
+        // <local_external_client>
+        var builder = Host.CreateApplicationBuilder(args);
+
+        builder.UseOrleansClient(clientBuilder =>
+        {
+            clientBuilder.UseLocalhostClustering();
+        });
+
+        await builder.Build().RunAsync();
+        // </local_external_client>
+    }
+
+    public static async Task RedisSilo(string[] args)
+    {
+        // <redis_silo>
+        var builder = Host.CreateApplicationBuilder(args);
+
+        builder.UseOrleans(siloBuilder =>
+        {
+            siloBuilder.Configure<ClusterOptions>(options =>
+            {
+                options.ServiceId = "orders";
+                options.ClusterId = "orders-production";
+            });
+
+            siloBuilder.UseRedisClustering(options =>
+            {
+                options.ConfigurationOptions =
+                    ConfigurationOptions.Parse(
+                        builder.Configuration.GetConnectionString("redis")!);
+            });
+        });
+
+        await builder.Build().RunAsync();
+        // </redis_silo>
+    }
+
+    public static void ConfigureAdvertisedAndListeningEndpoints(
+        ISiloBuilder siloBuilder)
+    {
+        // <advertised_and_listening_endpoints>
+        siloBuilder.Configure<EndpointOptions>(options =>
+        {
+            // Addresses that other silos and clients use.
+            options.AdvertisedIPAddress = IPAddress.Parse("172.16.0.42");
+            options.SiloPort = 11_111;
+            options.GatewayPort = 30_000;
+
+            // Sockets opened inside this process or container.
+            options.SiloListeningEndpoint =
+                new IPEndPoint(IPAddress.Any, 40_000);
+            options.GatewayListeningEndpoint =
+                new IPEndPoint(IPAddress.Any, 50_000);
+        });
+        // </advertised_and_listening_endpoints>
+    }
+
+    public static void ConfigureExternalClient(
+        IHostApplicationBuilder builder)
+    {
+        // <external_client>
+        builder.UseOrleansClient(clientBuilder =>
+        {
+            clientBuilder.Configure<ClusterOptions>(options =>
+            {
+                options.ServiceId = "orders";
+                options.ClusterId = "orders-production";
+            });
+
+            clientBuilder.UseRedisClustering(options =>
+            {
+                options.ConfigurationOptions =
+                    ConfigurationOptions.Parse(
+                        builder.Configuration.GetConnectionString("redis")!);
+            });
+        });
+        // </external_client>
+    }
+
+    public static void ConfigureClientRetry(
+        IHostApplicationBuilder builder)
+    {
+        // <client_retry>
+        var retryCount = 0;
+
+        builder.UseOrleansClient(clientBuilder =>
+        {
+            clientBuilder
+                .UseRedisClustering(options => { /* ... */ })
+                .UseConnectionRetryFilter(
+                    async (exception, cancellationToken) =>
+                    {
+                        if (exception is not ConnectionFailedException ||
+                            Interlocked.Increment(ref retryCount) > 5)
+                        {
+                            return false;
+                        }
+
+                        await Task.Delay(
+                            TimeSpan.FromSeconds(5),
+                            cancellationToken);
+                        return true;
+                    });
+        });
+        // </client_retry>
+    }
+
+    public static void ConfigureAdoNetSilo(
+        IHostApplicationBuilder builder)
+    {
+        // <adonet_silo>
+        var connectionString =
+            builder.Configuration.GetConnectionString("orleans")
+            ?? throw new InvalidOperationException(
+                "Connection string 'orleans' is required.");
+
+        builder.UseOrleans(siloBuilder =>
+        {
+            siloBuilder.UseAdoNetClustering(options =>
+            {
+                options.Invariant = "Microsoft.Data.SqlClient";
+                options.ConnectionString = connectionString;
+            });
+
+            siloBuilder.UseAdoNetReminderService(options =>
+            {
+                options.Invariant = "Microsoft.Data.SqlClient";
+                options.ConnectionString = connectionString;
+            });
+
+            siloBuilder.AddAdoNetGrainStorageAsDefault(options =>
+            {
+                options.Invariant = "Microsoft.Data.SqlClient";
+                options.ConnectionString = connectionString;
+            });
+        });
+        // </adonet_silo>
+    }
+
+    public static void ConfigureNamedGrainDirectory(
+        ISiloBuilder siloBuilder,
+        ConfigurationOptions redisConfiguration)
+    {
+        // <named_grain_directory>
+        siloBuilder.AddRedisGrainDirectory(
+            "durable-directory",
+            options =>
+            {
+                options.ConfigurationOptions = redisConfiguration;
+            });
+        // </named_grain_directory>
+    }
+
+    public static void ConfigureGrainTypes(ISiloBuilder siloBuilder)
+    {
+        // <configure_grain_types>
+        siloBuilder.Configure<GrainTypeOptions>(options =>
+        {
+            options.Classes.Clear();
+            options.Classes.Add(typeof(RecommendationGrain));
+            options.Classes.Add(typeof(ModelRegistryGrain));
+        });
+        // </configure_grain_types>
+    }
+
+    public static void ConfigureActivationCollection(
+        ISiloBuilder siloBuilder)
+    {
+        // <activation_collection>
+        siloBuilder.Configure<GrainCollectionOptions>(options =>
+        {
+            options.CollectionAge = TimeSpan.FromMinutes(20);
+            options.ClassSpecificCollectionAge[
+                typeof(ShoppingCartGrain).FullName!] = TimeSpan.FromMinutes(5);
+
+            options.EnableActivationSheddingOnMemoryPressure = true;
+            options.MemoryUsageLimitPercentage = 80;
+            options.MemoryUsageTargetPercentage = 75;
+            options.MemoryUsagePollingPeriod = TimeSpan.FromSeconds(5);
+        });
+        // </activation_collection>
+    }
+}
+
+public sealed class CacheLifecycleParticipant
+    : ILifecycleParticipant<ISiloLifecycle>
+{
+    private readonly IApplicationCache _cache;
+
+    public CacheLifecycleParticipant(IApplicationCache cache)
+    {
+        _cache = cache;
+    }
+
+    // <lifecycle_participant>
+    public void Participate(ISiloLifecycle lifecycle)
+    {
+        lifecycle.Subscribe<CacheLifecycleParticipant>(
+            ServiceLifecycleStage.ApplicationServices,
+            cancellationToken => _cache.StartAsync(cancellationToken),
+            cancellationToken => _cache.StopAsync(cancellationToken));
+    }
+    // </lifecycle_participant>
+}
+
+public sealed class GrainPingService : BackgroundService
+{
+    private readonly IGrainFactory _grainFactory;
+    private readonly ILogger<GrainPingService> _logger;
+
+    public GrainPingService(
+        IGrainFactory grainFactory,
+        ILogger<GrainPingService> logger)
+    {
+        _grainFactory = grainFactory;
+        _logger = logger;
+    }
+
+    // <background_service>
+    protected override async Task ExecuteAsync(
+        CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(30));
+        var grain = _grainFactory.GetGrain<IHealthGrain>("background-check");
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try
+            {
+                await grain.Ping();
+            }
+            catch (Exception exception)
+                when (exception is not OperationCanceledException)
+            {
+                _logger.LogError(exception, "Grain ping failed");
+            }
+        }
+    }
+    // </background_service>
+}
+
+public interface IApplicationCache
+{
+    Task StartAsync(CancellationToken cancellationToken);
+
+    Task StopAsync(CancellationToken cancellationToken);
+}
+
+public interface IHelloGrain : IGrainWithStringKey
+{
+    Task<string> SayHello();
+}
+
+public interface IHealthGrain : IGrainWithStringKey
+{
+    Task Ping();
+}
+
+public interface IShoppingCartGrain : IGrainWithStringKey;
+
+[GrainDirectory("durable-directory")]
+public sealed class ShoppingCartGrain : Grain, IShoppingCartGrain;
+
+public interface IRecommendationGrain : IGrainWithStringKey;
+
+public sealed class RecommendationGrain : Grain, IRecommendationGrain;
+
+public interface IModelRegistryGrain : IGrainWithStringKey;
+
+public sealed class ModelRegistryGrain : Grain, IModelRegistryGrain;

--- a/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
+++ b/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
@@ -9,6 +9,7 @@ using Orleans.Configuration;
 using Orleans.GrainDirectory;
 using Orleans.Hosting;
 using Orleans.Runtime;
+using Orleans.Runtime.MembershipService.SiloMetadata;
 using Orleans.Runtime.Messaging;
 using StackExchange.Redis;
 
@@ -221,6 +222,24 @@ public static class HostingExamples
         });
         // </activation_collection>
     }
+
+    public static void ReadSiloMetadata(
+        ISiloMetadataCache siloMetadataCache,
+        SiloAddress siloAddress,
+        ILogger logger)
+    {
+        // <read_silo_metadata>
+        var metadata = siloMetadataCache.GetSiloMetadata(siloAddress);
+
+        if (metadata.Metadata.TryGetValue("role", out var role))
+        {
+            logger.LogInformation(
+                "Silo {Silo} has role {Role}",
+                siloAddress,
+                role);
+        }
+        // </read_silo_metadata>
+    }
 }
 
 public sealed class CacheLifecycleParticipant
@@ -297,15 +316,27 @@ public interface IHealthGrain : IGrainWithStringKey
     Task Ping();
 }
 
-public interface IShoppingCartGrain : IGrainWithStringKey;
+public interface IShoppingCartGrain : IGrainWithStringKey
+{
+}
 
 [GrainDirectory("durable-directory")]
-public sealed class ShoppingCartGrain : Grain, IShoppingCartGrain;
+public sealed class ShoppingCartGrain : Grain, IShoppingCartGrain
+{
+}
 
-public interface IRecommendationGrain : IGrainWithStringKey;
+public interface IRecommendationGrain : IGrainWithStringKey
+{
+}
 
-public sealed class RecommendationGrain : Grain, IRecommendationGrain;
+public sealed class RecommendationGrain : Grain, IRecommendationGrain
+{
+}
 
-public interface IModelRegistryGrain : IGrainWithStringKey;
+public interface IModelRegistryGrain : IGrainWithStringKey
+{
+}
 
-public sealed class ModelRegistryGrain : Grain, IModelRegistryGrain;
+public sealed class ModelRegistryGrain : Grain, IModelRegistryGrain
+{
+}

--- a/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
+++ b/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
@@ -17,9 +17,9 @@ namespace Hosting;
 
 public static class HostingExamples
 {
+    // <local_silo_and_client>
     public static async Task LocalSiloAndClient(string[] args)
     {
-        // <local_silo_and_client>
         var builder = WebApplication.CreateBuilder(args);
 
         builder.UseOrleans(siloBuilder =>
@@ -35,12 +35,12 @@ public static class HostingExamples
             await client.GetGrain<IHelloGrain>(name).SayHello());
 
         await app.RunAsync();
-        // </local_silo_and_client>
     }
+    // </local_silo_and_client>
 
+    // <local_external_client>
     public static async Task LocalExternalClient(string[] args)
     {
-        // <local_external_client>
         var builder = Host.CreateApplicationBuilder(args);
 
         builder.UseOrleansClient(clientBuilder =>
@@ -49,12 +49,12 @@ public static class HostingExamples
         });
 
         await builder.Build().RunAsync();
-        // </local_external_client>
     }
+    // </local_external_client>
 
+    // <redis_silo>
     public static async Task RedisSilo(string[] args)
     {
-        // <redis_silo>
         var builder = Host.CreateApplicationBuilder(args);
 
         builder.UseOrleans(siloBuilder =>
@@ -74,13 +74,13 @@ public static class HostingExamples
         });
 
         await builder.Build().RunAsync();
-        // </redis_silo>
     }
+    // </redis_silo>
 
+    // <advertised_and_listening_endpoints>
     public static void ConfigureAdvertisedAndListeningEndpoints(
         ISiloBuilder siloBuilder)
     {
-        // <advertised_and_listening_endpoints>
         siloBuilder.Configure<EndpointOptions>(options =>
         {
             // Addresses that other silos and clients use.
@@ -94,13 +94,14 @@ public static class HostingExamples
             options.GatewayListeningEndpoint =
                 new IPEndPoint(IPAddress.Any, 50_000);
         });
-        // </advertised_and_listening_endpoints>
     }
+    // </advertised_and_listening_endpoints>
 
-    public static void ConfigureExternalClient(
-        IHostApplicationBuilder builder)
+    // <external_client>
+    public static async Task RunExternalClient(string[] args)
     {
-        // <external_client>
+        var builder = Host.CreateApplicationBuilder(args);
+
         builder.UseOrleansClient(clientBuilder =>
         {
             clientBuilder.Configure<ClusterOptions>(options =>
@@ -116,13 +117,15 @@ public static class HostingExamples
                         builder.Configuration.GetConnectionString("redis")!);
             });
         });
-        // </external_client>
-    }
 
-    public static void ConfigureClientRetry(
-        IHostApplicationBuilder builder)
+        await builder.Build().RunAsync();
+    }
+    // </external_client>
+
+    // <client_retry>
+    public static void ConfigureClientRetry(string[] args)
     {
-        // <client_retry>
+        var builder = Host.CreateApplicationBuilder(args);
         var retryCount = 0;
 
         builder.UseOrleansClient(clientBuilder =>
@@ -144,13 +147,13 @@ public static class HostingExamples
                         return true;
                     });
         });
-        // </client_retry>
     }
+    // </client_retry>
 
-    public static void ConfigureAdoNetSilo(
-        IHostApplicationBuilder builder)
+    // <adonet_silo>
+    public static void ConfigureAdoNetSilo(string[] args)
     {
-        // <adonet_silo>
+        var builder = Host.CreateApplicationBuilder(args);
         var connectionString =
             builder.Configuration.GetConnectionString("orleans")
             ?? throw new InvalidOperationException(
@@ -176,39 +179,106 @@ public static class HostingExamples
                 options.ConnectionString = connectionString;
             });
         });
-        // </adonet_silo>
     }
+    // </adonet_silo>
 
+    // <adonet_client>
+    public static void ConfigureAdoNetClient(
+        IHostApplicationBuilder builder,
+        string connectionString)
+    {
+        builder.UseOrleansClient(clientBuilder =>
+        {
+            clientBuilder.UseAdoNetClustering(options =>
+            {
+                options.Invariant = "Microsoft.Data.SqlClient";
+                options.ConnectionString = connectionString;
+            });
+        });
+    }
+    // </adonet_client>
+
+    // <named_grain_directory>
     public static void ConfigureNamedGrainDirectory(
         ISiloBuilder siloBuilder,
         ConfigurationOptions redisConfiguration)
     {
-        // <named_grain_directory>
         siloBuilder.AddRedisGrainDirectory(
             "durable-directory",
             options =>
             {
                 options.ConfigurationOptions = redisConfiguration;
             });
-        // </named_grain_directory>
     }
+    // </named_grain_directory>
 
+    // <configure_grain_types>
     public static void ConfigureGrainTypes(ISiloBuilder siloBuilder)
     {
-        // <configure_grain_types>
         siloBuilder.Configure<GrainTypeOptions>(options =>
         {
             options.Classes.Clear();
             options.Classes.Add(typeof(RecommendationGrain));
             options.Classes.Add(typeof(ModelRegistryGrain));
         });
-        // </configure_grain_types>
     }
+    // </configure_grain_types>
 
+    // <exclude_grain_type>
+    public static void ExcludeGrainType(ISiloBuilder siloBuilder)
+    {
+        siloBuilder.Configure<GrainTypeOptions>(options =>
+        {
+            options.Classes.Remove(typeof(RecommendationGrain));
+        });
+    }
+    // </exclude_grain_type>
+
+    // <direct_endpoints>
+    public static void ConfigureDirectEndpoints(ISiloBuilder siloBuilder)
+    {
+        siloBuilder.ConfigureEndpoints(
+            advertisedIP: IPAddress.Parse("10.0.0.12"),
+            siloPort: 11_111,
+            gatewayPort: 30_000,
+            listenOnAnyHostAddress: true);
+    }
+    // </direct_endpoints>
+
+    // <named_providers>
+    public static void ConfigureNamedProviders(ISiloBuilder siloBuilder)
+    {
+        siloBuilder
+            .AddRedisGrainStorage(
+                "hot-state",
+                options => options.ConfigurationOptions =
+                    ConfigurationOptions.Parse("localhost:6379"))
+            .AddAdoNetGrainStorage("archive", options =>
+            {
+                options.Invariant = "Microsoft.Data.SqlClient";
+                options.ConnectionString =
+                    "Server=localhost;Database=Orleans;Integrated Security=true";
+            })
+            .UseRedisReminderService(
+                options => options.ConfigurationOptions =
+                    ConfigurationOptions.Parse("localhost:6379"));
+    }
+    // </named_providers>
+
+    // <membership_options>
+    public static void ConfigureMembership(ISiloBuilder siloBuilder)
+    {
+        siloBuilder.Configure<ClusterMembershipOptions>(options =>
+        {
+            options.ProbeTimeout = TimeSpan.FromSeconds(10);
+        });
+    }
+    // </membership_options>
+
+    // <activation_collection>
     public static void ConfigureActivationCollection(
         ISiloBuilder siloBuilder)
     {
-        // <activation_collection>
         siloBuilder.Configure<GrainCollectionOptions>(options =>
         {
             options.CollectionAge = TimeSpan.FromMinutes(20);
@@ -220,15 +290,15 @@ public static class HostingExamples
             options.MemoryUsageTargetPercentage = 75;
             options.MemoryUsagePollingPeriod = TimeSpan.FromSeconds(5);
         });
-        // </activation_collection>
     }
+    // </activation_collection>
 
+    // <read_silo_metadata>
     public static void ReadSiloMetadata(
         ISiloMetadataCache siloMetadataCache,
         SiloAddress siloAddress,
         ILogger logger)
     {
-        // <read_silo_metadata>
         var metadata = siloMetadataCache.GetSiloMetadata(siloAddress);
 
         if (metadata.Metadata.TryGetValue("role", out var role))
@@ -238,10 +308,134 @@ public static class HostingExamples
                 siloAddress,
                 role);
         }
-        // </read_silo_metadata>
     }
+    // </read_silo_metadata>
+
+    // <configure_silo_metadata>
+    public static void ConfigureSiloMetadata(
+        ISiloBuilder siloBuilder,
+        string region,
+        bool hasGpu)
+    {
+        siloBuilder.UseSiloMetadata(new Dictionary<string, string>
+        {
+            ["cloud.region"] = region,
+            ["hardware.accelerator"] = hasGpu ? "gpu" : "none",
+            ["role"] = "recommendations"
+        });
+    }
+    // </configure_silo_metadata>
+
+    // <silo_metadata_from_configuration>
+    public static void ConfigureSiloMetadataFromConfiguration(string[] args)
+    {
+        var builder = Host.CreateApplicationBuilder(args);
+
+        builder.UseOrleans(siloBuilder =>
+        {
+            siloBuilder.UseSiloMetadata();
+        });
+    }
+    // </silo_metadata_from_configuration>
+
+    // <distributed_grain_directory>
+    public static void ConfigureDistributedDirectory(ISiloBuilder siloBuilder)
+    {
+#pragma warning disable ORLEANSEXP003
+        siloBuilder.AddDistributedGrainDirectory();
+#pragma warning restore ORLEANSEXP003
+    }
+    // </distributed_grain_directory>
+
+    // <register_lifecycle_participant>
+    public static void RegisterLifecycleParticipant(ISiloBuilder siloBuilder)
+    {
+        siloBuilder.Services.AddSingleton<CacheLifecycleParticipant>();
+        siloBuilder.Services.AddSingleton<
+            ILifecycleParticipant<ISiloLifecycle>>(
+            services =>
+                services.GetRequiredService<CacheLifecycleParticipant>());
+    }
+    // </register_lifecycle_participant>
+
+    // <register_startup_task>
+    public static void RegisterStartupTask(ISiloBuilder siloBuilder)
+    {
+        siloBuilder.AddStartupTask(
+            async (services, cancellationToken) =>
+            {
+                var grainFactory =
+                    services.GetRequiredService<IGrainFactory>();
+                var grain =
+                    grainFactory.GetGrain<IInitializerGrain>("application");
+                await grain.Initialize(cancellationToken);
+            },
+            ServiceLifecycleStage.Active);
+    }
+    // </register_startup_task>
+
+    // <register_validate_dependencies_task>
+    public static void RegisterValidateDependenciesTask(
+        ISiloBuilder siloBuilder)
+    {
+        siloBuilder.AddStartupTask<ValidateDependenciesTask>(
+            ServiceLifecycleStage.ApplicationServices);
+    }
+    // </register_validate_dependencies_task>
+
+    // <register_background_service>
+    public static async Task RunBackgroundService(string[] args)
+    {
+        var builder = Host.CreateApplicationBuilder(args);
+
+        builder.UseOrleans(siloBuilder =>
+        {
+            // Configure Orleans.
+        });
+
+        builder.Services.AddHostedService<GrainPingService>();
+
+        await builder.Build().RunAsync();
+    }
+    // </register_background_service>
+
+    // <run_silo>
+    public static async Task RunSilo(string[] args)
+    {
+        var builder = Host.CreateApplicationBuilder(args);
+
+        builder.UseOrleans(siloBuilder =>
+        {
+            // Configure Orleans.
+        });
+
+        await builder.Build().RunAsync();
+    }
+    // </run_silo>
+
+    // <stop_host>
+    public static async Task StopHost(
+        IHost host,
+        CancellationToken cancellationToken)
+    {
+        await host.StopAsync(cancellationToken);
+        host.Dispose();
+    }
+    // </stop_host>
+
+    // <shutdown_timeout>
+    public static void ConfigureShutdownTimeout(
+        IHostApplicationBuilder builder)
+    {
+        builder.Services.Configure<HostOptions>(options =>
+        {
+            options.ShutdownTimeout = TimeSpan.FromSeconds(45);
+        });
+    }
+    // </shutdown_timeout>
 }
 
+// <lifecycle_participant>
 public sealed class CacheLifecycleParticipant
     : ILifecycleParticipant<ISiloLifecycle>
 {
@@ -252,7 +446,6 @@ public sealed class CacheLifecycleParticipant
         _cache = cache;
     }
 
-    // <lifecycle_participant>
     public void Participate(ISiloLifecycle lifecycle)
     {
         lifecycle.Subscribe<CacheLifecycleParticipant>(
@@ -260,9 +453,10 @@ public sealed class CacheLifecycleParticipant
             cancellationToken => _cache.StartAsync(cancellationToken),
             cancellationToken => _cache.StopAsync(cancellationToken));
     }
-    // </lifecycle_participant>
 }
+// </lifecycle_participant>
 
+// <background_service>
 public sealed class GrainPingService : BackgroundService
 {
     private readonly IGrainFactory _grainFactory;
@@ -276,7 +470,6 @@ public sealed class GrainPingService : BackgroundService
         _logger = logger;
     }
 
-    // <background_service>
     protected override async Task ExecuteAsync(
         CancellationToken stoppingToken)
     {
@@ -296,8 +489,8 @@ public sealed class GrainPingService : BackgroundService
             }
         }
     }
-    // </background_service>
 }
+// </background_service>
 
 public interface IApplicationCache
 {
@@ -316,14 +509,21 @@ public interface IHealthGrain : IGrainWithStringKey
     Task Ping();
 }
 
+public interface IInitializerGrain : IGrainWithStringKey
+{
+    Task Initialize(CancellationToken cancellationToken);
+}
+
 public interface IShoppingCartGrain : IGrainWithStringKey
 {
 }
 
+// <grain_directory_attribute>
 [GrainDirectory("durable-directory")]
 public sealed class ShoppingCartGrain : Grain, IShoppingCartGrain
 {
 }
+// </grain_directory_attribute>
 
 public interface IRecommendationGrain : IGrainWithStringKey
 {
@@ -339,4 +539,51 @@ public interface IModelRegistryGrain : IGrainWithStringKey
 
 public sealed class ModelRegistryGrain : Grain, IModelRegistryGrain
 {
+}
+
+// <deactivate_on_idle>
+public sealed class DeactivateOnIdleGrain : Grain
+{
+    public void RequestDeactivation()
+    {
+        this.DeactivateOnIdle();
+    }
+}
+// </deactivate_on_idle>
+
+// <delay_deactivation>
+public sealed class DelayDeactivationGrain : Grain
+{
+    public void DelayCollection()
+    {
+        this.DelayDeactivation(TimeSpan.FromMinutes(30));
+    }
+}
+// </delay_deactivation>
+
+// <keep_alive_grain>
+[KeepAlive]
+public sealed class ReferenceDataGrain : Grain
+{
+}
+// </keep_alive_grain>
+
+// <validate_dependencies_task>
+public sealed class ValidateDependenciesTask : IStartupTask
+{
+    private readonly IDependencyValidator _validator;
+
+    public ValidateDependenciesTask(IDependencyValidator validator)
+    {
+        _validator = validator;
+    }
+
+    public Task Execute(CancellationToken cancellationToken) =>
+        _validator.ValidateAsync(cancellationToken);
+}
+// </validate_dependencies_task>
+
+public interface IDependencyValidator
+{
+    Task ValidateAsync(CancellationToken cancellationToken);
 }

--- a/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
+++ b/docs/site/src/content/docs/host/snippets/hosting/HostingExamples.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/docs/site/src/content/docs/host/snippets/snippets.sln
+++ b/docs/site/src/content/docs/host/snippets/snippets.sln
@@ -14,6 +14,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceDefaults", "aspire\S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharedContracts", "aspire\SharedContracts\SharedContracts.csproj", "{A1B2C3D4-1111-2222-3333-444455556670}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hosting", "hosting\Hosting.csproj", "{A1B2C3D4-1111-2222-3333-444455556671}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,5 +46,9 @@ Global
 		{A1B2C3D4-1111-2222-3333-444455556670}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1B2C3D4-1111-2222-3333-444455556670}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-1111-2222-3333-444455556670}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455556671}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455556671}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455556671}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-1111-2222-3333-444455556671}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/docs/site/src/content/includes/managed-identities.md
+++ b/docs/site/src/content/includes/managed-identities.md
@@ -1,2 +1,2 @@
 > [!IMPORTANT]
-> Microsoft recommends that you use the most secure authentication flow available. If you're connecting to Azure SQL, [Managed Identities for Azure resources](/sql/connect/ado-net/sql/azure-active-directory-authentication#using-managed-identity-authentication) is the recommended authentication method.
+> Microsoft recommends that you use the most secure authentication flow available. If you're connecting to Azure SQL, [managed identities for Azure resources](https://learn.microsoft.com/sql/connect/ado-net/sql/azure-active-directory-authentication#using-managed-identity-authentication) is the recommended authentication method.


### PR DESCRIPTION
Modernizes Orleans 10 hosting and configuration guidance across silo/client hosting, declarative configuration, networking, providers, Aspire, lifecycle, resource management, heterogeneous silos, metadata, and grain directories.

Replaces stale version pivots and hand-maintained option catalogs with task-oriented guidance backed by compiled snippets and current APIs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10335)