### PR TITLE
docs: restore authoritative grain references

### DIFF
--- a/docs/site/src/content/docs/grains/cancellation-tokens.md
+++ b/docs/site/src/content/docs/grains/cancellation-tokens.md
@@ -11,7 +11,7 @@ Orleans supports <xref:System.Threading.CancellationToken> parameters on grain m
 
 ## Add cancellation to a contract
 
-Add at most one `CancellationToken` parameter. Put it last and make it optional when callers commonly don't need cancellation:
+Add at most one <xref:System.Threading.CancellationToken> parameter. Put it last and make it optional when callers commonly don't need cancellation:
 
 ```csharp
 public interface IImportGrain : IGrainWithGuidKey
@@ -99,7 +99,7 @@ clientBuilder.Configure<ClientMessagingOptions>(options =>
 
 Even when enabled, the timeout doesn't prove that the operation stopped. The cancellation message can be delayed, the method might not observe its token, or side effects might already have completed.
 
-`WaitForCancellationAcknowledgement` also defaults to `false`. Enabling it makes the caller wait for acknowledgement from the callee rather than completing local cancellation immediately. Use it only when that stronger coordination is worth the added latency and messaging.
+<xref:Orleans.Configuration.MessagingOptions.WaitForCancellationAcknowledgement> also defaults to `false`. Enabling it makes the caller wait for acknowledgement from the callee rather than completing local cancellation immediately. Use it only when that stronger coordination is worth the added latency and messaging.
 
 ## Design cancellable operations
 
@@ -113,9 +113,9 @@ Cancellation callbacks registered from grain code execute in the grain's schedul
 
 ## Contract evolution
 
-Orleans treats a `CancellationToken` specially in generated request contracts. Adding or removing a token parameter is wire-compatible with callers compiled against the other form: a missing token is represented as `CancellationToken.None`, and an extra token from an older caller can be ignored. Making a newly added parameter optional also preserves C# source compatibility for common call sites.
+Orleans treats <xref:System.Threading.CancellationToken> specially in generated request contracts. Adding or removing a token parameter is wire-compatible with callers compiled against the other form: a missing token is represented as <xref:System.Threading.CancellationToken.None?displayProperty=nameWithType>, and an extra token from an older caller can be ignored. Making a newly added parameter optional also preserves C# source compatibility for common call sites.
 
-The older `GrainCancellationToken` API isn't needed for new applications. Use the standard .NET token.
+The older <xref:Orleans.GrainCancellationToken> API isn't needed for new applications. Use the standard .NET token.
 
 ## Related .NET guidance
 

--- a/docs/site/src/content/docs/grains/cancellation-tokens.md
+++ b/docs/site/src/content/docs/grains/cancellation-tokens.md
@@ -1,7 +1,7 @@
 ---
 title: Cancel Orleans grain calls
 description: Use CancellationToken for cooperative cancellation of Orleans grain calls.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: concept-article
 ---
 
@@ -116,3 +116,8 @@ Cancellation callbacks registered from grain code execute in the grain's schedul
 Orleans treats a `CancellationToken` specially in generated request contracts. Adding or removing a token parameter is wire-compatible with callers compiled against the other form: a missing token is represented as `CancellationToken.None`, and an extra token from an older caller can be ignored. Making a newly added parameter optional also preserves C# source compatibility for common call sites.
 
 The older `GrainCancellationToken` API isn't needed for new applications. Use the standard .NET token.
+
+## Related .NET guidance
+
+- [Cancellation in managed threads](https://learn.microsoft.com/dotnet/standard/threading/cancellation-in-managed-threads)
+- [Task cancellation](https://learn.microsoft.com/dotnet/standard/parallel-programming/task-cancellation)

--- a/docs/site/src/content/docs/grains/code-generation.md
+++ b/docs/site/src/content/docs/grains/code-generation.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans source generation
 description: Understand build-time code generation for grains and serialization in Orleans.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: concept-article
 ---
 
@@ -13,9 +13,9 @@ Orleans generates grain proxies, method dispatch code, serializers, and copiers 
 
 Use the package matching the project role:
 
-- `Microsoft.Orleans.Client` for client applications.
-- `Microsoft.Orleans.Server` for silo applications.
-- `Microsoft.Orleans.Sdk` for class libraries containing grain contracts, implementations, or serializable types.
+- [Microsoft.Orleans.Client](https://www.nuget.org/packages/Microsoft.Orleans.Client) for client applications.
+- [Microsoft.Orleans.Server](https://www.nuget.org/packages/Microsoft.Orleans.Server) for silo applications.
+- [Microsoft.Orleans.Sdk](https://www.nuget.org/packages/Microsoft.Orleans.Sdk) for class libraries containing grain contracts, implementations, or serializable types.
 
 These packages include the source generator and analyzers.
 
@@ -54,8 +54,12 @@ When a project must generate serializers for accessible types declared elsewhere
 
 Prefer owning serialization annotations with the type whenever possible. Generating for external declaring assemblies broadens the compatibility surface and can increase build output.
 
+## Other .NET languages
+
+For end-to-end interop examples, see the [Orleans F# sample](https://learn.microsoft.com/samples/dotnet/samples/orleans-fsharp-sample/) and [Orleans Visual Basic sample](https://learn.microsoft.com/samples/dotnet/samples/orleans-vb-sample/).
+
 ## Inspect diagnostics and output
 
 Treat Orleans analyzer and generator diagnostics as contract errors, not warnings to suppress. Generated files can be inspected through normal compiler-generated-file tooling when debugging, but application code should depend on the public interfaces rather than generated implementation names.
 
-For serialization rules and version tolerance, see the Orleans serialization documentation. For the runtime invocation pipeline, see the advanced implementation documentation.
+For serialization rules and version tolerance, see [Orleans serialization](../host/configuration-guide/serialization.md).

--- a/docs/site/src/content/docs/grains/code-generation.md
+++ b/docs/site/src/content/docs/grains/code-generation.md
@@ -23,7 +23,7 @@ These packages include the source generator and analyzers.
 
 The generator discovers grain interfaces and implementations from their Orleans base interfaces. It reports build diagnostics for unsupported signatures, inaccessible types, multiple cancellation token parameters, and other contract errors.
 
-Supported grain method return types are `Task`, `Task<T>`, `ValueTask`, and `ValueTask<T>`. The generator emits strongly typed references and invocation classes for those methods.
+Supported grain method return types are <xref:System.Threading.Tasks.Task>, <xref:System.Threading.Tasks.Task`1>, <xref:System.Threading.Tasks.ValueTask>, and <xref:System.Threading.Tasks.ValueTask`1>. The generator emits strongly typed references and invocation classes for those methods.
 
 ## Serializable types
 

--- a/docs/site/src/content/docs/grains/external-tasks-and-grains.md
+++ b/docs/site/src/content/docs/grains/external-tasks-and-grains.md
@@ -17,13 +17,13 @@ public async Task Refresh()
 }
 ```
 
