### PR TITLE
docs: improve Orleans Aspire integration documentation

### DIFF
--- a/docs/site/src/content/docs/host/aspire-integration.md
+++ b/docs/site/src/content/docs/host/aspire-integration.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans and Aspire integration
 description: Model and run Orleans applications with Aspire.
-ms.date: 08/02/2026
+ms.date: 08/10/2026
 ms.topic: how-to
 ---
 
@@ -90,6 +90,49 @@ Register the matching Azure Tables client in the silo:
 
 The same principle applies to Redis and databases: the AppHost resource can launch a local container during development and bind to a managed service in deployment.
 
+## Provider wiring reference
+
+For automatically configured external resources, the AppHost needs the corresponding Aspire hosting integration. The silo or client needs both the Orleans provider package and the Aspire client integration, and it must register the client using the Aspire resource name.
+
+| Resource | Application registration | Supported automatic Orleans configuration |
+|---|---|---|
+| Redis | `AddKeyedRedisClient` | Clustering, grain storage, reminders, and grain directories |
+| Azure Tables | `AddKeyedAzureTableServiceClient` | Clustering, grain storage, reminders, and grain directories |
+| Azure Blobs | `AddKeyedAzureBlobServiceClient` | Grain storage |
+| ADO.NET database | Configure the Orleans provider from the injected connection string | Clustering, grain storage, and reminders require manual configuration |
+| In-memory | None | Development clustering, grain storage, reminders, and streaming |
+
+The resulting provider support matrix is:
+
+| Capability | Redis | Azure Tables | Azure Blobs | ADO.NET | In-memory |
+|---|---|---|---|---|---|
+| Clustering | Automatic | Automatic | No | Manual | Development only |
+| Grain storage | Automatic | Automatic | Automatic | Manual | Development only |
+| Reminders | Automatic | Automatic | No | Manual | Development only |
+| Grain directory | Automatic | Automatic | No | No | No |
+
+### ADO.NET providers
+
+ADO.NET resource types don't infer the `AdoNet` provider name expected by Orleans, and `Aspire.Hosting.Orleans` doesn't expose an API to override the inferred name. Reference the database resource directly from the silo project so that Aspire injects its connection string:
+
+:::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="adonet_apphost":::
+
+Configure the Orleans ADO.NET providers from that connection string:
+
+:::code language="csharp" source="snippets/aspire/Silo/SiloProgram.cs" id="adonet_silo":::
+
+Register an Aspire database client separately only when application code also consumes that database client. Orleans ADO.NET providers use their configured connection string directly.
+
+### Grain directories
+
+Redis and Azure Tables can back named grain directories. This example configures a Redis grain directory in the AppHost:
+
+:::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="grain_directory_apphost":::
+
+Register the Redis client with the same resource name in the silo:
+
+:::code language="csharp" source="snippets/aspire/Silo/SiloProgram.cs" id="grain_directory_silo":::
+
 ## AppHost extension methods reference
 
 `AddOrleans` produces standard Orleans configuration. The application projects still call <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> or <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*>, and Orleans validates the resulting provider configuration at startup. You can inspect injected environment variables in the Aspire dashboard when diagnosing a missing provider, keyed resource, or endpoint.
@@ -121,6 +164,10 @@ Consult the [Aspire Orleans integration reference](https://aspire.dev/integratio
 <a id="opentelemetry-configuration"></a>
 <a id="health-checks"></a>
 <a id="see-also"></a>
+
+Set stable service and cluster identifiers for environments that must interoperate across restarts and rolling deployments:
+
+:::code language="csharp" source="snippets/aspire/AppHost/AppHostExamples.cs" id="explicit_cluster_ids":::
 
 - Treat the AppHost as a resource model, not as a substitute for durable services.
 - Use managed identities or workload identities instead of embedding secrets.

--- a/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHost.csproj
+++ b/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHost.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
   </ItemGroup>
 
   <!-- Project references removed - Silo and Client are library projects

--- a/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHostExamples.cs
+++ b/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHostExamples.cs
@@ -1,5 +1,6 @@
 using Aspire.Hosting;
 using Aspire.Hosting.Azure;
+using Aspire.Hosting.SqlServer;
 
 namespace Orleans.Docs.Snippets.Aspire;
 
@@ -194,4 +195,74 @@ public static class AppHostExamples
         builder.Build().Run();
     }
     // </reminders_inmemory_apphost>
