### PR TITLE
fix(testing): enforce strict wait deadlines

### DIFF
--- a/src/Orleans.TestingHost/TestCluster.cs
+++ b/src/Orleans.TestingHost/TestCluster.cs
@@ -904,7 +904,13 @@ namespace Orleans.TestingHost
         public static async Task<SiloHandle> StartSiloAsync(TestCluster cluster, int instanceNumber, TestClusterOptions clusterOptions, IReadOnlyList<IConfigurationSource>? configurationOverrides = null, bool startSiloOnNewPort = false)
         {
             if (cluster == null) throw new ArgumentNullException(nameof(cluster));
-            return await cluster.StartSiloAsync(instanceNumber, clusterOptions, configurationOverrides, startSiloOnNewPort);
+            var silo = await cluster.StartSiloAsync(instanceNumber, clusterOptions, configurationOverrides, startSiloOnNewPort);
+            lock (cluster.additionalSilos)
+            {
+                cluster.additionalSilos.Add(silo);
+            }
+
+            return silo;
         }
 
         /// <summary>

--- a/src/Orleans.TestingHost/Utils/TestingUtils.cs
+++ b/src/Orleans.TestingHost/Utils/TestingUtils.cs
@@ -71,40 +71,85 @@ namespace Orleans.TestingHost.Utils
             return factory;
         }
 
-        /// <summary> Run the predicate until it succeed or times out </summary>
+        /// <summary>Run the predicate until it succeeds or times out.</summary>
         /// <param name="predicate">The predicate to run</param>
         /// <param name="timeout">The timeout value</param>
         /// <param name="delayOnFail">The time to delay next call upon failure</param>
-        /// <returns>True if the predicate succeed, false otherwise</returns>
+        /// <returns>A task representing the operation.</returns>
+        /// <exception cref="TimeoutException">The predicate did not succeed before the timeout elapsed.</exception>
         public static async Task WaitUntilAsync(Func<bool,Task<bool>> predicate, TimeSpan timeout, TimeSpan? delayOnFail = null)
         {
-            delayOnFail = delayOnFail ?? TimeSpan.FromSeconds(1);
-            var keepGoing = new[] { true };
-            async Task loop()
+            ArgumentNullException.ThrowIfNull(predicate);
+
+            if (!await WaitUntilSucceededAsync(_ => predicate(false), timeout, delayOnFail))
             {
-                bool passed;
-                do
+                var predicateName = $"{predicate.Method.DeclaringType?.FullName ?? "<unknown>"}.{predicate.Method.Name}";
+                throw new TimeoutException(
+                    $"The condition evaluated by '{predicateName}' was not satisfied within {timeout} "
+                    + $"using a retry delay of {delayOnFail ?? TimeSpan.FromSeconds(1)}. "
+                    + "The predicate was not invoked again after the deadline.");
+            }
+        }
+
+        /// <summary>Runs the predicate until it succeeds or the monotonic deadline expires.</summary>
+        /// <param name="predicate">The predicate to run. The token is cancelled when the deadline expires or cancellation is requested.</param>
+        /// <param name="timeout">The timeout value.</param>
+        /// <param name="delayOnFail">The delay before retrying after an unsuccessful attempt.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns><see langword="true"/> if the predicate succeeded before the deadline; otherwise, <see langword="false"/>.</returns>
+        public static async Task<bool> WaitUntilSucceededAsync(
+            Func<CancellationToken, Task<bool>> predicate,
+            TimeSpan timeout,
+            TimeSpan? delayOnFail = null,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(predicate);
+            ArgumentOutOfRangeException.ThrowIfLessThan(timeout, TimeSpan.Zero);
+
+            var retryDelay = delayOnFail ?? TimeSpan.FromSeconds(1);
+            ArgumentOutOfRangeException.ThrowIfLessThan(retryDelay, TimeSpan.Zero);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var startedAt = Stopwatch.GetTimestamp();
+            using var deadlineCancellation = new CancellationTokenSource(timeout);
+            using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deadlineCancellation.Token);
+
+            while (Stopwatch.GetElapsedTime(startedAt) < timeout)
+            {
+                bool succeeded;
+                try
                 {
-                    // need to wait a bit to before re-checking the condition.
-                    await Task.Delay(delayOnFail.Value);
-                    passed = await predicate(false);
+                    succeeded = await predicate(linkedCancellation.Token);
                 }
-                while (!passed && keepGoing[0]);
-                if (!passed)
-                    await predicate(true);
+                catch (OperationCanceledException) when (deadlineCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    return false;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                var elapsed = Stopwatch.GetElapsedTime(startedAt);
+                if (elapsed >= timeout)
+                {
+                    return false;
+                }
+
+                if (succeeded)
+                {
+                    return true;
+                }
+
+                var delay = retryDelay < timeout - elapsed ? retryDelay : timeout - elapsed;
+                try
+                {
+                    await Task.Delay(delay, linkedCancellation.Token);
+                }
+                catch (OperationCanceledException) when (deadlineCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    return false;
+                }
             }
 
-            var task = loop();
-            try
-            {
-                await Task.WhenAny(task, Task.Delay(timeout));
-            }
-            finally
-            {
-                keepGoing[0] = false;
-            }
-
-            await task;
+            return false;
         }
 
         /// <summary>

--- a/src/Orleans.TestingHost/Utils/TestingUtils.cs
+++ b/src/Orleans.TestingHost/Utils/TestingUtils.cs
@@ -87,32 +87,6 @@ namespace Orleans.TestingHost.Utils
         }
 
         /// <summary>Run the predicate until it succeeds or times out.</summary>
-        /// <param name="predicate">The predicate to run. The token is cancelled when the deadline expires or cancellation is requested.</param>
-        /// <param name="timeout">The timeout value.</param>
-        /// <param name="delayOnFail">The delay before retrying after an unsuccessful attempt.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <param name="predicateExpression">The expression supplied for <paramref name="predicate"/>.</param>
-        /// <returns>A task representing the operation.</returns>
-        /// <exception cref="TimeoutException">The predicate did not succeed before the timeout elapsed.</exception>
-        public static async Task WaitUntilAsync(
-            Func<CancellationToken, Task<bool>> predicate,
-            TimeSpan timeout,
-            TimeSpan? delayOnFail = null,
-            CancellationToken cancellationToken = default,
-            [CallerArgumentExpression(nameof(predicate))] string? predicateExpression = null)
-        {
-            ArgumentNullException.ThrowIfNull(predicate);
-
-            if (!await WaitUntilSucceededAsync((_, token) => predicate(token), timeout, delayOnFail, cancellationToken, invokeFinalAttempt: false))
-            {
-                throw new TimeoutException(
-                    $"The condition evaluated by '{predicateExpression ?? "<unknown>"}' was not satisfied within {timeout} "
-                    + $"using a retry delay of {delayOnFail ?? TimeSpan.FromSeconds(1)}. "
-                    + "The predicate was not invoked again after the deadline.");
-            }
-        }
-
-        /// <summary>Run the predicate until it succeeds or times out.</summary>
         /// <param name="predicate">
         /// The predicate to run. The first argument indicates the final attempt, allowing the predicate to throw a detailed assertion failure.
         /// The token is cancelled when the deadline expires or cancellation is requested.

--- a/src/Orleans.TestingHost/Utils/TestingUtils.cs
+++ b/src/Orleans.TestingHost/Utils/TestingUtils.cs
@@ -83,7 +83,7 @@ namespace Orleans.TestingHost.Utils
             ArgumentNullException.ThrowIfNull(predicate);
 
             var predicateName = $"{predicate.Method.DeclaringType?.FullName ?? "<unknown>"}.{predicate.Method.Name}";
-            return WaitUntilAsync(_ => predicate(false), timeout, delayOnFail, default, predicateName);
+            return WaitUntilAsync((lastTry, _) => predicate(lastTry), timeout, delayOnFail, default, predicateName);
         }
 
         /// <summary>Run the predicate until it succeeds or times out.</summary>