-Async libraries don't need `Task.Run`. Await them directly.
+Async libraries don't need <xref:System.Threading.Tasks.Task.Run*>. Await them directly.
 
 ## Don't block the grain scheduler
 
-Never wait synchronously on incomplete tasks using `.Result`, `.Wait()`, `WaitAll`, or `GetAwaiter().GetResult()`. Blocking can deadlock the activation and starve the .NET thread pool.
+Never wait synchronously on incomplete tasks using <xref:System.Threading.Tasks.Task`1.Result>, <xref:System.Threading.Tasks.Task.Wait*>, <xref:System.Threading.Tasks.Task.WaitAll*>, or `GetAwaiter().GetResult()`. Blocking can deadlock the activation and starve the .NET thread pool.
 
-Avoid `async void`, including async lambdas passed to APIs expecting `Action<T>`. Exceptions can't be observed through a returned task and can terminate the process.
+Avoid `async void`, including async lambdas passed to APIs expecting <xref:System.Action`1>. Exceptions can't be observed through a returned task and can terminate the process.
 
 ## Use Task.Run narrowly
 
@@ -47,7 +47,7 @@ public async Task<int> Compress(byte[] input)
 }
 ```
 
-Don't read or mutate grain fields inside the `Task.Run` delegate. That code isn't protected by the grain scheduler.
+Don't read or mutate grain fields inside the <xref:System.Threading.Tasks.Task.Run*> delegate. That code isn't protected by the grain scheduler.
 
 ## ConfigureAwait
 
@@ -55,9 +55,9 @@ Don't use `ConfigureAwait(false)` directly in grain methods. It can resume the c
 
 ## Start activation-scheduled work
 
-`Task.Factory.StartNew` without an explicit scheduler uses `TaskScheduler.Current`, which is the Orleans scheduler in grain code. This is rarely needed; ordinary async methods are clearer. For the .NET scheduling differences, see [Task.Run vs Task.Factory.StartNew](https://devblogs.microsoft.com/dotnet/task-run-vs-task-factory-startnew/).
+<xref:System.Threading.Tasks.TaskFactory.StartNew*> without an explicit scheduler uses <xref:System.Threading.Tasks.TaskScheduler.Current?displayProperty=nameWithType>, which is the Orleans scheduler in grain code. This is rarely needed; ordinary async methods are clearer. For the .NET scheduling differences, see [Task.Run vs Task.Factory.StartNew](https://devblogs.microsoft.com/dotnet/task-run-vs-task-factory-startnew/).
 
-If an advanced integration passes an async delegate to `Task.Factory.StartNew`, unwrap the nested task:
+If an advanced integration passes an async delegate to <xref:System.Threading.Tasks.TaskFactory.StartNew*>, unwrap the nested task:
 
 ```csharp
 Task work = Task.Factory

--- a/docs/site/src/content/docs/grains/external-tasks-and-grains.md
+++ b/docs/site/src/content/docs/grains/external-tasks-and-grains.md
@@ -1,7 +1,7 @@
 ---
 title: External tasks and grain scheduling
 description: Safely use asynchronous libraries, CPU work, and blocking APIs from Orleans grains.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: concept-article
 ---
 
@@ -51,11 +51,11 @@ Don't read or mutate grain fields inside the `Task.Run` delegate. That code isn'
 
 ## ConfigureAwait
 