+
+    // <adonet_apphost>
+    public static void AdoNetAppHost(string[] args)
+    {
+        var builder = DistributedApplication.CreateBuilder(args);
+
+        // Add a SQL Server instance and database
+        var sql = builder.AddSqlServer("sql");
+        var db = sql.AddDatabase("orleans-db")
+            // Aspire infers the provider name from the C# class name
+            // (SqlServerDatabaseResource → "SqlServerDatabase"), which doesn't
+            // match what Orleans expects. Override it explicitly:
+            .WithOrleansProviderType("AdoNet");
+
+        var orleans = builder.AddOrleans("cluster")
+            .WithClustering(db)
+            .WithGrainStorage("Default", db)
+            .WithReminders(db);
+
+        builder.AddProject<Projects.Silo>("silo")
+            .WithReference(orleans)
+            .WaitFor(sql);
+
+        builder.Build().Run();
+    }
+    // </adonet_apphost>
+
+    // <grain_directory_apphost>
+    public static void GrainDirectoryAppHost(string[] args)
+    {
+        var builder = DistributedApplication.CreateBuilder(args);
+
+        var redis = builder.AddRedis("orleans-redis");
+
+        var orleans = builder.AddOrleans("cluster")
+            .WithClustering(redis)
+            .WithGrainDirectory("MyDirectory", redis);
+
+        builder.AddProject<Projects.Silo>("silo")
+            .WithReference(orleans)
+            .WaitFor(redis);
+
+        builder.Build().Run();
+    }
+    // </grain_directory_apphost>
+
+    // <explicit_cluster_ids>
+    public static void ExplicitClusterIds(string[] args)
+    {
+        var builder = DistributedApplication.CreateBuilder(args);
+
+        var redis = builder.AddRedis("orleans-redis");
+
+        var orleans = builder.AddOrleans("cluster")
+            // Set stable IDs for rolling deployments and cross-restart compatibility.
+            // If omitted, random IDs are generated per run — fine for development,
+            // but problematic in production because silos from different runs
+            // will not recognize each other.
+            .WithClusterId("my-cluster")
+            .WithServiceId("my-service")
+            .WithClustering(redis);
+
+        builder.AddProject<Projects.Silo>("silo")
+            .WithReference(orleans)
+            .WaitFor(redis)
+            .WithReplicas(3);
+
+        builder.Build().Run();
+    }
+    // </explicit_cluster_ids>
 }

--- a/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHostExamples.cs
+++ b/docs/site/src/content/docs/host/snippets/aspire/AppHost/AppHostExamples.cs
@@ -1,6 +1,5 @@
 using Aspire.Hosting;
 using Aspire.Hosting.Azure;
-using Aspire.Hosting.SqlServer;
 
 namespace Orleans.Docs.Snippets.Aspire;
 
