### PR TITLE
revert(deps): restore mermaid 11.15.0

### DIFF
--- a/src/Dashboard/Orleans.Dashboard.App/package-lock.json
+++ b/src/Dashboard/Orleans.Dashboard.App/package-lock.json
@@ -15,7 +15,7 @@
         "chart.js": "^4.4.8",
         "eventthing": "^1.0.7",
         "humanize-duration": "^3.32.1",
-        "mermaid": "^11.16.1",
+        "mermaid": "^11.15.0",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1"
@@ -631,12 +631,12 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
-      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.2"
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3304,26 +3304,26 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.16.1",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
-      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.2",
+        "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.2.0",
+        "@mermaid-js/parser": "^1.1.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.3",
+        "cytoscape": "^3.33.1",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.20",
-        "dompurify": "^3.3.3",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.45",
+        "katex": "^0.16.25",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",

--- a/src/Dashboard/Orleans.Dashboard.App/package.json
+++ b/src/Dashboard/Orleans.Dashboard.App/package.json
@@ -17,7 +17,7 @@
     "chart.js": "^4.4.8",
     "eventthing": "^1.0.7",
     "humanize-duration": "^3.32.1",
-    "mermaid": "^11.16.1",
+    "mermaid": "^11.15.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
Microsoft's npm proxy returns 404 for mermaid 11.16.1 while 11.15.0 remains available, which breaks npm ci and solution builds.

This reverts only the dependency changes from 4a0d53403519c69ecce796aaa4f04777350a5ac1 (#10350), restoring package.json and the matching package-lock entries to mermaid 11.15.0.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10357)