### PR TITLE
fix(durablejobs): preserve job state across retries

### DIFF
--- a/src/Orleans.DurableJobs/IDurableJobHandler.cs
+++ b/src/Orleans.DurableJobs/IDurableJobHandler.cs
@@ -14,7 +14,8 @@ public interface IJobRunContext
     DurableJob Job { get; }
 
     /// <summary>
-    /// Gets the unique identifier for this execution run.
+    /// Gets the unique identifier for this execution run. A new identifier is generated each time the job is dequeued
+    /// and is not preserved across retries or shard reassignment.
     /// </summary>
     string RunId { get; }
 
@@ -37,7 +38,8 @@ internal class JobRunContext : IJobRunContext
     public DurableJob Job { get; }
 
     /// <summary>
-    /// Gets the unique identifier for this execution run.
+    /// Gets the unique identifier for this execution run. A new identifier is generated each time the job is dequeued
+    /// and is not preserved across retries or shard reassignment.
     /// </summary>
     [Id(1)]
     public string RunId { get; }

--- a/src/Orleans.DurableJobs/InMemoryJobQueue.cs
+++ b/src/Orleans.DurableJobs/InMemoryJobQueue.cs
@@ -144,7 +144,9 @@ internal sealed class InMemoryJobQueue : IAsyncEnumerable<IJobRunContext>
                 DueTime = newDueTime,
                 TargetGrainId = existing.Job.TargetGrainId,
                 ShardId = existing.Job.ShardId,
-                Metadata = existing.Job.Metadata
+                Metadata = existing.Job.Metadata,
+                TraceParent = existing.Job.TraceParent,
+                TraceState = existing.Job.TraceState,
             };
 
             oldBucket.RemoveJob(jobId);

--- a/src/Orleans.DurableJobs/JobShard.cs
+++ b/src/Orleans.DurableJobs/JobShard.cs
@@ -78,7 +78,10 @@ public interface IJobShard : IAsyncDisposable
     /// Reschedules a job to be retried at a later time.
     /// </summary>
     /// <param name="jobContext">The context of the job to retry.</param>
-    /// <param name="newDueTime">The new due time for the job.</param>
+    /// <param name="newDueTime">
+    /// The new due time for the job. This value supersedes <see cref="DurableJob.DueTime"/> on
+    /// <see cref="IJobRunContext.Job"/>.
+    /// </param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken);
@@ -164,7 +167,7 @@ public abstract class JobShard : IJobShard
             TraceState = request.TraceState,
         };
 
-        await PersistAddJobAsync(jobId, request.JobName, request.DueTime, request.Target, request.Metadata, cancellationToken);
+        await PersistAddJobAsync(job, cancellationToken);
         _jobQueue.Enqueue(job, 0);
         return job;
     }
@@ -187,7 +190,7 @@ public abstract class JobShard : IJobShard
     /// <inheritdoc/>
     public async Task RetryJobLaterAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken)
     {
-        await PersistRetryJobAsync(jobContext.Job.Id, newDueTime, cancellationToken);
+        await PersistRetryJobAsync(jobContext, newDueTime, cancellationToken);
         _jobQueue.RetryJobLater(jobContext, newDueTime);
     }
 
@@ -204,14 +207,10 @@ public abstract class JobShard : IJobShard
     /// <summary>
     /// Persists the addition of a new job to the underlying storage.
     /// </summary>
-    /// <param name="jobId">The unique identifier of the job.</param>
-    /// <param name="jobName">The name of the job.</param>
-    /// <param name="dueTime">The time when the job should be executed.</param>
-    /// <param name="target">The grain identifier of the target grain.</param>
-    /// <param name="metadata">Optional metadata to associate with the job.</param>
+    /// <param name="job">The job to persist.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    protected abstract Task PersistAddJobAsync(string jobId, string jobName, DateTimeOffset dueTime, GrainId target, IReadOnlyDictionary<string, string>? metadata, CancellationToken cancellationToken);
+    protected abstract Task PersistAddJobAsync(DurableJob job, CancellationToken cancellationToken);
 
     /// <summary>
     /// Persists the removal of a job from the underlying storage.