@@ -103,7 +103,36 @@ namespace Orleans.TestingHost.Utils
         {
             ArgumentNullException.ThrowIfNull(predicate);
 
-            if (!await WaitUntilSucceededAsync(predicate, timeout, delayOnFail, cancellationToken))
+            if (!await WaitUntilSucceededAsync((_, token) => predicate(token), timeout, delayOnFail, cancellationToken, invokeFinalAttempt: false))
+            {
+                throw new TimeoutException(
+                    $"The condition evaluated by '{predicateExpression ?? "<unknown>"}' was not satisfied within {timeout} "
+                    + $"using a retry delay of {delayOnFail ?? TimeSpan.FromSeconds(1)}. "
+                    + "The predicate was not invoked again after the deadline.");
+            }
+        }
+
+        /// <summary>Run the predicate until it succeeds or times out.</summary>
+        /// <param name="predicate">
+        /// The predicate to run. The first argument indicates the final attempt, allowing the predicate to throw a detailed assertion failure.
+        /// The token is cancelled when the deadline expires or cancellation is requested.
+        /// </param>
+        /// <param name="timeout">The timeout value.</param>
+        /// <param name="delayOnFail">The delay before retrying after an unsuccessful attempt.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="predicateExpression">The expression supplied for <paramref name="predicate"/>.</param>
+        /// <returns>A task representing the operation.</returns>
+        /// <exception cref="TimeoutException">The predicate did not succeed before the timeout elapsed.</exception>
+        public static async Task WaitUntilAsync(
+            Func<bool, CancellationToken, Task<bool>> predicate,
+            TimeSpan timeout,
+            TimeSpan? delayOnFail = null,
+            CancellationToken cancellationToken = default,
+            [CallerArgumentExpression(nameof(predicate))] string? predicateExpression = null)
+        {
+            ArgumentNullException.ThrowIfNull(predicate);
+
+            if (!await WaitUntilSucceededAsync(predicate, timeout, delayOnFail, cancellationToken, invokeFinalAttempt: true))
             {
                 throw new TimeoutException(
                     $"The condition evaluated by '{predicateExpression ?? "<unknown>"}' was not satisfied within {timeout} "
@@ -125,6 +154,17 @@ namespace Orleans.TestingHost.Utils
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(predicate);
+            return await WaitUntilSucceededAsync((_, token) => predicate(token), timeout, delayOnFail, cancellationToken, invokeFinalAttempt: false);
+        }
+
+        private static async Task<bool> WaitUntilSucceededAsync(
+            Func<bool, CancellationToken, Task<bool>> predicate,
+            TimeSpan timeout,
+            TimeSpan? delayOnFail,
+            CancellationToken cancellationToken,
+            bool invokeFinalAttempt)
+        {
+            ArgumentNullException.ThrowIfNull(predicate);
             ArgumentOutOfRangeException.ThrowIfLessThan(timeout, TimeSpan.Zero);
 
             var retryDelay = delayOnFail ?? TimeSpan.FromSeconds(1);
@@ -134,19 +174,28 @@ namespace Orleans.TestingHost.Utils
             var startedAt = Stopwatch.GetTimestamp();
             using var deadlineCancellation = new CancellationTokenSource(timeout);
             using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deadlineCancellation.Token);
+            var finalAttempt = false;
+            var lastAttemptDuration = TimeSpan.Zero;
 
             while (Stopwatch.GetElapsedTime(startedAt) < timeout)
             {
+                if (deadlineCancellation.IsCancellationRequested || Stopwatch.GetElapsedTime(startedAt) >= timeout)
+                {
+                    return false;
+                }
+
                 bool succeeded;
+                var attemptStartedAt = Stopwatch.GetTimestamp();
                 try
                 {
-                    succeeded = await predicate(linkedCancellation.Token);
+                    succeeded = await predicate(finalAttempt, linkedCancellation.Token);
                 }
                 catch (OperationCanceledException) when (deadlineCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
                     return false;
                 }
 
+                lastAttemptDuration = Stopwatch.GetElapsedTime(attemptStartedAt);
                 cancellationToken.ThrowIfCancellationRequested();
                 var elapsed = Stopwatch.GetElapsedTime(startedAt);
                 if (elapsed >= timeout)
@@ -159,7 +208,48 @@ namespace Orleans.TestingHost.Utils
                     return true;
                 }
 
-                var delay = retryDelay < timeout - elapsed ? retryDelay : timeout - elapsed;
+                var remaining = timeout - elapsed;
+                if (finalAttempt)
+                {
+                    try
+                    {
+                        await Task.Delay(remaining, linkedCancellation.Token);
+                    }
+                    catch (OperationCanceledException) when (deadlineCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                    {
+                        return false;
+                    }
+
+                    continue;
+                }
+
+                var finalAttemptWindow = retryDelay > TimeSpan.Zero ? retryDelay : TimeSpan.FromMilliseconds(10);
+                if (invokeFinalAttempt && remaining <= finalAttemptWindow)
+                {
+                    var minimumBudget = TimeSpan.FromMilliseconds(100);
+                    var finalAttemptBudget = lastAttemptDuration > minimumBudget
+                        ? lastAttemptDuration.Ticks >= remaining.Ticks / 2
+                            ? remaining
+                            : TimeSpan.FromTicks(lastAttemptDuration.Ticks * 2)
+                        : minimumBudget;
+                    var delayBeforeFinalAttempt = remaining - finalAttemptBudget;
+                    if (delayBeforeFinalAttempt > TimeSpan.Zero)
+                    {
+                        try
+                        {
+                            await Task.Delay(delayBeforeFinalAttempt, linkedCancellation.Token);
+                        }
+                        catch (OperationCanceledException) when (deadlineCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                        {
+                            return false;
+                        }
+                    }
+
+                    finalAttempt = true;
+                    continue;
+                }
+
+                var delay = retryDelay < remaining ? retryDelay : remaining;
                 try
                 {
                     await Task.Delay(delay, linkedCancellation.Token);

--- a/src/Orleans.TestingHost/Utils/TestingUtils.cs
+++ b/src/Orleans.TestingHost/Utils/TestingUtils.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -77,15 +78,35 @@ namespace Orleans.TestingHost.Utils
         /// <param name="delayOnFail">The time to delay next call upon failure</param>
         /// <returns>A task representing the operation.</returns>
         /// <exception cref="TimeoutException">The predicate did not succeed before the timeout elapsed.</exception>
-        public static async Task WaitUntilAsync(Func<bool,Task<bool>> predicate, TimeSpan timeout, TimeSpan? delayOnFail = null)
+        public static Task WaitUntilAsync(Func<bool,Task<bool>> predicate, TimeSpan timeout, TimeSpan? delayOnFail = null)
         {
             ArgumentNullException.ThrowIfNull(predicate);
 
-            if (!await WaitUntilSucceededAsync(_ => predicate(false), timeout, delayOnFail))
+            var predicateName = $"{predicate.Method.DeclaringType?.FullName ?? "<unknown>"}.{predicate.Method.Name}";
+            return WaitUntilAsync(_ => predicate(false), timeout, delayOnFail, default, predicateName);
+        }
+
+        /// <summary>Run the predicate until it succeeds or times out.</summary>
+        /// <param name="predicate">The predicate to run. The token is cancelled when the deadline expires or cancellation is requested.</param>
+        /// <param name="timeout">The timeout value.</param>
+        /// <param name="delayOnFail">The delay before retrying after an unsuccessful attempt.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="predicateExpression">The expression supplied for <paramref name="predicate"/>.</param>
+        /// <returns>A task representing the operation.</returns>
+        /// <exception cref="TimeoutException">The predicate did not succeed before the timeout elapsed.</exception>
+        public static async Task WaitUntilAsync(
+            Func<CancellationToken, Task<bool>> predicate,
+            TimeSpan timeout,
+            TimeSpan? delayOnFail = null,
+            CancellationToken cancellationToken = default,
+            [CallerArgumentExpression(nameof(predicate))] string? predicateExpression = null)
+        {
+            ArgumentNullException.ThrowIfNull(predicate);
+
+            if (!await WaitUntilSucceededAsync(predicate, timeout, delayOnFail, cancellationToken))
             {
-                var predicateName = $"{predicate.Method.DeclaringType?.FullName ?? "<unknown>"}.{predicate.Method.Name}";
                 throw new TimeoutException(
-                    $"The condition evaluated by '{predicateName}' was not satisfied within {timeout} "
+                    $"The condition evaluated by '{predicateExpression ?? "<unknown>"}' was not satisfied within {timeout} "
                     + $"using a retry delay of {delayOnFail ?? TimeSpan.FromSeconds(1)}. "
                     + "The predicate was not invoked again after the deadline.");
             }

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
@@ -109,7 +109,7 @@ namespace Orleans.Transactions.TestKit
 
             this.Log($"Waiting for system to recover. Performed {index[0]} transactions on each group.");
             List<ExpectedGrainActivity>[]?[] transactionGroupsRef = new[] { transactionGroups };
-            await TestingUtils.WaitUntilAsync(lastTry => CheckTxResult(transactionGroupsRef, getIndex, lastTry), RecoveryTimeout, RetryDelay);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckTxResult(transactionGroupsRef, getIndex, false), RecoveryTimeout, RetryDelay);
             this.Log($"Recovery completed. Performed {index[0]} transactions on each group. Validating results.");
             await ValidateResults(txGrains, transactionGroups);
         }

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryTestsRunner.cs
@@ -109,7 +109,7 @@ namespace Orleans.Transactions.TestKit
 
             this.Log($"Waiting for system to recover. Performed {index[0]} transactions on each group.");
             List<ExpectedGrainActivity>[]?[] transactionGroupsRef = new[] { transactionGroups };
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckTxResult(transactionGroupsRef, getIndex, false), RecoveryTimeout, RetryDelay);
+            await TestingUtils.WaitUntilAsync(lastTry => CheckTxResult(transactionGroupsRef, getIndex, lastTry), RecoveryTimeout, RetryDelay);
             this.Log($"Recovery completed. Performed {index[0]} transactions on each group. Validating results.");
             await ValidateResults(txGrains, transactionGroups);
         }

--- a/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
+++ b/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
@@ -822,6 +822,8 @@ namespace Orleans.TestingHost.Utils
         public static System.TimeSpan Multiply(System.TimeSpan time, double value) { throw null; }
 
         public static System.Threading.Tasks.Task WaitUntilAsync(System.Func<bool, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null) { throw null; }
+
+        public static System.Threading.Tasks.Task<bool> WaitUntilSucceededAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
 

--- a/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
+++ b/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
@@ -823,8 +823,6 @@ namespace Orleans.TestingHost.Utils
 
         public static System.Threading.Tasks.Task WaitUntilAsync(System.Func<bool, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null) { throw null; }
 
-        public static System.Threading.Tasks.Task WaitUntilAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string predicateExpression = null) { throw null; }
-
         public static System.Threading.Tasks.Task WaitUntilAsync(System.Func<bool, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string predicateExpression = null) { throw null; }
 
         public static System.Threading.Tasks.Task<bool> WaitUntilSucceededAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
+++ b/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
@@ -823,6 +823,8 @@ namespace Orleans.TestingHost.Utils
 
         public static System.Threading.Tasks.Task WaitUntilAsync(System.Func<bool, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null) { throw null; }
 
+        public static System.Threading.Tasks.Task WaitUntilAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string predicateExpression = null) { throw null; }
+
         public static System.Threading.Tasks.Task<bool> WaitUntilSucceededAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }

--- a/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
+++ b/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
@@ -825,6 +825,8 @@ namespace Orleans.TestingHost.Utils
 
         public static System.Threading.Tasks.Task WaitUntilAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string predicateExpression = null) { throw null; }
 
+        public static System.Threading.Tasks.Task WaitUntilAsync(System.Func<bool, System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string predicateExpression = null) { throw null; }
+
         public static System.Threading.Tasks.Task<bool> WaitUntilSucceededAsync(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<bool>> predicate, System.TimeSpan timeout, System.TimeSpan? delayOnFail = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
@@ -169,8 +169,8 @@ namespace UnitTests.HaloTests.Streaming
 
         private async Task<bool> CheckCounters(IProducerEventCountingGrain producer, IConsumerEventCountingGrain consumer, CancellationToken cancellationToken)
         {
-            var numProduced = await producer.GetNumberProduced().WaitAsync(cancellationToken);
-            var numConsumed = await consumer.GetNumberConsumed().WaitAsync(cancellationToken);
+            var numProduced = await producer.GetNumberProduced(cancellationToken);
+            var numConsumed = await consumer.GetNumberConsumed(cancellationToken);
             this.fixture.Logger.LogInformation("CheckCounters: numProduced = {ProducedCount}, numConsumed = {ConsumedCount}", numProduced, numConsumed);
             return numProduced == numConsumed;
         }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
@@ -140,7 +140,7 @@ namespace UnitTests.HaloTests.Streaming
             var streamId = Orleans.Runtime.StreamId.Create("HaloStreamingNamespace", _streamId);
             await observer.WaitForMessageDeliveredAsync(streamId, _streamProvider, cts.Token);
 
-            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(producer, consumer, cancellationToken), Timeout);
+            await TestingUtils.WaitUntilAsync((_, cancellationToken) => CheckCounters(producer, consumer, cancellationToken), Timeout);
 
             await consumer.StopConsuming();
         }
@@ -162,7 +162,7 @@ namespace UnitTests.HaloTests.Streaming
             var streamId = Orleans.Runtime.StreamId.Create("HaloStreamingNamespace", _streamId);
             await observer.WaitForMessageDeliveredAsync(streamId, _streamProvider, cts.Token);
 
-            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(producer, consumer, cancellationToken), Timeout);
+            await TestingUtils.WaitUntilAsync((_, cancellationToken) => CheckCounters(producer, consumer, cancellationToken), Timeout);
 
             await consumer.StopConsuming();
         }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
@@ -140,7 +140,7 @@ namespace UnitTests.HaloTests.Streaming
             var streamId = Orleans.Runtime.StreamId.Create("HaloStreamingNamespace", _streamId);
             await observer.WaitForMessageDeliveredAsync(streamId, _streamProvider, cts.Token);
 
-            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer), Timeout);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(producer, consumer), Timeout);
 
             await consumer.StopConsuming();
         }
@@ -162,7 +162,7 @@ namespace UnitTests.HaloTests.Streaming
             var streamId = Orleans.Runtime.StreamId.Create("HaloStreamingNamespace", _streamId);
             await observer.WaitForMessageDeliveredAsync(streamId, _streamProvider, cts.Token);
 
-            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer), Timeout);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(producer, consumer), Timeout);
 
             await consumer.StopConsuming();
         }

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
@@ -140,7 +140,7 @@ namespace UnitTests.HaloTests.Streaming
             var streamId = Orleans.Runtime.StreamId.Create("HaloStreamingNamespace", _streamId);
             await observer.WaitForMessageDeliveredAsync(streamId, _streamProvider, cts.Token);
 
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(producer, consumer), Timeout);
+            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(producer, consumer, cancellationToken), Timeout);
 
             await consumer.StopConsuming();
         }
@@ -162,15 +162,15 @@ namespace UnitTests.HaloTests.Streaming
             var streamId = Orleans.Runtime.StreamId.Create("HaloStreamingNamespace", _streamId);
             await observer.WaitForMessageDeliveredAsync(streamId, _streamProvider, cts.Token);
 
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(producer, consumer), Timeout);
+            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(producer, consumer, cancellationToken), Timeout);
 
             await consumer.StopConsuming();
         }
 
-        private async Task<bool> CheckCounters(IProducerEventCountingGrain producer, IConsumerEventCountingGrain consumer)
+        private async Task<bool> CheckCounters(IProducerEventCountingGrain producer, IConsumerEventCountingGrain consumer, CancellationToken cancellationToken)
         {
-            var numProduced = await producer.GetNumberProduced();
-            var numConsumed = await consumer.GetNumberConsumed();
+            var numProduced = await producer.GetNumberProduced().WaitAsync(cancellationToken);
+            var numConsumed = await consumer.GetNumberConsumed().WaitAsync(cancellationToken);
             this.fixture.Logger.LogInformation("CheckCounters: numProduced = {ProducedCount}, numConsumed = {ConsumedCount}", numProduced, numConsumed);
             return numProduced == numConsumed;
         }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
@@ -85,14 +85,14 @@ namespace ServiceBus.Tests.SlowConsumingTests
             await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
                 (int)EventDataGeneratorAdapterFactory.Commands.Randomly_Place_Stream_To_Queue, randomStreamPlacementArg);
             //since there's an extreme slow consumer, so the back pressure algorithm should be triggered
-            await TestingUtils.WaitUntilAsync(cancellationToken => AssertCacheBackPressureTriggered(true, false, cancellationToken), timeout);
+            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => AssertCacheBackPressureTriggered(true, lastTry, cancellationToken), timeout);
 
             //make slow consumer stop consuming
             await slowConsumer.StopConsuming();
 
             //slowConsumer stopped consuming, back pressure algorithm should be cleared in next check period.
             await Task.Delay(monitorPressureWindowSize);
-            await TestingUtils.WaitUntilAsync(cancellationToken => AssertCacheBackPressureTriggered(false, false, cancellationToken), timeout);
+            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => AssertCacheBackPressureTriggered(false, lastTry, cancellationToken), timeout);
 
             //clean up test
             await StopHealthyConsumerGrainComing(healthyConsumers);

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
@@ -85,14 +85,14 @@ namespace ServiceBus.Tests.SlowConsumingTests
             await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
                 (int)EventDataGeneratorAdapterFactory.Commands.Randomly_Place_Stream_To_Queue, randomStreamPlacementArg);
             //since there's an extreme slow consumer, so the back pressure algorithm should be triggered
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => AssertCacheBackPressureTriggered(true, false), timeout);
+            await TestingUtils.WaitUntilAsync(cancellationToken => AssertCacheBackPressureTriggered(true, false, cancellationToken), timeout);
 
             //make slow consumer stop consuming
             await slowConsumer.StopConsuming();
 
             //slowConsumer stopped consuming, back pressure algorithm should be cleared in next check period.
             await Task.Delay(monitorPressureWindowSize);
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => AssertCacheBackPressureTriggered(false, false), timeout);
+            await TestingUtils.WaitUntilAsync(cancellationToken => AssertCacheBackPressureTriggered(false, false, cancellationToken), timeout);
 
             //clean up test
             await StopHealthyConsumerGrainComing(healthyConsumers);
