### PR TITLE
fix(serialization): cap codec allocations

### DIFF
--- a/src/Orleans.Serialization/Buffers/Reader.cs
+++ b/src/Orleans.Serialization/Buffers/Reader.cs
@@ -97,6 +97,7 @@ namespace Orleans.Serialization.Buffers
 
         public override long Position => _stream.Position;
         public override long Length => _stream.Length;
+        internal long Remaining => _stream.CanSeek ? _stream.Length - _stream.Position : long.MaxValue;
 
         public StreamReaderInput(Stream stream, ArrayPool<byte> memoryPool)
         {
@@ -435,6 +436,58 @@ namespace Orleans.Serialization.Buffers
                 {
                     return ThrowNotSupportedInput<long>();
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of unread bytes in the input.
+        /// </summary>
+        public long Remaining
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if (IsReadOnlySequenceInput)
+                {
+                    ref var input = ref Unsafe.As<TInput, ReadOnlySequenceInput>(ref _input);
+                    return input.Sequence.Length - input.PreviousBuffersSize - _bufferPos;
+                }
+                else if (IsBufferSliceInput)
+                {
+                    ref var input = ref Unsafe.As<TInput, BufferSliceReaderInput>(ref _input);
+                    return input.Length - input.PreviousBuffersSize - _bufferPos;
+                }
+                else if (IsArcBufferInput)
+                {
+                    ref var input = ref Unsafe.As<TInput, ArcBufferReaderInput>(ref _input);
+                    return input.Length - input.PreviousBuffersSize - _bufferPos;
+                }
+                else if (IsSpanInput)
+                {
+                    return _currentSpan.Length - _bufferPos;
+                }
+                else if (_input is ReaderInput readerInput)
+                {
+                    return readerInput is StreamReaderInput streamInput ? streamInput.Remaining : readerInput.Length - readerInput.Position;
+                }
+                else
+                {
+                    return ThrowNotSupportedInput<long>();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Throws if fewer than <paramref name="count"/> bytes remain in the input.
+        /// </summary>
+        /// <param name="count">The number of bytes which are required.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void EnsureAvailable(uint count)
+        {
+            var remaining = Remaining;
+            if (count > remaining)
+            {
+                ThrowInvalidSizeException(count, remaining);
             }
         }
 
@@ -850,6 +903,13 @@ namespace Orleans.Serialization.Buffers
         /// </summary>
         public void ReadBytes<TBufferWriter>(scoped ref TBufferWriter writer, int count) where TBufferWriter : IBufferWriter<byte>
         {
+            if (count < 0)
+            {
+                ThrowArgumentOutOfRangeException(count);
+            }
+
+            EnsureAvailable((uint)count);
+
             int chunkSize;
             for (var remaining = count; remaining > 0; remaining -= chunkSize)
             {
@@ -877,10 +937,7 @@ namespace Orleans.Serialization.Buffers
                 return Array.Empty<byte>();
             }
 
-            if (count > 10240 && count > Length)
-            {
-                ThrowInvalidSizeException(count);
-            }
+            EnsureAvailable(count);
 
             var bytes = new byte[count];
             if (IsReadOnlySequenceInput || IsSpanInput || IsBufferSliceInput || IsArcBufferInput)
@@ -1160,7 +1217,14 @@ namespace Orleans.Serialization.Buffers
 
         private static void ThrowNotSupportedInput() => throw new NotSupportedException($"Type {typeof(TInput)} is not supported");
 
-        private static void ThrowInvalidSizeException(uint length) => throw new IndexOutOfRangeException(
-            $"Declared length of {typeof(byte[])}, {length}, is greater than total length of input.");
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalidSizeException(uint length, long remaining) => throw new IndexOutOfRangeException(
+            $"Declared length, {length}, is greater than the remaining length of the input, {remaining}.");
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowArgumentOutOfRangeException(int count) => throw new ArgumentOutOfRangeException(
+            nameof(count), count, "The count must not be negative.");
     }
 }

--- a/src/Orleans.Serialization/Codecs/ArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ArrayCodec.cs
@@ -80,10 +80,7 @@ namespace Orleans.Serialization.Codecs
                 {
                     case 0:
                         length = (int)UInt32Codec.ReadValue(ref reader, header);
-                        if (length > 10240 && length > reader.Length)
-                        {
-                            ThrowInvalidSizeException(length);
-                        }
+                        reader.EnsureAvailable((uint)length);
 
                         result = new T[length];
                         ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
@@ -119,9 +116,6 @@ namespace Orleans.Serialization.Codecs
 
         private static void ThrowIndexOutOfRangeException(int length) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {typeof(T[])} with declared length {length}.");
-
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-            $"Declared length of {typeof(T[])}, {length}, is greater than total length of input.");
 
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
     }
@@ -237,10 +231,7 @@ namespace Orleans.Serialization.Codecs
                 {
                     case 0:
                         length = (int)UInt32Codec.ReadValue(ref reader, header);
-                        if (length > 10240 && length > reader.Length)
-                        {
-                            ThrowInvalidSizeException(length);
-                        }
+                        reader.EnsureAvailable((uint)length);
 
                         result = new T[length];
                         ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
@@ -273,8 +264,6 @@ namespace Orleans.Serialization.Codecs
 
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-            $"Declared length of {typeof(ReadOnlyMemory<T>)}, {length}, is greater than total length of input.");
     }
 
     /// <summary>
