### PR TITLE
docs: restore legacy Orleans 10 migration context

### DIFF
--- a/docs/site/src/content/docs/migration/3-to-7-archive.md
+++ b/docs/site/src/content/docs/migration/3-to-7-archive.md
@@ -1,7 +1,7 @@
 ---
 title: Archived Orleans 3.x to 7.x migration notes
 description: Historical guidance for crossing the incompatible Orleans 3-to-7 identity, hosting, and serialization boundary.
-ms.date: 08/07/2026
+ms.date: 08/08/2026
 ms.topic: how-to
 ---
 
@@ -30,6 +30,43 @@ These notes apply to an Orleans 3.x application that must first become an Orlean
 The old <xref:Orleans.Hosting.GrainCallFilterServiceCollectionExtensions.AddGrainCallFilter*> API was removed before Orleans 7. Register incoming and outgoing filters on <xref:Orleans.Hosting.ISiloBuilder> or <xref:Orleans.Hosting.IClientBuilder>.
 
 For an itemized record of the Orleans samples migrated to Orleans 7, see [dotnet/orleans issue #8035](https://github.com/dotnet/orleans/issues/8035).
+
+## Why this boundary requires conversion
+
+Orleans 7 changed two durable contracts which Orleans 10 retains:
+
+- Grain, grain-interface, and stream identities moved to the string-based type, namespace, and key representations used by <xref:Orleans.Runtime.GrainId> and <xref:Orleans.Runtime.StreamId>.
+- The Orleans wire serializer was replaced by the version-tolerant serializer based on <xref:Orleans.GenerateSerializerAttribute>, <xref:Orleans.IdAttribute>, and <xref:Orleans.AliasAttribute>.
+
+These changes make applications easier to evolve after the Orleans 7 checkpoint, but they don't make Orleans 3 identities or payloads automatically compatible. Define and test the conversion before the Orleans 7 cluster reads production data.
+
+### Map identities and serialized state
+
+Create an explicit mapping for every durable identity:
+
+- Preserve the domain value of each GUID, integer, string, or compound grain key while mapping the old grain type to its Orleans 7-and-later type name. Use <xref:Orleans.GrainTypeAttribute> when that name must remain independent of the CLR class name.
+- Map stream namespaces and GUID keys to stable <xref:Orleans.Runtime.StreamId> namespace and key strings. Keep provider names stable unless the migration deliberately moves subscriptions to another provider.
+- Add stable serializer member IDs, and add aliases before renaming serialized types. Don't reuse IDs or aliases after the Orleans 7 checkpoint.
+- Treat serialized grain references, queued messages, reminders, stream subscriptions, and provider metadata as part of the conversion, not only grain-state rows.
+
+The version-tolerant serializer governs compatible changes after conversion. Don't assume that it can decode payloads written by the Orleans 3 wire serializer or by a storage serializer with different settings. Verify each stored type using representative production data. See [Grain identity](../grains/grain-identity.md) and [Orleans serialization](../host/configuration-guide/serialization.md) for the Orleans 10 contracts.
+
+### Replace Simple Message Streams
+
+Simple Message Streams were removed in Orleans 7. Choose the replacement based on the behavior the application relied on:
+
+- Use [broadcast channels](../streaming/broadcast-channel.md) for nonpersistent, best-effort delivery to implicit subscribers. Broadcast channels don't retain events, replay messages, or support explicit subscriptions.
+- Use an [Orleans stream provider](../streaming/index.md) when the application requires explicit subscriptions, durable subscription metadata, an external broker, replay, or provider-backed delivery.
+
+Don't select a replacement only because both APIs deliver notifications. Record how each old provider name, namespace, key, and subscription maps to the new abstraction, then test duplicate, delayed, and lost-message behavior. See [Choose an Orleans messaging abstraction](../streaming/streams-why.md) for the current behavior matrix.
+
+### Replace legacy telemetry consumers
+
+The `Microsoft.Orleans.TelemetryConsumers.*` packages and legacy telemetry-consumer model were removed. Orleans 10 emits structured logs, a `Microsoft.Orleans` <xref:System.Diagnostics.Metrics.Meter>, and <xref:System.Diagnostics.ActivitySource> traces. Replace old consumers with the application's logging and OpenTelemetry pipeline, and register activity propagation on every participating silo and client. See [Orleans observability](../host/monitoring/index.md).
+
+### Account for separated feature packages
+
+Streaming, reminders, and transactions moved out of the core package. Add `Microsoft.Orleans.Streaming`, `Microsoft.Orleans.Reminders`, and `Microsoft.Orleans.Transactions` only where those features are used. APIs which previously appeared as <xref:Orleans.Grain> instance methods are extension methods in these packages, so unqualified calls might need `this.`, such as `this.GetReminders()` or `this.GetStreamProvider("provider")`.
 
 ## State and deployment boundary
 


### PR DESCRIPTION
PR #10329 condensed the legacy migration path into a checklist and removed context needed to cross the Orleans 3 identity and serialization boundary on the way to Orleans 10.

This restores focused guidance for mapping durable identities and state, choosing broadcast channels versus Orleans streams, replacing legacy telemetry consumers, and accounting for separated feature packages. It links to the current Orleans 10 conceptual documentation and omits obsolete or inaccurate historical claims.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10361)