### PR TITLE
docs: restore durability operational contracts

### DIFF
--- a/docs/site/src/content/docs/grains/event-sourcing/journaledgrain-basics.md
+++ b/docs/site/src/content/docs/grains/event-sourcing/journaledgrain-basics.md
@@ -1,7 +1,7 @@
 ---
 title: The JournaledGrain API
 description: Define state transitions and confirm events using JournaledGrain.
-ms.date: 08/02/2026
+ms.date: 08/08/2026
 ms.topic: concept-article
 ---
 
@@ -49,6 +49,9 @@ public sealed class AccountState
 ```
 
 Alternatively, override <xref:Orleans.EventSourcing.JournaledGrain`2.TransitionState*>. Transition logic must be deterministic and must only mutate the supplied state. Providers can replay transitions more than once, so don't perform I/O or other side effects from transition methods.
+
+> [!CAUTION]
+> Don't throw from <xref:Orleans.EventSourcing.JournaledGrain`2.TransitionState*> to reject an event. When transition code invoked by the Event Sourcing runtime throws, the built-in providers catch and log the exception; it doesn't cancel the submission. If storage accepts the update, <xref:Orleans.EventSourcing.JournaledGrain`2.ConfirmEvents*> can complete, <xref:Orleans.EventSourcing.JournaledGrain`2.RaiseConditionalEvent*> can return `true`, and <xref:Orleans.EventSourcing.JournaledGrain`2.Version> can advance even though the transition didn't complete. Orleans doesn't roll back mutations made before the exception, so in-memory state—and, with state storage, the persisted snapshot—can contain a partial transition. Validate commands before raising events and keep transition methods nonthrowing.
 
 ## Raise and confirm events
 

--- a/docs/site/src/content/docs/grains/grain-persistence/relational-storage.md
+++ b/docs/site/src/content/docs/grains/grain-persistence/relational-storage.md
@@ -1,7 +1,7 @@
 ---
 title: ADO.NET grain persistence
 description: Configure relational databases, including SQLite, for Orleans grain persistence.
-ms.date: 08/02/2026
+ms.date: 08/08/2026
 ms.topic: how-to
 ---
 
@@ -68,5 +68,13 @@ Provider queries must preserve the parameter names, result names, and types expe
 ## Customize queries
 
 The `OrleansQuery` table contains vendor-specific statements used by the provider. Administrators can tune those statements while preserving the Orleans query contract. Keep customized scripts under source control, apply them through the normal database deployment process—for example, using a [data-tier application (DACPAC)](https://learn.microsoft.com/sql/tools/sql-database-projects/concepts/data-tier-applications/overview)—and test reads, writes, clears, first-write races, and ETag conflicts after every change.
+
+### Operational query shape
+
+The provider supplies the common identity parameters `GrainIdHash`, `GrainIdN0`, `GrainIdN1`, `GrainTypeHash`, `GrainTypeString`, `GrainIdExtensionString`, and `ServiceId`. `WriteToStorageKey` also receives `GrainStateVersion` and `PayloadBinary`; `ClearStorageKey` and the optional `DeleteStorageKey` receive `GrainStateVersion`.
+
+`ReadFromStorageKey` must return columns named `PayloadBinary` and `Version`. `WriteToStorageKey` must return the resulting version as `NewGrainStateVersion`. Clear and delete queries return one version value in their first result column; its name is ignored. A successful operation returns an advanced version, while an unchanged or missing value signals an ETag conflict. Versions must be representable as a signed 32-bit integer.
+
+Each provider instance reads `OrleansQuery` during silo startup and doesn't poll it afterward. Changing the table therefore affects newly initialized providers only. A rolling silo restart is appropriate when old and new queries and schemas can coexist; coordinate an outage or staged migration when they can't.
 
 Database-specific customization can use features such as [partitioned tables and indexes](https://learn.microsoft.com/sql/relational-databases/partitions/partitioned-tables-and-indexes), [memory-optimized tables](https://learn.microsoft.com/sql/relational-databases/in-memory-oltp/overview-and-usage-scenarios), [natively compiled modules](https://learn.microsoft.com/sql/relational-databases/in-memory-oltp/native-compilation-of-tables-and-stored-procedures), [PolyBase](https://learn.microsoft.com/sql/relational-databases/polybase/overview), or [linked servers](https://learn.microsoft.com/sql/relational-databases/linked-servers/linked-servers-database-engine) when those capabilities fit the deployment.


### PR DESCRIPTION
PR #10333 modernized the durability documentation but dropped two operational contracts which remain important in Orleans 10. This restores precise guidance for Event Sourcing transition failures and customized ADO.NET query shapes, startup behavior, versioning, and rollout safety. The wording reflects current behavior across the built-in Event Sourcing providers and supported ADO.NET persistence scripts.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10366)