### PR TITLE
feat(analyzers): detect RPC contract changes

### DIFF
--- a/docs/site/src/content/docs/grains/code-generation.md
+++ b/docs/site/src/content/docs/grains/code-generation.md
@@ -62,4 +62,6 @@ For end-to-end interop examples, see the [Orleans F# sample](https://learn.micro
 
 Treat Orleans analyzer and generator diagnostics as contract errors, not warnings to suppress. Generated files can be inspected through normal compiler-generated-file tooling when debugging, but application code should depend on the public interfaces rather than generated implementation names.
 
+The optional [Orleans contract compatibility analyzer](grain-versioning/contract-compatibility-analyzer.md) records grain RPC identities and signatures in `OrleansContracts.txt` so contract drift can be reviewed before a rolling upgrade.
+
 For serialization rules and version tolerance, see [Orleans serialization](../host/configuration-guide/serialization.md).

--- a/docs/site/src/content/docs/grains/grain-versioning/contract-compatibility-analyzer.md
+++ b/docs/site/src/content/docs/grains/grain-versioning/contract-compatibility-analyzer.md
@@ -1,0 +1,111 @@
+---
+title: Orleans contract compatibility analyzer
+description: Track grain RPC contracts during development to identify changes which can break rolling upgrades.
+ms.date: 08/11/2026
+ms.topic: concept-article
+---
+
+# Orleans contract compatibility analyzer
+
+The Orleans contract compatibility analyzer compares the grain interfaces and concrete grain classes in a project with a checked-in contract manifest. It helps reviewers identify changes to RPC identities and signatures which can break rolling upgrades.
+
+The analyzer is **disabled by default**. Enable it explicitly in a project file or a shared `Directory.Build.props`:
+
+```xml
+<PropertyGroup>
+  <EnableOrleansContractsAnalyzer>true</EnableOrleansContractsAnalyzer>
+</PropertyGroup>
+```
+
+Projects which use `Microsoft.Orleans.Sdk`, `Microsoft.Orleans.Client`, or `Microsoft.Orleans.Server` already receive the Orleans analyzers through those packages. A project which references `Microsoft.Orleans.Analyzers` directly can use the same property.
+
+## Configure the manifest path
+
+By default, the analyzer looks for `OrleansContracts.txt` beside the project file. The analyzer package automatically adds an existing file at that location as a compiler `AdditionalFile`; no explicit `AdditionalFiles` item is required.
+
+Set `OrleansContractsPath` to use another location or filename:
+
+```xml
+<PropertyGroup>
+  <EnableOrleansContractsAnalyzer>true</EnableOrleansContractsAnalyzer>
+  <OrleansContractsPath>$(MSBuildProjectDirectory)\contracts\rpc-contracts.txt</OrleansContractsPath>
+</PropertyGroup>
+```
+
+The path can also be set in `Directory.Build.props` to apply a repository convention. Each project needs its own manifest because the analyzer evaluates the contracts compiled into that project.
+
+## Create and update the manifest
+
+After opting in, build the project. If no manifest exists, diagnostic `ORLEANS0020` identifies the missing file. Create the file, include it in source control, and apply the Orleans code fixes to add missing interface and class entries. Apply the code fixes again after adding RPC methods.
+
+Code fixes preserve the file's line endings and write entries in stable ordinal order. The resulting file is deterministic regardless of the order in which fixes are applied.
+
+## Manifest format
+
+Interface methods are indented beneath their interface:
+
+```text
+interface Contoso.Grains.ICartGrain [Version(1)]
+  AddAsync(Contoso.Grains.Item) -> Task
+  GetAsync() -> Task<Contoso.Grains.Cart>
+
+class Contoso.Grains.CartGrain
+```
+
+Stable Orleans identities are written when source code supplies them:
+
+```text
+# Contoso.Grains.ICartGrain
+interface [GrainInterfaceType("cart")] Contoso.Grains.ICartGrain [Version(1)]
+  # Contoso.Grains.ICartGrain.AddAsync(Item item) -> Task
+  add(Contoso.Grains.Item) -> Task
+
+# Contoso.Grains.CartGrain
+class [GrainType("cart")] Contoso.Grains.CartGrain
+```
+
+Comments record CLR names only when they differ from the stable identity. Comments are informational and aren't part of contract matching.
+
+`*RETIRED*` marks an intentionally removed contract:
+
+```text
+*RETIRED* interface Contoso.Grains.ILegacyGrain [Version(0)]
+
+*RETIRED* class Contoso.Grains.LegacyGrain
+```
+
+Don't delete retired entries. They preserve the contract history and prevent a removed identity from being unintentionally reused.
+
+## Refactor-safe identities
+
+The analyzer uses Orleans identities before CLR names:
+
+- <xref:Orleans.GrainTypeAttribute> identifies grain classes.
+- <xref:Orleans.Runtime.GrainInterfaceTypeAttribute> identifies grain interfaces.
+- <xref:Orleans.IdAttribute> or <xref:Orleans.AliasAttribute> identifies grain methods.
+- <xref:Orleans.AliasAttribute> identifies serialized parameter and return types.
+
+When these identities remain unchanged, renaming a CLR class, interface, method, parameter, or aliased data type doesn't require a manifest update. Changing an Orleans identity remains a contract change and produces a diagnostic.
+
+Without an explicit stable identity, the CLR name is the identity. Renaming it therefore changes the contract.
+
+## Diagnostics
+
+| Diagnostic | Default severity | Meaning |
+| --- | --- | --- |
+| `ORLEANS0016` | Warning | A grain interface has no active manifest declaration. |
+| `ORLEANS0017` | Warning | The interface version differs from the manifest. |
+| `ORLEANS0018` | Warning | An RPC method signature isn't declared. |
+| `ORLEANS0019` | Warning | A removed interface isn't marked `*RETIRED*`. |
+| `ORLEANS0020` | Info | The opted-in project has no manifest. |
+| `ORLEANS0021` | Warning | An interface is declared more than once. |
+| `ORLEANS0022` | Warning | A concrete grain class has no active declaration. |
+| `ORLEANS0023` | Warning | A grain class identity differs from the manifest. |
+| `ORLEANS0024` | Warning | A removed grain class isn't marked `*RETIRED*`. |
+| `ORLEANS0025` | Warning | A grain class is declared more than once. |
+
+Standard `.editorconfig` diagnostic configuration can change these severities. Prefer fixing contract drift instead of suppressing diagnostics.
+
+## Scope
+
+The analyzer tracks RPC interface signatures, numeric interface versions, and concrete grain class identities. It doesn't prove behavioral compatibility or validate persisted state schemas. Continue to follow the [backward compatibility guidelines](backward-compatibility-guidelines.md) and test mixed-version deployments before production rollout.

--- a/docs/site/src/content/docs/grains/grain-versioning/grain-versioning.md
+++ b/docs/site/src/content/docs/grains/grain-versioning/grain-versioning.md
@@ -36,7 +36,7 @@ Every versioned request carries the numeric interface version used by its caller
 If a request reaches an existing activation whose version is incompatible, Orleans deactivates it with reason `IncompatibleRequest`, invalidates the stale address, and retries placement for a compatible activation.
 
 > [!IMPORTANT]
-> The compatibility check compares version numbers only. Orleans doesn't inspect methods, parameter types, serializer contracts, or behavior to prove compatibility. The application must uphold the contract represented by the selected strategy.
+> The runtime compatibility check compares version numbers only. Orleans doesn't inspect methods, parameter types, serializer contracts, or behavior to prove compatibility. The application must uphold the contract represented by the selected strategy. During development, opt in to the [Orleans contract compatibility analyzer](contract-compatibility-analyzer.md) to track RPC signatures and identities in source control.
 
 ## Configure cluster defaults
 

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -70,6 +70,8 @@ items:
             href: grains/grain-placement-filtering.md
           - name: Interface versioning
             href: grains/grain-versioning/grain-versioning.md
+          - name: Contract compatibility analyzer
+            href: grains/grain-versioning/contract-compatibility-analyzer.md
           - name: Backward compatibility guidelines
             href: grains/grain-versioning/backward-compatibility-guidelines.md
           - name: Compatible grains

--- a/src/Dashboard/Orleans.Dashboard/OrleansContracts.txt
+++ b/src/Dashboard/Orleans.Dashboard/OrleansContracts.txt
@@ -1,0 +1,33 @@
+interface Orleans.Dashboard.Core.IDashboardGrain [Version(0)]
+  GetClusterTracing() -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.GrainTraceEntry>>>
+  GetCounters(string[]) -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.DashboardCounters>>
+  GetGrainState(string?, string?) -> Task<Orleans.Concurrency.Immutable<string>>
+  GetGrainTracing(string) -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.GrainTraceEntry>>>>
+  GetGrainTypes(string[]) -> Task<Orleans.Concurrency.Immutable<string[]>>
+  GetSiloTracing(string) -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.GrainTraceEntry>>>
+  InitializeAsync() -> Task
+  SubmitTracing(string, Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.SiloGrainTraceEntry[]>) -> Task
+  TopGrainMethods(int, string[]) -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, Orleans.Dashboard.Model.History.GrainMethodAggregate[]>>>
+
+interface Orleans.Dashboard.Core.IDashboardRemindersGrain [Version(0)]
+  GetReminders(int, int) -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.ReminderResponse>>
+
+interface Orleans.Dashboard.Core.ISiloGrainProxy [Version(0)]
+  GetMetadata() -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, string>>>
+
+interface Orleans.Dashboard.Core.ISiloGrainService [Version(0)]
+  Enable(bool) -> Task
+  GetCounters() -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.StatCounter[]>>
+  GetExtendedProperties() -> Task<Orleans.Concurrency.Immutable<System.Collections.Generic.Dictionary<string, string?>>>
+  GetLifecycleStages() -> Task<Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.LifecycleStageInfo[]>>
+  GetRuntimeStatistics() -> Task<Orleans.Concurrency.Immutable<Orleans.Runtime.SiloRuntimeStatistics?[]>>
+  ReportCounters(Orleans.Concurrency.Immutable<Orleans.Dashboard.Model.StatCounter[]>) -> Task
+  SetVersion(string, string) -> Task
+
+class Orleans.Dashboard.Implementation.Grains.DashboardGrain
+
+class Orleans.Dashboard.Implementation.Grains.DashboardRemindersGrain
+
+class Orleans.Dashboard.Implementation.Grains.SiloGrainProxy
+
+class Orleans.Dashboard.Implementation.SiloGrainService

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,6 +32,15 @@
     <AssemblyAttribute Include="Orleans.Metadata.FrameworkPartAttribute" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <OrleansContractsPath Condition="'$(OrleansContractsPath)' == ''">$(MSBuildProjectDirectory)\OrleansContracts.txt</OrleansContractsPath>
+  </PropertyGroup>
+
+  <ItemGroup Condition="Exists('$(OrleansContractsPath)')">
+    <AdditionalFiles Include="$(OrleansContractsPath)" OrleansContractsFile="true" />
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="OrleansContractsFile" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.GenAPI.Task" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -33,13 +33,9 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <EnableOrleansContractsAnalyzer>true</EnableOrleansContractsAnalyzer>
     <OrleansContractsPath Condition="'$(OrleansContractsPath)' == ''">$(MSBuildProjectDirectory)\OrleansContracts.txt</OrleansContractsPath>
   </PropertyGroup>
-
-  <ItemGroup Condition="Exists('$(OrleansContractsPath)')">
-    <AdditionalFiles Include="$(OrleansContractsPath)" OrleansContractsFile="true" />
-    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="OrleansContractsFile" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.GenAPI.Task" PrivateAssets="All" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -5,6 +5,15 @@
 
   <Import Project="$(_ParentDirectoryBuildTargetsPath)" Condition="Exists('$(_ParentDirectoryBuildTargetsPath)')"/>
 
+  <ItemGroup>
+    <CompilerVisibleProperty Include="EnableOrleansContractsAnalyzer" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(EnableOrleansContractsAnalyzer)' == 'true' and Exists('$(OrleansContractsPath)')">
+    <AdditionalFiles Include="$(OrleansContractsPath)" OrleansContractsFile="true" />
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="OrleansContractsFile" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(IsPackable)'=='true' and '$(SourceLinkCreate)'=='true' and '$(IncludeBuildOutput)'=='true'">
     <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" PrivateAssets="All"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />

--- a/src/Orleans.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Orleans.Analyzers/AnalyzerReleases.Unshipped.md
@@ -5,9 +5,13 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 ORLEANS0014 | Usage | Warning | ConfigureAwaitAnalyzer, Grain code should not use ConfigureAwait(false) or ConfigureAwait without ContinueOnCapturedContext
-ORLEANS0016 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface not declared in GrainInterfaces.txt
+ORLEANS0016 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface not declared in OrleansContracts.txt
 ORLEANS0017 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface version mismatch between code and file
-ORLEANS0018 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface member not declared in GrainInterfaces.txt
+ORLEANS0018 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface member not declared in OrleansContracts.txt
 ORLEANS0019 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Removed interface not marked as *RETIRED*
-ORLEANS0020 | Orleans.Versioning | Info | GrainInterfaceVersionAnalyzer, GrainInterfaces.txt file is missing
+ORLEANS0020 | Orleans.Versioning | Info | GrainInterfaceVersionAnalyzer, OrleansContracts.txt file is missing
 ORLEANS0021 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Duplicate interface declaration in file
+ORLEANS0022 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain class not declared in OrleansContracts.txt
+ORLEANS0023 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain class alias mismatch
+ORLEANS0024 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Removed grain class not marked as *RETIRED*
+ORLEANS0025 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Duplicate grain class declaration in file

--- a/src/Orleans.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Orleans.Analyzers/AnalyzerReleases.Unshipped.md
@@ -5,3 +5,9 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 ORLEANS0014 | Usage | Warning | ConfigureAwaitAnalyzer, Grain code should not use ConfigureAwait(false) or ConfigureAwait without ContinueOnCapturedContext
+ORLEANS0016 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface not declared in GrainInterfaces.txt
+ORLEANS0017 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface version mismatch between code and file
+ORLEANS0018 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Grain interface member not declared in GrainInterfaces.txt
+ORLEANS0019 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Removed interface not marked as *RETIRED*
+ORLEANS0020 | Orleans.Versioning | Info | GrainInterfaceVersionAnalyzer, GrainInterfaces.txt file is missing
+ORLEANS0021 | Orleans.Versioning | Warning | GrainInterfaceVersionAnalyzer, Duplicate interface declaration in file

--- a/src/Orleans.Analyzers/Constants.cs
+++ b/src/Orleans.Analyzers/Constants.cs
@@ -13,6 +13,8 @@ namespace Orleans.Analyzers
         public const string AliasAttributeFullyQualifiedName = "Orleans.AliasAttribute";
         public const string IdAttributeFullyQualifiedName = "Orleans.IdAttribute";
         public const string GenerateSerializerAttributeFullyQualifiedName = "Orleans.GenerateSerializerAttribute";
+        public const string GrainInterfaceTypeAttributeFullyQualifiedName = "Orleans.Runtime.GrainInterfaceTypeAttribute";
+        public const string GrainTypeAttributeFullyQualifiedName = "Orleans.GrainTypeAttribute";
         public const string VersionAttributeFullyQualifiedName = "Orleans.CodeGeneration.VersionAttribute";
 
         public const string SerializableAttributeFullyQualifiedName = "System.SerializableAttribute";
@@ -23,6 +25,6 @@ namespace Orleans.Analyzers
         public const string GenerateSerializerAttributeSourceName = "global::Orleans.GenerateSerializerAttribute";
         public const string NonSerializedAttributeSourceName = "global::System.NonSerializedAttribute";
 
-        public const string GrainInterfacesFileName = "GrainInterfaces.txt";
+        public const string OrleansContractsFileName = "OrleansContracts.txt";
     }
 }

--- a/src/Orleans.Analyzers/Constants.cs
+++ b/src/Orleans.Analyzers/Constants.cs
@@ -13,6 +13,7 @@ namespace Orleans.Analyzers
         public const string AliasAttributeFullyQualifiedName = "Orleans.AliasAttribute";
         public const string IdAttributeFullyQualifiedName = "Orleans.IdAttribute";
         public const string GenerateSerializerAttributeFullyQualifiedName = "Orleans.GenerateSerializerAttribute";
+        public const string VersionAttributeFullyQualifiedName = "Orleans.CodeGeneration.VersionAttribute";
 
         public const string SerializableAttributeFullyQualifiedName = "System.SerializableAttribute";
         public const string NonSerializedAttributeFullyQualifiedName = "System.NonSerializedAttribute";
@@ -21,5 +22,7 @@ namespace Orleans.Analyzers
         public const string IdAttributeSourceName = "global::Orleans.IdAttribute";
         public const string GenerateSerializerAttributeSourceName = "global::Orleans.GenerateSerializerAttribute";
         public const string NonSerializedAttributeSourceName = "global::System.NonSerializedAttribute";
+
+        public const string GrainInterfacesFileName = "GrainInterfaces.txt";
     }
 }

--- a/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
@@ -643,6 +643,11 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         var methodId = GetAttributeValue(method, Constants.IdAttributeFullyQualifiedName);
         var methodAlias = GetStringAttributeValue(method, Constants.AliasAttributeFullyQualifiedName);
         sb.Append(methodId ?? methodAlias ?? method.Name);
+        if (method.Arity > 0)
+        {
+            sb.Append('`');
+            sb.Append(method.Arity);
+        }
         sb.Append('(');
 
         for (int i = 0; i < method.Parameters.Length; i++)
@@ -664,6 +669,12 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         sb.Append(method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", ""));
         sb.Append('.');
         sb.Append(method.Name);
+        if (method.Arity > 0)
+        {
+            sb.Append('<');
+            sb.Append(string.Join(", ", method.TypeParameters.Select(parameter => parameter.Name)));
+            sb.Append('>');
+        }
         sb.Append('(');
 
         for (var i = 0; i < method.Parameters.Length; i++)

--- a/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
@@ -28,14 +28,23 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
     public const string RuleId0019 = "ORLEANS0019";
     public const string RuleId0020 = "ORLEANS0020";
     public const string RuleId0021 = "ORLEANS0021";
+    public const string RuleId0022 = "ORLEANS0022";
+    public const string RuleId0023 = "ORLEANS0023";
+    public const string RuleId0024 = "ORLEANS0024";
+    public const string RuleId0025 = "ORLEANS0025";
 
     // Property bag keys for code fixes
     internal const string InterfaceNamePropertyKey = "InterfaceName";
     internal const string MemberNamePropertyKey = "MemberName";
+    internal const string MemberAliasPropertyKey = "MemberAlias";
+    internal const string MemberClrSignaturePropertyKey = "MemberClrSignature";
     internal const string ExpectedVersionPropertyKey = "ExpectedVersion";
     internal const string ActualVersionPropertyKey = "ActualVersion";
     internal const string ExpectedSignaturePropertyKey = "ExpectedSignature";
     internal const string ActualSignaturePropertyKey = "ActualSignature";
+    internal const string ClassNamePropertyKey = "ClassName";
+    internal const string ActualAliasPropertyKey = "ActualAlias";
+    internal const string GrainInterfaceTypePropertyKey = "GrainInterfaceType";
 
     internal const string RetiredPrefix = "*RETIRED*";
 
@@ -76,14 +85,14 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         description: new LocalizableResourceString(nameof(Resources.GrainInterfaceRemovedNotRetiredDescription), Resources.ResourceManager, typeof(Resources)),
         customTags: WellKnownDiagnosticTags.CompilationEnd);
 
-    private static readonly DiagnosticDescriptor GrainInterfacesFileMissingRule = new(
+    private static readonly DiagnosticDescriptor OrleansContractsFileMissingRule = new(
         id: RuleId0020,
-        title: new LocalizableResourceString(nameof(Resources.GrainInterfacesFileMissingTitle), Resources.ResourceManager, typeof(Resources)),
-        messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfacesFileMissingMessageFormat), Resources.ResourceManager, typeof(Resources)),
+        title: new LocalizableResourceString(nameof(Resources.OrleansContractsFileMissingTitle), Resources.ResourceManager, typeof(Resources)),
+        messageFormat: new LocalizableResourceString(nameof(Resources.OrleansContractsFileMissingMessageFormat), Resources.ResourceManager, typeof(Resources)),
         category: "Orleans.Versioning",
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true,
-        description: new LocalizableResourceString(nameof(Resources.GrainInterfacesFileMissingDescription), Resources.ResourceManager, typeof(Resources)),
+        description: new LocalizableResourceString(nameof(Resources.OrleansContractsFileMissingDescription), Resources.ResourceManager, typeof(Resources)),
         customTags: WellKnownDiagnosticTags.CompilationEnd);
 
     internal static readonly DiagnosticDescriptor DuplicateInterfaceDeclarationRule = new(
@@ -95,14 +104,55 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: new LocalizableResourceString(nameof(Resources.GrainInterfaceDuplicateDeclarationDescription), Resources.ResourceManager, typeof(Resources)));
 
+    private static readonly DiagnosticDescriptor GrainClassNotDeclaredRule = new(
+        id: RuleId0022,
+        title: new LocalizableResourceString(nameof(Resources.GrainClassNotDeclaredTitle), Resources.ResourceManager, typeof(Resources)),
+        messageFormat: new LocalizableResourceString(nameof(Resources.GrainClassNotDeclaredMessageFormat), Resources.ResourceManager, typeof(Resources)),
+        category: "Orleans.Versioning",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: new LocalizableResourceString(nameof(Resources.GrainClassNotDeclaredDescription), Resources.ResourceManager, typeof(Resources)));
+
+    private static readonly DiagnosticDescriptor GrainClassAliasMismatchRule = new(
+        id: RuleId0023,
+        title: new LocalizableResourceString(nameof(Resources.GrainClassAliasMismatchTitle), Resources.ResourceManager, typeof(Resources)),
+        messageFormat: new LocalizableResourceString(nameof(Resources.GrainClassAliasMismatchMessageFormat), Resources.ResourceManager, typeof(Resources)),
+        category: "Orleans.Versioning",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: new LocalizableResourceString(nameof(Resources.GrainClassAliasMismatchDescription), Resources.ResourceManager, typeof(Resources)));
+
+    private static readonly DiagnosticDescriptor RemovedGrainClassNotRetiredRule = new(
+        id: RuleId0024,
+        title: new LocalizableResourceString(nameof(Resources.GrainClassRemovedNotRetiredTitle), Resources.ResourceManager, typeof(Resources)),
+        messageFormat: new LocalizableResourceString(nameof(Resources.GrainClassRemovedNotRetiredMessageFormat), Resources.ResourceManager, typeof(Resources)),
+        category: "Orleans.Versioning",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: new LocalizableResourceString(nameof(Resources.GrainClassRemovedNotRetiredDescription), Resources.ResourceManager, typeof(Resources)),
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
+
+    internal static readonly DiagnosticDescriptor DuplicateGrainClassDeclarationRule = new(
+        id: RuleId0025,
+        title: new LocalizableResourceString(nameof(Resources.GrainClassDuplicateDeclarationTitle), Resources.ResourceManager, typeof(Resources)),
+        messageFormat: new LocalizableResourceString(nameof(Resources.GrainClassDuplicateDeclarationMessageFormat), Resources.ResourceManager, typeof(Resources)),
+        category: "Orleans.Versioning",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: new LocalizableResourceString(nameof(Resources.GrainClassDuplicateDeclarationDescription), Resources.ResourceManager, typeof(Resources)));
+
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(
             InterfaceNotDeclaredRule,
             InterfaceVersionMismatchRule,
             MemberNotDeclaredRule,
             RemovedInterfaceNotRetiredRule,
-            GrainInterfacesFileMissingRule,
-            DuplicateInterfaceDeclarationRule);
+            OrleansContractsFileMissingRule,
+            DuplicateInterfaceDeclarationRule,
+            GrainClassNotDeclaredRule,
+            GrainClassAliasMismatchRule,
+            RemovedGrainClassNotRetiredRule,
+            DuplicateGrainClassDeclarationRule);
 
     public override void Initialize(AnalysisContext context)
     {
@@ -113,9 +163,13 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
 
     private void OnCompilationStart(CompilationStartAnalysisContext context)
     {
-        // Try to find the GrainInterfaces.txt file
+        // Try to find the OrleansContracts.txt file
         var grainInterfacesFile = context.Options.AdditionalFiles
-            .FirstOrDefault(f => Path.GetFileName(f.Path).Equals(Constants.GrainInterfacesFileName, StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefault(file =>
+                Path.GetFileName(file.Path).Equals(Constants.OrleansContractsFileName, StringComparison.OrdinalIgnoreCase)
+                || context.Options.AnalyzerConfigOptionsProvider.GetOptions(file)
+                    .TryGetValue("build_metadata.AdditionalFiles.OrleansContractsFile", out var value)
+                    && string.Equals(value, "true", StringComparison.OrdinalIgnoreCase));
 
         GrainInterfaceData? data = null;
         List<Diagnostic>? fileParseErrors = null;
@@ -142,8 +196,11 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         private readonly AdditionalText? _grainInterfacesFile;
         private readonly List<Diagnostic>? _fileParseErrors;
         private readonly ConcurrentDictionary<string, bool> _visitedInterfaces = new(StringComparer.Ordinal);
-        private readonly INamedTypeSymbol? _iGrainType;
+        private readonly ConcurrentDictionary<string, bool> _visitedClasses = new(StringComparer.Ordinal);
+        private readonly INamedTypeSymbol? _iAddressableType;
         private readonly INamedTypeSymbol? _aliasAttributeType;
+        private readonly INamedTypeSymbol? _grainInterfaceTypeAttributeType;
+        private readonly INamedTypeSymbol? _grainTypeAttributeType;
         private readonly INamedTypeSymbol? _versionAttributeType;
 
         public Impl(
@@ -157,8 +214,10 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
             _grainInterfacesFile = grainInterfacesFile;
             _fileParseErrors = fileParseErrors;
 
-            _iGrainType = compilation.GetTypeByMetadataName(Constants.IGrainFullyQualifiedName);
+            _iAddressableType = compilation.GetTypeByMetadataName(Constants.IAddressibleFullyQualifiedName);
             _aliasAttributeType = compilation.GetTypeByMetadataName(Constants.AliasAttributeFullyQualifiedName);
+            _grainInterfaceTypeAttributeType = compilation.GetTypeByMetadataName(Constants.GrainInterfaceTypeAttributeFullyQualifiedName);
+            _grainTypeAttributeType = compilation.GetTypeByMetadataName(Constants.GrainTypeAttributeFullyQualifiedName);
             _versionAttributeType = compilation.GetTypeByMetadataName(Constants.VersionAttributeFullyQualifiedName);
         }
 
@@ -166,20 +225,19 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
         {
             var namedType = (INamedTypeSymbol)context.Symbol;
 
-            // Only analyze interfaces
+            if (namedType.TypeKind == TypeKind.Class && !namedType.IsAbstract && namedType.IsGrainClass())
+            {
+                AnalyzeGrainClass(context, namedType);
+                return;
+            }
+
             if (namedType.TypeKind != TypeKind.Interface)
             {
                 return;
             }
 
-            // Check if this is a grain interface (extends IGrain)
-            if (!IsGrainInterface(namedType))
-            {
-                return;
-            }
-
-            // Skip IGrain itself and its base interfaces
-            if (IsBaseGrainInterface(namedType))
+            // Check if this is an RPC contract (extends IAddressable)
+            if (!IsRpcContract(namedType))
             {
                 return;
             }
@@ -187,21 +245,24 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
             var interfaceName = namedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
                 .Replace("global::", "");
 
-            _visitedInterfaces.TryAdd(interfaceName, true);
-
             // If no file exists, report that interfaces are not being tracked
             if (_data is null)
             {
+                _visitedInterfaces.TryAdd(interfaceName, true);
                 // We'll report file missing at compilation end
                 return;
             }
 
             // Check if interface is declared in the file
-            if (!_data.Interfaces.TryGetValue(interfaceName, out var declaredInterface))
+            var grainInterfaceType = GetGrainInterfaceTypeFromAttribute(namedType);
+            var declaredInterface = FindDeclaredInterface(interfaceName, grainInterfaceType);
+            if (declaredInterface is null)
             {
+                _visitedInterfaces.TryAdd(interfaceName, true);
                 // Interface not found in file
                 var properties = ImmutableDictionary<string, string?>.Empty
-                    .Add(InterfaceNamePropertyKey, interfaceName);
+                    .Add(InterfaceNamePropertyKey, interfaceName)
+                    .Add(GrainInterfaceTypePropertyKey, grainInterfaceType);
 
                 foreach (var location in namedType.Locations.Where(l => l.IsInSource))
                 {
@@ -214,13 +275,16 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
+            _visitedInterfaces.TryAdd(declaredInterface.Name, true);
+
             // Check if retired
             if (declaredInterface.IsRetired)
             {
                 // Interface exists in code but is marked as retired in file
                 // This could be a diagnostic, but for now we treat it as a mismatch
                 var properties = ImmutableDictionary<string, string?>.Empty
-                    .Add(InterfaceNamePropertyKey, interfaceName);
+                    .Add(InterfaceNamePropertyKey, interfaceName)
+                    .Add(GrainInterfaceTypePropertyKey, grainInterfaceType);
 
                 foreach (var location in namedType.Locations.Where(l => l.IsInSource))
                 {
@@ -239,6 +303,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
             {
                 var properties = ImmutableDictionary<string, string?>.Empty
                     .Add(InterfaceNamePropertyKey, interfaceName)
+                    .Add(GrainInterfaceTypePropertyKey, grainInterfaceType)
                     .Add(ExpectedVersionPropertyKey, declaredInterface.Version.ToString())
                     .Add(ActualVersionPropertyKey, codeVersion.ToString());
 
@@ -264,7 +329,7 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
             // Check members
             foreach (var member in namedType.GetMembers().OfType<IMethodSymbol>())
             {
-                if (member.MethodKind != MethodKind.Ordinary)
+                if (member.MethodKind != MethodKind.Ordinary || member.IsStatic)
                 {
                     continue;
                 }
@@ -272,12 +337,35 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
                 var memberSignature = GetMethodSignature(member);
                 var memberAlias = GetAliasFromAttribute(member);
 
-                if (!declaredInterface.Members.TryGetValue(memberSignature, out var declaredMember))
+                if (!declaredInterface.Members.ContainsKey(memberSignature)
+                    && !declaredInterface.Members.Keys.Any(signature =>
+                    {
+                        if (string.Equals(
+                            NormalizeStoredMemberSignature(signature, declaredInterface.Name),
+                            memberSignature,
+                            StringComparison.Ordinal))
+                        {
+                            return true;
+                        }
+
+                        var normalized = NormalizeLegacyMethodSignature(signature);
+                        var clrSignature = GetClrMethodSignature(member);
+                        var containingTypePrefix =
+                            $"{member.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", "")}.";
+                        return string.Equals(normalized, NormalizeLegacyMethodSignature(clrSignature), StringComparison.Ordinal)
+                            || string.Equals(
+                                normalized,
+                                NormalizeLegacyMethodSignature(clrSignature.Substring(containingTypePrefix.Length)),
+                                StringComparison.Ordinal);
+                    }))
                 {
                     // Member not found - interface has changed
                     var properties = ImmutableDictionary<string, string?>.Empty
                         .Add(InterfaceNamePropertyKey, interfaceName)
-                        .Add(MemberNamePropertyKey, memberSignature);
+                        .Add(GrainInterfaceTypePropertyKey, grainInterfaceType)
+                        .Add(MemberNamePropertyKey, memberSignature)
+                        .Add(MemberAliasPropertyKey, memberAlias)
+                        .Add(MemberClrSignaturePropertyKey, RequiresClrComment(member) ? GetClrMethodSignature(member) : null);
 
                     foreach (var location in member.Locations.Where(l => l.IsInSource))
                     {
@@ -304,12 +392,12 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
             }
 
             // Report file missing if any grain interfaces were found but no file exists
-            if (_data is null && _visitedInterfaces.Count > 0)
+            if (_data is null && (_visitedInterfaces.Count > 0 || _visitedClasses.Count > 0))
             {
                 context.ReportDiagnostic(Diagnostic.Create(
-                    GrainInterfacesFileMissingRule,
+                    OrleansContractsFileMissingRule,
                     Location.None,
-                    Constants.GrainInterfacesFileName));
+                    Constants.OrleansContractsFileName));
             }
 
             // Check for removed interfaces (in file but not in code)
@@ -340,26 +428,119 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
                                 kvp.Key));
                         }
                     }
+
+                    foreach (var kvp in _data.Classes)
+                    {
+                        if (kvp.Value.IsRetired || _visitedClasses.ContainsKey(kvp.Key))
+                        {
+                            continue;
+                        }
+
+                        var location = kvp.Value.GetLocation(sourceText, _grainInterfacesFile.Path);
+                        var properties = ImmutableDictionary<string, string?>.Empty
+                            .Add(ClassNamePropertyKey, kvp.Key);
+
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            RemovedGrainClassNotRetiredRule,
+                            location,
+                            properties,
+                            kvp.Key));
+                    }
                 }
             }
         }
 
