### PR TITLE
fix(transactions): harden Azure Table transactional state storage

### DIFF
--- a/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorage.cs
+++ b/src/Azure/Orleans.Transactions.AzureStorage/TransactionalState/AzureTableTransactionalStateStorage.cs
@@ -15,6 +15,12 @@ namespace Orleans.Transactions.AzureStorage
     public partial class AzureTableTransactionalStateStorage<TState> : ITransactionalStateStorage<TState>
         where TState : class, new()
     {
+        private const int MaxSnapshotLoadAttempts = 5;
+        private const string LowerBoundaryRowKey = "!";
+        private const string UpperBoundaryRowKey = "~";
+        private const string BoundaryVersionPropertyName = "SnapshotVersion";
+        private const int BoundaryRowCount = 2;
+
         private readonly TableClient table;
         private readonly string partition;
         private readonly JsonSerializerSettings jsonSettings;
@@ -22,6 +28,7 @@ namespace Orleans.Transactions.AzureStorage
 
         private KeyEntity key = null!;
         private List<KeyValuePair<long, StateEntity>> states = null!;
+        private bool _storeRequiresLoad;
 
         public AzureTableTransactionalStateStorage(TableClient table, string partition, JsonSerializerSettings JsonSettings, ILogger<AzureTableTransactionalStateStorage<TState>> logger)
         {
@@ -40,16 +47,14 @@ namespace Orleans.Transactions.AzureStorage
         {
             try
             {
-                var keyTask = ReadKey();
-                var statesTask = ReadStates();
-                key = await keyTask.ConfigureAwait(false);
-                states = await statesTask.ConfigureAwait(false);
+                (key, states) = await LoadSnapshot().ConfigureAwait(false);
 
                 if (string.IsNullOrEmpty(key.ETag.ToString()))
                 {
                     LogDebugLoadedV0Fresh(partition);
 
                     // first time load
+                    _storeRequiresLoad = false;
                     return new TransactionalStorageLoadResponse<TState>();
                 }
                 else
@@ -105,7 +110,9 @@ namespace Orleans.Transactions.AzureStorage
                     LogDebugLoadedPartitionKeyRows(partition, this.key.CommittedSequenceId, new(states));
 
                     TransactionalStateMetaData metadata = JsonConvert.DeserializeObject<TransactionalStateMetaData>(this.key.Metadata!, this.jsonSettings)!;
-                    return new TransactionalStorageLoadResponse<TState>(this.key.ETag.ToString(), committedState, this.key.CommittedSequenceId, metadata, PrepareRecordsToRecover);
+                    var result = new TransactionalStorageLoadResponse<TState>(this.key.ETag.ToString(), committedState, this.key.CommittedSequenceId, metadata, PrepareRecordsToRecover);
+                    _storeRequiresLoad = false;
+                    return result;
                 }
             }
             catch (Exception ex)
@@ -117,10 +124,35 @@ namespace Orleans.Transactions.AzureStorage
 
         public async Task<string> Store(string? expectedETag, TransactionalStateMetaData metadata, List<PendingTransactionState<TState>>? statesToPrepare, long? commitUpTo, long? abortAfter)
         {
+            if (_storeRequiresLoad)
+            {
+                throw new InvalidOperationException("Load must complete successfully before Store can be called again after a failed Store operation.");
+            }
+
             var keyETag = key.ETag.ToString();
             if ((!string.IsNullOrWhiteSpace(keyETag) || !string.IsNullOrWhiteSpace(expectedETag)) && keyETag != expectedETag)
             {
                 throw new ArgumentException(nameof(expectedETag), "Etag does not match");
+            }
+
+            try
+            {
+                return await StoreCore(metadata, statesToPrepare, commitUpTo, abortAfter).ConfigureAwait(false);
+            }
+            catch
+            {
+                _storeRequiresLoad = true;
+                throw;
+            }
+        }
+
+        private async Task<string> StoreCore(TransactionalStateMetaData metadata, List<PendingTransactionState<TState>>? statesToPrepare, long? commitUpTo, long? abortAfter)
+        {
+            if (string.IsNullOrEmpty(key.ETag.ToString()) && string.IsNullOrEmpty(key.Metadata))
+            {
+                // A split prepare can persist the fresh key before phase three publishes the incoming metadata.
+                // Until then, the key must represent the valid previous (empty) committed state.
+                key.Metadata = JsonConvert.SerializeObject(new TransactionalStateMetaData(), this.jsonSettings);
             }
 
             // assemble all storage operations into a single batch
@@ -138,7 +170,7 @@ namespace Orleans.Transactions.AzureStorage
                     key.ETag = batchOperation.KeyETag;
                     states.RemoveAt(states.Count - 1);
 
-                    LogTraceDeleteTransaction(partition, entity.RowKey, entity.TransactionId);
+                    LogTraceDeleteTransaction(partition, entity.RowKey);
                 }
             }
 
@@ -159,7 +191,7 @@ namespace Orleans.Transactions.AzureStorage
                             await batchOperation.Add(new TableTransactionAction(TableTransactionActionType.UpdateReplace, existing.Entity, existing.ETag)).ConfigureAwait(false);
                             key.ETag = batchOperation.KeyETag;
 
-                            LogTraceUpdateTransaction(partition, existing.RowKey, existing.TransactionId);
+                            LogTraceUpdateTransaction(partition, existing.RowKey);
                         }
                         else
                         {
@@ -168,7 +200,7 @@ namespace Orleans.Transactions.AzureStorage
                             key.ETag = batchOperation.KeyETag;
                             states.Insert(pos, new KeyValuePair<long, StateEntity>(s.SequenceId, entity));
 
-                            LogTraceInsertTransaction(partition, entity.RowKey, entity.TransactionId);
+                            LogTraceInsertTransaction(partition, entity.RowKey);
                         }
                     }
 
@@ -202,7 +234,7 @@ namespace Orleans.Transactions.AzureStorage
                     await batchOperation.Add(new TableTransactionAction(TableTransactionActionType.Delete, states[i].Value.Entity, states[i].Value.ETag)).ConfigureAwait(false);
                     key.ETag = batchOperation.KeyETag;
 
-                    LogTraceDeleteTransaction(partition, states[i].Value.RowKey, states[i].Value.TransactionId);
+                    LogTraceDeleteTransaction(partition, states[i].Value.RowKey);
                 }
                 states.RemoveRange(0, pos);
             }
@@ -233,33 +265,96 @@ namespace Orleans.Transactions.AzureStorage
             return false;
         }
 