@@ -400,10 +389,7 @@ namespace Orleans.Serialization.Codecs
                 {
                     case 0:
                         length = (int)UInt32Codec.ReadValue(ref reader, header);
-                        if (length > 10240 && length > reader.Length)
-                        {
-                            ThrowInvalidSizeException(length);
-                        }
+                        reader.EnsureAvailable((uint)length);
 
                         result = new T[length];
                         ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
@@ -436,8 +422,6 @@ namespace Orleans.Serialization.Codecs
 
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-            $"Declared length of {typeof(Memory<T>)}, {length}, is greater than total length of input.");
     }
 
     /// <summary>
@@ -566,10 +550,7 @@ namespace Orleans.Serialization.Codecs
                 {
                     case 0:
                         length = (int)UInt32Codec.ReadValue(ref reader, header);
-                        if (length > 10240 && length > reader.Length)
-                        {
-                            ThrowInvalidSizeException(length);
-                        }
+                        reader.EnsureAvailable((uint)length);
 
                         result = new T[length];
                         ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
@@ -602,8 +583,6 @@ namespace Orleans.Serialization.Codecs
 
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-            $"Declared length of {typeof(ArraySegment<T>)}, {length}, is greater than total length of input.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/ByteArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ByteArrayCodec.cs
@@ -45,6 +45,12 @@ namespace Orleans.Serialization.Codecs
 
             field.EnsureWireType(WireType.LengthPrefixed);
             var numBytes = reader.ReadVarUInt32();
+            reader.EnsureAvailable(numBytes);
+            if (numBytes > int.MaxValue / 8)
+            {
+                ThrowInvalidSizeException(numBytes);
+            }
+
             var result = new BitArray((int)numBytes * 8, false);
 #if NET10_0_OR_GREATER
             reader.ReadBytes(CollectionsMarshal.AsBytes(result)[..(int)numBytes]);
@@ -56,6 +62,10 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(reader.Session, result);
             return result!;
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalidSizeException(uint numBytes) => throw new IndexOutOfRangeException(
+            $"The declared BitArray length, {numBytes} bytes, exceeds the maximum supported length.");
 
         void IFieldCodec<BitArray>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, [System.Diagnostics.CodeAnalysis.AllowNull] Type expectedType, [System.Diagnostics.CodeAnalysis.AllowNull] BitArray value)
         {
@@ -431,7 +441,9 @@ namespace Orleans.Serialization.Codecs
             field.EnsureWireType(WireType.LengthPrefixed);
             var value = new PooledBuffer();
             const int MaxSpanLength = 4096;
-            var length = (int)reader.ReadVarUInt32();
+            var encodedLength = reader.ReadVarUInt32();
+            reader.EnsureAvailable(encodedLength);
+            var length = checked((int)encodedLength);
             while (length > 0)
             {
                 var copied = Math.Min(length, MaxSpanLength);

--- a/src/Orleans.Serialization/Codecs/ByteArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ByteArrayCodec.cs
@@ -439,11 +439,16 @@ namespace Orleans.Serialization.Codecs
         {
             ReferenceCodec.MarkValueField(reader.Session);
             field.EnsureWireType(WireType.LengthPrefixed);
-            var value = new PooledBuffer();
             const int MaxSpanLength = 4096;
             var encodedLength = reader.ReadVarUInt32();
+            if (encodedLength > int.MaxValue)
+            {
+                ThrowInvalidSizeException(encodedLength);
+            }
+
             reader.EnsureAvailable(encodedLength);
-            var length = checked((int)encodedLength);
+            var length = (int)encodedLength;
+            var value = new PooledBuffer();
             while (length > 0)
             {
                 var copied = Math.Min(length, MaxSpanLength);
@@ -456,6 +461,11 @@ namespace Orleans.Serialization.Codecs
             Debug.Assert(length == 0);
             return value;
         }
+
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalidSizeException(uint length) => throw new IndexOutOfRangeException(
+            $"The declared PooledBuffer length, {length}, exceeds the maximum supported length, {int.MaxValue}.");
     }
 
     /// <summary>

--- a/src/Orleans.Serialization/Codecs/CollectionCodec.cs
+++ b/src/Orleans.Serialization/Codecs/CollectionCodec.cs
@@ -74,10 +74,7 @@ public sealed class CollectionCodec<T> : IFieldCodec<Collection<T>>, IBaseCodec<
             {
                 case 0:
                     var length = (int)UInt32Codec.ReadValue(ref reader, header);
-                    if (length > 10240 && length > reader.Length)
-                    {
-                        ThrowInvalidSizeException(length);
-                    }
+                    reader.EnsureAvailable((uint)length);
 
                     result = new Collection<T>(new List<T>(length));
                     ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
@@ -104,9 +101,6 @@ public sealed class CollectionCodec<T> : IFieldCodec<Collection<T>>, IBaseCodec<
 
         return result!;
     }
-
-    private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-        $"Declared length of {typeof(Collection<T>)}, {length}, is greater than total length of input.");
 
     private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
@@ -144,10 +138,7 @@ public sealed class CollectionCodec<T> : IFieldCodec<Collection<T>>, IBaseCodec<
             {
                 case 0:
                     var length = (int)UInt32Codec.ReadValue(ref reader, header);
-                    if (length > 10240 && length > reader.Length)
-                    {
-                        ThrowInvalidSizeException(length);
-                    }
+                    reader.EnsureAvailable((uint)length);
 
                     break;
                 case 1:

--- a/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
+++ b/src/Orleans.Serialization/Codecs/DictionaryCodec.cs
@@ -105,10 +105,7 @@ namespace Orleans.Serialization.Codecs
                         break;
                     case 1:
                         var length = (int)UInt32Codec.ReadValue(ref reader, header);
-                        if (length > 10240 && length > reader.Length)
-                        {
-                            ThrowInvalidSizeException(length);
-                        }
+                        reader.EnsureAvailable((uint)length);
 
                         result = CreateInstance(length, comparer, reader.Session, placeholderReferenceId);
                         break;
@@ -143,9 +140,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(session, result, placeholderReferenceId);
             return result;
         }
-
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-            $"Declared length of {typeof(Dictionary<TKey, TValue>)}, {length}, is greater than total length of input.");
 
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized dictionary is missing its length field.");
     }