-Don't use `ConfigureAwait(false)` directly in grain methods. It can resume the continuation outside the activation scheduler. General-purpose libraries can use `ConfigureAwait(false)` internally; grain code returns to its scheduler when it normally awaits the library's task.
+Don't use `ConfigureAwait(false)` directly in grain methods. It can resume the continuation outside the activation scheduler. General-purpose libraries can use `ConfigureAwait(false)` internally; grain code returns to its scheduler when it normally awaits the library's task. For more information about context capture in .NET, see the [ConfigureAwait FAQ](https://devblogs.microsoft.com/dotnet/configureawait-faq/).
 
 ## Start activation-scheduled work
 
-`Task.Factory.StartNew` without an explicit scheduler uses `TaskScheduler.Current`, which is the Orleans scheduler in grain code. This is rarely needed; ordinary async methods are clearer.
+`Task.Factory.StartNew` without an explicit scheduler uses `TaskScheduler.Current`, which is the Orleans scheduler in grain code. This is rarely needed; ordinary async methods are clearer. For the .NET scheduling differences, see [Task.Run vs Task.Factory.StartNew](https://devblogs.microsoft.com/dotnet/task-run-vs-task-factory-startnew/).
 
 If an advanced integration passes an async delegate to `Task.Factory.StartNew`, unwrap the nested task:
 

--- a/docs/site/src/content/docs/grains/grain-lifecycle.md
+++ b/docs/site/src/content/docs/grains/grain-lifecycle.md
@@ -33,7 +33,7 @@ public sealed class DeviceGrain(
 }
 ```
 
-The parameterless `OnActivateAsync()` overload is obsolete. If activation fails, Orleans doesn't make that activation available for calls.
+<xref:Orleans.Grain.OnActivateAsync*> accepts a <xref:System.Threading.CancellationToken>; there is no parameterless overload. If activation fails, Orleans doesn't make that activation available for calls.
 
 Avoid doing unnecessary work during activation. Activations can be recreated after collection, migration, silo restart, or failure.
 
@@ -55,11 +55,11 @@ public override async Task OnDeactivateAsync(
 }
 ```
 
-Deactivation is best effort. `OnDeactivateAsync` doesn't run if the process terminates abruptly or in some failure cases. Persist important state as part of the operation that changes it, not only during deactivation.
+Deactivation is best effort. <xref:Orleans.Grain.OnDeactivateAsync*> doesn't run if the process terminates abruptly or in some failure cases. Persist important state as part of the operation that changes it, not only during deactivation.
 
 ## Influence activation lifetime
 
-Call `DeactivateOnIdle()` to ask Orleans to deactivate the grain after the current request and queued work complete:
+Call <xref:Orleans.Grain.DeactivateOnIdle> to ask Orleans to deactivate the grain after the current request and queued work complete:
 
 ```csharp
 public Task Close()
@@ -69,9 +69,9 @@ public Task Close()
 }
 ```
 
-Call `DelayDeactivation(TimeSpan)` to keep an otherwise idle activation eligible for a specified period. This is a hint, not a durability guarantee; failures and shutdown can still remove the activation.
+Call <xref:Orleans.Grain.DelayDeactivation*> to keep an otherwise idle activation eligible for a specified period. This is a hint, not a durability guarantee; failures and shutdown can still remove the activation.
 
-Grain timers don't keep an activation alive by default. Set `GrainTimerCreationOptions.KeepAlive` only when timer activity should extend the activation lifetime.
+Grain timers don't keep an activation alive by default. Set <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive?displayProperty=nameWithType> only when timer activity should extend the activation lifetime.
 
 ## Lifecycle stages and participants
 
@@ -79,12 +79,12 @@ The grain lifecycle exposes ordered stages:
 
 | Stage | Purpose |
 |---|---|
-| `GrainLifecycleStage.First` | Earliest subscription point. |
-| `GrainLifecycleStage.SetupState` | State setup and loading. |
-| `GrainLifecycleStage.Activate` | Grain activation and deactivation callbacks. |
-| `GrainLifecycleStage.Last` | Latest subscription point. |
+| <xref:Orleans.Runtime.GrainLifecycleStage.First?displayProperty=nameWithType> | Earliest subscription point. |
+| <xref:Orleans.Runtime.GrainLifecycleStage.SetupState?displayProperty=nameWithType> | State setup and loading. |
+| <xref:Orleans.Runtime.GrainLifecycleStage.Activate?displayProperty=nameWithType> | Grain activation and deactivation callbacks. |
+| <xref:Orleans.Runtime.GrainLifecycleStage.Last?displayProperty=nameWithType> | Latest subscription point. |
 
-Components that need ordered activation-scoped behavior can implement `ILifecycleParticipant<IGrainLifecycle>` and subscribe through <xref:Orleans.Runtime.IGrainContext.ObservableLifecycle>. `IGrainActivationContext` has been removed; use <xref:Orleans.Runtime.IGrainContext>.
+Components that need ordered activation-scoped behavior can implement <xref:Orleans.ILifecycleParticipant`1> for <xref:Orleans.Runtime.IGrainLifecycle> and subscribe through <xref:Orleans.Runtime.IGrainContext.ObservableLifecycle>. `IGrainActivationContext` has been removed; use <xref:Orleans.Runtime.IGrainContext>.
 
 ```csharp
 public sealed class CacheParticipant : ILifecycleParticipant<IGrainLifecycle>
@@ -105,13 +105,13 @@ public sealed class CacheParticipant : ILifecycleParticipant<IGrainLifecycle>
 }
 ```
 
-Lifecycle participation is an advanced integration mechanism. Most grains should use `OnActivateAsync` and `OnDeactivateAsync`.
+Lifecycle participation is an advanced integration mechanism. Most grains should use <xref:Orleans.Grain.OnActivateAsync*> and <xref:Orleans.Grain.OnDeactivateAsync*>.
 
 For the runtime lifecycle model shared by silos and grain activations, see [Orleans runtime lifecycle](../implementation/orleans-lifecycle.md).
 
 ## Grain migration
 
-Migration moves an activation to another silo while preserving migration-participating in-memory state. Call `MigrateOnIdle()` to request migration after the activation finishes its current work:
+Migration moves an activation to another silo while preserving migration-participating in-memory state. Call <xref:Orleans.Grain.MigrateOnIdle> to request migration after the activation finishes its current work:
 
 ```csharp
 public Task RequestMigration()
@@ -149,4 +149,4 @@ Persistent-state components supplied by Orleans participate automatically. Migra
 
 Automatic activation repartitioning and rebalancing use migration to improve locality or cluster balance. Both are experimental. See [Grain placement](grain-placement.md) for their status and configuration.
 
-Use <xref:Orleans.Placement.ImmovableAttribute> to exclude a grain type from automatic migration. It doesn't block an explicit `MigrateOnIdle()` request.
+Use <xref:Orleans.Placement.ImmovableAttribute> to exclude a grain type from automatic migration. It doesn't block an explicit <xref:Orleans.Grain.MigrateOnIdle> request.

--- a/docs/site/src/content/docs/grains/grain-lifecycle.md
+++ b/docs/site/src/content/docs/grains/grain-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: Grain activation and lifecycle
 description: Understand grain activation, deactivation, collection, lifecycle participation, and migration in Orleans.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: concept-article
 ---
 
@@ -106,6 +106,8 @@ public sealed class CacheParticipant : ILifecycleParticipant<IGrainLifecycle>
 ```
 
 Lifecycle participation is an advanced integration mechanism. Most grains should use `OnActivateAsync` and `OnDeactivateAsync`.
+
+For the runtime lifecycle model shared by silos and grain activations, see [Orleans runtime lifecycle](../implementation/orleans-lifecycle.md).
 
 ## Grain migration
 

--- a/docs/site/src/content/docs/grains/grain-placement-filtering.md
+++ b/docs/site/src/content/docs/grains/grain-placement-filtering.md
@@ -31,7 +31,7 @@ External clients don't have silo metadata. Design filtered grain activation path
 
 ## Require metadata matches
 
-<xref:Orleans.Placement.RequiredMatchSiloMetadataPlacementFilterAttribute> keeps only candidates matching every configured key:
+<xref:Orleans.Runtime.Placement.Filtering.RequiredMatchSiloMetadataPlacementFilterAttribute> keeps only candidates matching every configured key:
 
 ```csharp
 #pragma warning disable ORLEANSEXP004
@@ -49,7 +49,7 @@ Placement fails if no compatible silo matches. Use this filter only for hard req
 
 ## Prefer metadata matches
 
-<xref:Orleans.Placement.PreferredMatchSiloMetadataPlacementFilterAttribute> prefers candidates matching the ordered keys and progressively falls back by dropping earlier keys:
+<xref:Orleans.Runtime.Placement.Filtering.PreferredMatchSiloMetadataPlacementFilterAttribute> prefers candidates matching the ordered keys and progressively falls back by dropping earlier keys:
 
 ```csharp
 #pragma warning disable ORLEANSEXP004
@@ -91,15 +91,15 @@ The placement strategy sees only candidates that remain after every filter. A pr
 
 ## Read metadata from a grain
 
-Inject `ISiloMetadataCache` when grain logic needs silo metadata. Use `this.GetSiloAddress()` to identify the current activation's silo. Metadata reads don't influence placement retroactively.
+Inject <xref:Orleans.Runtime.MembershipService.SiloMetadata.ISiloMetadataCache> and <xref:Orleans.Runtime.IGrainRuntime> when grain logic needs silo metadata. Use <xref:Orleans.Runtime.IGrainRuntime.SiloAddress?displayProperty=nameWithType> to identify the current activation's silo. Metadata reads don't influence placement retroactively.
 
 ## Custom filters
 
 A custom filter consists of:
 
-1. A `PlacementFilterStrategy` carrying serializable configuration and a unique order.
-1. A `PlacementFilterAttribute` that attaches the strategy to a grain class.
-1. An `IPlacementFilterDirector` that returns a subset of candidate `SiloAddress` values.
+1. A <xref:Orleans.Placement.PlacementFilterStrategy> carrying serializable configuration and a unique order.
+1. A <xref:Orleans.Placement.PlacementFilterAttribute> that attaches the strategy to a grain class.
+1. An <xref:Orleans.Placement.IPlacementFilterDirector> that returns a subset of candidate <xref:Orleans.Runtime.SiloAddress> values.
 1. Registration from the silo's service collection, including the strategy lifetime:
 
     ```csharp
@@ -109,8 +109,8 @@ A custom filter consists of:
             ServiceLifetime.Transient);
     ```
 
-    The `ServiceLifetime` argument controls the placement strategy lifetime. Orleans always registers the director as a keyed singleton.
+    The <xref:Microsoft.Extensions.DependencyInjection.ServiceLifetime> argument controls the placement strategy lifetime. Orleans always registers the director as a keyed singleton.
 
 Custom filters are part of the same `ORLEANSEXP004` API surface. Keep directors deterministic and fast, don't return silos outside the input candidate set, and define behavior for no matches. Prefer the built-in metadata filters unless custom logic is essential.
 
-During placement, read application request metadata from `PlacementTarget.RequestContextData`; the static <xref:Orleans.Runtime.RequestContext> isn't populated because no activation exists yet.
+During placement, read application request metadata from <xref:Orleans.Runtime.Placement.PlacementTarget.RequestContextData?displayProperty=nameWithType>; the static <xref:Orleans.Runtime.RequestContext> isn't populated because no activation exists yet.

--- a/docs/site/src/content/docs/grains/grain-placement-filtering.md
+++ b/docs/site/src/content/docs/grains/grain-placement-filtering.md
@@ -1,7 +1,7 @@
 ---
 title: Grain placement filters
 description: Filter Orleans grain placement candidates using silo metadata.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: concept-article
 ---
 
@@ -16,7 +16,7 @@ Use filters for constraints and preferences such as availability zone, hardware 
 
 ## Configure silo metadata
 
-Built-in filters compare metadata on the calling silo with metadata on candidate silos. Configure consistent keys and values on every participating silo:
+Built-in filters compare [silo metadata](../host/configuration-guide/silo-metadata.md) on the calling silo with metadata on candidate silos. Configure consistent keys and values on every participating silo:
 
 ```csharp
 siloBuilder.UseSiloMetadata(

--- a/docs/site/src/content/docs/grains/grain-placement.md
+++ b/docs/site/src/content/docs/grains/grain-placement.md
@@ -100,7 +100,7 @@ public sealed class HardwareSessionGrain :
 }
 ```
 
-The attribute doesn't prevent explicit `MigrateOnIdle()` calls.
+The attribute doesn't prevent explicit <xref:Orleans.Grain.MigrateOnIdle> calls.
 
 ## Experimental automatic movement
 

--- a/docs/site/src/content/docs/grains/grain-placement.md
+++ b/docs/site/src/content/docs/grains/grain-placement.md
@@ -1,7 +1,7 @@
 ---
 title: Grain placement and migration
 description: Understand placement, resource-optimized defaults, and activation movement in Orleans.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: concept-article
 ---
 
@@ -12,6 +12,8 @@ When a grain isn't active, Orleans selects a compatible silo and creates an acti
 ## Default placement
 
 <xref:Orleans.Runtime.ResourceOptimizedPlacement> is the default placement strategy. It uses sampled silo runtime statistics and a power-of-k-choices algorithm to balance new activations while avoiding overloaded silos. It considers CPU, memory, available memory, activation count, and a preference for the local silo.
+
+For design background on its resource scoring and signal smoothing, see [Resource-based placement with cooperative dual-mode Kalman filtering](https://www.ledjonbehluli.com/posts/orleans_resource_placement_kalman/).
 
 Configure its weights through <xref:Orleans.Configuration.ResourceOptimizedPlacementOptions>:
 
@@ -40,7 +42,9 @@ Apply a placement attribute to a grain implementation when its requirements diff
 | <xref:Orleans.Placement.HashBasedPlacementAttribute> | Maps the grain ID across the current compatible silo set. |
 | <xref:Orleans.Placement.ActivationCountBasedPlacementAttribute> | Favors sampled silos with fewer activations. |
 | <xref:Orleans.Placement.SiloRoleBasedPlacementAttribute> | Restricts placement by silo role. |
-| <xref:Orleans.Concurrency.StatelessWorkerAttribute> | Uses local, scalable worker-pool placement. |
+| <xref:Orleans.Concurrency.StatelessWorkerAttribute> | Uses local, scalable [worker-pool placement](stateless-worker-grains.md). |
+
+Activation-count-based placement applies the power-of-two-choices technique described in [The Power of Two Choices in Randomized Load Balancing](https://www.eecs.harvard.edu/~michaelm/postscripts/mythesis.pdf).
 
 ```csharp
 [PreferLocalPlacement]
