### PR TITLE
fix(dynamodb): harden transactional storage conflicts

### DIFF
--- a/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorage.cs
+++ b/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorage.cs
@@ -410,11 +410,9 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
         }
         catch (Exception exc)
         {
-            var message = $"Unable to convert from storage format GrainStateEntity.Data={entity.State}";
-            if (dataValue is not null)
-            {
-                message += $"Data Value={dataValue} Type={dataValue.GetType()}";
-            }
+            var message = dataValue is not null
+                ? $"Unable to convert from storage format GrainStateEntity.Data={entity.State}Data Value={dataValue} Type={dataValue.GetType()}"
+                : $"Unable to convert from storage format GrainStateEntity.Data={entity.State}";
 
             LogError(logger, message);
             throw new AggregateException(message, exc);

--- a/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorage.cs
+++ b/src/AWS/Orleans.Transactions.DynamoDB/TransactionalState/DynamoDBTransactionalStateStorage.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2.Model;
 using Microsoft.Extensions.Logging;
@@ -42,6 +41,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
     // Caches loaded data for this storage instance
     private KeyEntity key = null!;
     private List<KeyValuePair<long, StateEntity>> states = null!;
+    private bool requiresReload;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DynamoDBTransactionalStateStorage{TState}"/> class.
@@ -69,6 +69,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
             if (string.IsNullOrEmpty(key.ETag.ToString()))
             {
                 LogDebugLoadedV0Fresh(this.partitionKey);
+                this.requiresReload = false;
 
                 // first time load
                 return new TransactionalStorageLoadResponse<TState>();
@@ -128,6 +129,7 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
             var metadata = this.key.Metadata is { Length: > 0 }
                 ? this.ConvertFromStorageFormat<TransactionalStateMetaData>(this.key.Metadata)
                 : new TransactionalStateMetaData();
+            this.requiresReload = false;
             return new TransactionalStorageLoadResponse<TState>(this.key.ETag.ToString(), committedState, this.key.CommittedSequenceId, metadata, PrepareRecordsToRecover);
         }
         catch (Exception ex)
@@ -140,6 +142,11 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
     /// <inheritdoc />
     public async Task<string> Store(string? expectedETag, TransactionalStateMetaData metadata, List<PendingTransactionState<TState>>? statesToPrepare, long? commitUpTo, long? abortAfter)
     {
+        if (this.requiresReload)
+        {
+            throw new InvalidOperationException("Load must be called after a failed Store before this storage instance can be reused.");
+        }
+
         var batchOperation = new BatchOperation(this.storage, this.tableName, this.key, this.logger);
         var keyWasNew = !this.key.ETag.HasValue;
 
@@ -158,6 +165,10 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
                 ? commitUpTo.Value
                 : key.CommittedSequenceId;
             this.ValidateKeyItemSize(serializedMetadata, timestamp, committedSequenceId);
+
+            // Store mutates the cached entities while constructing the transaction. If any operation
+            // fails, Load must restore the cache before this instance can be used again.
+            this.requiresReload = true;
 
             // assemble all storage operations into a single batch
             // these operations must commit in sequence, but not necessarily atomically
@@ -294,8 +305,13 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
 
             await batchOperation.Flush().ConfigureAwait(false);
 
+            this.requiresReload = false;
             LogDebugStoredETag(this.partitionKey, this.key.CommittedSequenceId, this.key.ETag);
             return key.ETag!.Value.ToString();
+        }
+        catch (InconsistentStateException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -394,15 +410,12 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
         }
         catch (Exception exc)
         {
-            var sb = new StringBuilder();
-            sb.AppendFormat("Unable to convert from storage format GrainStateEntity.Data={0}", entity.State);
-
+            var message = $"Unable to convert from storage format GrainStateEntity.Data={entity.State}";
             if (dataValue is not null)
             {
-                sb.Append($"Data Value={dataValue} Type={dataValue.GetType()}");
+                message += $"Data Value={dataValue} Type={dataValue.GetType()}";
             }
 
-            var message = sb.ToString();
             LogError(logger, message);
             throw new AggregateException(message, exc);
         }
@@ -575,8 +588,10 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
             catch (TransactionCanceledException exception) when (IsStorageConflict(exception))
             {
                 LogFailures();
+                var conflictMessage = GetConflictMessage(exception, keyPut);
+                LogWarningTransactionalStateConflict(logger, conflictMessage);
                 throw new InconsistentStateException(
-                    "DynamoDB transactional state storage conflict.",
+                    conflictMessage,
                     storedEtag: "Unknown",
                     currentEtag: currentETag?.ToString() ?? "null",
                     exception);
@@ -602,6 +617,55 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
             }
 
             LogTraceBatchOpFailed(logger, key.PartitionKey, key.RowKey, this.operations.Count);
+        }
+
+        private string GetConflictMessage(TransactionCanceledException exception, Put keyPut)
+        {
+            var operations = new string[this.operations.Count + 1];
+
+            for (var index = 0; index < this.operations.Count; index++)
+            {
+                operations[index] = FormatOperationDiagnostic(
+                    index,
+                    this.operations[index].Item,
+                    this.operations[index].RowKey,
+                    "Data",
+                    exception);
+            }
+
+            operations[^1] = FormatOperationDiagnostic(
+                this.operations.Count,
+                new TransactWriteItem { Put = keyPut },
+                key.RowKey,
+                "KeySynchronizer",
+                exception);
+            return $"DynamoDB transactional state storage conflict. PartitionKey={key.PartitionKey}. {string.Join(' ', operations)}";
+        }
+
+        private static string FormatOperationDiagnostic(
+            int index,
+            TransactWriteItem operation,
+            string rowKey,
+            string role,
+            TransactionCanceledException exception)
+        {
+            var (operationType, conditionExpression, expressionAttributeValues) = operation.Put is { } put
+                ? ("Put", put.ConditionExpression, put.ExpressionAttributeValues)
+                : ("Delete", operation.Delete?.ConditionExpression, operation.Delete?.ExpressionAttributeValues);
+            var reason = exception.CancellationReasons is { Count: > 0 } reasons && index < reasons.Count
+                ? reasons[index]
+                : null;
+            var condition = string.IsNullOrEmpty(conditionExpression)
+                ? string.Empty
+                : $" Condition={conditionExpression}";
+            var expectedETag = expressionAttributeValues?.TryGetValue(
+                DynamoDBTransactionalStateConstants.CURRENT_ETAG_ALIAS,
+                out var value) is true
+                    ? $" ExpectedETag={value.N}"
+                    : string.Empty;
+            return $"TransactWriteItems[{index}] Operation={operationType} Role={role} RowKey={rowKey}"
+                + $"{condition}{expectedETag} CancellationReasonCode={reason?.Code ?? "Unavailable"}"
+                + $" CancellationReasonMessage={reason?.Message ?? "Unavailable"}.";
         }
 
         private static bool IsStorageConflict(TransactionCanceledException exception)
