### PR TITLE
fix(directory): stabilize rolling upgrade handoff test

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -856,45 +856,35 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
             {
                 if (!range.Contains(entry.Key))
                 {
-                    Debug.Fail($"Invariant violated. This host is not the owner of grain '{entry.Key}'.");
+                    throw new InvalidOperationException($"Invariant violated. This host is not the owner of grain '{entry.Key}'.");
                 }
 
                 DebugAssertOwnership(current, entry.Key);
             }
 
-            var missing = 0;
-            var mismatched = 0;
-            var total = 0;
             await foreach (var activationList in GetRegisteredActivations(current, range, isValidation: true))
             {
-                total += activationList.Count;
                 foreach (var entry in activationList)
                 {
                     if (!IsOwner(current, entry.GrainId))
                     {
-                        // The view has been refreshed since the request for registered activations was made.
-                        if (current.Version <= current.Version)
-                        {
-                            Debug.Fail("Invariant violated. This host was sent a registration which it should not have been.");
-                        }
-
-                        continue;
+                        throw new InvalidOperationException(
+                            $"Invariant violated. This host was sent a registration for grain '{entry.GrainId}' which it should not own.");
                     }
 
                     if (_directory.TryGetValue(entry.GrainId, out var existingEntry))
                     {
                         if (!existingEntry.Equals(entry))
                         {
-                            ++mismatched;
                             LogErrorIntegrityViolation(_logger, entry, existingEntry);
-                            Debug.Fail($"Integrity violation: Recovered entry '{entry}' does not match existing entry '{existingEntry}'.");
+                            throw new InvalidOperationException(
+                                $"Integrity violation: activation '{entry}' does not match existing directory entry '{existingEntry}'.");
                         }
                     }
                     else
                     {
-                        ++missing;
                         LogErrorIntegrityViolation(_logger, entry);
-                        Debug.Fail($"Integrity violation: Recovered entry '{entry}' not found in directory.");
+                        throw new InvalidOperationException($"Integrity violation: activation '{entry}' not found in directory.");
                     }
                 }
             }
@@ -964,13 +954,14 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                     if (!existingEntry.Equals(activation))
                     {
                         LogErrorIntegrityViolation(_logger, activation, existingEntry);
-                        Debug.Fail($"Integrity violation: activation '{activation}' does not match existing directory entry '{existingEntry}'.");
+                        throw new InvalidOperationException(
+                            $"Integrity violation: activation '{activation}' does not match existing directory entry '{existingEntry}'.");
                     }
                 }
                 else
                 {
                     LogErrorIntegrityViolation(_logger, activation);
-                    Debug.Fail($"Integrity violation: activation '{activation}' not found in directory.");
+                    throw new InvalidOperationException($"Integrity violation: activation '{activation}' not found in directory.");
                 }
             }
 

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -270,6 +270,17 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         output.WriteLine($"  Validating grain directory integrity {stage}...");
 
         var activations = GetDirectoryActivations(cluster);
+        var duplicateActivations = activations
+            .GroupBy(static activation => activation.Address.GrainId)
+            .Where(static group => group.Count() > 1)
+            .ToArray();
+        Assert.True(
+            duplicateActivations.Length == 0,
+            $"Found duplicate activations during '{stage}': "
+            + string.Join(
+                "; ",
+                duplicateActivations.Select(static group =>
+                    $"{group.Key}=[{string.Join(", ", group.Select(static activation => activation.Address.ToFullString()))}]")));
         var distributedPartitions = new List<IGrainDirectoryTestHooks>();
         foreach (var silo in cluster.Silos)
         {
@@ -293,13 +304,6 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         }
         else
         {
-            var integrityChecks = distributedPartitions.Select(static partition => partition.RecoverAndCheckIntegrityAsync().AsTask()).ToArray();
-            await Task.WhenAll(integrityChecks);
-            foreach (var task in integrityChecks)
-            {
-                await task;
-            }
-
             var activationAddresses = activations.Select(static activation => activation.Address).ToList().AsImmutable();
             var activationChecks = distributedPartitions.Select(partition => partition.CheckActivationsAsync(activationAddresses).AsTask()).ToArray();
             await Task.WhenAll(activationChecks);
@@ -329,6 +333,9 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             {
                 await task;
             }
+
+            var integrityChecks = distributedPartitions.Select(static partition => partition.CheckIntegrityAsync().AsTask()).ToArray();
+            await Task.WhenAll(integrityChecks);
         }
 
         output.WriteLine($"  Validated {activations.Count} activations and {distributedPartitions.Count} DistributedGrainDirectory partitions {stage}.");