-        private bool IsGrainInterface(INamedTypeSymbol type)
+        private void AnalyzeGrainClass(SymbolAnalysisContext context, INamedTypeSymbol namedType)
         {
-            if (_iGrainType is null)
+            var className = namedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", "");
+
+            if (_data is null)
+            {
+                _visitedClasses.TryAdd(className, true);
+                return;
+            }
+
+            var codeAlias = GetGrainTypeAliasFromAttribute(namedType);
+            var declaredClass = FindDeclaredClass(className, codeAlias);
+            if (declaredClass is null || declaredClass.IsRetired)
+            {
+                _visitedClasses.TryAdd(className, true);
+                var properties = ImmutableDictionary<string, string?>.Empty.Add(ClassNamePropertyKey, className);
+                foreach (var location in namedType.Locations.Where(location => location.IsInSource))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(GrainClassNotDeclaredRule, location, properties, className));
+                }
+
+                return;
+            }
+
+            _visitedClasses.TryAdd(declaredClass.Name, true);
+            if (string.Equals(codeAlias, declaredClass.Alias, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var aliasProperties = ImmutableDictionary<string, string?>.Empty
+                .Add(ClassNamePropertyKey, className)
+                .Add(ActualAliasPropertyKey, codeAlias);
+            foreach (var location in namedType.Locations.Where(location => location.IsInSource))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    GrainClassAliasMismatchRule,
+                    location,
+                    aliasProperties,
+                    className,
+                    declaredClass.Alias ?? "<none>",
+                    codeAlias ?? "<none>"));
+            }
+        }
+
+        private bool IsRpcContract(INamedTypeSymbol type)
+        {
+            if (_iAddressableType is null)
             {
                 return false;
             }
 
-            return type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, _iGrainType))
-                   || SymbolEqualityComparer.Default.Equals(type, _iGrainType);
+            return !SymbolEqualityComparer.Default.Equals(type, _iAddressableType)
+                && type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, _iAddressableType));
         }
 
-        private static bool IsBaseGrainInterface(INamedTypeSymbol type)
+        private DeclaredGrainInterface? FindDeclaredInterface(string interfaceName, string? grainInterfaceType)
         {
-            var fullName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            return fullName.StartsWith("global::Orleans.IGrain", StringComparison.Ordinal)
-                   || fullName.StartsWith("global::Orleans.Runtime.IAddressable", StringComparison.Ordinal);
+            if (grainInterfaceType is not null)
+            {
+                var stableMatch = _data!.Interfaces.Values.FirstOrDefault(candidate =>
+                    string.Equals(candidate.GrainInterfaceType, grainInterfaceType, StringComparison.Ordinal));
+                if (stableMatch is not null)
+                {
+                    return stableMatch;
+                }
+
+                return _data.Interfaces.TryGetValue(interfaceName, out var legacyMatch)
+                    && legacyMatch.GrainInterfaceType is null
+                        ? legacyMatch
+                        : null;
+            }
+
+            return _data!.Interfaces.TryGetValue(interfaceName, out var result) ? result : null;
+        }
+
+        private DeclaredGrainClass? FindDeclaredClass(string className, string? alias)
+        {
+            if (alias is not null)
+            {
+                var stableMatch = _data!.Classes.Values.FirstOrDefault(candidate =>
+                    string.Equals(candidate.Alias, alias, StringComparison.Ordinal));
+                if (stableMatch is not null)
+                {
+                    return stableMatch;
+                }
+
+                return _data.Classes.TryGetValue(className, out var exactNameMatch) ? exactNameMatch : null;
+            }
+
+            return _data!.Classes.TryGetValue(className, out var result) ? result : null;
         }
 
         private ushort GetVersionFromAttribute(INamedTypeSymbol type)
@@ -406,42 +587,238 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
             return null;
         }
 
-        private static string GetMethodSignature(IMethodSymbol method)
+        private string? GetGrainTypeAliasFromAttribute(ISymbol symbol)
         {
-            var sb = new StringBuilder();
-            sb.Append(method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", ""));
-            sb.Append('.');
-            sb.Append(method.Name);
-            sb.Append('(');
-
-            for (int i = 0; i < method.Parameters.Length; i++)
+            if (_grainTypeAttributeType is null)
             {
-                if (i > 0) sb.Append(", ");
-                var param = method.Parameters[i];
-                sb.Append(param.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
-                sb.Append(' ');
-                sb.Append(param.Name);
+                return null;
             }
 
-            sb.Append(')');
-            sb.Append(" -> ");
-            sb.Append(method.ReturnType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+            foreach (var attribute in symbol.GetAttributes())
+            {
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, _grainTypeAttributeType)
+                    && attribute.ConstructorArguments.Length > 0
+                    && attribute.ConstructorArguments[0].Value is string alias)
+                {
+                    return alias;
+                }
+            }
 
-            return sb.ToString();
+            return null;
+        }
+
+        private string? GetGrainInterfaceTypeFromAttribute(ISymbol symbol)
+        {
+            if (_grainInterfaceTypeAttributeType is null)
+            {
+                return null;
+            }
+
+            foreach (var attribute in symbol.GetAttributes())
+            {
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, _grainInterfaceTypeAttributeType)
+                    && attribute.ConstructorArguments.Length > 0
+                    && attribute.ConstructorArguments[0].Value is string value)
+                {
+                    return value;
+                }
+            }
+
+            return null;
         }
     }