@@ -702,6 +766,12 @@ public partial class DynamoDBTransactionalStateStorage<TState> : ITransactionalS
         Message = "{PartitionKey}.{RowKey} batch-op failed {BatchCount}"
     )]
     private static partial void LogTraceBatchOpFailed(ILogger logger, string partitionKey, string rowKey, int batchCount);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "{ConflictMessage}"
+    )]
+    private static partial void LogWarningTransactionalStateConflict(ILogger logger, string conflictMessage);
 
     [LoggerMessage(
         Level = LogLevel.Error,

--- a/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateStorageTests.cs
@@ -1,5 +1,7 @@
+using Amazon;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
+using Amazon.Runtime;
 using AWSUtils.Tests.StorageTests;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -20,9 +22,13 @@ namespace Orleans.Transactions.DynamoDB.Tests
     {
         public int State { get; set; }
 
+        public string? SensitiveValue { get; set; }
+
         public bool Equals(TestState? other)
         {
-            return other is not null && this.State.Equals(other.State);
+            return other is not null
+                && this.State.Equals(other.State)
+                && this.SensitiveValue == other.SensitiveValue;
         }
     }
 
@@ -38,24 +44,437 @@ namespace Orleans.Transactions.DynamoDB.Tests
         {
         }
 
+        [Fact]
+        public override Task StoreWithoutChanges() => base.StoreWithoutChanges();
+
+        [Fact]
+        public override async Task WrongEtags()
+        {
+            var storage = await this.stateStorageFactory();
+            var empty = await storage.Load();
+
+            await Assert.ThrowsAsync<ArgumentException>(() => storage.Store(
+                "wrong-etag",
+                empty.Metadata,
+                [],
+                commitUpTo: null,
+                abortAfter: null));
+
+            var etag = await storage.Store(empty.ETag, empty.Metadata, [], commitUpTo: null, abortAfter: null);
+
+            await Assert.ThrowsAsync<ArgumentException>(() => storage.Store(
+                null,
+                empty.Metadata,
+                [],
+                commitUpTo: null,
+                abortAfter: null));
+
+            var durable = await storage.Load();
+            Assert.Equal(etag, durable.ETag);
+            Assert.Equal(0, durable.CommittedSequenceId);
+            Assert.Empty(durable.PendingStates);
+        }
+
         private static async Task<ITransactionalStateStorage<TestState>> StateStorageFactory(TestFixture fixture)
         {
             var storage = await InitTableAsync(NullLogger.Instance);
+            var stateStorage = new DynamoDBTransactionalStateStorage<TestState>(
+                storage,
+                CreateOptions(),
+                $"{partition}{DateTime.UtcNow.Ticks}",
+                NullLoggerFactory.Instance.CreateLogger<DynamoDBTransactionalStateStorage<TestState>>());
+            return stateStorage;
+        }
+
+        [Fact]
+        public async Task Store_NewRowConflict_ReportsOperationsAndRequiresLoadBeforeReuse()
+        {
+            var partitionKey = $"{partition}-{Guid.NewGuid():N}";
+            var logger = new RecordingLogger();
+            var (winner, loser) = await CreateStoragePairAsync(partitionKey, logger);
+            var winnerSnapshot = await winner.Load();
+            var staleSnapshot = await loser.Load();
+            const string loserPayload = "new-row-loser-payload-must-not-appear";
+
+            var winnerETag = await winner.Store(
+                winnerSnapshot.ETag,
+                winnerSnapshot.Metadata,
+                [CreatePendingState(1, 101)],
+                commitUpTo: 1,
+                abortAfter: null);
+
+            var conflict = await Assert.ThrowsAsync<InconsistentStateException>(() => loser.Store(
+                staleSnapshot.ETag,
+                staleSnapshot.Metadata,
+                [CreatePendingState(1, 999, loserPayload)],
+                commitUpTo: 1,
+                abortAfter: null));
+
+            AssertConflictDiagnostics(conflict, partitionKey, expectedDataETag: null, expectedKeyETag: null, loserPayload);
+            AssertConflictWarning(logger, conflict, loserPayload);
+            var reuseError = await Assert.ThrowsAsync<InvalidOperationException>(() => loser.Store(
+                staleSnapshot.ETag,
+                staleSnapshot.Metadata,
+                [CreatePendingState(1, 998)],
+                commitUpTo: 1,
+                abortAfter: null));
+            Assert.Contains("Load must be called after a failed Store", reuseError.Message);
+
+            var durableWinner = await winner.Load();
+            Assert.Equal(winnerETag, durableWinner.ETag);
+            Assert.Equal(1, durableWinner.CommittedSequenceId);
+            Assert.Equal(101, durableWinner.CommittedState.State);
+
+            var restoredLoser = await loser.Load();
+            Assert.Equal(winnerETag, restoredLoser.ETag);
+            Assert.Equal(101, restoredLoser.CommittedState.State);
+
+            var recoveredETag = await loser.Store(
+                restoredLoser.ETag,
+                restoredLoser.Metadata,
+                [CreatePendingState(1, 202)],
+                commitUpTo: 1,
+                abortAfter: null);
+            var recovered = await loser.Load();
+            Assert.Equal(recoveredETag, recovered.ETag);
+            Assert.Equal(202, recovered.CommittedState.State);
+        }
+
+        [Fact]
+        public async Task Store_ExistingRowETagConflict_MapsCancellationReasonsInOperationOrder()
+        {
+            var partitionKey = $"{partition}-{Guid.NewGuid():N}";
+            var logger = new RecordingLogger();
+            var (winner, loser) = await CreateStoragePairAsync(partitionKey, logger);
+            var empty = await winner.Load();
+            await winner.Store(
+                empty.ETag,
+                empty.Metadata,
+                [CreatePendingState(1, 10)],
+                commitUpTo: 1,
+                abortAfter: null);
+
+            var winnerSnapshot = await winner.Load();
+            var staleSnapshot = await loser.Load();
+            const string loserPayload = "existing-row-loser-payload-must-not-appear";
+
+            var winnerETag = await winner.Store(
+                winnerSnapshot.ETag,
+                winnerSnapshot.Metadata,
+                [CreatePendingState(1, 20)],
+                commitUpTo: 1,
+                abortAfter: null);
+
+            var conflict = await Assert.ThrowsAsync<InconsistentStateException>(() => loser.Store(
+                staleSnapshot.ETag,
+                staleSnapshot.Metadata,
+                [CreatePendingState(1, 30, loserPayload), CreatePendingState(2, 31)],
+                commitUpTo: 1,
+                abortAfter: null));
+
+            AssertConflictDiagnostics(
+                conflict,
+                partitionKey,
+                expectedDataETag: "0",
+                expectedKeyETag: staleSnapshot.ETag,
+                loserPayload,
+                hasSecondDataOperation: true);
+            AssertConflictWarning(logger, conflict, loserPayload);
+
+            var durableWinner = await winner.Load();
+            Assert.Equal(winnerETag, durableWinner.ETag);
+            Assert.Equal(20, durableWinner.CommittedState.State);
+
+            var restoredLoser = await loser.Load();
+            Assert.Equal(winnerETag, restoredLoser.ETag);
+            Assert.Equal(20, restoredLoser.CommittedState.State);
+
+            var recoveredETag = await loser.Store(
+                restoredLoser.ETag,
+                restoredLoser.Metadata,
+                [CreatePendingState(1, 40)],
+                commitUpTo: 1,
+                abortAfter: null);
+            var recovered = await loser.Load();
+            Assert.Equal(recoveredETag, recovered.ETag);
+            Assert.Equal(40, recovered.CommittedState.State);
+        }
+
+        [Fact]
+        public async Task Store_StaleDeleteConflict_ReportsDeleteOperation()
+        {
+            var partitionKey = $"{partition}-{Guid.NewGuid():N}";
+            var logger = new RecordingLogger();
+            var (winner, loser) = await CreateStoragePairAsync(partitionKey, logger);
+            var empty = await winner.Load();
+            var initialETag = await winner.Store(
+                empty.ETag,
+                empty.Metadata,
+                [CreatePendingState(1, 10), CreatePendingState(2, 20)],
+                commitUpTo: 1,
+                abortAfter: null);
+
+            var staleSnapshot = await loser.Load();
+            var winnerETag = await winner.Store(
+                initialETag,
+                empty.Metadata,
+                [CreatePendingState(2, 21)],
+                commitUpTo: 2,
+                abortAfter: null);
+
+            var conflict = await Assert.ThrowsAsync<InconsistentStateException>(() => loser.Store(
+                staleSnapshot.ETag,
+                staleSnapshot.Metadata,
+                statesToPrepare: null,
+                commitUpTo: null,
+                abortAfter: 1));
+
+            AssertConflictDiagnostics(
+                conflict,
+                partitionKey,
+                expectedDataETag: "0",
+                expectedKeyETag: staleSnapshot.ETag,
+                payload: string.Empty,
+                dataOperation: "Delete",
+                dataRowKey: "state_0000000000000002");
+            AssertConflictWarning(logger, conflict, string.Empty);
+
+            var durableWinner = await winner.Load();
+            Assert.Equal(winnerETag, durableWinner.ETag);
+            Assert.Equal(2, durableWinner.CommittedSequenceId);
+            Assert.Equal(21, durableWinner.CommittedState.State);
+        }
+
+        [Fact]
+        public async Task Store_DuplicateSequenceInSingleBatch_IsRejectedAndRequiresLoad()
+        {
+            var partitionKey = $"{partition}-{Guid.NewGuid():N}";
+            var logger = new RecordingLogger();
+            var (storage, _) = await CreateStoragePairAsync(partitionKey, logger);
+            var empty = await storage.Load();
+
+            var exception = await Assert.ThrowsAsync<AmazonDynamoDBException>(() => storage.Store(
+                empty.ETag,
+                empty.Metadata,
+                [CreatePendingState(1, 10), CreatePendingState(1, 20)],
+                commitUpTo: 1,
+                abortAfter: null));
+
+            Assert.Equal("ValidationException", exception.ErrorCode);
+            Assert.Contains("multiple operations on one item", exception.Message, StringComparison.OrdinalIgnoreCase);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => storage.Store(
+                empty.ETag,
+                empty.Metadata,
+                [CreatePendingState(1, 30)],
+                commitUpTo: 1,
+                abortAfter: null));
+
+            var restored = await storage.Load();
+            var recoveredETag = await storage.Store(
+                restored.ETag,
+                restored.Metadata,
+                [CreatePendingState(1, 40)],
+                commitUpTo: 1,
+                abortAfter: null);
+            var recovered = await storage.Load();
+            Assert.Equal(recoveredETag, recovered.ETag);
+            Assert.Equal(40, recovered.CommittedState.State);
+        }
+
+        [Fact]
+        public async Task TransactWriteItems_ExplicitClientRequestToken_ReplaysIdenticalRequest()
+        {
+            _ = await InitTableAsync(NullLogger.Instance);
+            using var client = CreateDynamoDBClient();
+            var partitionKey = $"{partition}-{Guid.NewGuid():N}";
+            var request = new TransactWriteItemsRequest
+            {
+                ClientRequestToken = Guid.NewGuid().ToString("N"),
+                TransactItems =
+                [
+                    new TransactWriteItem
+                    {
+                        Put = new Put
+                        {
+                            TableName = tableName,
+                            Item = new Dictionary<string, AttributeValue>
+                            {
+                                [DynamoDBTransactionalStateConstants.PARTITION_KEY_PROPERTY_NAME] = new AttributeValue { S = partitionKey },
+                                [DynamoDBTransactionalStateConstants.ROW_KEY_PROPERTY_NAME] = new AttributeValue { S = "idempotency" },
+                                ["Value"] = new AttributeValue { N = "1" }
+                            },
+                            ConditionExpression =
+                                $"attribute_not_exists({DynamoDBTransactionalStateConstants.PARTITION_KEY_PROPERTY_NAME}) AND attribute_not_exists({DynamoDBTransactionalStateConstants.ROW_KEY_PROPERTY_NAME})"
+                        }
+                    }
+                ]
+            };
+
+            await client.TransactWriteItemsAsync(request);
+            await client.TransactWriteItemsAsync(request);
+
+            var response = await client.GetItemAsync(new GetItemRequest
+            {
+                TableName = tableName,
+                ConsistentRead = true,
+                Key = new Dictionary<string, AttributeValue>
+                {
+                    [DynamoDBTransactionalStateConstants.PARTITION_KEY_PROPERTY_NAME] = new AttributeValue { S = partitionKey },
+                    [DynamoDBTransactionalStateConstants.ROW_KEY_PROPERTY_NAME] = new AttributeValue { S = "idempotency" }
+                }
+            });
+            Assert.Equal("1", response.Item["Value"].N);
+        }
+
+        [Fact]
+        public void TransactionConflictCancellation_IsNotClassifiedAsStorageConflict()
+        {
+            var batchOperation = typeof(DynamoDBTransactionalStateStorage<TestState>).GetNestedType(
+                "BatchOperation",
+                System.Reflection.BindingFlags.NonPublic);
+            if (batchOperation?.ContainsGenericParameters is true)
+            {
+                batchOperation = batchOperation.MakeGenericType(typeof(TestState));
+            }
+
+            var isStorageConflict = batchOperation?.GetMethod(
+                "IsStorageConflict",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            Assert.NotNull(isStorageConflict);
+            var exception = new TransactionCanceledException("Transaction conflict")
+            {
+                CancellationReasons =
+                [
+                    new CancellationReason { Code = "TransactionConflict", Message = "Transaction is ongoing for the item" },
+                    new CancellationReason { Code = "TransactionConflict", Message = "Transaction is ongoing for the item" }
+                ]
+            };
+
+            Assert.False(Assert.IsType<bool>(isStorageConflict.Invoke(null, [exception])));
+        }
+
+        private static async Task<(
+            DynamoDBTransactionalStateStorage<TestState> Winner,
+            DynamoDBTransactionalStateStorage<TestState> Loser)> CreateStoragePairAsync(
+                string partitionKey,
+                ILogger<DynamoDBTransactionalStateStorage<TestState>> logger)
+        {
+            var storage = await InitTableAsync(NullLogger.Instance);
+            var options = CreateOptions();
+            return (
+                new DynamoDBTransactionalStateStorage<TestState>(storage, options, partitionKey, logger),
+                new DynamoDBTransactionalStateStorage<TestState>(storage, options, partitionKey, logger));
+        }
+
+        private static DynamoDBTransactionalStorageOptions CreateOptions()
+        {
             var orleansJsonSerializer = new OrleansJsonSerializer(
                 new OptionsWrapper<OrleansJsonSerializerOptions>(new OrleansJsonSerializerOptions()));
-
-            var options = new DynamoDBTransactionalStorageOptions
+            return new DynamoDBTransactionalStorageOptions
             {
                 TableName = tableName,
                 GrainStorageSerializer = new JsonGrainStorageSerializer(orleansJsonSerializer)
             };
+        }
 
-            var stateStorage = new DynamoDBTransactionalStateStorage<TestState>(
-                storage,
-                options,
-                $"{partition}{DateTime.UtcNow.Ticks}",
-                NullLoggerFactory.Instance.CreateLogger<DynamoDBTransactionalStateStorage<TestState>>());
-            return stateStorage;
+        private static PendingTransactionState<TestState> CreatePendingState(long sequenceId, int value, string? sensitiveValue = null)
+        {
+            return new PendingTransactionState<TestState>
+            {
+                SequenceId = sequenceId,
+                TransactionId = Guid.NewGuid().ToString(),
+                TimeStamp = DateTime.UtcNow,
+                TransactionManager = default!,
+                State = new TestState { State = value, SensitiveValue = sensitiveValue }
+            };
+        }
+
+        private static void AssertConflictDiagnostics(
+            InconsistentStateException conflict,
+            string partitionKey,
+            string? expectedDataETag,
+            string? expectedKeyETag,
+            string payload,
+            bool hasSecondDataOperation = false,
+            string dataOperation = "Put",
+            string dataRowKey = "state_0000000000000001")
+        {
+            var cancellation = Assert.IsType<TransactionCanceledException>(conflict.InnerException);
+            var reasons = Assert.IsAssignableFrom<IReadOnlyList<CancellationReason>>(cancellation.CancellationReasons);
+            Assert.Equal(hasSecondDataOperation ? 3 : 2, reasons.Count);
+            Assert.Equal("ConditionalCheckFailed", reasons[0].Code);
+            Assert.Equal("ConditionalCheckFailed", reasons[^1].Code);
+
+            var message = conflict.Message;
+            Assert.Contains($"PartitionKey={partitionKey}", message);
+            var dataStart = message.IndexOf(
+                $"TransactWriteItems[0] Operation={dataOperation} Role=Data RowKey={dataRowKey}",
+                StringComparison.Ordinal);
+            var keyIndex = hasSecondDataOperation ? 2 : 1;
+            var keyStart = message.IndexOf(
+                $"TransactWriteItems[{keyIndex}] Operation=Put Role=KeySynchronizer RowKey=key",
+                StringComparison.Ordinal);
+            Assert.True(dataStart >= 0, message);
+            Assert.True(keyStart > dataStart, message);
+
+            var secondDataStart = hasSecondDataOperation
+                ? message.IndexOf(
+                    "TransactWriteItems[1] Operation=Put Role=Data RowKey=state_0000000000000002",
+                    StringComparison.Ordinal)
+                : keyStart;
+            Assert.True(secondDataStart > dataStart, message);
+
+            var dataDiagnostic = message[dataStart..secondDataStart];
+            var keyDiagnostic = message[keyStart..];
+            Assert.Contains("CancellationReasonCode=ConditionalCheckFailed", dataDiagnostic);
+            Assert.Contains($"CancellationReasonMessage={reasons[0].Message ?? "Unavailable"}", dataDiagnostic);
+            Assert.Contains("CancellationReasonCode=ConditionalCheckFailed", keyDiagnostic);
+            Assert.Contains($"CancellationReasonMessage={reasons[^1].Message ?? "Unavailable"}", keyDiagnostic);
+
+            if (hasSecondDataOperation)
+            {
+                var secondDataDiagnostic = message[secondDataStart..keyStart];
+                Assert.Equal("None", reasons[1].Code);
+                Assert.Contains("Condition=attribute_not_exists(PartitionKey) AND attribute_not_exists(RowKey)", secondDataDiagnostic);
+                Assert.Contains("CancellationReasonCode=None", secondDataDiagnostic);
+                Assert.Contains($"CancellationReasonMessage={reasons[1].Message ?? "Unavailable"}", secondDataDiagnostic);
+            }
+
+            if (expectedDataETag is not null)
+            {
+                Assert.Contains("Condition=ETag = :currentETag", dataDiagnostic);
+                Assert.Contains($"ExpectedETag={expectedDataETag}", dataDiagnostic);
+            }
+            else
+            {
+                Assert.Contains("Condition=attribute_not_exists(PartitionKey) AND attribute_not_exists(RowKey)", dataDiagnostic);
+            }
+
+            if (expectedKeyETag is not null)
+            {
+                Assert.Contains("Condition=ETag = :currentETag", keyDiagnostic);
+                Assert.Contains($"ExpectedETag={expectedKeyETag}", keyDiagnostic);
+            }
+            else
+            {
+                Assert.Contains("Condition=attribute_not_exists(PartitionKey) AND attribute_not_exists(RowKey)", keyDiagnostic);
+            }
+
+            if (payload.Length > 0)
+            {
+                Assert.DoesNotContain(payload, conflict.ToString());
+            }
+        }
+
+        private static void AssertConflictWarning(RecordingLogger logger, InconsistentStateException conflict, string payload)
+        {
+            var warning = Assert.Single(logger.Entries, entry => entry.Level == LogLevel.Warning);
+            Assert.Equal(conflict.Message, warning.Message);
+            Assert.DoesNotContain(logger.Entries, entry => entry.Level >= LogLevel.Error);
+            if (payload.Length > 0)
+            {
+                Assert.DoesNotContain(payload, warning.Message);
+            }
         }
 
         private static async Task<DynamoDBStorage> InitTableAsync(ILogger logger)
@@ -100,6 +519,45 @@ namespace Orleans.Transactions.DynamoDB.Tests
             {
                 logger.LogError(exc, "Error creating CloudTableCreationClient");
                 throw;
+            }
+        }
+
+        private static AmazonDynamoDBClient CreateDynamoDBClient()
+        {
+            var service = AWSTestConstants.DynamoDbService;
+            if (service.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                || service.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                return new AmazonDynamoDBClient(
+                    new BasicAWSCredentials("dummy", "dummyKey"),
+                    new AmazonDynamoDBConfig { ServiceURL = service });
+            }
+
+            var config = new AmazonDynamoDBConfig { RegionEndpoint = RegionEndpoint.GetBySystemName(service) };
+            return string.IsNullOrEmpty(AWSTestConstants.DynamoDbAccessKey)
+                || string.IsNullOrEmpty(AWSTestConstants.DynamoDbSecretKey)
+                    ? new AmazonDynamoDBClient(config)
+                    : new AmazonDynamoDBClient(
+                        new BasicAWSCredentials(AWSTestConstants.DynamoDbAccessKey, AWSTestConstants.DynamoDbSecretKey),
+                        config);
+        }
+
+        private sealed class RecordingLogger : ILogger<DynamoDBTransactionalStateStorage<TestState>>
+        {
+            public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullLogger.Instance.BeginScope(state);
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                this.Entries.Add((logLevel, formatter(state, exception)));
             }
         }
     }


### PR DESCRIPTION
DynamoDB transactional state storage conflicts could leave a storage instance reusable without reloading and provided limited context for diagnosing failed transaction operations.

This change hardens conflict handling by requiring a successful `Load` after failed stores and adding operation-indexed, partition-scoped diagnostics without exposing payloads. It also expands coverage for strict ETags, no-change and duplicate-sequence behavior, stale-writer convergence, idempotency, and `TransactionConflict` characterization so conflict behavior remains predictable while preserving public APIs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10372)