@@ -67,7 +71,7 @@ Per-grain attributes still take precedence.
 
 ## Placement filters
 
-Placement filters reduce the compatible candidate set before the placement strategy selects a silo. They can express requirements or preferences based on silo metadata. Placement filters are experimental and produce diagnostic `ORLEANSEXP004`.
+Placement filters reduce the compatible candidate set before the placement strategy selects a silo. They can express requirements or preferences based on [silo metadata](../host/configuration-guide/silo-metadata.md). Placement filters are experimental and produce diagnostic `ORLEANSEXP004`.
 
 See [Placement filters](grain-placement-filtering.md) for the built-in filters and experimental status.
 
@@ -125,4 +129,4 @@ Both features migrate eligible activations and can operate together. They add cl
 
 Custom placement strategies and directors are advanced runtime extensions. Implement them only when built-in strategies plus placement filters can't express the requirement. A director must handle membership changes, empty candidate sets, overloaded silos, and deterministic testing.
 
-For implementation details and examples, inspect the built-in directors under [`src/Orleans.Runtime/Placement`](https://github.com/dotnet/orleans/tree/main/src/Orleans.Runtime/Placement).
+For implementation details and examples, inspect the built-in directors under [`src/Orleans.Runtime/Placement`](https://github.com/dotnet/orleans/tree/main/src/Orleans.Runtime/Placement), including [`PreferLocalPlacementDirector`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Placement/PreferLocalPlacementDirector.cs).

--- a/docs/site/src/content/docs/grains/grainservices.md
+++ b/docs/site/src/content/docs/grains/grainservices.md
@@ -7,7 +7,7 @@ ms.topic: how-to
 
 # Grain services
 
-A grain service is a silo-resident, remotely callable service that supports grain functionality. Orleans starts one instance on every silo and keeps it for the silo lifetime. A `GrainServiceClient<T>` maps a calling grain to the service instance responsible for it.
+A grain service is a silo-resident, remotely callable service that supports grain functionality. Orleans starts one instance on every silo and keeps it for the silo lifetime. A <xref:Orleans.Runtime.Services.GrainServiceClient`1> maps a calling grain to the service instance responsible for it.
 
 Reminders are an example of this pattern. Most application workloads should use regular grains or hosted services; use grain services when a framework-level capability must be partitioned across every silo.
 
@@ -45,7 +45,7 @@ public sealed class IndexService :
 }
 ```
 
-Override `Init`, `Start`, `StartInBackground`, and `Stop` only when the service needs work at those lifecycle points. Grain services aren't ordinary grains: they don't have a stable application identity, aren't collected when idle, and don't migrate.
+Override <xref:Orleans.Runtime.GrainService.Init*>, <xref:Orleans.Runtime.GrainService.Start*>, <xref:Orleans.Runtime.GrainService.StartInBackground*>, and <xref:Orleans.Runtime.GrainService.Stop*> only when the service needs work at those lifecycle points. Grain services aren't ordinary grains: they don't have a stable application identity, aren't collected when idle, and don't migrate.
 
 ## Create the grain-facing client
 
@@ -77,7 +77,7 @@ public sealed class IndexServiceClient :
 }
 ```
 
-`GetGrainService(GrainId)` consistently maps the calling grain to a service partition. Other overloads support explicit silo or hash routing for advanced implementations.
+<xref:Orleans.Runtime.Services.GrainServiceClient`1.GetGrainService*> consistently maps the calling grain to a service partition. Other overloads support explicit silo or hash routing for advanced implementations.
 
 ## Register and consume the service
 

--- a/docs/site/src/content/docs/grains/grainservices.md
+++ b/docs/site/src/content/docs/grains/grainservices.md
@@ -1,7 +1,7 @@
 ---
 title: Grain services
 description: Implement silo-resident partitioned services for Orleans grains.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: how-to
 ---
 
@@ -106,5 +106,7 @@ public sealed class DocumentGrain(
 ```
 
 The client can route to a remote silo; don't assume calls stay local.
+
+Grain service implementation APIs are provided by [Microsoft.Orleans.Runtime](https://www.nuget.org/packages/Microsoft.Orleans.Runtime), which silo applications receive through `Microsoft.Orleans.Server`.
 
 For a compiled implementation used by Orleans tests, see [`TestGrainService.cs`](https://github.com/dotnet/orleans/blob/main/test/Orleans.Runtime.Tests/GrainServiceTests/TestGrainService.cs).

--- a/docs/site/src/content/docs/grains/index.md
+++ b/docs/site/src/content/docs/grains/index.md
@@ -44,7 +44,7 @@ Orleans supports these grain method return types:
 - <xref:System.Threading.Tasks.ValueTask>
 - <xref:System.Threading.Tasks.ValueTask`1>
 
-Use `Task` or `ValueTask` for methods without a result, and their generic forms for methods returning a result. Don't use `void`, `async void`, or synchronous return types in grain contracts. A <xref:System.Threading.CancellationToken> can be included as a method parameter for cooperative cancellation. For the underlying C# model, see [Asynchronous programming](https://learn.microsoft.com/dotnet/csharp/asynchronous-programming/).
+Use <xref:System.Threading.Tasks.Task> or <xref:System.Threading.Tasks.ValueTask> for methods without a result, and their generic forms for methods returning a result. Don't use `void`, `async void`, or synchronous return types in grain contracts. A <xref:System.Threading.CancellationToken> can be included as a method parameter for cooperative cancellation. For the underlying C# model, see [Asynchronous programming](https://learn.microsoft.com/dotnet/csharp/asynchronous-programming/).
 
 Arguments, return values, and exceptions cross process boundaries. Make application data serializable by Orleans, normally using <xref:Orleans.GenerateSerializerAttribute> and stable <xref:Orleans.IdAttribute> values. Grain references are already serializable and can be passed in calls or stored as part of grain state.
 
@@ -73,10 +73,10 @@ public sealed class ShoppingCartGrain : Grain, IShoppingCartGrain
 }
 ```
 
-Orleans creates grain classes through dependency injection. Constructor injection is available for application services, and <xref:Orleans.IGrainFactory> is available through the `GrainFactory` property on <xref:Orleans.Grain>.
+Orleans creates grain classes through dependency injection. Constructor injection is available for application services, and <xref:Orleans.IGrainFactory> is available through <xref:Orleans.Grain.GrainFactory?displayProperty=nameWithType>.
 
 > [!IMPORTANT]
-> A grain activation processes one turn at a time. Don't block on tasks using `.Result`, `.Wait()`, or `GetAwaiter().GetResult()`. Use `await` so Orleans can resume the request on the activation scheduler.
+> A grain activation processes one turn at a time. Don't block on tasks using <xref:System.Threading.Tasks.Task`1.Result>, <xref:System.Threading.Tasks.Task.Wait*>, or `GetAwaiter().GetResult()`. Use `await` so Orleans can resume the request on the activation scheduler.
 
 ## Get and call a grain reference
 
@@ -102,7 +102,7 @@ A regular grain call completes in one of these ways:
 - The caller doesn't receive a response before its response timeout and observes <xref:System.TimeoutException>.
 - Messaging or cluster failures prevent the call from completing.
 
-A timeout tells the caller that no response arrived in time. It doesn't prove that the grain method didn't run or won't finish. `CancelRequestOnTimeout` defaults to `false`; when enabled, Orleans sends a best-effort cancellation signal after a timeout, and the grain must still cooperate by observing a cancellation token.
+A timeout tells the caller that no response arrived in time. It doesn't prove that the grain method didn't run or won't finish. <xref:Orleans.Configuration.MessagingOptions.CancelRequestOnTimeout> defaults to `false`; when enabled, Orleans sends a best-effort cancellation signal after a timeout, and the grain must still cooperate by observing a cancellation token.
 
 Distributed calls can be retried by application code or infrastructure after an uncertain outcome. Design operations to be idempotent when duplicate execution would be harmful. A common pattern is to include an operation ID and persist completed IDs with the state change.
 
@@ -136,7 +136,7 @@ public override Task OnDeactivateAsync(
 }
 ```
 
-The parameterless `OnActivateAsync()` overload is obsolete. Deactivation callbacks are best effort and don't run after process termination or some failures, so don't rely on them to persist critical state.
+<xref:Orleans.Grain.OnActivateAsync*> accepts a <xref:System.Threading.CancellationToken>; there is no parameterless overload. Deactivation callbacks are best effort and don't run after process termination or some failures, so don't rely on them to persist critical state.
 
 See [Grain lifecycle](grain-lifecycle.md) for collection, lifecycle participation, and migration.
 

--- a/docs/site/src/content/docs/grains/index.md
+++ b/docs/site/src/content/docs/grains/index.md
@@ -1,13 +1,15 @@
 ---
 title: Develop Orleans grains
 description: Define grain contracts, implement grains, and call them in Orleans.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: article
 ---
 
 # Develop Orleans grains
 
 A grain is an application object with a stable logical identity. Orleans activates it on demand, routes calls to its current activation, and removes idle activations from memory. Application code works with grain references instead of constructing grain classes or locating activations.
+
+Projects defining grain contracts or implementations reference [Microsoft.Orleans.Sdk](https://www.nuget.org/packages/Microsoft.Orleans.Sdk). For host and project setup, see [Orleans basics](../tutorials-and-samples/tutorial-1.md#project-setup).
 
 ## Define a grain contract
 
@@ -42,7 +44,7 @@ Orleans supports these grain method return types:
 - <xref:System.Threading.Tasks.ValueTask>
 - <xref:System.Threading.Tasks.ValueTask`1>
 
-Use `Task` or `ValueTask` for methods without a result, and their generic forms for methods returning a result. Don't use `void`, `async void`, or synchronous return types in grain contracts. A <xref:System.Threading.CancellationToken> can be included as a method parameter for cooperative cancellation.
+Use `Task` or `ValueTask` for methods without a result, and their generic forms for methods returning a result. Don't use `void`, `async void`, or synchronous return types in grain contracts. A <xref:System.Threading.CancellationToken> can be included as a method parameter for cooperative cancellation. For the underlying C# model, see [Asynchronous programming](https://learn.microsoft.com/dotnet/csharp/asynchronous-programming/).
 
 Arguments, return values, and exceptions cross process boundaries. Make application data serializable by Orleans, normally using <xref:Orleans.GenerateSerializerAttribute> and stable <xref:Orleans.IdAttribute> values. Grain references are already serializable and can be passed in calls or stored as part of grain state.
 
@@ -114,7 +116,7 @@ public interface IReportGrain : IGrainWithGuidKey
 }
 ```
 
-Global defaults are configured through <xref:Orleans.Configuration.ClientMessagingOptions> and <xref:Orleans.Configuration.SiloMessagingOptions>. See [Cancellation tokens](cancellation-tokens.md) for cancellation semantics and configuration.
+Global defaults are configured through <xref:Orleans.Configuration.ClientMessagingOptions> and <xref:Orleans.Configuration.SiloMessagingOptions>. See [client configuration](../host/configuration-guide/client-configuration.md), [server configuration](../host/configuration-guide/server-configuration.md), and [cancellation tokens](cancellation-tokens.md).
 
 ## Activation and deactivation
 

--- a/docs/site/src/content/docs/grains/observers.md
+++ b/docs/site/src/content/docs/grains/observers.md
@@ -95,9 +95,9 @@ public sealed class ChatRoomGrain : Grain, IChatRoomGrain
 }
 ```
 