+
+    internal static string GetMethodSignature(IMethodSymbol method)
+    {
+        var sb = new StringBuilder();
+        var methodId = GetAttributeValue(method, Constants.IdAttributeFullyQualifiedName);
+        var methodAlias = GetStringAttributeValue(method, Constants.AliasAttributeFullyQualifiedName);
+        sb.Append(methodId ?? methodAlias ?? method.Name);
+        sb.Append('(');
+
+        for (int i = 0; i < method.Parameters.Length; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(GetContractTypeName(method.Parameters[i].Type));
+        }
+
+        sb.Append(')');
+        sb.Append(" -> ");
+        sb.Append(GetContractTypeName(method.ReturnType));
+
+        return sb.ToString();
+    }
+
+    internal static string GetClrMethodSignature(IMethodSymbol method)
+    {
+        var sb = new StringBuilder();
+        sb.Append(method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", ""));
+        sb.Append('.');
+        sb.Append(method.Name);
+        sb.Append('(');
+
+        for (var i = 0; i < method.Parameters.Length; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(method.Parameters[i].Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+            sb.Append(' ');
+            sb.Append(method.Parameters[i].Name);
+        }
+
+        sb.Append(") -> ");
+        sb.Append(method.ReturnType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+        return sb.ToString();
+    }
+
+    internal static bool RequiresClrComment(IMethodSymbol method)
+    {
+        var methodId = GetAttributeValue(method, Constants.IdAttributeFullyQualifiedName)?.ToString();
+        var methodAlias = GetStringAttributeValue(method, Constants.AliasAttributeFullyQualifiedName);
+        if (methodId is not null && !string.Equals(methodId, method.Name, StringComparison.Ordinal)
+            || methodAlias is not null && !string.Equals(methodAlias, method.Name, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return method.Parameters.Any(parameter => HasMeaningfulTypeAlias(parameter.Type))
+            || HasMeaningfulTypeAlias(method.ReturnType);
+    }
+
+    internal static bool IdentityDiffersFromClrName(string? identity, INamedTypeSymbol type)
+    {
+        if (identity is null)
+        {
+            return false;
+        }
+
+        var fullName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", "");
+        return !string.Equals(identity, type.Name, StringComparison.Ordinal)
+            && !string.Equals(identity, type.MetadataName, StringComparison.Ordinal)
+            && !string.Equals(identity, fullName, StringComparison.Ordinal);
+    }
+
+    internal static string NormalizeLegacyMethodSignature(string signature)
+        => Regex.Replace(signature, @"\s+[A-Za-z_]\w*(?=\s*[,)\]])", "");
+
+    internal static string NormalizeStoredMemberSignature(string signature, string interfaceName)
+    {
+        var result = signature;
+        if (result.StartsWith($"{interfaceName}.", StringComparison.Ordinal))
+        {
+            result = result.Substring(interfaceName.Length + 1);
+        }
+
+        result = Regex.Replace(result, @"^grain-interface\(""[^""]+""\)\.", "");
+        return Regex.Replace(result, @"alias\(""([^""]+)""\)", "$1");
+    }
+
+    private static string GetContractTypeName(ITypeSymbol type)
+    {
+        if (type is IArrayTypeSymbol array)
+        {
+            return $"{GetContractTypeName(array.ElementType)}[{new string(',', array.Rank - 1)}]";
+        }
+
+        if (type is ITypeParameterSymbol typeParameter)
+        {
+            return typeParameter.Name;
+        }
+
+        if (type is not INamedTypeSymbol namedType)
+        {
+            return type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+        }
+
+        if (namedType.IsTupleType)
+        {
+            return $"({string.Join(", ", namedType.TupleElements.Select(element => GetContractTypeName(element.Type)))})";
+        }
+
+        var alias = GetStringAttributeValue(namedType.OriginalDefinition, Constants.AliasAttributeFullyQualifiedName);
+        if (alias is not null)
+        {
+            return namedType.TypeArguments.IsEmpty
+                ? alias
+                : $"{alias}<{string.Join(", ", namedType.TypeArguments.Select(GetContractTypeName))}>";
+        }
+
+        if (namedType is
+        {
+            Name: "Task" or "ValueTask",
+            ContainingNamespace: { } containingNamespace
+        }
+            && containingNamespace.ToDisplayString() == "System.Threading.Tasks")
+        {
+            if (namedType.TypeArguments.IsEmpty)
+            {
+                return namedType.Name;
+            }
+
+            return $"{namedType.Name}<{string.Join(", ", namedType.TypeArguments.Select(GetContractTypeName))}>";
+        }
+
+        if (namedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+        {
+            return $"{GetContractTypeName(namedType.TypeArguments[0])}?";
+        }
+
+        if (namedType.TypeArguments.IsEmpty)
+        {
+            return namedType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+        }
+
+        var genericName = namedType.ConstructedFrom.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+        var typeArgumentStart = genericName.IndexOf('<');
+        if (typeArgumentStart >= 0)
+        {
+            genericName = genericName.Substring(0, typeArgumentStart);
+        }
+
+        return $"{genericName}<{string.Join(", ", namedType.TypeArguments.Select(GetContractTypeName))}>";
+    }
+
+    private static bool HasMeaningfulTypeAlias(ITypeSymbol type)
+    {
+        if (type is IArrayTypeSymbol array)
+        {
+            return HasMeaningfulTypeAlias(array.ElementType);
+        }
+
+        if (type is not INamedTypeSymbol namedType)
+        {
+            return false;
+        }
+
+        var alias = GetStringAttributeValue(namedType.OriginalDefinition, Constants.AliasAttributeFullyQualifiedName);
+        if (IdentityDiffersFromClrName(alias, namedType.OriginalDefinition))
+        {
+            return true;
+        }
+
+        return namedType.TypeArguments.Any(HasMeaningfulTypeAlias);
+    }
+
+    private static object? GetAttributeValue(ISymbol symbol, string attributeName)
+        => symbol.GetAttributes()
+            .FirstOrDefault(attribute => string.Equals(attribute.AttributeClass?.ToDisplayString(), attributeName, StringComparison.Ordinal))
+            ?.ConstructorArguments.FirstOrDefault().Value;
+
+    private static string? GetStringAttributeValue(ISymbol symbol, string attributeName)
+        => GetAttributeValue(symbol, attributeName) as string;
 }
 
 /// <summary>
-/// Represents the parsed data from a GrainInterfaces.txt file.
+/// Represents the parsed data from an OrleansContracts.txt file.
 /// </summary>
 internal sealed class GrainInterfaceData
 {
     public Dictionary<string, DeclaredGrainInterface> Interfaces { get; } = new(StringComparer.Ordinal);
+
+    public Dictionary<string, DeclaredGrainClass> Classes { get; } = new(StringComparer.Ordinal);
 }
 
 /// <summary>
-/// Represents a declared grain interface in the GrainInterfaces.txt file.
+/// Represents a declared grain interface in the OrleansContracts.txt file.
 /// </summary>
 internal sealed class DeclaredGrainInterface
 {
@@ -452,6 +829,8 @@ internal sealed class DeclaredGrainInterface
 
     public string Name { get; }
     public string? Alias { get; set; }
+
+    public string? GrainInterfaceType { get; set; }
     public ushort Version { get; set; }
     public bool IsRetired { get; set; }
     public TextSpan Span { get; set; }
@@ -465,7 +844,7 @@ internal sealed class DeclaredGrainInterface
 }
 
 /// <summary>
-/// Represents a declared grain interface member in the GrainInterfaces.txt file.
+/// Represents a declared grain interface member in the OrleansContracts.txt file.
 /// </summary>
 internal sealed class DeclaredGrainMember
 {
@@ -480,23 +859,123 @@ internal sealed class DeclaredGrainMember
 }
 
 /// <summary>
-/// Parses GrainInterfaces.txt files.
+/// Represents a declared grain class in the OrleansContracts.txt file.
+/// </summary>
+internal sealed class DeclaredGrainClass
+{
+    public DeclaredGrainClass(string name)
+    {
+        Name = name;
+    }
+
+    public string Name { get; }
+
+    public string? Alias { get; set; }
+
+    public bool IsRetired { get; set; }
+
+    public TextSpan Span { get; set; }
+
+    public Location GetLocation(SourceText sourceText, string filePath)
+    {
+        var lineSpan = sourceText.Lines.GetLinePositionSpan(Span);
+        return Location.Create(filePath, Span, lineSpan);
+    }
+}
+
+/// <summary>
+/// Parses OrleansContracts.txt files.
 /// </summary>
 internal static class GrainInterfaceFileParser
 {
     // Regex patterns for parsing
-    // Interface line: [Alias("x")] Namespace.IInterface<T> [Version(N)]
-    // Or with retired: *RETIRED* [Alias("x")] Namespace.IInterface<T> [Version(N)]
+    // Interface line: interface [GrainInterfaceType("x")] Namespace.IInterface<T> [Version(N)]
+    // Or with retired: *RETIRED* interface [GrainInterfaceType("x")] Namespace.IInterface<T> [Version(N)]
     // The name can include generic type parameters like IMyGrain<T> or IMyGrain<TKey, TValue>
     private static readonly Regex InterfacePattern = new(
-        @"^(?<retired>\*RETIRED\*\s*)?(\[Alias\(""(?<alias>[^""]+)""\)\]\s*)?(?<name>[\w.]+(?:<[\w,\s]+>)?)\s*\[Version\((?<version>\d+)\)\]$",
+        @"^(?<retired>\*RETIRED\*\s*)?(?:interface\s+)?(\[GrainInterfaceType\(""(?<grainInterfaceType>[^""]+)""\)\]\s*)?(\[Alias\(""(?<alias>[^""]+)""\)\]\s*)?(?<name>[\w.]+(?:<[\w,\s]+>)?)\s*\[Version\((?<version>\d+)\)\]$",
+        RegexOptions.Compiled);
+
+    // Grain class line: class [GrainType("x")] Namespace.GrainClass
+    // Or with retired: *RETIRED* class [GrainType("x")] Namespace.GrainClass
+    private static readonly Regex GrainClassPattern = new(
+        @"^(?<retired>\*RETIRED\*\s*)?class\s+(\[(?:GrainType|Alias)\(""(?<alias>[^""]+)""\)\]\s*)?(?<name>[\w.]+(?:<[\w,\s]+>)?)$",
         RegexOptions.Compiled);
 
     // Member line: [Alias("x")] Namespace.IInterface<T>.Method(params) -> ReturnType
     // The signature includes the full interface name (possibly generic) and method
     private static readonly Regex MemberPattern = new(
-        @"^(\[Alias\(""(?<alias>[^""]+)""\)\]\s*)?(?<signature>[\w.]+(?:<[\w,\s]+>)?\.[^(]+\([^)]*\)\s*->\s*.+)$",
+        @"^(\[Alias\(""(?<alias>[^""]+)""\)\]\s*)?(?<signature>.+\(.*\)\s*->\s*.+)$",
         RegexOptions.Compiled);
+
+    internal static bool TryGetInterfaceName(string line, out string name)
+    {
+        var match = InterfacePattern.Match(StripClrComment(line));
+        if (match.Success)
+        {
+            name = match.Groups["name"].Value;
+            return true;
+        }
+
+        name = string.Empty;
+        return false;
+    }
+
+    internal static bool TryGetGrainInterfaceType(string line, out string grainInterfaceType)
+    {
+        var match = InterfacePattern.Match(StripClrComment(line));
+        if (match.Success && match.Groups["grainInterfaceType"].Success)
+        {
+            grainInterfaceType = match.Groups["grainInterfaceType"].Value;
+            return true;
+        }
+
+        grainInterfaceType = string.Empty;
+        return false;
+    }
+
+    internal static bool TryGetGrainClassName(string line, out string name)
+    {
+        var match = GrainClassPattern.Match(StripClrComment(line));
+        if (match.Success)
+        {
+            name = match.Groups["name"].Value;
+            return true;
+        }
+
+        name = string.Empty;
+        return false;
+    }
+
+    internal static bool TryGetContractName(string line, out string name)
+        => TryGetGrainClassName(line, out name) || TryGetInterfaceName(line, out name);
+
+    internal static bool TryGetMemberSignature(string line, out string signature)
+    {
+        var match = MemberPattern.Match(StripClrComment(line));
+        if (match.Success)
+        {
+            signature = match.Groups["signature"].Value;
+            return true;
+        }
+
+        signature = string.Empty;
+        return false;
+    }
+
+    internal static string GetClrComment(string line)
+    {
+        const string Prefix = " # CLR: ";
+        var index = line.IndexOf(Prefix, StringComparison.Ordinal);
+        return index < 0 ? string.Empty : line.Substring(index);
+    }
+
+    internal static string StripClrComment(string line)
+    {
+        const string Prefix = " # CLR: ";
+        var index = line.IndexOf(Prefix, StringComparison.Ordinal);
+        return (index < 0 ? line : line.Substring(0, index)).Trim();
+    }
 
     public static (GrainInterfaceData Data, List<Diagnostic>? Errors) Parse(SourceText sourceText, string filePath)
     {
@@ -506,11 +985,39 @@ internal static class GrainInterfaceFileParser
 
         foreach (var textLine in sourceText.Lines)
         {
-            var lineText = textLine.ToString().Trim();
+            var lineText = StripClrComment(textLine.ToString());
 
             // Skip empty lines and comments
             if (string.IsNullOrWhiteSpace(lineText) || lineText.StartsWith("#", StringComparison.Ordinal))
             {
+                continue;
+            }
+
+            // Try to match interface declaration
+            var grainClassMatch = GrainClassPattern.Match(lineText);
+            if (grainClassMatch.Success)
+            {
+                currentInterface = null;
+                var name = grainClassMatch.Groups["name"].Value;
+                var alias = grainClassMatch.Groups["alias"].Success ? grainClassMatch.Groups["alias"].Value : null;
+                if (data.Classes.ContainsKey(name)
+                    || alias is not null && data.Classes.Values.Any(candidate => string.Equals(candidate.Alias, alias, StringComparison.Ordinal)))
+                {
+                    errors ??= new List<Diagnostic>();
+                    var location = Location.Create(
+                        filePath,
+                        textLine.Span,
+                        sourceText.Lines.GetLinePositionSpan(textLine.Span));
+                    errors.Add(Diagnostic.Create(GrainInterfaceVersionAnalyzer.DuplicateGrainClassDeclarationRule, location, name));
+                    continue;
+                }
+
+                data.Classes[name] = new DeclaredGrainClass(name)
+                {
+                    Alias = alias,
+                    IsRetired = grainClassMatch.Groups["retired"].Success,
+                    Span = textLine.Span
+                };
                 continue;
             }
 
@@ -520,10 +1027,17 @@ internal static class GrainInterfaceFileParser
             {
                 var name = interfaceMatch.Groups["name"].Value;
                 var alias = interfaceMatch.Groups["alias"].Success ? interfaceMatch.Groups["alias"].Value : null;
-                var version = ushort.Parse(interfaceMatch.Groups["version"].Value);
+                var grainInterfaceType = interfaceMatch.Groups["grainInterfaceType"].Success ? interfaceMatch.Groups["grainInterfaceType"].Value : null;
+                if (!ushort.TryParse(interfaceMatch.Groups["version"].Value, out var version))
+                {
+                    currentInterface = null;
+                    continue;
+                }
                 var isRetired = interfaceMatch.Groups["retired"].Success;
 
-                if (data.Interfaces.ContainsKey(name))
+                if (data.Interfaces.ContainsKey(name)
+                    || grainInterfaceType is not null
+                    && data.Interfaces.Values.Any(candidate => string.Equals(candidate.GrainInterfaceType, grainInterfaceType, StringComparison.Ordinal)))
                 {
                     // Duplicate declaration
                     errors ??= new List<Diagnostic>();
@@ -541,6 +1055,7 @@ internal static class GrainInterfaceFileParser
                 currentInterface = new DeclaredGrainInterface(name)
                 {
                     Alias = alias,
+                    GrainInterfaceType = grainInterfaceType,
                     Version = version,
                     IsRetired = isRetired,
                     Span = textLine.Span
@@ -556,27 +1071,11 @@ internal static class GrainInterfaceFileParser
                 var signature = memberMatch.Groups["signature"].Value;
                 var alias = memberMatch.Groups["alias"].Success ? memberMatch.Groups["alias"].Value : null;
 
-                // Extract interface name from signature to verify it belongs to current interface
-                // Signature format: Namespace.IInterface<T>.Method(params) -> ReturnType
-                // We need to find the last '.' before the '(' to get the method separator
-                var parenIndex = signature.IndexOf('(');
-                if (parenIndex > 0)
+                currentInterface.Members[signature] = new DeclaredGrainMember(signature)
                 {
-                    var methodPartBeforeParen = signature.Substring(0, parenIndex);
-                    var dotIndex = methodPartBeforeParen.LastIndexOf('.');
-                    if (dotIndex > 0)
-                    {
-                        var memberInterfaceName = signature.Substring(0, dotIndex);
-                        if (memberInterfaceName == currentInterface.Name)
-                        {
-                            currentInterface.Members[signature] = new DeclaredGrainMember(signature)
-                            {
-                                Alias = alias,
-                                Span = textLine.Span
-                            };
-                        }
-                    }
-                }
+                    Alias = alias,
+                    Span = textLine.Span
+                };
             }
         }
 

--- a/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
@@ -1,0 +1,585 @@
+#nullable enable
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace Orleans.Analyzers;
+
+/// <summary>
+/// An analyzer that tracks grain interface definitions and their versions.
+/// It ensures that interface changes are accompanied by version increments.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
+{
+    public const string RuleId0016 = "ORLEANS0016";
+    public const string RuleId0017 = "ORLEANS0017";
+    public const string RuleId0018 = "ORLEANS0018";
+    public const string RuleId0019 = "ORLEANS0019";
+    public const string RuleId0020 = "ORLEANS0020";
+    public const string RuleId0021 = "ORLEANS0021";
+
+    // Property bag keys for code fixes
+    internal const string InterfaceNamePropertyKey = "InterfaceName";
+    internal const string MemberNamePropertyKey = "MemberName";
+    internal const string ExpectedVersionPropertyKey = "ExpectedVersion";
+    internal const string ActualVersionPropertyKey = "ActualVersion";
+    internal const string ExpectedSignaturePropertyKey = "ExpectedSignature";
+    internal const string ActualSignaturePropertyKey = "ActualSignature";
+
+    internal const string RetiredPrefix = "*RETIRED*";
+
+    private static readonly DiagnosticDescriptor InterfaceNotDeclaredRule = new(
+        id: RuleId0016,
+        title: new LocalizableResourceString(nameof(Resources.GrainInterfaceNotDeclaredTitle), Resources.ResourceManager, typeof(Resources)),
+        messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfaceNotDeclaredMessageFormat), Resources.ResourceManager, typeof(Resources)),
+        category: "Orleans.Versioning",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: new LocalizableResourceString(nameof(Resources.GrainInterfaceNotDeclaredDescription), Resources.ResourceManager, typeof(Resources)));
+
+    private static readonly DiagnosticDescriptor InterfaceVersionMismatchRule = new(
+        id: RuleId0017,
+        title: new LocalizableResourceString(nameof(Resources.GrainInterfaceVersionMismatchTitle), Resources.ResourceManager, typeof(Resources)),
+        messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfaceVersionMismatchMessageFormat), Resources.ResourceManager, typeof(Resources)),
+        category: "Orleans.Versioning",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: new LocalizableResourceString(nameof(Resources.GrainInterfaceVersionMismatchDescription), Resources.ResourceManager, typeof(Resources)));
+
+    private static readonly DiagnosticDescriptor MemberNotDeclaredRule = new(
+        id: RuleId0018,
+        title: new LocalizableResourceString(nameof(Resources.GrainInterfaceMemberNotDeclaredTitle), Resources.ResourceManager, typeof(Resources)),
+        messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfaceMemberNotDeclaredMessageFormat), Resources.ResourceManager, typeof(Resources)),
+        category: "Orleans.Versioning",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: new LocalizableResourceString(nameof(Resources.GrainInterfaceMemberNotDeclaredDescription), Resources.ResourceManager, typeof(Resources)));
+
+    private static readonly DiagnosticDescriptor RemovedInterfaceNotRetiredRule = new(
+        id: RuleId0019,
+        title: new LocalizableResourceString(nameof(Resources.GrainInterfaceRemovedNotRetiredTitle), Resources.ResourceManager, typeof(Resources)),
+        messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfaceRemovedNotRetiredMessageFormat), Resources.ResourceManager, typeof(Resources)),
+        category: "Orleans.Versioning",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: new LocalizableResourceString(nameof(Resources.GrainInterfaceRemovedNotRetiredDescription), Resources.ResourceManager, typeof(Resources)),
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
+
+    private static readonly DiagnosticDescriptor GrainInterfacesFileMissingRule = new(
+        id: RuleId0020,
+        title: new LocalizableResourceString(nameof(Resources.GrainInterfacesFileMissingTitle), Resources.ResourceManager, typeof(Resources)),
+        messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfacesFileMissingMessageFormat), Resources.ResourceManager, typeof(Resources)),
+        category: "Orleans.Versioning",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: new LocalizableResourceString(nameof(Resources.GrainInterfacesFileMissingDescription), Resources.ResourceManager, typeof(Resources)),
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
+
+    internal static readonly DiagnosticDescriptor DuplicateInterfaceDeclarationRule = new(
+        id: RuleId0021,
+        title: new LocalizableResourceString(nameof(Resources.GrainInterfaceDuplicateDeclarationTitle), Resources.ResourceManager, typeof(Resources)),
+        messageFormat: new LocalizableResourceString(nameof(Resources.GrainInterfaceDuplicateDeclarationMessageFormat), Resources.ResourceManager, typeof(Resources)),
+        category: "Orleans.Versioning",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: new LocalizableResourceString(nameof(Resources.GrainInterfaceDuplicateDeclarationDescription), Resources.ResourceManager, typeof(Resources)));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(
+            InterfaceNotDeclaredRule,
+            InterfaceVersionMismatchRule,
+            MemberNotDeclaredRule,
+            RemovedInterfaceNotRetiredRule,
+            GrainInterfacesFileMissingRule,
+            DuplicateInterfaceDeclarationRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    private void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        // Try to find the GrainInterfaces.txt file
+        var grainInterfacesFile = context.Options.AdditionalFiles
+            .FirstOrDefault(f => Path.GetFileName(f.Path).Equals(Constants.GrainInterfacesFileName, StringComparison.OrdinalIgnoreCase));
+
+        GrainInterfaceData? data = null;
+        List<Diagnostic>? fileParseErrors = null;
+
+        if (grainInterfacesFile is not null)
+        {
+            var sourceText = grainInterfacesFile.GetText(context.CancellationToken);
+            if (sourceText is not null)
+            {
+                (data, fileParseErrors) = GrainInterfaceFileParser.Parse(sourceText, grainInterfacesFile.Path);
+            }
+        }
+
+        var impl = new Impl(context.Compilation, data, grainInterfacesFile, fileParseErrors);
+
+        context.RegisterSymbolAction(impl.AnalyzeNamedType, SymbolKind.NamedType);
+        context.RegisterCompilationEndAction(impl.OnCompilationEnd);
+    }
+
+    private sealed class Impl
+    {
+        private readonly Compilation _compilation;
+        private readonly GrainInterfaceData? _data;
+        private readonly AdditionalText? _grainInterfacesFile;
+        private readonly List<Diagnostic>? _fileParseErrors;
+        private readonly ConcurrentDictionary<string, bool> _visitedInterfaces = new(StringComparer.Ordinal);
+        private readonly INamedTypeSymbol? _iGrainType;
+        private readonly INamedTypeSymbol? _aliasAttributeType;
+        private readonly INamedTypeSymbol? _versionAttributeType;
+
+        public Impl(
+            Compilation compilation,
+            GrainInterfaceData? data,
+            AdditionalText? grainInterfacesFile,
+            List<Diagnostic>? fileParseErrors)
+        {
+            _compilation = compilation;
+            _data = data;
+            _grainInterfacesFile = grainInterfacesFile;
+            _fileParseErrors = fileParseErrors;
+
+            _iGrainType = compilation.GetTypeByMetadataName(Constants.IGrainFullyQualifiedName);
+            _aliasAttributeType = compilation.GetTypeByMetadataName(Constants.AliasAttributeFullyQualifiedName);
+            _versionAttributeType = compilation.GetTypeByMetadataName(Constants.VersionAttributeFullyQualifiedName);
+        }
+
+        public void AnalyzeNamedType(SymbolAnalysisContext context)
+        {
+            var namedType = (INamedTypeSymbol)context.Symbol;
+
+            // Only analyze interfaces
+            if (namedType.TypeKind != TypeKind.Interface)
+            {
+                return;
+            }
+
+            // Check if this is a grain interface (extends IGrain)
+            if (!IsGrainInterface(namedType))
+            {
+                return;
+            }
+
+            // Skip IGrain itself and its base interfaces
+            if (IsBaseGrainInterface(namedType))
+            {
+                return;
+            }
+
+            var interfaceName = namedType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                .Replace("global::", "");
+
+            _visitedInterfaces.TryAdd(interfaceName, true);
+
+            // If no file exists, report that interfaces are not being tracked
+            if (_data is null)
+            {
+                // We'll report file missing at compilation end
+                return;
+            }
+
+            // Check if interface is declared in the file
+            if (!_data.Interfaces.TryGetValue(interfaceName, out var declaredInterface))
+            {
+                // Interface not found in file
+                var properties = ImmutableDictionary<string, string?>.Empty
+                    .Add(InterfaceNamePropertyKey, interfaceName);
+
+                foreach (var location in namedType.Locations.Where(l => l.IsInSource))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        InterfaceNotDeclaredRule,
+                        location,
+                        properties,
+                        interfaceName));
+                }
+                return;
+            }
+
+            // Check if retired
+            if (declaredInterface.IsRetired)
+            {
+                // Interface exists in code but is marked as retired in file
+                // This could be a diagnostic, but for now we treat it as a mismatch
+                var properties = ImmutableDictionary<string, string?>.Empty
+                    .Add(InterfaceNamePropertyKey, interfaceName);
+
+                foreach (var location in namedType.Locations.Where(l => l.IsInSource))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        InterfaceNotDeclaredRule,
+                        location,
+                        properties,
+                        interfaceName));
+                }
+                return;
+            }
+
+            // Check version attribute matches
+            var codeVersion = GetVersionFromAttribute(namedType);
+            if (codeVersion != declaredInterface.Version)
+            {
+                var properties = ImmutableDictionary<string, string?>.Empty
+                    .Add(InterfaceNamePropertyKey, interfaceName)
+                    .Add(ExpectedVersionPropertyKey, declaredInterface.Version.ToString())
+                    .Add(ActualVersionPropertyKey, codeVersion.ToString());
+
+                foreach (var location in namedType.Locations.Where(l => l.IsInSource))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        InterfaceVersionMismatchRule,
+                        location,
+                        properties,
+                        interfaceName,
+                        declaredInterface.Version,
+                        codeVersion));
+                }
+            }
+
+            // Check alias matches
+            var codeAlias = GetAliasFromAttribute(namedType);
+            if (!string.Equals(codeAlias, declaredInterface.Alias, StringComparison.Ordinal))
+            {
+                // Alias mismatch - could add a separate diagnostic for this
+            }
+
+            // Check members
+            foreach (var member in namedType.GetMembers().OfType<IMethodSymbol>())
+            {
+                if (member.MethodKind != MethodKind.Ordinary)
+                {
+                    continue;
+                }
+
+                var memberSignature = GetMethodSignature(member);
+                var memberAlias = GetAliasFromAttribute(member);
+
+                if (!declaredInterface.Members.TryGetValue(memberSignature, out var declaredMember))
+                {
+                    // Member not found - interface has changed
+                    var properties = ImmutableDictionary<string, string?>.Empty
+                        .Add(InterfaceNamePropertyKey, interfaceName)
+                        .Add(MemberNamePropertyKey, memberSignature);
+
+                    foreach (var location in member.Locations.Where(l => l.IsInSource))
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            MemberNotDeclaredRule,
+                            location,
+                            properties,
+                            memberSignature,
+                            interfaceName));
+                    }
+                }
+            }
+        }
+
+        public void OnCompilationEnd(CompilationAnalysisContext context)
+        {
+            // Report file parse errors
+            if (_fileParseErrors is not null)
+            {
+                foreach (var error in _fileParseErrors)
+                {
+                    context.ReportDiagnostic(error);
+                }
+            }
+
+            // Report file missing if any grain interfaces were found but no file exists
+            if (_data is null && _visitedInterfaces.Count > 0)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    GrainInterfacesFileMissingRule,
+                    Location.None,
+                    Constants.GrainInterfacesFileName));
+            }
+
+            // Check for removed interfaces (in file but not in code)
+            if (_data is not null && _grainInterfacesFile is not null)
+            {
+                var sourceText = _grainInterfacesFile.GetText(context.CancellationToken);
+                if (sourceText is not null)
+                {
+                    foreach (var kvp in _data.Interfaces)
+                    {
+                        if (kvp.Value.IsRetired)
+                        {
+                            continue;
+                        }
+
+                        if (!_visitedInterfaces.ContainsKey(kvp.Key))
+                        {
+                            // Interface in file but not in code - needs to be retired
+                            var location = kvp.Value.GetLocation(sourceText, _grainInterfacesFile.Path);
+
+                            var properties = ImmutableDictionary<string, string?>.Empty
+                                .Add(InterfaceNamePropertyKey, kvp.Key);
+
+                            context.ReportDiagnostic(Diagnostic.Create(
+                                RemovedInterfaceNotRetiredRule,
+                                location,
+                                properties,
+                                kvp.Key));
+                        }
+                    }
+                }
+            }
+        }
+
+        private bool IsGrainInterface(INamedTypeSymbol type)
+        {
+            if (_iGrainType is null)
+            {
+                return false;
+            }
+
+            return type.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, _iGrainType))
+                   || SymbolEqualityComparer.Default.Equals(type, _iGrainType);
+        }
+
+        private static bool IsBaseGrainInterface(INamedTypeSymbol type)
+        {
+            var fullName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return fullName.StartsWith("global::Orleans.IGrain", StringComparison.Ordinal)
+                   || fullName.StartsWith("global::Orleans.Runtime.IAddressable", StringComparison.Ordinal);
+        }
+
+        private ushort GetVersionFromAttribute(INamedTypeSymbol type)
+        {
+            if (_versionAttributeType is null)
+            {
+                return 0;
+            }
+
+            foreach (var attribute in type.GetAttributes())
+            {
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, _versionAttributeType))
+                {
+                    if (attribute.ConstructorArguments.Length > 0 &&
+                        attribute.ConstructorArguments[0].Value is ushort version)
+                    {
+                        return version;
+                    }
+                }
+            }
+
+            return 0;
+        }
+
+        private string? GetAliasFromAttribute(ISymbol symbol)
+        {
+            if (_aliasAttributeType is null)
+            {
+                return null;
+            }
+
+            foreach (var attribute in symbol.GetAttributes())
+            {
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, _aliasAttributeType))
+                {
+                    if (attribute.ConstructorArguments.Length > 0 &&
+                        attribute.ConstructorArguments[0].Value is string alias)
+                    {
+                        return alias;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static string GetMethodSignature(IMethodSymbol method)
+        {
+            var sb = new StringBuilder();
+            sb.Append(method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", ""));
+            sb.Append('.');
+            sb.Append(method.Name);
+            sb.Append('(');
+
+            for (int i = 0; i < method.Parameters.Length; i++)
+            {
+                if (i > 0) sb.Append(", ");
+                var param = method.Parameters[i];
+                sb.Append(param.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                sb.Append(' ');
+                sb.Append(param.Name);
+            }
+
+            sb.Append(')');
+            sb.Append(" -> ");
+            sb.Append(method.ReturnType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+
+            return sb.ToString();
+        }
+    }
+}
+
+/// <summary>
+/// Represents the parsed data from a GrainInterfaces.txt file.
+/// </summary>
+internal sealed class GrainInterfaceData
+{
+    public Dictionary<string, DeclaredGrainInterface> Interfaces { get; } = new(StringComparer.Ordinal);
+}
+
+/// <summary>
+/// Represents a declared grain interface in the GrainInterfaces.txt file.
+/// </summary>
+internal sealed class DeclaredGrainInterface
+{
+    public DeclaredGrainInterface(string name)
+    {
+        Name = name;
+    }
+
+    public string Name { get; }
+    public string? Alias { get; set; }
+    public ushort Version { get; set; }
+    public bool IsRetired { get; set; }
+    public TextSpan Span { get; set; }
+    public Dictionary<string, DeclaredGrainMember> Members { get; } = new Dictionary<string, DeclaredGrainMember>(StringComparer.Ordinal);
+
+    public Location GetLocation(SourceText sourceText, string filePath)
+    {
+        var lineSpan = sourceText.Lines.GetLinePositionSpan(Span);
+        return Location.Create(filePath, Span, lineSpan);
+    }
+}
+
+/// <summary>
+/// Represents a declared grain interface member in the GrainInterfaces.txt file.
+/// </summary>
+internal sealed class DeclaredGrainMember
+{
+    public DeclaredGrainMember(string signature)
+    {
+        Signature = signature;
+    }
+
+    public string Signature { get; }
+    public string? Alias { get; set; }
+    public TextSpan Span { get; set; }
+}
+
+/// <summary>
+/// Parses GrainInterfaces.txt files.
+/// </summary>
+internal static class GrainInterfaceFileParser
+{
+    // Regex patterns for parsing
+    // Interface line: [Alias("x")] Namespace.IInterface<T> [Version(N)]
+    // Or with retired: *RETIRED* [Alias("x")] Namespace.IInterface<T> [Version(N)]
+    // The name can include generic type parameters like IMyGrain<T> or IMyGrain<TKey, TValue>
+    private static readonly Regex InterfacePattern = new(
+        @"^(?<retired>\*RETIRED\*\s*)?(\[Alias\(""(?<alias>[^""]+)""\)\]\s*)?(?<name>[\w.]+(?:<[\w,\s]+>)?)\s*\[Version\((?<version>\d+)\)\]$",
+        RegexOptions.Compiled);
+
+    // Member line: [Alias("x")] Namespace.IInterface<T>.Method(params) -> ReturnType
+    // The signature includes the full interface name (possibly generic) and method
+    private static readonly Regex MemberPattern = new(
+        @"^(\[Alias\(""(?<alias>[^""]+)""\)\]\s*)?(?<signature>[\w.]+(?:<[\w,\s]+>)?\.[^(]+\([^)]*\)\s*->\s*.+)$",
+        RegexOptions.Compiled);
+
+    public static (GrainInterfaceData Data, List<Diagnostic>? Errors) Parse(SourceText sourceText, string filePath)
+    {
+        var data = new GrainInterfaceData();
+        List<Diagnostic>? errors = null;
+        DeclaredGrainInterface? currentInterface = null;
+
+        foreach (var textLine in sourceText.Lines)
+        {
+            var lineText = textLine.ToString().Trim();
+
+            // Skip empty lines and comments
+            if (string.IsNullOrWhiteSpace(lineText) || lineText.StartsWith("#", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Try to match interface declaration
+            var interfaceMatch = InterfacePattern.Match(lineText);
+            if (interfaceMatch.Success)
+            {
+                var name = interfaceMatch.Groups["name"].Value;
+                var alias = interfaceMatch.Groups["alias"].Success ? interfaceMatch.Groups["alias"].Value : null;
+                var version = ushort.Parse(interfaceMatch.Groups["version"].Value);
+                var isRetired = interfaceMatch.Groups["retired"].Success;
+
+                if (data.Interfaces.ContainsKey(name))
+                {
+                    // Duplicate declaration
+                    errors ??= new List<Diagnostic>();
+                    var location = Location.Create(
+                        filePath,
+                        textLine.Span,
+                        sourceText.Lines.GetLinePositionSpan(textLine.Span));
+                    errors.Add(Diagnostic.Create(
+                        GrainInterfaceVersionAnalyzer.DuplicateInterfaceDeclarationRule,
+                        location,
+                        name));
+                    continue;
+                }
+
+                currentInterface = new DeclaredGrainInterface(name)
+                {
+                    Alias = alias,
+                    Version = version,
+                    IsRetired = isRetired,
+                    Span = textLine.Span
+                };
+                data.Interfaces[name] = currentInterface;
+                continue;
+            }
+
+            // Try to match member declaration
+            var memberMatch = MemberPattern.Match(lineText);
+            if (memberMatch.Success && currentInterface is not null)
+            {
+                var signature = memberMatch.Groups["signature"].Value;
+                var alias = memberMatch.Groups["alias"].Success ? memberMatch.Groups["alias"].Value : null;
+
+                // Extract interface name from signature to verify it belongs to current interface
+                // Signature format: Namespace.IInterface<T>.Method(params) -> ReturnType
+                // We need to find the last '.' before the '(' to get the method separator
+                var parenIndex = signature.IndexOf('(');
+                if (parenIndex > 0)
+                {
+                    var methodPartBeforeParen = signature.Substring(0, parenIndex);
+                    var dotIndex = methodPartBeforeParen.LastIndexOf('.');
+                    if (dotIndex > 0)
+                    {
+                        var memberInterfaceName = signature.Substring(0, dotIndex);
+                        if (memberInterfaceName == currentInterface.Name)
+                        {
+                            currentInterface.Members[signature] = new DeclaredGrainMember(signature)
+                            {
+                                Alias = alias,
+                                Span = textLine.Span
+                            };
+                        }
+                    }
+                }
+            }
+        }
+
+        return (data, errors);
+    }
+}

--- a/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceVersionAnalyzer.cs
@@ -22,6 +22,7 @@ namespace Orleans.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
 {
+    public const string EnableAnalyzerPropertyName = "EnableOrleansContractsAnalyzer";
     public const string RuleId0016 = "ORLEANS0016";
     public const string RuleId0017 = "ORLEANS0017";
     public const string RuleId0018 = "ORLEANS0018";
@@ -163,6 +164,14 @@ public sealed partial class GrainInterfaceVersionAnalyzer : DiagnosticAnalyzer
 
     private void OnCompilationStart(CompilationStartAnalysisContext context)
     {
+        if (!context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue(
+                $"build_property.{EnableAnalyzerPropertyName}",
+                out var enabled)
+            || !string.Equals(enabled, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
         // Try to find the OrleansContracts.txt file
         var grainInterfacesFile = context.Options.AdditionalFiles
             .FirstOrDefault(file =>

--- a/src/Orleans.Analyzers/GrainInterfaceVersionCodeFix.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceVersionCodeFix.cs
@@ -1,0 +1,499 @@
+#nullable enable
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Orleans.Analyzers;
+
+/// <summary>
+/// A code fix provider that adds grain interfaces to GrainInterfaces.txt or updates their version.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(GrainInterfaceVersionCodeFix)), Shared]
+public class GrainInterfaceVersionCodeFix : CodeFixProvider
+{
+    private const string NewLine = "\r\n";
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
+        GrainInterfaceVersionAnalyzer.RuleId0016,  // Interface not declared
+        GrainInterfaceVersionAnalyzer.RuleId0017,  // Version mismatch
+        GrainInterfaceVersionAnalyzer.RuleId0018,  // Member not declared
+        GrainInterfaceVersionAnalyzer.RuleId0019); // Removed interface not retired
+
+    // Note: We don't use BatchFixer because each fix may need to coordinate updates to the same file
+    public sealed override FixAllProvider? GetFixAllProvider() => null;
+
+    public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            switch (diagnostic.Id)
+            {
+                case GrainInterfaceVersionAnalyzer.RuleId0016:
+                    RegisterAddInterfaceCodeFix(context, diagnostic);
+                    break;
+                case GrainInterfaceVersionAnalyzer.RuleId0017:
+                    RegisterUpdateVersionCodeFix(context, diagnostic);
+                    break;
+                case GrainInterfaceVersionAnalyzer.RuleId0018:
+                    RegisterAddMemberCodeFix(context, diagnostic);
+                    break;
+                case GrainInterfaceVersionAnalyzer.RuleId0019:
+                    RegisterRetireInterfaceCodeFix(context, diagnostic);
+                    break;
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static void RegisterAddInterfaceCodeFix(CodeFixContext context, Diagnostic diagnostic)
+    {
+        if (!diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.InterfaceNamePropertyKey, out var interfaceName) ||
+            string.IsNullOrEmpty(interfaceName))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Resources.AddToGrainInterfacesFileTitle,
+                createChangedSolution: ct => AddInterfaceToFileAsync(context.Document, interfaceName!, ct),
+                equivalenceKey: GrainInterfaceVersionAnalyzer.RuleId0016),
+            diagnostic);
+    }
+
+    private static void RegisterUpdateVersionCodeFix(CodeFixContext context, Diagnostic diagnostic)
+    {
+        if (!diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.InterfaceNamePropertyKey, out var interfaceName) ||
+            string.IsNullOrEmpty(interfaceName))
+        {
+            return;
+        }
+
+        if (!diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.ActualVersionPropertyKey, out var actualVersion) ||
+            string.IsNullOrEmpty(actualVersion))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Resources.UpdateGrainInterfaceVersionTitle,
+                createChangedSolution: ct => UpdateVersionInFileAsync(context.Document, interfaceName!, actualVersion!, ct),
+                equivalenceKey: GrainInterfaceVersionAnalyzer.RuleId0017),
+            diagnostic);
+    }
+
+    private static void RegisterAddMemberCodeFix(CodeFixContext context, Diagnostic diagnostic)
+    {
+        if (!diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.InterfaceNamePropertyKey, out var interfaceName) ||
+            string.IsNullOrEmpty(interfaceName))
+        {
+            return;
+        }
+
+        if (!diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.MemberNamePropertyKey, out var memberSignature) ||
+            string.IsNullOrEmpty(memberSignature))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Resources.AddToGrainInterfacesFileTitle,
+                createChangedSolution: ct => AddMemberToFileAsync(context.Document, interfaceName!, memberSignature!, ct),
+                equivalenceKey: GrainInterfaceVersionAnalyzer.RuleId0018),
+            diagnostic);
+    }
+
+    private static void RegisterRetireInterfaceCodeFix(CodeFixContext context, Diagnostic diagnostic)
+    {
+        if (!diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.InterfaceNamePropertyKey, out var interfaceName) ||
+            string.IsNullOrEmpty(interfaceName))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Resources.RetireGrainInterfaceTitle,
+                createChangedSolution: ct => RetireInterfaceInFileAsync(context.Document, interfaceName!, ct),
+                equivalenceKey: GrainInterfaceVersionAnalyzer.RuleId0019),
+            diagnostic);
+    }
+
+    private static async Task<Solution> AddInterfaceToFileAsync(
+        Document document,
+        string interfaceName,
+        CancellationToken cancellationToken)
+    {
+        var project = document.Project;
+        var solution = project.Solution;
+
+        // Get version and alias from the source code
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        if (semanticModel is null || root is null)
+        {
+            return solution;
+        }
+
+        var interfaceDecl = root.DescendantNodes()
+            .OfType<InterfaceDeclarationSyntax>()
+            .FirstOrDefault(i =>
+            {
+                var symbol = semanticModel.GetDeclaredSymbol(i, cancellationToken);
+                if (symbol is null) return false;
+                var fullName = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", "");
+                return string.Equals(fullName, interfaceName, StringComparison.Ordinal);
+            });
+
+        if (interfaceDecl is null)
+        {
+            return solution;
+        }
+
+        var symbol = semanticModel.GetDeclaredSymbol(interfaceDecl, cancellationToken) as INamedTypeSymbol;
+        if (symbol is null)
+        {
+            return solution;
+        }
+
+        var version = GetVersionFromAttributes(symbol);
+        var alias = GetAliasFromAttributes(symbol);
+
+        // Build the interface declaration line
+        var sb = new StringBuilder();
+        if (!string.IsNullOrEmpty(alias))
+        {
+            sb.Append($"[Alias(\"{alias}\")] ");
+        }
+        sb.Append(interfaceName);
+        sb.Append($" [Version({version})]");
+        var interfaceLine = sb.ToString();
+
+        // Build member lines
+        var memberLines = new StringBuilder();
+        foreach (var member in symbol.GetMembers().OfType<IMethodSymbol>())
+        {
+            if (member.MethodKind != MethodKind.Ordinary)
+            {
+                continue;
+            }
+
+            var memberAlias = GetAliasFromAttributes(member);
+            var memberSignature = GetMethodSignature(member);
+
+            if (!string.IsNullOrEmpty(memberAlias))
+            {
+                memberLines.Append($"[Alias(\"{memberAlias}\")] ");
+            }
+            memberLines.AppendLine(memberSignature);
+        }
+
+        // Find or create the GrainInterfaces.txt file
+        var grainInterfacesFile = project.AdditionalDocuments
+            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.GrainInterfacesFileName, StringComparison.OrdinalIgnoreCase));
+
+        if (grainInterfacesFile is not null)
+        {
+            // Append to existing file
+            var text = await grainInterfacesFile.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var existingContent = text?.ToString() ?? "";
+
+            var newContent = existingContent.TrimEnd();
+            if (!string.IsNullOrEmpty(newContent))
+            {
+                newContent += NewLine + NewLine;
+            }
+            newContent += interfaceLine + NewLine;
+            newContent += memberLines.ToString();
+
+            var newText = Microsoft.CodeAnalysis.Text.SourceText.From(newContent, Encoding.UTF8);
+            solution = solution.WithAdditionalDocumentText(grainInterfacesFile.Id, newText);
+        }
+        else
+        {
+            // Create new file with header
+            var content = new StringBuilder();
+            content.AppendLine("# GrainInterfaces.txt");
+            content.AppendLine("# This file tracks grain interface versions for compatibility during rolling upgrades.");
+            content.AppendLine("# Format:");
+            content.AppendLine("#   [Alias(\"alias\")] Namespace.IInterface [Version(N)]");
+            content.AppendLine("#   [Alias(\"alias\")] Namespace.IInterface.Method(params) -> ReturnType");
+            content.AppendLine();
+            content.AppendLine(interfaceLine);
+            content.Append(memberLines);
+
+            var newText = Microsoft.CodeAnalysis.Text.SourceText.From(content.ToString(), Encoding.UTF8);
+            var projectDir = Path.GetDirectoryName(project.FilePath);
+            var filePath = projectDir is not null
+                ? Path.Combine(projectDir, Constants.GrainInterfacesFileName)
+                : Constants.GrainInterfacesFileName;
+
+            solution = solution.AddAdditionalDocument(
+                DocumentId.CreateNewId(project.Id),
+                Constants.GrainInterfacesFileName,
+                newText,
+                filePath: filePath);
+        }
+
+        return solution;
+    }
+
+    private static async Task<Solution> UpdateVersionInFileAsync(
+        Document document,
+        string interfaceName,
+        string newVersion,
+        CancellationToken cancellationToken)
+    {
+        var project = document.Project;
+        var solution = project.Solution;
+
+        var grainInterfacesFile = project.AdditionalDocuments
+            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.GrainInterfacesFileName, StringComparison.OrdinalIgnoreCase));
+
+        if (grainInterfacesFile is null)
+        {
+            return solution;
+        }
+
+        var text = await grainInterfacesFile.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        if (text is null)
+        {
+            return solution;
+        }
+
+        var lines = text.ToString().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+        var newLines = new StringBuilder();
+
+        foreach (var line in lines)
+        {
+            var trimmedLine = line.Trim();
+
+            // Check if this line contains the interface declaration
+            if (trimmedLine.Contains(interfaceName) && trimmedLine.Contains("[Version("))
+            {
+                // Replace the version number
+                var versionStart = trimmedLine.IndexOf("[Version(", StringComparison.Ordinal);
+                var versionEnd = trimmedLine.IndexOf(")]", versionStart, StringComparison.Ordinal);
+
+                if (versionStart >= 0 && versionEnd > versionStart)
+                {
+                    var before = trimmedLine.Substring(0, versionStart);
+                    var after = trimmedLine.Substring(versionEnd + 2);
+                    newLines.AppendLine($"{before}[Version({newVersion})]{after}");
+                    continue;
+                }
+            }
+
+            newLines.AppendLine(line);
+        }
+
+        // Remove trailing newline added by AppendLine
+        var newContent = newLines.ToString();
+        if (newContent.EndsWith(NewLine))
+        {
+            newContent = newContent.Substring(0, newContent.Length - NewLine.Length);
+        }
+
+        var newText = Microsoft.CodeAnalysis.Text.SourceText.From(newContent, Encoding.UTF8);
+        return solution.WithAdditionalDocumentText(grainInterfacesFile.Id, newText);
+    }
+
+    private static async Task<Solution> AddMemberToFileAsync(
+        Document document,
+        string interfaceName,
+        string memberSignature,
+        CancellationToken cancellationToken)
+    {
+        var project = document.Project;
+        var solution = project.Solution;
+
+        var grainInterfacesFile = project.AdditionalDocuments
+            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.GrainInterfacesFileName, StringComparison.OrdinalIgnoreCase));
+
+        if (grainInterfacesFile is null)
+        {
+            return solution;
+        }
+
+        var text = await grainInterfacesFile.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        if (text is null)
+        {
+            return solution;
+        }
+
+        var lines = text.ToString().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+        var newLines = new StringBuilder();
+        var foundInterface = false;
+        var insertedMember = false;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var trimmedLine = line.Trim();
+
+            newLines.AppendLine(line);
+
+            // Check if this line contains the interface declaration
+            if (!foundInterface && trimmedLine.Contains(interfaceName) && trimmedLine.Contains("[Version("))
+            {
+                foundInterface = true;
+                continue;
+            }
+
+            // If we found the interface, look for where to insert the member
+            if (foundInterface && !insertedMember)
+            {
+                // Insert before the next interface declaration or at the end of members
+                var nextLine = i + 1 < lines.Length ? lines[i + 1].Trim() : "";
+
+                // If next line is empty, a comment, or another interface, insert the member here
+                if (string.IsNullOrEmpty(nextLine) ||
+                    nextLine.StartsWith("#", StringComparison.Ordinal) ||
+                    (nextLine.Contains("[Version(") && !nextLine.StartsWith(interfaceName, StringComparison.Ordinal)))
+                {
+                    newLines.AppendLine(memberSignature);
+                    insertedMember = true;
+                }
+            }
+        }
+
+        // If we didn't insert the member yet, append it at the end
+        if (foundInterface && !insertedMember)
+        {
+            newLines.AppendLine(memberSignature);
+        }
+
+        // Remove trailing newline added by AppendLine
+        var newContent = newLines.ToString();
+        if (newContent.EndsWith(NewLine))
+        {
+            newContent = newContent.Substring(0, newContent.Length - NewLine.Length);
+        }
+
+        var newText = Microsoft.CodeAnalysis.Text.SourceText.From(newContent, Encoding.UTF8);
+        return solution.WithAdditionalDocumentText(grainInterfacesFile.Id, newText);
+    }
+
+    private static async Task<Solution> RetireInterfaceInFileAsync(
+        Document document,
+        string interfaceName,
+        CancellationToken cancellationToken)
+    {
+        var project = document.Project;
+        var solution = project.Solution;
+
+        var grainInterfacesFile = project.AdditionalDocuments
+            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.GrainInterfacesFileName, StringComparison.OrdinalIgnoreCase));
+
+        if (grainInterfacesFile is null)
+        {
+            return solution;
+        }
+
+        var text = await grainInterfacesFile.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        if (text is null)
+        {
+            return solution;
+        }
+
+        var lines = text.ToString().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+        var newLines = new StringBuilder();
+
+        foreach (var line in lines)
+        {
+            var trimmedLine = line.Trim();
+
+            // Check if this line contains the interface declaration
+            if (trimmedLine.Contains(interfaceName) && trimmedLine.Contains("[Version(") &&
+                !trimmedLine.StartsWith(GrainInterfaceVersionAnalyzer.RetiredPrefix, StringComparison.Ordinal))
+            {
+                // Add *RETIRED* prefix
+                newLines.AppendLine($"{GrainInterfaceVersionAnalyzer.RetiredPrefix} {trimmedLine}");
+                continue;
+            }
+
+            newLines.AppendLine(line);
+        }
+
+        // Remove trailing newline added by AppendLine
+        var newContent = newLines.ToString();
+        if (newContent.EndsWith(NewLine))
+        {
+            newContent = newContent.Substring(0, newContent.Length - NewLine.Length);
+        }
+
+        var newText = Microsoft.CodeAnalysis.Text.SourceText.From(newContent, Encoding.UTF8);
+        return solution.WithAdditionalDocumentText(grainInterfacesFile.Id, newText);
+    }
+
+    private static ushort GetVersionFromAttributes(ISymbol symbol)
+    {
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (string.Equals(attribute.AttributeClass?.ToDisplayString(), Constants.VersionAttributeFullyQualifiedName, StringComparison.Ordinal))
+            {
+                if (attribute.ConstructorArguments.Length > 0 &&
+                    attribute.ConstructorArguments[0].Value is ushort version)
+                {
+                    return version;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    private static string? GetAliasFromAttributes(ISymbol symbol)
+    {
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (string.Equals(attribute.AttributeClass?.ToDisplayString(), Constants.AliasAttributeFullyQualifiedName, StringComparison.Ordinal))
+            {
+                if (attribute.ConstructorArguments.Length > 0 &&
+                    attribute.ConstructorArguments[0].Value is string alias)
+                {
+                    return alias;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string GetMethodSignature(IMethodSymbol method)
+    {
+        var sb = new StringBuilder();
+        sb.Append(method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", ""));
+        sb.Append('.');
+        sb.Append(method.Name);
+        sb.Append('(');
+
+        for (int i = 0; i < method.Parameters.Length; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            var param = method.Parameters[i];
+            sb.Append(param.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+            sb.Append(' ');
+            sb.Append(param.Name);
+        }
+
+        sb.Append(')');
+        sb.Append(" -> ");
+        sb.Append(method.ReturnType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+
+        return sb.ToString();
+    }
+}

--- a/src/Orleans.Analyzers/GrainInterfaceVersionCodeFix.cs
+++ b/src/Orleans.Analyzers/GrainInterfaceVersionCodeFix.cs
@@ -4,7 +4,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.IO;
@@ -16,17 +18,21 @@ using System.Threading.Tasks;
 namespace Orleans.Analyzers;
 
 /// <summary>
-/// A code fix provider that adds grain interfaces to GrainInterfaces.txt or updates their version.
+/// A code fix provider that adds grain interfaces to OrleansContracts.txt or updates their version.
 /// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(GrainInterfaceVersionCodeFix)), Shared]
 public class GrainInterfaceVersionCodeFix : CodeFixProvider
 {
-    private const string NewLine = "\r\n";
+    private const string DefaultNewLine = "\n";
+
     public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
         GrainInterfaceVersionAnalyzer.RuleId0016,  // Interface not declared
         GrainInterfaceVersionAnalyzer.RuleId0017,  // Version mismatch
         GrainInterfaceVersionAnalyzer.RuleId0018,  // Member not declared
-        GrainInterfaceVersionAnalyzer.RuleId0019); // Removed interface not retired
+        GrainInterfaceVersionAnalyzer.RuleId0019,  // Removed interface not retired
+        GrainInterfaceVersionAnalyzer.RuleId0022,  // Grain class not declared
+        GrainInterfaceVersionAnalyzer.RuleId0023,  // Grain class alias mismatch
+        GrainInterfaceVersionAnalyzer.RuleId0024); // Removed grain class not retired
 
     // Note: We don't use BatchFixer because each fix may need to coordinate updates to the same file
     public sealed override FixAllProvider? GetFixAllProvider() => null;
@@ -49,6 +55,15 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
                 case GrainInterfaceVersionAnalyzer.RuleId0019:
                     RegisterRetireInterfaceCodeFix(context, diagnostic);
                     break;
+                case GrainInterfaceVersionAnalyzer.RuleId0022:
+                    RegisterAddGrainClassCodeFix(context, diagnostic);
+                    break;
+                case GrainInterfaceVersionAnalyzer.RuleId0023:
+                    RegisterUpdateGrainClassAliasCodeFix(context, diagnostic);
+                    break;
+                case GrainInterfaceVersionAnalyzer.RuleId0024:
+                    RegisterRetireGrainClassCodeFix(context, diagnostic);
+                    break;
             }
         }
 
@@ -63,10 +78,11 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             return;
         }
 
+        diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.GrainInterfaceTypePropertyKey, out var grainInterfaceType);
         context.RegisterCodeFix(
             CodeAction.Create(
-                title: Resources.AddToGrainInterfacesFileTitle,
-                createChangedSolution: ct => AddInterfaceToFileAsync(context.Document, interfaceName!, ct),
+                title: Resources.AddToOrleansContractsFileTitle,
+                createChangedSolution: ct => AddInterfaceToFileAsync(context.Document, interfaceName!, grainInterfaceType, ct),
                 equivalenceKey: GrainInterfaceVersionAnalyzer.RuleId0016),
             diagnostic);
     }
@@ -85,10 +101,11 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             return;
         }
 
+        diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.GrainInterfaceTypePropertyKey, out var grainInterfaceType);
         context.RegisterCodeFix(
             CodeAction.Create(
                 title: Resources.UpdateGrainInterfaceVersionTitle,
-                createChangedSolution: ct => UpdateVersionInFileAsync(context.Document, interfaceName!, actualVersion!, ct),
+                createChangedSolution: ct => UpdateVersionInFileAsync(context.Document, interfaceName!, grainInterfaceType, actualVersion!, ct),
                 equivalenceKey: GrainInterfaceVersionAnalyzer.RuleId0017),
             diagnostic);
     }