-        private async Task<KeyEntity> ReadKey()
+        private async Task<(KeyEntity Key, List<KeyValuePair<long, StateEntity>> States)> LoadSnapshot()
         {
-            var queryResult = table.QueryAsync<KeyEntity>(AzureTableUtils.PointQuery(this.partition, KeyEntity.RK)).ConfigureAwait(false);
-            await foreach (var result in queryResult)
+            KeyEntity keyBefore = null!;
+            string? versionBefore = null;
+            string? versionAfter = null;
+            for (var attempt = 0; attempt < MaxSnapshotLoadAttempts; attempt++)
             {
-                return result;
+                (keyBefore, var loadedStates, var isPaginated, versionBefore, versionAfter) = await ReadSnapshot().ConfigureAwait(false);
+                if (!isPaginated)
+                {
+                    // A single Query Entities response is one strongly consistent storage operation.
+                    return (keyBefore, loadedStates);
+                }
+
+                if (versionBefore is null && versionAfter is null)
+                {
+                    // Legacy partitions do not have boundary rows. During rolling upgrades, older
+                    // writers also leave existing boundaries stale, so torn reads remain allowed
+                    // until every writer is upgraded to advance them.
+                    return (keyBefore, loadedStates);
+                }
+
+                if (versionBefore is not null
+                    && string.Equals(versionBefore, versionAfter, StringComparison.Ordinal))
+                {
+                    return (keyBefore, loadedStates);
+                }
             }
 
-            return new KeyEntity()
+            throw new InconsistentStateException(
+                "Could not load a consistent Azure Table transactional state snapshot.",
+                storedEtag: versionBefore ?? "null",
+                currentEtag: versionAfter ?? "null");
+        }
+
+        private async Task<(
+            KeyEntity Key,
+            List<KeyValuePair<long, StateEntity>> States,
+            bool IsPaginated,
+            string? LowerBoundaryVersion,
+            string? UpperBoundaryVersion)> ReadSnapshot()
+        {
+            var query = AzureTableUtils.RangeQuery(this.partition, LowerBoundaryRowKey, UpperBoundaryRowKey);
+            var key = CreateFreshKey();
+            var states = new List<KeyValuePair<long, StateEntity>>();
+            var pageCount = 0;
+            string? lowerBoundaryVersion = null;
+            string? upperBoundaryVersion = null;
+            await foreach (var page in table.QueryAsync<TableEntity>(query).AsPages().ConfigureAwait(false))
+            {
+                pageCount++;
+                foreach (var entity in page.Values)
+                {
+                    if (entity.RowKey == KeyEntity.RK)
+                    {
+                        key = new KeyEntity
+                        {
+                            PartitionKey = entity.PartitionKey,
+                            RowKey = entity.RowKey,
+                            Timestamp = entity.Timestamp,
+                            ETag = entity.ETag,
+                            CommittedSequenceId = entity.GetInt64(nameof(KeyEntity.CommittedSequenceId)).GetValueOrDefault(),
+                            Metadata = entity.GetString(nameof(KeyEntity.Metadata))
+                        };
+                    }
+                    else if (entity.RowKey.StartsWith(StateEntity.RK_PREFIX, StringComparison.Ordinal))
+                    {
+                        var state = new StateEntity(entity);
+                        states.Add(new KeyValuePair<long, StateEntity>(state.SequenceId, state));
+                    }
+                    else if (entity.RowKey == LowerBoundaryRowKey)
+                    {
+                        lowerBoundaryVersion = entity.GetString(BoundaryVersionPropertyName);
+                    }
+                    else if (entity.RowKey == UpperBoundaryRowKey)
+                    {
+                        upperBoundaryVersion = entity.GetString(BoundaryVersionPropertyName);
+                    }
+                }
+            }
+
+            return (key, states, pageCount > 1, lowerBoundaryVersion, upperBoundaryVersion);
+        }
+
+        private KeyEntity CreateFreshKey()
+            => new()
             {
                 PartitionKey = partition,
                 RowKey = KeyEntity.RK
             };
-        }
-
-        private async Task<List<KeyValuePair<long, StateEntity>>> ReadStates()
-        {
-            var query = AzureTableUtils.RangeQuery(this.partition, StateEntity.RK_MIN, StateEntity.RK_MAX);
-            var results = new List<KeyValuePair<long, StateEntity>>();
-            var queryResult = table.QueryAsync<TableEntity>(query).ConfigureAwait(false);
-            await foreach (var entity in queryResult)
-            {
-                var state = new StateEntity(entity);
-                results.Add(new KeyValuePair<long, StateEntity>(state.SequenceId, state));
-            };
-            return results;
-        }
 
         private class BatchOperation
         {
@@ -291,12 +386,18 @@ namespace Orleans.Transactions.AzureStorage
 
                 batchOperation.Add(operation);
 
-                if (batchOperation.Count == AzureTableConstants.MaxBatchSize - (BatchHasKey ? 0 : 1))
+                if (batchOperation.Count == AzureTableConstants.MaxBatchSize - BoundaryRowCount - (BatchHasKey ? 0 : 1))
                 {
                     // the key serves as a synchronizer, to prevent modification by multiple grains under edge conditions,
-                    // like duplicate activations or deployments.Every batch write needs to include the key,
-                    // even if the key values don't change.
+                    // like duplicate activations or deployments. The boundary rows fence paginated reads.
+                    await Flush().ConfigureAwait(false);
+                }
+            }
 
+            public async Task Flush()
+            {
+                if (batchOperation.Count > 0)
+                {
                     if (!BatchHasKey)
                     {
                         keyIndex = batchOperation.Count;
@@ -310,20 +411,20 @@ namespace Orleans.Transactions.AzureStorage
                         }
                     }
 
-                    await Flush().ConfigureAwait(false);
-                }
-            }
+                    var boundaryVersion = Guid.NewGuid().ToString("N");
+                    batchOperation.Add(new TableTransactionAction(
+                        TableTransactionActionType.UpsertReplace,
+                        CreateBoundaryEntity(key.PartitionKey, LowerBoundaryRowKey, boundaryVersion)));
+                    batchOperation.Add(new TableTransactionAction(
+                        TableTransactionActionType.UpsertReplace,
+                        CreateBoundaryEntity(key.PartitionKey, UpperBoundaryRowKey, boundaryVersion)));
 
