### PR TITLE
feat(directory): add cancellation-aware operations

### DIFF
--- a/src/Orleans.Core.Abstractions/GrainDirectory/IGrainDirectory.cs
+++ b/src/Orleans.Core.Abstractions/GrainDirectory/IGrainDirectory.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Runtime;
 
@@ -20,12 +21,31 @@ namespace Orleans.GrainDirectory
 
         /// <summary>
         /// Register a <see cref="GrainAddress"/> entry in the directory.
+        /// </summary>
+        /// <param name="address">The <see cref="GrainAddress"/> to register.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The <see cref="GrainAddress"/> that is effectively registered in the directory.</returns>
+        Task<GrainAddress?> Register(GrainAddress address, CancellationToken cancellationToken) =>
+            Register(address).WaitAsync(cancellationToken);
+
+        /// <summary>
+        /// Register a <see cref="GrainAddress"/> entry in the directory.
         /// Only one <see cref="GrainAddress"/> per <see cref="GrainAddress.GrainId"/> can be registered. If there is already an
         /// existing entry, the directory will not override it.
         /// </summary>
         /// <param name="address">The <see cref="GrainAddress"/> to register</param>
         /// <returns>The <see cref="GrainAddress"/> that is effectively registered in the directory.</returns>
         Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress) => GrainDirectoryExtension.Register(this, address, previousAddress);
+
+        /// <summary>
+        /// Register a <see cref="GrainAddress"/> entry in the directory.
+        /// </summary>
+        /// <param name="address">The <see cref="GrainAddress"/> to register.</param>
+        /// <param name="previousAddress">The previous registration, if any.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The <see cref="GrainAddress"/> that is effectively registered in the directory.</returns>
+        Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress, CancellationToken cancellationToken) =>
+            Register(address, previousAddress).WaitAsync(cancellationToken);
 
         /// <summary>
         /// Unregisters the specified <see cref="GrainAddress"/> entry from the directory.
@@ -39,11 +59,29 @@ namespace Orleans.GrainDirectory
         Task Unregister(GrainAddress address);
 
         /// <summary>
+        /// Unregisters the specified <see cref="GrainAddress"/> entry from the directory.
+        /// </summary>
+        /// <param name="address">The <see cref="GrainAddress"/> to unregister.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A <see cref="Task"/> representing the operation.</returns>
+        Task Unregister(GrainAddress address, CancellationToken cancellationToken) =>
+            Unregister(address).WaitAsync(cancellationToken);
+
+        /// <summary>
         /// Lookup for a <see cref="GrainAddress"/> for a given Grain ID.
         /// </summary>
         /// <param name="grainId">The Grain ID to lookup</param>
         /// <returns>The <see cref="GrainAddress"/> entry found in the directory, if any</returns>
         Task<GrainAddress?> Lookup(GrainId grainId);
+
+        /// <summary>
+        /// Lookup for a <see cref="GrainAddress"/> for a given Grain ID.
+        /// </summary>
+        /// <param name="grainId">The Grain ID to lookup.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The <see cref="GrainAddress"/> entry found in the directory, if any.</returns>
+        Task<GrainAddress?> Lookup(GrainId grainId, CancellationToken cancellationToken) =>
+            Lookup(grainId).WaitAsync(cancellationToken);
 
         /// <summary>
         /// Unregisters all grain directory entries which point to any of the specified silos.
@@ -56,6 +94,15 @@ namespace Orleans.GrainDirectory
         /// A <see cref="Task"/> representing the operation.
         /// </returns>
         Task UnregisterSilos(List<SiloAddress> siloAddresses);
+
+        /// <summary>
+        /// Unregisters all grain directory entries which point to any of the specified silos.
+        /// </summary>
+        /// <param name="siloAddresses">The silos to be removed from the directory.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A <see cref="Task"/> representing the operation.</returns>
+        Task UnregisterSilos(List<SiloAddress> siloAddresses, CancellationToken cancellationToken) =>
+            UnregisterSilos(siloAddresses).WaitAsync(cancellationToken);
     }
 
     internal static class GrainDirectoryExtension

--- a/src/Orleans.Runtime/Catalog/ActivationData.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationData.cs
@@ -1662,7 +1662,7 @@ internal sealed partial class ActivationData :
                             LogRegisteringGrain(_shared.Logger, this, previousRegistration);
 
                             var result = await _shared.InternalRuntime.GrainLocator