@@ -201,21 +200,22 @@ public static class AppHostExamples
     {
         var builder = DistributedApplication.CreateBuilder(args);
 
-        // Add a SQL Server instance and database
+        // Add a SQL Server instance and database.
+        // Note: Aspire infers the Orleans provider type from the resource class name
+        // (SqlServerDatabaseResource → "SqlServerDatabase"), which does not match
+        // the Orleans provider name "AdoNet".
+        //
+        // There is no public API to override this inference in the current version
+        // of Aspire.Hosting.Orleans. As a workaround, configure the Orleans providers
+        // manually in the silo using UseOrleans(siloBuilder => {...}) and read the
+        // connection string from IConfiguration.
         var sql = builder.AddSqlServer("sql");
-        var db = sql.AddDatabase("orleans-db")
-            // Aspire infers the provider name from the C# class name
-            // (SqlServerDatabaseResource → "SqlServerDatabase"), which doesn't
-            // match what Orleans expects. Override it explicitly:
-            .WithOrleansProviderType("AdoNet");
+        var db = sql.AddDatabase("orleans-db");
 
-        var orleans = builder.AddOrleans("cluster")
-            .WithClustering(db)
-            .WithGrainStorage("Default", db)
-            .WithReminders(db);
-
+        // Pass the database resource so Aspire injects ConnectionStrings__orleans-db.
+        // Then configure Orleans manually in the silo (see silo example).
         builder.AddProject<Projects.Silo>("silo")
-            .WithReference(orleans)
+            .WithReference(db)
             .WaitFor(sql);
 
         builder.Build().Run();

--- a/docs/site/src/content/docs/host/snippets/aspire/Silo/Silo.csproj
+++ b/docs/site/src/content/docs/host/snippets/aspire/Silo/Silo.csproj
@@ -18,7 +18,13 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Azure.Data.Tables" Version="13.4.6" />
+    <PackageReference Include="Aspire.Microsoft.Data.SqlClient" Version="13.4.6" />
     <PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.Redis" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.GrainDirectory.Redis" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Clustering.AdoNet" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="10.2.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
   </ItemGroup>
 

--- a/docs/site/src/content/docs/host/snippets/aspire/Silo/SiloProgram.cs
+++ b/docs/site/src/content/docs/host/snippets/aspire/Silo/SiloProgram.cs
@@ -123,13 +123,31 @@ public static class SiloProgram
 
         builder.AddServiceDefaults();
 
-        // Register the ADO.NET client using the Aspire resource name as the key.
-        // The key must match the resource name used in the AppHost exactly.
-        builder.AddKeyedSqlServerClient("orleans-db");
+        // Configure Orleans manually because Aspire cannot automatically wire ADO.NET
+        // providers — provider type inference produces "SqlServerDatabase" instead of
+        // the "AdoNet" provider name Orleans expects.
+        builder.UseOrleans(siloBuilder =>
+        {
+            var connectionString = builder.Configuration.GetConnectionString("orleans-db")!;
 
-        // Aspire injects Orleans__Clustering__ProviderType=AdoNet,
-        // Orleans__Clustering__ServiceKey=orleans-db, etc.
-        builder.UseOrleans();
+            siloBuilder.UseAdoNetClustering(options =>
+            {
+                options.Invariant = "System.Data.SqlClient";
+                options.ConnectionString = connectionString;
+            });
+
+            siloBuilder.AddAdoNetGrainStorageAsDefault(options =>
+            {
+                options.Invariant = "System.Data.SqlClient";
+                options.ConnectionString = connectionString;
+            });
+
+            siloBuilder.UseAdoNetReminderService(options =>
+            {
+                options.Invariant = "System.Data.SqlClient";
+                options.ConnectionString = connectionString;
+            });
+        });
 
         builder.Build().Run();
     }

--- a/docs/site/src/content/docs/host/snippets/aspire/Silo/SiloProgram.cs
+++ b/docs/site/src/content/docs/host/snippets/aspire/Silo/SiloProgram.cs
@@ -132,19 +132,19 @@ public static class SiloProgram
 
             siloBuilder.UseAdoNetClustering(options =>
             {
-                options.Invariant = "System.Data.SqlClient";
+                options.Invariant = "Microsoft.Data.SqlClient";
                 options.ConnectionString = connectionString;
             });
 
             siloBuilder.AddAdoNetGrainStorageAsDefault(options =>
             {
-                options.Invariant = "System.Data.SqlClient";
+                options.Invariant = "Microsoft.Data.SqlClient";
                 options.ConnectionString = connectionString;
             });
 
             siloBuilder.UseAdoNetReminderService(options =>
             {
-                options.Invariant = "System.Data.SqlClient";
+                options.Invariant = "Microsoft.Data.SqlClient";
                 options.ConnectionString = connectionString;
             });
         });

--- a/docs/site/src/content/docs/host/snippets/aspire/Silo/SiloProgram.cs
+++ b/docs/site/src/content/docs/host/snippets/aspire/Silo/SiloProgram.cs
@@ -115,6 +115,38 @@ public static class SiloProgram
         builder.Build().Run();
     }
     // </reminders_inmemory_silo>
+
+    // <adonet_silo>
+    public static void AdoNetSilo(string[] args)
+    {
+        var builder = Host.CreateApplicationBuilder(args);
+
+        builder.AddServiceDefaults();
+
+        // Register the ADO.NET client using the Aspire resource name as the key.
+        // The key must match the resource name used in the AppHost exactly.
+        builder.AddKeyedSqlServerClient("orleans-db");
+
+        // Aspire injects Orleans__Clustering__ProviderType=AdoNet,
+        // Orleans__Clustering__ServiceKey=orleans-db, etc.
+        builder.UseOrleans();
+
+        builder.Build().Run();
+    }
+    // </adonet_silo>
+
+    // <grain_directory_silo>
+    public static void GrainDirectorySilo(string[] args)
+    {
+        var builder = Host.CreateApplicationBuilder(args);
+
+        builder.AddServiceDefaults();
+        builder.AddKeyedRedisClient("orleans-redis");
+        builder.UseOrleans();
+
+        builder.Build().Run();
+    }
+    // </grain_directory_silo>
 }
 
 // Stub health check classes for documentation examples


### PR DESCRIPTION
Improves the Aspire integration docs with adapter wiring reference, provider support matrix, ADO.NET coverage, and production guidance.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10344)