### PR TITLE
docs: restore virtual actor design context

### DIFF
--- a/docs/site/src/content/docs/benefits.md
+++ b/docs/site/src/content/docs/benefits.md
@@ -17,7 +17,7 @@ Application code addresses grains by interface and key. Orleans maps that logica
 
 Because identity is independent of activation, Orleans can activate grains on demand and remove idle activations from memory. Applications can represent far more logical entities than fit in memory at once.
 
-The [Orleans virtual actor research](https://www.microsoft.com/research/project/orleans-virtual-actors/) compares this to virtual memory: application code can address a large logical space of grains while the runtime decides which activations are currently resident and where. The analogy applies to identity, indirection, and residency, not to state preservation.
+The [Orleans virtual actor research](https://www.microsoft.com/research/project/orleans-virtual-actors/) compares this to virtual memory: application code can address a large logical space of grains while the runtime decides which activations are currently resident and where.
 
 ## Isolated, turn-based execution
 

--- a/docs/site/src/content/docs/benefits.md
+++ b/docs/site/src/content/docs/benefits.md
@@ -1,7 +1,7 @@
 ---
 title: Why Orleans
 description: Understand the benefits and tradeoffs of the Orleans virtual actor model.
-ms.date: 08/02/2026
+ms.date: 08/08/2026
 ms.topic: overview
 ---
 
@@ -16,6 +16,8 @@ Its main benefit is not that distribution becomes invisible. Network calls can f
 Application code addresses grains by interface and key. Orleans maps that logical identity to an activation and routes calls to it. Callers don't maintain a server registry or recreate references when placement changes.
 
 Because identity is independent of activation, Orleans can activate grains on demand and remove idle activations from memory. Applications can represent far more logical entities than fit in memory at once.
+
+The [Orleans virtual actor research](https://www.microsoft.com/research/project/orleans-virtual-actors/) compares this to virtual memory: application code can address a large logical space of grains while the runtime decides which activations are currently resident and where. The analogy applies to identity, indirection, and residency, not to state preservation.
 
 ## Isolated, turn-based execution
 

--- a/docs/site/src/content/docs/resources/frequently-asked-questions.md
+++ b/docs/site/src/content/docs/resources/frequently-asked-questions.md
@@ -1,7 +1,7 @@
 ---
 title: Frequently asked questions
 description: Answers to common questions about Orleans.
-ms.date: 08/02/2026
+ms.date: 08/08/2026
 ms.topic: faq
 ---
 
@@ -55,7 +55,9 @@ No. An ordinary stateful grain normally has one activation in the cluster. Volat
 
 ### How do I avoid hot grains?
 
-Partition work across keys, use hierarchical aggregation, batch calls, or use stateless workers for suitable stateless operations. Changing placement can move a hot activation but doesn't increase the throughput of that single activation.
+An ordinary grain activation processes one turn at a time by default, so a single key can become a bottleneck even when the rest of the cluster has capacity. Partition work across keys, use staged or hierarchical aggregation, batch calls, or use stateless workers for suitable stateless operations. Changing placement can move a hot activation but doesn't increase the throughput of that activation.
+
+For example, if many grains regularly report counters or statistics, hash each reporter's stable key across a controlled set of intermediate aggregator grains. Each intermediate grain combines updates and periodically sends partial results to a final aggregator. This distributes the reporting load and reduces the number of turns at the central grain; add another level if one stage still receives too much fan-in. Choose the shard count and reporting cadence from load tests, and design persistence, idempotency, or reconciliation when losing or repeating an update would matter.
 
 ### Can I choose where a grain activates?
 

--- a/docs/site/src/content/docs/resources/frequently-asked-questions.md
+++ b/docs/site/src/content/docs/resources/frequently-asked-questions.md
@@ -55,7 +55,7 @@ No. An ordinary stateful grain normally has one activation in the cluster. Volat
 
 ### How do I avoid hot grains?
 
-An ordinary grain activation processes one turn at a time by default, so a single key can become a bottleneck even when the rest of the cluster has capacity. Partition work across keys, use staged or hierarchical aggregation, batch calls, or use stateless workers for suitable stateless operations. Changing placement can move a hot activation but doesn't increase the throughput of that activation.
+An ordinary grain activation processes one turn at a time by default, so a single key can become a bottleneck even when the rest of the cluster has capacity. Partition work across keys, use staged or hierarchical aggregation, batch calls, or use stateless workers for suitable stateless operations. Moving an activation to a less-loaded host or closer to the grains it calls can improve throughput by reducing contention, RPC overhead, and latency, but placement alone doesn't partition a hot key or add concurrency to an ordinary grain activation.
 
 For example, if many grains regularly report counters or statistics, hash each reporter's stable key across a controlled set of intermediate aggregator grains. Each intermediate grain combines updates and periodically sends partial results to a final aggregator. This distributes the reporting load and reduces the number of turns at the central grain; add another level if one stage still receives too much fan-in. Choose the shard count and reporting cadence from load tests, and design persistence, idempotency, or reconciliation when losing or repeating an update would matter.
 

--- a/docs/site/src/content/docs/resources/orleans-architecture-principles-and-approach.md
+++ b/docs/site/src/content/docs/resources/orleans-architecture-principles-and-approach.md
@@ -1,7 +1,7 @@
 ---
 title: Orleans architecture design principles
 description: Understand the design principles behind Orleans.
-ms.date: 08/02/2026
+ms.date: 08/08/2026
 ms.topic: conceptual
 ---
 
@@ -29,7 +29,9 @@ Orleans provides scalable building blocks, not automatic scalability for every m
 
 ## Recovery-oriented operation
 
-Processes and networks fail. Orleans detects membership changes and can reactivate grains on healthy silos after failures. In-flight calls can still fail, and volatile state is lost with its process.
+Detect and repair problems; don't assume they can be prevented completely. At cloud scale, bad things happen often, and seemingly impossible things happen, only less often. Prevention and fault-tolerance mechanisms remain valuable, but they cannot cover every failure in hardware, software, dependencies, or operations. Orleans therefore complements them with an approach often called *recovery-oriented computing*: expect failures to escape prevention, detect them, and restore service.
+
+In practice, Orleans detects membership changes and can reactivate grains on healthy silos after failures. In-flight calls can still fail, and volatile state is lost with its process.
 
 Applications therefore need explicit durability, idempotency, bounded retries, observability, and operational procedures. The runtime handles common mechanics but doesn't invent application-level recovery semantics.
 


### PR DESCRIPTION
PR #10331 condensed three still-current explanations into brief labels. This restores concise context for staged aggregation around hot grains, recovery-oriented operation, and the virtual-memory analogy behind transparent activation.

The restored wording uses current turn-based scheduling terminology, treats recovery as a complement to prevention and fault tolerance, and scopes the virtual-memory analogy so it does not imply automatic state persistence.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10368)