@@ -125,25 +125,25 @@ namespace ServiceBus.Tests.SlowConsumingTests
             await Task.WhenAll(tasks);
         }
 
-        private async Task<bool> AssertCacheBackPressureTriggered(bool expectedResult, bool assertIsTrue)
+        private async Task<bool> AssertCacheBackPressureTriggered(bool expectedResult, bool assertIsTrue, CancellationToken cancellationToken)
         {
             if (assertIsTrue)
             {
-                bool actualResult = await IsBackPressureTriggered();
+                bool actualResult = await IsBackPressureTriggered(cancellationToken);
                 Assert.True(expectedResult == actualResult, $"Back pressure algorithm should be triggered? expected: {expectedResult}, actual: {actualResult}");
                 return true;
             }
             else
             {
-                return (await IsBackPressureTriggered()) == expectedResult;
+                return (await IsBackPressureTriggered(cancellationToken)) == expectedResult;
             }
         }
 
-        private async Task<bool> IsBackPressureTriggered()
+        private async Task<bool> IsBackPressureTriggered(CancellationToken cancellationToken)
         {
             IManagementGrain mgmtGrain = this.fixture.HostedCluster.GrainFactory!.GetGrain<IManagementGrain>(0); // The fixture deploys the client.
             object?[] replies = await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(
-                             StreamProviderName, EHStreamProviderWithCreatedCacheListAdapterFactory.IsCacheBackPressureTriggeredCommand, null);
+                             StreamProviderName, EHStreamProviderWithCreatedCacheListAdapterFactory.IsCacheBackPressureTriggeredCommand, null).WaitAsync(cancellationToken);
             foreach (var re in replies)
             {
                 if ((bool)re!) // The command returns a Boolean result from each silo.

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/SlowConsumingTests/EHSlowConsumingTests.cs
@@ -85,14 +85,14 @@ namespace ServiceBus.Tests.SlowConsumingTests
             await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
                 (int)EventDataGeneratorAdapterFactory.Commands.Randomly_Place_Stream_To_Queue, randomStreamPlacementArg);
             //since there's an extreme slow consumer, so the back pressure algorithm should be triggered
-            await TestingUtils.WaitUntilAsync(lastTry => AssertCacheBackPressureTriggered(true, lastTry), timeout);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => AssertCacheBackPressureTriggered(true, false), timeout);
 
             //make slow consumer stop consuming
             await slowConsumer.StopConsuming();
 
             //slowConsumer stopped consuming, back pressure algorithm should be cleared in next check period.
             await Task.Delay(monitorPressureWindowSize);
-            await TestingUtils.WaitUntilAsync(lastTry => AssertCacheBackPressureTriggered(false, lastTry), timeout);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => AssertCacheBackPressureTriggered(false, false), timeout);
 
             //clean up test
             await StopHealthyConsumerGrainComing(healthyConsumers);

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -124,9 +124,9 @@ namespace ServiceBus.Tests.StreamingTests
         private static async Task<bool> CheckCounters(List<ISampleStreaming_ConsumerGrain> consumers, int totalEventCount, bool assertIsTrue, CancellationToken cancellationToken)
         {
             List<Task<int>> becomeConsumersTasks = consumers
-                .Select((consumer, i) => consumer.GetNumberConsumed())
+                .Select((consumer, i) => consumer.GetNumberConsumed(cancellationToken))
                 .ToList();
-            int[] counts = await Task.WhenAll(becomeConsumersTasks).WaitAsync(cancellationToken);
+            int[] counts = await Task.WhenAll(becomeConsumersTasks);
 
             if (assertIsTrue)
             {

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -100,7 +100,7 @@ namespace ServiceBus.Tests.StreamingTests
             await Task.WhenAll(becomeConsumersTasks);
 
             await GenerateEvents(streamCount, eventsInStream);
-            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(consumers, streamCount * eventsInStream, false, cancellationToken), TimeSpan.FromSeconds(30));
+            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(consumers, streamCount * eventsInStream, lastTry, cancellationToken), TimeSpan.FromSeconds(30));
         }
 
         private async Task GenerateEvents(int streamCount, int eventsInStream)

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -100,7 +100,7 @@ namespace ServiceBus.Tests.StreamingTests
             await Task.WhenAll(becomeConsumersTasks);
 
             await GenerateEvents(streamCount, eventsInStream);
-            await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(consumers, streamCount * eventsInStream, assertIsTrue), TimeSpan.FromSeconds(30));
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(consumers, streamCount * eventsInStream, false), TimeSpan.FromSeconds(30));
         }
 
         private async Task GenerateEvents(int streamCount, int eventsInStream)

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamPerPartitionTests.cs
@@ -100,7 +100,7 @@ namespace ServiceBus.Tests.StreamingTests
             await Task.WhenAll(becomeConsumersTasks);
 
             await GenerateEvents(streamCount, eventsInStream);
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(consumers, streamCount * eventsInStream, false), TimeSpan.FromSeconds(30));
+            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(consumers, streamCount * eventsInStream, false, cancellationToken), TimeSpan.FromSeconds(30));
         }
 
         private async Task GenerateEvents(int streamCount, int eventsInStream)
@@ -121,12 +121,12 @@ namespace ServiceBus.Tests.StreamingTests
             }
         }
 
-        private static async Task<bool> CheckCounters(List<ISampleStreaming_ConsumerGrain> consumers, int totalEventCount, bool assertIsTrue)
+        private static async Task<bool> CheckCounters(List<ISampleStreaming_ConsumerGrain> consumers, int totalEventCount, bool assertIsTrue, CancellationToken cancellationToken)
         {
             List<Task<int>> becomeConsumersTasks = consumers
                 .Select((consumer, i) => consumer.GetNumberConsumed())
                 .ToList();
-            int[] counts = await Task.WhenAll(becomeConsumersTasks);
+            int[] counts = await Task.WhenAll(becomeConsumersTasks).WaitAsync(cancellationToken);
 
             if (assertIsTrue)
             {

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamProviderCheckpointTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamProviderCheckpointTests.cs
@@ -102,12 +102,12 @@ namespace ServiceBus.Tests.StreamingTests
             try
             {
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 4096);
-                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream, assertIsTrue), TimeSpan.FromSeconds(60));
+                await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(streamNamespace, streamCount, eventsInStream, false), TimeSpan.FromSeconds(60));
 
                 await RestartAgents();
 
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 4096);
-                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, assertIsTrue), TimeSpan.FromSeconds(90));
+                await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, false), TimeSpan.FromSeconds(90));
             }
             finally
             {
@@ -122,13 +122,13 @@ namespace ServiceBus.Tests.StreamingTests
             try
             {
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 0);
-                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream, assertIsTrue), TimeSpan.FromSeconds(60));
+                await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(streamNamespace, streamCount, eventsInStream, false), TimeSpan.FromSeconds(60));
 
                 await HostedCluster.RestartSiloAsync(HostedCluster.SecondarySilos[0]);
                 await HostedCluster.WaitForLivenessToStabilizeAsync();
 
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 0);
-                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, assertIsTrue), TimeSpan.FromSeconds(90));
+                await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, false), TimeSpan.FromSeconds(90));
             }
             finally
             {

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamProviderCheckpointTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamProviderCheckpointTests.cs
@@ -141,7 +141,7 @@ namespace ServiceBus.Tests.StreamingTests
         {
             var reporter = this.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
 
-            var report = await reporter.GetReport(StreamProviderName, streamNamespace).WaitAsync(cancellationToken);
+            var report = await reporter.GetReport(StreamProviderName, streamNamespace, cancellationToken);
             if (assertIsTrue)
             {
                 // one stream per queue

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamProviderCheckpointTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamProviderCheckpointTests.cs
@@ -102,12 +102,12 @@ namespace ServiceBus.Tests.StreamingTests
             try
             {
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 4096);
-                await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(streamNamespace, streamCount, eventsInStream, false), TimeSpan.FromSeconds(60));
+                await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(streamNamespace, streamCount, eventsInStream, false, cancellationToken), TimeSpan.FromSeconds(60));
 
                 await RestartAgents();
 
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 4096);
-                await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, false), TimeSpan.FromSeconds(90));
+                await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, false, cancellationToken), TimeSpan.FromSeconds(90));
             }
             finally
             {
@@ -122,13 +122,13 @@ namespace ServiceBus.Tests.StreamingTests
             try
             {
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 0);
-                await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(streamNamespace, streamCount, eventsInStream, false), TimeSpan.FromSeconds(60));
+                await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(streamNamespace, streamCount, eventsInStream, false, cancellationToken), TimeSpan.FromSeconds(60));
 
                 await HostedCluster.RestartSiloAsync(HostedCluster.SecondarySilos[0]);
                 await HostedCluster.WaitForLivenessToStabilizeAsync();
 
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 0);
-                await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, false), TimeSpan.FromSeconds(90));
+                await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, false, cancellationToken), TimeSpan.FromSeconds(90));
             }
             finally
             {
@@ -137,11 +137,11 @@ namespace ServiceBus.Tests.StreamingTests
             }
         }
 
-        private async Task<bool> CheckCounters(string streamNamespace, int streamCount, int eventsInStream, bool assertIsTrue)
+        private async Task<bool> CheckCounters(string streamNamespace, int streamCount, int eventsInStream, bool assertIsTrue, CancellationToken cancellationToken)
         {
             var reporter = this.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
 
-            var report = await reporter.GetReport(StreamProviderName, streamNamespace);
+            var report = await reporter.GetReport(StreamProviderName, streamNamespace).WaitAsync(cancellationToken);
             if (assertIsTrue)
             {
                 // one stream per queue

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamProviderCheckpointTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/Streaming/EHStreamProviderCheckpointTests.cs
@@ -102,12 +102,12 @@ namespace ServiceBus.Tests.StreamingTests
             try
             {
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 4096);
-                await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(streamNamespace, streamCount, eventsInStream, false, cancellationToken), TimeSpan.FromSeconds(60));
+                await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(streamNamespace, streamCount, eventsInStream, lastTry, cancellationToken), TimeSpan.FromSeconds(60));
 
                 await RestartAgents();
 
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 4096);
-                await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, false, cancellationToken), TimeSpan.FromSeconds(90));
+                await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, lastTry, cancellationToken), TimeSpan.FromSeconds(90));
             }
             finally
             {
@@ -122,13 +122,13 @@ namespace ServiceBus.Tests.StreamingTests
             try
             {
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 0);
-                await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(streamNamespace, streamCount, eventsInStream, false, cancellationToken), TimeSpan.FromSeconds(60));
+                await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(streamNamespace, streamCount, eventsInStream, lastTry, cancellationToken), TimeSpan.FromSeconds(60));
 
                 await HostedCluster.RestartSiloAsync(HostedCluster.SecondarySilos[0]);
                 await HostedCluster.WaitForLivenessToStabilizeAsync();
 
                 await GenerateEvents(streamNamespace, streamGuids, eventsInStream, 0);
-                await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, false, cancellationToken), TimeSpan.FromSeconds(90));
+                await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(streamNamespace, streamCount, eventsInStream * 2, lastTry, cancellationToken), TimeSpan.FromSeconds(90));
             }
             finally
             {

--- a/test/Grains/TestGrainInterfaces/IConsumerEventCountingGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IConsumerEventCountingGrain.cs
@@ -9,6 +9,6 @@
 
         Task StopConsuming();
 
-        Task<int> GetNumberConsumed();
+        Task<int> GetNumberConsumed(CancellationToken cancellationToken = default);
     }
 }

--- a/test/Grains/TestGrainInterfaces/IGeneratedEventReporterGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IGeneratedEventReporterGrain.cs
@@ -6,7 +6,7 @@ namespace TestGrainInterfaces
     {
         Task ReportResult(Guid streamGuid, string streamProvider, string streamNamespace, int count);
 
-        Task<IDictionary<Guid,int>> GetReport(string streamProvider, string streamNamespace);
+        Task<IDictionary<Guid,int>> GetReport(string streamProvider, string streamNamespace, CancellationToken cancellationToken = default);
 
         Task Reset();
 

--- a/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
+++ b/test/Grains/TestGrainInterfaces/IGenericInterfaces.cs
@@ -184,7 +184,7 @@ namespace UnitTests.GrainInterfaces
         Task<T> PingSelf(T t);
         Task<T> PingOther(IGenericPingSelf<T> target, T t);
         Task<T> PingSelfThroughOther(IGenericPingSelf<T> target, T t);
-        Task<T> GetLastValue();
+        Task<T> GetLastValue(CancellationToken cancellationToken = default);
         Task ScheduleDelayedPing(IGenericPingSelf<T> target, T t, TimeSpan delay);
         Task ScheduleDelayedPingToSelfAndDeactivate(IGenericPingSelf<T> target, T t, TimeSpan delay);
     }