@@ -297,10 +291,7 @@ namespace Orleans.Serialization.Codecs
                         break;
                     case 1:
                         var length = (int)UInt32Codec.ReadValue(ref reader, header);
-                        if (length > 10240 && length > reader.Length)
-                        {
-                            ThrowInvalidSizeException(length);
-                        }
+                        reader.EnsureAvailable((uint)length);
 
                         hasLengthField = true;
                         if (comparer is not null)
@@ -336,9 +327,6 @@ namespace Orleans.Serialization.Codecs
                 }
             }
         }
-
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-            $"Declared length of {typeof(Dictionary<TKey, TValue>)}, {length}, is greater than total length of input.");
 
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized dictionary is missing its length field.");
 

--- a/src/Orleans.Serialization/Codecs/HashSetCodec.cs
+++ b/src/Orleans.Serialization/Codecs/HashSetCodec.cs
@@ -84,10 +84,7 @@ namespace Orleans.Serialization.Codecs
                         break;
                     case 1:
                         var length = (int)UInt32Codec.ReadValue(ref reader, header);
-                        if (length > 10240 && length > reader.Length)
-                        {
-                            ThrowInvalidSizeException(length);
-                        }
+                        reader.EnsureAvailable((uint)length);
 
                         result = CreateInstance(length, comparer, reader.Session, placeholderReferenceId);
                         break;
