### PR TITLE
test: add ambiguous transaction write coverage

### DIFF
--- a/test/Transactions/Orleans.Transactions.DynamoDB.Test/FaultInjection/ControlledInjection/BankTransferFaultInjectionTests.cs
+++ b/test/Transactions/Orleans.Transactions.DynamoDB.Test/FaultInjection/ControlledInjection/BankTransferFaultInjectionTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Orleans.Transactions.TestKit;
+using Orleans.Transactions.Tests;
+using TestExtensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.DynamoDB.Tests.FaultInjection.ControlledInjection;
+
+[TestCategory("DynamoDB"), TestCategory("Transactions"), TestCategory("Functional")]
+public sealed class BankTransferFaultInjectionTests : IClassFixture<ControlledFaultInjectionTestFixture>
+{
+    private readonly IGrainFactory grainFactory;
+    private readonly ITestOutputHelper output;
+
+    public BankTransferFaultInjectionTests(ControlledFaultInjectionTestFixture fixture, ITestOutputHelper output)
+    {
+        fixture.EnsurePreconditionsMet();
+        grainFactory = fixture.GrainFactory;
+        this.output = output;
+    }
+
+    [SkippableFact]
+    public async Task StorageExceptionAfterCommitStore_CommitsDurableFullBankTransfer()
+    {
+        var commitFault = new BankTransferFault
+        {
+            Phase = TransactionFaultInjectPhase.BeforePrepareAndCommit,
+            Type = FaultInjectionType.ExceptionAfterStore
+        };
+
+        await RunFaultedTransfer(
+            commitFault,
+            expectedFrom: 99,
+            expectedTo: 1,
+            "the transaction manager committed its durable state before the storage exception was surfaced");
+    }
+
+    [SkippableFact]
+    public async Task GenericStorageExceptionAfterCommitStore_CommitsDurableFullBankTransfer()
+    {
+        var commitFault = new BankTransferFault
+        {
+            Phase = TransactionFaultInjectPhase.BeforePrepareAndCommit,
+            Type = FaultInjectionType.GenericExceptionAfterStore
+        };
+
+        await RunFaultedTransfer(
+            commitFault,
+            expectedFrom: 99,
+            expectedTo: 1,
+            "a generic exception surfaced after the underlying storage write and recovery must preserve the committed transfer");
+    }
+
+    private async Task RunFaultedTransfer(BankTransferFault commitFault, long expectedFrom, long expectedTo, string because)
+    {
+        BankTransferTrace.Clear();
+
+        var from = grainFactory.GetGrain<IBankTransferFaultInjectionAccountGrain>(Guid.NewGuid());
+        var to = grainFactory.GetGrain<IBankTransferFaultInjectionAccountGrain>(Guid.NewGuid());
+        var teller = grainFactory.GetGrain<IBankTransferFaultInjectionTellerGrain>(0);
+
+        await from.SetBalance(100);
+        await to.SetBalance(0);
+
+        var exception = await Assert.ThrowsAnyAsync<OrleansTransactionException>(
+            () => teller.TransferReturnBalancesWithDepositAsManager(from, to, 1, commitFault));
+
+        var committed = await teller.GetBalances(from, to);
+
+        output.WriteLine($"faultedTransferException={exception.GetType().Name}, committed={committed.From}+{committed.To}={committed.Total}");
+        foreach (var traceEvent in BankTransferTrace.Snapshot().TakeLast(160))
+        {
+            output.WriteLine($"{traceEvent.Timestamp:O} {traceEvent.TransactionId} {traceEvent.GrainId} {traceEvent.Stage} {traceEvent.Balance}");
+        }
+
+        committed.From.Should().Be(expectedFrom, because);
+        committed.To.Should().Be(expectedTo, because);
+        committed.Total.Should().Be(100, "ambiguous storage faults must not durably persist a partial bank transfer");
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/Memory/BankTransferFaultInjectionMemoryTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/Memory/BankTransferFaultInjectionMemoryTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using TestExtensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Orleans.Transactions.Tests;
+
+[TestCategory("BVT"), TestCategory("Transactions")]
+public sealed class BankTransferFaultInjectionMemoryTests : IClassFixture<MemoryTransactionsFixture>
+{
+    private readonly IGrainFactory grainFactory;
+    private readonly ITestOutputHelper output;
+
+    public BankTransferFaultInjectionMemoryTests(MemoryTransactionsFixture fixture, ITestOutputHelper output)
+    {
+        grainFactory = fixture.GrainFactory;
+        this.output = output;
+    }
+
+    [Fact]
+    public async Task GenericExceptionAfterStorageWriteCompleted_CommitsDurableFullBankTransfer()
+    {
+        BankTransferTrace.Clear();
+
+        var from = grainFactory.GetGrain<IBankTransferAccountGrain>(Guid.NewGuid());
+        var to = grainFactory.GetGrain<IBankTransferAccountGrain>(Guid.NewGuid());
+        var teller = grainFactory.GetGrain<IBankTransferTellerGrain>(0);
+
+        await from.SetBalance(100);
+        await to.SetBalance(0);
+
+        var diagnosticFaults = new[]
+        {
+            BankTransferDiagnosticFaults.ThrowOnStorageWriteCompleted(from),
+            BankTransferDiagnosticFaults.ThrowOnStorageWriteCompleted(to)
+        };
+
+        OrleansTransactionException exception;
+        try
+        {
+            exception = await Assert.ThrowsAnyAsync<OrleansTransactionException>(
+                () => teller.TransferReturnBalances(from, to, 1));
+        }
+        finally
+        {
+            foreach (var diagnosticFault in diagnosticFaults)
+            {
+                diagnosticFault.Dispose();
+            }
+        }
+
+        diagnosticFaults.Should().Contain(
+            diagnosticFault => diagnosticFault.FaultInjected,
+            "the selected transaction manager should surface a single post-store fault");
+        diagnosticFaults.Sum(diagnosticFault => diagnosticFault.ObservedCount).Should().BeGreaterThan(
+            0,
+            "the provider-neutral storage-write-completed diagnostic event should be observed");
+
+        var committed = await teller.GetBalances(from, to);
+
+        output.WriteLine($"faultedTransferException={exception.GetType().Name}, committed={committed.From}+{committed.To}={committed.Total}");
+        foreach (var traceEvent in BankTransferTrace.Snapshot().TakeLast(160))
+        {
+            output.WriteLine($"{traceEvent.Timestamp:O} {traceEvent.TransactionId} {traceEvent.GrainId} {traceEvent.Stage} {traceEvent.Balance}");
+        }
+
+        committed.From.Should().Be(
+            99,
+            "the post-store exception is ambiguous and recovery must preserve the completed withdrawal");
+        committed.To.Should().Be(
+            1,
+            "the post-store exception is ambiguous and recovery must preserve the completed deposit");
+        committed.Total.Should().Be(100, "the durable result must remain a full committed bank transfer");
+    }
+}


### PR DESCRIPTION
## Summary
Add the remaining deterministic ambiguous transaction write integration coverage without touching the provider-wrapper, shared diagnostics, or Azure-owned files.

## Changes
- add focused DynamoDB controlled-fault bank-transfer tests for `ExceptionAfterStore` and `GenericExceptionAfterStore` at transaction-manager commit, asserting exact durable participant balances
- add a provider-neutral in-memory bank-transfer test that throws after `StorageWriteCompleted` and asserts the committed durable balances plus diagnostic fault observation
- keep the change isolated to two new test files
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10379)