--- a/test/Grains/TestGrainInterfaces/IImplicitSubscriptionCounterGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IImplicitSubscriptionCounterGrain.cs
@@ -2,7 +2,7 @@ namespace UnitTests.GrainInterfaces
 {
     public interface IImplicitSubscriptionCounterGrain : IGrainWithGuidKey
     {
-        Task<int> GetEventCounter();
+        Task<int> GetEventCounter(CancellationToken cancellationToken = default);
 
         Task<int> GetErrorCounter();
 

--- a/test/Grains/TestGrainInterfaces/IImplicitSubscriptionKeyTypeGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IImplicitSubscriptionKeyTypeGrain.cs
@@ -2,7 +2,7 @@ namespace UnitTests.GrainInterfaces
 {
     public interface IImplicitSubscriptionKeyTypeGrain
     {
-        Task<int> GetValue();
+        Task<int> GetValue(CancellationToken cancellationToken = default);
     }
 
     public interface IImplicitSubscriptionLongKeyGrain : IImplicitSubscriptionKeyTypeGrain, IGrainWithIntegerKey

--- a/test/Grains/TestGrainInterfaces/IProducerEventCountingGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IProducerEventCountingGrain.cs
@@ -13,6 +13,6 @@
         /// <returns></returns>
         Task SendEvent();
 
-        Task<int> GetNumberProduced();
+        Task<int> GetNumberProduced(CancellationToken cancellationToken = default);
     }
 }

--- a/test/Grains/TestGrainInterfaces/ISampleStreamingGrain.cs
+++ b/test/Grains/TestGrainInterfaces/ISampleStreamingGrain.cs
@@ -8,7 +8,7 @@ namespace UnitTests.GrainInterfaces
 
         Task StopPeriodicProducing();
 
-        Task<int> GetNumberProduced();
+        Task<int> GetNumberProduced(CancellationToken cancellationToken = default);
 
         Task ClearNumberProduced();
         Task Produce();
@@ -20,7 +20,7 @@ namespace UnitTests.GrainInterfaces
 
         Task StopConsuming();
 
-        Task<int> GetNumberConsumed();
+        Task<int> GetNumberConsumed(CancellationToken cancellationToken = default);
     }
 
     public interface ISampleStreaming_InlineConsumerGrain : ISampleStreaming_ConsumerGrain

--- a/test/Grains/TestGrainInterfaces/IStuckGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IStuckGrain.cs
@@ -8,7 +8,7 @@ namespace UnitTests.GrainInterfaces
 
         Task NonBlockingCall();
 
-        Task<int> GetNonBlockingCallCounter();
+        Task<int> GetNonBlockingCallCounter(CancellationToken cancellationToken = default);
 
         Task<bool> DidActivationTryToStart(GrainId id);
 

--- a/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ConsumerEventCountingGrain.cs
@@ -89,8 +89,9 @@ namespace UnitTests.Grains
             }
         }
 
-        public Task<int> GetNumberConsumed()
+        public Task<int> GetNumberConsumed(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(_numConsumedItems);
         }
     }

--- a/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
+++ b/test/Grains/TestGrains/GeneratedEventReporterGrain.cs
@@ -43,8 +43,9 @@ namespace TestGrains
             return Task.CompletedTask;
         }
 
-        public Task<IDictionary<Guid, int>> GetReport(string streamProvider, string streamNamespace)
+        public Task<IDictionary<Guid, int>> GetReport(string streamProvider, string streamNamespace, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             Dictionary<Guid, int>? counts;
             Tuple<string, string> key = Tuple.Create(streamProvider, streamNamespace);
             if (!reports.TryGetValue(key, out counts))

--- a/test/Grains/TestGrains/GenericGrains.cs
+++ b/test/Grains/TestGrains/GenericGrains.cs
@@ -608,8 +608,9 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public Task<T> GetLastValue()
+        public Task<T> GetLastValue(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(_lastValue!);
         }
 

--- a/test/Grains/TestGrains/ImplicitSubscriptionCounterGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscriptionCounterGrain.cs
@@ -41,7 +41,11 @@ namespace UnitTests.Grains
 
         public Task<int> GetErrorCounter() => Task.FromResult(this.State.ErrorCounter);
 
-        public Task<int> GetEventCounter() => Task.FromResult(this.State.EventCounter);
+        public Task<int> GetEventCounter(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(this.State.EventCounter);
+        }
 
         public Task Deactivate()
         {

--- a/test/Grains/TestGrains/ImplicitSubscriptionWithKeyTypeGrain.cs
+++ b/test/Grains/TestGrains/ImplicitSubscriptionWithKeyTypeGrain.cs
@@ -32,6 +32,10 @@ namespace UnitTests.Grains
                 });
         }
 
-        public Task<int> GetValue() => Task.FromResult(value);
+        public Task<int> GetValue(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(value);
+        }
     }
 }

--- a/test/Grains/TestGrains/ProducerEventCountingGrain.cs
+++ b/test/Grains/TestGrains/ProducerEventCountingGrain.cs
@@ -42,8 +42,9 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public Task<int> GetNumberProduced()
+        public Task<int> GetNumberProduced(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(_numProducedItems);
         }
 

--- a/test/Grains/TestGrains/SampleStreamingGrain.cs
+++ b/test/Grains/TestGrains/SampleStreamingGrain.cs
@@ -79,8 +79,9 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public Task<int> GetNumberProduced()
+        public Task<int> GetNumberProduced(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             logger.LogInformation("GetNumberProduced {Count}", numProducedItems);
             return Task.FromResult(numProducedItems);
         }
@@ -156,8 +157,9 @@ namespace UnitTests.Grains
             }
         }
 
-        public Task<int> GetNumberConsumed()
+        public Task<int> GetNumberConsumed(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(numConsumedItems);
         }
 
@@ -207,8 +209,9 @@ namespace UnitTests.Grains
             }
         }
 
-        public Task<int> GetNumberConsumed()
+        public Task<int> GetNumberConsumed(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult( numConsumedItems );
         }
 

--- a/test/Grains/TestGrains/StuckGrain.cs
+++ b/test/Grains/TestGrains/StuckGrain.cs
@@ -94,8 +94,9 @@ namespace UnitTests.Grains
             return Task.CompletedTask;
         }
 
-        public Task<int> GetNonBlockingCallCounter()
+        public Task<int> GetNonBlockingCallCounter(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(counters[this.GetPrimaryKey()]);
         }
 