@@ -224,11 +223,14 @@ public abstract class JobShard : IJobShard
     /// <summary>
     /// Persists the rescheduling of a job to the underlying storage.
     /// </summary>
-    /// <param name="jobId">The unique identifier of the job to retry.</param>
-    /// <param name="newDueTime">The new due time for the job.</param>
+    /// <param name="jobContext">The execution context of the job to retry.</param>
+    /// <param name="newDueTime">
+    /// The new due time for the job. This value supersedes <see cref="DurableJob.DueTime"/> on
+    /// <see cref="IJobRunContext.Job"/>.
+    /// </param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    protected abstract Task PersistRetryJobAsync(string jobId, DateTimeOffset newDueTime, CancellationToken cancellationToken);
+    protected abstract Task PersistRetryJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken);
 
     /// <inheritdoc/>
     public virtual ValueTask DisposeAsync()

--- a/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
+++ b/src/api/Orleans.DurableJobs/Orleans.DurableJobs.cs
@@ -140,9 +140,9 @@ namespace Orleans.DurableJobs
 
         public System.Threading.Tasks.Task MarkAsCompleteAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
 
-        protected abstract System.Threading.Tasks.Task PersistAddJobAsync(string jobId, string jobName, System.DateTimeOffset dueTime, Runtime.GrainId target, System.Collections.Generic.IReadOnlyDictionary<string, string>? metadata, System.Threading.CancellationToken cancellationToken);
+        protected abstract System.Threading.Tasks.Task PersistAddJobAsync(DurableJob job, System.Threading.CancellationToken cancellationToken);
         protected abstract System.Threading.Tasks.Task PersistRemoveJobAsync(string jobId, System.Threading.CancellationToken cancellationToken);
-        protected abstract System.Threading.Tasks.Task PersistRetryJobAsync(string jobId, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken);
+        protected abstract System.Threading.Tasks.Task PersistRetryJobAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken);
         public System.Threading.Tasks.Task<bool> RemoveJobAsync(string jobId, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task RetryJobLaterAsync(IJobRunContext jobContext, System.DateTimeOffset newDueTime, System.Threading.CancellationToken cancellationToken) { throw null; }

--- a/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
@@ -248,6 +248,22 @@ public class InMemoryJobQueueTests
     }
 
     [Fact]