@@ -113,9 +110,6 @@ namespace Orleans.Serialization.Codecs
             ReferenceCodec.RecordObject(session, result, placeholderReferenceId);
             return result;
         }
-
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-            $"Declared length of {typeof(HashSet<T>)}, {length}, is greater than total length of input.");
 
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized set is missing its length field.");
 
@@ -162,10 +156,7 @@ namespace Orleans.Serialization.Codecs
                         break;
                     case 1:
                         var length = (int)UInt32Codec.ReadValue(ref reader, header);
-                        if (length > 10240 && length > reader.Length)
-                        {
-                            ThrowInvalidSizeException(length);
-                        }
+                        reader.EnsureAvailable((uint)length);
 
                         // Re-initialize the class by calling the constructor.
                         if (comparer is not null)

--- a/src/Orleans.Serialization/Codecs/ListCodec.cs
+++ b/src/Orleans.Serialization/Codecs/ListCodec.cs
@@ -73,10 +73,7 @@ namespace Orleans.Serialization.Codecs
                 {
                     case 0:
                         var length = (int)UInt32Codec.ReadValue(ref reader, header);
-                        if (length > 10240 && length > reader.Length)
-                        {
-                            ThrowInvalidSizeException(length);
-                        }
+                        reader.EnsureAvailable((uint)length);
 
                         result = new(length);
                         ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
@@ -103,9 +100,6 @@ namespace Orleans.Serialization.Codecs
 
             return result!;
         }
-
-        private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-            $"Declared length of {typeof(List<T>)}, {length}, is greater than total length of input.");
 
         private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its length field.");
 