@@ -107,10 +124,13 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             return;
         }
 
+        diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.MemberClrSignaturePropertyKey, out var memberClrSignature);
+        diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.GrainInterfaceTypePropertyKey, out var grainInterfaceType);
+
         context.RegisterCodeFix(
             CodeAction.Create(
-                title: Resources.AddToGrainInterfacesFileTitle,
-                createChangedSolution: ct => AddMemberToFileAsync(context.Document, interfaceName!, memberSignature!, ct),
+                title: Resources.AddToOrleansContractsFileTitle,
+                createChangedSolution: ct => AddMemberToFileAsync(context.Document, interfaceName!, grainInterfaceType, memberSignature!, memberClrSignature, ct),
                 equivalenceKey: GrainInterfaceVersionAnalyzer.RuleId0018),
             diagnostic);
     }
@@ -131,9 +151,219 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             diagnostic);
     }
 
+    private static void RegisterAddGrainClassCodeFix(CodeFixContext context, Diagnostic diagnostic)
+    {
+        if (!diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.ClassNamePropertyKey, out var className) ||
+            string.IsNullOrEmpty(className))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Resources.AddToOrleansContractsFileTitle,
+                createChangedSolution: ct => AddGrainClassToFileAsync(context.Document, className!, ct),
+                equivalenceKey: GrainInterfaceVersionAnalyzer.RuleId0022),
+            diagnostic);
+    }
+
+    private static void RegisterUpdateGrainClassAliasCodeFix(CodeFixContext context, Diagnostic diagnostic)
+    {
+        if (!diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.ClassNamePropertyKey, out var className) ||
+            string.IsNullOrEmpty(className))
+        {
+            return;
+        }
+
+        diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.ActualAliasPropertyKey, out var alias);
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Resources.UpdateGrainClassAliasTitle,
+                createChangedSolution: ct => UpdateGrainClassAliasInFileAsync(context.Document, className!, alias, ct),
+                equivalenceKey: GrainInterfaceVersionAnalyzer.RuleId0023),
+            diagnostic);
+    }
+
+    private static void RegisterRetireGrainClassCodeFix(CodeFixContext context, Diagnostic diagnostic)
+    {
+        if (!diagnostic.Properties.TryGetValue(GrainInterfaceVersionAnalyzer.ClassNamePropertyKey, out var className) ||
+            string.IsNullOrEmpty(className))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: Resources.RetireGrainClassTitle,
+                createChangedSolution: ct => RetireGrainClassInFileAsync(context.Document, className!, ct),
+                equivalenceKey: GrainInterfaceVersionAnalyzer.RuleId0024),
+            diagnostic);
+    }
+
+    private static async Task<Solution> AddGrainClassToFileAsync(
+        Document document,
+        string className,
+        CancellationToken cancellationToken)
+    {
+        var project = document.Project;
+        var solution = project.Solution;
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null || root is null)
+        {
+            return solution;
+        }
+
+        var declaration = root.DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .FirstOrDefault(candidate =>
+            {
+                var symbol = semanticModel.GetDeclaredSymbol(candidate, cancellationToken) as INamedTypeSymbol;
+                var fullName = symbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", "");
+                return symbol?.TypeKind == TypeKind.Class && string.Equals(fullName, className, StringComparison.Ordinal);
+            });
+        if (declaration is null || semanticModel.GetDeclaredSymbol(declaration, cancellationToken) is not INamedTypeSymbol classSymbol)
+        {
+            return solution;
+        }
+
+        var alias = GetGrainTypeAliasFromAttributes(classSymbol);
+        var classClrComment = GrainInterfaceVersionAnalyzer.IdentityDiffersFromClrName(alias, classSymbol) ? className : null;
+        var classLine = string.IsNullOrEmpty(alias)
+            ? $"class {className}"
+            : $"class [GrainType(\"{alias}\")] {className}";
+        var contractsFile = project.AdditionalDocuments
+            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.OrleansContractsFileName, StringComparison.OrdinalIgnoreCase));
+        if (contractsFile is null)
+        {
+            return solution;
+        }
+
+        var text = await contractsFile.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        if (text is null)
+        {
+            return solution;
+        }
+
+        var newLine = GetNewLine(text);
+        var lines = text.ToString().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (GrainInterfaceFileParser.TryGetGrainClassName(lines[i], out var declaredName)
+                && string.Equals(declaredName, className, StringComparison.Ordinal))
+            {
+                var updatedLines = lines.ToList();
+                i = SetClrCommentBefore(updatedLines, i, classClrComment);
+                updatedLines[i] = classLine;
+                var reactivatedContent = SortContractEntries(string.Join(newLine, updatedLines), newLine);
+                return solution.WithAdditionalDocumentText(
+                    contractsFile.Id,
+                    Microsoft.CodeAnalysis.Text.SourceText.From(reactivatedContent, Encoding.UTF8));
+            }
+        }
+
+        var content = text.ToString().TrimEnd();
+        if (content.Length > 0)
+        {
+            content += newLine + newLine;
+        }
+
+        if (classClrComment is not null)
+        {
+            content += $"# {classClrComment}{newLine}";
+        }
+        content = SortContractEntries(content + classLine, newLine);
+        return solution.WithAdditionalDocumentText(
+            contractsFile.Id,
+            Microsoft.CodeAnalysis.Text.SourceText.From(content, Encoding.UTF8));
+    }
+
+    private static async Task<Solution> UpdateGrainClassAliasInFileAsync(
+        Document document,
+        string className,
+        string? alias,
+        CancellationToken cancellationToken)
+    {
+        var project = document.Project;
+        var contractsFile = project.AdditionalDocuments
+            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.OrleansContractsFileName, StringComparison.OrdinalIgnoreCase));
+        if (contractsFile is null)
+        {
+            return project.Solution;
+        }
+
+        var text = await contractsFile.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        if (text is null)
+        {
+            return project.Solution;
+        }
+
+        var newLine = GetNewLine(text);
+        var replacement = string.IsNullOrEmpty(alias)
+            ? $"class {className}"
+            : $"class [GrainType(\"{alias}\")] {className}";
+        var lines = text.ToString().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None).ToList();
+        for (var i = 0; i < lines.Count; i++)
+        {
+            if (GrainInterfaceFileParser.TryGetGrainClassName(lines[i], out var declaredName)
+                && string.Equals(declaredName, className, StringComparison.Ordinal))
+            {
+                var clrComment = IdentityDiffersFromClrName(alias, className) ? className : null;
+                i = SetClrCommentBefore(lines, i, clrComment);
+                lines[i] = replacement;
+                break;
+            }
+        }
+
+        var content = SortContractEntries(string.Join(newLine, lines), newLine);
+        return project.Solution.WithAdditionalDocumentText(
+            contractsFile.Id,
+            Microsoft.CodeAnalysis.Text.SourceText.From(content, Encoding.UTF8));
+    }
+
+    private static async Task<Solution> RetireGrainClassInFileAsync(
+        Document document,
+        string className,
+        CancellationToken cancellationToken)
+    {
+        var project = document.Project;
+        var contractsFile = project.AdditionalDocuments
+            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.OrleansContractsFileName, StringComparison.OrdinalIgnoreCase));
+        if (contractsFile is null)
+        {
+            return project.Solution;
+        }
+
+        var text = await contractsFile.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        if (text is null)
+        {
+            return project.Solution;
+        }
+
+        var newLine = GetNewLine(text);
+        var lines = text.ToString().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var trimmedLine = lines[i].Trim();
+            if (GrainInterfaceFileParser.TryGetGrainClassName(trimmedLine, out var declaredName)
+                && string.Equals(declaredName, className, StringComparison.Ordinal)
+                && !trimmedLine.StartsWith(GrainInterfaceVersionAnalyzer.RetiredPrefix, StringComparison.Ordinal))
+            {
+                lines[i] = $"{GrainInterfaceVersionAnalyzer.RetiredPrefix} {trimmedLine}";
+                break;
+            }
+        }
+
+        var content = SortContractEntries(string.Join(newLine, lines), newLine);
+        return project.Solution.WithAdditionalDocumentText(
+            contractsFile.Id,
+            Microsoft.CodeAnalysis.Text.SourceText.From(content, Encoding.UTF8));
+    }
+
     private static async Task<Solution> AddInterfaceToFileAsync(
         Document document,
         string interfaceName,
+        string? grainInterfaceType,
         CancellationToken cancellationToken)
     {
         var project = document.Project;
@@ -170,54 +400,82 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
         }
 
         var version = GetVersionFromAttributes(symbol);
-        var alias = GetAliasFromAttributes(symbol);
+        grainInterfaceType ??= GetGrainInterfaceTypeFromAttributes(symbol);
+        var interfaceClrComment = GrainInterfaceVersionAnalyzer.IdentityDiffersFromClrName(grainInterfaceType, symbol)
+            ? interfaceName
+            : null;
 
         // Build the interface declaration line
         var sb = new StringBuilder();
-        if (!string.IsNullOrEmpty(alias))
+        sb.Append("interface ");
+        if (!string.IsNullOrEmpty(grainInterfaceType))
         {
-            sb.Append($"[Alias(\"{alias}\")] ");
+            sb.Append($"[GrainInterfaceType(\"{grainInterfaceType}\")] ");
         }
         sb.Append(interfaceName);
         sb.Append($" [Version({version})]");
         var interfaceLine = sb.ToString();
 
         // Build member lines
-        var memberLines = new StringBuilder();
+        var memberLines = new List<(string Signature, string? ClrSignature)>();
         foreach (var member in symbol.GetMembers().OfType<IMethodSymbol>())
         {
-            if (member.MethodKind != MethodKind.Ordinary)
+            if (member.MethodKind != MethodKind.Ordinary || member.IsStatic)
             {
                 continue;
             }
 
-            var memberAlias = GetAliasFromAttributes(member);
-            var memberSignature = GetMethodSignature(member);
-
-            if (!string.IsNullOrEmpty(memberAlias))
-            {
-                memberLines.Append($"[Alias(\"{memberAlias}\")] ");
-            }
-            memberLines.AppendLine(memberSignature);
+            var memberSignature = GrainInterfaceVersionAnalyzer.GetMethodSignature(member);
+            memberLines.Add((
+                memberSignature,
+                GrainInterfaceVersionAnalyzer.RequiresClrComment(member)
+                    ? GrainInterfaceVersionAnalyzer.GetClrMethodSignature(member)
+                    : null));
         }
 
-        // Find or create the GrainInterfaces.txt file
+        // Find or create the OrleansContracts.txt file
         var grainInterfacesFile = project.AdditionalDocuments
-            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.GrainInterfacesFileName, StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.OrleansContractsFileName, StringComparison.OrdinalIgnoreCase));
 
         if (grainInterfacesFile is not null)
         {
             // Append to existing file
             var text = await grainInterfacesFile.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var existingContent = text?.ToString() ?? "";
+            var newLine = text is null ? DefaultNewLine : GetNewLine(text);
+            var lines = existingContent.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (IsMatchingInterface(lines[i], interfaceName, grainInterfaceType))
+                {
+                    var updatedLines = lines.ToList();
+                    i = SetClrCommentBefore(updatedLines, i, interfaceClrComment);
+                    updatedLines[i] = interfaceLine;
+                    var reactivatedContent = SortContractEntries(string.Join(newLine, updatedLines), newLine);
+                    var reactivatedText = Microsoft.CodeAnalysis.Text.SourceText.From(reactivatedContent, Encoding.UTF8);
+                    return solution.WithAdditionalDocumentText(grainInterfacesFile.Id, reactivatedText);
+                }
+            }
 
             var newContent = existingContent.TrimEnd();
             if (!string.IsNullOrEmpty(newContent))
             {
-                newContent += NewLine + NewLine;
+                newContent += newLine + newLine;
             }
-            newContent += interfaceLine + NewLine;
-            newContent += memberLines.ToString();
+            if (interfaceClrComment is not null)
+            {
+                newContent += $"# {interfaceClrComment}{newLine}";
+            }
+            newContent += interfaceLine;
+            foreach (var member in memberLines)
+            {
+                if (member.ClrSignature is not null)
+                {
+                    newContent += $"{newLine}  # {member.ClrSignature}";
+                }
+                newContent += $"{newLine}  {member.Signature}";
+            }
+            newContent = SortContractEntries(newContent, newLine);
 
             var newText = Microsoft.CodeAnalysis.Text.SourceText.From(newContent, Encoding.UTF8);
             solution = solution.WithAdditionalDocumentText(grainInterfacesFile.Id, newText);
@@ -226,24 +484,38 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
         {
             // Create new file with header
             var content = new StringBuilder();
-            content.AppendLine("# GrainInterfaces.txt");
-            content.AppendLine("# This file tracks grain interface versions for compatibility during rolling upgrades.");
-            content.AppendLine("# Format:");
-            content.AppendLine("#   [Alias(\"alias\")] Namespace.IInterface [Version(N)]");
-            content.AppendLine("#   [Alias(\"alias\")] Namespace.IInterface.Method(params) -> ReturnType");
-            content.AppendLine();
-            content.AppendLine(interfaceLine);
-            content.Append(memberLines);
+            AppendLine(content, "# This file tracks grain interface versions for compatibility during rolling upgrades.", DefaultNewLine);
+            AppendLine(content, "# Format:", DefaultNewLine);
+            AppendLine(content, "#   # Namespace.GrainClass", DefaultNewLine);
+            AppendLine(content, "#   class [GrainType(\"identity\")] Namespace.GrainClass", DefaultNewLine);
+            AppendLine(content, "#   # Namespace.IInterface", DefaultNewLine);
+            AppendLine(content, "#   interface [GrainInterfaceType(\"identity\")] Namespace.IInterface [Version(N)]", DefaultNewLine);
+            AppendLine(content, "#   # Namespace.IInterface.Method(params) -> ReturnType", DefaultNewLine);
+            AppendLine(content, "#   contract-signature", DefaultNewLine);
+            AppendLine(content, "", DefaultNewLine);
+            if (interfaceClrComment is not null)
+            {
+                AppendLine(content, $"# {interfaceClrComment}", DefaultNewLine);
+            }
+            AppendLine(content, interfaceLine, DefaultNewLine);
+            foreach (var member in memberLines)
+            {
+                if (member.ClrSignature is not null)
+                {
+                    AppendLine(content, $"  # {member.ClrSignature}", DefaultNewLine);
+                }
+                AppendLine(content, $"  {member.Signature}", DefaultNewLine);
+            }
 
-            var newText = Microsoft.CodeAnalysis.Text.SourceText.From(content.ToString(), Encoding.UTF8);
+            var newText = Microsoft.CodeAnalysis.Text.SourceText.From(SortContractEntries(content.ToString(), DefaultNewLine), Encoding.UTF8);
             var projectDir = Path.GetDirectoryName(project.FilePath);
             var filePath = projectDir is not null
-                ? Path.Combine(projectDir, Constants.GrainInterfacesFileName)
-                : Constants.GrainInterfacesFileName;
+                ? Path.Combine(projectDir, Constants.OrleansContractsFileName)
+                : Constants.OrleansContractsFileName;
 
             solution = solution.AddAdditionalDocument(
                 DocumentId.CreateNewId(project.Id),
-                Constants.GrainInterfacesFileName,
+                Constants.OrleansContractsFileName,
                 newText,
                 filePath: filePath);
         }
@@ -254,6 +526,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
     private static async Task<Solution> UpdateVersionInFileAsync(
         Document document,
         string interfaceName,
+        string? grainInterfaceType,
         string newVersion,
         CancellationToken cancellationToken)
     {
@@ -261,7 +534,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
         var solution = project.Solution;
 
         var grainInterfacesFile = project.AdditionalDocuments
-            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.GrainInterfacesFileName, StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.OrleansContractsFileName, StringComparison.OrdinalIgnoreCase));
 
         if (grainInterfacesFile is null)
         {
@@ -274,6 +547,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             return solution;
         }
 
+        var newLine = GetNewLine(text);
         var lines = text.ToString().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
         var newLines = new StringBuilder();
 
@@ -282,7 +556,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             var trimmedLine = line.Trim();
 
             // Check if this line contains the interface declaration
-            if (trimmedLine.Contains(interfaceName) && trimmedLine.Contains("[Version("))
+            if (IsMatchingInterface(trimmedLine, interfaceName, grainInterfaceType))
             {
                 // Replace the version number
                 var versionStart = trimmedLine.IndexOf("[Version(", StringComparison.Ordinal);
@@ -292,20 +566,21 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
                 {
                     var before = trimmedLine.Substring(0, versionStart);
                     var after = trimmedLine.Substring(versionEnd + 2);
-                    newLines.AppendLine($"{before}[Version({newVersion})]{after}");
+                    AppendLine(newLines, $"{before}[Version({newVersion})]{after}", newLine);
                     continue;
                 }
             }
 
-            newLines.AppendLine(line);
+            AppendLine(newLines, line, newLine);
         }
 
         // Remove trailing newline added by AppendLine
         var newContent = newLines.ToString();
-        if (newContent.EndsWith(NewLine))
+        if (newContent.EndsWith(newLine, StringComparison.Ordinal))
         {
-            newContent = newContent.Substring(0, newContent.Length - NewLine.Length);
+            newContent = newContent.Substring(0, newContent.Length - newLine.Length);
         }
+        newContent = SortContractEntries(newContent, newLine);
 
         var newText = Microsoft.CodeAnalysis.Text.SourceText.From(newContent, Encoding.UTF8);
         return solution.WithAdditionalDocumentText(grainInterfacesFile.Id, newText);
@@ -314,14 +589,16 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
     private static async Task<Solution> AddMemberToFileAsync(
         Document document,
         string interfaceName,
+        string? grainInterfaceType,
         string memberSignature,
+        string? memberClrSignature,
         CancellationToken cancellationToken)
     {
         var project = document.Project;
         var solution = project.Solution;
 
         var grainInterfacesFile = project.AdditionalDocuments
-            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.GrainInterfacesFileName, StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.OrleansContractsFileName, StringComparison.OrdinalIgnoreCase));
 
         if (grainInterfacesFile is null)
         {
@@ -334,6 +611,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             return solution;
         }
 
+        var newLine = GetNewLine(text);
         var lines = text.ToString().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
         var newLines = new StringBuilder();
         var foundInterface = false;
@@ -344,44 +622,38 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             var line = lines[i];
             var trimmedLine = line.Trim();
 
-            newLines.AppendLine(line);
+            if (foundInterface
+                && !insertedMember
+                && (string.IsNullOrEmpty(trimmedLine)
+                    || trimmedLine.StartsWith("#", StringComparison.Ordinal)
+                    || GrainInterfaceFileParser.TryGetContractName(trimmedLine, out _)))
+            {
+                AppendMember(newLines, memberSignature, memberClrSignature, newLine);
+                insertedMember = true;
+            }
 
             // Check if this line contains the interface declaration
-            if (!foundInterface && trimmedLine.Contains(interfaceName) && trimmedLine.Contains("[Version("))
+            if (!foundInterface && IsMatchingInterface(trimmedLine, interfaceName, grainInterfaceType))
             {
                 foundInterface = true;
-                continue;
             }
 
-            // If we found the interface, look for where to insert the member
-            if (foundInterface && !insertedMember)
-            {
-                // Insert before the next interface declaration or at the end of members
-                var nextLine = i + 1 < lines.Length ? lines[i + 1].Trim() : "";
-
-                // If next line is empty, a comment, or another interface, insert the member here
-                if (string.IsNullOrEmpty(nextLine) ||
-                    nextLine.StartsWith("#", StringComparison.Ordinal) ||
-                    (nextLine.Contains("[Version(") && !nextLine.StartsWith(interfaceName, StringComparison.Ordinal)))
-                {
-                    newLines.AppendLine(memberSignature);
-                    insertedMember = true;
-                }
-            }
+            AppendLine(newLines, line, newLine);
         }
 
         // If we didn't insert the member yet, append it at the end
         if (foundInterface && !insertedMember)
         {
-            newLines.AppendLine(memberSignature);
+            AppendMember(newLines, memberSignature, memberClrSignature, newLine);
         }
 
         // Remove trailing newline added by AppendLine
         var newContent = newLines.ToString();
-        if (newContent.EndsWith(NewLine))
+        if (newContent.EndsWith(newLine, StringComparison.Ordinal))
         {
-            newContent = newContent.Substring(0, newContent.Length - NewLine.Length);
+            newContent = newContent.Substring(0, newContent.Length - newLine.Length);
         }
+        newContent = SortContractEntries(newContent, newLine);
 
         var newText = Microsoft.CodeAnalysis.Text.SourceText.From(newContent, Encoding.UTF8);
         return solution.WithAdditionalDocumentText(grainInterfacesFile.Id, newText);
@@ -396,7 +668,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
         var solution = project.Solution;
 
         var grainInterfacesFile = project.AdditionalDocuments
-            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.GrainInterfacesFileName, StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefault(d => Path.GetFileName(d.FilePath ?? d.Name).Equals(Constants.OrleansContractsFileName, StringComparison.OrdinalIgnoreCase));
 
         if (grainInterfacesFile is null)
         {
@@ -409,6 +681,7 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             return solution;
         }
 
+        var newLine = GetNewLine(text);
         var lines = text.ToString().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
         var newLines = new StringBuilder();
 
@@ -417,26 +690,253 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
             var trimmedLine = line.Trim();
 
             // Check if this line contains the interface declaration
-            if (trimmedLine.Contains(interfaceName) && trimmedLine.Contains("[Version(") &&
+            if (GrainInterfaceFileParser.TryGetInterfaceName(trimmedLine, out var declaredInterfaceName)
+                && string.Equals(declaredInterfaceName, interfaceName, StringComparison.Ordinal) &&
                 !trimmedLine.StartsWith(GrainInterfaceVersionAnalyzer.RetiredPrefix, StringComparison.Ordinal))
             {
                 // Add *RETIRED* prefix
-                newLines.AppendLine($"{GrainInterfaceVersionAnalyzer.RetiredPrefix} {trimmedLine}");
+                AppendLine(newLines, $"{GrainInterfaceVersionAnalyzer.RetiredPrefix} {trimmedLine}", newLine);
                 continue;
             }
 
-            newLines.AppendLine(line);
+            AppendLine(newLines, line, newLine);
         }
 
         // Remove trailing newline added by AppendLine
         var newContent = newLines.ToString();
-        if (newContent.EndsWith(NewLine))
+        if (newContent.EndsWith(newLine, StringComparison.Ordinal))
         {
-            newContent = newContent.Substring(0, newContent.Length - NewLine.Length);
+            newContent = newContent.Substring(0, newContent.Length - newLine.Length);
         }
+        newContent = SortContractEntries(newContent, newLine);
 
         var newText = Microsoft.CodeAnalysis.Text.SourceText.From(newContent, Encoding.UTF8);
         return solution.WithAdditionalDocumentText(grainInterfacesFile.Id, newText);