--- a/test/Orleans.DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/GenericGrainTests.cs
@@ -734,9 +734,9 @@ namespace DefaultCluster.Tests.General
             await grain.ScheduleDelayedPingToSelfAndDeactivate(target, s1, TimeSpan.FromSeconds(5));
             string? s2 = null;
             await TestingUtils.WaitUntilAsync(
-                async (CancellationToken _) =>
+                async cancellationToken =>
                 {
-                    s2 = await grain.GetLastValue();
+                    s2 = await grain.GetLastValue().WaitAsync(cancellationToken);
                     if (s2 == s1)
                     {
                         return true;

--- a/test/Orleans.DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/GenericGrainTests.cs
@@ -734,12 +734,17 @@ namespace DefaultCluster.Tests.General
             await grain.ScheduleDelayedPingToSelfAndDeactivate(target, s1, TimeSpan.FromSeconds(5));
             string? s2 = null;
             await TestingUtils.WaitUntilAsync(
-                async cancellationToken =>
+                async (lastTry, cancellationToken) =>
                 {
                     s2 = await grain.GetLastValue(cancellationToken);
                     if (s2 == s1)
                     {
                         return true;
+                    }
+
+                    if (lastTry)
+                    {
+                        Assert.Fail($"Expected delayed ping to set value '{s1}', but saw '{s2 ?? "null"}'.");
                     }
 
                     return false;

--- a/test/Orleans.DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/GenericGrainTests.cs
@@ -736,7 +736,7 @@ namespace DefaultCluster.Tests.General
             await TestingUtils.WaitUntilAsync(
                 async cancellationToken =>
                 {
-                    s2 = await grain.GetLastValue().WaitAsync(cancellationToken);
+                    s2 = await grain.GetLastValue(cancellationToken);
                     if (s2 == s1)
                     {
                         return true;

--- a/test/Orleans.DefaultCluster.Tests/GenericGrainTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/GenericGrainTests.cs
@@ -734,17 +734,12 @@ namespace DefaultCluster.Tests.General
             await grain.ScheduleDelayedPingToSelfAndDeactivate(target, s1, TimeSpan.FromSeconds(5));
             string? s2 = null;
             await TestingUtils.WaitUntilAsync(
-                async lastTry =>
+                async (CancellationToken _) =>
                 {
                     s2 = await grain.GetLastValue();
                     if (s2 == s1)
                     {
                         return true;
-                    }
-
-                    if (lastTry)
-                    {
-                        Assert.Fail($"Expected delayed ping to set value '{s1}', but saw '{s2 ?? "null"}'.");
                     }
 
                     return false;

--- a/test/Orleans.Runtime.Internal.Tests/OrleansRuntime/StuckGrainTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/OrleansRuntime/StuckGrainTests.cs
@@ -117,14 +117,9 @@ namespace UnitTests.StuckGrainTests
             }
 
             await TestingUtils.WaitUntilAsync(
-                async lastTry =>
+                async (CancellationToken _) =>
                 {
                     var count = await stuckGrain.GetNonBlockingCallCounter();
-                    if (lastTry)
-                    {
-                        Assert.Equal(3, count);
-                    }
-
                     return count == 3;
                 },
                 TimeSpan.FromSeconds(10),

--- a/test/Orleans.Runtime.Internal.Tests/OrleansRuntime/StuckGrainTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/OrleansRuntime/StuckGrainTests.cs
@@ -119,7 +119,7 @@ namespace UnitTests.StuckGrainTests
             await TestingUtils.WaitUntilAsync(
                 async cancellationToken =>
                 {
-                    var count = await stuckGrain.GetNonBlockingCallCounter().WaitAsync(cancellationToken);
+                    var count = await stuckGrain.GetNonBlockingCallCounter(cancellationToken);
                     return count == 3;
                 },
                 TimeSpan.FromSeconds(10),

--- a/test/Orleans.Runtime.Internal.Tests/OrleansRuntime/StuckGrainTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/OrleansRuntime/StuckGrainTests.cs
@@ -117,9 +117,14 @@ namespace UnitTests.StuckGrainTests
             }
 
             await TestingUtils.WaitUntilAsync(
-                async cancellationToken =>
+                async (lastTry, cancellationToken) =>
                 {
                     var count = await stuckGrain.GetNonBlockingCallCounter(cancellationToken);
+                    if (lastTry)
+                    {
+                        Assert.Equal(3, count);
+                    }
+
                     return count == 3;
                 },
                 TimeSpan.FromSeconds(10),

--- a/test/Orleans.Runtime.Internal.Tests/OrleansRuntime/StuckGrainTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/OrleansRuntime/StuckGrainTests.cs
@@ -117,9 +117,9 @@ namespace UnitTests.StuckGrainTests
             }
 
             await TestingUtils.WaitUntilAsync(
-                async (CancellationToken _) =>
+                async cancellationToken =>
                 {
-                    var count = await stuckGrain.GetNonBlockingCallCounter();
+                    var count = await stuckGrain.GetNonBlockingCallCounter().WaitAsync(cancellationToken);
                     return count == 3;
                 },
                 TimeSpan.FromSeconds(10),

--- a/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Configuration.Memory;
 using Orleans.Configuration;
 using Orleans.Runtime;
 using Orleans.TestingHost;
-using Orleans.TestingHost.Utils;
 using System.Runtime.InteropServices;
 using TestExtensions;
 using TestVersionGrainInterfaces;
@@ -244,21 +243,11 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
         private async Task WaitForActiveSilosAsync()
         {
             var expectedSiloCount = this.deployedSilos.Count;
-            var timeout = TestCluster.GetLivenessStabilizationTime(new ClusterMembershipOptions(), didKill: false);
-            await Task.Delay(RefreshInterval);
-            await TestingUtils.WaitUntilAsync(async (lastTry, cancellationToken) =>
-            {
-                var hosts = await ManagementGrain.GetHosts(false).WaitAsync(cancellationToken);
-                var activeSiloCount = hosts.Count(host => host.Value == SiloStatus.Active);
-                if (lastTry)
-                {
-                    Assert.Equal(expectedSiloCount, activeSiloCount);
-                }
+            await cluster.WaitForLivenessToStabilizeAsync();
+            await cluster.WaitForClusterManifestToStabilizeAsync();
 
-                return activeSiloCount == expectedSiloCount;
-            },
-            timeout,
-            RefreshInterval);
+            var hosts = await ManagementGrain.GetHosts(false);
+            Assert.Equal(expectedSiloCount, hosts.Count(host => host.Value == SiloStatus.Active));
         }
 
         public void Dispose()

--- a/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -245,15 +245,10 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
         {
             var expectedSiloCount = this.deployedSilos.Count;
             var timeout = TestCluster.GetLivenessStabilizationTime(new ClusterMembershipOptions(), didKill: false);
-            return TestingUtils.WaitUntilAsync(async assertIsTrue =>
+            return TestingUtils.WaitUntilAsync(async (CancellationToken _) =>
             {
                 var hosts = await ManagementGrain.GetHosts(false);
                 var activeSiloCount = hosts.Count(host => host.Value == SiloStatus.Active);
-                if (assertIsTrue)
-                {
-                    Assert.Equal(expectedSiloCount, activeSiloCount);
-                }
-
                 return activeSiloCount == expectedSiloCount;
             },
             timeout,

--- a/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -241,11 +241,12 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
             await WaitForActiveSilosAsync();
         }
 
-        private Task WaitForActiveSilosAsync()
+        private async Task WaitForActiveSilosAsync()
         {
             var expectedSiloCount = this.deployedSilos.Count;
             var timeout = TestCluster.GetLivenessStabilizationTime(new ClusterMembershipOptions(), didKill: false);
-            return TestingUtils.WaitUntilAsync(async (lastTry, cancellationToken) =>
+            await Task.Delay(RefreshInterval);
+            await TestingUtils.WaitUntilAsync(async (lastTry, cancellationToken) =>
             {
                 var hosts = await ManagementGrain.GetHosts(false).WaitAsync(cancellationToken);
                 var activeSiloCount = hosts.Count(host => host.Value == SiloStatus.Active);

--- a/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -235,7 +235,7 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
 
         protected async Task StopSilo(SiloHandle handle)
         {
-            await handle?.StopSiloAsync(true)!;
+            await cluster.StopSiloAsync(handle);
             this.deployedSilos.Remove(handle);
             await WaitForActiveSilosAsync();
         }

--- a/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -245,10 +245,15 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
         {
             var expectedSiloCount = this.deployedSilos.Count;
             var timeout = TestCluster.GetLivenessStabilizationTime(new ClusterMembershipOptions(), didKill: false);
-            return TestingUtils.WaitUntilAsync(async cancellationToken =>
+            return TestingUtils.WaitUntilAsync(async (lastTry, cancellationToken) =>
             {
                 var hosts = await ManagementGrain.GetHosts(false).WaitAsync(cancellationToken);
                 var activeSiloCount = hosts.Count(host => host.Value == SiloStatus.Active);
+                if (lastTry)
+                {
+                    Assert.Equal(expectedSiloCount, activeSiloCount);
+                }
+
                 return activeSiloCount == expectedSiloCount;
             },
             timeout,

--- a/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Orleans.Runtime.Tests/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -245,9 +245,9 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
         {
             var expectedSiloCount = this.deployedSilos.Count;
             var timeout = TestCluster.GetLivenessStabilizationTime(new ClusterMembershipOptions(), didKill: false);
-            return TestingUtils.WaitUntilAsync(async (CancellationToken _) =>
+            return TestingUtils.WaitUntilAsync(async cancellationToken =>
             {
-                var hosts = await ManagementGrain.GetHosts(false);
+                var hosts = await ManagementGrain.GetHosts(false).WaitAsync(cancellationToken);
                 var activeSiloCount = hosts.Count(host => host.Value == SiloStatus.Active);
                 return activeSiloCount == expectedSiloCount;
             },

--- a/test/Orleans.Streaming.Tests/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -92,7 +92,7 @@ namespace UnitTests.StreamingTests
                     Assert.True(controlCommandResult);
                 }
 
-                await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(generatorConfig, false, cancellationToken), Timeout);
+                await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(generatorConfig, lastTry, cancellationToken), Timeout);
             }
             finally
             {
@@ -126,7 +126,7 @@ namespace UnitTests.StreamingTests
         {
             var reporter = this.fixture.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
             await reporter.Reset();
-            await TestingUtils.WaitUntilAsync(cancellationToken => CheckReporterIsEmpty(reporter, streamNamespace, false, cancellationToken), Timeout);
+            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckReporterIsEmpty(reporter, streamNamespace, lastTry, cancellationToken), Timeout);
         }
 
         private static async Task<bool> CheckReporterIsEmpty(IGeneratedEventReporterGrain reporter, string streamNamespace, bool assertIsTrue, CancellationToken cancellationToken)

--- a/test/Orleans.Streaming.Tests/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -104,7 +104,7 @@ namespace UnitTests.StreamingTests
         {
             var reporter = this.fixture.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
 
-            var report = await reporter.GetReport(GeneratedStreamTestConstants.StreamProviderName, generatorConfig.StreamNamespace).WaitAsync(cancellationToken);
+            var report = await reporter.GetReport(GeneratedStreamTestConstants.StreamProviderName, generatorConfig.StreamNamespace, cancellationToken);
             if (assertIsTrue)
             {
                 // one stream per queue
@@ -131,7 +131,7 @@ namespace UnitTests.StreamingTests
 
         private static async Task<bool> CheckReporterIsEmpty(IGeneratedEventReporterGrain reporter, string streamNamespace, bool assertIsTrue, CancellationToken cancellationToken)
         {
-            var report = await reporter.GetReport(GeneratedStreamTestConstants.StreamProviderName, streamNamespace).WaitAsync(cancellationToken);
+            var report = await reporter.GetReport(GeneratedStreamTestConstants.StreamProviderName, streamNamespace, cancellationToken);
             if (assertIsTrue)
             {
                 Assert.Empty(report);

--- a/test/Orleans.Streaming.Tests/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -92,7 +92,7 @@ namespace UnitTests.StreamingTests
                     Assert.True(controlCommandResult);
                 }
 
-                await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(generatorConfig, false), Timeout);
+                await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(generatorConfig, false, cancellationToken), Timeout);
             }
             finally
             {
@@ -100,11 +100,11 @@ namespace UnitTests.StreamingTests
             }
         }
 
-        private async Task<bool> CheckCounters(SimpleGeneratorOptions generatorConfig, bool assertIsTrue)
+        private async Task<bool> CheckCounters(SimpleGeneratorOptions generatorConfig, bool assertIsTrue, CancellationToken cancellationToken)
         {
             var reporter = this.fixture.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
 
-            var report = await reporter.GetReport(GeneratedStreamTestConstants.StreamProviderName, generatorConfig.StreamNamespace);
+            var report = await reporter.GetReport(GeneratedStreamTestConstants.StreamProviderName, generatorConfig.StreamNamespace).WaitAsync(cancellationToken);
             if (assertIsTrue)
             {
                 // one stream per queue
@@ -126,12 +126,12 @@ namespace UnitTests.StreamingTests
         {
             var reporter = this.fixture.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
             await reporter.Reset();
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckReporterIsEmpty(reporter, streamNamespace, false), Timeout);
+            await TestingUtils.WaitUntilAsync(cancellationToken => CheckReporterIsEmpty(reporter, streamNamespace, false, cancellationToken), Timeout);
         }
 
-        private static async Task<bool> CheckReporterIsEmpty(IGeneratedEventReporterGrain reporter, string streamNamespace, bool assertIsTrue)
+        private static async Task<bool> CheckReporterIsEmpty(IGeneratedEventReporterGrain reporter, string streamNamespace, bool assertIsTrue, CancellationToken cancellationToken)
         {
-            var report = await reporter.GetReport(GeneratedStreamTestConstants.StreamProviderName, streamNamespace);
+            var report = await reporter.GetReport(GeneratedStreamTestConstants.StreamProviderName, streamNamespace).WaitAsync(cancellationToken);
             if (assertIsTrue)
             {
                 Assert.Empty(report);

--- a/test/Orleans.Streaming.Tests/StreamingTests/ControllableStreamGeneratorProviderTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ControllableStreamGeneratorProviderTests.cs
@@ -92,7 +92,7 @@ namespace UnitTests.StreamingTests
                     Assert.True(controlCommandResult);
                 }
 
-                await TestingUtils.WaitUntilAsync(assertIsTrue => CheckCounters(generatorConfig, assertIsTrue), Timeout);
+                await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(generatorConfig, false), Timeout);
             }
             finally
             {
@@ -126,7 +126,7 @@ namespace UnitTests.StreamingTests
         {
             var reporter = this.fixture.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
             await reporter.Reset();
-            await TestingUtils.WaitUntilAsync(assertIsTrue => CheckReporterIsEmpty(reporter, streamNamespace, assertIsTrue), Timeout);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckReporterIsEmpty(reporter, streamNamespace, false), Timeout);
         }
 
         private static async Task<bool> CheckReporterIsEmpty(IGeneratedEventReporterGrain reporter, string streamNamespace, bool assertIsTrue)

--- a/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscriptionKeyTypeGrainTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscriptionKeyTypeGrainTests.cs
@@ -68,7 +68,7 @@ namespace UnitTests.StreamingTests
 
         private async Task<bool> CheckValue(IImplicitSubscriptionKeyTypeGrain consumer, int expectedValue, bool assertIsTrue, CancellationToken cancellationToken)
         {
-            int value = await consumer.GetValue().WaitAsync(cancellationToken);
+            int value = await consumer.GetValue(cancellationToken);
 
             if (assertIsTrue)
             {

--- a/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscriptionKeyTypeGrainTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscriptionKeyTypeGrainTests.cs
@@ -63,7 +63,7 @@ namespace UnitTests.StreamingTests
             await stream.OnNextAsync(value);
 
             var consumer = fixture.GrainFactory.GetGrain<IImplicitSubscriptionLongKeyGrain>(grainId);
-            await TestingUtils.WaitUntilAsync(lastTry => CheckValue(consumer, value, lastTry), TimeSpan.FromSeconds(30));
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckValue(consumer, value, false), TimeSpan.FromSeconds(30));
         }
 
         private async Task<bool> CheckValue(IImplicitSubscriptionKeyTypeGrain consumer, int expectedValue, bool assertIsTrue)

--- a/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscriptionKeyTypeGrainTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscriptionKeyTypeGrainTests.cs
@@ -63,7 +63,7 @@ namespace UnitTests.StreamingTests
             await stream.OnNextAsync(value);
 
             var consumer = fixture.GrainFactory.GetGrain<IImplicitSubscriptionLongKeyGrain>(grainId);
-            await TestingUtils.WaitUntilAsync(cancellationToken => CheckValue(consumer, value, false, cancellationToken), TimeSpan.FromSeconds(30));
+            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckValue(consumer, value, lastTry, cancellationToken), TimeSpan.FromSeconds(30));
         }
 
         private async Task<bool> CheckValue(IImplicitSubscriptionKeyTypeGrain consumer, int expectedValue, bool assertIsTrue, CancellationToken cancellationToken)

--- a/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscriptionKeyTypeGrainTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscriptionKeyTypeGrainTests.cs
@@ -63,12 +63,12 @@ namespace UnitTests.StreamingTests
             await stream.OnNextAsync(value);
 
             var consumer = fixture.GrainFactory.GetGrain<IImplicitSubscriptionLongKeyGrain>(grainId);
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckValue(consumer, value, false), TimeSpan.FromSeconds(30));
+            await TestingUtils.WaitUntilAsync(cancellationToken => CheckValue(consumer, value, false, cancellationToken), TimeSpan.FromSeconds(30));
         }
 
-        private async Task<bool> CheckValue(IImplicitSubscriptionKeyTypeGrain consumer, int expectedValue, bool assertIsTrue)
+        private async Task<bool> CheckValue(IImplicitSubscriptionKeyTypeGrain consumer, int expectedValue, bool assertIsTrue, CancellationToken cancellationToken)
         {
-            int value = await consumer.GetValue();
+            int value = await consumer.GetValue().WaitAsync(cancellationToken);
 
             if (assertIsTrue)
             {

--- a/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
@@ -21,7 +21,7 @@ namespace Tester.StreamingTests
             try
             {
                 await generateFn(streamNamespace, streamCount, eventsInStream);
-                await TestingUtils.WaitUntilAsync((CancellationToken _) => this.CheckCounters(streamNamespace, streamCount, eventsInStream, false), TimeSpan.FromSeconds(30));
+                await TestingUtils.WaitUntilAsync(cancellationToken => this.CheckCounters(streamNamespace, streamCount, eventsInStream, false, cancellationToken), TimeSpan.FromSeconds(30));
             }
             finally
             {
@@ -36,7 +36,7 @@ namespace Tester.StreamingTests
             {
                 await generateFn(streamNamespace, streamCount, eventsInStream);
                 // should eventually skip the faulted event, so event count should be one (faulted event) less that number of events in stream.
-                await TestingUtils.WaitUntilAsync((CancellationToken _) => this.CheckCounters(streamNamespace, streamCount, eventsInStream - 1, false), TimeSpan.FromSeconds(90));
+                await TestingUtils.WaitUntilAsync(cancellationToken => this.CheckCounters(streamNamespace, streamCount, eventsInStream - 1, false, cancellationToken), TimeSpan.FromSeconds(90));
             }
             finally
             {
@@ -45,11 +45,11 @@ namespace Tester.StreamingTests
             }
         }
 
-        private async Task<bool> CheckCounters(string streamNamespace, int streamCount, int eventsInStream, bool assertIsTrue)
+        private async Task<bool> CheckCounters(string streamNamespace, int streamCount, int eventsInStream, bool assertIsTrue, CancellationToken cancellationToken)
         {
             var reporter = grainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
 
-            var report = await reporter.GetReport(streamProviderName, streamNamespace);
+            var report = await reporter.GetReport(streamProviderName, streamNamespace).WaitAsync(cancellationToken);
             if (assertIsTrue)
             {
                 // one stream per queue

--- a/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
@@ -21,7 +21,7 @@ namespace Tester.StreamingTests
             try
             {
                 await generateFn(streamNamespace, streamCount, eventsInStream);
-                await TestingUtils.WaitUntilAsync(assertIsTrue => this.CheckCounters(streamNamespace, streamCount, eventsInStream, assertIsTrue), TimeSpan.FromSeconds(30));
+                await TestingUtils.WaitUntilAsync((CancellationToken _) => this.CheckCounters(streamNamespace, streamCount, eventsInStream, false), TimeSpan.FromSeconds(30));
             }
             finally
             {
@@ -36,7 +36,7 @@ namespace Tester.StreamingTests
             {
                 await generateFn(streamNamespace, streamCount, eventsInStream);
                 // should eventually skip the faulted event, so event count should be one (faulted event) less that number of events in stream.
-                await TestingUtils.WaitUntilAsync(assertIsTrue => this.CheckCounters(streamNamespace, streamCount, eventsInStream - 1, assertIsTrue), TimeSpan.FromSeconds(90));
+                await TestingUtils.WaitUntilAsync((CancellationToken _) => this.CheckCounters(streamNamespace, streamCount, eventsInStream - 1, false), TimeSpan.FromSeconds(90));
             }
             finally
             {

--- a/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
@@ -21,7 +21,7 @@ namespace Tester.StreamingTests
             try
             {
                 await generateFn(streamNamespace, streamCount, eventsInStream);
-                await TestingUtils.WaitUntilAsync(cancellationToken => this.CheckCounters(streamNamespace, streamCount, eventsInStream, false, cancellationToken), TimeSpan.FromSeconds(30));
+                await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => this.CheckCounters(streamNamespace, streamCount, eventsInStream, lastTry, cancellationToken), TimeSpan.FromSeconds(30));
             }
             finally
             {
@@ -36,7 +36,7 @@ namespace Tester.StreamingTests
             {
                 await generateFn(streamNamespace, streamCount, eventsInStream);
                 // should eventually skip the faulted event, so event count should be one (faulted event) less that number of events in stream.
-                await TestingUtils.WaitUntilAsync(cancellationToken => this.CheckCounters(streamNamespace, streamCount, eventsInStream - 1, false, cancellationToken), TimeSpan.FromSeconds(90));
+                await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => this.CheckCounters(streamNamespace, streamCount, eventsInStream - 1, lastTry, cancellationToken), TimeSpan.FromSeconds(90));
             }
             finally
             {

--- a/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/ImplicitSubscritionRecoverableStreamTestRunner.cs
@@ -49,7 +49,7 @@ namespace Tester.StreamingTests
         {
             var reporter = grainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
 
-            var report = await reporter.GetReport(streamProviderName, streamNamespace).WaitAsync(cancellationToken);
+            var report = await reporter.GetReport(streamProviderName, streamNamespace, cancellationToken);
             if (assertIsTrue)
             {
                 // one stream per queue

--- a/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/LeaseManagerGrain.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/LeaseManagerGrain.cs
@@ -14,7 +14,7 @@ namespace Tester.StreamingTests
         Task SetQueuesAsLeases(IEnumerable<QueueId> queues);
         //methods used in test asserts
         Task RecordBalancerResponsibility(string balancerId, int ownedQueues);
-        Task<Dictionary<string, int>> GetResponsibilityMap();
+        Task<Dictionary<string, int>> GetResponsibilityMap(CancellationToken cancellationToken = default);
 
     }
 
@@ -90,8 +90,9 @@ namespace Tester.StreamingTests
             return Task.CompletedTask;
         }
 
-        public Task<Dictionary<string, int>> GetResponsibilityMap()
+        public Task<Dictionary<string, int>> GetResponsibilityMap(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(responsibilityMap);
         }
     }

--- a/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
@@ -15,7 +15,7 @@ namespace Tester.StreamingTests
         {
             var leaseManager = fixture.GrainFactory.GetGrain<ILeaseManagerGrain>(streamProviderName);
             var expectedResponsibilityPerBalancer = totalQueueCount / siloCount;
-            await TestingUtils.WaitUntilAsync(cancellationToken => CheckLeases(leaseManager, siloCount, expectedResponsibilityPerBalancer, false, cancellationToken), Timeout);
+            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckLeases(leaseManager, siloCount, expectedResponsibilityPerBalancer, lastTry, cancellationToken), Timeout);
         }
 
         public class SiloBuilderConfigurator : ISiloConfigurator
@@ -32,7 +32,7 @@ namespace Tester.StreamingTests
             if(lastTry)
             {
                 //there should be one StreamQueueBalancer per silo
-                Assert.Equal(responsibilityMap.Count, siloCount);
+                Assert.Equal(siloCount, responsibilityMap.Count);
                 foreach (int responsibility in responsibilityMap.Values)
                 {
                     Assert.Equal(expectedResponsibilityPerBalancer, responsibility);

--- a/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
@@ -15,7 +15,7 @@ namespace Tester.StreamingTests
         {
             var leaseManager = fixture.GrainFactory.GetGrain<ILeaseManagerGrain>(streamProviderName);
             var expectedResponsibilityPerBalancer = totalQueueCount / siloCount;
-            await TestingUtils.WaitUntilAsync(lastTry => CheckLeases(leaseManager, siloCount, expectedResponsibilityPerBalancer, lastTry), Timeout);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckLeases(leaseManager, siloCount, expectedResponsibilityPerBalancer, false), Timeout);
         }
 
         public class SiloBuilderConfigurator : ISiloConfigurator

--- a/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
@@ -15,7 +15,7 @@ namespace Tester.StreamingTests
         {
             var leaseManager = fixture.GrainFactory.GetGrain<ILeaseManagerGrain>(streamProviderName);
             var expectedResponsibilityPerBalancer = totalQueueCount / siloCount;
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckLeases(leaseManager, siloCount, expectedResponsibilityPerBalancer, false), Timeout);
+            await TestingUtils.WaitUntilAsync(cancellationToken => CheckLeases(leaseManager, siloCount, expectedResponsibilityPerBalancer, false, cancellationToken), Timeout);
         }
 
         public class SiloBuilderConfigurator : ISiloConfigurator
@@ -26,9 +26,9 @@ namespace Tester.StreamingTests
             }
         }
 
-        private async Task<bool> CheckLeases(ILeaseManagerGrain leaseManager, int siloCount, int expectedResponsibilityPerBalancer, bool lastTry)
+        private async Task<bool> CheckLeases(ILeaseManagerGrain leaseManager, int siloCount, int expectedResponsibilityPerBalancer, bool lastTry, CancellationToken cancellationToken)
         {
-            Dictionary<string,int> responsibilityMap = await leaseManager.GetResponsibilityMap();
+            Dictionary<string,int> responsibilityMap = await leaseManager.GetResponsibilityMap().WaitAsync(cancellationToken);
             if(lastTry)
             {
                 //there should be one StreamQueueBalancer per silo

--- a/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
@@ -28,7 +28,7 @@ namespace Tester.StreamingTests
 
         private async Task<bool> CheckLeases(ILeaseManagerGrain leaseManager, int siloCount, int expectedResponsibilityPerBalancer, bool lastTry, CancellationToken cancellationToken)
         {
-            Dictionary<string,int> responsibilityMap = await leaseManager.GetResponsibilityMap().WaitAsync(cancellationToken);
+            Dictionary<string,int> responsibilityMap = await leaseManager.GetResponsibilityMap(cancellationToken);
             if(lastTry)
             {
                 //there should be one StreamQueueBalancer per silo

--- a/test/Orleans.Streaming.Tests/StreamingTests/SampleStreamingTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SampleStreamingTests.cs
@@ -56,7 +56,7 @@ namespace UnitTests.StreamingTests
 
             await producer.StopPeriodicProducing();
 
-            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(producer, consumer, false, cancellationToken), _timeout);
+            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(producer, consumer, lastTry, cancellationToken), _timeout);
 
             await consumer.StopConsuming();
         }
@@ -84,7 +84,7 @@ namespace UnitTests.StreamingTests
             await producer.StopPeriodicProducing();
             //int numProduced = await producer.NumberProduced;
 
-            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(producer, consumer, false, cancellationToken), _timeout);
+            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(producer, consumer, lastTry, cancellationToken), _timeout);
 
             await consumer.StopConsuming();
         }
@@ -112,7 +112,7 @@ namespace UnitTests.StreamingTests
             await producer.StopPeriodicProducing();
             //int numProduced = await producer.NumberProduced;
 
-            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(producer, consumer, false, cancellationToken), _timeout);
+            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(producer, consumer, lastTry, cancellationToken), _timeout);
 
             await consumer.StopConsuming();
         }

--- a/test/Orleans.Streaming.Tests/StreamingTests/SampleStreamingTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SampleStreamingTests.cs
@@ -126,8 +126,8 @@ namespace UnitTests.StreamingTests
         /// </summary>
         private async Task<bool> CheckCounters(ISampleStreaming_ProducerGrain producer, ISampleStreaming_ConsumerGrain consumer, bool assertIsTrue, CancellationToken cancellationToken)
         {
-            var numProduced = await producer.GetNumberProduced().WaitAsync(cancellationToken);
-            var numConsumed = await consumer.GetNumberConsumed().WaitAsync(cancellationToken);
+            var numProduced = await producer.GetNumberProduced(cancellationToken);
+            var numConsumed = await consumer.GetNumberConsumed(cancellationToken);
             this.logger.LogInformation("CheckCounters: numProduced = {ProducedCount}, numConsumed = {ConsumedCount}", numProduced, numConsumed);
             if (assertIsTrue)
             {

--- a/test/Orleans.Streaming.Tests/StreamingTests/SampleStreamingTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SampleStreamingTests.cs
@@ -56,7 +56,7 @@ namespace UnitTests.StreamingTests
 
             await producer.StopPeriodicProducing();
 
-            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, lastTry), _timeout);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(producer, consumer, false), _timeout);
 
             await consumer.StopConsuming();
         }
@@ -84,7 +84,7 @@ namespace UnitTests.StreamingTests
             await producer.StopPeriodicProducing();
             //int numProduced = await producer.NumberProduced;
 
-            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, lastTry), _timeout);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(producer, consumer, false), _timeout);
 
             await consumer.StopConsuming();
         }
@@ -112,7 +112,7 @@ namespace UnitTests.StreamingTests
             await producer.StopPeriodicProducing();
             //int numProduced = await producer.NumberProduced;
 
-            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(producer, consumer, lastTry), _timeout);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(producer, consumer, false), _timeout);
 
             await consumer.StopConsuming();
         }

--- a/test/Orleans.Streaming.Tests/StreamingTests/SampleStreamingTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SampleStreamingTests.cs
@@ -56,7 +56,7 @@ namespace UnitTests.StreamingTests
 
             await producer.StopPeriodicProducing();
 
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(producer, consumer, false), _timeout);
+            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(producer, consumer, false, cancellationToken), _timeout);
 
             await consumer.StopConsuming();
         }