@@ -143,10 +137,7 @@ namespace Orleans.Serialization.Codecs
                 {
                     case 0:
                         var length = (int)UInt32Codec.ReadValue(ref reader, header);
-                        if (length > 10240 && length > reader.Length)
-                        {
-                            ThrowInvalidSizeException(length);
-                        }
+                        reader.EnsureAvailable((uint)length);
 
 #if NET6_0_OR_GREATER
                         value.EnsureCapacity(length);

--- a/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
+++ b/src/Orleans.Serialization/Codecs/MultiDimensionalArrayCodec.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Orleans.Serialization.Buffers;
 using Orleans.Serialization.Cloning;
 using Orleans.Serialization.GeneratedCodeHelpers;
@@ -116,6 +117,7 @@ namespace Orleans.Serialization.Codecs
                         {
                             lengths = _intArrayCodec.ReadValue(ref reader, header)!;
                             rank = lengths.Length;
+                            EnsureSufficientData(ref reader, lengths);
 
                             // Multi-dimensional arrays must be indexed using indexing arrays, so create one now.
                             indices = new int[rank];
@@ -157,6 +159,31 @@ namespace Orleans.Serialization.Codecs
 
         private void ThrowIndexOutOfRangeException(int[] lengths) => throw new IndexOutOfRangeException(
             $"Encountered too many elements in array of type {CodecElementType} with declared lengths {string.Join(", ", lengths)}.");
+
+        private static void EnsureSufficientData<TInput>(ref Reader<TInput> reader, int[] lengths)
+        {
+            var remaining = (ulong)reader.Remaining;
+            ulong elementCount = 1;
+            foreach (var length in lengths)
+            {
+                if (length < 0)
+                {
+                    return;
+                }
+
+                if (length != 0 && elementCount > remaining / (uint)length)
+                {
+                    ThrowInvalidSizeException(lengths, reader.Remaining);
+                }
+
+                elementCount *= (uint)length;
+            }
+        }
+
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalidSizeException(int[] lengths, long remaining) => throw new IndexOutOfRangeException(
+            $"Declared dimensions [{string.Join(", ", lengths)}] require more elements than the remaining length of the input, {remaining}.");
 
         private static void ThrowLengthsFieldMissing() => throw new RequiredFieldMissingException("Serialized array is missing its lengths field.");
     }

--- a/src/Orleans.Serialization/Codecs/QueueCodec.cs
+++ b/src/Orleans.Serialization/Codecs/QueueCodec.cs
@@ -78,6 +78,7 @@ namespace Orleans.Serialization.Codecs
                 {
                     case 0:
                         var length = (int)UInt32Codec.ReadValue(ref reader, header);
+                        reader.EnsureAvailable((uint)length);
                         result = new Queue<T>(length);
                         ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
                         break;

--- a/src/Orleans.Serialization/Codecs/StackCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StackCodec.cs
@@ -82,10 +82,7 @@ public sealed class StackCodec<T> : IFieldCodec<Stack<T>>
             {
                 case 0:
                     var length = (int)UInt32Codec.ReadValue(ref reader, header);
-                    if (length > 10240 && length > reader.Length)
-                    {
-                        ThrowInvalidSizeException(length);
-                    }
+                    reader.EnsureAvailable((uint)length);
 
                     array = new T[length];
                     i = length - 1;
@@ -109,9 +106,6 @@ public sealed class StackCodec<T> : IFieldCodec<Stack<T>>
         ReferenceCodec.RecordObject(reader.Session, array, placeholderReferenceId);
         return result!;
     }
-
-    private void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-        $"Declared length of {typeof(Stack<T>)}, {length}, is greater than total length of input.");
 
     private void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized stack is missing its length field.");
 }

--- a/src/Orleans.Serialization/Codecs/StringCodec.cs
+++ b/src/Orleans.Serialization/Codecs/StringCodec.cs
@@ -47,6 +47,10 @@ namespace Orleans.Serialization.Codecs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ReadRaw<TInput>(ref Reader<TInput> reader, uint numBytes)
         {
+            reader.EnsureAvailable(numBytes);
+            if (numBytes > int.MaxValue)
+                ThrowInvalidSizeException(numBytes);
+
             if (reader.TryReadBytes((int)numBytes, out var span))
                 return Encoding.UTF8.GetString(span);
 
@@ -62,6 +66,10 @@ namespace Orleans.Serialization.Codecs
             ArrayPool<byte>.Shared.Return(array);
             return res;
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalidSizeException(uint numBytes) => throw new IndexOutOfRangeException(
+            $"The declared string length, {numBytes}, exceeds the maximum supported length.");
 
         void IFieldCodec<string>.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, [System.Diagnostics.CodeAnalysis.AllowNull] Type expectedType, [System.Diagnostics.CodeAnalysis.AllowNull] string value)
         {

--- a/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCodec.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/MapFieldCodec.cs
@@ -91,10 +91,7 @@ public sealed class MapFieldCodec<TKey, TValue> : IFieldCodec<MapField<TKey, TVa
             {
                 case 0:
                     var length = (int)UInt32Codec.ReadValue(ref reader, header);
-                    if (length > 10240 && length > reader.Length)
-                    {
-                        ThrowInvalidSizeException(length);
-                    }
+                    reader.EnsureAvailable((uint)length);
 
                     result = CreateInstance(reader.Session, placeholderReferenceId);
                     break;
@@ -129,9 +126,6 @@ public sealed class MapFieldCodec<TKey, TValue> : IFieldCodec<MapField<TKey, TVa
         ReferenceCodec.RecordObject(session, result, placeholderReferenceId);
         return result;
     }
-
-    private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-        $"Declared length of {typeof(MapField<TKey, TValue>)}, {length}, is greater than total length of input.");
 
     private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized MapField is missing its length field.");
 }