+    }
+
+    private static string GetNewLine(SourceText text)
+    {
+        foreach (var line in text.Lines)
+        {
+            if (line.EndIncludingLineBreak > line.End)
+            {
+                return text.ToString(TextSpan.FromBounds(line.End, line.EndIncludingLineBreak));
+            }
+        }
+
+        return DefaultNewLine;
+    }
+
+    private static bool IsMatchingInterface(string line, string interfaceName, string? grainInterfaceType)
+    {
+        if (!GrainInterfaceFileParser.TryGetInterfaceName(line, out var declaredInterfaceName))
+        {
+            return false;
+        }
+
+        if (grainInterfaceType is not null)
+        {
+            return GrainInterfaceFileParser.TryGetGrainInterfaceType(line, out var declaredGrainInterfaceType)
+                ? string.Equals(declaredGrainInterfaceType, grainInterfaceType, StringComparison.Ordinal)
+                : string.Equals(declaredInterfaceName, interfaceName, StringComparison.Ordinal);
+        }
+
+        return string.Equals(declaredInterfaceName, interfaceName, StringComparison.Ordinal);
+    }
+
+    private static bool IdentityDiffersFromClrName(string? identity, string fullName)
+    {
+        if (identity is null)
+        {
+            return false;
+        }
+
+        var simpleName = fullName.Substring(fullName.LastIndexOf('.') + 1);
+        return !string.Equals(identity, fullName, StringComparison.Ordinal)
+            && !string.Equals(identity, simpleName, StringComparison.Ordinal);
+    }
+
+    private static int SetClrCommentBefore(List<string> lines, int entryIndex, string? clrName)
+    {
+        if (entryIndex > 0 && lines[entryIndex - 1].TrimStart().StartsWith("# ", StringComparison.Ordinal))
+        {
+            if (clrName is null)
+            {
+                lines.RemoveAt(entryIndex - 1);
+                return entryIndex - 1;
+            }
+
+            lines[entryIndex - 1] = $"# {clrName}";
+            return entryIndex;
+        }
+
+        if (clrName is null)
+        {
+            return entryIndex;
+        }
+
+        lines.Insert(entryIndex, $"# {clrName}");
+        return entryIndex + 1;
+    }
+
+    private static string SortContractEntries(string content, string newLine)
+    {
+        var preamble = new List<string>();
+        var blocks = new List<ContractBlock>();
+        ContractBlock? currentBlock = null;
+        string? pendingComment = null;
+        var lines = content.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+
+        for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+        {
+            var line = lines[lineIndex];
+            var trimmedLine = line.TrimStart();
+            if (string.Equals(trimmedLine, "# OrleansContracts.txt", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (trimmedLine.StartsWith("# ", StringComparison.Ordinal)
+                && !trimmedLine.StartsWith("# This file ", StringComparison.Ordinal)
+                && !trimmedLine.StartsWith("# Format:", StringComparison.Ordinal)
+                && !trimmedLine.StartsWith("#   ", StringComparison.Ordinal)
+                && lineIndex + 1 < lines.Length
+                && (GrainInterfaceFileParser.TryGetContractName(lines[lineIndex + 1], out _)
+                    || GrainInterfaceFileParser.TryGetMemberSignature(lines[lineIndex + 1], out _)))
+            {
+                pendingComment = NormalizeComment(line);
+                continue;
+            }
+
+            if (GrainInterfaceFileParser.TryGetContractName(line, out var contractName))
+            {
+                var inlineComment = GrainInterfaceFileParser.GetClrComment(line);
+                currentBlock = new ContractBlock(
+                    contractName,
+                    NormalizeContractDeclaration(line),
+                    pendingComment ?? (inlineComment.Length > 0 ? NormalizeComment(inlineComment) : null));
+                blocks.Add(currentBlock);
+                pendingComment = null;
+            }
+            else if (currentBlock is null)
+            {
+                if (pendingComment is not null)
+                {
+                    preamble.Add(pendingComment);
+                    pendingComment = null;
+                }
+                preamble.Add(line);
+            }
+            else if (GrainInterfaceFileParser.TryGetMemberSignature(line, out var memberSignature))
+            {
+                var inlineComment = GrainInterfaceFileParser.GetClrComment(line);
+                var normalizedMemberLine = NormalizeMemberLine(memberSignature, currentBlock.Name);
+                currentBlock.Members.Add((
+                    normalizedMemberLine,
+                    normalizedMemberLine,
+                    pendingComment ?? (inlineComment.Length > 0 ? NormalizeComment(inlineComment) : null)));
+                pendingComment = null;
+            }
+            else if (!string.IsNullOrWhiteSpace(line))
+            {
+                if (pendingComment is not null)
+                {
+                    currentBlock.OtherLines.Add(pendingComment);
+                    pendingComment = null;
+                }
+                currentBlock.OtherLines.Add(line);
+            }
+        }
+
+        while (preamble.Count > 0 && string.IsNullOrWhiteSpace(preamble[preamble.Count - 1]))
+        {
+            preamble.RemoveAt(preamble.Count - 1);
+        }
+
+        var result = new List<string>(preamble);
+        if (result.Count > 0 && blocks.Count > 0)
+        {
+            result.Add("");
+        }
+
+        var orderedBlocks = blocks.OrderBy(block => block.Name, StringComparer.Ordinal).ToArray();
+        for (var i = 0; i < orderedBlocks.Length; i++)
+        {
+            if (i > 0)
+            {
+                result.Add("");
+            }
+
+            var block = orderedBlocks[i];
+            if (block.ClrComment is not null)
+            {
+                result.Add(block.ClrComment);
+            }
+            result.Add(block.Declaration);
+            foreach (var member in block.Members
+                .OrderBy(member => member.Signature, StringComparer.Ordinal)
+                .ThenBy(member => member.Line, StringComparer.Ordinal))
+            {
+                if (member.ClrComment is not null)
+                {
+                    result.Add($"  {member.ClrComment}");
+                }
+                result.Add($"  {member.Line}");
+            }
+            result.AddRange(block.OtherLines);
+        }
+
+        return string.Join(newLine, result) + newLine;
+    }
+
+    private static string NormalizeComment(string comment)
+    {
+        var result = comment.Trim();
+        return result.StartsWith("# CLR: ", StringComparison.Ordinal)
+            ? $"# {result.Substring("# CLR: ".Length)}"
+            : result;
+    }
+
+    private static string NormalizeMemberLine(string signature, string contractName)
+        => GrainInterfaceVersionAnalyzer.NormalizeStoredMemberSignature(signature, contractName);
+
+    private static string NormalizeContractDeclaration(string line)
+    {
+        var result = GrainInterfaceFileParser.StripClrComment(line);
+        if (GrainInterfaceFileParser.TryGetGrainClassName(result, out _))
+        {
+            return result;
+        }
+
+        if (result.StartsWith(GrainInterfaceVersionAnalyzer.RetiredPrefix, StringComparison.Ordinal))
+        {
+            var declaration = result.Substring(GrainInterfaceVersionAnalyzer.RetiredPrefix.Length).TrimStart();
+            return declaration.StartsWith("interface ", StringComparison.Ordinal)
+                ? result
+                : $"{GrainInterfaceVersionAnalyzer.RetiredPrefix} interface {declaration}";
+        }
+
+        return result.StartsWith("interface ", StringComparison.Ordinal) ? result : $"interface {result}";
+    }
+
+    private static void AppendLine(StringBuilder builder, string value, string newLine)
+    {
+        builder.Append(value);
+        builder.Append(newLine);
+    }
+
+    private static void AppendMember(
+        StringBuilder builder,
+        string memberSignature,
+        string? memberClrSignature,
+        string newLine)
+    {
+        if (!string.IsNullOrEmpty(memberClrSignature))
+        {
+            AppendLine(builder, $"  # {memberClrSignature}", newLine);
+        }
+
+        AppendLine(builder, $"  {memberSignature}", newLine);
     }
 
     private static ushort GetVersionFromAttributes(ISymbol symbol)
@@ -473,27 +973,53 @@ public class GrainInterfaceVersionCodeFix : CodeFixProvider
         return null;
     }
 
-    private static string GetMethodSignature(IMethodSymbol method)
+    private static string? GetGrainTypeAliasFromAttributes(ISymbol symbol)
     {
-        var sb = new StringBuilder();
-        sb.Append(method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", ""));
-        sb.Append('.');
-        sb.Append(method.Name);
-        sb.Append('(');
-
-        for (int i = 0; i < method.Parameters.Length; i++)
+        foreach (var attribute in symbol.GetAttributes())
         {
-            if (i > 0) sb.Append(", ");
-            var param = method.Parameters[i];
-            sb.Append(param.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
-            sb.Append(' ');
-            sb.Append(param.Name);
+            if (string.Equals(attribute.AttributeClass?.ToDisplayString(), Constants.GrainTypeAttributeFullyQualifiedName, StringComparison.Ordinal)
+                && attribute.ConstructorArguments.Length > 0
+                && attribute.ConstructorArguments[0].Value is string alias)
+            {
+                return alias;
+            }
         }
 
-        sb.Append(')');
-        sb.Append(" -> ");
-        sb.Append(method.ReturnType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+        return null;
+    }
 
-        return sb.ToString();
+    private static string? GetGrainInterfaceTypeFromAttributes(ISymbol symbol)
+    {
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (string.Equals(attribute.AttributeClass?.ToDisplayString(), Constants.GrainInterfaceTypeAttributeFullyQualifiedName, StringComparison.Ordinal)
+                && attribute.ConstructorArguments.Length > 0
+                && attribute.ConstructorArguments[0].Value is string value)
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    private sealed class ContractBlock
+    {
+        public ContractBlock(string name, string declaration, string? clrComment)
+        {
+            Name = name;
+            Declaration = declaration;
+            ClrComment = clrComment;
+        }
+
+        public string Name { get; }
+
+        public string Declaration { get; }
+
+        public string? ClrComment { get; }
+
+        public List<(string Signature, string Line, string? ClrComment)> Members { get; } = new();
+
+        public List<string> OtherLines { get; } = new();
     }
 }

--- a/src/Orleans.Analyzers/Orleans.Analyzers.csproj
+++ b/src/Orleans.Analyzers/Orleans.Analyzers.csproj
@@ -29,7 +29,17 @@
       <PackagePath>%(Identity)</PackagePath>
       <Visible>true</Visible>
     </Content>
+    <Content Include="build\Microsoft.Orleans.Analyzers.targets">
+      <Pack>true</Pack>
+      <PackagePath>%(Identity)</PackagePath>
+      <Visible>true</Visible>
+    </Content>
     <Content Include="buildTransitive\Microsoft.Orleans.Analyzers.props">
+      <Pack>true</Pack>
+      <PackagePath>%(Identity)</PackagePath>
+      <Visible>true</Visible>
+    </Content>
+    <Content Include="buildTransitive\Microsoft.Orleans.Analyzers.targets">
       <Pack>true</Pack>
       <PackagePath>%(Identity)</PackagePath>
       <Visible>true</Visible>

--- a/src/Orleans.Analyzers/Orleans.Analyzers.csproj
+++ b/src/Orleans.Analyzers/Orleans.Analyzers.csproj
@@ -24,6 +24,19 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="build\Microsoft.Orleans.Analyzers.props">
+      <Pack>true</Pack>
+      <PackagePath>%(Identity)</PackagePath>
+      <Visible>true</Visible>
+    </Content>
+    <Content Include="buildTransitive\Microsoft.Orleans.Analyzers.props">
+      <Pack>true</Pack>
+      <PackagePath>%(Identity)</PackagePath>
+      <Visible>true</Visible>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Orleans.Analyzers/Resources.Designer.cs
+++ b/src/Orleans.Analyzers/Resources.Designer.cs
@@ -293,5 +293,193 @@ namespace Orleans.Analyzers {
                 return ResourceManager.GetString("ConfigureAwaitCodeFixTitle", resourceCulture);
             }
         }
+        /// <summary>
+        ///   Looks up a localized string similar to Add to GrainInterfaces.txt.
+        /// </summary>
+        internal static string AddToGrainInterfacesFileTitle {
+            get {
+                return ResourceManager.GetString("AddToGrainInterfacesFileTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Each grain interface should only be declared once in GrainInterfaces.txt..
+        /// </summary>
+        internal static string GrainInterfaceDuplicateDeclarationDescription {
+            get {
+                return ResourceManager.GetString("GrainInterfaceDuplicateDeclarationDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Grain interface '{0}' is declared multiple times in GrainInterfaces.txt.
+        /// </summary>
+        internal static string GrainInterfaceDuplicateDeclarationMessageFormat {
+            get {
+                return ResourceManager.GetString("GrainInterfaceDuplicateDeclarationMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Duplicate grain interface declaration.
+        /// </summary>
+        internal static string GrainInterfaceDuplicateDeclarationTitle {
+            get {
+                return ResourceManager.GetString("GrainInterfaceDuplicateDeclarationTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When adding or modifying grain interface members, update GrainInterfaces.txt and increment the interface version..
+        /// </summary>
+        internal static string GrainInterfaceMemberNotDeclaredDescription {
+            get {
+                return ResourceManager.GetString("GrainInterfaceMemberNotDeclaredDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Grain interface member '{0}' is not declared in GrainInterfaces.txt for interface '{1}'.
+        /// </summary>
+        internal static string GrainInterfaceMemberNotDeclaredMessageFormat {
+            get {
+                return ResourceManager.GetString("GrainInterfaceMemberNotDeclaredMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Grain interface member not declared in GrainInterfaces.txt.
+        /// </summary>
+        internal static string GrainInterfaceMemberNotDeclaredTitle {
+            get {
+                return ResourceManager.GetString("GrainInterfaceMemberNotDeclaredTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All grain interfaces should be tracked in GrainInterfaces.txt to ensure version compatibility during rolling upgrades..
+        /// </summary>
+        internal static string GrainInterfaceNotDeclaredDescription {
+            get {
+                return ResourceManager.GetString("GrainInterfaceNotDeclaredDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Grain interface '{0}' is not declared in GrainInterfaces.txt.
+        /// </summary>
+        internal static string GrainInterfaceNotDeclaredMessageFormat {
+            get {
+                return ResourceManager.GetString("GrainInterfaceNotDeclaredMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Grain interface not declared in GrainInterfaces.txt.
+        /// </summary>
+        internal static string GrainInterfaceNotDeclaredTitle {
+            get {
+                return ResourceManager.GetString("GrainInterfaceNotDeclaredTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When removing a grain interface, mark it as *RETIRED* in GrainInterfaces.txt to document that it has been intentionally removed..
+        /// </summary>
+        internal static string GrainInterfaceRemovedNotRetiredDescription {
+            get {
+                return ResourceManager.GetString("GrainInterfaceRemovedNotRetiredDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Grain interface '{0}' is declared in GrainInterfaces.txt but no longer exists in code - mark it as *RETIRED*.
+        /// </summary>
+        internal static string GrainInterfaceRemovedNotRetiredMessageFormat {
+            get {
+                return ResourceManager.GetString("GrainInterfaceRemovedNotRetiredMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removed grain interface not marked as retired.
+        /// </summary>
+        internal static string GrainInterfaceRemovedNotRetiredTitle {
+            get {
+                return ResourceManager.GetString("GrainInterfaceRemovedNotRetiredTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add a GrainInterfaces.txt file to track grain interface versions for compatibility during rolling upgrades..
+        /// </summary>
+        internal static string GrainInterfacesFileMissingDescription {
+            get {
+                return ResourceManager.GetString("GrainInterfacesFileMissingDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The project contains grain interfaces but no {0} file to track them.
+        /// </summary>
+        internal static string GrainInterfacesFileMissingMessageFormat {
+            get {
+                return ResourceManager.GetString("GrainInterfacesFileMissingMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to GrainInterfaces.txt file is missing.
+        /// </summary>
+        internal static string GrainInterfacesFileMissingTitle {
+            get {
+                return ResourceManager.GetString("GrainInterfacesFileMissingTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The [Version] attribute on the grain interface must match the version declared in GrainInterfaces.txt..
+        /// </summary>
+        internal static string GrainInterfaceVersionMismatchDescription {
+            get {
+                return ResourceManager.GetString("GrainInterfaceVersionMismatchDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Grain interface '{0}' has [Version({1})] in GrainInterfaces.txt but [Version({2})] in code.
+        /// </summary>
+        internal static string GrainInterfaceVersionMismatchMessageFormat {
+            get {
+                return ResourceManager.GetString("GrainInterfaceVersionMismatchMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Grain interface version mismatch.
+        /// </summary>
+        internal static string GrainInterfaceVersionMismatchTitle {
+            get {
+                return ResourceManager.GetString("GrainInterfaceVersionMismatchTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Mark as *RETIRED* in GrainInterfaces.txt.
+        /// </summary>
+        internal static string RetireGrainInterfaceTitle {
+            get {
+                return ResourceManager.GetString("RetireGrainInterfaceTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update version in GrainInterfaces.txt.
+        /// </summary>
+        internal static string UpdateGrainInterfaceVersionTitle {
+            get {
+                return ResourceManager.GetString("UpdateGrainInterfaceVersionTitle", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Orleans.Analyzers/Resources.Designer.cs
+++ b/src/Orleans.Analyzers/Resources.Designer.cs
@@ -294,16 +294,16 @@ namespace Orleans.Analyzers {
             }
         }
         /// <summary>
-        ///   Looks up a localized string similar to Add to GrainInterfaces.txt.
+        ///   Looks up a localized string similar to Add to OrleansContracts.txt.
         /// </summary>
-        internal static string AddToGrainInterfacesFileTitle {
+        internal static string AddToOrleansContractsFileTitle {
             get {
-                return ResourceManager.GetString("AddToGrainInterfacesFileTitle", resourceCulture);
+                return ResourceManager.GetString("AddToOrleansContractsFileTitle", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Each grain interface should only be declared once in GrainInterfaces.txt..
+        ///   Looks up a localized string similar to Each grain interface should only be declared once in OrleansContracts.txt..
         /// </summary>
         internal static string GrainInterfaceDuplicateDeclarationDescription {
             get {
@@ -312,7 +312,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Grain interface '{0}' is declared multiple times in GrainInterfaces.txt.
+        ///   Looks up a localized string similar to Grain interface '{0}' is declared multiple times in OrleansContracts.txt.
         /// </summary>
         internal static string GrainInterfaceDuplicateDeclarationMessageFormat {
             get {
@@ -330,7 +330,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to When adding or modifying grain interface members, update GrainInterfaces.txt and increment the interface version..
+        ///   Looks up a localized string similar to When adding or modifying grain interface members, update OrleansContracts.txt and increment the interface version..
         /// </summary>
         internal static string GrainInterfaceMemberNotDeclaredDescription {
             get {
@@ -339,7 +339,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Grain interface member '{0}' is not declared in GrainInterfaces.txt for interface '{1}'.
+        ///   Looks up a localized string similar to Grain interface member '{0}' is not declared in OrleansContracts.txt for interface '{1}'.
         /// </summary>
         internal static string GrainInterfaceMemberNotDeclaredMessageFormat {
             get {
@@ -348,7 +348,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Grain interface member not declared in GrainInterfaces.txt.
+        ///   Looks up a localized string similar to Grain interface member not declared in OrleansContracts.txt.
         /// </summary>
         internal static string GrainInterfaceMemberNotDeclaredTitle {
             get {
@@ -357,7 +357,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All grain interfaces should be tracked in GrainInterfaces.txt to ensure version compatibility during rolling upgrades..
+        ///   Looks up a localized string similar to All grain interfaces should have an active declaration in OrleansContracts.txt to ensure version compatibility during rolling upgrades..
         /// </summary>
         internal static string GrainInterfaceNotDeclaredDescription {
             get {
@@ -366,7 +366,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Grain interface '{0}' is not declared in GrainInterfaces.txt.
+        ///   Looks up a localized string similar to Grain interface '{0}' does not have an active declaration in OrleansContracts.txt.
         /// </summary>
         internal static string GrainInterfaceNotDeclaredMessageFormat {
             get {
@@ -375,7 +375,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Grain interface not declared in GrainInterfaces.txt.
+        ///   Looks up a localized string similar to Grain interface is not active in OrleansContracts.txt.
         /// </summary>
         internal static string GrainInterfaceNotDeclaredTitle {
             get {
@@ -384,7 +384,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to When removing a grain interface, mark it as *RETIRED* in GrainInterfaces.txt to document that it has been intentionally removed..
+        ///   Looks up a localized string similar to When removing a grain interface, mark it as *RETIRED* in OrleansContracts.txt to document that it has been intentionally removed..
         /// </summary>
         internal static string GrainInterfaceRemovedNotRetiredDescription {
             get {
@@ -393,7 +393,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Grain interface '{0}' is declared in GrainInterfaces.txt but no longer exists in code - mark it as *RETIRED*.
+        ///   Looks up a localized string similar to Grain interface '{0}' is declared in OrleansContracts.txt but no longer exists in code - mark it as *RETIRED*.
         /// </summary>
         internal static string GrainInterfaceRemovedNotRetiredMessageFormat {
             get {
@@ -411,34 +411,34 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add a GrainInterfaces.txt file to track grain interface versions for compatibility during rolling upgrades..
+        ///   Looks up a localized string similar to Add an OrleansContracts.txt file to track Orleans contracts for compatibility during rolling upgrades..
         /// </summary>
-        internal static string GrainInterfacesFileMissingDescription {
+        internal static string OrleansContractsFileMissingDescription {
             get {
-                return ResourceManager.GetString("GrainInterfacesFileMissingDescription", resourceCulture);
+                return ResourceManager.GetString("OrleansContractsFileMissingDescription", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to The project contains grain interfaces but no {0} file to track them.
         /// </summary>
-        internal static string GrainInterfacesFileMissingMessageFormat {
+        internal static string OrleansContractsFileMissingMessageFormat {
             get {
-                return ResourceManager.GetString("GrainInterfacesFileMissingMessageFormat", resourceCulture);
+                return ResourceManager.GetString("OrleansContractsFileMissingMessageFormat", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to GrainInterfaces.txt file is missing.
+        ///   Looks up a localized string similar to OrleansContracts.txt file is missing.
         /// </summary>
-        internal static string GrainInterfacesFileMissingTitle {
+        internal static string OrleansContractsFileMissingTitle {
             get {
-                return ResourceManager.GetString("GrainInterfacesFileMissingTitle", resourceCulture);
+                return ResourceManager.GetString("OrleansContractsFileMissingTitle", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The [Version] attribute on the grain interface must match the version declared in GrainInterfaces.txt..
+        ///   Looks up a localized string similar to The [Version] attribute on the grain interface must match the version declared in OrleansContracts.txt..
         /// </summary>
         internal static string GrainInterfaceVersionMismatchDescription {
             get {
@@ -447,7 +447,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Grain interface '{0}' has [Version({1})] in GrainInterfaces.txt but [Version({2})] in code.
+        ///   Looks up a localized string similar to Grain interface '{0}' has [Version({1})] in OrleansContracts.txt but [Version({2})] in code.
         /// </summary>
         internal static string GrainInterfaceVersionMismatchMessageFormat {
             get {
@@ -465,7 +465,7 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Mark as *RETIRED* in GrainInterfaces.txt.
+        ///   Looks up a localized string similar to Mark as *RETIRED* in OrleansContracts.txt.
         /// </summary>
         internal static string RetireGrainInterfaceTitle {
             get {
@@ -474,11 +474,95 @@ namespace Orleans.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Update version in GrainInterfaces.txt.
+        ///   Looks up a localized string similar to Update version in OrleansContracts.txt.
         /// </summary>
         internal static string UpdateGrainInterfaceVersionTitle {
             get {
                 return ResourceManager.GetString("UpdateGrainInterfaceVersionTitle", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassNotDeclaredTitle {
+            get {
+                return ResourceManager.GetString("GrainClassNotDeclaredTitle", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassNotDeclaredMessageFormat {
+            get {
+                return ResourceManager.GetString("GrainClassNotDeclaredMessageFormat", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassNotDeclaredDescription {
+            get {
+                return ResourceManager.GetString("GrainClassNotDeclaredDescription", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassAliasMismatchTitle {
+            get {
+                return ResourceManager.GetString("GrainClassAliasMismatchTitle", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassAliasMismatchMessageFormat {
+            get {
+                return ResourceManager.GetString("GrainClassAliasMismatchMessageFormat", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassAliasMismatchDescription {
+            get {
+                return ResourceManager.GetString("GrainClassAliasMismatchDescription", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassRemovedNotRetiredTitle {
+            get {
+                return ResourceManager.GetString("GrainClassRemovedNotRetiredTitle", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassRemovedNotRetiredMessageFormat {
+            get {
+                return ResourceManager.GetString("GrainClassRemovedNotRetiredMessageFormat", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassRemovedNotRetiredDescription {
+            get {
+                return ResourceManager.GetString("GrainClassRemovedNotRetiredDescription", resourceCulture);
+            }
+        }
+
+        internal static string UpdateGrainClassAliasTitle {
+            get {
+                return ResourceManager.GetString("UpdateGrainClassAliasTitle", resourceCulture);
+            }
+        }
+
+        internal static string RetireGrainClassTitle {
+            get {
+                return ResourceManager.GetString("RetireGrainClassTitle", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassDuplicateDeclarationTitle {
+            get {
+                return ResourceManager.GetString("GrainClassDuplicateDeclarationTitle", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassDuplicateDeclarationMessageFormat {
+            get {
+                return ResourceManager.GetString("GrainClassDuplicateDeclarationMessageFormat", resourceCulture);
+            }
+        }
+
+        internal static string GrainClassDuplicateDeclarationDescription {
+            get {
+                return ResourceManager.GetString("GrainClassDuplicateDeclarationDescription", resourceCulture);
             }
         }
     }

--- a/src/Orleans.Analyzers/Resources.resx
+++ b/src/Orleans.Analyzers/Resources.resx
@@ -195,4 +195,68 @@
   <data name="ConfigureAwaitCodeFixTitle" xml:space="preserve">
     <value>Use ConfigureAwait with ContinueOnCapturedContext</value>
   </data>
+  <!-- Grain Interface Version Analyzer (ORLEANS0016-0021) -->
+  <data name="GrainInterfaceNotDeclaredTitle" xml:space="preserve">
+    <value>Grain interface not declared in GrainInterfaces.txt</value>
+  </data>
+  <data name="GrainInterfaceNotDeclaredMessageFormat" xml:space="preserve">
+    <value>Grain interface '{0}' is not declared in GrainInterfaces.txt</value>
+  </data>
+  <data name="GrainInterfaceNotDeclaredDescription" xml:space="preserve">
+    <value>All grain interfaces should be tracked in GrainInterfaces.txt to ensure version compatibility during rolling upgrades.</value>
+  </data>
+  <data name="GrainInterfaceVersionMismatchTitle" xml:space="preserve">
+    <value>Grain interface version mismatch</value>
+  </data>
+  <data name="GrainInterfaceVersionMismatchMessageFormat" xml:space="preserve">
+    <value>Grain interface '{0}' has [Version({1})] in GrainInterfaces.txt but [Version({2})] in code</value>
+  </data>
+  <data name="GrainInterfaceVersionMismatchDescription" xml:space="preserve">
+    <value>The [Version] attribute on the grain interface must match the version declared in GrainInterfaces.txt.</value>
+  </data>
+  <data name="GrainInterfaceMemberNotDeclaredTitle" xml:space="preserve">
+    <value>Grain interface member not declared in GrainInterfaces.txt</value>
+  </data>
+  <data name="GrainInterfaceMemberNotDeclaredMessageFormat" xml:space="preserve">
+    <value>Grain interface member '{0}' is not declared in GrainInterfaces.txt for interface '{1}'</value>
+  </data>
+  <data name="GrainInterfaceMemberNotDeclaredDescription" xml:space="preserve">
+    <value>When adding or modifying grain interface members, update GrainInterfaces.txt and increment the interface version.</value>
+  </data>
+  <data name="GrainInterfaceRemovedNotRetiredTitle" xml:space="preserve">
+    <value>Removed grain interface not marked as retired</value>
+  </data>
+  <data name="GrainInterfaceRemovedNotRetiredMessageFormat" xml:space="preserve">
+    <value>Grain interface '{0}' is declared in GrainInterfaces.txt but no longer exists in code - mark it as *RETIRED*</value>
+  </data>
+  <data name="GrainInterfaceRemovedNotRetiredDescription" xml:space="preserve">
+    <value>When removing a grain interface, mark it as *RETIRED* in GrainInterfaces.txt to document that it has been intentionally removed.</value>
+  </data>
+  <data name="GrainInterfacesFileMissingTitle" xml:space="preserve">
+    <value>GrainInterfaces.txt file is missing</value>
+  </data>
+  <data name="GrainInterfacesFileMissingMessageFormat" xml:space="preserve">
+    <value>The project contains grain interfaces but no {0} file to track them</value>
+  </data>
+  <data name="GrainInterfacesFileMissingDescription" xml:space="preserve">
+    <value>Add a GrainInterfaces.txt file to track grain interface versions for compatibility during rolling upgrades.</value>
+  </data>
+  <data name="GrainInterfaceDuplicateDeclarationTitle" xml:space="preserve">
+    <value>Duplicate grain interface declaration</value>
+  </data>
+  <data name="GrainInterfaceDuplicateDeclarationMessageFormat" xml:space="preserve">
+    <value>Grain interface '{0}' is declared multiple times in GrainInterfaces.txt</value>
+  </data>
+  <data name="GrainInterfaceDuplicateDeclarationDescription" xml:space="preserve">
+    <value>Each grain interface should only be declared once in GrainInterfaces.txt.</value>
+  </data>
+  <data name="AddToGrainInterfacesFileTitle" xml:space="preserve">
+    <value>Add to GrainInterfaces.txt</value>
+  </data>
+  <data name="RetireGrainInterfaceTitle" xml:space="preserve">
+    <value>Mark as *RETIRED* in GrainInterfaces.txt</value>
+  </data>
+  <data name="UpdateGrainInterfaceVersionTitle" xml:space="preserve">
+    <value>Update version in GrainInterfaces.txt</value>
+  </data>
 </root>

--- a/src/Orleans.Analyzers/Resources.resx
+++ b/src/Orleans.Analyzers/Resources.resx
@@ -197,66 +197,108 @@
   </data>
   <!-- Grain Interface Version Analyzer (ORLEANS0016-0021) -->
   <data name="GrainInterfaceNotDeclaredTitle" xml:space="preserve">
-    <value>Grain interface not declared in GrainInterfaces.txt</value>
+    <value>Grain interface is not active in OrleansContracts.txt</value>
   </data>
   <data name="GrainInterfaceNotDeclaredMessageFormat" xml:space="preserve">
-    <value>Grain interface '{0}' is not declared in GrainInterfaces.txt</value>
+    <value>Grain interface '{0}' does not have an active declaration in OrleansContracts.txt</value>
   </data>
   <data name="GrainInterfaceNotDeclaredDescription" xml:space="preserve">
-    <value>All grain interfaces should be tracked in GrainInterfaces.txt to ensure version compatibility during rolling upgrades.</value>
+    <value>All grain interfaces should have an active declaration in OrleansContracts.txt to ensure version compatibility during rolling upgrades.</value>
   </data>
   <data name="GrainInterfaceVersionMismatchTitle" xml:space="preserve">
     <value>Grain interface version mismatch</value>
   </data>
   <data name="GrainInterfaceVersionMismatchMessageFormat" xml:space="preserve">
-    <value>Grain interface '{0}' has [Version({1})] in GrainInterfaces.txt but [Version({2})] in code</value>
+    <value>Grain interface '{0}' has [Version({1})] in OrleansContracts.txt but [Version({2})] in code</value>
   </data>
   <data name="GrainInterfaceVersionMismatchDescription" xml:space="preserve">
-    <value>The [Version] attribute on the grain interface must match the version declared in GrainInterfaces.txt.</value>
+    <value>The [Version] attribute on the grain interface must match the version declared in OrleansContracts.txt.</value>
   </data>
   <data name="GrainInterfaceMemberNotDeclaredTitle" xml:space="preserve">
-    <value>Grain interface member not declared in GrainInterfaces.txt</value>
+    <value>Grain interface member not declared in OrleansContracts.txt</value>
   </data>
   <data name="GrainInterfaceMemberNotDeclaredMessageFormat" xml:space="preserve">
-    <value>Grain interface member '{0}' is not declared in GrainInterfaces.txt for interface '{1}'</value>
+    <value>Grain interface member '{0}' is not declared in OrleansContracts.txt for interface '{1}'</value>
   </data>
   <data name="GrainInterfaceMemberNotDeclaredDescription" xml:space="preserve">
-    <value>When adding or modifying grain interface members, update GrainInterfaces.txt and increment the interface version.</value>
+    <value>When adding or modifying grain interface members, update OrleansContracts.txt and increment the interface version.</value>
   </data>
   <data name="GrainInterfaceRemovedNotRetiredTitle" xml:space="preserve">
     <value>Removed grain interface not marked as retired</value>
   </data>
   <data name="GrainInterfaceRemovedNotRetiredMessageFormat" xml:space="preserve">
-    <value>Grain interface '{0}' is declared in GrainInterfaces.txt but no longer exists in code - mark it as *RETIRED*</value>
+    <value>Grain interface '{0}' is declared in OrleansContracts.txt but no longer exists in code - mark it as *RETIRED*</value>
   </data>
   <data name="GrainInterfaceRemovedNotRetiredDescription" xml:space="preserve">
-    <value>When removing a grain interface, mark it as *RETIRED* in GrainInterfaces.txt to document that it has been intentionally removed.</value>
+    <value>When removing a grain interface, mark it as *RETIRED* in OrleansContracts.txt to document that it has been intentionally removed.</value>
   </data>
-  <data name="GrainInterfacesFileMissingTitle" xml:space="preserve">
-    <value>GrainInterfaces.txt file is missing</value>
+  <data name="OrleansContractsFileMissingTitle" xml:space="preserve">
+    <value>OrleansContracts.txt file is missing</value>
   </data>
-  <data name="GrainInterfacesFileMissingMessageFormat" xml:space="preserve">
+  <data name="OrleansContractsFileMissingMessageFormat" xml:space="preserve">
     <value>The project contains grain interfaces but no {0} file to track them</value>
   </data>
-  <data name="GrainInterfacesFileMissingDescription" xml:space="preserve">
-    <value>Add a GrainInterfaces.txt file to track grain interface versions for compatibility during rolling upgrades.</value>
+  <data name="OrleansContractsFileMissingDescription" xml:space="preserve">
+    <value>Add an OrleansContracts.txt file to track Orleans contracts for compatibility during rolling upgrades.</value>
   </data>
   <data name="GrainInterfaceDuplicateDeclarationTitle" xml:space="preserve">
     <value>Duplicate grain interface declaration</value>
   </data>
   <data name="GrainInterfaceDuplicateDeclarationMessageFormat" xml:space="preserve">
-    <value>Grain interface '{0}' is declared multiple times in GrainInterfaces.txt</value>
+    <value>Grain interface '{0}' is declared multiple times in OrleansContracts.txt</value>
   </data>
   <data name="GrainInterfaceDuplicateDeclarationDescription" xml:space="preserve">
-    <value>Each grain interface should only be declared once in GrainInterfaces.txt.</value>
+    <value>Each grain interface should only be declared once in OrleansContracts.txt.</value>
   </data>
-  <data name="AddToGrainInterfacesFileTitle" xml:space="preserve">
-    <value>Add to GrainInterfaces.txt</value>
+  <data name="AddToOrleansContractsFileTitle" xml:space="preserve">
+    <value>Add to OrleansContracts.txt</value>
   </data>
   <data name="RetireGrainInterfaceTitle" xml:space="preserve">
-    <value>Mark as *RETIRED* in GrainInterfaces.txt</value>
+    <value>Mark as *RETIRED* in OrleansContracts.txt</value>
   </data>
   <data name="UpdateGrainInterfaceVersionTitle" xml:space="preserve">
-    <value>Update version in GrainInterfaces.txt</value>
+    <value>Update version in OrleansContracts.txt</value>
+  </data>
+  <data name="GrainClassNotDeclaredTitle" xml:space="preserve">
+    <value>Grain class is not active in OrleansContracts.txt</value>
+  </data>
+  <data name="GrainClassNotDeclaredMessageFormat" xml:space="preserve">
+    <value>Grain class '{0}' does not have an active declaration in OrleansContracts.txt</value>
+  </data>
+  <data name="GrainClassNotDeclaredDescription" xml:space="preserve">
+    <value>All concrete grain classes should have an active declaration in OrleansContracts.txt to protect grain type identities during renames.</value>
+  </data>
+  <data name="GrainClassAliasMismatchTitle" xml:space="preserve">
+    <value>Grain class alias mismatch</value>
+  </data>
+  <data name="GrainClassAliasMismatchMessageFormat" xml:space="preserve">
+    <value>Grain class '{0}' has alias '{1}' in OrleansContracts.txt but alias '{2}' in code</value>
+  </data>
+  <data name="GrainClassAliasMismatchDescription" xml:space="preserve">
+    <value>The [GrainType] attribute on a grain class must match the alias declared in OrleansContracts.txt.</value>
+  </data>
+  <data name="GrainClassRemovedNotRetiredTitle" xml:space="preserve">
+    <value>Removed grain class not marked as retired</value>
+  </data>
+  <data name="GrainClassRemovedNotRetiredMessageFormat" xml:space="preserve">
+    <value>Grain class '{0}' is declared in OrleansContracts.txt but no longer exists in code - mark it as *RETIRED*</value>
+  </data>
+  <data name="GrainClassRemovedNotRetiredDescription" xml:space="preserve">
+    <value>When removing a grain class, mark it as *RETIRED* in OrleansContracts.txt to preserve its contract history.</value>
+  </data>
+  <data name="UpdateGrainClassAliasTitle" xml:space="preserve">
+    <value>Update grain class alias in OrleansContracts.txt</value>
+  </data>
+  <data name="RetireGrainClassTitle" xml:space="preserve">
+    <value>Mark grain class as *RETIRED* in OrleansContracts.txt</value>
+  </data>
+  <data name="GrainClassDuplicateDeclarationTitle" xml:space="preserve">
+    <value>Duplicate grain class declaration</value>
+  </data>
+  <data name="GrainClassDuplicateDeclarationMessageFormat" xml:space="preserve">
+    <value>Grain class '{0}' is declared multiple times in OrleansContracts.txt</value>
+  </data>
+  <data name="GrainClassDuplicateDeclarationDescription" xml:space="preserve">
+    <value>Each grain class should only be declared once in OrleansContracts.txt.</value>
   </data>
 </root>

--- a/src/Orleans.Analyzers/build/Microsoft.Orleans.Analyzers.props
+++ b/src/Orleans.Analyzers/build/Microsoft.Orleans.Analyzers.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <OrleansContractsPath Condition="'$(OrleansContractsPath)' == ''">$(MSBuildProjectDirectory)\OrleansContracts.txt</OrleansContractsPath>
+  </PropertyGroup>
+  <ItemGroup Condition="Exists('$(OrleansContractsPath)')">
+    <AdditionalFiles Include="$(OrleansContractsPath)" OrleansContractsFile="true" />
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="OrleansContractsFile" />
+  </ItemGroup>
+</Project>

--- a/src/Orleans.Analyzers/build/Microsoft.Orleans.Analyzers.props
+++ b/src/Orleans.Analyzers/build/Microsoft.Orleans.Analyzers.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
+    <EnableOrleansContractsAnalyzer Condition="'$(EnableOrleansContractsAnalyzer)' == ''">false</EnableOrleansContractsAnalyzer>
     <OrleansContractsPath Condition="'$(OrleansContractsPath)' == ''">$(MSBuildProjectDirectory)\OrleansContracts.txt</OrleansContractsPath>
   </PropertyGroup>
-  <ItemGroup Condition="Exists('$(OrleansContractsPath)')">
-    <AdditionalFiles Include="$(OrleansContractsPath)" OrleansContractsFile="true" />
-    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="OrleansContractsFile" />
+  <ItemGroup>
+    <CompilerVisibleProperty Include="EnableOrleansContractsAnalyzer" />
   </ItemGroup>
 </Project>

--- a/src/Orleans.Analyzers/build/Microsoft.Orleans.Analyzers.targets
+++ b/src/Orleans.Analyzers/build/Microsoft.Orleans.Analyzers.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup Condition="'$(EnableOrleansContractsAnalyzer)' == 'true' and Exists('$(OrleansContractsPath)')">
+    <AdditionalFiles Include="$(OrleansContractsPath)" OrleansContractsFile="true" />
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="OrleansContractsFile" />
+  </ItemGroup>
+</Project>

--- a/src/Orleans.Analyzers/buildTransitive/Microsoft.Orleans.Analyzers.props
+++ b/src/Orleans.Analyzers/buildTransitive/Microsoft.Orleans.Analyzers.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\build\Microsoft.Orleans.Analyzers.props" />
+</Project>

--- a/src/Orleans.Analyzers/buildTransitive/Microsoft.Orleans.Analyzers.targets
+++ b/src/Orleans.Analyzers/buildTransitive/Microsoft.Orleans.Analyzers.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\build\Microsoft.Orleans.Analyzers.targets" />
+</Project>

--- a/src/Orleans.BroadcastChannel/OrleansContracts.txt
+++ b/src/Orleans.BroadcastChannel/OrleansContracts.txt
@@ -1,0 +1,3 @@
+interface Orleans.BroadcastChannel.IBroadcastChannelConsumerExtension [Version(0)]
+  OnError(Orleans.BroadcastChannel.InternalChannelId, System.Exception) -> Task
+  OnPublished(Orleans.BroadcastChannel.InternalChannelId, object) -> Task

--- a/src/Orleans.Core.Abstractions/OrleansContracts.txt
+++ b/src/Orleans.Core.Abstractions/OrleansContracts.txt
@@ -1,0 +1,33 @@
+interface Orleans.Core.Internal.IGrainManagementExtension [Version(0)]
+  DeactivateOnIdle() -> ValueTask
+  MigrateOnIdle() -> ValueTask
+
+interface Orleans.IGrain [Version(0)]
+
+interface Orleans.IGrainObserver [Version(0)]
+
+interface Orleans.IGrainWithGuidCompoundKey [Version(0)]
+
+interface Orleans.IGrainWithGuidKey [Version(0)]
+
+interface Orleans.IGrainWithIntegerCompoundKey [Version(0)]
+
+interface Orleans.IGrainWithIntegerKey [Version(0)]
+
+interface Orleans.IGrainWithStringKey [Version(0)]
+
+interface Orleans.ISystemTarget [Version(0)]
+
+interface Orleans.Runtime.IAsyncEnumerableGrainExtension [Version(0)]
+  DisposeAsync(System.Guid) -> ValueTask
+  MoveNext(System.Guid) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+  MoveNext(System.Guid, System.Threading.CancellationToken) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+  StartEnumeration(System.Guid, Orleans.Runtime.IAsyncEnumerableRequest<T>) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+  StartEnumeration(System.Guid, Orleans.Runtime.IAsyncEnumerableRequest<T>, System.Threading.CancellationToken) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+
+interface Orleans.Runtime.ICancellationSourcesExtension [Version(0)]
+  CancelRemoteToken(System.Guid) -> Task
+
+interface Orleans.Runtime.IGrainExtension [Version(0)]
+
+interface Orleans.Services.IGrainService [Version(0)]

--- a/src/Orleans.Core.Abstractions/OrleansContracts.txt
+++ b/src/Orleans.Core.Abstractions/OrleansContracts.txt
@@ -20,10 +20,10 @@ interface Orleans.ISystemTarget [Version(0)]
 
 interface Orleans.Runtime.IAsyncEnumerableGrainExtension [Version(0)]
   DisposeAsync(System.Guid) -> ValueTask
-  MoveNext(System.Guid) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
-  MoveNext(System.Guid, System.Threading.CancellationToken) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
-  StartEnumeration(System.Guid, Orleans.Runtime.IAsyncEnumerableRequest<T>) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
-  StartEnumeration(System.Guid, Orleans.Runtime.IAsyncEnumerableRequest<T>, System.Threading.CancellationToken) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+  MoveNext`1(System.Guid) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+  MoveNext`1(System.Guid, System.Threading.CancellationToken) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+  StartEnumeration`1(System.Guid, Orleans.Runtime.IAsyncEnumerableRequest<T>) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
+  StartEnumeration`1(System.Guid, Orleans.Runtime.IAsyncEnumerableRequest<T>, System.Threading.CancellationToken) -> ValueTask<(Orleans.Runtime.EnumerationResult, object?)>
 
 interface Orleans.Runtime.ICancellationSourcesExtension [Version(0)]
   CancelRemoteToken(System.Guid) -> Task

--- a/src/Orleans.Core/OrleansContracts.txt
+++ b/src/Orleans.Core/OrleansContracts.txt
@@ -16,7 +16,7 @@ interface Orleans.ISiloControl [Version(0)]
   GetSimpleGrainStatistics() -> Task<Orleans.Runtime.SimpleGrainStatistic[]>
   MigrateRandomActivations(Orleans.Runtime.SiloAddress, int) -> Task
   Ping(string) -> Task
-  SendControlCommandToProvider(string, int, object?) -> Task<object?>
+  SendControlCommandToProvider`1(string, int, object?) -> Task<object?>
 
 interface Orleans.Placement.Rebalancing.IActivationRebalancerMonitor [Version(0)]
   Report(RebalancingReport) -> Task
@@ -63,7 +63,7 @@ interface Orleans.Runtime.IManagementGrain [Version(0)]
   GetSimpleGrainStatistics(Orleans.Runtime.SiloAddress[]) -> Task<Orleans.Runtime.SimpleGrainStatistic[]>
   GetTotalActivationCount() -> Task<int>
   ResetGrainCallFrequencies(Orleans.Runtime.SiloAddress[]) -> ValueTask
-  SendControlCommandToProvider(string, int, object?) -> Task<object?[]>
+  SendControlCommandToProvider`1(string, int, object?) -> Task<object?[]>
 
 interface Orleans.Runtime.IMembershipService [Version(0)]
   MembershipChangeNotification(Orleans.Runtime.MembershipTableSnapshot) -> Task
@@ -71,6 +71,6 @@ interface Orleans.Runtime.IMembershipService [Version(0)]
   ProbeIndirectly(Orleans.Runtime.SiloAddress, System.TimeSpan, int) -> Task<Orleans.Runtime.IndirectProbeResponse>
 
 interface Orleans.Storage.IMemoryStorageGrain [Version(0)]
-  DeleteStateAsync(string, string?) -> Task
-  ReadStateAsync(string) -> Task<Orleans.IGrainState<T>>
-  WriteStateAsync(string, Orleans.IGrainState<T>) -> Task<string>
+  DeleteStateAsync`1(string, string?) -> Task
+  ReadStateAsync`1(string) -> Task<Orleans.IGrainState<T>>
+  WriteStateAsync`1(string, Orleans.IGrainState<T>) -> Task<string>

--- a/src/Orleans.Core/OrleansContracts.txt
+++ b/src/Orleans.Core/OrleansContracts.txt
@@ -1,0 +1,76 @@
+interface Orleans.ClientObservers.IClientGatewayObserver [Version(0)]
+  StopSendingToGateway(Orleans.Runtime.SiloAddress) -> void
+
+interface Orleans.IMembershipTableSystemTarget [Version(0)]
+
+interface Orleans.ISiloControl [Version(0)]
+  ForceActivationCollection(System.TimeSpan) -> Task
+  ForceGarbageCollection() -> Task
+  ForceRuntimeStatisticsCollection() -> Task
+  GetActivationCount() -> Task<int>
+  GetActiveGrains(Orleans.Runtime.GrainType) -> Task<System.Collections.Generic.List<Orleans.Runtime.GrainId>>
+  GetDetailedGrainReport(Orleans.Runtime.GrainId) -> Task<Orleans.Runtime.DetailedGrainReport>
+  GetDetailedGrainStatistics(string[]) -> Task<System.Collections.Generic.List<Orleans.Runtime.DetailedGrainStatistic>>
+  GetGrainStatistics() -> Task<System.Collections.Generic.List<System.Tuple<Orleans.Runtime.GrainId, string, int>>>
+  GetRuntimeStatistics() -> Task<Orleans.Runtime.SiloRuntimeStatistics>
+  GetSimpleGrainStatistics() -> Task<Orleans.Runtime.SimpleGrainStatistic[]>
+  MigrateRandomActivations(Orleans.Runtime.SiloAddress, int) -> Task
+  Ping(string) -> Task
+  SendControlCommandToProvider(string, int, object?) -> Task<object?>
+
+interface Orleans.Placement.Rebalancing.IActivationRebalancerMonitor [Version(0)]
+  Report(RebalancingReport) -> Task
+
+interface Orleans.Placement.Rebalancing.IActivationRebalancerWorker [Version(0)]
+  GetReport() -> ValueTask<RebalancingReport>
+  ResumeRebalancing() -> Task
+  SuspendRebalancing(System.TimeSpan?) -> Task
+
+interface Orleans.Placement.Repartitioning.IActivationRepartitionerSystemTarget [Version(0)]
+  AcceptExchangeRequest(Orleans.Placement.Repartitioning.AcceptExchangeRequest) -> ValueTask<Orleans.Placement.Repartitioning.AcceptExchangeResponse>
+  FlushBuffers() -> ValueTask
+  GetActivationCount() -> ValueTask<int>
+  GetGrainCallFrequencies() -> ValueTask<System.Collections.Immutable.ImmutableArray<(Orleans.Placement.Repartitioning.Edge, ulong)>>
+  ResetCounters() -> ValueTask
+  SetActivationCountOffset(int) -> ValueTask
+  TriggerExchangeRequest() -> ValueTask
+
+interface Orleans.Runtime.IClusterManifestSystemTarget [Version(0)]
+  GetClusterManifest() -> ValueTask<Orleans.Metadata.ClusterManifest>
+  GetClusterManifestUpdate(Orleans.Metadata.MajorMinorVersion) -> ValueTask<Orleans.Runtime.ClusterManifestUpdate?>
+
+interface Orleans.Runtime.IDeploymentLoadPublisher [Version(0)]
+  UpdateRuntimeStatistics(Orleans.Runtime.SiloAddress, Orleans.Runtime.SiloRuntimeStatistics) -> Task
+
+interface Orleans.Runtime.IGrainCallCancellationExtension [Version(0)]
+  CancelRequestAsync(Orleans.Runtime.GrainId, Orleans.Runtime.CorrelationId) -> ValueTask
+
+interface Orleans.Runtime.IManagementGrain [Version(0)]
+  ForceActivationCollection(Orleans.Runtime.SiloAddress[], System.TimeSpan) -> Task
+  ForceActivationCollection(System.TimeSpan) -> Task
+  ForceGarbageCollection(Orleans.Runtime.SiloAddress[]) -> Task
+  ForceRuntimeStatisticsCollection(Orleans.Runtime.SiloAddress[]) -> Task
+  GetActivationAddress(Orleans.Runtime.IAddressable) -> ValueTask<Orleans.Runtime.SiloAddress?>
+  GetActiveGrains(Orleans.Runtime.GrainType) -> ValueTask<System.Collections.Generic.List<Orleans.Runtime.GrainId>>
+  GetDetailedGrainStatistics(string[], Orleans.Runtime.SiloAddress[]) -> Task<Orleans.Runtime.DetailedGrainStatistic[]>
+  GetDetailedHosts(bool) -> Task<Orleans.MembershipEntry[]>
+  # Orleans.Runtime.IManagementGrain.GetGrainActivationCount(GrainReference grainReference) -> Task<int>
+  GetGrainActivationCount(GrainRef) -> Task<int>
+  GetGrainCallFrequencies(Orleans.Runtime.SiloAddress[]) -> Task<System.Collections.Generic.List<Orleans.Runtime.GrainCallFrequency>>
+  GetHosts(bool) -> Task<System.Collections.Generic.Dictionary<Orleans.Runtime.SiloAddress, Orleans.Runtime.SiloStatus>>
+  GetRuntimeStatistics(Orleans.Runtime.SiloAddress[]) -> Task<Orleans.Runtime.SiloRuntimeStatistics[]>
+  GetSimpleGrainStatistics() -> Task<Orleans.Runtime.SimpleGrainStatistic[]>
+  GetSimpleGrainStatistics(Orleans.Runtime.SiloAddress[]) -> Task<Orleans.Runtime.SimpleGrainStatistic[]>
+  GetTotalActivationCount() -> Task<int>
+  ResetGrainCallFrequencies(Orleans.Runtime.SiloAddress[]) -> ValueTask
+  SendControlCommandToProvider(string, int, object?) -> Task<object?[]>
+
+interface Orleans.Runtime.IMembershipService [Version(0)]
+  MembershipChangeNotification(Orleans.Runtime.MembershipTableSnapshot) -> Task
+  Ping(int) -> Task
+  ProbeIndirectly(Orleans.Runtime.SiloAddress, System.TimeSpan, int) -> Task<Orleans.Runtime.IndirectProbeResponse>
+
+interface Orleans.Storage.IMemoryStorageGrain [Version(0)]
+  DeleteStateAsync(string, string?) -> Task
+  ReadStateAsync(string) -> Task<Orleans.IGrainState<T>>
+  WriteStateAsync(string, Orleans.IGrainState<T>) -> Task<string>

--- a/src/Orleans.DurableJobs/OrleansContracts.txt
+++ b/src/Orleans.DurableJobs/OrleansContracts.txt
@@ -1,0 +1,7 @@
+interface Orleans.DurableJobs.IDurableJobReceiverExtension [Version(0)]
+  HandleDurableJobAsync(Orleans.DurableJobs.IJobRunContext, System.Threading.CancellationToken) -> ValueTask<Orleans.DurableJobs.DurableJobRunResult>
+
+interface Orleans.DurableJobs.ILocalDurableJobManagerSystemTarget [Version(0)]
+  TryCancelDurableJobAsync(Orleans.DurableJobs.DurableJob, System.Threading.CancellationToken) -> Task<bool>
+
+class Orleans.DurableJobs.LocalDurableJobManager

--- a/src/Orleans.EventSourcing/OrleansContracts.txt
+++ b/src/Orleans.EventSourcing/OrleansContracts.txt
@@ -1,0 +1,7 @@
+interface Orleans.EventSourcing.ILogConsistencyProtocolParticipant [Version(0)]
+  DeactivateProtocolParticipant() -> Task
+  PostActivateProtocolParticipant() -> Task
+  PreActivateProtocolParticipant() -> Task
+
+interface Orleans.SystemTargetInterfaces.ILogConsistencyProtocolGateway [Version(0)]
+  RelayMessage(Orleans.Runtime.GrainId, Orleans.EventSourcing.ILogConsistencyProtocolMessage) -> Task<Orleans.EventSourcing.ILogConsistencyProtocolMessage?>

--- a/src/Orleans.Persistence.Memory/OrleansContracts.txt
+++ b/src/Orleans.Persistence.Memory/OrleansContracts.txt
@@ -1,0 +1,1 @@
+class Orleans.Storage.MemoryStorageGrain

--- a/src/Orleans.Reminders/OrleansContracts.txt
+++ b/src/Orleans.Reminders/OrleansContracts.txt
@@ -1,0 +1,22 @@
+interface Orleans.IRemindable [Version(0)]
+  ReceiveReminder(string, Orleans.Runtime.TickStatus) -> Task
+
+interface Orleans.IReminderService [Version(0)]
+  GetReminder(Orleans.Runtime.GrainId, string) -> Task<Orleans.Runtime.IGrainReminder?>
+  GetReminders(Orleans.Runtime.GrainId) -> Task<System.Collections.Generic.List<Orleans.Runtime.IGrainReminder>>
+  RegisterOrUpdateReminder(Orleans.Runtime.GrainId, string, System.TimeSpan, System.TimeSpan) -> Task<Orleans.Runtime.IGrainReminder>
+  Start() -> Task
+  Stop() -> Task
+  UnregisterReminder(Orleans.Runtime.IGrainReminder) -> Task
+
+interface Orleans.IReminderTableGrain [Version(0)]
+  ReadRow(Orleans.Runtime.GrainId, string) -> Task<Orleans.ReminderEntry?>
+  ReadRows(Orleans.Runtime.GrainId) -> Task<Orleans.ReminderTableData>
+  ReadRows(uint, uint) -> Task<Orleans.ReminderTableData>
+  RemoveRow(Orleans.Runtime.GrainId, string, string) -> Task<bool>
+  TestOnlyClearTable() -> Task
+  UpsertRow(Orleans.ReminderEntry) -> Task<string?>
+
+class Orleans.Runtime.ReminderService.LocalReminderService
+
+class Orleans.Runtime.ReminderService.ReminderTableGrain

--- a/src/Orleans.Runtime/OrleansContracts.txt
+++ b/src/Orleans.Runtime/OrleansContracts.txt
@@ -1,0 +1,104 @@
+class Orleans.Runtime.ActivationMigrationManager
+
+class Orleans.Runtime.Catalog
+
+class Orleans.Runtime.ClusterManifestSystemTarget
+
+class Orleans.Runtime.DeploymentLoadPublisher
+
+class Orleans.Runtime.Development.DevelopmentLeaseProviderGrain
+
+interface Orleans.Runtime.Development.IDevelopmentLeaseProviderGrain [Version(0)]
+  Reset() -> Task
+
+class Orleans.Runtime.GrainCallCancellationManager
+
+class Orleans.Runtime.GrainDirectory.ClientDirectory
+
+class Orleans.Runtime.GrainDirectory.DistributedGrainDirectory
+
+class Orleans.Runtime.GrainDirectory.DistributedRemoteGrainDirectory
+
+class Orleans.Runtime.GrainDirectory.GrainDirectoryPartition
+
+interface Orleans.Runtime.GrainDirectory.IGrainDirectoryClient [Version(0)]
+  GetRegisteredActivations(Orleans.Runtime.MembershipVersion, RingRange, bool, System.Threading.CancellationToken) -> ValueTask<Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainAddress>>>
+  RecoverRegisteredActivations(Orleans.Runtime.MembershipVersion, RingRange, Orleans.Runtime.SiloAddress, int, System.Threading.CancellationToken) -> ValueTask<Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainAddress>>>
+
+interface Orleans.Runtime.GrainDirectory.IGrainDirectoryPartition [Version(0)]
+  AcknowledgeSnapshotTransferAsync(Orleans.Runtime.SiloAddress, int, Orleans.Runtime.MembershipVersion, System.Threading.CancellationToken) -> ValueTask<bool>
+  DeregisterAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.GrainAddress, System.Threading.CancellationToken) -> ValueTask<DirectoryResult`1<bool>>
+  GetSnapshotAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.MembershipVersion, RingRange, System.Threading.CancellationToken) -> ValueTask<GrainDirectoryPartitionSnapshot>
+  LookupAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.GrainId, System.Threading.CancellationToken) -> ValueTask<DirectoryResult`1<Orleans.Runtime.GrainAddress?>>
+  RegisterAsync(Orleans.Runtime.MembershipVersion, Orleans.Runtime.GrainAddress, Orleans.Runtime.GrainAddress?, System.Threading.CancellationToken) -> ValueTask<DirectoryResult`1<Orleans.Runtime.GrainAddress>>
+
+interface Orleans.Runtime.GrainDirectory.IGrainDirectoryTestHooks [Version(0)]
+  CheckActivationsAsync(Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainAddress>>) -> ValueTask<Orleans.Concurrency.Immutable<System.Collections.Generic.List<Orleans.Runtime.GrainId>>>
+  CheckIntegrityAsync() -> ValueTask
+  RecoverAndCheckIntegrityAsync() -> ValueTask
+  WaitForMembershipVersionAsync(Orleans.Runtime.MembershipVersion) -> ValueTask
+
+interface Orleans.Runtime.GrainDirectory.IRemoteClientDirectory [Version(0)]
+  GetClientRoutes(System.Collections.Immutable.ImmutableDictionary<Orleans.Runtime.SiloAddress, long>) -> Task<System.Collections.Immutable.ImmutableDictionary<Orleans.Runtime.SiloAddress, (System.Collections.Immutable.ImmutableHashSet<Orleans.Runtime.GrainId>, long)>>
+  OnUpdateClientRoutes(System.Collections.Immutable.ImmutableDictionary<Orleans.Runtime.SiloAddress, (System.Collections.Immutable.ImmutableHashSet<Orleans.Runtime.GrainId>, long)>) -> Task
+
+class Orleans.Runtime.GrainDirectory.LocalGrainDirectoryClientCompatibility
+
+class Orleans.Runtime.GrainDirectory.LocalGrainDirectoryPartitionCompatibility
+
+class Orleans.Runtime.GrainDirectory.RemoteGrainDirectory
+
+interface Orleans.Runtime.IActivationMigrationManagerSystemTarget [Version(0)]
+  AcceptMigratingGrains(System.Collections.Generic.List<Orleans.Runtime.GrainMigrationPackage>) -> ValueTask
+
+interface Orleans.Runtime.ICatalog [Version(0)]
+  DeleteActivations(System.Collections.Generic.List<Orleans.Runtime.GrainAddress>, Orleans.DeactivationReasonCode, string) -> Task
+
+interface Orleans.Runtime.IGrainCallCancellationManagerSystemTarget [Version(0)]
+  CancelCallsAsync(System.Collections.Generic.List<Orleans.Runtime.GrainCallCancellationRequest>) -> ValueTask
+
+interface Orleans.Runtime.IGrainTimerInvoker [Version(0)]
+  InvokeCallbackAsync() -> Task
+
+interface Orleans.Runtime.IRemoteGrainDirectory [Version(0)]
+  AcceptSplitPartition(System.Collections.Generic.List<Orleans.Runtime.GrainAddress>) -> Task
+  LookUpMany(System.Collections.Generic.List<(Orleans.Runtime.GrainId, int)>) -> Task<System.Collections.Generic.List<Orleans.GrainDirectory.AddressAndTag>>
+  RegisterMany(System.Collections.Generic.List<Orleans.Runtime.GrainAddress>) -> Task
+
+interface Orleans.Runtime.ISiloManifestSystemTarget [Version(0)]
+  GetSiloManifest() -> ValueTask<Orleans.Metadata.GrainManifest>
+
+class Orleans.Runtime.Management.ManagementGrain
+
+class Orleans.Runtime.MembershipService.MembershipSystemTarget
+
+class Orleans.Runtime.MembershipService.MembershipTableSystemTarget
+
+interface Orleans.Runtime.MembershipService.SiloMetadata.ISiloMetadataSystemTarget [Version(0)]
+  GetSiloMetadata() -> Task<Orleans.Runtime.MembershipService.SiloMetadata.SiloMetadata>
+
+class Orleans.Runtime.MembershipService.SiloMetadata.SiloMetadataSystemTarget
+
+class Orleans.Runtime.Placement.Rebalancing.ActivationRebalancerMonitor
+
+class Orleans.Runtime.Placement.Rebalancing.ActivationRebalancerWorker
+
+class Orleans.Runtime.Placement.Repartitioning.ActivationRepartitioner
+
+class Orleans.Runtime.SiloControl
+
+interface Orleans.Runtime.TestHooks.ITestHooksSystemTarget [Version(0)]
+
+class Orleans.Runtime.TestHooks.TestHooksSystemTarget
+
+interface Orleans.Runtime.Versions.IVersionStoreGrain [Version(0)]
+  GetCompatibilityStrategies() -> Task<System.Collections.Generic.Dictionary<Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Compatibility.CompatibilityStrategy>>
+  GetCompatibilityStrategy() -> Task<Orleans.Versions.Compatibility.CompatibilityStrategy?>
+  GetSelectorStrategies() -> Task<System.Collections.Generic.Dictionary<Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Selector.VersionSelectorStrategy>>
+  GetSelectorStrategy() -> Task<Orleans.Versions.Selector.VersionSelectorStrategy?>
+  SetCompatibilityStrategy(Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Compatibility.CompatibilityStrategy) -> Task
+  SetCompatibilityStrategy(Orleans.Versions.Compatibility.CompatibilityStrategy) -> Task
+  SetSelectorStrategy(Orleans.Runtime.GrainInterfaceType, Orleans.Versions.Selector.VersionSelectorStrategy) -> Task
+  SetSelectorStrategy(Orleans.Versions.Selector.VersionSelectorStrategy) -> Task
+
+class Orleans.Runtime.Versions.VersionStoreGrain

--- a/src/Orleans.Streaming/OrleansContracts.txt
+++ b/src/Orleans.Streaming/OrleansContracts.txt
@@ -4,6 +4,11 @@ interface Orleans.Providers.IMemoryStreamQueueGrain [Version(0)]
 
 class Orleans.Providers.MemoryStreamQueueGrain
 
+# Orleans.Streams.ConfiguredStreamCheckpointGrain
+class [GrainType("stream.checkpoint.configured")] Orleans.Streams.ConfiguredStreamCheckpointGrain
+
+interface Orleans.Streams.IConfiguredStreamCheckpointerGrain [Version(0)]
+
 interface Orleans.Streams.IPersistentStreamPullingAgent [Version(0)]
   Initialize() -> Task
   Shutdown() -> Task
@@ -27,6 +32,10 @@ interface Orleans.Streams.IPubSubRendezvousGrain [Version(0)]
   UnregisterProducer(Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId) -> Task
   Validate() -> Task
 
+interface Orleans.Streams.IStreamCheckpointerGrain [Version(0)]
+  Load(System.Threading.CancellationToken) -> ValueTask<string>
+  Update(string, string, System.Threading.CancellationToken) -> ValueTask<string>
+
 interface Orleans.Streams.IStreamConsumerExtension [Version(0)]
   CompleteStream(Orleans.Runtime.GuidId) -> Task
   DeliverBatch(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, Orleans.Streams.IBatchContainer, Orleans.Streams.StreamHandshakeToken?) -> Task<Orleans.Streams.StreamHandshakeToken?>
@@ -45,3 +54,6 @@ class Orleans.Streams.PersistentStreamPullingManager
 
 # Orleans.Streams.PubSubRendezvousGrain
 class [GrainType("pubsubrendezvous")] Orleans.Streams.PubSubRendezvousGrain
+
+# Orleans.Streams.StreamCheckpointGrain
+class [GrainType("stream.checkpoint")] Orleans.Streams.StreamCheckpointGrain

--- a/src/Orleans.Streaming/OrleansContracts.txt
+++ b/src/Orleans.Streaming/OrleansContracts.txt
@@ -1,0 +1,47 @@
+interface Orleans.Providers.IMemoryStreamQueueGrain [Version(0)]
+  Dequeue(int) -> Task<System.Collections.Generic.List<Orleans.Providers.MemoryMessageData>>
+  Enqueue(Orleans.Providers.MemoryMessageData) -> Task
+
+class Orleans.Providers.MemoryStreamQueueGrain
+
+interface Orleans.Streams.IPersistentStreamPullingAgent [Version(0)]
+  Initialize() -> Task
+  Shutdown() -> Task
+
+interface Orleans.Streams.IPersistentStreamPullingManager [Version(0)]
+  ExecuteCommand(Orleans.Providers.Streams.Common.PersistentStreamProviderCommand, object?) -> Task<object?>
+  Initialize() -> Task
+  StartAgents() -> Task
+  Stop() -> Task
+  StopAgents() -> Task
+
+interface Orleans.Streams.IPubSubRendezvousGrain [Version(0)]
+  ConsumerCount(Orleans.Runtime.QualifiedStreamId) -> Task<int>
+  DiagGetConsumers(Orleans.Runtime.QualifiedStreamId) -> Task<Orleans.Streams.PubSubSubscriptionState[]>
+  FaultSubscription(Orleans.Runtime.GuidId) -> Task
+  GetAllSubscriptions(Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId) -> Task<System.Collections.Generic.List<Orleans.Streams.Core.StreamSubscription>>
+  ProducerCount(Orleans.Runtime.QualifiedStreamId) -> Task<int>
+  RegisterConsumer(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId, string?) -> Task
+  RegisterProducer(Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId) -> Task<System.Collections.Generic.ISet<Orleans.Streams.PubSubSubscriptionState>>
+  UnregisterConsumer(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId) -> Task
+  UnregisterProducer(Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId) -> Task
+  Validate() -> Task
+
+interface Orleans.Streams.IStreamConsumerExtension [Version(0)]
+  CompleteStream(Orleans.Runtime.GuidId) -> Task
+  DeliverBatch(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, Orleans.Streams.IBatchContainer, Orleans.Streams.StreamHandshakeToken?) -> Task<Orleans.Streams.StreamHandshakeToken?>
+  DeliverImmutable(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, object, Orleans.Streams.StreamSequenceToken, Orleans.Streams.StreamHandshakeToken?) -> Task<Orleans.Streams.StreamHandshakeToken?>
+  DeliverMutable(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, object, Orleans.Streams.StreamSequenceToken, Orleans.Streams.StreamHandshakeToken?) -> Task<Orleans.Streams.StreamHandshakeToken?>
+  ErrorInStream(Orleans.Runtime.GuidId, System.Exception) -> Task
+  GetSequenceToken(Orleans.Runtime.GuidId) -> Task<Orleans.Streams.StreamHandshakeToken?>
+
+interface Orleans.Streams.IStreamProducerExtension [Version(0)]
+  AddSubscriber(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId, Orleans.Runtime.GrainId, string?) -> Task
+  RemoveSubscriber(Orleans.Runtime.GuidId, Orleans.Runtime.QualifiedStreamId) -> Task
+
+class Orleans.Streams.PersistentStreamPullingAgent
+
+class Orleans.Streams.PersistentStreamPullingManager
+
+# Orleans.Streams.PubSubRendezvousGrain
+class [GrainType("pubsubrendezvous")] Orleans.Streams.PubSubRendezvousGrain

--- a/src/Orleans.TestingHost/OrleansContracts.txt
+++ b/src/Orleans.TestingHost/OrleansContracts.txt
@@ -1,0 +1,9 @@
+interface Orleans.TestingHost.IStorageFaultGrain [Version(0)]
+  AddFaultOnClear(Orleans.Runtime.GrainId, System.Exception) -> Task
+  AddFaultOnRead(Orleans.Runtime.GrainId, System.Exception) -> Task
+  AddFaultOnWrite(Orleans.Runtime.GrainId, System.Exception) -> Task
+  OnClear(Orleans.Runtime.GrainId) -> Task
+  OnRead(Orleans.Runtime.GrainId) -> Task
+  OnWrite(Orleans.Runtime.GrainId) -> Task
+
+class Orleans.TestingHost.StorageFaultGrain

--- a/src/Orleans.Transactions.TestKit.Base/OrleansContracts.txt
+++ b/src/Orleans.Transactions.TestKit.Base/OrleansContracts.txt
@@ -1,0 +1,121 @@
+class Orleans.Transactions.TestKit.Consistency.ConsistencyTestGrain
+
+interface Orleans.Transactions.TestKit.Consistency.IConsistencyTestGrain [Version(0)]
+  Run(Orleans.Transactions.TestKit.Consistency.ConsistencyTestOptions, int, string, int, System.DateTime) -> Task<Orleans.Transactions.TestKit.Consistency.Observation[]>
+
+# Orleans.Transactions.TestKit.Correctnesss.DoubleStateTransactionalGrain
+class [GrainType("txn-correctness-DoubleStateTransactionalGrain")] Orleans.Transactions.TestKit.Correctnesss.DoubleStateTransactionalGrain
+
+interface Orleans.Transactions.TestKit.Correctnesss.ITransactionalBitArrayGrain [Version(0)]
+  Get() -> Task<System.Collections.Generic.List<Orleans.Transactions.TestKit.Correctnesss.BitArrayState>>
+  Ping() -> Task
+  SetBit(int) -> Task
+
+# Orleans.Transactions.TestKit.Correctnesss.MaxStateTransactionalGrain
+class [GrainType("txn-correctness-MaxStateTransactionalGrain")] Orleans.Transactions.TestKit.Correctnesss.MaxStateTransactionalGrain
+
+# Orleans.Transactions.TestKit.Correctnesss.MultiStateTransactionalBitArrayGrain
+class [GrainType("txn-correctness-MultiStateTransactionalBitArrayGrain")] Orleans.Transactions.TestKit.Correctnesss.MultiStateTransactionalBitArrayGrain
+
+# Orleans.Transactions.TestKit.Correctnesss.SingleStateTransactionalGrain
+class [GrainType("txn-correctness-SingleStateTransactionalGrain")] Orleans.Transactions.TestKit.Correctnesss.SingleStateTransactionalGrain
+
+class Orleans.Transactions.TestKit.CreateAttributionGrain
+
+class Orleans.Transactions.TestKit.CreateOrJoinAttributionGrain
+
+class Orleans.Transactions.TestKit.DoubleStateTransactionalGrain
+
+class Orleans.Transactions.TestKit.ExclusiveLockCoordinatorGrain
+
+class Orleans.Transactions.TestKit.ExclusiveLockTransactionTestGrain
+
+class Orleans.Transactions.TestKit.FaultInjectionTransactionCoordinatorGrain
+
+interface Orleans.Transactions.TestKit.ICreateAttributionGrain [Version(0)]
+  GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+
+interface Orleans.Transactions.TestKit.ICreateOrJoinAttributionGrain [Version(0)]
+  GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+
+interface Orleans.Transactions.TestKit.IExclusiveLockCoordinatorGrain [Version(0)]
+  ReadThenWrite(Orleans.Transactions.TestKit.ITransactionTestGrain, int) -> Task
+  ReadThenWriteWithExclusiveLock(Orleans.Transactions.TestKit.IExclusiveLockTransactionTestGrain, int) -> Task
+
+interface Orleans.Transactions.TestKit.IExclusiveLockTransactionTestGrain [Version(0)]
+  Add(int) -> Task<int[]>
+  Get() -> Task<int[]>
+  Set(int) -> Task
+
+interface Orleans.Transactions.TestKit.IFaultInjectionTransactionCoordinatorGrain [Version(0)]
+  MultiGrainAddAndFaultInjection(System.Collections.Generic.List<Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain>, int, Orleans.Transactions.TestKit.FaultInjectionControl?) -> Task
+  MultiGrainSet(System.Collections.Generic.List<Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain>, int) -> Task
+
+interface Orleans.Transactions.TestKit.IFaultInjectionTransactionTestGrain [Version(0)]
+  Add(int, Orleans.Transactions.TestKit.FaultInjectionControl?) -> Task
+  Deactivate() -> Task
+  Get() -> Task<int>
+  Set(int) -> Task
+
+interface Orleans.Transactions.TestKit.IJoinAttributionGrain [Version(0)]
+  GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+
+interface Orleans.Transactions.TestKit.INoAttributionGrain [Version(0)]
+  GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+
+interface Orleans.Transactions.TestKit.INotAllowedAttributionGrain [Version(0)]
+  GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+
+interface Orleans.Transactions.TestKit.ISupportedAttributionGrain [Version(0)]
+  GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+
+interface Orleans.Transactions.TestKit.ISuppressAttributionGrain [Version(0)]
+  GetNestedTransactionIds(int, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionAttributionGrain>[]) -> Task<System.Collections.Generic.List<string?>[]>
+
+interface Orleans.Transactions.TestKit.ITransactionCommitterTestGrain [Version(0)]
+  Commit(Orleans.Transactions.Abstractions.ITransactionCommitOperation<Orleans.Transactions.TestKit.IRemoteCommitService>) -> Task
+
+interface Orleans.Transactions.TestKit.ITransactionCoordinatorGrain [Version(0)]
+  AddAndThrow(Orleans.Transactions.TestKit.ITransactionTestGrain, int) -> Task
+  MultiGrainAdd(Orleans.Transactions.TestKit.ITransactionCommitterTestGrain, Orleans.Transactions.Abstractions.ITransactionCommitOperation<Orleans.Transactions.TestKit.IRemoteCommitService>, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  MultiGrainAdd(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  MultiGrainAddAndThrow(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  MultiGrainDouble(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>) -> Task
+  MultiGrainDoubleByRWRW(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  MultiGrainDoubleByWRWR(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  MultiGrainSet(System.Collections.Generic.List<Orleans.Transactions.TestKit.ITransactionTestGrain>, int) -> Task
+  MultiGrainSetBit(System.Collections.Generic.List<Orleans.Transactions.TestKit.Correctnesss.ITransactionalBitArrayGrain>, int) -> Task
+  OrphanCallTransaction() -> Task
+  UpdateViolated(Orleans.Transactions.TestKit.ITransactionTestGrain, int) -> Task
+
+interface Orleans.Transactions.TestKit.ITransactionTestGrain [Version(0)]
+  Add(int) -> Task<int[]>
+  AddAndThrow(int) -> Task
+  Deactivate() -> Task
+  Get() -> Task<int[]>
+  Set(int) -> Task
+  SetAndThrow(int) -> Task
+
+class Orleans.Transactions.TestKit.JoinAttributionGrain
+
+class Orleans.Transactions.TestKit.MaxStateTransactionalGrain
+
+class Orleans.Transactions.TestKit.MultiStateTransactionalGrainBaseClass
+
+class Orleans.Transactions.TestKit.NoAttributionGrain
+
+class Orleans.Transactions.TestKit.NoStateTransactionalGrain
+
+class Orleans.Transactions.TestKit.NotAllowedAttributionGrain
+
+class Orleans.Transactions.TestKit.SingleStateFaultInjectionTransactionalGrain
+
+class Orleans.Transactions.TestKit.SingleStateTransactionalGrain
+
+class Orleans.Transactions.TestKit.SupportedAttributionGrain
+
+class Orleans.Transactions.TestKit.SuppressAttributionGrain
+
+class Orleans.Transactions.TestKit.TransactionCommitterTestGrain
+
+class Orleans.Transactions.TestKit.TransactionCoordinatorGrain

--- a/src/Orleans.Transactions/OrleansContracts.txt
+++ b/src/Orleans.Transactions/OrleansContracts.txt
@@ -1,0 +1,11 @@
+interface Orleans.Transactions.Abstractions.ITransactionManagerExtension [Version(0)]
+  Ping(string, System.Guid, System.DateTime, Orleans.Transactions.ParticipantId) -> Task
+  PrepareAndCommit(string, System.Guid, Orleans.Transactions.Abstractions.AccessCounter, System.DateTime, System.Collections.Generic.List<Orleans.Transactions.ParticipantId>, int) -> Task<Orleans.Transactions.TransactionalStatus>
+  Prepared(string, System.Guid, System.DateTime, Orleans.Transactions.ParticipantId, Orleans.Transactions.TransactionalStatus) -> Task
+
+interface Orleans.Transactions.Abstractions.ITransactionalResourceExtension [Version(0)]
+  Abort(string, System.Guid) -> Task
+  Cancel(string, System.Guid, System.DateTime, Orleans.Transactions.TransactionalStatus) -> Task
+  CommitReadOnly(string, System.Guid, Orleans.Transactions.Abstractions.AccessCounter, System.DateTime) -> Task<Orleans.Transactions.TransactionalStatus>
+  Confirm(string, System.Guid, System.DateTime) -> Task
+  Prepare(string, System.Guid, Orleans.Transactions.Abstractions.AccessCounter, System.DateTime, Orleans.Transactions.ParticipantId) -> Task

--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -1,0 +1,967 @@
+#nullable enable
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Orleans.Analyzers;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace Analyzers.Tests;
+
+/// <summary>
+/// Tests for the analyzer that tracks grain interface definitions and their versions.
+/// This analyzer ensures that interface changes are accompanied by version increments
+/// for compatibility during rolling upgrades.
+/// </summary>
+[TestCategory("BVT"), TestCategory("Analyzer")]
+public class GrainInterfaceVersionAnalyzerTest
+{
+    private const string GrainInterfacesFileName = "GrainInterfaces.txt";
+
+    private static readonly string[] Usings = new[]
+    {
+        "System",
+        "System.Threading.Tasks",
+        "Orleans",
+        "Orleans.CodeGeneration"
+    };
+
+    #region Test Infrastructure
+
+    private async Task<Diagnostic[]> GetDiagnosticsAsync(string source, string? grainInterfacesFileContent = null)
+    {
+        var project = CreateProjectWithAdditionalFiles(source, grainInterfacesFileContent);
+        var compilation = await project.GetCompilationAsync();
+        var errors = compilation!.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
+
+        Assert.Empty(errors);
+
+        var analyzer = new GrainInterfaceVersionAnalyzer();
+
+        // Build analyzer options with additional files
+        var additionalFiles = grainInterfacesFileContent is not null
+            ? ImmutableArray.Create<AdditionalText>(new TestAdditionalText(GrainInterfacesFileName, grainInterfacesFileContent))
+            : ImmutableArray<AdditionalText>.Empty;
+
+        var analyzerOptions = new AnalyzerOptions(additionalFiles);
+
+        var compilationWithAnalyzers = compilation
+            .WithOptions(compilation.Options.WithSpecificDiagnosticOptions(
+                analyzer.SupportedDiagnostics.ToDictionary(d => d.Id, d => ReportDiagnostic.Default)))
+            .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer), analyzerOptions);
+
+        var diagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+    }
+
+    private static Project CreateProjectWithAdditionalFiles(string source, string? grainInterfacesFileContent)
+    {
+        const string fileName = "Test.cs";
+
+        // Prepend usings
+        var sb = new StringBuilder();
+        foreach (var @using in Usings)
+        {
+            sb.AppendLine($"using {@using};");
+        }
+        sb.AppendLine(source);
+        var fullSource = sb.ToString();
+
+        var projectId = ProjectId.CreateNewId(debugName: "TestProject");
+        var documentId = DocumentId.CreateNewId(projectId, fileName);
+
+        var assemblies = new[]
+        {
+            typeof(Task).Assembly,
+            typeof(Orleans.IGrain).Assembly,
+            typeof(Orleans.Grain).Assembly,
+            typeof(Attribute).Assembly,
+            typeof(int).Assembly,
+            typeof(object).Assembly,
+        };
+
+        var metadataReferences = assemblies
+            .SelectMany(x => x.GetReferencedAssemblies().Select(Assembly.Load))
+            .Concat(assemblies)
+            .Distinct()
+            .Select(x => MetadataReference.CreateFromFile(x.Location))
+            .Cast<MetadataReference>()
+            .ToList();
+
+        var assemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "mscorlib.dll")));
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.dll")));
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Core.dll")));
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Runtime.dll")));
+
+        var solution = new AdhocWorkspace()
+            .CurrentSolution
+            .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+            .AddMetadataReferences(projectId, metadataReferences)
+            .AddDocument(documentId, fileName, SourceText.From(fullSource));
+
+        return solution.GetProject(projectId)!
+            .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    /// <summary>
+    /// A simple implementation of AdditionalText for testing purposes.
+    /// </summary>
+    private sealed class TestAdditionalText : AdditionalText
+    {
+        private readonly SourceText _text;
+
+        public TestAdditionalText(string path, string content)
+        {
+            Path = path;
+            _text = SourceText.From(content);
+        }
+
+        public override string Path { get; }
+
+        public override SourceText? GetText(CancellationToken cancellationToken = default) => _text;
+    }
+
+    #endregion
+
+    #region ORLEANS0016 - Interface Not Declared
+
+    [Fact]
+    public async Task InterfaceNotInFile_WithExistingFile_ReportsDiagnostic()
+    {
+        const string source = @"
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        // Use *RETIRED* for the dummy interface so it doesn't trigger ORLEANS0019
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+*RETIRED* SomeOther.IGrain [Version(1)]
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.Single(diagnostics);
+        Assert.Equal(GrainInterfaceVersionAnalyzer.RuleId0016, diagnostics[0].Id);
+        Assert.Contains("IMyGrain", diagnostics[0].GetMessage());
+    }
+
+    [Fact]
+    public async Task InterfaceInFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        // No ORLEANS0016 diagnostic
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+    }
+
+    [Fact]
+    public async Task InterfaceWithAlias_InFile_NoDiagnostic()
+    {
+        const string source = @"
+[Alias(""my-grain"")]
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+[Alias(""my-grain"")] IMyGrain [Version(1)]
+IMyGrain.DoSomething() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+    }
+
+    #endregion
+
+    #region ORLEANS0017 - Version Mismatch
+
+    [Fact]
+    public async Task VersionMismatch_ReportsDiagnostic()
+    {
+        const string source = @"
+[Version(2)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.Contains(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0017);
+        var diagnostic = diagnostics.First(d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0017);
+        Assert.Contains("IMyGrain", diagnostic.GetMessage());
+        Assert.Contains("1", diagnostic.GetMessage()); // Expected version
+        Assert.Contains("2", diagnostic.GetMessage()); // Actual version
+    }
+
+    [Fact]
+    public async Task VersionMatch_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0017);
+    }
+
+    [Fact]
+    public async Task NoVersionAttribute_DefaultsToZero()
+    {
+        const string source = @"
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain [Version(0)]
+IMyGrain.DoSomething() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0017);
+    }
+
+    #endregion
+
+    #region ORLEANS0018 - Member Not Declared
+
+    [Fact]
+    public async Task NewMember_NotInFile_ReportsDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+    Task NewMethod();
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.Contains(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+        var diagnostic = diagnostics.First(d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+        Assert.Contains("NewMethod", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task MemberInFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    [Fact]
+    public async Task MemberWithParameters_InFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething(string name, int count);
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething(string name, int count) -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    #endregion
+
+    #region ORLEANS0019 - Removed Interface Not Retired
+
+    [Fact]
+    public async Task RemovedInterface_NotRetired_ReportsDiagnostic()
+    {
+        const string source = @"
+// No interfaces in code
+public class SomeClass { }
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IOldGrain [Version(1)]
+IOldGrain.DoSomething() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.Contains(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0019);
+        var diagnostic = diagnostics.First(d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0019);
+        Assert.Contains("IOldGrain", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task RetiredInterface_NoDiagnostic()
+    {
+        const string source = @"
+// No interfaces in code
+public class SomeClass { }
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+*RETIRED* IOldGrain [Version(1)]
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0019);
+    }
+
+    #endregion
+
+    #region ORLEANS0020 - File Missing
+
+    [Fact]
+    public async Task NoFile_WithGrainInterfaces_ReportsDiagnostic()
+    {
+        const string source = @"
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFileContent: null);
+
+        Assert.Contains(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0020);
+    }
+
+    [Fact]
+    public async Task NoFile_NoGrainInterfaces_NoDiagnostic()
+    {
+        const string source = @"
+// No grain interfaces, just regular code
+public class RegularClass
+{
+    public void DoSomething() { }
+}
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFileContent: null);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0020);
+    }
+
+    #endregion
+
+    #region ORLEANS0021 - Duplicate Declaration
+
+    [Fact]
+    public async Task DuplicateInterfaceDeclaration_ReportsDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain [Version(1)]
+IMyGrain [Version(2)]
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.Contains(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0021);
+    }
+
+    #endregion
+
+    #region Non-Grain Interfaces
+
+    [Fact]
+    public async Task NonGrainInterface_NoDiagnostic()
+    {
+        const string source = @"
+// Regular interface, not a grain
+public interface IMyService
+{
+    void DoSomething();
+}
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFileContent: null);
+
+        // No diagnostics at all - non-grain interfaces are not tracked
+        Assert.Empty(diagnostics);
+    }
+
+    #endregion
+
+    #region Base Grain Interfaces
+
+    [Fact]
+    public async Task IGrainBase_NotTracked()
+    {
+        // Test that Orleans base interfaces like IGrain itself are not reported
+        const string source = @"
+// User code doesn't define IGrain - it comes from Orleans
+public class SomeClass { }
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        // Should not report IGrain, IGrainWithStringKey, etc. as missing
+        Assert.Empty(diagnostics);
+    }
+
+    #endregion
+
+    #region Namespaced Interfaces
+
+    [Fact]
+    public async Task NamespacedInterface_InFile_NoDiagnostic()
+    {
+        const string source = @"
+namespace MyApp.Grains
+{
+    [Version(1)]
+    public interface IMyGrain : IGrain
+    {
+        Task DoSomething();
+    }
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+MyApp.Grains.IMyGrain [Version(1)]
+MyApp.Grains.IMyGrain.DoSomething() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0017);
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    #endregion
+
+    #region File Format
+
+    [Fact]
+    public async Task FileWithComments_ParsedCorrectly()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"
+# This is a comment
+# Another comment
+IMyGrain [Version(1)]
+# Comment between entries
+IMyGrain.DoSomething() -> Task
+# Final comment
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        // Should parse correctly despite comments
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0017);
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    [Fact]
+    public async Task FileWithBlankLines_ParsedCorrectly()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"
+
+IMyGrain [Version(1)]
+
+IMyGrain.DoSomething() -> Task
+
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+    }
+
+    #endregion
+
+    #region Code Fix Tests Infrastructure
+
+    private async Task<(Solution ChangedSolution, DocumentId? AdditionalDocumentId)> ApplyCodeFixAsync(
+        string source,
+        string? grainInterfacesFileContent,
+        string expectedDiagnosticId)
+    {
+        var project = CreateProjectWithAdditionalFilesForCodeFix(source, grainInterfacesFileContent);
+        var document = project.Documents.First();
+        var compilation = await project.GetCompilationAsync();
+
+        Assert.NotNull(compilation);
+        var errors = compilation!.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Empty(errors);
+
+        var analyzer = new GrainInterfaceVersionAnalyzer();
+
+        // Build analyzer options with additional files
+        var additionalFiles = grainInterfacesFileContent is not null
+            ? ImmutableArray.Create<AdditionalText>(new TestAdditionalText(GrainInterfacesFileName, grainInterfacesFileContent))
+            : ImmutableArray<AdditionalText>.Empty;
+
+        var analyzerOptions = new AnalyzerOptions(additionalFiles);
+
+        var compilationWithAnalyzers = compilation
+            .WithOptions(compilation.Options.WithSpecificDiagnosticOptions(
+                analyzer.SupportedDiagnostics.ToDictionary(d => d.Id, d => ReportDiagnostic.Default)))
+            .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(analyzer), analyzerOptions);
+
+        var diagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        var diagnostic = diagnostics.FirstOrDefault(d => d.Id == expectedDiagnosticId);
+
+        Assert.NotNull(diagnostic);
+
+        // Apply code fix
+        var codeFixer = new GrainInterfaceVersionCodeFix();
+        var actions = new List<CodeAction>();
+        var context = new CodeFixContext(
+            document,
+            diagnostic!,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        await codeFixer.RegisterCodeFixesAsync(context);
+        Assert.NotEmpty(actions);
+
+        var operations = await actions.First().GetOperationsAsync(CancellationToken.None);
+        var changedSolution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
+
+        var additionalDocumentId = changedSolution.GetProject(project.Id)?.AdditionalDocumentIds.FirstOrDefault();
+
+        return (changedSolution, additionalDocumentId);
+    }
+
+    private static Project CreateProjectWithAdditionalFilesForCodeFix(string source, string? grainInterfacesFileContent)
+    {
+        const string fileName = "Test.cs";
+
+        // Prepend usings
+        var sb = new StringBuilder();
+        foreach (var @using in Usings)
+        {
+            sb.AppendLine($"using {@using};");
+        }
+        sb.AppendLine(source);
+        var fullSource = sb.ToString();
+
+        var projectId = ProjectId.CreateNewId(debugName: "TestProject");
+        var documentId = DocumentId.CreateNewId(projectId, fileName);
+
+        var assemblies = new[]
+        {
+            typeof(Task).Assembly,
+            typeof(Orleans.IGrain).Assembly,
+            typeof(Orleans.Grain).Assembly,
+            typeof(Attribute).Assembly,
+            typeof(int).Assembly,
+            typeof(object).Assembly,
+        };
+
+        var metadataReferences = assemblies
+            .SelectMany(x => x.GetReferencedAssemblies().Select(Assembly.Load))
+            .Concat(assemblies)
+            .Distinct()
+            .Select(x => MetadataReference.CreateFromFile(x.Location))
+            .Cast<MetadataReference>()
+            .ToList();
+
+        var assemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "mscorlib.dll")));
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.dll")));
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Core.dll")));
+        metadataReferences.Add(MetadataReference.CreateFromFile(Path.Combine(assemblyPath, "System.Runtime.dll")));
+
+        var solution = new AdhocWorkspace()
+            .CurrentSolution
+            .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+            .AddMetadataReferences(projectId, metadataReferences)
+            .AddDocument(documentId, fileName, SourceText.From(fullSource));
+
+        // Add additional document if content is provided
+        if (grainInterfacesFileContent is not null)
+        {
+            var additionalDocumentId = DocumentId.CreateNewId(projectId, GrainInterfacesFileName);
+            solution = solution.AddAdditionalDocument(additionalDocumentId, GrainInterfacesFileName, SourceText.From(grainInterfacesFileContent));
+        }
+
+        return solution.GetProject(projectId)!
+            .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    #endregion
+
+    #region Code Fix Tests - ORLEANS0016 Add Interface
+
+    [Fact]
+    public async Task CodeFix_AddInterface_ToExistingFile()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"# GrainInterfaces.txt
+*RETIRED* SomeOther.IOldGrain [Version(1)]";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0016);
+
+        Assert.NotNull(additionalDocumentId);
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        var changedText = await changedDocument!.GetTextAsync();
+        var content = changedText.ToString();
+
+        // Should contain the new interface
+        Assert.Contains("IMyGrain [Version(1)]", content);
+        Assert.Contains("IMyGrain.DoSomething() -> Task", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddInterface_WithAlias()
+    {
+        const string source = @"
+[Alias(""my-grain"")]
+[Version(2)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething(string name);
+}
+";
+        const string grainInterfacesFile = @"# GrainInterfaces.txt
+*RETIRED* SomeOther.IOldGrain [Version(1)]";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0016);
+
+        Assert.NotNull(additionalDocumentId);
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        var changedText = await changedDocument!.GetTextAsync();
+        var content = changedText.ToString();
+
+        // Should contain the alias
+        Assert.Contains("[Alias(\"my-grain\")]", content);
+        Assert.Contains("IMyGrain [Version(2)]", content);
+        Assert.Contains("IMyGrain.DoSomething(string name) -> Task", content);
+    }
+
+    #endregion
+
+    #region Code Fix Tests - ORLEANS0017 Update Version
+
+    [Fact]
+    public async Task CodeFix_UpdateVersion()
+    {
+        const string source = @"
+[Version(2)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"# GrainInterfaces.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething() -> Task";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0017);
+
+        Assert.NotNull(additionalDocumentId);
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        var changedText = await changedDocument!.GetTextAsync();
+        var content = changedText.ToString();
+
+        // Should have updated version
+        Assert.Contains("IMyGrain [Version(2)]", content);
+        Assert.DoesNotContain("[Version(1)]", content);
+    }
+
+    #endregion
+
+    #region Code Fix Tests - ORLEANS0018 Add Member
+
+    [Fact]
+    public async Task CodeFix_AddMember()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+    Task NewMethod(int value);
+}
+";
+        const string grainInterfacesFile = @"# GrainInterfaces.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething() -> Task";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0018);
+
+        Assert.NotNull(additionalDocumentId);
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        var changedText = await changedDocument!.GetTextAsync();
+        var content = changedText.ToString();
+
+        // Should contain the new member
+        Assert.Contains("IMyGrain.NewMethod(int value) -> Task", content);
+    }
+
+    #endregion
+
+    #region Generic Grain Interfaces
+
+    [Fact]
+    public async Task GenericInterface_InFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain<T> : IGrain
+{
+    Task DoSomething(T value);
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain<T> [Version(1)]
+IMyGrain<T>.DoSomething(T value) -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0017);
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    [Fact]
+    public async Task GenericInterface_WithConstraint_InFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain<T> : IGrain where T : class
+{
+    Task DoSomething(T value);
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain<T> [Version(1)]
+IMyGrain<T>.DoSomething(T value) -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+    }
+
+    [Fact]
+    public async Task GenericInterface_MultipleTypeParams_InFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain<TKey, TValue> : IGrain
+{
+    Task DoSomething(TKey key, TValue value);
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain<TKey, TValue> [Version(1)]
+IMyGrain<TKey, TValue>.DoSomething(TKey key, TValue value) -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+    }
+
+    #endregion
+
+    #region Code Fix Tests - ORLEANS0019 Retire Interface
+
+    [Fact]
+    public async Task CodeFix_RetireInterface()
+    {
+        const string source = @"
+// No grain interfaces - IOldGrain was removed
+public class SomeClass { }
+";
+        const string grainInterfacesFile = @"# GrainInterfaces.txt
+IOldGrain [Version(1)]
+IOldGrain.DoSomething() -> Task";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0019);
+
+        Assert.NotNull(additionalDocumentId);
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        var changedText = await changedDocument!.GetTextAsync();
+        var content = changedText.ToString();
+
+        // Should have *RETIRED* prefix
+        Assert.Contains("*RETIRED* IOldGrain [Version(1)]", content);
+    }
+
+    #endregion
+
+    #region Inherited Interfaces
+
+    [Fact]
+    public async Task InheritedInterface_BothTracked_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IBaseGrain : IGrain
+{
+    Task DoBase();
+}
+
+[Version(1)]
+public interface IDerivedGrain : IBaseGrain
+{
+    Task DoDerived();
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IBaseGrain [Version(1)]
+IBaseGrain.DoBase() -> Task
+
+IDerivedGrain [Version(1)]
+IDerivedGrain.DoDerived() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        // Both interfaces should be matched
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0017);
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    [Fact]
+    public async Task InheritedInterface_DerivedNotTracked_ReportsDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IBaseGrain : IGrain
+{
+    Task DoBase();
+}
+
+[Version(1)]
+public interface IDerivedGrain : IBaseGrain
+{
+    Task DoDerived();
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IBaseGrain [Version(1)]
+IBaseGrain.DoBase() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        // IDerivedGrain should be reported as not declared
+        Assert.Contains(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+        var diagnostic = diagnostics.First(d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+        Assert.Contains("IDerivedGrain", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task InterfaceInheritingFromGrainWithKey_Tracked()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrainWithStringKey
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"
+# GrainInterfaces.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething() -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+    }
+
+    #endregion
+}

--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -476,6 +476,46 @@ IMyGrain [Version(1)]
         Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
     }
 
+    [Fact]
+    public async Task GenericMethod_InFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task<T> ReadStateAsync<T>(T value);
+}
+";
+        const string contractsFile = @"
+interface IMyGrain [Version(1)]
+  ReadStateAsync`1(T) -> Task<T>
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    [Fact]
+    public async Task GenericMethodArityChanged_ReportsDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task<T1> ReadStateAsync<T1, T2>(T1 first, T2 second);
+}
+";
+        const string contractsFile = @"
+interface IMyGrain [Version(1)]
+  ReadStateAsync`1(T) -> Task<T>
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Contains(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
     #endregion
 
     #region ORLEANS0019 - Removed Interface Not Retired
@@ -1553,6 +1593,28 @@ public interface IMyGrain : IGrain
             GrainInterfaceVersionAnalyzer.RuleId0018);
 
         Assert.Equal("interface IMyGrain [Version(1)]\n  NewMethod() -> Task\n", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddMember_IncludesGenericMethodArity()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task<T> ReadStateAsync<T>(T value);
+}
+";
+        const string contractsFile = "interface IMyGrain [Version(1)]";
+
+        var content = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            contractsFile,
+            GrainInterfaceVersionAnalyzer.RuleId0018);
+
+        Assert.Equal(
+            "interface IMyGrain [Version(1)]\n  ReadStateAsync`1(T) -> Task<T>\n",
+            content);
     }
 
     [Fact]

--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -22,14 +22,15 @@ namespace Analyzers.Tests;
 [TestCategory("BVT"), TestCategory("Analyzer")]
 public class GrainInterfaceVersionAnalyzerTest
 {
-    private const string GrainInterfacesFileName = "GrainInterfaces.txt";
+    private const string OrleansContractsFileName = "OrleansContracts.txt";
 
     private static readonly string[] Usings = new[]
     {
         "System",
         "System.Threading.Tasks",
         "Orleans",
-        "Orleans.CodeGeneration"
+        "Orleans.CodeGeneration",
+        "Orleans.Runtime"
     };
 
     #region Test Infrastructure
@@ -46,7 +47,7 @@ public class GrainInterfaceVersionAnalyzerTest
 
         // Build analyzer options with additional files
         var additionalFiles = grainInterfacesFileContent is not null
-            ? ImmutableArray.Create<AdditionalText>(new TestAdditionalText(GrainInterfacesFileName, grainInterfacesFileContent))
+            ? ImmutableArray.Create<AdditionalText>(new TestAdditionalText(OrleansContractsFileName, grainInterfacesFileContent))
             : ImmutableArray<AdditionalText>.Empty;
 
         var analyzerOptions = new AnalyzerOptions(additionalFiles);
@@ -143,7 +144,7 @@ public interface IMyGrain : IGrain
 ";
         // Use *RETIRED* for the dummy interface so it doesn't trigger ORLEANS0019
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 *RETIRED* SomeOther.IGrain [Version(1)]
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
@@ -164,7 +165,7 @@ public interface IMyGrain : IGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain [Version(1)]
 IMyGrain.DoSomething() -> Task
 ";
@@ -186,13 +187,31 @@ public interface IMyGrain : IGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 [Alias(""my-grain"")] IMyGrain [Version(1)]
 IMyGrain.DoSomething() -> Task
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
         Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+    }
+
+    [Fact]
+    public async Task InterfaceMarkedRetired_ReportsActiveDeclarationDiagnostic()
+    {
+        const string source = @"
+public interface IMyGrain : IGrain
+{
+}
+";
+        const string grainInterfacesFile = @"
+*RETIRED* IMyGrain [Version(0)]
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(GrainInterfaceVersionAnalyzer.RuleId0016, diagnostic.Id);
+        Assert.Contains("does not have an active declaration", diagnostic.GetMessage());
     }
 
     #endregion
@@ -210,7 +229,7 @@ public interface IMyGrain : IGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain [Version(1)]
 IMyGrain.DoSomething() -> Task
 ";
@@ -234,7 +253,7 @@ public interface IMyGrain : IGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain [Version(1)]
 IMyGrain.DoSomething() -> Task
 ";
@@ -253,7 +272,7 @@ public interface IMyGrain : IGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain [Version(0)]
 IMyGrain.DoSomething() -> Task
 ";
@@ -278,7 +297,7 @@ public interface IMyGrain : IGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain [Version(1)]
 IMyGrain.DoSomething() -> Task
 ";
@@ -300,7 +319,7 @@ public interface IMyGrain : IGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain [Version(1)]
 IMyGrain.DoSomething() -> Task
 ";
@@ -320,9 +339,93 @@ public interface IMyGrain : IGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain [Version(1)]
 IMyGrain.DoSomething(string name, int count) -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    [Fact]
+    public async Task LegacyMemberParameterRename_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething(string renamed, int newCount);
+}
+";
+        const string contractsFile = @"
+IMyGrain [Version(1)]
+IMyGrain.DoSomething(string original, int oldCount) -> Task
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    [Fact]
+    public async Task MemberWithTupleParameter_InFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething((int X, int Y) value);
+}
+";
+        const string grainInterfacesFile = @"
+# OrleansContracts.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething((int X, int Y) value) -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    [Fact]
+    public async Task MemberTypeNamespaceChanged_ReportsDiagnostic()
+    {
+        const string source = @"
+namespace NamespaceA
+{
+    public sealed class Request { }
+}
+
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething(NamespaceA.Request request);
+}
+";
+        const string grainInterfacesFile = @"
+# OrleansContracts.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething(NamespaceB.Request request) -> Task
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.Contains(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0018);
+    }
+
+    [Fact]
+    public async Task StaticMember_NotInFile_NoDiagnostic()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    static Task Utility() => Task.CompletedTask;
+}
+";
+        const string grainInterfacesFile = @"
+# OrleansContracts.txt
+IMyGrain [Version(1)]
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -341,7 +444,7 @@ IMyGrain.DoSomething(string name, int count) -> Task
 public class SomeClass { }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IOldGrain [Version(1)]
 IOldGrain.DoSomething() -> Task
 ";
@@ -360,7 +463,7 @@ IOldGrain.DoSomething() -> Task
 public class SomeClass { }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 *RETIRED* IOldGrain [Version(1)]
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
@@ -383,7 +486,8 @@ public interface IMyGrain : IGrain
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFileContent: null);
 
-        Assert.Contains(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0020);
+        var diagnostic = Assert.Single(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0020);
+        Assert.Contains(OrleansContractsFileName, diagnostic.GetMessage());
     }
 
     [Fact]
@@ -416,7 +520,7 @@ public interface IMyGrain : IGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain [Version(1)]
 IMyGrain [Version(2)]
 ";
@@ -445,6 +549,25 @@ public interface IMyService
         Assert.Empty(diagnostics);
     }
 
+    [Fact]
+    public async Task ObserverInterface_InFile_NoDiagnostic()
+    {
+        const string source = @"
+public interface IMyObserver : IGrainObserver
+{
+    void OnEvent(string value);
+}
+";
+        const string grainInterfacesFile = @"
+# OrleansContracts.txt
+IMyObserver [Version(0)]
+IMyObserver.OnEvent(string value) -> void
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.Empty(diagnostics);
+    }
+
     #endregion
 
     #region Base Grain Interfaces
@@ -458,7 +581,7 @@ public interface IMyService
 public class SomeClass { }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 ";
         var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
 
@@ -484,7 +607,7 @@ namespace MyApp.Grains
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 MyApp.Grains.IMyGrain [Version(1)]
 MyApp.Grains.IMyGrain.DoSomething() -> Task
 ";
@@ -547,6 +670,258 @@ IMyGrain.DoSomething() -> Task
         Assert.DoesNotContain(diagnostics, d => d.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
     }
 
+    [Fact]
+    public async Task VersionOutsideUShortRange_DoesNotCrashAnalyzer()
+    {
+        const string source = @"
+public interface IMyGrain : IGrain
+{
+}
+";
+        const string grainInterfacesFile = @"
+IMyGrain [Version(65536)]
+";
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFile);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "AD0001");
+    }
+
+    #endregion
+
+    #region Grain Class Contracts
+
+    [Fact]
+    public async Task GrainClassNotInFile_ReportsDiagnostic()
+    {
+        const string source = @"
+public class MyGrain : Grain, IGrainWithStringKey
+{
+}
+";
+        const string contractsFile = "# OrleansContracts.txt\n";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(GrainInterfaceVersionAnalyzer.RuleId0022, diagnostic.Id);
+        Assert.Contains("MyGrain", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task GrainClassWithMatchingAlias_NoDiagnostic()
+    {
+        const string source = @"
+[GrainType(""my-grain"")]
+public class MyGrain : Grain, IGrainWithStringKey
+{
+}
+";
+        const string contractsFile = @"
+class [GrainType(""my-grain"")] MyGrain
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task GrainClassAliasMismatch_ReportsDiagnostic()
+    {
+        const string source = @"
+[GrainType(""new-alias"")]
+public class MyGrain : Grain, IGrainWithStringKey
+{
+}
+";
+        const string contractsFile = @"
+class [GrainType(""old-alias"")] MyGrain
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(GrainInterfaceVersionAnalyzer.RuleId0023, diagnostic.Id);
+        Assert.Contains("old-alias", diagnostic.GetMessage());
+        Assert.Contains("new-alias", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public async Task RemovedGrainClass_NotRetired_ReportsDiagnostic()
+    {
+        const string source = "public class SomeClass { }";
+        const string contractsFile = "class [GrainType(\"my-grain\")] MyGrain";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(GrainInterfaceVersionAnalyzer.RuleId0024, diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task AbstractGrainClass_IsNotTracked()
+    {
+        const string source = @"
+public abstract class MyGrainBase : Grain
+{
+}
+";
+        const string contractsFile = "# OrleansContracts.txt\n";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task PocoGrainClass_IsTracked()
+    {
+        const string source = @"
+public interface IPocoGrain : IGrain
+{
+}
+
+public class PocoGrain : IGrainBase, IPocoGrain
+{
+    public Orleans.Runtime.IGrainContext GrainContext => throw new NotImplementedException();
+}
+";
+        const string contractsFile = @"
+IPocoGrain [Version(0)]
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        var diagnostic = Assert.Single(diagnostics, diagnostic => diagnostic.Id == GrainInterfaceVersionAnalyzer.RuleId0022);
+        Assert.Equal(GrainInterfaceVersionAnalyzer.RuleId0022, diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task DuplicateGrainClassDeclaration_ReportsDiagnostic()
+    {
+        const string source = @"
+public class MyGrain : Grain, IGrainWithStringKey
+{
+}
+";
+        const string contractsFile = @"
+class MyGrain
+class MyGrain
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Equal(GrainInterfaceVersionAnalyzer.RuleId0025, diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task GrainClassRename_WithStableGrainType_NoDiagnostic()
+    {
+        const string oldSource = @"
+[GrainType(""stable-grain"")]
+public class OldGrain : Grain, IGrainWithStringKey
+{
+}
+";
+        const string newSource = @"
+[GrainType(""stable-grain"")]
+public class NewGrain : Grain, IGrainWithStringKey
+{
+}
+";
+        var contractsFile = await ApplyCodeFixAndGetContractsAsync(
+            oldSource,
+            "# OrleansContracts.txt\n",
+            GrainInterfaceVersionAnalyzer.RuleId0022);
+
+        var diagnostics = await GetDiagnosticsAsync(newSource, contractsFile);
+
+        Assert.Empty(diagnostics);
+        Assert.Contains("# OldGrain\nclass [GrainType(\"stable-grain\")] OldGrain", contractsFile);
+    }
+
+    [Fact]
+    public async Task RpcContractRefactor_WithStableIdentities_NoDiagnostic()
+    {
+        const string oldSource = @"
+[Alias(""request"")]
+public sealed class OldRequest { }
+
+[Alias(""response"")]
+public sealed class OldResponse { }
+
+[GrainInterfaceType(""stable-interface"")]
+public interface IOldGrain : IGrain
+{
+    [Alias(""stable-method"")]
+    Task<OldResponse> OldMethod(OldRequest request);
+}
+";
+        const string newSource = @"
+[Alias(""request"")]
+public sealed class NewRequest { }
+
+[Alias(""response"")]
+public sealed class NewResponse { }
+
+[GrainInterfaceType(""stable-interface"")]
+public interface INewGrain : IGrain
+{
+    [Alias(""stable-method"")]
+    Task<NewResponse> NewMethod(NewRequest renamedParameter);
+}
+";
+        var contractsFile = await ApplyCodeFixAndGetContractsAsync(
+            oldSource,
+            "# OrleansContracts.txt\n",
+            GrainInterfaceVersionAnalyzer.RuleId0016);
+
+        var diagnostics = await GetDiagnosticsAsync(newSource, contractsFile);
+
+        Assert.Empty(diagnostics);
+        Assert.Contains("# IOldGrain\ninterface [GrainInterfaceType(\"stable-interface\")] IOldGrain [Version(0)]", contractsFile);
+        Assert.Contains(
+            "  stable-method(request) -> Task<response>",
+            contractsFile);
+        Assert.Contains("# IOldGrain", contractsFile);
+        Assert.Contains("# IOldGrain.OldMethod", contractsFile);
+    }
+
+    [Fact]
+    public async Task StableInterfaceIdentityChange_IsBreaking()
+    {
+        const string source = @"
+[GrainInterfaceType(""new-identity"")]
+public interface IMyGrain : IGrain
+{
+}
+";
+        const string contractsFile = @"
+[GrainInterfaceType(""old-identity"")] IMyGrain [Version(0)]
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == GrainInterfaceVersionAnalyzer.RuleId0016);
+    }
+
+    [Fact]
+    public async Task StableGrainTypeChange_IsBreaking()
+    {
+        const string source = @"
+[GrainType(""new-identity"")]
+public class MyGrain : Grain, IGrainWithStringKey
+{
+}
+";
+        const string contractsFile = "class [GrainType(\"old-identity\")] MyGrain";
+
+        var diagnostics = await GetDiagnosticsAsync(source, contractsFile);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == GrainInterfaceVersionAnalyzer.RuleId0023);
+    }
+
     #endregion
 
     #region Code Fix Tests Infrastructure
@@ -568,7 +943,7 @@ IMyGrain.DoSomething() -> Task
 
         // Build analyzer options with additional files
         var additionalFiles = grainInterfacesFileContent is not null
-            ? ImmutableArray.Create<AdditionalText>(new TestAdditionalText(GrainInterfacesFileName, grainInterfacesFileContent))
+            ? ImmutableArray.Create<AdditionalText>(new TestAdditionalText(OrleansContractsFileName, grainInterfacesFileContent))
             : ImmutableArray<AdditionalText>.Empty;
 
         var analyzerOptions = new AnalyzerOptions(additionalFiles);
@@ -601,6 +976,20 @@ IMyGrain.DoSomething() -> Task
         var additionalDocumentId = changedSolution.GetProject(project.Id)?.AdditionalDocumentIds.FirstOrDefault();
 
         return (changedSolution, additionalDocumentId);
+    }
+
+    private async Task<string> ApplyCodeFixAndGetContractsAsync(
+        string source,
+        string contractsFileContent,
+        string expectedDiagnosticId)
+    {
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, contractsFileContent, expectedDiagnosticId);
+        Assert.NotNull(additionalDocumentId);
+
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        return (await changedDocument!.GetTextAsync()).ToString();
     }
 
     private static Project CreateProjectWithAdditionalFilesForCodeFix(string source, string? grainInterfacesFileContent)
@@ -652,12 +1041,130 @@ IMyGrain.DoSomething() -> Task
         // Add additional document if content is provided
         if (grainInterfacesFileContent is not null)
         {
-            var additionalDocumentId = DocumentId.CreateNewId(projectId, GrainInterfacesFileName);
-            solution = solution.AddAdditionalDocument(additionalDocumentId, GrainInterfacesFileName, SourceText.From(grainInterfacesFileContent));
+            var additionalDocumentId = DocumentId.CreateNewId(projectId, OrleansContractsFileName);
+            solution = solution.AddAdditionalDocument(additionalDocumentId, OrleansContractsFileName, SourceText.From(grainInterfacesFileContent));
         }
 
         return solution.GetProject(projectId)!
             .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    #endregion
+
+    #region Code Fix Tests - Grain Classes
+
+    [Fact]
+    public async Task CodeFix_AddGrainClass()
+    {
+        const string source = @"
+[GrainType(""my-grain"")]
+public class MyGrain : Grain, IGrainWithStringKey
+{
+}
+";
+        const string contractsFile = @"# OrleansContracts.txt
+IZulu [Version(1)]";
+
+        var content = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            contractsFile,
+            GrainInterfaceVersionAnalyzer.RuleId0022);
+
+        Assert.Contains("class [GrainType(\"my-grain\")] MyGrain", content);
+        Assert.True(
+            content.IndexOf("IZulu [Version(1)]", StringComparison.Ordinal)
+                < content.IndexOf("class [GrainType(\"my-grain\")] MyGrain", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CodeFix_AddRecordGrainClass()
+    {
+        const string source = @"
+[GrainType(""my-grain"")]
+public record MyGrain : IGrainBase, IGrainWithStringKey
+{
+    public Orleans.Runtime.IGrainContext GrainContext => throw new NotImplementedException();
+}
+";
+        const string contractsFile = "# OrleansContracts.txt\n";
+
+        var content = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            contractsFile,
+            GrainInterfaceVersionAnalyzer.RuleId0022);
+
+        Assert.Contains("class [GrainType(\"my-grain\")] MyGrain", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddGrainClass_OmitsMatchingIdentityComment()
+    {
+        const string source = @"
+[GrainType(""MyGrain"")]
+public class MyGrain : Grain, IGrainWithStringKey
+{
+}
+";
+
+        var content = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            "# OrleansContracts.txt\n",
+            GrainInterfaceVersionAnalyzer.RuleId0022);
+
+        Assert.Equal("class [GrainType(\"MyGrain\")] MyGrain\n", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_UpdateGrainClassAlias()
+    {
+        const string source = @"
+[GrainType(""new-alias"")]
+public class MyGrain : Grain, IGrainWithStringKey
+{
+}
+";
+        const string contractsFile = "class [GrainType(\"old-alias\")] MyGrain";
+
+        var content = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            contractsFile,
+            GrainInterfaceVersionAnalyzer.RuleId0023);
+
+        Assert.Contains("class [GrainType(\"new-alias\")] MyGrain", content);
+        Assert.DoesNotContain("old-alias", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_RetireGrainClass()
+    {
+        const string source = "public class SomeClass { }";
+        const string contractsFile = "class [GrainType(\"my-grain\")] MyGrain";
+
+        var content = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            contractsFile,
+            GrainInterfaceVersionAnalyzer.RuleId0024);
+
+        Assert.Contains("*RETIRED* class [GrainType(\"my-grain\")] MyGrain", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddGrainClass_ReactivatesRetiredDeclaration()
+    {
+        const string source = @"
+[GrainType(""my-grain"")]
+public class MyGrain : Grain, IGrainWithStringKey
+{
+}
+";
+        const string contractsFile = "*RETIRED* class [GrainType(\"old-alias\")] MyGrain";
+
+        var content = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            contractsFile,
+            GrainInterfaceVersionAnalyzer.RuleId0022);
+
+        Assert.Equal("# MyGrain\nclass [GrainType(\"my-grain\")] MyGrain\n", content);
     }
 
     #endregion
@@ -672,9 +1179,10 @@ IMyGrain.DoSomething() -> Task
 public interface IMyGrain : IGrain
 {
     Task DoSomething();
+    static Task Utility() => Task.CompletedTask;
 }
 ";
-        const string grainInterfacesFile = @"# GrainInterfaces.txt
+        const string grainInterfacesFile = @"# OrleansContracts.txt
 *RETIRED* SomeOther.IOldGrain [Version(1)]";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0016);
@@ -688,7 +1196,8 @@ public interface IMyGrain : IGrain
 
         // Should contain the new interface
         Assert.Contains("IMyGrain [Version(1)]", content);
-        Assert.Contains("IMyGrain.DoSomething() -> Task", content);
+        Assert.Contains("\n  DoSomething() -> Task", content);
+        Assert.DoesNotContain("Utility", content);
     }
 
     [Fact]
@@ -702,7 +1211,7 @@ public interface IMyGrain : IGrain
     Task DoSomething(string name);
 }
 ";
-        const string grainInterfacesFile = @"# GrainInterfaces.txt
+        const string grainInterfacesFile = @"# OrleansContracts.txt
 *RETIRED* SomeOther.IOldGrain [Version(1)]";
 
         var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0016);
@@ -714,10 +1223,116 @@ public interface IMyGrain : IGrain
         var changedText = await changedDocument!.GetTextAsync();
         var content = changedText.ToString();
 
-        // Should contain the alias
-        Assert.Contains("[Alias(\"my-grain\")]", content);
+        Assert.DoesNotContain("[Alias(", content);
         Assert.Contains("IMyGrain [Version(2)]", content);
-        Assert.Contains("IMyGrain.DoSomething(string name) -> Task", content);
+        Assert.Contains("\n  DoSomething(string) -> Task", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddInterface_SortsContractsAndMembers()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMiddle : IGrain
+{
+    Task Zeta();
+    Task Alpha();
+}
+";
+        const string grainInterfacesFile = "# OrleansContracts.txt\n" +
+            "IZulu [Version(1)]\n" +
+            "IZulu.Method() -> Task\n\n" +
+            "interface IAlpha [Version(1)]\n" +
+            "IAlpha.Method() -> Task";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0016);
+
+        Assert.NotNull(additionalDocumentId);
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        var changedText = await changedDocument!.GetTextAsync();
+        var content = changedText.ToString();
+
+        var alphaInterface = content.IndexOf("IAlpha [Version(1)]", StringComparison.Ordinal);
+        var middleInterface = content.IndexOf("IMiddle [Version(1)]", StringComparison.Ordinal);
+        var zuluInterface = content.IndexOf("IZulu [Version(1)]", StringComparison.Ordinal);
+        var alphaMember = content.IndexOf("  Alpha() -> Task", StringComparison.Ordinal);
+        var zetaMember = content.IndexOf("  Zeta() -> Task", StringComparison.Ordinal);
+
+        Assert.True(alphaInterface < middleInterface);
+        Assert.True(middleInterface < zuluInterface);
+        Assert.True(alphaMember < zetaMember);
+        Assert.Equal(
+            "interface IAlpha [Version(1)]\n" +
+            "  Method() -> Task\n\n" +
+            "interface IMiddle [Version(1)]\n" +
+            "  Alpha() -> Task\n" +
+            "  Zeta() -> Task\n\n" +
+            "interface IZulu [Version(1)]\n" +
+            "  Method() -> Task\n",
+            content);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddInterface_ProducesSameContentRegardlessOfApplicationOrder()
+    {
+        const string alphaSource = @"
+[Version(1)]
+public interface IAlpha : IGrain
+{
+    Task Method();
+}
+";
+        const string zuluSource = @"
+[Version(1)]
+public interface IZulu : IGrain
+{
+    Task Method();
+}
+";
+
+        var alphaThenZulu = await ApplyCodeFixAndGetContractsAsync(
+            zuluSource,
+            await ApplyCodeFixAndGetContractsAsync(
+                alphaSource,
+                "# OrleansContracts.txt\n",
+                GrainInterfaceVersionAnalyzer.RuleId0016),
+            GrainInterfaceVersionAnalyzer.RuleId0016);
+
+        var zuluThenAlpha = await ApplyCodeFixAndGetContractsAsync(
+            alphaSource,
+            await ApplyCodeFixAndGetContractsAsync(
+                zuluSource,
+                "# OrleansContracts.txt\n",
+                GrainInterfaceVersionAnalyzer.RuleId0016),
+            GrainInterfaceVersionAnalyzer.RuleId0016);
+
+        Assert.Equal(alphaThenZulu, zuluThenAlpha);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddInterface_ReactivatesByStableIdentity()
+    {
+        const string source = @"
+[GrainInterfaceType(""stable-interface"")]
+public interface INewGrain : IGrain
+{
+}
+";
+        const string contractsFile =
+            "*RETIRED* [GrainInterfaceType(\"stable-interface\")] IOldGrain [Version(0)] # CLR: IOldGrain\n";
+
+        var content = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            contractsFile,
+            GrainInterfaceVersionAnalyzer.RuleId0016);
+
+        Assert.Contains(
+            "# INewGrain\ninterface [GrainInterfaceType(\"stable-interface\")] INewGrain [Version(0)]",
+            content);
+        Assert.DoesNotContain("*RETIRED*", content);
+        Assert.Equal(1, content.Split(new[] { "stable-interface" }, StringSplitOptions.None).Length - 1);
     }
 
     #endregion
@@ -734,7 +1349,7 @@ public interface IMyGrain : IGrain
     Task DoSomething();
 }
 ";
-        const string grainInterfacesFile = @"# GrainInterfaces.txt
+        const string grainInterfacesFile = @"# OrleansContracts.txt
 IMyGrain [Version(1)]
 IMyGrain.DoSomething() -> Task";
 
@@ -752,6 +1367,67 @@ IMyGrain.DoSomething() -> Task";
         Assert.DoesNotContain("[Version(1)]", content);
     }
 
+    [Fact]
+    public async Task CodeFix_UpdateVersion_UsesExactInterfaceName()
+    {
+        const string source = @"
+[Version(2)]
+public interface IFoo : IGrain
+{
+    Task DoSomething();
+}
+
+[Version(1)]
+public interface IFooBar : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = @"# OrleansContracts.txt
+IFooBar [Version(1)]
+IFooBar.DoSomething() -> Task
+
+IFoo [Version(1)]
+IFoo.DoSomething() -> Task";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0017);
+
+        Assert.NotNull(additionalDocumentId);
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        var changedText = await changedDocument!.GetTextAsync();
+        var content = changedText.ToString();
+
+        Assert.Contains("IFooBar [Version(1)]", content);
+        Assert.Contains("IFoo [Version(2)]", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_UpdateVersion_PreservesLfLineEndings()
+    {
+        const string source = @"
+[Version(2)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+        const string grainInterfacesFile = "# OrleansContracts.txt\nIMyGrain [Version(1)]\nIMyGrain.DoSomething() -> Task\n";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0017);
+
+        Assert.NotNull(additionalDocumentId);
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        var changedText = await changedDocument!.GetTextAsync();
+        var content = changedText.ToString();
+
+        Assert.DoesNotContain("\r", content);
+        Assert.Equal("interface IMyGrain [Version(2)]\n  DoSomething() -> Task\n", content);
+    }
+
     #endregion
 
     #region Code Fix Tests - ORLEANS0018 Add Member
@@ -767,7 +1443,7 @@ public interface IMyGrain : IGrain
     Task NewMethod(int value);
 }
 ";
-        const string grainInterfacesFile = @"# GrainInterfaces.txt
+        const string grainInterfacesFile = @"# OrleansContracts.txt
 IMyGrain [Version(1)]
 IMyGrain.DoSomething() -> Task";
 
@@ -781,7 +1457,117 @@ IMyGrain.DoSomething() -> Task";
         var content = changedText.ToString();
 
         // Should contain the new member
-        Assert.Contains("IMyGrain.NewMethod(int value) -> Task", content);
+        Assert.Contains("\n  NewMethod(int) -> Task", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddMember_WithAlias()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+
+    [Alias(""new-method"")]
+    Task NewMethod(int value);
+}
+";
+        const string grainInterfacesFile = @"# OrleansContracts.txt
+IMyGrain [Version(1)]
+IMyGrain.DoSomething() -> Task";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0018);
+
+        Assert.NotNull(additionalDocumentId);
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        var changedText = await changedDocument!.GetTextAsync();
+        var content = changedText.ToString();
+
+        Assert.Contains("\n  new-method(int) -> Task", content);
+        Assert.Contains("  # IMyGrain.NewMethod(int value) -> Task", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddMember_OmitsMatchingAliasComment()
+    {
+        const string source = @"
+[Version(1)]
+public interface IMyGrain : IGrain
+{
+    [Alias(""NewMethod"")]
+    Task NewMethod();
+}
+";
+        const string contractsFile = "IMyGrain [Version(1)]";
+
+        var content = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            contractsFile,
+            GrainInterfaceVersionAnalyzer.RuleId0018);
+
+        Assert.Equal("interface IMyGrain [Version(1)]\n  NewMethod() -> Task\n", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_AddMember_InsertsBeforeNextInterface()
+    {
+        const string source = @"
+[Version(1)]
+public interface IFoo : IGrain
+{
+    Task NewMethod();
+}
+
+[Version(1)]
+public interface IFooBar : IGrain
+{
+    Task ExistingMethod();
+}
+";
+        const string grainInterfacesFile = @"# OrleansContracts.txt
+IFoo [Version(1)]
+IFooBar [Version(1)]
+IFooBar.ExistingMethod() -> Task";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0018);
+
+        Assert.NotNull(additionalDocumentId);
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        var changedText = await changedDocument!.GetTextAsync();
+        var content = changedText.ToString();
+
+        Assert.True(
+            content.IndexOf("  NewMethod() -> Task", StringComparison.Ordinal)
+                < content.IndexOf("IFooBar [Version(1)]", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CodeFix_AddMember_InsertsBeforeNextGrainClass()
+    {
+        const string source = @"
+[Version(1)]
+public interface IFoo : IGrain
+{
+    Task NewMethod();
+}
+";
+        const string contractsFile = @"# OrleansContracts.txt
+IFoo [Version(1)]
+class SomeGrain";
+
+        var content = await ApplyCodeFixAndGetContractsAsync(
+            source,
+            contractsFile,
+            GrainInterfaceVersionAnalyzer.RuleId0018);
+
+        Assert.True(
+            content.IndexOf("  NewMethod() -> Task", StringComparison.Ordinal)
+                < content.IndexOf("class SomeGrain", StringComparison.Ordinal));
     }
 
     #endregion
@@ -799,7 +1585,7 @@ public interface IMyGrain<T> : IGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain<T> [Version(1)]
 IMyGrain<T>.DoSomething(T value) -> Task
 ";
@@ -821,7 +1607,7 @@ public interface IMyGrain<T> : IGrain where T : class
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain<T> [Version(1)]
 IMyGrain<T>.DoSomething(T value) -> Task
 ";
@@ -841,7 +1627,7 @@ public interface IMyGrain<TKey, TValue> : IGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain<TKey, TValue> [Version(1)]
 IMyGrain<TKey, TValue>.DoSomething(TKey key, TValue value) -> Task
 ";
@@ -861,7 +1647,7 @@ IMyGrain<TKey, TValue>.DoSomething(TKey key, TValue value) -> Task
 // No grain interfaces - IOldGrain was removed
 public class SomeClass { }
 ";
-        const string grainInterfacesFile = @"# GrainInterfaces.txt
+        const string grainInterfacesFile = @"# OrleansContracts.txt
 IOldGrain [Version(1)]
 IOldGrain.DoSomething() -> Task";
 
@@ -875,7 +1661,31 @@ IOldGrain.DoSomething() -> Task";
         var content = changedText.ToString();
 
         // Should have *RETIRED* prefix
-        Assert.Contains("*RETIRED* IOldGrain [Version(1)]", content);
+        Assert.Contains("*RETIRED* interface IOldGrain [Version(1)]", content);
+    }
+
+    [Fact]
+    public async Task CodeFix_RetireInterface_UsesExactInterfaceName()
+    {
+        const string source = @"
+public class SomeClass { }
+";
+        const string grainInterfacesFile = @"# OrleansContracts.txt
+IFoo [Version(1)]
+IFooBar [Version(1)]";
+
+        var (changedSolution, additionalDocumentId) = await ApplyCodeFixAsync(source, grainInterfacesFile, GrainInterfaceVersionAnalyzer.RuleId0019);
+
+        Assert.NotNull(additionalDocumentId);
+        var changedDocument = changedSolution.GetAdditionalDocument(additionalDocumentId!);
+        Assert.NotNull(changedDocument);
+
+        var changedText = await changedDocument!.GetTextAsync();
+        var content = changedText.ToString();
+
+        Assert.Contains("*RETIRED* interface IFoo [Version(1)]", content);
+        Assert.Contains("\ninterface IFooBar [Version(1)]", content);
+        Assert.DoesNotContain("*RETIRED* interface IFooBar", content);
     }
 
     #endregion
@@ -899,7 +1709,7 @@ public interface IDerivedGrain : IBaseGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IBaseGrain [Version(1)]
 IBaseGrain.DoBase() -> Task
 
@@ -931,7 +1741,7 @@ public interface IDerivedGrain : IBaseGrain
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IBaseGrain [Version(1)]
 IBaseGrain.DoBase() -> Task
 ";
@@ -954,7 +1764,7 @@ public interface IMyGrain : IGrainWithStringKey
 }
 ";
         const string grainInterfacesFile = @"
-# GrainInterfaces.txt
+# OrleansContracts.txt
 IMyGrain [Version(1)]
 IMyGrain.DoSomething() -> Task
 ";

--- a/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
+++ b/test/Orleans.Analyzers.Tests/GrainInterfaceVersionAnalyzerTest.cs
@@ -35,7 +35,10 @@ public class GrainInterfaceVersionAnalyzerTest
 
     #region Test Infrastructure
 
-    private async Task<Diagnostic[]> GetDiagnosticsAsync(string source, string? grainInterfacesFileContent = null)
+    private async Task<Diagnostic[]> GetDiagnosticsAsync(
+        string source,
+        string? grainInterfacesFileContent = null,
+        bool analyzerEnabled = true)
     {
         var project = CreateProjectWithAdditionalFiles(source, grainInterfacesFileContent);
         var compilation = await project.GetCompilationAsync();
@@ -50,7 +53,7 @@ public class GrainInterfaceVersionAnalyzerTest
             ? ImmutableArray.Create<AdditionalText>(new TestAdditionalText(OrleansContractsFileName, grainInterfacesFileContent))
             : ImmutableArray<AdditionalText>.Empty;
 
-        var analyzerOptions = new AnalyzerOptions(additionalFiles);
+        var analyzerOptions = CreateAnalyzerOptions(additionalFiles, analyzerEnabled);
 
         var compilationWithAnalyzers = compilation
             .WithOptions(compilation.Options.WithSpecificDiagnosticOptions(
@@ -129,9 +132,50 @@ public class GrainInterfaceVersionAnalyzerTest
         public override SourceText? GetText(CancellationToken cancellationToken = default) => _text;
     }
 
+    private static AnalyzerOptions CreateAnalyzerOptions(
+        ImmutableArray<AdditionalText> additionalFiles,
+        bool analyzerEnabled)
+        => new(additionalFiles, new TestAnalyzerConfigOptionsProvider(analyzerEnabled));
+
+    private sealed class TestAnalyzerConfigOptionsProvider(bool analyzerEnabled) : AnalyzerConfigOptionsProvider
+    {
+        private readonly AnalyzerConfigOptions _globalOptions = new TestAnalyzerConfigOptions(
+            ImmutableDictionary<string, string>.Empty.Add(
+                $"build_property.{GrainInterfaceVersionAnalyzer.EnableAnalyzerPropertyName}",
+                analyzerEnabled.ToString()));
+
+        public override AnalyzerConfigOptions GlobalOptions => _globalOptions;
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => TestAnalyzerConfigOptions.Empty;
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => TestAnalyzerConfigOptions.Empty;
+    }
+
+    private sealed class TestAnalyzerConfigOptions(ImmutableDictionary<string, string> values) : AnalyzerConfigOptions
+    {
+        public static TestAnalyzerConfigOptions Empty { get; } = new(ImmutableDictionary<string, string>.Empty);
+
+        public override bool TryGetValue(string key, out string value) => values.TryGetValue(key, out value!);
+    }
+
     #endregion
 
     #region ORLEANS0016 - Interface Not Declared
+
+    [Fact]
+    public async Task AnalyzerDisabled_NoDiagnostic()
+    {
+        const string source = @"
+public interface IMyGrain : IGrain
+{
+    Task DoSomething();
+}
+";
+
+        var diagnostics = await GetDiagnosticsAsync(source, grainInterfacesFileContent: null, analyzerEnabled: false);
+
+        Assert.Empty(diagnostics);
+    }
 
     [Fact]
     public async Task InterfaceNotInFile_WithExistingFile_ReportsDiagnostic()
@@ -946,7 +990,7 @@ public class MyGrain : Grain, IGrainWithStringKey
             ? ImmutableArray.Create<AdditionalText>(new TestAdditionalText(OrleansContractsFileName, grainInterfacesFileContent))
             : ImmutableArray<AdditionalText>.Empty;
 
-        var analyzerOptions = new AnalyzerOptions(additionalFiles);
+        var analyzerOptions = CreateAnalyzerOptions(additionalFiles, analyzerEnabled: true);
 
         var compilationWithAnalyzers = compilation
             .WithOptions(compilation.Options.WithSpecificDiagnosticOptions(


### PR DESCRIPTION
Orleans RPC contracts can change without an explicit record of the prior interface shape, making accidental incompatibilities difficult to catch before rolling upgrades.

This adds a grain interface version analyzer and code fixes which compare source interfaces with a `GrainInterfaces.txt` contract manifest. It reports undeclared interfaces and members, version mismatches, unretired removals, missing manifests, and duplicate declarations, with focused analyzer coverage for versioning, aliases, generics, inheritance, and code fixes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10337)