### PR TITLE
docs: restore grain call filter examples

### DIFF
--- a/docs/site/src/content/docs/grains/interceptors.md
+++ b/docs/site/src/content/docs/grains/interceptors.md
@@ -1,7 +1,7 @@
 ---
 title: Grain call filters
 description: Intercept incoming and outgoing Orleans grain calls.
-ms.date: 08/02/2026
+ms.date: 08/08/2026
 ms.topic: concept-article
 ---
 
@@ -24,7 +24,27 @@ Register it for the silo:
 
 :::code language="csharp" source="snippets/interceptors/Configuration.cs" id="register_incoming_filter":::
 
-A grain class can also implement `IIncomingGrainCallFilter` to filter calls to that grain only. Silo-wide incoming filters run in registration order, followed by the grain-level filter, and then the target method.
+### Per-grain filters
+
+A grain class can implement <xref:Orleans.IIncomingGrainCallFilter> to filter calls to that grain without affecting other grain classes:
+
+:::code language="csharp" source="snippets/interceptors/GrainFilters.cs" id="per_grain_filter":::
+
+The filter changes the result of `GetFavoriteNumber` from `7` to `38`. A grain-level filter doesn't need builder registration because Orleans discovers it on the grain instance. It also wraps grain extension calls dispatched through that activation, so select calls using `InterfaceMethod` or `ImplementationMethod` when the behavior isn't intended for extensions.
+
+### Authorization with method attributes
+
+A per-grain filter can enforce an application authorization policy declared by an attribute. Keep the identity and policy decision in a service supplied by trusted application infrastructure:
+
+:::code language="csharp" source="snippets/interceptors/GrainFilters.cs" id="access_control_contract":::
+
+The grain injects that service and checks the attribute before continuing the call:
+
+:::code language="csharp" source="snippets/interceptors/GrainFilters.cs" id="access_control_grain":::
+
+The attribute is on the grain implementation method, so the filter reads it from `ImplementationMethod`. Put attributes on the grain interface and inspect `InterfaceMethod` instead if the policy is part of the public contract.
+
+The authorization service must base its decision on an identity or credential established and validated by trusted infrastructure. <xref:Orleans.Runtime.RequestContext> is caller-provided data: a client can set an `"isAdmin"` flag or claimed user ID, so such values aren't an authentication or authorization boundary. If trusted ingress code propagates identity through request context, protect its integrity and have the authorization service validate it. `SourceId` identifies an Orleans caller, not an authenticated end user.
 
 ## Outgoing filters
 
@@ -56,6 +76,22 @@ The compiled delegate example demonstrates request context and result modificati
 
 Changing arguments or results can violate interface expectations. Preserve declared types and apply transformations only to methods whose contract explicitly permits them.
 
