### PR TITLE
perf(runtime): reduce activation collection sorting allocations

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationCollector.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationCollector.cs
@@ -378,7 +378,8 @@ namespace Orleans.Runtime
 
             // snapshot to avoid concurrency collection modification issues
             var bucketSnapshot = buckets.ToArray();
-            foreach (var bucket in bucketSnapshot.OrderBy(b => b.Key))
+            Array.Sort(bucketSnapshot, static (left, right) => left.Key.CompareTo(right.Key));
+            foreach (var bucket in bucketSnapshot)
             {
                 foreach (var item in bucket.Value.Items)
                 {

--- a/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
+++ b/test/Orleans.Core.Tests/Runtime/ActivationCollectorTests.cs
@@ -298,7 +298,7 @@ namespace UnitTests.Runtime
             });
 
             // Task 3: Run DeactivateInDueTimeOrder MANY times concurrently
-            // This is where OrderBy enumerates buckets and can race with add/remove
+            // This is where the collector snapshots and sorts buckets while they are being added and removed.
             var deactivateTasks = Enumerable.Range(0, 20).Select(_ => Task.Run(async () =>
             {
                 for (int i = 0; i < 100; i++)


### PR DESCRIPTION
Activation shedding snapshots and orders collection buckets by due time. Using LINQ `OrderBy` allocated an additional sort buffer and iterator objects on every memory-pressure collection pass.

Sort the existing snapshot array in place instead. This preserves due-time ordering and concurrency safety while avoiding the extra allocations.

In a BenchmarkDotNet comparison with 500 buckets, the in-place sort reduced mean time from 33.87 us to 27.20 us (20% faster) and allocations from 21.79 KB to 7.84 KB (64% lower).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10342)