### PR TITLE
docs: restore migration reference links

### DIFF
--- a/docs/site/src/content/docs/migration-guide.md
+++ b/docs/site/src/content/docs/migration-guide.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans migration guides
 description: Plan and execute an upgrade to Orleans 10 from Orleans 9, 8, 7, or an older release.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: how-to
 ms.custom: migration-guide
 ---
@@ -33,7 +33,7 @@ Before changing packages, record the following compatibility contract:
 
 See [Upgrade deployment and rollback](migration/deployment-and-rollback.md) before choosing a deployment strategy.
 
-## POCO grains and `IGrainBase` <a name="poco-grains-and-igrainbase"></a>
+## POCO grains and <xref:Orleans.IGrainBase> <a name="poco-grains-and-igrainbase"></a>
 
 POCO grains remain supported. A grain that doesn't inherit from <xref:Orleans.Grain> implements <xref:Orleans.IGrainBase> and receives its <xref:Orleans.Runtime.IGrainContext> through dependency injection. This also enables grain extension methods such as timers, reminders, streaming, deactivation, and migration.
 

--- a/docs/site/src/content/docs/migration/3-to-7-archive.md
+++ b/docs/site/src/content/docs/migration/3-to-7-archive.md
@@ -20,14 +20,14 @@ These notes apply to an Orleans 3.x application that must first become an Orlean
 - Remove the legacy MSBuild code-generator and `Microsoft.Orleans.OrleansRuntime` packages.
 - Replace `Microsoft.Orleans.OrleansServiceBus` with [Microsoft.Orleans.Streaming.EventHubs](https://www.nuget.org/packages/Microsoft.Orleans.Streaming.EventHubs). Add explicit [Microsoft.Orleans.Reminders](https://www.nuget.org/packages/Microsoft.Orleans.Reminders) and [Microsoft.Orleans.Streaming](https://www.nuget.org/packages/Microsoft.Orleans.Streaming) references when the application uses those features.
 - Remove Application Parts configuration. The Orleans source generator discovers application types.
-- Use the [.NET generic host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) with `UseOrleans` and `UseOrleansClient`.
-- Update `OnActivateAsync` and `OnDeactivateAsync` overrides to the Orleans 7 cancellation-token and deactivation-reason signatures.
-- Add `[GenerateSerializer]` and stable `[Id]` values to application types.
+- Use the [.NET generic host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) with <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> and <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*>.
+- Update <xref:Orleans.Grain.OnActivateAsync*> and <xref:Orleans.Grain.OnDeactivateAsync*> overrides to the Orleans 7 cancellation-token and deactivation-reason signatures.
+- Add <xref:Orleans.GenerateSerializerAttribute> and stable <xref:Orleans.IdAttribute> values to application types.
 - Replace legacy grain, interface, and stream identity assumptions with the Orleans 7 string-based identity model.
 - Replace Simple Message Streams with broadcast channels or a persistent stream provider.
-- Replace legacy telemetry consumers with .NET metrics and `ActivitySource`-based tracing.
+- Replace legacy telemetry consumers with .NET metrics and <xref:System.Diagnostics.ActivitySource>-based tracing.
 
-The old `IServiceCollection.AddGrainCallFilter` API was removed before Orleans 7. Register incoming and outgoing filters on `ISiloBuilder` or `IClientBuilder`.
+The old <xref:Orleans.Hosting.GrainCallFilterServiceCollectionExtensions.AddGrainCallFilter*> API was removed before Orleans 7. Register incoming and outgoing filters on <xref:Orleans.Hosting.ISiloBuilder> or <xref:Orleans.IClientBuilder>.
 
 For an itemized record of the Orleans samples migrated to Orleans 7, see [dotnet/orleans issue #8035](https://github.com/dotnet/orleans/issues/8035).
 

--- a/docs/site/src/content/docs/migration/3-to-7-archive.md
+++ b/docs/site/src/content/docs/migration/3-to-7-archive.md
@@ -1,7 +1,7 @@
 ---
 title: Archived Orleans 3.x to 7.x migration notes
 description: Historical guidance for crossing the incompatible Orleans 3-to-7 identity, hosting, and serialization boundary.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: how-to
 ---
 
@@ -16,10 +16,11 @@ These notes apply to an Orleans 3.x application that must first become an Orlean
 
 ## Required architectural changes
 
-- Reference `Microsoft.Orleans.Server` from silo projects, `Microsoft.Orleans.Client` from client projects, and `Microsoft.Orleans.Sdk` from shared contract projects.
+- Reference [Microsoft.Orleans.Server](https://www.nuget.org/packages/Microsoft.Orleans.Server) from silo projects, [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client) from client projects, and [Microsoft.Orleans.Sdk](https://www.nuget.org/packages/Microsoft.Orleans.Sdk) from shared contract projects.
 - Remove the legacy MSBuild code-generator and `Microsoft.Orleans.OrleansRuntime` packages.
+- Replace `Microsoft.Orleans.OrleansServiceBus` with [Microsoft.Orleans.Streaming.EventHubs](https://www.nuget.org/packages/Microsoft.Orleans.Streaming.EventHubs). Add explicit [Microsoft.Orleans.Reminders](https://www.nuget.org/packages/Microsoft.Orleans.Reminders) and [Microsoft.Orleans.Streaming](https://www.nuget.org/packages/Microsoft.Orleans.Streaming) references when the application uses those features.
 - Remove Application Parts configuration. The Orleans source generator discovers application types.
-- Use the .NET generic host with `UseOrleans` and `UseOrleansClient`.
+- Use the [.NET generic host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) with `UseOrleans` and `UseOrleansClient`.
 - Update `OnActivateAsync` and `OnDeactivateAsync` overrides to the Orleans 7 cancellation-token and deactivation-reason signatures.
 - Add `[GenerateSerializer]` and stable `[Id]` values to application types.
 - Replace legacy grain, interface, and stream identity assumptions with the Orleans 7 string-based identity model.
@@ -27,6 +28,8 @@ These notes apply to an Orleans 3.x application that must first become an Orlean
 - Replace legacy telemetry consumers with .NET metrics and `ActivitySource`-based tracing.
 
 The old `IServiceCollection.AddGrainCallFilter` API was removed before Orleans 7. Register incoming and outgoing filters on `ISiloBuilder` or `IClientBuilder`.
+
+For an itemized record of the Orleans samples migrated to Orleans 7, see [dotnet/orleans issue #8035](https://github.com/dotnet/orleans/issues/8035).
 
 ## State and deployment boundary
 

--- a/docs/site/src/content/docs/migration/7-to-10.md
+++ b/docs/site/src/content/docs/migration/7-to-10.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrade Orleans 7.x to 10.x
 description: Upgrade an Orleans 7 application sequentially through Orleans 8.2 and 9.2 to Orleans 10.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: how-to
 ---
 
@@ -32,11 +32,11 @@ Before moving to Orleans 8:
 - Align all `Microsoft.Orleans.*` packages on the same latest 7.2 patch.
 - Remove obsolete APIs and resolve analyzer warnings.
 - Confirm silos use `Microsoft.Orleans.Server`, clients use `Microsoft.Orleans.Client`, and shared contract projects use `Microsoft.Orleans.Sdk`.
-- Confirm hosting uses the .NET generic host with `UseOrleans` or `UseOrleansClient`.
+- Confirm hosting uses the .NET generic host with <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> or <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*>.
 - Inventory serializer member IDs, aliases, provider names, stream partition counts, and database schemas.
 - Capture representative persisted state and a tested recovery point.
 
-Call filters should already be registered using `AddIncomingGrainCallFilter` or `AddOutgoingGrainCallFilter` on the Orleans builders. The old `IServiceCollection.AddGrainCallFilter` API has been unsupported since before Orleans 7 and isn't an Orleans 10 change.
+Call filters should already be registered using <xref:Orleans.Hosting.GrainCallFilterSiloBuilderExtensions.AddIncomingGrainCallFilter*> or <xref:Orleans.Hosting.GrainCallFilterSiloBuilderExtensions.AddOutgoingGrainCallFilter*> on the Orleans builders. The old <xref:Orleans.Hosting.GrainCallFilterServiceCollectionExtensions.AddGrainCallFilter*> API has been unsupported since before Orleans 7 and isn't an Orleans 10 change.
 
 ## Move to Orleans 8.2
 
@@ -51,31 +51,31 @@ options.CpuThreshold = 95;
 options.LeaseAcquisitionPeriod = TimeSpan.FromSeconds(30);
 ```
 
-`LoadSheddingOptions.LoadSheddingLimit` became `CpuThreshold` in Orleans 8.1. Orleans 8.2 corrected the spelling of `LeaseBasedQueueBalancerOptions.LeaseAquisitionPeriod`.
+<xref:Orleans.Configuration.LoadSheddingOptions.LoadSheddingLimit> became <xref:Orleans.Configuration.LoadSheddingOptions.CpuThreshold> in Orleans 8.1. Orleans 8.2 corrected the spelling of <xref:Orleans.Configuration.LeaseBasedQueueBalancerOptions.LeaseAquisitionPeriod>.
 
 ### Timer behavior
 
-Replace the obsolete `RegisterTimer` API with `RegisterGrainTimer`. The old API interleaved callbacks, while the new API defaults `Interleave` to `false`. Preserve old behavior explicitly when required:
+Replace the obsolete <xref:Orleans.Grain.RegisterTimer*> API with <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*>. The old API interleaved callbacks, while the new API defaults <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave> to `false`. Preserve old behavior explicitly when required:
 
 :::code language="csharp" source="snippets/Orleans10MigrationExamples.cs" id="grain_timer":::
 
-Test activation collection and set `KeepAlive` only when timer ticks must prevent collection.
+Test activation collection and set <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive> only when timer ticks must prevent collection.
 
 ## Move to Orleans 9.2
 
 Complete the Orleans 9.2 checkpoint described in [Upgrade Orleans 8.x to 10.x](8-to-10.md):
 
-- Decide whether to accept `ResourceOptimizedPlacement`, the new default, or register `RandomPlacement`.
+- Decide whether to accept <xref:Orleans.Runtime.ResourceOptimizedPlacement>, the new default, or register <xref:Orleans.Runtime.RandomPlacement>.
 - Remove adaptive grain-directory cache configuration.
-- Test the aligned `IGrainState<T>` read and clear semantics.
-- Adopt native `CancellationToken` grain method parameters only after the runtime checkpoint is stable.
+- Test the aligned <xref:Orleans.IGrainState`1> read and clear semantics.
+- Adopt native <xref:System.Threading.CancellationToken> grain method parameters only after the runtime checkpoint is stable.
 
 ## Move to Orleans 10
 
 Complete [Upgrade Orleans 9.x to 10.x](9-to-10.md). The Orleans 10-specific changes are concentrated in:
 
-- Obsolete `[Unordered]` and `[OrleansConstructor]` annotations.
-- The `CancelRequestOnTimeout` default changing to `false`.
+- Obsolete <xref:Orleans.Concurrency.UnorderedAttribute> and <xref:Orleans.OrleansConstructorAttribute> annotations.
+- The <xref:Orleans.Configuration.MessagingOptions.CancelRequestOnTimeout> default changing to `false`.
 - SQL Server ADO.NET providers moving to `Microsoft.Data.SqlClient`.
 - Cancellation support expanding to observers and system targets.
 
@@ -87,8 +87,8 @@ Orleans 7 introduced the identity and serializer model used by later releases, s
 
 Still, preserve the application contract:
 
-- Never renumber or reuse `[Id]` values.
-- Keep `[Alias]` values stable across type or assembly moves.
+- Never renumber or reuse <xref:Orleans.IdAttribute> values.
+- Keep <xref:Orleans.AliasAttribute> values stable across type or assembly moves.
 - Don't reorder record primary-constructor parameters.
 - Keep storage serializers and provider names stable during each runtime upgrade.
 - Test reminders, stream subscriptions, queued payloads, and representative grain state at every checkpoint.

--- a/docs/site/src/content/docs/migration/8-to-10.md
+++ b/docs/site/src/content/docs/migration/8-to-10.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrade Orleans 8.x to 10.x
 description: Upgrade an Orleans 8 application through Orleans 9.2 to Orleans 10 with validated compatibility checkpoints.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: how-to
 ---
 
@@ -24,9 +24,9 @@ Applications starting before Orleans 8.2 must account for these changes:
 
 | Area | Change | Action |
 |------|--------|--------|
-| Load shedding | `LoadSheddingLimit` was replaced by `CpuThreshold` in Orleans 8.1 | Rename the option and review the added `MemoryThreshold`. |
-| Streaming | `LeaseAquisitionPeriod` and `DefaultMinLeaseAquisitionPeriod` were corrected in Orleans 8.2 | Use `LeaseAcquisitionPeriod` and `DefaultMinLeaseAcquisitionPeriod`. |
-| Timers | `RegisterGrainTimer` replaced the obsolete `RegisterTimer` API in Orleans 8.2 | Migrate callbacks and choose `Interleave` and `KeepAlive` deliberately. |
+| Load shedding | <xref:Orleans.Configuration.LoadSheddingOptions.LoadSheddingLimit> was replaced by <xref:Orleans.Configuration.LoadSheddingOptions.CpuThreshold> in Orleans 8.1 | Rename the option and review the added <xref:Orleans.Configuration.LoadSheddingOptions.MemoryThreshold>. |
+| Streaming | <xref:Orleans.Configuration.LeaseBasedQueueBalancerOptions.LeaseAquisitionPeriod> and <xref:Orleans.Configuration.LeaseBasedQueueBalancerOptions.DefaultMinLeaseAquisitionPeriod> were corrected in Orleans 8.2 | Use <xref:Orleans.Configuration.LeaseBasedQueueBalancerOptions.LeaseAcquisitionPeriod> and <xref:Orleans.Configuration.LeaseBasedQueueBalancerOptions.DefaultMinLeaseAcquisitionPeriod>. |
+| Timers | <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> replaced the obsolete <xref:Orleans.Grain.RegisterTimer*> API in Orleans 8.2 | Migrate callbacks and choose <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave> and <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive> deliberately. |
 | Serialization | MessagePack integration became available in Orleans 8.2 | Don't change the active serializer during the runtime upgrade unless separately qualified. |
 
 When translating an old timer and preserving its interleaving behavior:
@@ -39,9 +39,9 @@ For the full timer behavior matrix, see [Timers and reminders](../grains/timers-
 
 Orleans 9.2 introduces behavior that must be understood before moving to Orleans 10.
 
-### Native `CancellationToken` parameters
+### Native <xref:System.Threading.CancellationToken> parameters
 
-Grain interface methods can use `System.Threading.CancellationToken` directly. Existing `GrainCancellationToken` code can be migrated independently; don't combine that API conversion with business-logic changes.
+Grain interface methods can use <xref:System.Threading.CancellationToken> directly. Existing <xref:Orleans.GrainCancellationToken> code can be migrated independently; don't combine that API conversion with business-logic changes.
 
 :::code language="csharp" source="snippets/Orleans10MigrationExamples.cs" id="grain_cancellation":::
 
@@ -49,23 +49,23 @@ Only one cancellation token is allowed in a grain method. Test cancellation that
 
 ### Resource-optimized placement is the default
 
-Orleans 9.2 changed the default placement strategy from `RandomPlacement` to `ResourceOptimizedPlacement`. This can change activation distribution and locality. Either accept and load-test the new default or register `RandomPlacement` explicitly:
+Orleans 9.2 changed the default placement strategy from <xref:Orleans.Runtime.RandomPlacement> to <xref:Orleans.Runtime.ResourceOptimizedPlacement>. This can change activation distribution and locality. Either accept and load-test the new default or register <xref:Orleans.Runtime.RandomPlacement> explicitly:
 
 :::code language="csharp" source="snippets/Orleans10MigrationExamples.cs" id="random_placement":::
 
 ### Grain directory caching
 
-The adaptive grain-directory cache implementation was removed in Orleans 9.2. `GrainDirectoryOptions.CachingStrategyType.Adaptive` remains as an obsolete alias for LRU. Remove explicit adaptive-cache configuration and tune LRU cache size and expiration based on production measurements.
+The adaptive grain-directory cache implementation was removed in Orleans 9.2. The <xref:Orleans.Configuration.GrainDirectoryOptions.CachingStrategyType> value `Adaptive` remains as an obsolete alias for LRU. Remove explicit adaptive-cache configuration and tune LRU cache size and expiration based on production measurements.
 
 ### Grain storage behavior
 
-Orleans 9.2 aligned storage providers so that `IGrainState<T>.State`, `RecordExists`, and `ETag` follow consistent rules after reads and clears. Test activation initialization and `ClearStateAsync` behavior for every provider, especially code that inferred record existence from a null state object.
+Orleans 9.2 aligned storage providers so that <xref:Orleans.IGrainState`1.State>, <xref:Orleans.IGrainState`1.RecordExists>, and <xref:Orleans.IGrainState`1.ETag> follow consistent rules after reads and clears. Test activation initialization and <xref:Orleans.Core.IStorage.ClearStateAsync*> behavior for every provider, especially code that inferred record existence from a null state object.
 
 ## Apply the Orleans 10 changes
 
 After the Orleans 9.2 checkpoint is stable, complete every step in [Upgrade Orleans 9.x to 10.x](9-to-10.md), including:
 
-- Removing obsolete `[Unordered]` and valid `[OrleansConstructor]` uses.
+- Removing obsolete <xref:Orleans.Concurrency.UnorderedAttribute> and valid <xref:Orleans.OrleansConstructorAttribute> uses.
 - Setting timeout-cancellation behavior explicitly.
 - Moving SQL Server ADO.NET providers to `Microsoft.Data.SqlClient`.
 - Keeping hosting, call filters, serializer contracts, and provider schemas stable.
@@ -74,7 +74,7 @@ After the Orleans 9.2 checkpoint is stable, complete every step in [Upgrade Orle
 
 Orleans 8, 9, and 10 use the version-tolerant serializer introduced in Orleans 7, but application changes can still make stored data incompatible.
 
-- Keep all `[Id]` and `[Alias]` values stable.
+- Keep all <xref:Orleans.IdAttribute> and <xref:Orleans.AliasAttribute> values stable.
 - Don't reorder record primary-constructor parameters.
 - Don't change storage serializers while changing runtime majors.
 - Test old-state reads and rollback reads after every checkpoint.
@@ -91,7 +91,7 @@ Follow [Upgrade deployment and rollback](deployment-and-rollback.md) at each che
 
 - [ ] Update the application to the latest Orleans 8.2 patch on .NET 8.
 - [ ] Replace renamed load-shedding and lease-balancer options.
-- [ ] Migrate `RegisterTimer` to `RegisterGrainTimer` and select timer options.
+- [ ] Migrate <xref:Orleans.Grain.RegisterTimer*> to <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> and select timer options.
 - [ ] Build and test on the latest Orleans 9.2 patch.
 - [ ] Decide whether to keep resource-optimized placement or register random placement.
 - [ ] Remove adaptive grain-directory cache configuration.

--- a/docs/site/src/content/docs/migration/9-to-10.md
+++ b/docs/site/src/content/docs/migration/9-to-10.md
@@ -22,15 +22,15 @@ Orleans 10 packages target both .NET 8 and .NET 10. Retargeting the application 
 
 | Area | Orleans 10 impact | Required action |
 |------|-------------------|-----------------|
-| Source and analyzers | `[Unordered]` and `[OrleansConstructor]` are obsolete | Remove `[Unordered]`. Replace `[OrleansConstructor]` only when DI constructor selection is required. |
-| Behavior | `MessagingOptions.CancelRequestOnTimeout` now defaults to `false` | Set it explicitly if the application depends on cancellation being sent after a timeout. |
+| Source and analyzers | <xref:Orleans.Concurrency.UnorderedAttribute> and <xref:Orleans.OrleansConstructorAttribute> are obsolete | Remove <xref:Orleans.Concurrency.UnorderedAttribute>. Replace <xref:Orleans.OrleansConstructorAttribute> only when DI constructor selection is required. |
+| Behavior | <xref:Orleans.Configuration.MessagingOptions.CancelRequestOnTimeout> now defaults to `false` | Set it explicitly if the application depends on cancellation being sent after a timeout. |
 | ADO.NET providers | SQL Server now uses `Microsoft.Data.SqlClient` and its invariant name by default | Replace `System.Data.SqlClient`, update the invariant, and test every ADO.NET provider. |
 | Serialization and state | Orleans 10 doesn't require a wire-format or grain-state rewrite from Orleans 9 | Preserve serializer IDs, aliases, provider serializer settings, and stored type compatibility. |
-| Hosting | The generic-host `UseOrleans` and `UseOrleansClient` model remains current | No hosting rewrite is required for an Orleans 9 application already using these APIs. |
-| Placement | Orleans 9.2 already changed the default to `ResourceOptimizedPlacement` | Keep it, or register `RandomPlacement` explicitly before the upgrade if deterministic continuity is required. |
-| Cancellation | Orleans 10 adds cancellation support for observers and system targets | Keep at most one `CancellationToken` parameter per grain method and test timeout/cancellation races. |
-| Timers | No new Orleans 10 timer break | Continue using `RegisterGrainTimer`; `RegisterTimer` was already obsolete in Orleans 8.2. |
-| Call filters | No new Orleans 10 filter registration model | Continue registering incoming and outgoing filters on `ISiloBuilder` or `IClientBuilder`. |
+| Hosting | The generic-host <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*> and <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*> model remains current | No hosting rewrite is required for an Orleans 9 application already using these APIs. |
+| Placement | Orleans 9.2 already changed the default to <xref:Orleans.Runtime.ResourceOptimizedPlacement> | Keep it, or register <xref:Orleans.Runtime.RandomPlacement> explicitly before the upgrade if deterministic continuity is required. |
+| Cancellation | Orleans 10 adds cancellation support for observers and system targets | Keep at most one <xref:System.Threading.CancellationToken> parameter per grain method and test timeout/cancellation races. |
+| Timers | No new Orleans 10 timer break | Continue using <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*>; <xref:Orleans.Grain.RegisterTimer*> was already obsolete in Orleans 8.2. |
+| Call filters | No new Orleans 10 filter registration model | Continue registering incoming and outgoing filters on <xref:Orleans.Hosting.ISiloBuilder> or <xref:Orleans.IClientBuilder>. |
 | Deployment | Cross-major mixed clusters aren't covered by the documented compatibility guarantee | Use a parallel Orleans 10 cluster unless your exact mixed-version topology has been qualified. |
 
 ## Update packages centrally
@@ -55,19 +55,19 @@ Use the current stable Orleans 10.x patch when you perform the migration. Add ev
 
 ## Review source warnings
 
-### Remove `[Unordered]`
+### Remove <xref:Orleans.Concurrency.UnorderedAttribute> <a name="remove-unordered"></a>
 
-`[Unordered]` has no effect because Orleans doesn't guarantee message ordering based on this attribute. Remove it from grain interfaces.
+<xref:Orleans.Concurrency.UnorderedAttribute> has no effect because Orleans doesn't guarantee message ordering based on this attribute. Remove it from grain interfaces.
 
-### Replace `[OrleansConstructor]` only for dependency injection
+### Replace <xref:Orleans.OrleansConstructorAttribute> only for dependency injection <a name="replace-orleansconstructor-only-for-dependency-injection"></a>
 
-`OrleansConstructorAttribute` is no longer recognized by Orleans. If a serializable type needs a constructor selected for dependency injection, use <xref:Orleans.GeneratedActivatorConstructorAttribute> or <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute>. These attributes don't select a constructor for deserializing data members.
+<xref:Orleans.OrleansConstructorAttribute> is no longer recognized by Orleans. If a serializable type needs a constructor selected for dependency injection, use <xref:Orleans.GeneratedActivatorConstructorAttribute> or <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute>. These attributes don't select a constructor for deserializing data members.
 
 Don't change member IDs or constructor-visible state as part of this cleanup.
 
 ## Make timeout cancellation explicit
 
-Orleans 10 defaults `CancelRequestOnTimeout` to `false`. A timed-out caller therefore stops waiting, but Orleans doesn't automatically send cancellation to the target.
+Orleans 10 defaults <xref:Orleans.Configuration.MessagingOptions.CancelRequestOnTimeout> to `false`. A timed-out caller therefore stops waiting, but Orleans doesn't automatically send cancellation to the target.
 
 :::code language="csharp" source="snippets/Orleans10MigrationExamples.cs" id="timeout_cancellation":::
 
@@ -89,10 +89,10 @@ The client-library switch doesn't itself change your grain-state payload format.
 
 ## Preserve serialization and state compatibility
 
-No Orleans 9-to-10 migration step requires renumbering `[Id]` values or rewriting state. Preserve the existing contract:
+No Orleans 9-to-10 migration step requires renumbering <xref:Orleans.IdAttribute> values or rewriting state. Preserve the existing contract:
 
-- Don't reuse or renumber serializer member IDs.
-- Keep `[Alias]` values stable when types or assemblies move.
+- Don't reuse or renumber <xref:Orleans.IdAttribute> values.
+- Keep <xref:Orleans.AliasAttribute> values stable when types or assemblies move.
 - Don't reorder record primary-constructor parameters used as implicit serializer IDs.
 - Keep the configured grain-storage serializer unchanged during the runtime upgrade.
 - Read representative old state, write it with Orleans 10, and verify that the rollback build can still read it before allowing production writes.
@@ -102,17 +102,17 @@ For the version-tolerance rules, see [Orleans serialization](../host/configurati
 
 ## Confirm hosting, placement, timers, and filters
 
-An Orleans 9 application already using `Host.CreateApplicationBuilder`, `UseOrleans`, or `UseOrleansClient` doesn't need a hosting rewrite.
+An Orleans 9 application already using <xref:Microsoft.Extensions.Hosting.Host.CreateApplicationBuilder*>, <xref:Microsoft.Extensions.Hosting.OrleansSiloGenericHostExtensions.UseOrleans*>, or <xref:Microsoft.Extensions.Hosting.OrleansClientGenericHostExtensions.UseOrleansClient*> doesn't need a hosting rewrite.
 
-Orleans 9.2 made `ResourceOptimizedPlacement` the default. If the production cluster still relies on random placement, make that policy explicit:
+Orleans 9.2 made <xref:Orleans.Runtime.ResourceOptimizedPlacement> the default. If the production cluster still relies on <xref:Orleans.Runtime.RandomPlacement>, make that policy explicit:
 
 :::code language="csharp" source="snippets/Orleans10MigrationExamples.cs" id="random_placement":::
 
-Continue using `RegisterGrainTimer`. When preserving behavior from the old `RegisterTimer` API, set `Interleave = true`; the new API defaults to non-interleaving callbacks.
+Continue using <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*>. When preserving behavior from the old <xref:Orleans.Grain.RegisterTimer*> API, set <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave> to `true`; the new API defaults to non-interleaving callbacks.
 
 :::code language="csharp" source="snippets/Orleans10MigrationExamples.cs" id="grain_timer":::
 
-Register call filters on the Orleans builders, not directly on `IServiceCollection`:
+Register call filters on the Orleans builders, not directly on <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>:
 
 :::code language="csharp" source="snippets/Orleans10MigrationExamples.cs" id="call_filters":::
 
@@ -130,8 +130,8 @@ Follow [Upgrade deployment and rollback](deployment-and-rollback.md). Use a sepa
 - [ ] Update to the latest Orleans 9.x patch and remove build warnings.
 - [ ] Align every `Microsoft.Orleans.*` package on one current 10.x patch.
 - [ ] Keep .NET 8 for the first deployment, or qualify the .NET 10 retarget separately.
-- [ ] Remove `[Unordered]` and replace valid `[OrleansConstructor]` uses.
-- [ ] Set `CancelRequestOnTimeout` explicitly.
+- [ ] Remove <xref:Orleans.Concurrency.UnorderedAttribute> and replace valid <xref:Orleans.OrleansConstructorAttribute> uses.
+- [ ] Set <xref:Orleans.Configuration.MessagingOptions.CancelRequestOnTimeout> explicitly.
 - [ ] Replace `System.Data.SqlClient` and its invariant if SQL Server is used.
 - [ ] Preserve serializer IDs, aliases, and grain-storage serializer settings.
 - [ ] Confirm the intended placement strategy, timer interleaving, and call-filter registration.

--- a/docs/site/src/content/docs/migration/9-to-10.md
+++ b/docs/site/src/content/docs/migration/9-to-10.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrade Orleans 9.x to 10.x
 description: Upgrade an Orleans 9 application to Orleans 10, including packages, behavior changes, state compatibility, and deployment.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: how-to
 ---
 
@@ -82,6 +82,8 @@ Orleans 10 ADO.NET clustering, persistence, reminders, and streaming use `Micros
 1. Change the provider invariant from `System.Data.SqlClient` to `Microsoft.Data.SqlClient`.
 1. Apply any provider migration scripts required between the schema version currently deployed and the target Orleans version.
 1. Test clustering, grain storage, reminders, and streams independently.
+
+Use the repository migration directories for [clustering](https://github.com/dotnet/orleans/tree/main/src/AdoNet/Orleans.Clustering.AdoNet/Migrations), [persistence](https://github.com/dotnet/orleans/tree/main/src/AdoNet/Orleans.Persistence.AdoNet/Migrations), and [reminders](https://github.com/dotnet/orleans/tree/main/src/AdoNet/Orleans.Reminders.AdoNet/Migrations). Select the scripts for your database and apply them in version order.
 
 The client-library switch doesn't itself change your grain-state payload format. It can change connection defaults and authentication behavior, so validate connection encryption, certificates, authentication, retry policy, and transaction behavior in staging.
 


### PR DESCRIPTION
PR #10329 replaced the monolithic migration guide and unintentionally removed useful authoritative references.

Restore canonical package, hosting, and ADO.NET schema references, and link public Orleans/.NET symbols through resolving DocFX xrefs. Preserve historical migration context, stable anchors, and inline formatting for package IDs, configuration values, and provider invariants.