-            public async Task Flush()
-            {
-                if (batchOperation.Count > 0)
-                {
                     try
                     {
                         var batchResponse = await table.SubmitTransactionAsync(batchOperation).ConfigureAwait(false);
                         if (batchResponse?.Value is { Count: > 0 } responses)
                         {
-                            if (BatchHasKey && responses.Count >= keyIndex && responses[keyIndex].Headers.ETag is { } etag)
+                            if (BatchHasKey && responses.Count > keyIndex && responses[keyIndex].Headers.ETag is { } etag)
                             {
                                 key.ETag = etag;
                             }
@@ -342,20 +443,50 @@ namespace Orleans.Transactions.AzureStorage
                     }
                     catch (Exception ex) when (IsStorageConflict(ex))
                     {
+                        var requestFailedException = GetStorageConflict(ex)!;
+                        var failedOperationIndex = requestFailedException is TableTransactionFailedException transactionFailedException
+                            ? transactionFailedException.FailedTransactionActionIndex
+                            : null;
+                        var actionIndex = failedOperationIndex is >= 0 && failedOperationIndex < batchOperation.Count
+                            ? failedOperationIndex
+                            : batchOperation.Count == 1 ? 0 : null;
+                        var action = actionIndex.HasValue ? batchOperation[actionIndex.Value] : null;
+                        var actionIndexText = actionIndex?.ToString() ?? "Unavailable";
+                        var actionType = action?.ActionType.ToString() ?? "Unavailable";
+                        var rowKey = action?.Entity.RowKey ?? "Unavailable";
+                        var errorCode = requestFailedException.ErrorCode ?? "Unavailable";
+                        var failedOperationIndexText = failedOperationIndex?.ToString() ?? "Unavailable";
+
                         if (logger.IsEnabled(LogLevel.Trace))
                         {
                             for (int i = 0; i < batchOperation.Count; i++)
                             {
-                                LogTraceBatchOpFailed(logger, batchOperation[i].Entity.PartitionKey, batchOperation[i].Entity.RowKey, i);
+                                LogTraceBatchOpFailed(
+                                    logger,
+                                    batchOperation[i].Entity.PartitionKey,
+                                    batchOperation[i].Entity.RowKey,
+                                    i,
+                                    batchOperation[i].ActionType,
+                                    requestFailedException.Status,
+                                    errorCode,
+                                    failedOperationIndexText);
                             }
                         }
 
-                        LogErrorTransactionalStateStoreFailed(logger, ex);
+                        LogErrorTransactionalStateStoreConflict(
+                            logger,
+                            key.PartitionKey,
+                            actionIndexText,
+                            actionType,
+                            rowKey,
+                            requestFailedException.Status,
+                            errorCode,
+                            failedOperationIndexText);
+
                         throw new InconsistentStateException(
-                            "Azure Table transactional state storage conflict.",
+                            $"Azure Table transactional state storage conflict. Partition={key.PartitionKey} ActionIndex={actionIndexText} ActionType={actionType} RowKey={rowKey} HttpStatus={requestFailedException.Status} ErrorCode={errorCode} FailedOperationIndex={failedOperationIndexText}",
                             "Unknown",
-                            key.ETag.ToString(),
-                            ex);
+                            key.ETag.ToString());
                     }
                     catch (Exception ex)
                     {
@@ -363,7 +494,15 @@ namespace Orleans.Transactions.AzureStorage
                         {
                             for (int i = 0; i < batchOperation.Count; i++)
                             {
-                                LogTraceBatchOpFailed(logger, batchOperation[i].Entity.PartitionKey, batchOperation[i].Entity.RowKey, i);
+                                LogTraceBatchOpFailed(
+                                    logger,
+                                    batchOperation[i].Entity.PartitionKey,
+                                    batchOperation[i].Entity.RowKey,
+                                    i,
+                                    batchOperation[i].ActionType,
+                                    ex is RequestFailedException requestFailedException ? requestFailedException.Status : 0,
+                                    ex is RequestFailedException { ErrorCode: { } errorCode } ? errorCode : "Unavailable",
+                                    "Unavailable");
                             }
                         }
 
@@ -373,20 +512,34 @@ namespace Orleans.Transactions.AzureStorage
                 }
             }
 
+            private static TableEntity CreateBoundaryEntity(string partitionKey, string rowKey, string version)
+                => new(partitionKey, rowKey)
+                {
+                    [BoundaryVersionPropertyName] = version
+                };
+
             private static bool IsStorageConflict(Exception? exception)
+                => GetStorageConflict(exception) is not null;
+
+            private static RequestFailedException? GetStorageConflict(Exception? exception)
             {
+                RequestFailedException? result = null;
                 while (exception is not null)
                 {
                     if (exception is RequestFailedException requestFailedException
                         && requestFailedException.Status is (int)HttpStatusCode.Conflict or (int)HttpStatusCode.PreconditionFailed)
                     {
-                        return true;
+                        result = requestFailedException;
+                        if (requestFailedException is TableTransactionFailedException)
+                        {
+                            break;
+                        }
                     }
 
                     exception = exception.InnerException;
                 }
 
-                return false;
+                return result;
             }
         }
 
@@ -421,21 +574,21 @@ namespace Orleans.Transactions.AzureStorage
 
         [LoggerMessage(
             Level = LogLevel.Trace,
-            Message = "{PartitionKey}.{RowKey} Delete {TransactionId}"
+            Message = "{PartitionKey}.{RowKey} Delete"
         )]
-        private partial void LogTraceDeleteTransaction(string partitionKey, string rowKey, string? transactionId);
+        private partial void LogTraceDeleteTransaction(string partitionKey, string rowKey);
 
         [LoggerMessage(
             Level = LogLevel.Trace,
-            Message = "{PartitionKey}.{RowKey} Update {TransactionId}"
+            Message = "{PartitionKey}.{RowKey} Update"
         )]
-        private partial void LogTraceUpdateTransaction(string partitionKey, string rowKey, string? transactionId);
+        private partial void LogTraceUpdateTransaction(string partitionKey, string rowKey);
 
         [LoggerMessage(
             Level = LogLevel.Trace,
-            Message = "{PartitionKey}.{RowKey} Insert {TransactionId}"
+            Message = "{PartitionKey}.{RowKey} Insert"
         )]