-The current API is `Notify`, including the overload that accepts `Func<TObserver, Task>`. There is no `NotifyAsync` method.
+The current API is <xref:Orleans.Utilities.ObserverManager`2.Notify*>, including the overload that accepts <xref:System.Func`2> returning a <xref:System.Threading.Tasks.Task>. There is no `NotifyAsync` method.
 
-Subscriptions expire lazily after `ExpirationDuration`. Clients should renew before expiry. A notification exception causes `ObserverManager` to remove that observer; it doesn't fail the entire publish operation.
+Subscriptions expire lazily after <xref:Orleans.Utilities.ObserverManager`2.ExpirationDuration>. Clients should renew before expiry. A notification exception causes <xref:Orleans.Utilities.ObserverManager`1> to remove that observer; it doesn't fail the entire publish operation.
 
 Use <xref:Orleans.Utilities.ObserverManager`2> when the subscription identity should differ from the observer reference.
 
@@ -112,7 +112,7 @@ IChatObserver observer =
 await room.Subscribe(observer);
 ```
 
-Don't call `CreateObjectReference` for a grain. Grains are already addressable.
+Don't call <xref:Orleans.IGrainFactory.CreateObjectReference*> for a grain. Grains are already addressable.
 
 ## Execution and cancellation
 

--- a/docs/site/src/content/docs/grains/observers.md
+++ b/docs/site/src/content/docs/grains/observers.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans observers
 description: Send asynchronous notifications from grains to clients or other grains.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: concept-article
 ---
 