-                                .Register(Address, previousRegistration).WaitAsync(cancellationToken);
+                                .Register(Address, previousRegistration, cancellationToken);
                             if (Address.Matches(result))
                             {
                                 Address = result;

--- a/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/CachedGrainLocator.cs
@@ -84,7 +84,13 @@ namespace Orleans.Runtime.GrainDirectory
             return entry;
         }
 
-        public async Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress)
+        public Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress) =>
+            Register(address, previousAddress, CancellationToken.None);
+
+        internal async Task<GrainAddress?> Register(
+            GrainAddress address,
+            GrainAddress? previousAddress,
+            CancellationToken cancellationToken)
         {
             var grainType = address.GrainId.Type;
             if (grainType.IsClient() || grainType.IsSystemTarget())
@@ -100,7 +106,8 @@ namespace Orleans.Runtime.GrainDirectory
                 MembershipVersion = clusterMembershipService.CurrentSnapshot.Version
             };
 
-            var result = await GetGrainDirectory(grainType).Register(address, previousAddress);
+            var directory = GetGrainDirectory(grainType);
+            var result = await directory.Register(address, previousAddress, cancellationToken);
 
             if (result is null)
             {
@@ -111,9 +118,8 @@ namespace Orleans.Runtime.GrainDirectory
             // Check if the entry point to a dead silo
             if (IsKnownDeadSilo(result))
             {
-                // Remove outdated entry and retry to register
-                await GetGrainDirectory(grainType).Unregister(result);
-                result = await GetGrainDirectory(grainType).Register(address, previousAddress);
+                // Conditionally replace the outdated entry.
+                result = await directory.Register(address, result, cancellationToken);
             }
 
             // Cache update

--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -113,19 +113,51 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         DistributedRemoteGrainDirectory.Create(this, membershipService, shared);
     }
 
-    public async Task<GrainAddress?> Lookup(GrainId grainId) => await LookupAsync(grainId, _stoppedCts.Token);
+    public Task<GrainAddress?> Lookup(GrainId grainId) => Lookup(grainId, _stoppedCts.Token);
 
-    public async Task<GrainAddress?> Register(GrainAddress address) => await RegisterAsync(address, null, _stoppedCts.Token);
+    public async Task<GrainAddress?> Lookup(GrainId grainId, CancellationToken cancellationToken)
+    {
+        using var linkedCts = LinkWithStoppedToken(cancellationToken, out var effectiveCancellationToken);
+        return await LookupAsync(grainId, effectiveCancellationToken);
+    }
 
-    public async Task Unregister(GrainAddress address) => await InvokeAsync(
-        address.GrainId,
-        static (partition, version, address, cancellationToken) => partition.DeregisterAsync(version, address, cancellationToken),
-        address,
-        _stoppedCts.Token);
+    public Task<GrainAddress?> Register(GrainAddress address) => Register(address, _stoppedCts.Token);
 
-    public async Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress) => await RegisterAsync(address, previousAddress, _stoppedCts.Token);
+    public async Task<GrainAddress?> Register(GrainAddress address, CancellationToken cancellationToken)
+    {
+        using var linkedCts = LinkWithStoppedToken(cancellationToken, out var effectiveCancellationToken);
+        return await RegisterAsync(address, null, effectiveCancellationToken);
+    }
 