+    public void RetryJobLater_PreservesTraceContext()
+    {
+        const string traceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        const string traceState = "vendor=value";
+        var queue = new InMemoryJobQueue();
+        var job = CreateJob("job1", DateTimeOffset.UtcNow.AddSeconds(1), traceParent, traceState);
+
+        queue.Enqueue(job, 0);
+        queue.RetryJobLater(CreateJobContext(job, "run1", 1), DateTimeOffset.UtcNow.AddSeconds(10));
+
+        var retriedJob = Assert.Single(queue.GetSnapshot()).Job;
+        Assert.Equal(traceParent, retriedJob.TraceParent);
+        Assert.Equal(traceState, retriedJob.TraceState);
+    }
+
+    [Fact]
     public void RetryJobLater_NonExistentJob_DoesNotThrow()
     {
         var queue = new InMemoryJobQueue();
@@ -410,7 +426,7 @@ public class InMemoryJobQueueTests
         Assert.False(await enumerator.MoveNextAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
     }
 
-    private static DurableJob CreateJob(string id, DateTimeOffset dueTime)
+    private static DurableJob CreateJob(string id, DateTimeOffset dueTime, string? traceParent = null, string? traceState = null)
     {
         return new DurableJob
         {
@@ -419,7 +435,9 @@ public class InMemoryJobQueueTests
             DueTime = dueTime,
             TargetGrainId = GrainId.Create("test", id),
             ShardId = "shard1",
-            Metadata = null
+            Metadata = null,
+            TraceParent = traceParent,
+            TraceState = traceState,
         };
     }
 

--- a/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/JobShardTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Orleans.DurableJobs;
+using Orleans.Runtime;
+using Xunit;
+
+namespace NonSilo.Tests.DurableJobs;
+
+[TestCategory("DurableJobs")]
+public class JobShardTests
+{
+    [Fact]
+    public async Task TryScheduleJobAsync_ForwardsCompleteJobForPersistence()
+    {
+        const string traceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        const string traceState = "vendor=value";
+        var dueTime = DateTimeOffset.UtcNow.AddMinutes(1);
+        var target = GrainId.Create("test", "job");
+        var metadata = new Dictionary<string, string> { ["key"] = "value" };
+        var shard = new TestJobShard(dueTime.AddMinutes(-1), dueTime.AddMinutes(1));
+
+        var job = await shard.TryScheduleJobAsync(
+            new ScheduleJobRequest
+            {
+                Target = target,
+                JobName = "job",
+                DueTime = dueTime,
+                Metadata = metadata,
+                TraceParent = traceParent,
+                TraceState = traceState,
+            },
+            CancellationToken.None);
+
+        var persistedJob = Assert.IsType<DurableJob>(shard.PersistedJob);
+        Assert.Same(job, persistedJob);
+        Assert.Equal(target, persistedJob.TargetGrainId);
+        Assert.Equal("job", persistedJob.Name);
+        Assert.Equal(dueTime, persistedJob.DueTime);
+        Assert.Same(metadata, persistedJob.Metadata);
+        Assert.Equal(traceParent, persistedJob.TraceParent);
+        Assert.Equal(traceState, persistedJob.TraceState);
+    }
+
+    [Fact]
+    public async Task RetryJobLaterAsync_ForwardsCompleteRunContextForPersistence()
+    {
+        var dueTime = DateTimeOffset.UtcNow.AddMinutes(1);
+        var shard = new TestJobShard(dueTime.AddMinutes(-1), dueTime.AddMinutes(1));
+        var job = await shard.TryScheduleJobAsync(
+            new ScheduleJobRequest
+            {
+                Target = GrainId.Create("test", "job"),
+                JobName = "job",
+                DueTime = dueTime,
+            },
+            CancellationToken.None);
+        var context = Substitute.For<IJobRunContext>();
+        context.Job.Returns(job);
+        context.RunId.Returns("run");
+        context.DequeueCount.Returns(3);
+        var retryTime = dueTime.AddMinutes(1);
+
+        await shard.RetryJobLaterAsync(context, retryTime, CancellationToken.None);
+
+        var persistedContext = Assert.IsAssignableFrom<IJobRunContext>(shard.PersistedRetryContext);
+        Assert.Same(context, persistedContext);
+        Assert.Equal(retryTime, shard.PersistedRetryTime);
+        Assert.Equal(3, persistedContext.DequeueCount);
+    }
+
+    private sealed class TestJobShard(DateTimeOffset startTime, DateTimeOffset endTime)
+        : JobShard("shard", startTime, endTime)
+    {
+        public DurableJob? PersistedJob { get; private set; }
+
+        public IJobRunContext? PersistedRetryContext { get; private set; }
+
+        public DateTimeOffset PersistedRetryTime { get; private set; }
+
+        protected override Task PersistAddJobAsync(DurableJob job, CancellationToken cancellationToken)
+        {
+            PersistedJob = job;
+            return Task.CompletedTask;
+        }
+
+        protected override Task PersistRemoveJobAsync(string jobId, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        protected override Task PersistRetryJobAsync(IJobRunContext jobContext, DateTimeOffset newDueTime, CancellationToken cancellationToken)
+        {
+            PersistedRetryContext = jobContext;
+            PersistedRetryTime = newDueTime;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Durable job retries reconstructed the queued job without copying its persisted W3C trace context, so a retried execution could start an unrelated trace.

Preserve trace context when rescheduling in-memory jobs. Also pass the complete `DurableJob` and `IJobRunContext` through the public `JobShard` persistence hooks so custom persistent shards cannot lose trace fields or dequeue state across reloads and reassignment. Add focused coverage for both paths.