### PR TITLE
docs(transactions): clarify storage recovery contract

### DIFF
--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionalStateStorageTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionalStateStorageTestRunner.cs
@@ -98,14 +98,15 @@ namespace Orleans.Transactions.TestKit
             var loadresponse = await stateStorage.Load();
 
             // store with wrong e-tag, must fail
-            try
-            {
-                var etag1 = await stateStorage.Store("wrong-etag", loadresponse.Metadata, emptyPendingStates, null, null);
-                throw new Exception("storage did not catch e-tag mismatch");
-            }
-            catch (Exception) { }
+            Func<Task> storeWithWrongETag = () => stateStorage.Store(
+                "wrong-etag",
+                loadresponse.Metadata,
+                emptyPendingStates,
+                null,
+                null);
+            await storeWithWrongETag.Should().ThrowAsync<Exception>("the ETag does not identify the loaded version");
 
-            // load again
+            // load again and verify that the rejected write made no changes
             loadresponse = await stateStorage.Load();
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.TimeStamp.Should().Be(default);
@@ -113,6 +114,7 @@ namespace Orleans.Transactions.TestKit
             loadresponse.ETag.Should().BeNull();
             loadresponse.CommittedSequenceId.Should().Be(0);
             loadresponse.PendingStates.Should().BeEmpty();
+            AssertTState(loadresponse.CommittedState, new TState());
 
             // update timestamp in metadata, then write back with correct e-tag
             var now = DateTime.UtcNow;
@@ -121,25 +123,36 @@ namespace Orleans.Transactions.TestKit
             var etag2 = await stateStorage.Store(null, metadata, emptyPendingStates, null, null);
             etag2.Should().NotBeNullOrEmpty();
 
-            // update timestamp in metadata, then write back with wrong e-tag, must fail
-            try
-            {
-                var now2 = DateTime.UtcNow;
-                var metadata2 = new TransactionalStateMetaData() { TimeStamp = now2, CommitRecords = MakeCommitRecords(3,3) };
-                await stateStorage.Store(null, metadata, emptyPendingStates, null, null);
-                throw new Exception("storage did not catch e-tag mismatch");
-            }
-            catch (Exception) { }
+            var storedResponse = await stateStorage.Load();
+            storedResponse.ETag.Should().Be(etag2);
+            storedResponse.Metadata.Should().BeEquivalentTo(metadata);
+            storedResponse.CommittedSequenceId.Should().Be(0);
+            storedResponse.PendingStates.Should().BeEmpty();
+            AssertTState(storedResponse.CommittedState, new TState());
 
-            // load again, check content
+            // update timestamp in metadata, then write back with wrong e-tag, must fail
+            var metadata2 = new TransactionalStateMetaData()
+            {
+                TimeStamp = now.AddSeconds(1),
+                CommitRecords = MakeCommitRecords(3, 3)
+            };
+            Func<Task> storeWithStaleETag = () => stateStorage.Store(
+                null,
+                metadata2,
+                emptyPendingStates,
+                null,
+                null);
+            await storeWithStaleETag.Should().ThrowAsync<Exception>("the ETag is stale");
+
+            // load again and verify that the rejected write made no changes
             loadresponse = await stateStorage.Load();
             loadresponse.Should().NotBeNull();
             loadresponse.Metadata.Should().NotBeNull();
-            loadresponse.Metadata.TimeStamp.Should().Be(now);
-            loadresponse.Metadata.CommitRecords.Count.Should().Be(cr.Count);
-            loadresponse.ETag.Should().Be(etag2);
-            loadresponse.CommittedSequenceId.Should().Be(0);
-            loadresponse.PendingStates.Should().BeEmpty();
+            loadresponse.ETag.Should().Be(storedResponse.ETag);
+            loadresponse.Metadata.Should().BeEquivalentTo(storedResponse.Metadata);
+            loadresponse.CommittedSequenceId.Should().Be(storedResponse.CommittedSequenceId);
+            loadresponse.PendingStates.Should().BeEquivalentTo(storedResponse.PendingStates);
+            AssertTState(loadresponse.CommittedState, storedResponse.CommittedState);
         }
 
         private void AssertTState(TState actual, TState expected)

--- a/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs
@@ -34,6 +34,18 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.FirstTime_Load_ShouldReturnEmptyLoadResponse();
         }
 