-    public Task UnregisterSilos(List<SiloAddress> siloAddresses) => Task.CompletedTask;
+    public Task Unregister(GrainAddress address) => Unregister(address, _stoppedCts.Token);
+
+    public async Task Unregister(GrainAddress address, CancellationToken cancellationToken)
+    {
+        using var linkedCts = LinkWithStoppedToken(cancellationToken, out var effectiveCancellationToken);
+        await UnregisterAsync(address, effectiveCancellationToken);
+    }
+
+    public Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousAddress) =>
+        Register(address, previousAddress, _stoppedCts.Token);
+
+    public async Task<GrainAddress?> Register(
+        GrainAddress address,
+        GrainAddress? previousAddress,
+        CancellationToken cancellationToken)
+    {
+        using var linkedCts = LinkWithStoppedToken(cancellationToken, out var effectiveCancellationToken);
+        return await RegisterAsync(address, previousAddress, effectiveCancellationToken);
+    }
+
+    public Task UnregisterSilos(List<SiloAddress> siloAddresses) =>
+        UnregisterSilos(siloAddresses, _stoppedCts.Token);
+
+    public async Task UnregisterSilos(List<SiloAddress> siloAddresses, CancellationToken cancellationToken)
+    {
+        using var linkedCts = LinkWithStoppedToken(cancellationToken, out var effectiveCancellationToken);
+        effectiveCancellationToken.ThrowIfCancellationRequested();
+        await Task.CompletedTask;
+    }
 
     internal Task<GrainAddress?> LookupAsync(GrainId grainId, CancellationToken cancellationToken) => InvokeAsync(
         grainId,
@@ -144,6 +176,21 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
         static (partition, version, address, cancellationToken) => partition.DeregisterAsync(version, address, cancellationToken),
         address,
         cancellationToken);