@@ -9,7 +9,7 @@ ms.topic: concept-article
 
 Observers let grains call an object hosted by an Orleans client or another grain. They are useful for live, best-effort notifications while the receiver is connected.
 
-Observers aren't durable subscriptions. A client can disconnect without notice, and a recreated observer has a different identity. Use an Orleans stream or another durable messaging mechanism when subscriptions or delivery must survive failures.
+Observers aren't durable subscriptions. A client can disconnect without notice, and a recreated observer has a different identity. Use [Orleans streams](../streaming/index.md) or another durable messaging mechanism when subscriptions or delivery must survive failures.
 
 ## Define an observer
 
@@ -118,4 +118,4 @@ Don't call `CreateObjectReference` for a grain. Grains are already addressable.
 
 Calls to one client observer reference execute sequentially and aren't reentrant. Different observer references can execute concurrently.
 
-Observer methods can accept a <xref:System.Threading.CancellationToken> parameter. Cancellation remains cooperative and doesn't make observer delivery durable.
+Observer methods can accept a <xref:System.Threading.CancellationToken> parameter. Cancellation remains cooperative and doesn't make observer delivery durable. See [Cancel Orleans grain calls](cancellation-tokens.md) for cancellation semantics.

--- a/docs/site/src/content/docs/grains/snippets/interceptors/interceptors.csproj
+++ b/docs/site/src/content/docs/grains/snippets/interceptors/interceptors.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
   </ItemGroup>
 
 </Project>

