### PR TITLE
fix(docs): correct timer migration link

### DIFF
--- a/docs/site/src/content/docs/migration/8-to-10.md
+++ b/docs/site/src/content/docs/migration/8-to-10.md
@@ -33,7 +33,7 @@ When translating an old timer and preserving its interleaving behavior:
 
 :::code language="csharp" source="snippets/Orleans10MigrationExamples.cs" id="grain_timer":::
 
-For the full timer behavior matrix, see [Timers and reminders](../grains/timers-and-reminders.md#migrate-from-registertimer-to-registergraintimer).
+For the full timer behavior matrix, see [Timers and reminders](../grains/timers-and-reminders.md#timer-behavior).
 
 ## Validate the Orleans 9.2 checkpoint
 


### PR DESCRIPTION
The Orleans 8-to-10 migration guide links to a timer migration heading which was removed when the timer documentation was modernized. Update the link to target the current timer behavior section so documentation link validation succeeds.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10347)