+
+    private CancellationTokenSource? LinkWithStoppedToken(
+        CancellationToken cancellationToken,
+        out CancellationToken effectiveCancellationToken)
+    {
+        if (cancellationToken == _stoppedCts.Token)
+        {
+            effectiveCancellationToken = cancellationToken;
+            return null;
+        }
+
+        var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _stoppedCts.Token);
+        effectiveCancellationToken = linkedCts.Token;
+        return linkedCts;
+    }
 
     private async Task<TResult?> InvokeAsync<TState, TResult>(
         GrainId grainId,

--- a/src/Orleans.Runtime/GrainDirectory/GrainLocator.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainLocator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.GrainDirectory;
 
@@ -22,13 +23,18 @@ namespace Orleans.Runtime.GrainDirectory
 
         public ValueTask<GrainAddress?> Lookup(GrainId grainId) => GetGrainLocator(grainId.Type).Lookup(grainId);
 
-        public async Task<GrainAddress?> Register(GrainAddress address, GrainAddress? previousRegistration)
+        public async Task<GrainAddress?> Register(
+            GrainAddress address,
+            GrainAddress? previousRegistration,
+            CancellationToken cancellationToken = default)
         {
             var grainLocator = GetGrainLocator(address.GrainId.Type);
             var metrics = RegistrationMetricTracker.Start(_directoryInstruments, grainLocator);
             try
             {
-                var result = await grainLocator.Register(address, previousRegistration);
+                var result = grainLocator is CachedGrainLocator cachedGrainLocator
+                    ? await cachedGrainLocator.Register(address, previousRegistration, cancellationToken)
+                    : await grainLocator.Register(address, previousRegistration).WaitAsync(cancellationToken);
                 metrics.RecordSucceeded();
                 return result;
             }

--- a/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
+++ b/src/api/Orleans.Core.Abstractions/Orleans.Core.Abstractions.cs
@@ -1538,10 +1538,15 @@ namespace Orleans.GrainDirectory
 
     public partial interface IGrainDirectory
     {
+        System.Threading.Tasks.Task<Runtime.GrainAddress?> Lookup(Runtime.GrainId grainId, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<Runtime.GrainAddress?> Lookup(Runtime.GrainId grainId);
+        System.Threading.Tasks.Task<Runtime.GrainAddress?> Register(Runtime.GrainAddress address, Runtime.GrainAddress? previousAddress, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<Runtime.GrainAddress?> Register(Runtime.GrainAddress address, Runtime.GrainAddress? previousAddress);
+        System.Threading.Tasks.Task<Runtime.GrainAddress?> Register(Runtime.GrainAddress address, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<Runtime.GrainAddress?> Register(Runtime.GrainAddress address);
+        System.Threading.Tasks.Task Unregister(Runtime.GrainAddress address, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task Unregister(Runtime.GrainAddress address);
+        System.Threading.Tasks.Task UnregisterSilos(System.Collections.Generic.List<Runtime.SiloAddress> siloAddresses, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task UnregisterSilos(System.Collections.Generic.List<Runtime.SiloAddress> siloAddresses);
     }
 }

--- a/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
+++ b/test/Orleans.Core.Tests/Directory/CachedGrainLocatorTests.cs
@@ -41,6 +41,14 @@ namespace UnitTests.Directory
             this.lifecycle = new SiloLifecycleSubject(this.loggerFactory.CreateLogger<SiloLifecycleSubject>());
 
             this.grainDirectory = Substitute.For<IGrainDirectory>();
+            this.grainDirectory
+                .Register(Arg.Any<GrainAddress>(), Arg.Any<GrainAddress?>(), Arg.Any<CancellationToken>())
+                .Returns(call => this.grainDirectory.Register(
+                    call.ArgAt<GrainAddress>(0),
+                    call.ArgAt<GrainAddress?>(1)));
+            this.grainDirectory
+                .Unregister(Arg.Any<GrainAddress>(), Arg.Any<CancellationToken>())
+                .Returns(call => this.grainDirectory.Unregister(call.ArgAt<GrainAddress>(0)));
             var services = new ServiceCollection()
                 .AddGrainDirectory(GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY, (sp, name) => this.grainDirectory)
                 .BuildServiceProvider();
@@ -444,13 +452,14 @@ namespace UnitTests.Directory
             var expectedAddr = GenerateGrainAddress(expectedSilo);
             var outdatedAddr = GenerateGrainAddress(outdatedSilo);
 
-            // First returns the outdated entry, then the new one
-            this.grainDirectory.Register(expectedAddr, previousAddress: null).Returns(outdatedAddr, expectedAddr);
+            this.grainDirectory.Register(expectedAddr, previousAddress: null).Returns(outdatedAddr);
+            this.grainDirectory.Register(expectedAddr, previousAddress: outdatedAddr).Returns(expectedAddr);
 
             var actual = await this.grainLocator.Register(expectedAddr, previousAddress: null);
             Assert.Equal(expectedAddr, actual);
-            await this.grainDirectory.Received(2).Register(expectedAddr, previousAddress: null);
-            await this.grainDirectory.Received(1).Unregister(outdatedAddr);
+            await this.grainDirectory.Received(1).Register(expectedAddr, previousAddress: null);
+            await this.grainDirectory.Received(1).Register(expectedAddr, previousAddress: outdatedAddr);
+            await this.grainDirectory.DidNotReceive().Unregister(outdatedAddr);
 
             // Now should be in cache
             Assert.True(this.grainLocator.TryLookupInCache(expectedAddr.GrainId, out var result));

--- a/test/Orleans.Core.Tests/Directory/IGrainDirectoryTests.cs
+++ b/test/Orleans.Core.Tests/Directory/IGrainDirectoryTests.cs
@@ -1,0 +1,42 @@
+using Orleans.GrainDirectory;
+using Orleans.Runtime;
+using Xunit;
+
+namespace UnitTests.Directory;
+
+[TestCategory("BVT"), TestCategory("Directory")]
+public class IGrainDirectoryTests
+{
+    [Fact]
+    public async Task CancellationOverloads_DefaultToCancelableWait()
+    {
+        IGrainDirectory directory = new BlockingGrainDirectory();
+        var cancellationToken = new CancellationToken(canceled: true);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => directory.Register(default!, cancellationToken));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => directory.Register(default!, null, cancellationToken));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => directory.Unregister(default!, cancellationToken));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => directory.Lookup(default, cancellationToken));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => directory.UnregisterSilos([], cancellationToken));
+    }
+
+    private sealed class BlockingGrainDirectory : IGrainDirectory
+    {
+        public Task<GrainAddress?> Register(GrainAddress address) =>
+            new TaskCompletionSource<GrainAddress?>().Task;
+
+        public Task Unregister(GrainAddress address) =>
+            new TaskCompletionSource().Task;
+
+        public Task<GrainAddress?> Lookup(GrainId grainId) =>
+            new TaskCompletionSource<GrainAddress?>().Task;
+
+        public Task UnregisterSilos(List<SiloAddress> siloAddresses) =>
+            new TaskCompletionSource().Task;
+    }
+}


### PR DESCRIPTION
Grain directory callers cannot currently propagate cancellation into directory implementations, so activation shutdown can leave registration work running and stale registrations are replaced non-atomically.

Add backward-compatible cancellation overloads with default cancelable waits, implement linked shutdown/caller cancellation in the distributed directory, propagate activation cancellation through the locator stack, and conditionally replace stale registrations in one register operation.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10339)