--- a/docs/site/src/content/docs/grains/snippets/timers/Timers.csproj
+++ b/docs/site/src/content/docs/grains/snippets/timers/Timers.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Reminders" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Reminders.Redis" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Reminders.Cosmos" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Reminders.AzureStorage" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Reminders" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.Redis" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.Cosmos" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AdoNet" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Orleans.Reminders.AzureStorage" Version="10.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Azure.Identity" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="10.2.2" />
   </ItemGroup>
 
 </Project>

--- a/docs/site/src/content/docs/grains/timers-and-reminders.md
+++ b/docs/site/src/content/docs/grains/timers-and-reminders.md
@@ -1,7 +1,7 @@
 ---
 title: Grain timers and reminders
 description: Schedule activation-scoped and durable periodic work in Orleans.
-ms.date: 08/02/2026
+ms.date: 08/07/2026
 ms.topic: concept-article
 ---
 
@@ -113,10 +113,10 @@ Reminders are intended for periods measured in minutes, hours, or days, not high
 
 ## Configure reminder storage
 
-Every silo must configure a reminder provider. Production deployments should use a durable provider such as Azure Table, ADO.NET, Redis, or Cosmos DB. In-memory reminders are suitable only for local development and tests because definitions are lost when the cluster stops.
+Every silo must configure a reminder provider. Production deployments should use a durable provider such as Azure Table, ADO.NET, Redis, or [Cosmos DB](https://www.nuget.org/packages/Microsoft.Orleans.Reminders.Cosmos). In-memory reminders are suitable only for local development and tests because definitions are lost when the cluster stops.
 
-The provider-specific configuration is covered by each reminder provider package. For a compiled in-repository configuration example, see the [reminder configuration snippets](https://github.com/dotnet/orleans/tree/main/docs/site/src/content/docs/grains/snippets/timers).
+The provider-specific configuration is covered by each reminder provider package. For a compiled in-repository configuration example, see the [reminder configuration snippets](https://github.com/dotnet/orleans/tree/main/docs/site/src/content/docs/grains/snippets/timers). When composing resources with .NET Aspire, see [Orleans and Aspire integration](../host/aspire-integration.md).
 
 ## POCO grains
 
-Grains implementing <xref:Orleans.IGrainBase> directly can use the same extension APIs. Inject <xref:Orleans.Timers.ITimerRegistry> or <xref:Orleans.Timers.IReminderRegistry> when lower-level registration is required.
+Grains implementing <xref:Orleans.IGrainBase> directly can use the same extension APIs. Inject <xref:Orleans.Timers.ITimerRegistry> or <xref:Orleans.Timers.IReminderRegistry> when lower-level registration is required. See [POCO grains](../migration-guide.md#poco-grains-and-igrainbase) for the interface-only grain model.

--- a/docs/site/src/content/docs/grains/timers-and-reminders.md
+++ b/docs/site/src/content/docs/grains/timers-and-reminders.md
@@ -16,7 +16,7 @@ Use a timer for frequent, activation-scoped work. Use a reminder when the schedu
 
 ## Grain timers
 
-Register timers with <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*>. `RegisterTimer` is obsolete.
+Register timers with <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*>. <xref:Orleans.Grain.RegisterTimer*> is obsolete.
 
 ```csharp
 public sealed class CacheGrain : Grain, ICacheGrain
@@ -44,7 +44,7 @@ public sealed class CacheGrain : Grain, ICacheGrain
 }
 ```
 
-`RegisterGrainTimer` returns <xref:Orleans.Runtime.IGrainTimer>. Dispose it to stop the timer, or call <xref:Orleans.Runtime.IGrainTimer.Change*> to change its due time and period.
+<xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> returns <xref:Orleans.Runtime.IGrainTimer>. Dispose it to stop the timer, or call <xref:Orleans.Runtime.IGrainTimer.Change*> to change its due time and period.
 
 ### Timer behavior
 
@@ -52,10 +52,10 @@ public sealed class CacheGrain : Grain, ICacheGrain
 
 | Property | Default | Behavior |
 |---|---:|---|
-| `DueTime` | Required | Delay before the first callback. |
-| `Period` | Required | Delay from callback completion until the next callback. |
-| `Interleave` | `false` | Whether callbacks can interleave with other grain requests. |
-| `KeepAlive` | `false` | Whether timer activity extends activation lifetime. |
+| <xref:Orleans.Runtime.GrainTimerCreationOptions.DueTime> | Required | Delay before the first callback. |
+| <xref:Orleans.Runtime.GrainTimerCreationOptions.Period> | Required | Delay from callback completion until the next callback. |
+| <xref:Orleans.Runtime.GrainTimerCreationOptions.Interleave> | `false` | Whether callbacks can interleave with other grain requests. |
+| <xref:Orleans.Runtime.GrainTimerCreationOptions.KeepAlive> | `false` | Whether timer activity extends activation lifetime. |
 
 A timer callback never overlaps itself. Orleans waits for the callback task to complete before measuring the next period. Exceptions are logged, and later ticks continue.
 
@@ -103,7 +103,7 @@ if (reminder is not null)
 }
 ```
 
-Store the reminder name, not the `IGrainReminder` handle, across activations. Handles aren't guaranteed to remain valid beyond the activation that retrieved them.
+Store the reminder name, not the <xref:Orleans.Runtime.IGrainReminder> handle, across activations. Handles aren't guaranteed to remain valid beyond the activation that retrieved them.
 
 ### Reminder behavior
 
@@ -115,7 +115,7 @@ Reminders are intended for periods measured in minutes, hours, or days, not high
 
 Every silo must configure a reminder provider. Production deployments should use a durable provider such as Azure Table, ADO.NET, Redis, or [Cosmos DB](https://www.nuget.org/packages/Microsoft.Orleans.Reminders.Cosmos). In-memory reminders are suitable only for local development and tests because definitions are lost when the cluster stops.
 
-The provider-specific configuration is covered by each reminder provider package. For a compiled in-repository configuration example, see the [reminder configuration snippets](https://github.com/dotnet/orleans/tree/main/docs/site/src/content/docs/grains/snippets/timers). When composing resources with .NET Aspire, see [Orleans and Aspire integration](../host/aspire-integration.md).
+The provider-specific configuration is covered by each reminder provider package. For a compiled in-repository configuration example, see the [reminder configuration snippets](https://github.com/dotnet/orleans/tree/main/docs/site/src/content/docs/grains/snippets/timers). When composing resources with Aspire, see [Orleans and Aspire integration](../host/aspire-integration.md).
 
 ## POCO grains
 


### PR DESCRIPTION
Restores and updates useful authoritative references removed while rewriting the grain programming documentation. Canonical Microsoft Learn, NuGet, source, lifecycle, placement research, interoperability, and provider links are placed alongside the guidance they support; obsolete, dead, generic, and unsupported-topic links remain omitted.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10353)