+## Call grains from a filter
+
+Class-based filters are created by the dependency injection container, so they can receive <xref:Orleans.IGrainFactory> and call a grain:
+
+:::code language="csharp" source="snippets/interceptors/GrainFactoryInjection.cs" id="grain_factory_injection":::
+
+Register the filter on the silo so Orleans can construct it and supply its dependencies:
+
+:::code language="csharp" source="snippets/interceptors/Configuration.cs" id="register_grain_factory_filter":::
+
+A grain call made by a filter follows the normal outgoing and incoming pipelines. A silo-wide incoming filter must exclude the grain it calls, as the sample does, or the nested call reenters the same filter indefinitely. Don't call the request's current target from its incoming filter.
+
+Avoid call cycles. A non-reentrant grain remains busy while its filter awaits the nested call, so a downstream grain which calls back into that activation can deadlock. Prefer an acyclic design. If a deliberate callback is unavoidable, use <xref:Orleans.Runtime.RequestContext.AllowCallChainReentrancy> only for the narrow call chain and account for interleaving; see [Call-chain reentrancy](request-scheduling.md#call-chain-reentrancy).
+
+The sample awaits the audit grain before continuing, so audit failure prevents the original call. Use a synchronous grain call only when that coupling is intentional; prefer logging, tracing, or a decoupled telemetry path for observational work.
+
 ## Exceptions
 
 Code before `context.Invoke()` runs on the way into the call. Code after it runs on successful return. Use `try`, `catch`, and `finally` around the awaited call to observe or transform failures.
@@ -65,5 +101,15 @@ If a filter catches an exception and doesn't rethrow, the exception is handled. 
 ## Scope and ordering
 
 Incoming filters also observe grain extension calls. Outgoing filters can observe Orleans system calls in addition to application calls. Filter by interface or method when behavior isn't intended globally.
+
+Register silo-wide filters with <xref:Orleans.Hosting.GrainCallFilterSiloBuilderExtensions.AddIncomingGrainCallFilter*>. Class filters are singleton services created by the silo service provider, and their constructor dependencies are resolved from that provider.
+
+The incoming pipeline runs in this order:
+
+1. Silo-wide filters, in registration order.
+1. The grain-level filter, if the grain instance implements <xref:Orleans.IIncomingGrainCallFilter>.
+1. The target grain or grain extension method.
+
+Code before `context.Invoke()` follows that order. Code after the awaited call unwinds in reverse order.
 
 Keep filters asynchronous, fast, and free of blocking calls. A filter adds latency to every call in its scope and can become a cluster-wide bottleneck.

--- a/docs/site/src/content/docs/grains/snippets/interceptors/Configuration.cs
+++ b/docs/site/src/content/docs/grains/snippets/interceptors/Configuration.cs
@@ -46,6 +46,13 @@ public static class IncomingFilterConfiguration
             .AddSingleton<IIncomingGrainCallFilter, LoggingCallFilter>();
         // </register_incoming_filter_di>
     }
+
+    public static void RegisterGrainFactoryFilter(ISiloBuilder siloHostBuilder)
+    {
+        // <register_grain_factory_filter>
+        siloHostBuilder.AddIncomingGrainCallFilter<AuditCallFilter>();
+        // </register_grain_factory_filter>
+    }
 }
 
 public static class OutgoingFilterConfiguration

--- a/docs/site/src/content/docs/grains/snippets/interceptors/GrainFactoryInjection.cs
+++ b/docs/site/src/content/docs/grains/snippets/interceptors/GrainFactoryInjection.cs
@@ -1,31 +1,19 @@
-using Orleans.Runtime;
-
 namespace Orleans.Docs.Snippets.Interceptors;
 
 // <grain_factory_injection>
-public class CustomCallFilter : Orleans.IIncomingGrainCallFilter
+public sealed class AuditCallFilter(IGrainFactory grainFactory)
+    : IIncomingGrainCallFilter
 {
-    private readonly IGrainFactory _grainFactory;
-
-    public CustomCallFilter(IGrainFactory grainFactory)
+    public async Task Invoke(IIncomingGrainCallContext context)
     {
-        _grainFactory = grainFactory;
-    }
-
-    public async Task Invoke(Orleans.IIncomingGrainCallContext context)
-    {
-        // Hook calls to any grain other than ICustomFilterGrain implementations.
-        // This avoids potential infinite recursion when calling OnReceivedCall() below.
-        if (context.Grain is not ICustomFilterGrain)
+        // Exclude the audit grain so its call doesn't reenter this filter recursively.
+        if (context.Grain is not ICallAuditGrain)
         {
-            var filterGrain = _grainFactory.GetGrain<ICustomFilterGrain>(
-                ((IAddressable)context.Grain).GetPrimaryKeyLong());
-
-            // Perform some grain call here.
-            await filterGrain.OnReceivedCall();
+            var auditGrain = grainFactory.GetGrain<ICallAuditGrain>(
+                context.TargetId.ToString());
+            await auditGrain.OnReceivedCall(context.MethodName);
         }
 
-        // Continue invoking the call on the target grain.
         await context.Invoke();
     }
 }

--- a/docs/site/src/content/docs/grains/snippets/interceptors/GrainFilters.cs
+++ b/docs/site/src/content/docs/grains/snippets/interceptors/GrainFilters.cs
@@ -1,20 +1,19 @@
 using System.Reflection;
-using Orleans.Runtime;
 
 namespace Orleans.Docs.Snippets.Interceptors;
 
 // <per_grain_filter>