-        private partial void LogTraceInsertTransaction(string partitionKey, string rowKey, string? transactionId);
+        private partial void LogTraceInsertTransaction(string partitionKey, string rowKey);
 
         [LoggerMessage(
             Level = LogLevel.Trace,
@@ -463,9 +616,31 @@ namespace Orleans.Transactions.AzureStorage
 
         [LoggerMessage(
             Level = LogLevel.Trace,
-            Message = "{PartitionKey}.{RowKey} batch-op failed {BatchCount}"
+            Message = "{PartitionKey}.{RowKey} batch-op failed {BatchCount} ActionType={ActionType} HttpStatus={HttpStatus} ErrorCode={ErrorCode} FailedOperationIndex={FailedOperationIndex}"
         )]
-        private static partial void LogTraceBatchOpFailed(ILogger logger, string partitionKey, string rowKey, int batchCount);
+        private static partial void LogTraceBatchOpFailed(
+            ILogger logger,
+            string partitionKey,
+            string rowKey,
+            int batchCount,
+            TableTransactionActionType actionType,
+            int httpStatus,
+            string errorCode,
+            string failedOperationIndex);
+
+        [LoggerMessage(
+            Level = LogLevel.Error,
+            Message = "Azure Table transactional state storage conflict. Partition={PartitionKey} ActionIndex={ActionIndex} ActionType={ActionType} RowKey={RowKey} HttpStatus={HttpStatus} ErrorCode={ErrorCode} FailedOperationIndex={FailedOperationIndex}"
+        )]
+        private static partial void LogErrorTransactionalStateStoreConflict(
+            ILogger logger,
+            string partitionKey,
+            string actionIndex,
+            string actionType,
+            string rowKey,
+            int httpStatus,
+            string errorCode,
+            string failedOperationIndex);
 
         [LoggerMessage(
             Level = LogLevel.Error,

--- a/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
@@ -1,6 +1,10 @@
+using Azure;
+using Azure.Core;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+using Orleans.Storage;
 using Orleans.Transactions.Abstractions;
 using Orleans.Transactions.AzureStorage;
 using Orleans.Transactions.AzureStorage.Tests;
@@ -16,9 +20,11 @@ namespace Orleans.Transactions.Azure.Tests
     {
         public int State { get; set; }
 
+        public string? Payload { get; set; }
+
         public bool Equals(TestState? other)
         {
-            return other == null?false:this.State.Equals(other.State);
+            return other is not null && State.Equals(other.State) && Payload == other.Payload;
         }
     }
 
@@ -29,18 +35,163 @@ namespace Orleans.Transactions.Azure.Tests
     {
         private const string tableName = "StateStorageTests";
         private const string partition = "testpartition";
+        private readonly TestFixture _fixture;
+
         public AzureTransactionalStateStorageTests(TestFixture fixture, ITestOutputHelper testOutput)
             : base(() => StateStorageFactory(fixture), (seed) => new TestState() { State = seed }, fixture.GrainFactory, testOutput)
         {
+            _fixture = fixture;
         }
 
         private static async Task<ITransactionalStateStorage<TestState>> StateStorageFactory(TestFixture fixture)
         {
             var table = await InitTableAsync(NullLogger.Instance);
             var jsonSettings = TransactionalStateFactory.GetJsonSerializerSettings(fixture.HostedCluster.ServiceProvider);
-            var stateStorage = new AzureTableTransactionalStateStorage<TestState>(table, $"{partition}{DateTime.UtcNow.Ticks}", jsonSettings,
-                NullLoggerFactory.Instance.CreateLogger<AzureTableTransactionalStateStorage<TestState>>());
-            return stateStorage;
+            return CreateStorage(table, $"{partition}{DateTime.UtcNow.Ticks}", jsonSettings);
+        }
+
+        [Fact]
+        public async Task NoChangeStoreUsesStrictETag()
+        {
+            var (writer, staleWriter, writerLoad, staleLoad) = await CreateInitializedWriters();
+
+            var updatedETag = await writer.Store(writerLoad.ETag, writerLoad.Metadata, [], null, null);
+
+            Assert.NotEqual(writerLoad.ETag, updatedETag);
+            await Assert.ThrowsAsync<InconsistentStateException>(
+                () => staleWriter.Store(staleLoad.ETag, staleLoad.Metadata, [], null, null));
+        }
+
+        [Fact]
+        public async Task StaleWriterConvergesAfterLoad()
+        {
+            var (writer, staleWriter, writerLoad, staleLoad) = await CreateInitializedWriters();
+            var writerTimestamp = DateTime.UtcNow;
+            var staleWriterTimestamp = writerTimestamp.AddSeconds(1);
+
+            await writer.Store(
+                writerLoad.ETag,
+                new TransactionalStateMetaData { TimeStamp = writerTimestamp },
+                [],
+                null,
+                null);
+            await Assert.ThrowsAsync<InconsistentStateException>(
+                () => staleWriter.Store(
+                    staleLoad.ETag,
+                    new TransactionalStateMetaData { TimeStamp = staleWriterTimestamp },
+                    [],
+                    null,
+                    null));
+
+            var refreshed = await staleWriter.Load();
+            var storedETag = await staleWriter.Store(
+                refreshed.ETag,
+                new TransactionalStateMetaData { TimeStamp = staleWriterTimestamp },
+                [],
+                null,
+                null);
+            var converged = await staleWriter.Load();
+
+            Assert.Equal(storedETag, converged.ETag);
+            Assert.Equal(staleWriterTimestamp, converged.Metadata.TimeStamp);
+        }
+
+        [Fact]
+        public async Task FailedStoreRequiresSuccessfulLoadBeforeReuse()
+        {
+            var (writer, staleWriter, writerLoad, staleLoad) = await CreateInitializedWriters();
+
+            await writer.Store(writerLoad.ETag, writerLoad.Metadata, [], null, null);
+            await Assert.ThrowsAsync<InconsistentStateException>(
+                () => staleWriter.Store(staleLoad.ETag, staleLoad.Metadata, [], null, null));
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => staleWriter.Store(staleLoad.ETag, staleLoad.Metadata, [], null, null));
+            Assert.Contains("Load must complete successfully", exception.Message);
+
+            var refreshed = await staleWriter.Load();
+            await staleWriter.Store(refreshed.ETag, refreshed.Metadata, [], null, null);
+        }
+
+        [Fact]
+        public async Task ConflictDiagnosticsExcludePayloads()
+        {
+            var table = await InitTableAsync(NullLogger.Instance);
+            var jsonSettings = TransactionalStateFactory.GetJsonSerializerSettings(_fixture.HostedCluster.ServiceProvider);
+            var testPartition = $"{partition}{Guid.NewGuid():N}";
+            var logger = new CapturingLogger<AzureTableTransactionalStateStorage<TestState>>();
+            var writer = CreateStorage(table, testPartition, jsonSettings);
+            var staleWriter = CreateStorage(table, testPartition, jsonSettings, logger);
+            var statePayload = $"state-payload-{Guid.NewGuid():N}";
+            var transactionId = $"transaction-id-{Guid.NewGuid():N}";
+            var metadataId = Guid.NewGuid();
+            var pendingState = new PendingTransactionState<TestState>
+            {
+                SequenceId = 1,
+                State = new TestState { State = 1, Payload = statePayload },
+                TimeStamp = DateTime.UtcNow,
+                TransactionId = transactionId,
+            };
+            var metadata = new TransactionalStateMetaData
+            {
+                CommitRecords =
+                {
+                    [metadataId] = new CommitRecord
+                    {
+                        Timestamp = DateTime.UtcNow,
+                        WriteParticipants = [],
+                    },
+                },
+            };
+
+            var writerLoad = await writer.Load();
+            var staleLoad = await staleWriter.Load();
+            await writer.Store(writerLoad.ETag, metadata, [pendingState], null, null);
+            var exception = await Assert.ThrowsAsync<InconsistentStateException>(
+                () => staleWriter.Store(staleLoad.ETag, metadata, [pendingState], null, null));
+            var diagnostics = $"{exception}{Environment.NewLine}{string.Join(Environment.NewLine, logger.Messages)}";
+
+            Assert.Contains($"Partition={testPartition}", diagnostics);
+            Assert.Contains("ActionIndex=0", diagnostics);
+            Assert.Contains("ActionType=Add", diagnostics);
+            Assert.Contains("RowKey=s_0000000000000001", diagnostics);
+            Assert.Contains("HttpStatus=409", diagnostics);
+            Assert.Contains("ErrorCode=EntityAlreadyExists", diagnostics);
+            Assert.Contains("FailedOperationIndex=0", diagnostics);
+            Assert.DoesNotContain(statePayload, diagnostics);
+            Assert.DoesNotContain(transactionId, diagnostics);
+            Assert.DoesNotContain(metadataId.ToString(), diagnostics, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private async Task<(
+            AzureTableTransactionalStateStorage<TestState> Writer,
+            AzureTableTransactionalStateStorage<TestState> StaleWriter,
+            TransactionalStorageLoadResponse<TestState> WriterLoad,
+            TransactionalStorageLoadResponse<TestState> StaleLoad)> CreateInitializedWriters()
+        {
+            var table = await InitTableAsync(NullLogger.Instance);
+            var jsonSettings = TransactionalStateFactory.GetJsonSerializerSettings(_fixture.HostedCluster.ServiceProvider);
+            var testPartition = $"{partition}{Guid.NewGuid():N}";
+            var initializer = CreateStorage(table, testPartition, jsonSettings);
+            var initialLoad = await initializer.Load();
+            await initializer.Store(initialLoad.ETag, initialLoad.Metadata, [], null, null);
+
+            var writer = CreateStorage(table, testPartition, jsonSettings);
+            var staleWriter = CreateStorage(table, testPartition, jsonSettings);
+            return (writer, staleWriter, await writer.Load(), await staleWriter.Load());
+        }
+
+        private static AzureTableTransactionalStateStorage<TestState> CreateStorage(
+            TableClient table,
+            string partitionKey,
+            JsonSerializerSettings jsonSettings,
+            ILogger<AzureTableTransactionalStateStorage<TestState>>? logger = null)
+        {
+            return new AzureTableTransactionalStateStorage<TestState>(
+                table,
+                partitionKey,
+                jsonSettings,
+                logger ?? NullLoggerFactory.Instance.CreateLogger<AzureTableTransactionalStateStorage<TestState>>());
         }
 
         private static async Task<TableClient> InitTableAsync(ILogger logger)
@@ -73,6 +224,699 @@ namespace Orleans.Transactions.Azure.Tests
             {
                 logger.LogError(exc, "Error creating CloudTableCreationClient");
                 throw;
+            }
+        }
+
+        private sealed class CapturingLogger<T> : ILogger<T>
+        {
+            public List<string> Messages { get; } = [];
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                Messages.Add(exception is null
+                    ? formatter(state, exception)
+                    : $"{formatter(state, exception)}{Environment.NewLine}{exception}");
+            }
+        }
+    }
+
+    [TestCategory("BVT")]
+    public class AzureTransactionalStateStorageSnapshotTests
+    {
+        private const string Partition = "test-partition";
+        private const string LowerBoundaryRowKey = "!";
+        private const string UpperBoundaryRowKey = "~";
+        private const string BoundaryVersionPropertyName = "SnapshotVersion";
+        private static readonly string MetadataJson = JsonConvert.SerializeObject(new TransactionalStateMetaData());
+
+        [Fact]
+        public async Task Load_WhenBoundaryChangesDuringStateRead_RetriesAndReturnsCoherentSnapshot()
+        {
+            var table = new ScriptedTableClient { StorageVersion = "old" };
+            table.Enqueue(PagedSnapshotQuery(
+                "snapshot-crossing-mutation",
+                EntityPage(
+                    "page:snapshot-crossing-mutation:1",
+                    () => Assert.Equal("old", table.StorageVersion),
+                    BoundaryEntity(LowerBoundaryRowKey, "old"),
+                    KeyEntity(sequenceId: 1, etag: "old"),
+                    StateEntity(sequenceId: 1, value: 111)),
+                EntityPage(
+                    "page:snapshot-crossing-mutation:2",
+                    () =>
+                    {
+                        table.StorageVersion = "new";
+                        table.Events.Add("mutation:key-old-to-new");
+                    },
+                    StateEntity(sequenceId: 2, value: 222),
+                    BoundaryEntity(UpperBoundaryRowKey, "new"))));
+            table.Enqueue(PagedSnapshotQuery(
+                "snapshot-new",
+                EntityPage(
+                    "page:snapshot-new:1",
+                    () => Assert.Equal("new", table.StorageVersion),
+                    BoundaryEntity(LowerBoundaryRowKey, "new"),
+                    KeyEntity(sequenceId: 2, etag: "new")),
+                EntityPage(
+                    "page:snapshot-new:2",
+                    null,
+                    StateEntity(sequenceId: 2, value: 222),
+                    BoundaryEntity(UpperBoundaryRowKey, "new"))));
+            var storage = CreateStorage(table);
+
+            var result = await storage.Load();
+
+            Assert.Equal(new ETag("new").ToString(), result.ETag);
+            Assert.Equal(2, result.CommittedSequenceId);
+            Assert.Equal(222, result.CommittedState.State);
+            Assert.Empty(result.PendingStates);
+            Assert.Empty(result.Metadata.CommitRecords);
+            Assert.Equal(
+                [
+                    "query:snapshot-crossing-mutation",
+                    "page:snapshot-crossing-mutation:1",
+                    "page:snapshot-crossing-mutation:2",
+                    "mutation:key-old-to-new",
+                    "query:snapshot-new",
+                    "page:snapshot-new:1",
+                    "page:snapshot-new:2",
+                ],
+                table.Events);
+            Assert.Equal(0, table.RemainingQueryResponses);
+        }
+
+        [Fact]
+        public async Task Load_WhenSnapshotFitsOnePage_UsesSingleQuery()
+        {
+            var table = new ScriptedTableClient();
+            table.Enqueue(FencedSnapshotQuery(
+                "snapshot",
+                "stable",
+                KeyEntity(sequenceId: 2, etag: "stable"),
+                StateEntity(sequenceId: 1, value: 111),
+                StateEntity(sequenceId: 2, value: 222)));
+            var storage = CreateStorage(table);
+
+            var result = await storage.Load();
+
+            Assert.Equal(new ETag("stable").ToString(), result.ETag);
+            Assert.Equal(2, result.CommittedSequenceId);
+            Assert.Equal(222, result.CommittedState.State);
+            Assert.Equal(["snapshot"], table.QueryLabels);
+            Assert.Equal(["query:snapshot"], table.Events);
+            Assert.Equal(0, table.RemainingQueryResponses);
+        }
+
+        [Fact]
+        public async Task Load_WhenOnlyOneBoundaryPersists_ThrowsWithSafeVersionContext()
+        {
+            var table = new ScriptedTableClient();
+            for (var attempt = 0; attempt < 5; attempt++)
+            {
+                table.Enqueue(PagedSnapshotQuery(
+                    $"snapshot-{attempt}",
+                    EntityPage(
+                        $"page:snapshot-{attempt}:1",
+                        null,
+                        BoundaryEntity(LowerBoundaryRowKey, $"boundary-{attempt}")),
+                    EntityPage($"page:snapshot-{attempt}:2", null)));
+            }
+
+            var exception = await Assert.ThrowsAsync<InconsistentStateException>(
+                () => CreateStorage(table).Load());
+
+            Assert.Equal("boundary-4", exception.StoredEtag);
+            Assert.Equal("null", exception.CurrentEtag);
+            Assert.Equal(5, table.QueryLabels.Count);
+        }
+
+        [Fact]
+        public async Task Load_WhenPaginatedBoundaryVersionIsStable_UsesSingleQuery()
+        {
+            var table = new ScriptedTableClient();
+            table.Enqueue(PagedSnapshotQuery(
+                "snapshot",
+                EntityPage(
+                    "page:snapshot:1",
+                    null,
+                    BoundaryEntity(LowerBoundaryRowKey, "stable"),
+                    KeyEntity(sequenceId: 2, etag: "stable"),
+                    StateEntity(sequenceId: 1, value: 111)),
+                EntityPage(
+                    "page:snapshot:2",
+                    null,
+                    StateEntity(sequenceId: 2, value: 222),
+                    BoundaryEntity(UpperBoundaryRowKey, "stable"))));
+            var storage = CreateStorage(table);
+
+            var result = await storage.Load();
+
+            Assert.Equal(new ETag("stable").ToString(), result.ETag);
+            Assert.Equal(2, result.CommittedSequenceId);
+            Assert.Equal(222, result.CommittedState.State);
+            Assert.Equal(["snapshot"], table.QueryLabels);
+            Assert.Equal(
+                [
+                    "query:snapshot",
+                    "page:snapshot:1",
+                    "page:snapshot:2",
+                ],
+                table.Events);
+            Assert.Equal(0, table.RemainingQueryResponses);
+        }
+
+        [Fact]
+        public async Task Load_WhenLegacyPaginatedSnapshotHasNoBoundaries_AcceptsWithoutFence()
+        {
+            var table = new ScriptedTableClient();
+            table.Enqueue(PagedSnapshotQuery(
+                "snapshot",
+                EntityPage(
+                    "page:snapshot:1",
+                    null,
+                    KeyEntity(sequenceId: 2, etag: "stable"),
+                    StateEntity(sequenceId: 1, value: 111)),
+                EntityPage("page:snapshot:2", null, StateEntity(sequenceId: 2, value: 222))));
+            var storage = CreateStorage(table);
+
+            var result = await storage.Load();
+
+            Assert.Equal(new ETag("stable").ToString(), result.ETag);
+            Assert.Equal(2, result.CommittedSequenceId);
+            Assert.Equal(222, result.CommittedState.State);
+            Assert.Equal(["snapshot"], table.QueryLabels);
+            Assert.Equal(0, table.RemainingQueryResponses);
+        }
+
+        [Fact]
+        public async Task Load_WhenBoundaryVersionRemainsUnstable_ThrowsAfterBoundedAttempts()
+        {
+            var table = new ScriptedTableClient();
+            for (var attempt = 0; attempt < 5; attempt++)
+            {
+                table.Enqueue(PagedSnapshotQuery(
+                    $"snapshot-{attempt}",
+                    EntityPage(
+                        $"page:snapshot-{attempt}:1",
+                        null,
+                        BoundaryEntity(LowerBoundaryRowKey, $"boundary-{attempt}")),
+                    EntityPage(
+                        $"page:snapshot-{attempt}:2",
+                        null,
+                        BoundaryEntity(UpperBoundaryRowKey, $"boundary-{attempt + 1}"))));
+            }
+
+            var storage = CreateStorage(table);
+
+            var exception = await Assert.ThrowsAsync<InconsistentStateException>(() => storage.Load());
+
+            Assert.Equal("Could not load a consistent Azure Table transactional state snapshot.", exception.Message);
+            Assert.Equal("boundary-4", exception.StoredEtag);
+            Assert.Equal("boundary-5", exception.CurrentEtag);
+            Assert.Null(exception.InnerException);
+            Assert.Equal(5, table.QueryLabels.Count);
+            Assert.Equal(5, table.QueryLabels.Count(label => label.StartsWith("snapshot-", StringComparison.Ordinal)));
+            Assert.Equal(0, table.RemainingQueryResponses);
+        }
+
+        [Fact]
+        public async Task Load_WhenSinglePageKeyIsAbsent_AcceptsFreshSnapshot()
+        {
+            var table = new ScriptedTableClient();
+            table.Enqueue(SnapshotQuery("snapshot-empty", null));
+            var storage = CreateStorage(table);
+
+            var result = await storage.Load();
+
+            Assert.Null(result.ETag);
+            Assert.Equal(0, result.CommittedSequenceId);
+            Assert.Equal(0, result.CommittedState.State);
+            Assert.Empty(result.PendingStates);
+            Assert.Equal(["snapshot-empty"], table.QueryLabels);
+            Assert.Equal(0, table.RemainingQueryResponses);
+        }
+
+        [Fact]
+        public async Task Store_WhenFinalPhysicalBatchIsPartial_IncludesKeyFenceInEveryBatch()
+        {
+            var table = new ScriptedTableClient();
+            table.Enqueue(SnapshotQuery(
+                "snapshot",
+                KeyEntity(sequenceId: 1, etag: "loaded"),
+                Enumerable.Range(1, 101).Select(sequenceId => StateEntity(sequenceId, sequenceId)).ToArray()));
+            var storage = CreateStorage(table);
+            var loaded = await storage.Load();
+
+            var storedEtag = await storage.Store(
+                loaded.ETag,
+                new TransactionalStateMetaData(),
+                statesToPrepare: null,
+                commitUpTo: 101,
+                abortAfter: null);
+
+            Assert.Equal(new ETag("batch-2").ToString(), storedEtag);
+            Assert.Equal([100, 6], table.SubmittedTransactions.Select(batch => batch.Count));
+            Assert.All(
+                table.SubmittedTransactions,
+                batch =>
+                {
+                    Assert.Single(batch, action => action.RowKey == "k");
+                    var lower = Assert.Single(batch, action => action.RowKey == LowerBoundaryRowKey);
+                    var upper = Assert.Single(batch, action => action.RowKey == UpperBoundaryRowKey);
+                    Assert.NotNull(lower.BoundaryVersion);
+                    Assert.Equal(lower.BoundaryVersion, upper.BoundaryVersion);
+                });
+            Assert.Equal(
+                table.SubmittedTransactions.Count,
+                table.SubmittedTransactions
+                    .Select(batch => batch.Single(action => action.RowKey == LowerBoundaryRowKey).BoundaryVersion)
+                    .Distinct(StringComparer.Ordinal)
+                    .Count());
+
+            var finalBatch = table.SubmittedTransactions[1];
+            Assert.Contains(
+                finalBatch,
+                action => action.ActionType == TableTransactionActionType.Delete
+                    && action.RowKey == StateRowKey(100));
+            var finalKeyFence = Assert.Single(finalBatch, action => action.RowKey == "k");
+            Assert.Equal(TableTransactionActionType.UpdateReplace, finalKeyFence.ActionType);
+            Assert.Equal(new ETag("batch-1").ToString(), finalKeyFence.ETag.ToString());
+            Assert.Equal(0, table.RemainingQueryResponses);
+        }
+
+        [Fact]
+        public async Task Store_WhenFreshSplitFailsAfterFirstBatch_IntermediateStateIsRecoverable()
+        {
+            var table = new ScriptedTableClient
+            {
+                PersistTransactions = true,
+                FailTransactionNumber = 2,
+            };
+            var storage = CreateStorage(table);
+            var initial = await storage.Load();
+            var commitRecordId = Guid.NewGuid();
+            var incomingMetadata = new TransactionalStateMetaData
+            {
+                TimeStamp = DateTime.UtcNow,
+                CommitRecords =
+                {
+                    [commitRecordId] = new CommitRecord
+                    {
+                        Timestamp = DateTime.UtcNow,
+                        WriteParticipants = [],
+                    },
+                },
+            };
+            var statesToPrepare = Enumerable.Range(101, 101)
+                .Select(sequenceId => new PendingTransactionState<TestState>
+                {
+                    SequenceId = sequenceId,
+                    State = new TestState { State = sequenceId },
+                    TimeStamp = DateTime.UtcNow,
+                    TransactionId = $"transaction-{sequenceId}",
+                    TransactionManager = new ParticipantId(
+                        "tm",
+                        null!,
+                        ParticipantId.Role.Resource | ParticipantId.Role.Manager),
+                })
+                .ToList();
+
+            await Assert.ThrowsAsync<RequestFailedException>(
+                () => storage.Store(
+                    initial.ETag,
+                    incomingMetadata,
+                    statesToPrepare,
+                    commitUpTo: 101,
+                    abortAfter: null));
+
+            Assert.Equal([100, 7], table.SubmittedTransactions.Select(batch => batch.Count));
+            var firstBatchKey = Assert.Single(table.SubmittedTransactions[0], action => action.RowKey == "k");
+            Assert.Equal(TableTransactionActionType.Add, firstBatchKey.ActionType);
+            Assert.All(
+                table.SubmittedTransactions,
+                batch =>
+                {
+                    var lower = Assert.Single(batch, action => action.RowKey == LowerBoundaryRowKey);
+                    var upper = Assert.Single(batch, action => action.RowKey == UpperBoundaryRowKey);
+                    Assert.Equal(lower.BoundaryVersion, upper.BoundaryVersion);
+                });
+
+            var recoveryStorage = CreateStorage(table);
+            var intermediate = await recoveryStorage.Load();
+
+            Assert.Equal(new ETag("batch-1").ToString(), intermediate.ETag);
+            Assert.Equal(0, intermediate.CommittedSequenceId);
+            Assert.Equal(0, intermediate.CommittedState.State);
+            Assert.Equal(default, intermediate.Metadata.TimeStamp);
+            Assert.Empty(intermediate.Metadata.CommitRecords);
+            Assert.Equal(97, intermediate.PendingStates.Count);
+            Assert.Equal(Enumerable.Range(101, 97).Select(value => (long)value), intermediate.PendingStates.Select(state => state.SequenceId));
+
+            table.FailTransactionNumber = null;
+            await recoveryStorage.Store(
+                intermediate.ETag,
+                incomingMetadata,
+                statesToPrepare,
+                commitUpTo: 101,
+                abortAfter: null);
+
+            var loadedAfterRetry = await CreateStorage(table).Load();
+            Assert.Equal(101, loadedAfterRetry.CommittedSequenceId);
+            Assert.Equal(101, loadedAfterRetry.CommittedState.State);
+            Assert.Equal(incomingMetadata.TimeStamp, loadedAfterRetry.Metadata.TimeStamp);
+            Assert.True(loadedAfterRetry.Metadata.CommitRecords.ContainsKey(commitRecordId));
+            Assert.Equal(100, loadedAfterRetry.PendingStates.Count);
+            Assert.Equal(Enumerable.Range(102, 100).Select(value => (long)value), loadedAfterRetry.PendingStates.Select(state => state.SequenceId));
+        }
+
+        private static AzureTableTransactionalStateStorage<TestState> CreateStorage(TableClient table)
+            => new(
+                table,
+                Partition,
+                new JsonSerializerSettings(),
+                NullLoggerFactory.Instance.CreateLogger<AzureTableTransactionalStateStorage<TestState>>());
+
+        private static QueryResponse SnapshotQuery(string label, ScriptedEntity? key, params ScriptedEntity[] states)
+            => new(label, nameof(TableEntity), [SnapshotPage(null, null, key, states)]);
+
+        private static QueryResponse FencedSnapshotQuery(
+            string label,
+            string version,
+            ScriptedEntity key,
+            params ScriptedEntity[] states)
+            => new(
+                label,
+                nameof(TableEntity),
+                [
+                    EntityPage(
+                        null,
+                        null,
+                        [
+                            BoundaryEntity(LowerBoundaryRowKey, version),
+                            key,
+                            .. states,
+                            BoundaryEntity(UpperBoundaryRowKey, version)
+                        ])
+                ]);
+
+        private static QueryResponse PagedSnapshotQuery(string label, params QueryPage[] pages)
+            => new(label, nameof(TableEntity), pages);
+
+        private static QueryPage SnapshotPage(
+            string? eventLabel,
+            Action? onRead,
+            ScriptedEntity? key,
+            params ScriptedEntity[] states)
+        {
+            IReadOnlyList<ScriptedEntity> entities = key is null ? states : [key, .. states];
+            return new QueryPage(entities, eventLabel, onRead);
+        }
+
+        private static QueryPage EntityPage(string? eventLabel, Action? onRead, params ScriptedEntity[] entities)
+            => new(entities, eventLabel, onRead);
+
+        private static ScriptedEntity BoundaryEntity(string rowKey, string version)
+            => new(
+                Partition,
+                rowKey,
+                new ETag($"boundary-{rowKey}-{version}"),
+                new Dictionary<string, object>
+                {
+                    [BoundaryVersionPropertyName] = version,
+                });
+
+        private static ScriptedEntity KeyEntity(long sequenceId, string etag)
+            => new(
+                Partition,
+                "k",
+                new ETag(etag),
+                new Dictionary<string, object>
+                {
+                    ["CommittedSequenceId"] = sequenceId,
+                    ["Metadata"] = MetadataJson,
+                });
+
+        private static ScriptedEntity StateEntity(long sequenceId, int value)
+            => new(
+                Partition,
+                StateRowKey(sequenceId),
+                new ETag($"state-{sequenceId}"),
+                new Dictionary<string, object>
+                {
+                    ["StateJson"] = JsonConvert.SerializeObject(new TestState { State = value }),
+                });
+
+        private static string StateRowKey(long sequenceId) => $"s_{sequenceId:x16}";
+
+        private sealed record ScriptedEntity(
+            string PartitionKey,
+            string RowKey,
+            ETag ETag,
+            IReadOnlyDictionary<string, object> Properties);
+
+        private sealed record QueryResponse(
+            string Label,
+            string EntityTypeName,
+            IReadOnlyList<QueryPage> Pages,
+            Action? OnQuery = null);
+
+        private sealed record QueryPage(
+            IReadOnlyList<ScriptedEntity> Entities,
+            string? EventLabel = null,
+            Action? OnRead = null);
+
+        private sealed record SubmittedAction(
+            TableTransactionActionType ActionType,
+            string PartitionKey,
+            string RowKey,
+            ETag ETag,
+            string? BoundaryVersion);
+
+        private sealed class ScriptedTableClient : TableClient
+        {
+            private readonly Queue<QueryResponse> _queryResponses = new();
+            private readonly Dictionary<(string PartitionKey, string RowKey), ScriptedEntity> _durableEntities = [];
+
+            public override string Name => "scripted";
+
+            public string? StorageVersion { get; set; }
+
+            public bool PersistTransactions { get; set; }
+
+            public int? FailTransactionNumber { get; set; }
+
+            public List<string> Events { get; } = [];
+
+            public List<string> QueryLabels { get; } = [];
+
+            public List<IReadOnlyList<SubmittedAction>> SubmittedTransactions { get; } = [];
+
+            public int RemainingQueryResponses => _queryResponses.Count;
+
+            public void Enqueue(QueryResponse response) => _queryResponses.Enqueue(response);
+
+            public override AsyncPageable<T> QueryAsync<T>(
+                string? filter = null,
+                int? maxPerPage = null,
+                IEnumerable<string>? select = null,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!_queryResponses.TryDequeue(out var response))
+                {
+                    Assert.True(PersistTransactions, $"Unexpected {typeof(T).Name} query: {filter}");
+                    return QueryDurableEntities<T>(cancellationToken);
+                }
+
+                Assert.Equal(response.EntityTypeName, typeof(T).Name);
+                QueryLabels.Add(response.Label);
+                Events.Add($"query:{response.Label}");
+                response.OnQuery?.Invoke();
+
+                return AsyncPageable<T>.FromPages(EnumeratePages<T>(response, cancellationToken));
+            }
+
+            public override Task<Response<IReadOnlyList<Response>>> SubmitTransactionAsync(
+                IEnumerable<TableTransactionAction> transactionActions,
+                CancellationToken cancellationToken = default)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var actions = transactionActions.ToList();
+                var transactionNumber = SubmittedTransactions.Count + 1;
+                SubmittedTransactions.Add(
+                    actions.Select(action => new SubmittedAction(
+                        action.ActionType,
+                        action.Entity.PartitionKey,
+                        action.Entity.RowKey,
+                        action.ETag,
+                        action.Entity is TableEntity tableEntity
+                            ? tableEntity.GetString(BoundaryVersionPropertyName)
+                            : null)).ToList());
+
+                if (FailTransactionNumber == transactionNumber)
+                {
+                    throw new RequestFailedException(500, $"Injected failure for batch {transactionNumber}.");
+                }
+
+                var responseEtag = new ETag($"batch-{transactionNumber}");
+                if (PersistTransactions)
+                {
+                    foreach (var action in actions)
+                    {
+                        var entityKey = (action.Entity.PartitionKey, action.Entity.RowKey);
+                        if (action.ActionType == TableTransactionActionType.Delete)
+                        {
+                            _durableEntities.Remove(entityKey);
+                        }
+                        else
+                        {
+                            _durableEntities[entityKey] = CaptureEntity(action.Entity, responseEtag);
+                        }
+                    }
+                }
+
+                IReadOnlyList<Response> responses = actions.Select(_ => (Response)new StubResponse(responseEtag)).ToList();
+                return Task.FromResult(Response.FromValue(responses, new StubResponse(default)));
+            }
+
+            private AsyncPageable<T> QueryDurableEntities<T>(CancellationToken cancellationToken)
+                where T : class, ITableEntity
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var isKeyQuery = typeof(T).Name == "KeyEntity";
+                var label = $"durable:{typeof(T).Name}";
+                QueryLabels.Add(label);
+                Events.Add($"query:{label}");
+                var values = _durableEntities.Values
+                    .Where(entity => isKeyQuery
+                        ? entity.RowKey == "k"
+                        : true)
+                    .OrderBy(entity => entity.RowKey, StringComparer.Ordinal)
+                    .Select(entity => Materialize<T>(entity))
+                    .ToList();
+                var page = Page<T>.FromValues(values, null, new StubResponse(default));
+                return AsyncPageable<T>.FromPages([page]);
+            }
+
+            private static ScriptedEntity CaptureEntity(ITableEntity source, ETag etag)
+            {
+                Dictionary<string, object> properties;
+                if (source is TableEntity tableEntity)
+                {
+                    properties = tableEntity.ToDictionary(entry => entry.Key, entry => entry.Value);
+                }
+                else
+                {
+                    properties = source.GetType()
+                        .GetProperties()
+                        .Where(property => property.CanRead
+                            && property.Name is not (nameof(ITableEntity.PartitionKey)
+                                or nameof(ITableEntity.RowKey)
+                                or nameof(ITableEntity.Timestamp)
+                                or nameof(ITableEntity.ETag)))
+                        .Select(property => (property.Name, Value: property.GetValue(source)))
+                        .Where(entry => entry.Value is not null)
+                        .ToDictionary(entry => entry.Name, entry => entry.Value!);
+                }
+
+                return new ScriptedEntity(source.PartitionKey, source.RowKey, etag, properties);
+            }
+
+            private IEnumerable<Page<T>> EnumeratePages<T>(QueryResponse response, CancellationToken cancellationToken)
+                where T : class, ITableEntity
+            {
+                for (var i = 0; i < response.Pages.Count; i++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var scriptedPage = response.Pages[i];
+                    if (scriptedPage.EventLabel is { } eventLabel)
+                    {
+                        Events.Add(eventLabel);
+                    }
+
+                    scriptedPage.OnRead?.Invoke();
+                    var values = scriptedPage.Entities.Select(entity => Materialize<T>(entity)).ToList();
+                    var continuationToken = i < response.Pages.Count - 1 ? $"token-{i + 1}" : null;
+                    yield return Page<T>.FromValues(values, continuationToken, new StubResponse(default));
+                }
+            }
+
+            private static T Materialize<T>(ScriptedEntity source)
+                where T : class, ITableEntity
+            {
+                var entity = Activator.CreateInstance<T>();
+                entity.PartitionKey = source.PartitionKey;
+                entity.RowKey = source.RowKey;
+                entity.ETag = source.ETag;
+
+                foreach (var (name, value) in source.Properties)
+                {
+                    if (entity is TableEntity tableEntity)
+                    {
+                        tableEntity[name] = value;
+                    }
+                    else
+                    {
+                        var property = typeof(T).GetProperty(name);
+                        Assert.NotNull(property);
+                        property.SetValue(entity, value);
+                    }
+                }
+
+                return entity;
+            }
+        }
+
+        private sealed class StubResponse(ETag etag) : Response
+        {
+            public override int Status => 204;
+
+            public override string ReasonPhrase => "No Content";
+
+            public override Stream? ContentStream { get; set; }
+
+            public override string ClientRequestId { get; set; } = string.Empty;
+
+            public override void Dispose()
+            {
+            }
+
+            protected override bool ContainsHeader(string name) => TryGetHeader(name, out _);
+
+            protected override IEnumerable<HttpHeader> EnumerateHeaders()
+                => etag == default ? [] : [new HttpHeader("ETag", etag.ToString("H"))];
+
+            protected override bool TryGetHeader(string name, out string value)
+            {
+                if (etag != default && string.Equals(name, "ETag", StringComparison.OrdinalIgnoreCase))
+                {
+                    value = etag.ToString("H");
+                    return true;
+                }
+
+                value = string.Empty;
+                return false;
+            }
+
+            protected override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
+            {
+                if (TryGetHeader(name, out var value))
+                {
+                    values = [value];
+                    return true;
+                }
+
+                values = [];
+                return false;
             }
         }
     }