--- a/src/Serializers/Orleans.Serialization.Protobuf/ProtobufCodec.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/ProtobufCodec.cs
@@ -193,7 +193,9 @@ public sealed class ProtobufCodec : IGeneralizedCodec, IGeneralizedCopier, IType
                     }
 
                     ReferenceCodec.MarkValueField(reader.Session);
-                    var length = (int)reader.ReadVarUInt32();
+                    var encodedLength = reader.ReadVarUInt32();
+                    reader.EnsureAvailable(encodedLength);
+                    var length = checked((int)encodedLength);
 
                     using (var buffer = new PooledBuffer())
                     {

--- a/src/Serializers/Orleans.Serialization.Protobuf/ProtobufCodec.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/ProtobufCodec.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Orleans.Serialization;
 
@@ -194,8 +195,13 @@ public sealed class ProtobufCodec : IGeneralizedCodec, IGeneralizedCopier, IType
 
                     ReferenceCodec.MarkValueField(reader.Session);
                     var encodedLength = reader.ReadVarUInt32();
+                    if (encodedLength > int.MaxValue)
+                    {
+                        ThrowInvalidSizeException(encodedLength);
+                    }
+
                     reader.EnsureAvailable(encodedLength);
-                    var length = checked((int)encodedLength);
+                    var length = (int)encodedLength;
 
                     using (var buffer = new PooledBuffer())
                     {
@@ -215,6 +221,11 @@ public sealed class ProtobufCodec : IGeneralizedCodec, IGeneralizedCopier, IType
     }
 
     private static void ThrowTypeFieldMissing() => throw new RequiredFieldMissingException("Serialized value is missing its type field.");
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ThrowInvalidSizeException(uint length) => throw new IndexOutOfRangeException(
+        $"The declared protobuf payload length, {length}, exceeds the maximum supported length, {int.MaxValue}.");
 
     /// <inheritdoc/>
     void IFieldCodec.WriteField<TBufferWriter>(ref Writer<TBufferWriter> writer, uint fieldIdDelta, [AllowNull] Type expectedType, [AllowNull] object? value)

--- a/src/Serializers/Orleans.Serialization.Protobuf/RepeatedFieldCodec.cs
+++ b/src/Serializers/Orleans.Serialization.Protobuf/RepeatedFieldCodec.cs
@@ -82,10 +82,7 @@ public sealed class RepeatedFieldCodec<T> : IFieldCodec<RepeatedField<T>>
             {
                 case 0:
                     var length = (int)UInt32Codec.ReadValue(ref reader, header);
-                    if (length > 10240 && length > reader.Length)
-                    {
-                        ThrowInvalidSizeException(length);
-                    }
+                    reader.EnsureAvailable((uint)length);
 
                     result = new RepeatedField<T>{ Capacity = length };
                     ReferenceCodec.RecordObject(reader.Session, result, placeholderReferenceId);
@@ -112,9 +109,6 @@ public sealed class RepeatedFieldCodec<T> : IFieldCodec<RepeatedField<T>>
 
         return result;
     }
-
-    private static void ThrowInvalidSizeException(int length) => throw new IndexOutOfRangeException(
-        $"Declared length of {typeof(RepeatedField<T>)}, {length}, is greater than total length of input.");
 
     private static void ThrowLengthFieldMissing() => throw new RequiredFieldMissingException("Serialized RepeatedField is missing its length field.");
 }

--- a/src/api/Orleans.Serialization/Orleans.Serialization.cs
+++ b/src/api/Orleans.Serialization/Orleans.Serialization.cs
@@ -1017,7 +1017,11 @@ namespace Orleans.Serialization.Buffers
 
         public long Position { get { throw null; } }
 