@@ -929,6 +936,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 staleCacheEvidence);
             await WaitForClusterMembershipConvergenceAsync(cluster, retiredAddresses, phase.Current, operationTimeout);
             await WaitForDirectoryConvergenceAsync(cluster, "in the final all-DistributedGrainDirectory phase");
+            await ValidateDirectoryIntegrityAsync(cluster, phase.Current);
 
             Assert.Equal(SiloCount, traffic.MaximumObservedSiloCount);
             Assert.True(traffic.MaximumObservedSiloCount <= SiloCount);
@@ -1075,7 +1083,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             staleCacheEvidence);
 
         var integrityChecks = distributedPartitions
-            .Select(static partition => partition.RecoverAndCheckIntegrityAsync().AsTask())
+            .Select(static partition => partition.CheckIntegrityAsync().AsTask())
             .ToArray();
         await Task.WhenAll(integrityChecks);
         output.WriteLine(

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryRollingUpgradeTests.cs
@@ -53,6 +53,8 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         builder.Options.UseTestClusterGrainDirectory = false;
         var initialSiloCount = builder.Options.InitialSilosCount;
         var clusterId = builder.Options.ClusterId;
+        var handoffPhase = new RollingUpgradePhase("local-to-distributed", output);
+        var handoffLogs = new PhaseAwareLogCapture(handoffPhase);
         builder.ConfigureSilo((siloOptions, siloBuilder) =>
         {
             if (!ShouldUseDistributedDirectory(siloOptions.SiloName, initialSiloCount))
@@ -66,6 +68,9 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         });
         builder.ConfigureSiloHost((_, hostBuilder) => ConfigureErrorLogCapture(hostBuilder, clusterId));
         builder.ConfigureSiloHost((_, hostBuilder) => ConfigureRollingUpgradeDiagnosticCapture(hostBuilder, clusterId));
+        builder.ConfigureSiloHost((siloOptions, hostBuilder) =>
+            hostBuilder.Services.AddSingleton<ILoggerProvider>(
+                new PhaseAwareLoggerProvider(siloOptions.SiloName, handoffLogs)));
 
         var cluster = builder.Build();
         var errorLogs = ErrorLogCaptureRegistry.Get(cluster.Options.ClusterId);
@@ -125,6 +130,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                 output.WriteLine("Phase 4: Verifying fully-upgraded DistributedGrainDirectory cluster...");
                 await DriveLoad(client, nextGrainId, count: 200, id => failingGrainKey = id);
                 await ValidateDirectoryIntegrityAsync(cluster, "after final verification");
+                AssertSplitPartitionHandoffsAreDurable(handoffLogs, requireNonEmptyHandoff: true);
             }
             catch
             {
@@ -883,7 +889,7 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
                     staleCacheEvidence);
             }
 
-            AssertSplitPartitionHandoffsAreDurable(logs);
+            AssertSplitPartitionHandoffsAreDurable(logs, requireNonEmptyHandoff: false);
             var finalWorkerProgress = traffic.GetWorkerProgress();
             phase.Set("all-distributed-final");
             Assert.Equal(SiloCount, cluster.Silos.Count);
@@ -1306,7 +1312,9 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
         Assert.Empty(errors);
     }
 
-    private static void AssertSplitPartitionHandoffsAreDurable(PhaseAwareLogCapture logs)
+    private static void AssertSplitPartitionHandoffsAreDurable(
+        PhaseAwareLogCapture logs,
+        bool requireNonEmptyHandoff)
     {
         var completedHandoffs = new Dictionary<(string Silo, int Count), int>();
         var removedHandoffs = 0;
@@ -1343,7 +1351,10 @@ public sealed class GrainDirectoryRollingUpgradeTests(ITestOutputHelper output)
             }
         }
 
-        Assert.True(removedHandoffs > 0, "The rolling upgrade did not exercise a non-empty split-partition handoff.");
+        if (requireNonEmptyHandoff)
+        {
+            Assert.True(removedHandoffs > 0, "The rolling upgrade did not exercise a non-empty split-partition handoff.");
+        }
     }
 
     private static bool IsExpectedIntentionalRestartLog(PhaseAwareLogEntry entry)


### PR DESCRIPTION
The restart-in-place rolling upgrade test required a non-empty split-partition handoff even though its small grain set and randomized ring topology can legitimately produce only empty handoffs.

Move the mandatory non-empty durability assertion to the higher-load local-to-distributed upgrade scenario, where split handoffs are intentionally exercised. The restart-in-place scenario continues to verify that recipient completion precedes sender removal whenever a non-empty handoff occurs.

After final convergence, validate the complete live activation set: reject duplicate activations for a grain, require every activation to exactly match its directory registration, verify every directory entry belongs to the correct partition, and surface integrity violations in release builds. These checks are non-mutating so recovery cannot hide missing registrations.