### PR DESCRIPTION
Azure Table transactional state storage mutates its cached key and prepared-state records before submitting a transaction, so a failed write could leave the storage instance unsafe to reuse. A paginated entity query can also cross a concurrent multi-batch write because continuation pages are independent requests, while conflict failures previously exposed limited context.

Require a successful reload before reuse after a failed mutating store, preserve strict ETag conflict detection, and emit payload-free operation diagnostics with the failed action details supplied by Azure Table Storage. Load queries the key and state rows together. The normal single-page case returns the snapshot in one storage operation. Every physical write batch atomically upserts `!` and `~` boundary rows with the same fresh fence value; their keys sort before and after all transactional rows, so matching values from a completed paginated query prove that no boundary-aware batch committed while its pages were read. Torn boundary values retry up to a bound without an additional key read.

Legacy partitions without boundary rows retain the previous one-query behavior. During a rolling upgrade, older writers do not advance existing boundary rows, so paginated torn reads remain intentionally possible until every writer is upgraded; the stronger boundary guarantee applies once the cluster has fully transitioned.

Each physical batch still conditionally advances the key and now reserves two boundary slots, including the final partial batch. A fresh key carries valid empty prior metadata before any split prepare batch can persist it, so a failure after the first physical batch leaves a recoverable intermediate snapshot without prematurely publishing incoming commit metadata or sequence position. Deterministic coverage exercises one-query loads, stable and torn boundary pagination, legacy no-boundary acceptance, bounded churn, fresh split recovery, per-batch fence uniqueness, no-change conflicts, stale-writer recovery, failed-store reuse rejection, and diagnostic redaction.

Azure [entity group transactions](https://learn.microsoft.com/azure/storage/tables/table-storage-design#entity-group-transactions) atomically mutate up to 100 entities sharing a partition, and the [transaction batch protocol](https://learn.microsoft.com/rest/api/storageservices/performing-entity-group-transactions) plus [`TableTransactionActionType`](https://learn.microsoft.com/dotnet/api/azure.data.tables/tabletransactionactiontype?view=azure-dotnet) expose mutation actions but no transactional read batch. [Query Entities](https://learn.microsoft.com/rest/api/storageservices/query-entities) can return a single strongly consistent response, but larger or slower queries resume through subsequent requests under the documented [query timeout and pagination semantics](https://learn.microsoft.com/rest/api/storageservices/query-timeout-and-pagination). Once all writers maintain the boundary rows, paginated reads become self-validating without another storage request.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10376)