-public class MyFilteredGrain
-    : Grain, IMyFilteredGrain, Orleans.IIncomingGrainCallFilter
+public sealed class MyFilteredGrain
+    : Grain, IMyFilteredGrain, IIncomingGrainCallFilter
 {
-    public async Task Invoke(Orleans.IIncomingGrainCallContext context)
+    public async Task Invoke(IIncomingGrainCallContext context)
     {
         await context.Invoke();
 
         // Change the result of the call from 7 to 38.
         if (string.Equals(
             context.InterfaceMethod.Name,
-            nameof(this.GetFavoriteNumber)))
+            nameof(IMyFilteredGrain.GetFavoriteNumber)))
         {
             context.Result = 38;
         }
@@ -24,30 +23,47 @@ public class MyFilteredGrain
 }
 // </per_grain_filter>
 
-// <access_control_attribute>
+// <access_control_contract>
 [AttributeUsage(AttributeTargets.Method)]
-public class AdminOnlyAttribute : Attribute { }
-// </access_control_attribute>
+public sealed class AuthorizeGrainCallAttribute : Attribute
+{
+    public AuthorizeGrainCallAttribute(string policy) => Policy = policy;
+
+    public string Policy { get; }
+}
+
+public interface IGrainCallAuthorizationService
+{
+    // Implement this service using an identity validated by trusted infrastructure.
+    ValueTask<bool> AuthorizeAsync(
+        IIncomingGrainCallContext context,
+        string policy);
+}
+// </access_control_contract>
 
 // <access_control_grain>
-public class MyAccessControlledGrain
-    : Grain, IMyFilteredGrain, Orleans.IIncomingGrainCallFilter
+public sealed class MyAccessControlledGrain(
+    IGrainCallAuthorizationService authorizationService)
+    : Grain, IMyFilteredGrain, IIncomingGrainCallFilter
 {
-    public Task Invoke(Orleans.IIncomingGrainCallContext context)
+    public async Task Invoke(IIncomingGrainCallContext context)
     {
-        // Check access conditions.
-        var isAdminMethod =
-            context.ImplementationMethod.GetCustomAttribute<AdminOnlyAttribute>();
-        if (isAdminMethod is not null && RequestContext.Get("isAdmin") is not true)
+        var authorization = context.ImplementationMethod
+            .GetCustomAttribute<AuthorizeGrainCallAttribute>();
+
+        if (authorization is not null
+            && !await authorizationService.AuthorizeAsync(
+                context,
+                authorization.Policy))
         {
-            throw new AccessDeniedException(
-                $"Only admins can access {context.ImplementationMethod.Name}!");
+            throw new UnauthorizedAccessException(
+                "The caller isn't authorized to invoke this operation.");
         }
 
-        return context.Invoke();
+        await context.Invoke();
     }
 
-    [AdminOnly]
+    [AuthorizeGrainCall("Admin")]
     public Task<int> GetFavoriteNumber() => Task.FromResult(7);
 }
 // </access_control_grain>

--- a/docs/site/src/content/docs/grains/snippets/interceptors/SharedTypes.cs
+++ b/docs/site/src/content/docs/grains/snippets/interceptors/SharedTypes.cs
@@ -13,15 +13,9 @@ public interface IMyFilteredGrain : IGrainWithIntegerKey
     Task<int> GetFavoriteNumber();
 }
 
-public interface ICustomFilterGrain : IGrainWithIntegerKey
+public interface ICallAuditGrain : IGrainWithStringKey
 {
-    Task OnReceivedCall();
-}
-
-// Custom exception for access control example
-public class AccessDeniedException : Exception
-{
-    public AccessDeniedException(string message) : base(message) { }
+    Task OnReceivedCall(string methodName);
 }
 
 // Logger factory placeholder (matches legacy Orleans Logger pattern used in docs)


### PR DESCRIPTION
Restores useful call-filter guidance removed during the grain documentation modernization: per-grain filters, attribute-driven authorization, and calling grains from a dependency-injected filter. The examples now use a trusted application authorization service instead of caller-controlled request-context flags and document filter scope, pipeline ordering, recursion, call-cycle, and failure-coupling behavior.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10370)