@@ -84,7 +84,7 @@ namespace UnitTests.StreamingTests
             await producer.StopPeriodicProducing();
             //int numProduced = await producer.NumberProduced;
 
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(producer, consumer, false), _timeout);
+            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(producer, consumer, false, cancellationToken), _timeout);
 
             await consumer.StopConsuming();
         }
@@ -112,7 +112,7 @@ namespace UnitTests.StreamingTests
             await producer.StopPeriodicProducing();
             //int numProduced = await producer.NumberProduced;
 
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(producer, consumer, false), _timeout);
+            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(producer, consumer, false, cancellationToken), _timeout);
 
             await consumer.StopConsuming();
         }
@@ -124,10 +124,10 @@ namespace UnitTests.StreamingTests
         /// - No duplicate deliveries occurred
         /// - Producer and consumer are properly synchronized
         /// </summary>
-        private async Task<bool> CheckCounters(ISampleStreaming_ProducerGrain producer, ISampleStreaming_ConsumerGrain consumer, bool assertIsTrue)
+        private async Task<bool> CheckCounters(ISampleStreaming_ProducerGrain producer, ISampleStreaming_ConsumerGrain consumer, bool assertIsTrue, CancellationToken cancellationToken)
         {
-            var numProduced = await producer.GetNumberProduced();
-            var numConsumed = await consumer.GetNumberConsumed();
+            var numProduced = await producer.GetNumberProduced().WaitAsync(cancellationToken);
+            var numConsumed = await consumer.GetNumberConsumed().WaitAsync(cancellationToken);
             this.logger.LogInformation("CheckCounters: numProduced = {ProducedCount}, numConsumed = {ConsumedCount}", numProduced, numConsumed);
             if (assertIsTrue)
             {

--- a/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
@@ -303,8 +303,8 @@ public class SingleStreamTestRunner
         await consumer.DeactivateOnIdle();
         await producer.DeactivateOnIdle();
 
-        await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckGrainsDeactivated(null, consumer, false), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
-        await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckGrainsDeactivated(producer, null, false), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
+        await TestingUtils.WaitUntilAsync(cancellationToken => CheckGrainsDeactivated(null, consumer, false, cancellationToken), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
+        await TestingUtils.WaitUntilAsync(cancellationToken => CheckGrainsDeactivated(producer, null, false, cancellationToken), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
 
         logger.LogInformation("\n\n\n*******************************************************************\n\n\n");
 
@@ -521,19 +521,19 @@ public class SingleStreamTestRunner
         return rendez.Validate();
     }
 
-    private async Task<bool> CheckGrainsDeactivated(ProducerProxy? producer, ConsumerProxy? consumer, bool assertAreEqual = true)
+    private async Task<bool> CheckGrainsDeactivated(ProducerProxy? producer, ConsumerProxy? consumer, bool assertAreEqual, CancellationToken cancellationToken)
     {
         var activationCount = 0;
         string str = "";
         if (producer != null)
         {
             str = "Producer";
-            activationCount = await producer.GetNumActivations(this.client);
+            activationCount = await producer.GetNumActivations(this.client).WaitAsync(cancellationToken);
         }
         else if (consumer != null)
         {
             str = "Consumer";
-            activationCount = await consumer.GetNumActivations(this.client);
+            activationCount = await consumer.GetNumActivations(this.client).WaitAsync(cancellationToken);
         }
         var expectActivationCount = 0;
         logger.LogInformation(

--- a/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
@@ -303,8 +303,8 @@ public class SingleStreamTestRunner
         await consumer.DeactivateOnIdle();
         await producer.DeactivateOnIdle();
 
-        await TestingUtils.WaitUntilAsync(cancellationToken => CheckGrainsDeactivated(null, consumer, false, cancellationToken), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
-        await TestingUtils.WaitUntilAsync(cancellationToken => CheckGrainsDeactivated(producer, null, false, cancellationToken), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
+        await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckGrainsDeactivated(null, consumer, lastTry, cancellationToken), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
+        await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckGrainsDeactivated(producer, null, lastTry, cancellationToken), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
 
         logger.LogInformation("\n\n\n*******************************************************************\n\n\n");
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
@@ -528,12 +528,12 @@ public class SingleStreamTestRunner
         if (producer != null)
         {
             str = "Producer";
-            activationCount = await producer.GetNumActivations(this.client).WaitAsync(cancellationToken);
+            activationCount = await producer.GetNumActivations(this.client, cancellationToken);
         }
         else if (consumer != null)
         {
             str = "Consumer";
-            activationCount = await consumer.GetNumActivations(this.client).WaitAsync(cancellationToken);
+            activationCount = await consumer.GetNumActivations(this.client, cancellationToken);
         }
         var expectActivationCount = 0;
         logger.LogInformation(

--- a/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SingleStreamTestRunner.cs
@@ -303,8 +303,8 @@ public class SingleStreamTestRunner
         await consumer.DeactivateOnIdle();
         await producer.DeactivateOnIdle();
 
-        await TestingUtils.WaitUntilAsync(lastTry => CheckGrainsDeactivated(null, consumer, false), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
-        await TestingUtils.WaitUntilAsync(lastTry => CheckGrainsDeactivated(producer, null, false), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
+        await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckGrainsDeactivated(null, consumer, false), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
+        await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckGrainsDeactivated(producer, null, false), _timeout, delayOnFail: TimeSpan.FromMilliseconds(100));
 
         logger.LogInformation("\n\n\n*******************************************************************\n\n\n");
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamGeneratorProviderTests.cs
@@ -71,14 +71,14 @@ namespace UnitTests.StreamingTests
         public async Task ValidateGeneratedStreamsTest()
         {
             this.fixture.Logger.LogInformation("************************ ValidateGeneratedStreamsTest *********************************");
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(false), Timeout);
+            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(false, cancellationToken), Timeout);
         }
 
-        private async Task<bool> CheckCounters(bool assertIsTrue)
+        private async Task<bool> CheckCounters(bool assertIsTrue, CancellationToken cancellationToken)
         {
             var reporter = this.fixture.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
 
-            var report = await reporter.GetReport(Fixture.StreamProviderName, Fixture.StreamNamespace);
+            var report = await reporter.GetReport(Fixture.StreamProviderName, Fixture.StreamNamespace).WaitAsync(cancellationToken);
             if (assertIsTrue)
             {
                 // one stream per queue

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamGeneratorProviderTests.cs
@@ -71,7 +71,7 @@ namespace UnitTests.StreamingTests
         public async Task ValidateGeneratedStreamsTest()
         {
             this.fixture.Logger.LogInformation("************************ ValidateGeneratedStreamsTest *********************************");
-            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(false, cancellationToken), Timeout);
+            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(lastTry, cancellationToken), Timeout);
         }
 
         private async Task<bool> CheckCounters(bool assertIsTrue, CancellationToken cancellationToken)

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamGeneratorProviderTests.cs
@@ -71,7 +71,7 @@ namespace UnitTests.StreamingTests
         public async Task ValidateGeneratedStreamsTest()
         {
             this.fixture.Logger.LogInformation("************************ ValidateGeneratedStreamsTest *********************************");
-            await TestingUtils.WaitUntilAsync(CheckCounters, Timeout);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(false), Timeout);
         }
 
         private async Task<bool> CheckCounters(bool assertIsTrue)

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamGeneratorProviderTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamGeneratorProviderTests.cs
@@ -78,7 +78,7 @@ namespace UnitTests.StreamingTests
         {
             var reporter = this.fixture.GrainFactory.GetGrain<IGeneratedEventReporterGrain>(GeneratedStreamTestConstants.ReporterId);
 
-            var report = await reporter.GetReport(Fixture.StreamProviderName, Fixture.StreamNamespace).WaitAsync(cancellationToken);
+            var report = await reporter.GetReport(Fixture.StreamProviderName, Fixture.StreamNamespace, cancellationToken);
             if (assertIsTrue)
             {
                 // one stream per queue

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamTestHelperClasses.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamTestHelperClasses.cs
@@ -342,17 +342,17 @@ namespace UnitTests.StreamingTests
             await Task.WhenAll(tasks);
         }
 
-        public Task<int> GetNumActivations(IInternalGrainFactory grainFactory)
+        public Task<int> GetNumActivations(IInternalGrainFactory grainFactory, CancellationToken cancellationToken)
         {
-            return GetNumActivations(_targets.Distinct(), grainFactory);
-    }
+            return GetNumActivations(_targets.Distinct(), grainFactory, cancellationToken);
+        }
 
-        public static async Task<int> GetNumActivations(IEnumerable<IGrain> targets, IInternalGrainFactory grainFactory)
+        public static async Task<int> GetNumActivations(IEnumerable<IGrain> targets, IInternalGrainFactory grainFactory, CancellationToken cancellationToken)
         {
             var grainIds = targets.Distinct().Where(t => t is GrainReference).Select(t => ((GrainReference)t).GrainId).ToArray();
             IManagementGrain systemManagement = grainFactory.GetGrain<IManagementGrain>(0);
             var tasks = grainIds.Select(g => systemManagement.GetGrainActivationCount((GrainReference)grainFactory.GetGrain(g))).ToArray();
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(tasks).WaitAsync(cancellationToken);
             return tasks.Sum(t => t.Result);
         }
     }
@@ -568,9 +568,9 @@ namespace UnitTests.StreamingTests
             return Task.WhenAll(tasks);
         }
 
-        public Task<int> GetNumActivations(IInternalGrainFactory grainFactory)
+        public Task<int> GetNumActivations(IInternalGrainFactory grainFactory, CancellationToken cancellationToken)
         {
-            return ConsumerProxy.GetNumActivations(_targets.Distinct(), grainFactory);
+            return ConsumerProxy.GetNumActivations(_targets.Distinct(), grainFactory, cancellationToken);
         }
     }
 }

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
@@ -151,9 +151,14 @@ namespace Tester.StreamingTests
         private static Task WaitForEventCounterAsync(IImplicitSubscriptionCounterGrain grain, int expected)
         {
             return TestingUtils.WaitUntilAsync(
-                async cancellationToken =>
+                async (lastTry, cancellationToken) =>
                 {
                     var actual = await grain.GetEventCounter(cancellationToken);
+                    if (lastTry)
+                    {
+                        Assert.Equal(expected, actual);
+                    }
+
                     return actual == expected;
                 },
                 TimeSpan.FromSeconds(30),

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
@@ -151,9 +151,9 @@ namespace Tester.StreamingTests
         private static Task WaitForEventCounterAsync(IImplicitSubscriptionCounterGrain grain, int expected)
         {
             return TestingUtils.WaitUntilAsync(
-                async (CancellationToken _) =>
+                async cancellationToken =>
                 {
-                    var actual = await grain.GetEventCounter();
+                    var actual = await grain.GetEventCounter().WaitAsync(cancellationToken);
                     return actual == expected;
                 },
                 TimeSpan.FromSeconds(30),

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
@@ -153,7 +153,7 @@ namespace Tester.StreamingTests
             return TestingUtils.WaitUntilAsync(
                 async cancellationToken =>
                 {
-                    var actual = await grain.GetEventCounter().WaitAsync(cancellationToken);
+                    var actual = await grain.GetEventCounter(cancellationToken);
                     return actual == expected;
                 },
                 TimeSpan.FromSeconds(30),

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingCacheMissTests.cs
@@ -151,14 +151,9 @@ namespace Tester.StreamingTests
         private static Task WaitForEventCounterAsync(IImplicitSubscriptionCounterGrain grain, int expected)
         {
             return TestingUtils.WaitUntilAsync(
-                async lastTry =>
+                async (CancellationToken _) =>
                 {
                     var actual = await grain.GetEventCounter();
-                    if (lastTry)
-                    {
-                        Assert.Equal(expected, actual);
-                    }
-
                     return actual == expected;
                 },
                 TimeSpan.FromSeconds(30),

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -141,10 +141,10 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         var slowGrain = this.Client.GetGrain<ISlowImplicitSubscriptionCounterGrain>(key);
 
         await stream.OnNextAsync([1]);
-        await TestingUtils.WaitUntilAsync(cancellationToken => CheckFastCounter(1, false, cancellationToken), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
+        await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckFastCounter(1, lastTry, cancellationToken), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
 
         await stream.OnNextAsync([2]);
-        await TestingUtils.WaitUntilAsync(cancellationToken => CheckFastCounter(2, false, cancellationToken), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
+        await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckFastCounter(2, lastTry, cancellationToken), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
 
         async Task<bool> CheckFastCounter(int expected, bool lastTry, CancellationToken cancellationToken)
         {
@@ -161,9 +161,14 @@ public abstract class StreamingResumeTests : TestClusterPerTest
     private static Task WaitForEventCounterAsync(IImplicitSubscriptionCounterGrain grain, int expected)
     {
         return TestingUtils.WaitUntilAsync(
-            async cancellationToken =>
+            async (lastTry, cancellationToken) =>
             {
                 var actual = await grain.GetEventCounter(cancellationToken);
+                if (lastTry)
+                {
+                    Assert.Equal(expected, actual);
+                }
+
                 return actual == expected;
             },
             TimeSpan.FromSeconds(30),

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -148,7 +148,7 @@ public abstract class StreamingResumeTests : TestClusterPerTest
 
         async Task<bool> CheckFastCounter(int expected, bool lastTry, CancellationToken cancellationToken)
         {
-            var actual = await fastGrain.GetEventCounter().WaitAsync(cancellationToken);
+            var actual = await fastGrain.GetEventCounter(cancellationToken);
             if (lastTry)
             {
                 Assert.Equal(expected, actual);
@@ -163,7 +163,7 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         return TestingUtils.WaitUntilAsync(
             async cancellationToken =>
             {
-                var actual = await grain.GetEventCounter().WaitAsync(cancellationToken);
+                var actual = await grain.GetEventCounter(cancellationToken);
                 return actual == expected;
             },
             TimeSpan.FromSeconds(30),

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -141,14 +141,14 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         var slowGrain = this.Client.GetGrain<ISlowImplicitSubscriptionCounterGrain>(key);
 
         await stream.OnNextAsync([1]);
-        await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckFastCounter(1, false), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
+        await TestingUtils.WaitUntilAsync(cancellationToken => CheckFastCounter(1, false, cancellationToken), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
 
         await stream.OnNextAsync([2]);
-        await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckFastCounter(2, false), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
+        await TestingUtils.WaitUntilAsync(cancellationToken => CheckFastCounter(2, false, cancellationToken), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
 
-        async Task<bool> CheckFastCounter(int expected, bool lastTry)
+        async Task<bool> CheckFastCounter(int expected, bool lastTry, CancellationToken cancellationToken)
         {
-            var actual = await fastGrain.GetEventCounter();
+            var actual = await fastGrain.GetEventCounter().WaitAsync(cancellationToken);
             if (lastTry)
             {
                 Assert.Equal(expected, actual);
@@ -161,9 +161,9 @@ public abstract class StreamingResumeTests : TestClusterPerTest
     private static Task WaitForEventCounterAsync(IImplicitSubscriptionCounterGrain grain, int expected)
     {
         return TestingUtils.WaitUntilAsync(
-            async (CancellationToken _) =>
+            async cancellationToken =>
             {
-                var actual = await grain.GetEventCounter();
+                var actual = await grain.GetEventCounter().WaitAsync(cancellationToken);
                 return actual == expected;
             },
             TimeSpan.FromSeconds(30),

--- a/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/StreamingResumeTests.cs
@@ -141,10 +141,10 @@ public abstract class StreamingResumeTests : TestClusterPerTest
         var slowGrain = this.Client.GetGrain<ISlowImplicitSubscriptionCounterGrain>(key);
 
         await stream.OnNextAsync([1]);
-        await TestingUtils.WaitUntilAsync(lastTry => CheckFastCounter(1, lastTry), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
+        await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckFastCounter(1, false), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
 
         await stream.OnNextAsync([2]);
-        await TestingUtils.WaitUntilAsync(lastTry => CheckFastCounter(2, lastTry), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
+        await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckFastCounter(2, false), TimeSpan.FromSeconds(30), delayOnFail: PollInterval);
 
         async Task<bool> CheckFastCounter(int expected, bool lastTry)
         {
@@ -161,14 +161,9 @@ public abstract class StreamingResumeTests : TestClusterPerTest
     private static Task WaitForEventCounterAsync(IImplicitSubscriptionCounterGrain grain, int expected)
     {
         return TestingUtils.WaitUntilAsync(
-            async lastTry =>
+            async (CancellationToken _) =>
             {
                 var actual = await grain.GetEventCounter();
-                if (lastTry)
-                {
-                    Assert.Equal(expected, actual);
-                }
-
                 return actual == expected;
             },
             TimeSpan.FromSeconds(30),

--- a/test/Orleans.Streaming.Tests/StreamingTests/SystemTargetRouteTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SystemTargetRouteTests.cs
@@ -88,7 +88,7 @@ namespace Tester.StreamingTests
             int[] counts = await Task.WhenAll(Enumerable.Range(0, streamCount).Select(i => producers[i].GetNumberProduced()));
 
             // make sure all went well
-            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(counts.Sum(), false), Timeout);
+            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(counts.Sum(), false, cancellationToken), Timeout);
         }
 
         private Task OnNextAsync(int e, StreamSequenceToken? token)
@@ -97,8 +97,9 @@ namespace Tester.StreamingTests
             return Task.CompletedTask;
         }
 
-        private Task<bool> CheckCounters(int eventsProduced, bool assertIsTrue)
+        private Task<bool> CheckCounters(int eventsProduced, bool assertIsTrue, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             int numConsumed = this.eventsConsumed;
             if (!assertIsTrue) return Task.FromResult(eventsProduced == numConsumed);
             Assert.Equal(eventsProduced, numConsumed);

--- a/test/Orleans.Streaming.Tests/StreamingTests/SystemTargetRouteTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SystemTargetRouteTests.cs
@@ -88,7 +88,7 @@ namespace Tester.StreamingTests
             int[] counts = await Task.WhenAll(Enumerable.Range(0, streamCount).Select(i => producers[i].GetNumberProduced()));
 
             // make sure all went well
-            await TestingUtils.WaitUntilAsync(cancellationToken => CheckCounters(counts.Sum(), false, cancellationToken), Timeout);
+            await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckCounters(counts.Sum(), lastTry, cancellationToken), Timeout);
         }
 
         private Task OnNextAsync(int e, StreamSequenceToken? token)

--- a/test/Orleans.Streaming.Tests/StreamingTests/SystemTargetRouteTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/SystemTargetRouteTests.cs
@@ -88,7 +88,7 @@ namespace Tester.StreamingTests
             int[] counts = await Task.WhenAll(Enumerable.Range(0, streamCount).Select(i => producers[i].GetNumberProduced()));
 
             // make sure all went well
-            await TestingUtils.WaitUntilAsync(lastTry => CheckCounters(counts.Sum(), lastTry), Timeout);
+            await TestingUtils.WaitUntilAsync((CancellationToken _) => CheckCounters(counts.Sum(), false), Timeout);
         }
 
         private Task OnNextAsync(int e, StreamSequenceToken? token)

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
@@ -1,0 +1,121 @@
+using Orleans.TestingHost.Utils;
+using Xunit;
+
+namespace Orleans.TestingHost.Tests;
+
+public class TestingUtilsTests
+{
+    [Fact]
+    public async Task WaitUntilSucceededAsync_ReturnsImmediatelyOnSuccess()
+    {
+        var calls = 0;
+
+        var result = await TestingUtils.WaitUntilSucceededAsync(
+            _ =>
+            {
+                calls++;
+                return Task.FromResult(true);
+            },
+            TimeSpan.FromSeconds(1));
+
+        Assert.True(result);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task WaitUntilSucceededAsync_RetriesUntilSuccess()
+    {
+        var calls = 0;
+
+        var result = await TestingUtils.WaitUntilSucceededAsync(
+            _ => Task.FromResult(++calls == 3),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.Zero);
+
+        Assert.True(result);
+        Assert.Equal(3, calls);
+    }
+
+    [Fact]
+    public async Task WaitUntilSucceededAsync_TimesOutWhileWaitingToRetry()
+    {
+        var calls = 0;
+
+        var result = await TestingUtils.WaitUntilSucceededAsync(
+            _ =>
+            {
+                calls++;
+                return Task.FromResult(false);
+            },
+            TimeSpan.FromMilliseconds(50),
+            TimeSpan.FromSeconds(1));
+
+        Assert.False(result);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task WaitUntilSucceededAsync_LongPredicateCrossingDeadlineDoesNotSucceed()
+    {
+        var predicateSettled = false;
+
+        var result = await TestingUtils.WaitUntilSucceededAsync(
+            async _ =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                predicateSettled = true;
+                return true;
+            },
+            TimeSpan.FromMilliseconds(25));
+
+        Assert.False(result);
+        Assert.True(predicateSettled);
+    }
+
+    [Fact]
+    public async Task WaitUntilAsync_DoesNotMakeFinalPredicateCall()
+    {
+        var calls = 0;
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() => TestingUtils.WaitUntilAsync(
+            async _ =>
+            {
+                calls++;
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                return false;
+            },
+            TimeSpan.FromMilliseconds(25),
+            TimeSpan.FromSeconds(1)));
+
+        Assert.Equal(1, calls);
+        Assert.Contains(nameof(TestingUtilsTests), exception.Message);
+        Assert.Contains("not invoked again after the deadline", exception.Message);
+    }
+
+    [Fact]
+    public async Task WaitUntilSucceededAsync_PropagatesCancellation()
+    {
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => TestingUtils.WaitUntilSucceededAsync(
+            async token =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                return false;
+            },
+            TimeSpan.FromSeconds(10),
+            cancellationToken: cancellation.Token));
+    }
+
+    [Fact]
+    public async Task WaitUntilSucceededAsync_PropagatesPredicateException()
+    {
+        var exception = new InvalidOperationException("Expected failure");
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => TestingUtils.WaitUntilSucceededAsync(
+            _ => Task.FromException<bool>(exception),
+            TimeSpan.FromSeconds(1)));
+
+        Assert.Same(exception, actual);
+    }
+}

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
@@ -73,12 +73,12 @@ public class TestingUtilsTests
     }
 
     [Fact]
-    public async Task WaitUntilAsync_DoesNotMakeFinalPredicateCall()
+    public async Task WaitUntilAsync_LegacyOverloadDoesNotMakeFinalPredicateCall()
     {
         var calls = 0;
 
         var exception = await Assert.ThrowsAsync<TimeoutException>(() => TestingUtils.WaitUntilAsync(
-            async _ =>
+            async (bool _) =>
             {
                 calls++;
                 await Task.Delay(TimeSpan.FromMilliseconds(100));
@@ -90,6 +90,24 @@ public class TestingUtilsTests
         Assert.Equal(1, calls);
         Assert.Contains(nameof(TestingUtilsTests), exception.Message);
         Assert.Contains("not invoked again after the deadline", exception.Message);
+    }
+
+    [Fact]
+    public async Task WaitUntilAsync_PropagatesDeadlineCancellationAndReportsPredicateExpression()
+    {
+        var calls = 0;
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() => TestingUtils.WaitUntilAsync(
+            async cancellationToken =>
+            {
+                calls++;
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return false;
+            },
+            TimeSpan.FromMilliseconds(25)));
+
+        Assert.Equal(1, calls);
+        Assert.Contains("async cancellationToken =>", exception.Message);
     }
 
     [Fact]

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
@@ -6,6 +6,12 @@ namespace Orleans.TestingHost.Tests;
 public class TestingUtilsTests
 {
     [Fact]
+    public async Task WaitUntilAsync_UntypedSingleParameterLambdaBindsLegacyOverload()
+    {
+        await TestingUtils.WaitUntilAsync(_ => Task.FromResult(true), TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
     public async Task WaitUntilSucceededAsync_ReturnsImmediatelyOnSuccess()
     {
         var calls = 0;
@@ -121,7 +127,7 @@ public class TestingUtilsTests
         var calls = 0;
 
         var exception = await Assert.ThrowsAsync<TimeoutException>(() => TestingUtils.WaitUntilAsync(
-            async cancellationToken =>
+            async (_, cancellationToken) =>
             {
                 calls++;
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
@@ -130,7 +136,7 @@ public class TestingUtilsTests
             TimeSpan.FromMilliseconds(25)));
 
         Assert.Equal(1, calls);
-        Assert.Contains("async cancellationToken =>", exception.Message);
+        Assert.Contains("async (_, cancellationToken) =>", exception.Message);
     }
 
     [Fact]

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
@@ -73,7 +73,7 @@ public class TestingUtilsTests
     }
 
     [Fact]
-    public async Task WaitUntilAsync_LegacyOverloadDoesNotMakeFinalPredicateCall()
+    public async Task WaitUntilAsync_LegacyOverloadDoesNotInvokePredicateAfterDeadline()
     {
         var calls = 0;
 
@@ -93,6 +93,29 @@ public class TestingUtilsTests
     }
 
     [Fact]
+    public async Task WaitUntilAsync_LegacyOverloadInvokesFinalAttemptBeforeDeadline()
+    {
+        var calls = 0;
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => TestingUtils.WaitUntilAsync(
+            (bool lastTry) =>
+            {
+                calls++;
+                if (lastTry)
+                {
+                    throw new InvalidOperationException("Expected legacy detailed failure");
+                }
+
+                return Task.FromResult(false);
+            },
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromMilliseconds(200)));
+
+        Assert.Equal("Expected legacy detailed failure", exception.Message);
+        Assert.True(calls > 1);
+    }
+
+    [Fact]
     public async Task WaitUntilAsync_PropagatesDeadlineCancellationAndReportsPredicateExpression()
     {
         var calls = 0;
@@ -108,6 +131,29 @@ public class TestingUtilsTests
 
         Assert.Equal(1, calls);
         Assert.Contains("async cancellationToken =>", exception.Message);
+    }
+
+    [Fact]
+    public async Task WaitUntilAsync_InvokesFinalAttemptBeforeDeadline()
+    {
+        var calls = 0;
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => TestingUtils.WaitUntilAsync(
+            (lastTry, _) =>
+            {
+                calls++;
+                if (lastTry)
+                {
+                    throw new InvalidOperationException("Expected detailed failure");
+                }
+
+                return Task.FromResult(false);
+            },
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromMilliseconds(200)));
+
+        Assert.Equal("Expected detailed failure", exception.Message);
+        Assert.True(calls > 1);
     }
 
     [Fact]


### PR DESCRIPTION
Testing waits could complete after their deadline or continue mutating state after timeout, making failures nondeterministic and difficult to diagnose.

This change adds monotonic, cancellation-aware wait helpers and routes the legacy wait API through them without invoking predicates after the deadline. Active callers use a cancellation-aware `lastTry` overload: the linked deadline token reaches test grain calls directly, while a bounded final attempt runs before the deadline so existing expected/actual assertions still provide rich failure diagnostics. `WaitAsync` remains only around production management-grain APIs which do not expose cancellation parameters. Upgrade tests use TestingHost’s event-driven liveness and cluster-manifest convergence waits rather than timing-based stabilization. The API surface and focused cross-target tests are updated accordingly.