+        public long Remaining { get { throw null; } }
+
         public Session.SerializerSession Session { get { throw null; } }
+
+        public void EnsureAvailable(uint count) { }
 
         public void ForkFrom(long position, out Reader<TInput> forked) { throw null; }
 

--- a/test/Orleans.Serialization.UnitTests/ReaderWriterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/ReaderWriterTests.cs
@@ -38,10 +38,47 @@ namespace Orleans.Serialization.UnitTests
             var reader = Reader.Create(new byte[] { 0x12, 0x34 }, session: null!);
 
             Assert.Equal(0, reader.Position);
+            Assert.Equal(2, reader.Remaining);
             Assert.Equal(0x12, reader.PeekByte());
             Assert.Equal(0, reader.Position);
+            Assert.Equal(2, reader.Remaining);
             Assert.Equal(0x12, reader.ReadByte());
             Assert.Equal(1, reader.Position);
+            Assert.Equal(1, reader.Remaining);
+        }
+
+        [Fact]
+        public void Remaining_IsRelativeToForkedInput()
+        {
+            var reader = Reader.Create(new byte[10], session: null!);
+            reader.ForkFrom(4, out var forked);
+
+            Assert.Equal(6, forked.Remaining);
+            forked.ReadByte();
+            Assert.Equal(5, forked.Remaining);
+        }
+
+        [Fact]
+        public void ReadBytes_RejectsLengthGreaterThanRemainingInput()
+        {
+            var exception = Assert.Throws<IndexOutOfRangeException>(() => ReadBytes(new byte[4], 5));
+            Assert.Contains("remaining length of the input, 4", exception.Message);
+        }
+
+        [Fact]
+        public void StringCodec_RejectsLengthGreaterThanRemainingInput()
+        {
+            var exception = Assert.Throws<IndexOutOfRangeException>(() => ReadString(new byte[4], 5));
+            Assert.Contains("remaining length of the input, 4", exception.Message);
+        }
+
+        [Fact]
+        public void StringCodec_ReadsFromNonSeekableStream()
+        {
+            using var stream = new NonSeekableStream([0x74, 0x65, 0x73, 0x74]);
+            var reader = Reader.Create(stream, session: null!);
+
+            Assert.Equal("test", StringCodec.ReadRaw(ref reader, 4));
         }
 
         [Fact]
@@ -95,6 +132,18 @@ namespace Orleans.Serialization.UnitTests
             return reader.ReadVarUInt64();
         }
 
+        private static byte[] ReadBytes(byte[] bytes, uint count)
+        {
+            var reader = Reader.Create(bytes, session: null!);
+            return reader.ReadBytes(count);
+        }
+
+        private static string ReadString(byte[] bytes, uint count)
+        {
+            var reader = Reader.Create(bytes, session: null!);
+            return StringCodec.ReadRaw(ref reader, count);
+        }
+
         private static byte[] WriteVarUInt32(uint value)
         {
             var output = new ArrayBufferWriter<byte>();
@@ -111,6 +160,37 @@ namespace Orleans.Serialization.UnitTests
             writer.WriteVarUInt64(value);
             writer.Commit();
             return output.WrittenSpan.ToArray();
+        }
+
+        private sealed class NonSeekableStream(byte[] buffer) : Stream
+        {
+            private readonly MemoryStream _inner = new(buffer);
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override void Flush() { }
+            public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+            public override int Read(Span<byte> buffer) => _inner.Read(buffer);
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _inner.Dispose();
+                }
+
+                base.Dispose(disposing);
+            }
         }
     }
 


### PR DESCRIPTION
Corrupted length prefixes could cause codecs to allocate objects larger than the remaining serialized payload.

Add a shared remaining-byte check to the reader and apply it before allocating strings, buffers, arrays, collections, and protobuf payloads. Keep exception construction off hot paths and cover malformed lengths, forked readers, and non-seekable streams.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10340)