+        [Fact]
+        public override Task StoreWithoutChanges()
+        {
+            return base.StoreWithoutChanges();
+        }
+
+        [Fact]
+        public override Task WrongEtags()
+        {
+            return base.WrongEtags();
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/Orleans.Transactions/Abstractions/ITransactionalStateStorage.cs
+++ b/src/Orleans.Transactions/Abstractions/ITransactionalStateStorage.cs
@@ -11,24 +11,66 @@ namespace Orleans.Transactions.Abstractions
     public interface ITransactionalStateStorage<TState>
         where TState : class, new()
     {
+        /// <summary>
+        /// Loads the authoritative transactional state from durable storage.
+        /// </summary>
+        /// <returns>
+        /// A task whose result is a coherent snapshot containing the current ETag, committed state and sequence number,
+        /// transaction metadata, and pending prepare records in sequence-number order.
+        /// </returns>
+        /// <remarks>
+        /// The returned snapshot must be suitable for transaction recovery. In particular, it must represent one
+        /// recoverable durable state and must not combine values from incompatible storage versions.
+        /// <para>
+        /// A call to <see cref="Store"/> can fail after zero, some, or all of its requested changes become durable.
+        /// Therefore, <see cref="Load"/> must read the authoritative durable state and replace any provider-local state
+        /// cached for subsequent calls to <see cref="Store"/>. Callers use this operation after a failed
+        /// <see cref="Store"/> to resolve the outcome before issuing another update.
+        /// </para>
+        /// </remarks>
         Task<TransactionalStorageLoadResponse<TState>> Load();
 
         /// <summary>
         /// Stores transactional state changes.
         /// </summary>
-        /// <returns>A task whose result is the ETag assigned to the stored state.</returns>
+        /// <param name="expectedETag">
+        /// The ETag from the most recent <see cref="Load"/> or successful <see cref="Store"/>, identifying the durable
+        /// version to update.
+        /// </param>
+        /// <param name="metadata">The transaction metadata which replaces the currently stored metadata.</param>
+        /// <param name="statesToPrepare">
+        /// Prepare records to add or replace, keyed by their sequence numbers. A record replaces an existing record
+        /// with the same sequence number. A <see langword="null"/> or empty list adds no prepare records.
+        /// </param>
+        /// <param name="commitUpTo">
+        /// When non-null, advances the committed state through the prepared state with this sequence number and makes
+        /// prepare records at or below that sequence obsolete.
+        /// </param>
+        /// <param name="abortAfter">
+        /// When non-null, removes pending prepare records whose sequence numbers are strictly greater than this value.
+        /// </param>
+        /// <returns>
+        /// A task whose result is the ETag of the durable state produced by the completed operation. The returned ETag
+        /// is used as <paramref name="expectedETag"/> for the next update.
+        /// </returns>
+        /// <remarks>
+        /// Implementations must use <paramref name="expectedETag"/> for optimistic concurrency and fail the operation
+        /// rather than silently overwrite a different durable version. The exception type used to report a mismatch is
+        /// provider-specific.
+        /// <para>
+        /// Implementations may split an operation into provider-sized atomic batches. Those batches are applied in an
+        /// order which preserves recoverability, but the <see cref="Store"/> call as a whole is not required to be
+        /// atomic: if it throws, zero, some, or all requested changes may already be durable, including changes from
+        /// batches completed before the failing batch. An exception therefore does not prove that no durable change
+        /// occurred. The caller must not blindly retry using its cached state or ETag; it must call <see cref="Load"/>
+        /// and recover from the authoritative snapshot first.
+        /// </para>
+        /// </remarks>
         Task<string> Store(
-
             string? expectedETag,
             TransactionalStateMetaData metadata,
-
-            // a list of transactions to prepare.
             List<PendingTransactionState<TState>>? statesToPrepare,
-
-            // if non-null, commit all pending transaction up to and including this sequence number.
             long? commitUpTo,
-
-            // if non-null, abort all pending transactions with sequence numbers strictly larger than this one.
             long? abortAfter
         );
     }


### PR DESCRIPTION
Depends on #10376, which makes Azure Table transactional `Load` satisfy the coherent-snapshot requirement documented here.

Transactional storage providers can split a `Store` operation across backend-sized batches, so an exception can leave the durable outcome uncertain. The interface contract did not explain that recovery boundary, and the shared wrong-ETag test masked its own failure while two direct-provider cases were not discovered by xUnit.

This documents `Load` as the authoritative cache-reset and recovery operation, defines `Store` partial-progress and optimistic-concurrency semantics, repairs the shared wrong-ETag assertions, and exposes the missing `StoreWithoutChanges` and `WrongEtags` provider tests.