### PR TITLE
fix(telemetry)!: update RPC semantic convention keys

### DIFF
--- a/src/Orleans.Core.Abstractions/Diagnostics/ActivitySources.cs
+++ b/src/Orleans.Core.Abstractions/Diagnostics/ActivitySources.cs
@@ -29,9 +29,9 @@ public static class ActivitySources
     /// </summary>
     public const string AllActivitySourceName = "Microsoft.Orleans.*";
 
-    internal static readonly ActivitySource ApplicationGrainSource = new(ApplicationGrainActivitySourceName, "1.1.0");
-    internal static readonly ActivitySource RuntimeGrainSource = new(RuntimeActivitySourceName, "2.0.0");
-    internal static readonly ActivitySource LifecycleGrainSource = new(LifecycleActivitySourceName, "1.0.0");
-    internal static readonly ActivitySource StorageGrainSource = new(StorageActivitySourceName, "1.0.0");
+    internal static readonly ActivitySource ApplicationGrainSource = new(ApplicationGrainActivitySourceName, "1.2.0");
+    internal static readonly ActivitySource RuntimeGrainSource = new(RuntimeActivitySourceName, "2.1.0");
+    internal static readonly ActivitySource LifecycleGrainSource = new(LifecycleActivitySourceName, "1.1.0");
+    internal static readonly ActivitySource StorageGrainSource = new(StorageActivitySourceName, "1.1.0");
     internal static readonly ActivitySource DurableJobsSource = new(DurableJobsActivitySourceName, "1.0.0");
 }

--- a/src/Orleans.Core.Abstractions/Diagnostics/ActivityTagKeys.cs
+++ b/src/Orleans.Core.Abstractions/Diagnostics/ActivityTagKeys.cs
@@ -91,14 +91,14 @@ internal static class ActivityTagKeys
     public const string StorageStateType = "orleans.storage.state.type";
 
     /// <summary>
-    /// The RPC system tag key.
+    /// The RPC system name tag key.
     /// </summary>
-    public const string RpcSystem = "rpc.system";
+    public const string RpcSystem = "rpc.system.name";
 
     /// <summary>
-    /// The RPC service tag key.
+    /// The Orleans RPC service tag key.
     /// </summary>
-    public const string RpcService = "rpc.service";
+    public const string RpcService = "orleans.rpc.service";
 
     /// <summary>
     /// The RPC method tag key.
@@ -108,12 +108,12 @@ internal static class ActivityTagKeys
     /// <summary>
     /// The RPC Orleans target ID tag key.
     /// </summary>
-    public const string RpcOrleansTargetId = "rpc.orleans.target_id";
+    public const string RpcOrleansTargetId = "orleans.rpc.target_id";
 
     /// <summary>
     /// The RPC Orleans source ID tag key.
     /// </summary>
-    public const string RpcOrleansSourceId = "rpc.orleans.source_id";
+    public const string RpcOrleansSourceId = "orleans.rpc.source_id";
 
     /// <summary>
     /// The exception stacktrace tag key.
@@ -205,4 +205,3 @@ internal static class ActivityTagKeys
     /// </summary>
     public const string JournalStorageBatchSize = "orleans.journal.batch_size";
 }
-

--- a/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
+++ b/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
@@ -52,7 +52,7 @@ namespace Orleans.Runtime
                 // RPC attributes from https://opentelemetry.io/docs/specs/semconv/rpc/
                 activity.SetTag(ActivityTagKeys.RpcSystem, RpcSystem);
                 activity.SetTag(ActivityTagKeys.RpcService, context.InterfaceName);
-                activity.SetTag(ActivityTagKeys.RpcMethod, context.MethodName);
+                activity.SetTag(ActivityTagKeys.RpcMethod, $"{context.InterfaceName}/{context.MethodName}");
 
                 if (activity.IsAllDataRequested)
                 {

--- a/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
+++ b/src/Orleans.Core/Diagnostics/ActivityPropagationGrainCallFilter.cs
@@ -49,7 +49,7 @@ namespace Orleans.Runtime
         {
             if (activity is not null)
             {
-                // rpc attributes from https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md
+                // RPC attributes from https://opentelemetry.io/docs/specs/semconv/rpc/
                 activity.SetTag(ActivityTagKeys.RpcSystem, RpcSystem);
                 activity.SetTag(ActivityTagKeys.RpcService, context.InterfaceName);
                 activity.SetTag(ActivityTagKeys.RpcMethod, context.MethodName);

--- a/test/Orleans.Runtime.Tests/GrainCallTraceContextPropagationTests.cs
+++ b/test/Orleans.Runtime.Tests/GrainCallTraceContextPropagationTests.cs
@@ -99,6 +99,28 @@ namespace UnitTests.General
             }
         }
 
+        [Fact]
+        [TestCategory("BVT")]
+        public async Task GrainCallUsesCurrentRpcSemanticConventionKeys()
+        {
+            Started.Clear();
+
+            var grain = _fixture.GrainFactory.GetGrain<ITraceContextPropagationGrain>(Random.Shared.Next());
+            await grain.GetTraceContextInfo();
+
+            var activity = Started.FirstOrDefault(
+                a => a.Source.Name == ActivitySources.ApplicationGrainActivitySourceName
+                    && a.GetTagItem("rpc.system.name") is not null);
+
+            Assert.NotNull(activity);
+            Assert.Equal("orleans", activity.GetTagItem("rpc.system.name"));
+            Assert.Equal(typeof(ITraceContextPropagationGrain).FullName, activity.GetTagItem("orleans.rpc.service"));
+            Assert.Equal(nameof(ITraceContextPropagationGrain.GetTraceContextInfo), activity.GetTagItem("rpc.method"));
+            Assert.Null(activity.GetTagItem("rpc.system"));
+            Assert.Null(activity.GetTagItem("rpc.service"));
+            Assert.NotNull(activity.GetTagItem("orleans.rpc.target_id"));
+        }
+
         /// <summary>
         /// Verifies that the server-side activity is a Server kind and has a remote parent.
         /// This confirms proper W3C trace context handling.

--- a/test/Orleans.Runtime.Tests/GrainCallTraceContextPropagationTests.cs
+++ b/test/Orleans.Runtime.Tests/GrainCallTraceContextPropagationTests.cs
@@ -115,7 +115,9 @@ namespace UnitTests.General
             Assert.NotNull(activity);
             Assert.Equal("orleans", activity.GetTagItem("rpc.system.name"));
             Assert.Equal(typeof(ITraceContextPropagationGrain).FullName, activity.GetTagItem("orleans.rpc.service"));
-            Assert.Equal(nameof(ITraceContextPropagationGrain.GetTraceContextInfo), activity.GetTagItem("rpc.method"));
+            Assert.Equal(
+                $"{typeof(ITraceContextPropagationGrain).FullName}/{nameof(ITraceContextPropagationGrain.GetTraceContextInfo)}",
+                activity.GetTagItem("rpc.method"));
             Assert.Null(activity.GetTagItem("rpc.system"));
             Assert.Null(activity.GetTagItem("rpc.service"));
             Assert.NotNull(activity.GetTagItem("orleans.rpc.target_id"));


### PR DESCRIPTION
Updates Orleans RPC activity attributes to the current OpenTelemetry semantic conventions. Replaces legacy and reserved-namespace keys, preserves Orleans service/target/source metadata under the Orleans namespace, versions the affected ActivitySources, and adds regression coverage.

Semantic Convention for non-standard attributes is to prefix with something company or product specific. Using `orleans.**` which is also a pattern in use for other existing attributes.

Fixes #10320