### PR TITLE
fix(azure): fence paginated membership reads

### DIFF
--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -166,14 +166,18 @@ namespace Orleans.Runtime.MembershipService
         {
             try
             {
-                var memEntries = new List<Tuple<MembershipEntry, string>>();
+                var memEntries = new List<Tuple<MembershipEntry, string>>(Math.Max(0, entries.Count - 1));
                 TableVersion? tableVersion = null;
                 foreach (var tuple in entries)
                 {
                     var tableEntry = tuple.Entity;
                     if (tableEntry.RowKey.Equals(SiloInstanceTableEntry.TABLE_VERSION_ROW))
                     {
-                        tableVersion = new TableVersion(int.Parse(tableEntry.MembershipVersion!), tuple.ETag);
+                        var membershipVersion = tableEntry.MembershipVersion
+                            ?? throw new InvalidOperationException("The table version row does not contain a membership version.");
+                        tableVersion = new TableVersion(
+                            int.Parse(membershipVersion, CultureInfo.InvariantCulture),
+                            tuple.ETag);
                     }
                     else if (SiloInstanceTableEntry.IsVersionRow(tableEntry.RowKey))
                     {
@@ -193,7 +197,9 @@ namespace Orleans.Runtime.MembershipService
                         }
                     }
                 }
-                var data = new MembershipTableData(memEntries, tableVersion!);
+                var data = new MembershipTableData(
+                    memEntries,
+                    tableVersion ?? throw new InvalidOperationException("The membership table does not contain a version row."));
                 return data;
             }
             catch (Exception exc)

--- a/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/AzureBasedMembershipTable.cs
@@ -175,6 +175,10 @@ namespace Orleans.Runtime.MembershipService
                     {
                         tableVersion = new TableVersion(int.Parse(tableEntry.MembershipVersion!), tuple.ETag);
                     }
+                    else if (SiloInstanceTableEntry.IsVersionRow(tableEntry.RowKey))
+                    {
+                        continue;
+                    }
                     else
                     {
                         try

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
@@ -75,13 +77,30 @@ namespace Orleans.AzureUtils
 
         public SiloInstanceTableEntry CreateTableVersionEntry(int tableVersion)
         {
-            return new SiloInstanceTableEntry
+            return CreateTableVersionEntry(
+                SiloInstanceTableEntry.TABLE_VERSION_ROW,
+                tableVersion.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private SiloInstanceTableEntry CreateTableVersionEntry(string rowKey, string membershipVersion)
+        {
+            return new()
             {
                 DeploymentId = DeploymentId,
                 PartitionKey = DeploymentId,
-                RowKey = SiloInstanceTableEntry.TABLE_VERSION_ROW,
-                MembershipVersion = tableVersion.ToString(CultureInfo.InvariantCulture)
+                RowKey = rowKey,
+                MembershipVersion = membershipVersion
             };
+        }
+
+        private (SiloInstanceTableEntry Min, SiloInstanceTableEntry Max) CreateBoundaryVersionEntries(
+            SiloInstanceTableEntry tableVersionEntry)
+        {
+            var membershipVersion = tableVersionEntry.MembershipVersion
+                ?? throw new ArgumentException("The table version entry must have a membership version.", nameof(tableVersionEntry));
+            return (
+                CreateTableVersionEntry(SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN, membershipVersion),
+                CreateTableVersionEntry(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, membershipVersion));
         }
 
         public void RegisterSiloInstance(SiloInstanceTableEntry entry)
@@ -195,7 +214,7 @@ namespace Orleans.AzureUtils
         public async Task CleanupDefunctSiloEntries(DateTimeOffset beforeDate)
         {
             var entriesList = (await FindAllSiloEntries())
-                .Where(entry => !string.Equals(SiloInstanceTableEntry.TABLE_VERSION_ROW, entry.Item1.RowKey)
+                .Where(entry => !SiloInstanceTableEntry.IsVersionRow(entry.Entity.RowKey)
                     && entry.Item1.Status != INSTANCE_STATUS_ACTIVE
                     && entry.Item1.Timestamp < beforeDate)
                 .ToList();
@@ -239,79 +258,96 @@ namespace Orleans.AzureUtils
             return queryResults;
         }
 
-        internal async Task<List<(SiloInstanceTableEntry Entity, string ETag)>> FindAllSiloEntries()
+        internal async Task<List<(SiloInstanceTableEntry Entity, string ETag)>> FindAllSiloEntries(
+            CancellationToken cancellationToken = default)
         {
-            var initialRead = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(this.DeploymentId);
+            var initialRead = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(this.DeploymentId, cancellationToken);
             if (!initialRead.IsPaginated)
             {
                 ValidateAllSiloEntries(initialRead.Entries);
-                return initialRead.Entries;
+                return RemoveBoundaryVersionRows(initialRead.Entries);
             }
 
-            string? beforeEtag = null;
-            string? afterEtag = null;
-            for (var attempt = 0; attempt < MaxMembershipSnapshotAttempts; attempt++)
+            if (TryAcceptBoundaryFencedSnapshot(initialRead.Entries, out var accepted, out var beforeVersion, out var afterVersion))
             {
-                var before = await membershipTableReadStorage.ReadTableVersionAsync(
-                    DeploymentId,
-                    SiloInstanceTableEntry.TABLE_VERSION_ROW);
-                beforeEtag = before.ETag;
+                return accepted;
+            }
 
-                var query = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(DeploymentId);
+            if (HasNoBoundaryVersionRows(initialRead.Entries))
+            {
+                ValidateAllSiloEntries(initialRead.Entries);
+                return RemoveBoundaryVersionRows(initialRead.Entries);
+            }
 
-                var after = await membershipTableReadStorage.ReadTableVersionAsync(
-                    DeploymentId,
-                    SiloInstanceTableEntry.TABLE_VERSION_ROW);
-                afterEtag = after.ETag;
+            for (var attempt = 1; attempt < MaxMembershipSnapshotAttempts; attempt++)
+            {
+                var query = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(DeploymentId, cancellationToken);
+                if (!query.IsPaginated)
+                {
+                    ValidateAllSiloEntries(query.Entries);
+                    return RemoveBoundaryVersionRows(query.Entries);
+                }
 
-                if (TryAcceptMembershipSnapshot(before, query.Entries, after, out var accepted))
+                if (TryAcceptBoundaryFencedSnapshot(query.Entries, out accepted, out beforeVersion, out afterVersion))
                 {
                     return accepted;
+                }
+
+                if (HasNoBoundaryVersionRows(query.Entries))
+                {
+                    ValidateAllSiloEntries(query.Entries);
+                    return RemoveBoundaryVersionRows(query.Entries);
                 }
             }
 
             throw new InconsistentStateException(
                 $"Unable to read a consistent membership snapshot for cluster '{DeploymentId}' from table '{TableName}' after {MaxMembershipSnapshotAttempts} attempts.",
-                beforeEtag,
-                afterEtag);
+                beforeVersion,
+                afterVersion);
         }
 
-        private static bool TryAcceptMembershipSnapshot(
-            (SiloInstanceTableEntry? Entity, string? ETag) before,
+        private static bool TryAcceptBoundaryFencedSnapshot(
             List<(SiloInstanceTableEntry Entity, string ETag)> queryResults,
-            (SiloInstanceTableEntry? Entity, string? ETag) after,
-            out List<(SiloInstanceTableEntry Entity, string ETag)> accepted)
+            [NotNullWhen(true)] out List<(SiloInstanceTableEntry Entity, string ETag)>? accepted,
+            out string? beforeVersion,
+            out string? afterVersion)
         {
-            accepted = null!;
-            if (before.Entity is null
-                || after.Entity is null
-                || before.ETag is null
-                || after.ETag is null
-                || !string.Equals(before.ETag, after.ETag, StringComparison.Ordinal)
-                || !string.Equals(before.Entity.MembershipVersion, after.Entity.MembershipVersion, StringComparison.Ordinal))
+            accepted = null;
+            ValidateAllSiloEntries(queryResults);
+
+            // Boundary-aware membership updates write both rows in the same transaction. Matching
+            // values prove that none committed while the paginated query was being read.
+            var beforeRows = queryResults
+                .Where(tuple => tuple.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN)
+                .ToList();
+            var afterRows = queryResults
+                .Where(tuple => tuple.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX)
+                .ToList();
+
+            beforeVersion = beforeRows.Count == 1 ? beforeRows[0].Entity.MembershipVersion : null;
+            afterVersion = afterRows.Count == 1 ? afterRows[0].Entity.MembershipVersion : null;
+            if (beforeRows.Count != 1
+                || afterRows.Count != 1
+                || beforeVersion is null
+                || !string.Equals(beforeVersion, afterVersion, StringComparison.Ordinal))
             {
                 return false;
             }
 
-            var versionRows = queryResults
-                .Where(tuple => tuple.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW)
-                .ToList();
-            if (versionRows.Count != 1
-                || !string.Equals(versionRows[0].ETag, after.ETag, StringComparison.Ordinal)
-                || !string.Equals(versionRows[0].Entity.MembershipVersion, after.Entity.MembershipVersion, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            // TableVersion fences topology changes, which are written with the silo row in one EGT.
-            // UpdateIAmAlive is intentionally a dirty, version-neutral update and may race this read.
-            accepted = queryResults
-                .Where(tuple => tuple.Entity.RowKey != SiloInstanceTableEntry.TABLE_VERSION_ROW)
-                .Append((after.Entity, after.ETag))
-                .ToList();
-            ValidateAllSiloEntries(accepted);
+            accepted = RemoveBoundaryVersionRows(queryResults);
             return true;
         }
+
+        private static List<(SiloInstanceTableEntry Entity, string ETag)> RemoveBoundaryVersionRows(
+            List<(SiloInstanceTableEntry Entity, string ETag)> queryResults)
+            => queryResults
+                .Where(tuple => tuple.Entity.RowKey is not (
+                    SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN or SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX))
+                .ToList();
+
+        private static bool HasNoBoundaryVersionRows(List<(SiloInstanceTableEntry Entity, string ETag)> queryResults)
+            => queryResults.All(tuple => tuple.Entity.RowKey is not (
+                SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN or SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX));
 
         private static void ValidateAllSiloEntries(List<(SiloInstanceTableEntry Entity, string ETag)> queryResults)
         {
@@ -339,8 +375,9 @@ namespace Orleans.AzureUtils
                     return false;
                 }
 
-                SiloInstanceTableEntry entry = CreateTableVersionEntry(0);
-                await storage.CreateTableEntryAsync(entry);
+                var entry = CreateTableVersionEntry(0);
+                var boundaryEntries = CreateBoundaryVersionEntries(entry);
+                await storage.CreateTableEntriesAsync([entry, boundaryEntries.Min, boundaryEntries.Max]);
                 return true;
             }
             catch (Exception exc)
@@ -364,7 +401,13 @@ namespace Orleans.AzureUtils
         {
             try
             {
-                await storage.InsertTwoTableEntriesConditionallyAsync(siloEntry, tableVersionEntry, tableVersionEtag);
+                var boundaryEntries = CreateBoundaryVersionEntries(tableVersionEntry);
+                await storage.InsertTwoTableEntriesConditionallyAsync(
+                    siloEntry,
+                    tableVersionEntry,
+                    tableVersionEtag,
+                    boundaryEntries.Min,
+                    boundaryEntries.Max);
                 return true;
             }
             catch (Exception exc)
@@ -390,7 +433,14 @@ namespace Orleans.AzureUtils
         {
             try
             {
-                await storage.UpdateTwoTableEntriesConditionallyAsync(siloEntry, entryEtag, tableVersionEntry, versionEtag);
+                var boundaryEntries = CreateBoundaryVersionEntries(tableVersionEntry);
+                await storage.UpdateTwoTableEntriesConditionallyAsync(
+                    siloEntry,
+                    entryEtag,
+                    tableVersionEntry,
+                    versionEtag,
+                    boundaryEntries.Min,
+                    boundaryEntries.Max);
                 return true;
             }
             catch (Exception exc)
@@ -472,21 +522,20 @@ namespace Orleans.AzureUtils
 
     internal interface IMembershipTableReadStorage
     {
-        Task<MembershipTableQueryResult> ReadAllTableEntriesForPartitionAsync(string partitionKey);
-
-        Task<(SiloInstanceTableEntry? Entity, string? ETag)> ReadTableVersionAsync(string partitionKey, string rowKey);
+        Task<MembershipTableQueryResult> ReadAllTableEntriesForPartitionAsync(
+            string partitionKey,
+            CancellationToken cancellationToken = default);
     }
 
     internal sealed class AzureMembershipTableReadStorage(AzureTableDataManager<SiloInstanceTableEntry> storage)
         : IMembershipTableReadStorage
     {
-        public async Task<MembershipTableQueryResult> ReadAllTableEntriesForPartitionAsync(string partitionKey)
+        public async Task<MembershipTableQueryResult> ReadAllTableEntriesForPartitionAsync(
+            string partitionKey,
+            CancellationToken cancellationToken = default)
         {
-            var result = await storage.ReadAllTableEntriesForPartitionWithPaginationAsync(partitionKey);
+            var result = await storage.ReadAllTableEntriesForPartitionWithPaginationAsync(partitionKey, cancellationToken);
             return new(result.Entries, result.IsPaginated);
         }
-
-        public Task<(SiloInstanceTableEntry? Entity, string? ETag)> ReadTableVersionAsync(string partitionKey, string rowKey)
-            => storage.ReadSingleTableEntryAsync(partitionKey, rowKey);
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -98,9 +97,16 @@ namespace Orleans.AzureUtils
         {
             var membershipVersion = tableVersionEntry.MembershipVersion
                 ?? throw new ArgumentException("The table version entry must have a membership version.", nameof(tableVersionEntry));
-            return (
-                CreateTableVersionEntry(SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN, membershipVersion),
-                CreateTableVersionEntry(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, membershipVersion));
+            var min = CreateTableVersionEntry(SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN, membershipVersion);
+            var max = CreateTableVersionEntry(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, membershipVersion);
+
+            // Prevent older cleanup agents from treating boundary rows as defunct silo entries
+            // while ensuring that gateway discovery does not treat them as gateways.
+            min.Status = INSTANCE_STATUS_ACTIVE;
+            min.ProxyPort = "0";
+            max.Status = INSTANCE_STATUS_ACTIVE;
+            max.ProxyPort = "0";
+            return (min, max);
         }
 
         public void RegisterSiloInstance(SiloInstanceTableEntry entry)
@@ -219,6 +225,7 @@ namespace Orleans.AzureUtils
                     && entry.Item1.Timestamp < beforeDate)
                 .ToList();
 
+            // Defunct-row cleanup intentionally does not advance the membership snapshot fence.
             await DeleteEntriesBatch(entriesList);
         }
 
@@ -248,7 +255,15 @@ namespace Orleans.AzureUtils
             if (queryResults.Count < 1 || queryResults.Count > 2)
                 throw new KeyNotFoundException(string.Format("Could not find table version row or found too many entries. Was looking for key {0}, found = {1}", siloAddress, Utils.EnumerableToString(queryResults)));
 
-            int numTableVersionRows = queryResults.Count(tuple => tuple.Item1.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW);
+            var numTableVersionRows = 0;
+            foreach (var entry in queryResults)
+            {
+                if (entry.Item1.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW)
+                {
+                    numTableVersionRows++;
+                }
+            }
+
             if (numTableVersionRows < 1)
                 throw new KeyNotFoundException(string.Format("Did not read table version row. Read = {0}", Utils.EnumerableToString(queryResults)));
 
@@ -268,9 +283,9 @@ namespace Orleans.AzureUtils
                 return RemoveBoundaryVersionRows(initialRead.Entries);
             }
 
-            if (TryAcceptBoundaryFencedSnapshot(initialRead.Entries, out var accepted, out var beforeVersion, out var afterVersion))
+            if (TryAcceptBoundaryFencedSnapshot(initialRead.Entries, out var beforeVersion, out var afterVersion))
             {
-                return accepted;
+                return initialRead.Entries;
             }
 
             if (HasNoBoundaryVersionRows(initialRead.Entries))
@@ -288,9 +303,9 @@ namespace Orleans.AzureUtils
                     return RemoveBoundaryVersionRows(query.Entries);
                 }
 
-                if (TryAcceptBoundaryFencedSnapshot(query.Entries, out accepted, out beforeVersion, out afterVersion))
+                if (TryAcceptBoundaryFencedSnapshot(query.Entries, out beforeVersion, out afterVersion))
                 {
-                    return accepted;
+                    return query.Entries;
                 }
 
                 if (HasNoBoundaryVersionRows(query.Entries))
@@ -308,58 +323,97 @@ namespace Orleans.AzureUtils
 
         private static bool TryAcceptBoundaryFencedSnapshot(
             List<(SiloInstanceTableEntry Entity, string ETag)> queryResults,
-            [NotNullWhen(true)] out List<(SiloInstanceTableEntry Entity, string ETag)>? accepted,
             out string? beforeVersion,
             out string? afterVersion)
         {
-            accepted = null;
-            ValidateAllSiloEntries(queryResults);
+            var tableVersion = ValidateAllSiloEntries(queryResults);
 
             // Boundary-aware membership updates write both rows in the same transaction. Matching
             // values prove that none committed while the paginated query was being read.
-            var beforeRows = queryResults
-                .Where(tuple => tuple.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN)
-                .ToList();
-            var afterRows = queryResults
-                .Where(tuple => tuple.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX)
-                .ToList();
-
-            beforeVersion = beforeRows.Count == 1 ? beforeRows[0].Entity.MembershipVersion : null;
-            afterVersion = afterRows.Count == 1 ? afterRows[0].Entity.MembershipVersion : null;
-            if (beforeRows.Count != 1
-                || afterRows.Count != 1
-                || beforeVersion is null
-                || !string.Equals(beforeVersion, afterVersion, StringComparison.Ordinal))
+            var first = queryResults[0].Entity;
+            var last = queryResults[^1].Entity;
+            beforeVersion = first.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN
+                ? first.MembershipVersion
+                : null;
+            afterVersion = last.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX
+                ? last.MembershipVersion
+                : null;
+            if (beforeVersion is null
+                || afterVersion is null)
             {
                 return false;
             }
 
-            accepted = RemoveBoundaryVersionRows(queryResults);
+            if (!string.Equals(beforeVersion, afterVersion, StringComparison.Ordinal)
+                && !IsLegacyTableVersionAhead(tableVersion, beforeVersion, afterVersion))
+            {
+                return false;
+            }
+
+            RemoveBoundaryVersionRows(queryResults);
             return true;
+        }
+
+        private static bool IsLegacyTableVersionAhead(
+            string? tableVersion,
+            string beforeVersion,
+            string afterVersion)
+        {
+            // Older silos only advance VersionRow. During a rolling upgrade, prefer availability
+            // over snapshot consistency when that row proves that the boundary fence is stale.
+            return int.TryParse(tableVersion, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedTableVersion)
+                && int.TryParse(beforeVersion, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedBeforeVersion)
+                && int.TryParse(afterVersion, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedAfterVersion)
+                && parsedTableVersion > parsedBeforeVersion
+                && parsedTableVersion > parsedAfterVersion;
         }
 
         private static List<(SiloInstanceTableEntry Entity, string ETag)> RemoveBoundaryVersionRows(
             List<(SiloInstanceTableEntry Entity, string ETag)> queryResults)
-            => queryResults
-                .Where(tuple => tuple.Entity.RowKey is not (
-                    SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN or SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX))
-                .ToList();
+        {
+            if (queryResults.Count > 0
+                && queryResults[^1].Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX)
+            {
+                queryResults.RemoveAt(queryResults.Count - 1);
+            }
+
+            if (queryResults.Count > 0
+                && queryResults[0].Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN)
+            {
+                queryResults.RemoveAt(0);
+            }
+
+            return queryResults;
+        }
 
         private static bool HasNoBoundaryVersionRows(List<(SiloInstanceTableEntry Entity, string ETag)> queryResults)
-            => queryResults.All(tuple => tuple.Entity.RowKey is not (
-                SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN or SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX));
+        {
+            return queryResults[0].Entity.RowKey != SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN
+                && queryResults[^1].Entity.RowKey != SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX;
+        }
 
-        private static void ValidateAllSiloEntries(List<(SiloInstanceTableEntry Entity, string ETag)> queryResults)
+        private static string? ValidateAllSiloEntries(List<(SiloInstanceTableEntry Entity, string ETag)> queryResults)
         {
             if (queryResults.Count < 1)
                 throw new KeyNotFoundException(string.Format("Could not find enough rows in the FindAllSiloEntries call. Found = {0}", Utils.EnumerableToString(queryResults)));
 
-            int numTableVersionRows = queryResults.Count(tuple => tuple.Item1.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW);
+            var numTableVersionRows = 0;
+            string? tableVersion = null;
+            foreach (var entry in queryResults)
+            {
+                if (entry.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW)
+                {
+                    numTableVersionRows++;
+                    tableVersion = entry.Entity.MembershipVersion;
+                }
+            }
+
             if (numTableVersionRows < 1)
                 throw new KeyNotFoundException(string.Format("Did not find table version row. Read = {0}", Utils.EnumerableToString(queryResults)));
             if (numTableVersionRows > 1)
                 throw new KeyNotFoundException(string.Format("Read {0} table version rows, while was expecting only 1. Read = {1}", numTableVersionRows, Utils.EnumerableToString(queryResults)));
 
+            return tableVersion;
         }
 
         /// <summary>

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -279,18 +279,22 @@ namespace Orleans.AzureUtils
             {
                 var query = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(DeploymentId, cancellationToken);
                 var tableVersion = ValidateAllSiloEntries(query.Entries);
-                if (!query.IsPaginated || HasNoBoundaryVersionRows(query.Entries))
+                if (!query.IsPaginated)
                 {
                     return RemoveBoundaryVersionRows(query.Entries);
                 }
 
-                if (TryAcceptBoundaryFencedSnapshot(
-                    query.Entries,
-                    tableVersion,
-                    out beforeVersion,
-                    out afterVersion))
+                var first = query.Entries[0].Entity;
+                var last = query.Entries[^1].Entity;
+                beforeVersion = first.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN
+                    ? first.MembershipVersion
+                    : null;
+                afterVersion = last.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX
+                    ? last.MembershipVersion
+                    : null;
+                if (CanAcceptSnapshot(tableVersion, beforeVersion, afterVersion))
                 {
-                    return query.Entries;
+                    return RemoveBoundaryVersionRows(query.Entries);
                 }
             }
 
@@ -300,36 +304,26 @@ namespace Orleans.AzureUtils
                 afterVersion);
         }
 
-        private static bool TryAcceptBoundaryFencedSnapshot(
-            List<(SiloInstanceTableEntry Entity, string ETag)> queryResults,
+        private static bool CanAcceptSnapshot(
             string? tableVersion,
-            out string? beforeVersion,
-            out string? afterVersion)
+            string? beforeVersion,
+            string? afterVersion)
         {
             // Boundary-aware membership updates write both rows in the same transaction. Matching
             // values prove that none committed while the paginated query was being read.
-            var first = queryResults[0].Entity;
-            var last = queryResults[^1].Entity;
-            beforeVersion = first.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN
-                ? first.MembershipVersion
-                : null;
-            afterVersion = last.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX
-                ? last.MembershipVersion
-                : null;
+            if (beforeVersion is null && afterVersion is null)
+            {
+                return true;
+            }
+
             if (beforeVersion is null
                 || afterVersion is null)
             {
                 return false;
             }
 
-            if (!string.Equals(beforeVersion, afterVersion, StringComparison.Ordinal)
-                && !IsLegacyTableVersionAhead(tableVersion, beforeVersion, afterVersion))
-            {
-                return false;
-            }
-
-            RemoveBoundaryVersionRows(queryResults);
-            return true;
+            return string.Equals(beforeVersion, afterVersion, StringComparison.Ordinal)
+                || IsLegacyTableVersionAhead(tableVersion, beforeVersion, afterVersion);
         }
 
         private static bool IsLegacyTableVersionAhead(
@@ -362,12 +356,6 @@ namespace Orleans.AzureUtils
             }
 
             return queryResults;
-        }
-
-        private static bool HasNoBoundaryVersionRows(List<(SiloInstanceTableEntry Entity, string ETag)> queryResults)
-        {
-            return queryResults[0].Entity.RowKey != SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN
-                && queryResults[^1].Entity.RowKey != SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX;
         }
 
         private static string? ValidateAllSiloEntries(List<(SiloInstanceTableEntry Entity, string ETag)> queryResults)

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -10,11 +10,14 @@ using Microsoft.Extensions.Logging;
 using Orleans.Clustering.AzureStorage;
 using Orleans.Clustering.AzureStorage.Utilities;
 using Orleans.Runtime;
+using Orleans.Storage;
 
 namespace Orleans.AzureUtils
 {
     internal partial class OrleansSiloInstanceManager
     {
+        internal const int MaxMembershipSnapshotAttempts = 5;
+
         public string TableName { get; }
 
         private const string INSTANCE_STATUS_CREATED = nameof(SiloStatus.Created);  //"Created";
@@ -22,6 +25,7 @@ namespace Orleans.AzureUtils
         private const string INSTANCE_STATUS_DEAD = nameof(SiloStatus.Dead);        //"Dead";
 
         private readonly AzureTableDataManager<SiloInstanceTableEntry> storage;
+        private readonly IMembershipTableReadStorage membershipTableReadStorage;
         private readonly ILogger logger;
         private readonly AzureStoragePolicyOptions storagePolicyOptions;
 
@@ -31,6 +35,15 @@ namespace Orleans.AzureUtils
             string clusterId,
             ILoggerFactory loggerFactory,
             AzureStorageOperationOptions options)
+            : this(clusterId, loggerFactory, options, null)
+        {
+        }
+
+        internal OrleansSiloInstanceManager(
+            string clusterId,
+            ILoggerFactory loggerFactory,
+            AzureStorageOperationOptions options,
+            IMembershipTableReadStorage? membershipTableReadStorage)
         {
             DeploymentId = clusterId;
             TableName = options.TableName;
@@ -38,6 +51,7 @@ namespace Orleans.AzureUtils
             storage = new AzureTableDataManager<SiloInstanceTableEntry>(
                 options,
                 loggerFactory.CreateLogger<AzureTableDataManager<SiloInstanceTableEntry>>());
+            this.membershipTableReadStorage = membershipTableReadStorage ?? new AzureMembershipTableReadStorage(storage);
             this.storagePolicyOptions = options.StoragePolicyOptions;
         }
 
@@ -225,9 +239,82 @@ namespace Orleans.AzureUtils
             return queryResults;
         }
 
-        internal async Task<List<(SiloInstanceTableEntry, string)>> FindAllSiloEntries()
+        internal async Task<List<(SiloInstanceTableEntry Entity, string ETag)>> FindAllSiloEntries()
         {
-            var queryResults = await storage.ReadAllTableEntriesForPartitionAsync(this.DeploymentId);
+            var initialRead = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(this.DeploymentId);
+            if (!initialRead.IsPaginated)
+            {
+                ValidateAllSiloEntries(initialRead.Entries);
+                return initialRead.Entries;
+            }
+
+            string? beforeEtag = null;
+            string? afterEtag = null;
+            for (var attempt = 0; attempt < MaxMembershipSnapshotAttempts; attempt++)
+            {
+                var before = await membershipTableReadStorage.ReadTableVersionAsync(
+                    DeploymentId,
+                    SiloInstanceTableEntry.TABLE_VERSION_ROW);
+                beforeEtag = before.ETag;
+
+                var query = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(DeploymentId);
+
+                var after = await membershipTableReadStorage.ReadTableVersionAsync(
+                    DeploymentId,
+                    SiloInstanceTableEntry.TABLE_VERSION_ROW);
+                afterEtag = after.ETag;
+
+                if (TryAcceptMembershipSnapshot(before, query.Entries, after, out var accepted))
+                {
+                    return accepted;
+                }
+            }
+
+            throw new InconsistentStateException(
+                $"Unable to read a consistent membership snapshot for cluster '{DeploymentId}' from table '{TableName}' after {MaxMembershipSnapshotAttempts} attempts.",
+                beforeEtag,
+                afterEtag);
+        }
+
+        private static bool TryAcceptMembershipSnapshot(
+            (SiloInstanceTableEntry? Entity, string? ETag) before,
+            List<(SiloInstanceTableEntry Entity, string ETag)> queryResults,
+            (SiloInstanceTableEntry? Entity, string? ETag) after,
+            out List<(SiloInstanceTableEntry Entity, string ETag)> accepted)
+        {
+            accepted = null!;
+            if (before.Entity is null
+                || after.Entity is null
+                || before.ETag is null
+                || after.ETag is null
+                || !string.Equals(before.ETag, after.ETag, StringComparison.Ordinal)
+                || !string.Equals(before.Entity.MembershipVersion, after.Entity.MembershipVersion, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var versionRows = queryResults
+                .Where(tuple => tuple.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW)
+                .ToList();
+            if (versionRows.Count != 1
+                || !string.Equals(versionRows[0].ETag, after.ETag, StringComparison.Ordinal)
+                || !string.Equals(versionRows[0].Entity.MembershipVersion, after.Entity.MembershipVersion, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            // TableVersion fences topology changes, which are written with the silo row in one EGT.
+            // UpdateIAmAlive is intentionally a dirty, version-neutral update and may race this read.
+            accepted = queryResults
+                .Where(tuple => tuple.Entity.RowKey != SiloInstanceTableEntry.TABLE_VERSION_ROW)
+                .Append((after.Entity, after.ETag))
+                .ToList();
+            ValidateAllSiloEntries(accepted);
+            return true;
+        }
+
+        private static void ValidateAllSiloEntries(List<(SiloInstanceTableEntry Entity, string ETag)> queryResults)
+        {
             if (queryResults.Count < 1)
                 throw new KeyNotFoundException(string.Format("Could not find enough rows in the FindAllSiloEntries call. Found = {0}", Utils.EnumerableToString(queryResults)));
 
@@ -237,7 +324,6 @@ namespace Orleans.AzureUtils
             if (numTableVersionRows > 1)
                 throw new KeyNotFoundException(string.Format("Read {0} table version rows, while was expecting only 1. Read = {1}", numTableVersionRows, Utils.EnumerableToString(queryResults)));
 
-            return queryResults;
         }
 
         /// <summary>
@@ -378,5 +464,29 @@ namespace Orleans.AzureUtils
             Message = "UpdateSiloEntryConditionally failed with httpStatusCode={HttpStatusCode}, restStatus={RestStatus}"
         )]
         private partial void LogTraceUpdateSiloEntryConditionallyFailed(HttpStatusCode httpStatusCode, string? restStatus);
+    }
+
+    internal readonly record struct MembershipTableQueryResult(
+        List<(SiloInstanceTableEntry Entity, string ETag)> Entries,
+        bool IsPaginated);
+
+    internal interface IMembershipTableReadStorage
+    {
+        Task<MembershipTableQueryResult> ReadAllTableEntriesForPartitionAsync(string partitionKey);
+
+        Task<(SiloInstanceTableEntry? Entity, string? ETag)> ReadTableVersionAsync(string partitionKey, string rowKey);
+    }
+
+    internal sealed class AzureMembershipTableReadStorage(AzureTableDataManager<SiloInstanceTableEntry> storage)
+        : IMembershipTableReadStorage
+    {
+        public async Task<MembershipTableQueryResult> ReadAllTableEntriesForPartitionAsync(string partitionKey)
+        {
+            var result = await storage.ReadAllTableEntriesForPartitionWithPaginationAsync(partitionKey);
+            return new(result.Entries, result.IsPaginated);
+        }
+
+        public Task<(SiloInstanceTableEntry? Entity, string? ETag)> ReadTableVersionAsync(string partitionKey, string rowKey)
+            => storage.ReadSingleTableEntryAsync(partitionKey, rowKey);
     }
 }

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -273,21 +273,27 @@ namespace Orleans.AzureUtils
         internal async Task<List<(SiloInstanceTableEntry Entity, string ETag)>> FindAllSiloEntries(
             CancellationToken cancellationToken = default)
         {
-            for (var attempt = 1; ; attempt++)
+            MembershipTableQueryResult query = default;
+            for (var attempt = 0; attempt < MaxMembershipSnapshotAttempts; attempt++)
             {
-                var query = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(DeploymentId, cancellationToken);
+                query = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(DeploymentId, cancellationToken);
                 var tableVersion = ValidateAllSiloEntries(query.Entries);
-                if (CanAcceptSnapshot(query, tableVersion, attempt))
+                if (CanAcceptSnapshot(query, tableVersion))
                 {
                     return RemoveBoundaryVersionRows(query.Entries);
                 }
             }
+
+            var boundaryVersions = GetBoundaryVersions(query);
+            throw new InconsistentStateException(
+                $"Unable to read a consistent membership snapshot for cluster '{DeploymentId}' from table '{TableName}' after {MaxMembershipSnapshotAttempts} attempts.",
+                boundaryVersions.Before,
+                boundaryVersions.After);
         }
 
-        private bool CanAcceptSnapshot(
+        private static bool CanAcceptSnapshot(
             MembershipTableQueryResult query,
-            string? tableVersion,
-            int attempt)
+            string? tableVersion)
         {
             if (!query.IsPaginated)
             {
@@ -296,14 +302,9 @@ namespace Orleans.AzureUtils
 
             // Boundary-aware membership updates write both rows in the same transaction. Matching
             // values prove that none committed while the paginated query was being read.
-            var first = query.Entries[0].Entity;
-            var last = query.Entries[^1].Entity;
-            var beforeVersion = first.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN
-                ? first.MembershipVersion
-                : null;
-            var afterVersion = last.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX
-                ? last.MembershipVersion
-                : null;
+            var boundaryVersions = GetBoundaryVersions(query);
+            var beforeVersion = boundaryVersions.Before;
+            var afterVersion = boundaryVersions.After;
             if (beforeVersion is null && afterVersion is null)
             {
                 return true;
@@ -317,15 +318,16 @@ namespace Orleans.AzureUtils
                 return true;
             }
 
-            if (attempt >= MaxMembershipSnapshotAttempts)
-            {
-                throw new InconsistentStateException(
-                    $"Unable to read a consistent membership snapshot for cluster '{DeploymentId}' from table '{TableName}' after {MaxMembershipSnapshotAttempts} attempts.",
-                    beforeVersion,
-                    afterVersion);
-            }
-
             return false;
+        }
+
+        private static (string? Before, string? After) GetBoundaryVersions(MembershipTableQueryResult query)
+        {
+            var first = query.Entries[0].Entity;
+            var last = query.Entries[^1].Entity;
+            return (
+                first.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN ? first.MembershipVersion : null,
+                last.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX ? last.MembershipVersion : null);
         }
 
         private static bool IsLegacyTableVersionAhead(

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -273,57 +273,59 @@ namespace Orleans.AzureUtils
         internal async Task<List<(SiloInstanceTableEntry Entity, string ETag)>> FindAllSiloEntries(
             CancellationToken cancellationToken = default)
         {
-            string? beforeVersion = null;
-            string? afterVersion = null;
-            for (var attempt = 0; attempt < MaxMembershipSnapshotAttempts; attempt++)
+            for (var attempt = 1; ; attempt++)
             {
                 var query = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(DeploymentId, cancellationToken);
                 var tableVersion = ValidateAllSiloEntries(query.Entries);
-                if (!query.IsPaginated)
-                {
-                    return RemoveBoundaryVersionRows(query.Entries);
-                }
-
-                var first = query.Entries[0].Entity;
-                var last = query.Entries[^1].Entity;
-                beforeVersion = first.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN
-                    ? first.MembershipVersion
-                    : null;
-                afterVersion = last.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX
-                    ? last.MembershipVersion
-                    : null;
-                if (CanAcceptSnapshot(tableVersion, beforeVersion, afterVersion))
+                if (CanAcceptSnapshot(query, tableVersion, attempt))
                 {
                     return RemoveBoundaryVersionRows(query.Entries);
                 }
             }
-
-            throw new InconsistentStateException(
-                $"Unable to read a consistent membership snapshot for cluster '{DeploymentId}' from table '{TableName}' after {MaxMembershipSnapshotAttempts} attempts.",
-                beforeVersion,
-                afterVersion);
         }
 
-        private static bool CanAcceptSnapshot(
+        private bool CanAcceptSnapshot(
+            MembershipTableQueryResult query,
             string? tableVersion,
-            string? beforeVersion,
-            string? afterVersion)
+            int attempt)
         {
+            if (!query.IsPaginated)
+            {
+                return true;
+            }
+
             // Boundary-aware membership updates write both rows in the same transaction. Matching
             // values prove that none committed while the paginated query was being read.
+            var first = query.Entries[0].Entity;
+            var last = query.Entries[^1].Entity;
+            var beforeVersion = first.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN
+                ? first.MembershipVersion
+                : null;
+            var afterVersion = last.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX
+                ? last.MembershipVersion
+                : null;
             if (beforeVersion is null && afterVersion is null)
             {
                 return true;
             }
 
-            if (beforeVersion is null
-                || afterVersion is null)
+            if (beforeVersion is not null
+                && afterVersion is not null
+                && (string.Equals(beforeVersion, afterVersion, StringComparison.Ordinal)
+                    || IsLegacyTableVersionAhead(tableVersion, beforeVersion, afterVersion)))
             {
-                return false;
+                return true;
             }
 
-            return string.Equals(beforeVersion, afterVersion, StringComparison.Ordinal)
-                || IsLegacyTableVersionAhead(tableVersion, beforeVersion, afterVersion);
+            if (attempt >= MaxMembershipSnapshotAttempts)
+            {
+                throw new InconsistentStateException(
+                    $"Unable to read a consistent membership snapshot for cluster '{DeploymentId}' from table '{TableName}' after {MaxMembershipSnapshotAttempts} attempts.",
+                    beforeVersion,
+                    afterVersion);
+            }
+
+            return false;
         }
 
         private static bool IsLegacyTableVersionAhead(

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -273,42 +273,24 @@ namespace Orleans.AzureUtils
         internal async Task<List<(SiloInstanceTableEntry Entity, string ETag)>> FindAllSiloEntries(
             CancellationToken cancellationToken = default)
         {
-            var initialRead = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(this.DeploymentId, cancellationToken);
-            if (!initialRead.IsPaginated)
-            {
-                ValidateAllSiloEntries(initialRead.Entries);
-                return RemoveBoundaryVersionRows(initialRead.Entries);
-            }
-
-            if (TryAcceptBoundaryFencedSnapshot(initialRead.Entries, out var beforeVersion, out var afterVersion))
-            {
-                return initialRead.Entries;
-            }
-
-            if (HasNoBoundaryVersionRows(initialRead.Entries))
-            {
-                ValidateAllSiloEntries(initialRead.Entries);
-                return RemoveBoundaryVersionRows(initialRead.Entries);
-            }
-
-            for (var attempt = 1; attempt < MaxMembershipSnapshotAttempts; attempt++)
+            string? beforeVersion = null;
+            string? afterVersion = null;
+            for (var attempt = 0; attempt < MaxMembershipSnapshotAttempts; attempt++)
             {
                 var query = await membershipTableReadStorage.ReadAllTableEntriesForPartitionAsync(DeploymentId, cancellationToken);
-                if (!query.IsPaginated)
+                var tableVersion = ValidateAllSiloEntries(query.Entries);
+                if (!query.IsPaginated || HasNoBoundaryVersionRows(query.Entries))
                 {
-                    ValidateAllSiloEntries(query.Entries);
                     return RemoveBoundaryVersionRows(query.Entries);
                 }
 
-                if (TryAcceptBoundaryFencedSnapshot(query.Entries, out beforeVersion, out afterVersion))
+                if (TryAcceptBoundaryFencedSnapshot(
+                    query.Entries,
+                    tableVersion,
+                    out beforeVersion,
+                    out afterVersion))
                 {
                     return query.Entries;
-                }
-
-                if (HasNoBoundaryVersionRows(query.Entries))
-                {
-                    ValidateAllSiloEntries(query.Entries);
-                    return RemoveBoundaryVersionRows(query.Entries);
                 }
             }
 
@@ -320,11 +302,10 @@ namespace Orleans.AzureUtils
 
         private static bool TryAcceptBoundaryFencedSnapshot(
             List<(SiloInstanceTableEntry Entity, string ETag)> queryResults,
+            string? tableVersion,
             out string? beforeVersion,
             out string? afterVersion)
         {
-            var tableVersion = ValidateAllSiloEntries(queryResults);
-
             // Boundary-aware membership updates write both rows in the same transaction. Matching
             // values prove that none committed while the paginated query was being read.
             var first = queryResults[0].Entity;

--- a/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/OrleansSiloInstanceManager.cs
@@ -100,12 +100,9 @@ namespace Orleans.AzureUtils
             var min = CreateTableVersionEntry(SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN, membershipVersion);
             var max = CreateTableVersionEntry(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, membershipVersion);
 
-            // Prevent older cleanup agents from treating boundary rows as defunct silo entries
-            // while ensuring that gateway discovery does not treat them as gateways.
+            // Prevent older cleanup agents from treating boundary rows as defunct silo entries.
             min.Status = INSTANCE_STATUS_ACTIVE;
-            min.ProxyPort = "0";
             max.Status = INSTANCE_STATUS_ACTIVE;
-            max.ProxyPort = "0";
             return (min, max);
         }
 
@@ -456,12 +453,10 @@ namespace Orleans.AzureUtils
             try
             {
                 var boundaryEntries = CreateBoundaryVersionEntries(tableVersionEntry);
-                await storage.InsertTwoTableEntriesConditionallyAsync(
+                await storage.CreateAndUpdateTableEntriesAsync(
                     siloEntry,
-                    tableVersionEntry,
-                    tableVersionEtag,
-                    boundaryEntries.Min,
-                    boundaryEntries.Max);
+                    (tableVersionEntry, tableVersionEtag),
+                    (boundaryEntries.Min, boundaryEntries.Max));
                 return true;
             }
             catch (Exception exc)
@@ -488,13 +483,10 @@ namespace Orleans.AzureUtils
             try
             {
                 var boundaryEntries = CreateBoundaryVersionEntries(tableVersionEntry);
-                await storage.UpdateTwoTableEntriesConditionallyAsync(
-                    siloEntry,
-                    entryEtag,
-                    tableVersionEntry,
-                    versionEtag,
-                    boundaryEntries.Min,
-                    boundaryEntries.Max);
+                await storage.UpdateTableEntriesAsync(
+                    (siloEntry, entryEtag),
+                    (tableVersionEntry, versionEtag),
+                    (boundaryEntries.Min, boundaryEntries.Max));
                 return true;
             }
             catch (Exception exc)

--- a/src/Azure/Orleans.Clustering.AzureStorage/SiloInstanceTableEntry.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/SiloInstanceTableEntry.cs
@@ -39,8 +39,8 @@ namespace Orleans.AzureUtils
 
         internal const string TABLE_VERSION_ROW = "VersionRow";
         // Azure Table queries sort by RowKey. These values sort around every IPv4 and IPv6 address string.
-        internal const string TABLE_VERSION_ROW_MIN = "!VersionRow";
-        internal const string TABLE_VERSION_ROW_MAX = "~VersionRow";
+        internal const string TABLE_VERSION_ROW_MIN = "!Start";
+        internal const string TABLE_VERSION_ROW_MAX = "~End";
         internal const char Seperator = '-';
 
         internal static bool IsVersionRow(string rowKey)

--- a/src/Azure/Orleans.Clustering.AzureStorage/SiloInstanceTableEntry.cs
+++ b/src/Azure/Orleans.Clustering.AzureStorage/SiloInstanceTableEntry.cs
@@ -30,15 +30,21 @@ namespace Orleans.AzureUtils
 
         public string? StartTime       { get; set; }          // Time this silo was started. For diagnostics.
         public string? IAmAliveTime    { get; set; }           // Time this silo updated it was alive. For diagnostics.
-        public string? MembershipVersion      { get; set; }               // Special version row (for serializing table updates). // We'll have a designated row with only MembershipVersion column.
+        public string? MembershipVersion { get; set; }
 
         public string PartitionKey { get; set; } = null!;
         public string RowKey { get; set; } = null!;
         public DateTimeOffset? Timestamp { get; set; }
         public ETag ETag { get; set; }
 
-        internal const string TABLE_VERSION_ROW = "VersionRow"; // Row key for version row.
+        internal const string TABLE_VERSION_ROW = "VersionRow";
+        // Azure Table queries sort by RowKey. These values sort around every IPv4 and IPv6 address string.
+        internal const string TABLE_VERSION_ROW_MIN = "!VersionRow";
+        internal const string TABLE_VERSION_ROW_MAX = "~VersionRow";
         internal const char Seperator = '-';
+
+        internal static bool IsVersionRow(string rowKey)
+            => rowKey is TABLE_VERSION_ROW or TABLE_VERSION_ROW_MIN or TABLE_VERSION_ROW_MAX;
 
         public static string ConstructRowKey(SiloAddress silo)
         {
@@ -82,9 +88,9 @@ namespace Orleans.AzureUtils
         public override string ToString()
         {
             var sb = new StringBuilder();
-            if (RowKey.Equals(TABLE_VERSION_ROW))
+            if (IsVersionRow(RowKey))
             {
-                sb.Append("VersionRow [").Append(DeploymentId);
+                sb.Append("VersionRow [").Append(RowKey);
                 sb.Append(" Deployment=").Append(DeploymentId);
                 sb.Append(" MembershipVersion=").Append(MembershipVersion);
                 sb.Append("]");

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -642,37 +642,31 @@ namespace Orleans.GrainDirectory.AzureStorage
             }
         }
 
-        internal async Task<(string, string)> InsertTwoTableEntriesConditionallyAsync(
-            T data1,
-            T data2,
-            string data2Etag,
-            T? additionalEntry1 = null,
-            T? additionalEntry2 = null)
+        internal async Task<(string CreatedEntryETag, string UpdatedEntryETag)> CreateAndUpdateTableEntriesAsync(
+            T entryToCreate,
+            (T Entity, string ETag) entryToUpdate,
+            (T First, T Second)? entriesToUpsert = null)
         {
-            const string operation = "InsertTableEntryConditionally";
-            ArgumentNullException.ThrowIfNull(data2);
-            string? data2Str = data2.ToString();
+            const string operation = "CreateAndUpdateTableEntries";
+            ArgumentNullException.ThrowIfNull(entryToUpdate.Entity);
+            string? entryToUpdateString = entryToUpdate.Entity.ToString();
             var startTime = DateTime.UtcNow;
 
-            LogTraceTableEntries(Logger, operation, data1, data2Str, TableName);
+            LogTraceTableEntries(Logger, operation, entryToCreate, entryToUpdateString, TableName);
             try
             {
                 try
                 {
-                    data2.ETag = new ETag(data2Etag);
-                    var transaction = new List<TableTransactionAction>(4)
+                    entryToUpdate.Entity.ETag = new ETag(entryToUpdate.ETag);
+                    var transaction = new List<TableTransactionAction>(entriesToUpsert.HasValue ? 4 : 2)
                     {
-                        new TableTransactionAction(TableTransactionActionType.Add, data1),
-                        new TableTransactionAction(TableTransactionActionType.UpdateReplace, data2, data2.ETag)
+                        new(TableTransactionActionType.Add, entryToCreate),
+                        new(TableTransactionActionType.UpdateReplace, entryToUpdate.Entity, entryToUpdate.Entity.ETag)
                     };
-                    if (additionalEntry1 is not null)
+                    if (entriesToUpsert is { } upserts)
                     {
-                        transaction.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, additionalEntry1));
-                    }
-
-                    if (additionalEntry2 is not null)
-                    {
-                        transaction.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, additionalEntry2));
+                        transaction.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, upserts.First));
+                        transaction.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, upserts.Second));
                     }
 
                     var opResults = await Table.SubmitTransactionAsync(transaction);
@@ -686,7 +680,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                 }
                 catch (Exception exc)
                 {
-                    CheckAlertWriteError(operation, data1, data2Str, exc);
+                    CheckAlertWriteError(operation, entryToCreate, entryToUpdateString, exc);
                     throw;
                 }
             }
@@ -696,39 +690,38 @@ namespace Orleans.GrainDirectory.AzureStorage
             }
         }
 
-        internal async Task<(string, string)> UpdateTwoTableEntriesConditionallyAsync(
-            T data1,
-            string data1Etag,
-            T data2,
-            string data2Etag,
-            T? additionalEntry1 = null,
-            T? additionalEntry2 = null)
+        internal async Task<(string FirstEntryETag, string SecondEntryETag)> UpdateTableEntriesAsync(
+            (T Entity, string ETag) firstEntry,
+            (T Entity, string ETag) secondEntry,
+            (T First, T Second)? entriesToUpsert = null)
         {
-            const string operation = "UpdateTableEntryConditionally";
-            ArgumentNullException.ThrowIfNull(data2);
-            string? data2Str = data2.ToString();
+            const string operation = "UpdateTableEntries";
+            ArgumentNullException.ThrowIfNull(firstEntry.Entity);
+            ArgumentNullException.ThrowIfNull(secondEntry.Entity);
+            string? secondEntryString = secondEntry.Entity.ToString();
             var startTime = DateTime.UtcNow;
-            LogTraceTableEntries(Logger, operation, data1, data2Str, TableName);
+            LogTraceTableEntries(Logger, operation, firstEntry.Entity, secondEntryString, TableName);
 
             try
             {
                 try
                 {
-                    data1.ETag = new ETag(data1Etag);
-                    var entityBatch = new List<TableTransactionAction>(4);
-                    entityBatch.Add(new TableTransactionAction(TableTransactionActionType.UpdateReplace, data1, data1.ETag));
-
-                    data2.ETag = new ETag(data2Etag);
-                    entityBatch.Add(new TableTransactionAction(TableTransactionActionType.UpdateReplace, data2, data2.ETag));
-
-                    if (additionalEntry1 is not null)
+                    firstEntry.Entity.ETag = new ETag(firstEntry.ETag);
+                    var entityBatch = new List<TableTransactionAction>(entriesToUpsert.HasValue ? 4 : 2)
                     {
-                        entityBatch.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, additionalEntry1));
-                    }
+                        new(TableTransactionActionType.UpdateReplace, firstEntry.Entity, firstEntry.Entity.ETag)
+                    };
 
-                    if (additionalEntry2 is not null)
+                    secondEntry.Entity.ETag = new ETag(secondEntry.ETag);
+                    entityBatch.Add(new TableTransactionAction(
+                        TableTransactionActionType.UpdateReplace,
+                        secondEntry.Entity,
+                        secondEntry.Entity.ETag));
+
+                    if (entriesToUpsert is { } upserts)
                     {
-                        entityBatch.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, additionalEntry2));
+                        entityBatch.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, upserts.First));
+                        entityBatch.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, upserts.Second));
                     }
 
                     var opResults = await Table.SubmitTransactionAsync(entityBatch);
@@ -742,7 +735,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                 }
                 catch (Exception exc)
                 {
-                    CheckAlertWriteError(operation, data1, data2Str, exc);
+                    CheckAlertWriteError(operation, firstEntry.Entity, secondEntryString, exc);
                     throw;
                 }
             }

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -418,6 +418,17 @@ namespace Orleans.GrainDirectory.AzureStorage
         }
 
         /// <summary>
+        /// Read all entries in one partition of the storage table, preserving whether the query required multiple pages.
+        /// </summary>
+        /// <param name="partitionKey">The key for the partition to be searched.</param>
+        /// <returns>The entries in the partition and whether more than one response page was required.</returns>
+        public Task<(List<(T Entity, string ETag)> Entries, bool IsPaginated)> ReadAllTableEntriesForPartitionWithPaginationAsync(string partitionKey)
+        {
+            string query = TableClient.CreateQueryFilter($"PartitionKey eq {partitionKey}");
+            return ReadTableEntriesAndEtagsWithPaginationAsync(query);
+        }
+
+        /// <summary>
         /// Read all entries in the table.
         /// NOTE: This could be a very expensive and slow operation for large tables!
         /// </summary>
@@ -485,18 +496,29 @@ namespace Orleans.GrainDirectory.AzureStorage
         /// <returns>Enumeration of entries in the table which match the query condition.</returns>
         public async Task<List<(T Entity, string ETag)>> ReadTableEntriesAndEtagsAsync(string? filter)
         {
+            var result = await ReadTableEntriesAndEtagsWithPaginationAsync(filter);
+            return result.Entries;
+        }
+
+        private async Task<(List<(T Entity, string ETag)> Entries, bool IsPaginated)> ReadTableEntriesAndEtagsWithPaginationAsync(string? filter)
+        {
             const string operation = "ReadTableEntriesAndEtags";
             var startTime = DateTime.UtcNow;
 
             try
             {
                 var results = new List<(T, string)>();
-                await foreach (var value in Table.QueryAsync<T>(filter))
+                var pageCount = 0;
+                await foreach (var page in Table.QueryAsync<T>(filter).AsPages())
                 {
-                    results.Add((value, value.ETag.ToString()));
+                    pageCount++;
+                    foreach (var value in page.Values)
+                    {
+                        results.Add((value, value.ETag.ToString()));
+                    }
                 }
 
-                return results;
+                return (results, pageCount > 1);
             }
             catch (Exception exc)
             {

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Data.Tables;
@@ -371,8 +372,12 @@ namespace Orleans.GrainDirectory.AzureStorage
         /// </summary>
         /// <param name="partitionKey">The partition key for the entry.</param>
         /// <param name="rowKey">The row key for the entry.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>Value promise for tuple containing the data entry and its corresponding etag.</returns>
-        public async Task<(T? Entity, string? ETag)> ReadSingleTableEntryAsync(string partitionKey, string rowKey)
+        public async Task<(T? Entity, string? ETag)> ReadSingleTableEntryAsync(
+            string partitionKey,
+            string rowKey,
+            CancellationToken cancellationToken = default)
         {
             const string operation = "ReadSingleTableEntryAsync";
             var startTime = DateTime.UtcNow;
@@ -381,7 +386,10 @@ namespace Orleans.GrainDirectory.AzureStorage
             {
                 try
                 {
-                    var result = await Table.GetEntityIfExistsAsync<T>(partitionKey, rowKey);
+                    var result = await Table.GetEntityIfExistsAsync<T>(
+                        partitionKey,
+                        rowKey,
+                        cancellationToken: cancellationToken);
                     if (result.HasValue)
                     {
                         //The ETag of data is needed in further operations.
@@ -410,32 +418,40 @@ namespace Orleans.GrainDirectory.AzureStorage
         /// NOTE: This could be an expensive and slow operation for large table partitions!
         /// </summary>
         /// <param name="partitionKey">The key for the partition to be searched.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>Enumeration of all entries in the specified table partition.</returns>
-        public Task<List<(T Entity, string ETag)>> ReadAllTableEntriesForPartitionAsync(string partitionKey)
+        public Task<List<(T Entity, string ETag)>> ReadAllTableEntriesForPartitionAsync(
+            string partitionKey,
+            CancellationToken cancellationToken = default)
         {
             string query = TableClient.CreateQueryFilter($"PartitionKey eq {partitionKey}");
-            return ReadTableEntriesAndEtagsAsync(query);
+            return ReadTableEntriesAndEtagsAsync(query, cancellationToken);
         }
 
         /// <summary>
         /// Read all entries in one partition of the storage table, preserving whether the query required multiple pages.
         /// </summary>
         /// <param name="partitionKey">The key for the partition to be searched.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The entries in the partition and whether more than one response page was required.</returns>
-        public Task<(List<(T Entity, string ETag)> Entries, bool IsPaginated)> ReadAllTableEntriesForPartitionWithPaginationAsync(string partitionKey)
+        public Task<(List<(T Entity, string ETag)> Entries, bool IsPaginated)> ReadAllTableEntriesForPartitionWithPaginationAsync(
+            string partitionKey,
+            CancellationToken cancellationToken = default)
         {
             string query = TableClient.CreateQueryFilter($"PartitionKey eq {partitionKey}");
-            return ReadTableEntriesAndEtagsWithPaginationAsync(query);
+            return ReadTableEntriesAndEtagsWithPaginationAsync(query, cancellationToken);
         }
 
         /// <summary>
         /// Read all entries in the table.
         /// NOTE: This could be a very expensive and slow operation for large tables!
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>Enumeration of all entries in the table.</returns>
-        public Task<List<(T Entity, string ETag)>> ReadAllTableEntriesAsync()
+        public Task<List<(T Entity, string ETag)>> ReadAllTableEntriesAsync(
+            CancellationToken cancellationToken = default)
         {
-            return ReadTableEntriesAndEtagsAsync(null);
+            return ReadTableEntriesAndEtagsAsync(null, cancellationToken);
         }
 
         /// <summary>
@@ -493,14 +509,19 @@ namespace Orleans.GrainDirectory.AzureStorage
         /// Read data entries and their corresponding eTags from the Azure table.
         /// </summary>
         /// <param name="filter">Filter string to use for querying the table and filtering the results.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>Enumeration of entries in the table which match the query condition.</returns>
-        public async Task<List<(T Entity, string ETag)>> ReadTableEntriesAndEtagsAsync(string? filter)
+        public async Task<List<(T Entity, string ETag)>> ReadTableEntriesAndEtagsAsync(
+            string? filter,
+            CancellationToken cancellationToken = default)
         {
-            var result = await ReadTableEntriesAndEtagsWithPaginationAsync(filter);
+            var result = await ReadTableEntriesAndEtagsWithPaginationAsync(filter, cancellationToken);
             return result.Entries;
         }
 
-        private async Task<(List<(T Entity, string ETag)> Entries, bool IsPaginated)> ReadTableEntriesAndEtagsWithPaginationAsync(string? filter)
+        private async Task<(List<(T Entity, string ETag)> Entries, bool IsPaginated)> ReadTableEntriesAndEtagsWithPaginationAsync(
+            string? filter,
+            CancellationToken cancellationToken)
         {
             const string operation = "ReadTableEntriesAndEtags";
             var startTime = DateTime.UtcNow;
@@ -509,7 +530,7 @@ namespace Orleans.GrainDirectory.AzureStorage
             {
                 var results = new List<(T, string)>();
                 var pageCount = 0;
-                await foreach (var page in Table.QueryAsync<T>(filter).AsPages())
+                await foreach (var page in Table.QueryAsync<T>(filter, cancellationToken: cancellationToken).AsPages())
                 {
                     pageCount++;
                     foreach (var value in page.Values)
@@ -520,7 +541,7 @@ namespace Orleans.GrainDirectory.AzureStorage
 
                 return (results, pageCount > 1);
             }
-            catch (Exception exc)
+            catch (Exception exc) when (exc is not OperationCanceledException)
             {
                 if (!AzureTableUtils.TableStorageDataNotFound(exc))
                 {
@@ -581,10 +602,52 @@ namespace Orleans.GrainDirectory.AzureStorage
             }
         }
 
-        internal async Task<(string, string)> InsertTwoTableEntriesConditionallyAsync(T data1, T data2, string data2Etag)
+        internal async Task CreateTableEntriesAsync(IReadOnlyCollection<T> collection)
+        {
+            const string operation = "CreateTableEntries";
+            const int maxTransactionSize = 100;
+            ArgumentNullException.ThrowIfNull(collection);
+            if (collection.Count is 0 or > maxTransactionSize)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(collection),
+                    collection.Count,
+                    $"The collection must contain between 1 and {maxTransactionSize} rows.");
+            }
+
+            var startTime = DateTime.UtcNow;
+            LogTraceTableEntriesCount(Logger, operation, collection.Count, TableName);
+            try
+            {
+                try
+                {
+                    var transaction = collection
+                        .Select(entry => new TableTransactionAction(TableTransactionActionType.Add, entry))
+                        .ToList();
+                    await Table.SubmitTransactionAsync(transaction);
+                }
+                catch (Exception exception)
+                {
+                    CheckAlertWriteError(operation, collection, null, exception);
+                    throw;
+                }
+            }
+            finally
+            {
+                CheckAlertSlowAccess(startTime, operation);
+            }
+        }
+
+        internal async Task<(string, string)> InsertTwoTableEntriesConditionallyAsync(
+            T data1,
+            T data2,
+            string data2Etag,
+            T? additionalEntry1 = null,
+            T? additionalEntry2 = null)
         {
             const string operation = "InsertTableEntryConditionally";
-            string? data2Str = data2 == null ? "null" : data2.ToString();
+            ArgumentNullException.ThrowIfNull(data2);
+            string? data2Str = data2.ToString();
             var startTime = DateTime.UtcNow;
 
             LogTraceTableEntries(Logger, operation, data1, data2Str, TableName);
@@ -592,12 +655,23 @@ namespace Orleans.GrainDirectory.AzureStorage
             {
                 try
                 {
-                    data2!.ETag = new ETag(data2Etag);
-                    var opResults = await Table.SubmitTransactionAsync(new TableTransactionAction[]
+                    data2.ETag = new ETag(data2Etag);
+                    var transaction = new List<TableTransactionAction>(4)
                     {
                         new TableTransactionAction(TableTransactionActionType.Add, data1),
                         new TableTransactionAction(TableTransactionActionType.UpdateReplace, data2, data2.ETag)
-                    });
+                    };
+                    if (additionalEntry1 is not null)
+                    {
+                        transaction.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, additionalEntry1));
+                    }
+
+                    if (additionalEntry2 is not null)
+                    {
+                        transaction.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, additionalEntry2));
+                    }
+
+                    var opResults = await Table.SubmitTransactionAsync(transaction);
 
                     //The batch results are returned in order of execution,
                     //see reference at https://msdn.microsoft.com/en-us/library/microsoft.windowsazure.storage.table.cloudtable.executebatch.aspx.
@@ -618,10 +692,17 @@ namespace Orleans.GrainDirectory.AzureStorage
             }
         }
 
-        internal async Task<(string, string)> UpdateTwoTableEntriesConditionallyAsync(T data1, string data1Etag, T? data2, string? data2Etag)
+        internal async Task<(string, string)> UpdateTwoTableEntriesConditionallyAsync(
+            T data1,
+            string data1Etag,
+            T data2,
+            string data2Etag,
+            T? additionalEntry1 = null,
+            T? additionalEntry2 = null)
         {
             const string operation = "UpdateTableEntryConditionally";
-            string? data2Str = data2 == null ? "null" : data2.ToString();
+            ArgumentNullException.ThrowIfNull(data2);
+            string? data2Str = data2.ToString();
             var startTime = DateTime.UtcNow;
             LogTraceTableEntries(Logger, operation, data1, data2Str, TableName);
 
@@ -630,13 +711,20 @@ namespace Orleans.GrainDirectory.AzureStorage
                 try
                 {
                     data1.ETag = new ETag(data1Etag);
-                    var entityBatch = new List<TableTransactionAction>(2);
+                    var entityBatch = new List<TableTransactionAction>(4);
                     entityBatch.Add(new TableTransactionAction(TableTransactionActionType.UpdateReplace, data1, data1.ETag));
 
-                    if (data2 != null && data2Etag != null)
+                    data2.ETag = new ETag(data2Etag);
+                    entityBatch.Add(new TableTransactionAction(TableTransactionActionType.UpdateReplace, data2, data2.ETag));
+
+                    if (additionalEntry1 is not null)
                     {
-                        data2.ETag = new ETag(data2Etag);
-                        entityBatch.Add(new TableTransactionAction(TableTransactionActionType.UpdateReplace, data2, data2.ETag));
+                        entityBatch.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, additionalEntry1));
+                    }
+
+                    if (additionalEntry2 is not null)
+                    {
+                        entityBatch.Add(new TableTransactionAction(TableTransactionActionType.UpsertReplace, additionalEntry2));
                     }
 
                     var opResults = await Table.SubmitTransactionAsync(entityBatch);

--- a/src/Azure/Shared/Storage/AzureTableDataManager.cs
+++ b/src/Azure/Shared/Storage/AzureTableDataManager.cs
@@ -533,6 +533,7 @@ namespace Orleans.GrainDirectory.AzureStorage
                 await foreach (var page in Table.QueryAsync<T>(filter, cancellationToken: cancellationToken).AsPages())
                 {
                     pageCount++;
+                    results.EnsureCapacity(results.Count + page.Values.Count);
                     foreach (var value in page.Values)
                     {
                         results.Add((value, value.ETag.ToString()));
@@ -621,9 +622,12 @@ namespace Orleans.GrainDirectory.AzureStorage
             {
                 try
                 {
-                    var transaction = collection
-                        .Select(entry => new TableTransactionAction(TableTransactionActionType.Add, entry))
-                        .ToList();
+                    var transaction = new List<TableTransactionAction>(collection.Count);
+                    foreach (var entry in collection)
+                    {
+                        transaction.Add(new TableTransactionAction(TableTransactionActionType.Add, entry));
+                    }
+
                     await Table.SubmitTransactionAsync(transaction);
                 }
                 catch (Exception exception)

--- a/test/Extensions/Orleans.Azure.Tests/AzureMembershipPaginationTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureMembershipPaginationTests.cs
@@ -56,6 +56,23 @@ public class AzureMembershipPaginationTests
     }
 
     [Fact]
+    public async Task LegacyVersionAheadAllowsTornReadDuringRollingUpgrade()
+    {
+        var storage = new ScriptedMembershipTableReadStorage();
+        storage.AddQuery(Query(
+            true,
+            BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN, 9, "before-9"),
+            Silo("silo-1", "stale"),
+            Version(11, "legacy-11"),
+            BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, 10, "after-10")));
+
+        var result = await CreateManager(storage).FindAllSiloEntries();
+
+        Assert.Equal("stale", result.Single(entry => entry.Entity.RowKey == "silo-1").ETag);
+        Assert.Equal(1, storage.QueryCount);
+    }
+
+    [Fact]
     public async Task MultipleWritesDuringReadAreDetected()
     {
         var storage = new ScriptedMembershipTableReadStorage();
@@ -194,12 +211,12 @@ public class AzureMembershipPaginationTests
 
     private sealed class ScriptedMembershipTableReadStorage : IMembershipTableReadStorage
     {
-    private readonly Queue<Func<MembershipTableQueryResult>> queries = new();
-    private readonly List<CancellationToken> cancellationTokens = new();
+        private readonly Queue<Func<MembershipTableQueryResult>> queries = new();
+        private readonly List<CancellationToken> cancellationTokens = new();
 
-    public int QueryCount { get; private set; }
+        public int QueryCount { get; private set; }
 
-    public IReadOnlyList<CancellationToken> CancellationTokens => cancellationTokens;
+        public IReadOnlyList<CancellationToken> CancellationTokens => cancellationTokens;
 
         public void AddQuery(MembershipTableQueryResult result) => AddQuery(() => result);
 

--- a/test/Extensions/Orleans.Azure.Tests/AzureMembershipPaginationTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureMembershipPaginationTests.cs
@@ -1,0 +1,219 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans.AzureUtils;
+using Orleans.Clustering.AzureStorage;
+using Orleans.Storage;
+using Xunit;
+
+namespace Tester.AzureUtils;
+
+[TestCategory("AzureStorage"), TestCategory("Storage")]
+public class AzureMembershipPaginationTests
+{
+    private const string ClusterId = "membership-pagination-tests";
+    private const string TableName = "MembershipPaginationTests";
+
+    [Fact]
+    public async Task OnePageReadUsesOneQuery()
+    {
+        var storage = new ScriptedMembershipTableReadStorage();
+        storage.AddQuery(Query(false, Version(1, "v1"), Silo("silo-1", "s1")));
+
+        var result = await CreateManager(storage).FindAllSiloEntries();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, storage.QueryCount);
+        Assert.Equal(0, storage.VersionReadCount);
+    }
+
+    [Fact]
+    public async Task StablePaginationSucceeds()
+    {
+        var storage = new ScriptedMembershipTableReadStorage();
+        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
+        storage.AddVersion(VersionRead(1, "v1"));
+        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
+        storage.AddVersion(VersionRead(1, "v1"));
+
+        var result = await CreateManager(storage).FindAllSiloEntries();
+
+        Assert.Equal(["silo-1", SiloInstanceTableEntry.TABLE_VERSION_ROW], result.Select(entry => entry.Entity.RowKey));
+        Assert.Equal(2, storage.QueryCount);
+        Assert.Equal(2, storage.VersionReadCount);
+    }
+
+    [Fact]
+    public async Task MutationBetweenPagesRetriesAndReturnsCoherentSnapshot()
+    {
+        var storage = new ScriptedMembershipTableReadStorage();
+        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
+
+        storage.AddVersion(VersionRead(1, "v1"));
+        storage.AddQuery(Query(true, Version(2, "v2"), Silo("silo-2", "s2")));
+        storage.AddVersion(VersionRead(2, "v2"));
+
+        storage.AddVersion(VersionRead(2, "v2"));
+        storage.AddQuery(Query(true, Version(2, "v2"), Silo("silo-2", "s2")));
+        storage.AddVersion(VersionRead(2, "v2"));
+
+        var result = await CreateManager(storage).FindAllSiloEntries();
+
+        Assert.Equal(["silo-2", SiloInstanceTableEntry.TABLE_VERSION_ROW], result.Select(entry => entry.Entity.RowKey));
+        Assert.Equal("v2", result.Single(entry => entry.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW).ETag);
+        Assert.Equal(3, storage.QueryCount);
+        Assert.Equal(4, storage.VersionReadCount);
+    }
+
+    [Fact]
+    public async Task PerpetualChurnFailsAfterBoundWithVersionContext()
+    {
+        var storage = new ScriptedMembershipTableReadStorage();
+        storage.AddQuery(Query(true, Version(0, "v0"), Silo("silo-0", "s0")));
+
+        for (var attempt = 0; attempt < OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts; attempt++)
+        {
+            storage.AddVersion(VersionRead(attempt, $"v{attempt}"));
+            storage.AddQuery(Query(true, Version(attempt, $"v{attempt}"), Silo($"silo-{attempt}", $"s{attempt}")));
+            storage.AddVersion(VersionRead(attempt + 1, $"v{attempt + 1}"));
+        }
+
+        var exception = await Assert.ThrowsAsync<InconsistentStateException>(
+            () => CreateManager(storage).FindAllSiloEntries());
+
+        Assert.Equal($"v{OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts - 1}", exception.StoredEtag);
+        Assert.Equal($"v{OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts}", exception.CurrentEtag);
+        Assert.Equal(OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts + 1, storage.QueryCount);
+        Assert.Equal(OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts * 2, storage.VersionReadCount);
+    }
+
+    [Fact]
+    public async Task VersionRowAbsencePresenceTransitionRetries()
+    {
+        var storage = new ScriptedMembershipTableReadStorage();
+        storage.AddQuery(Query(true, Silo("silo-1", "s1")));
+
+        storage.AddVersion((null, null));
+        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
+        storage.AddVersion(VersionRead(1, "v1"));
+
+        storage.AddVersion(VersionRead(1, "v1"));
+        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
+        storage.AddVersion(VersionRead(1, "v1"));
+
+        var result = await CreateManager(storage).FindAllSiloEntries();
+
+        Assert.Equal("v1", result.Single(entry => entry.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW).ETag);
+        Assert.Equal(3, storage.QueryCount);
+    }
+
+    [Fact]
+    public async Task PageEnumerationCompletesBeforeAfterFenceRead()
+    {
+        var events = new List<string>();
+        var storage = new ScriptedMembershipTableReadStorage();
+        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
+        storage.AddVersion(() =>
+        {
+            events.Add("before");
+            return VersionRead(1, "v1");
+        });
+        storage.AddQuery(() =>
+        {
+            events.Add("page-1");
+            events.Add("page-2");
+            events.Add("query-complete");
+            return Query(true, Version(1, "v1"), Silo("silo-1", "s1"));
+        });
+        storage.AddVersion(() =>
+        {
+            Assert.Equal("query-complete", events[^1]);
+            events.Add("after");
+            return VersionRead(1, "v1");
+        });
+
+        await CreateManager(storage).FindAllSiloEntries();
+
+        Assert.Equal(["before", "page-1", "page-2", "query-complete", "after"], events);
+    }
+
+    [Fact]
+    public async Task VersionFenceAllowsDirtyIAmAliveEtagUpdate()
+    {
+        var storage = new ScriptedMembershipTableReadStorage();
+        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "heartbeat-1")));
+        storage.AddVersion(VersionRead(1, "v1"));
+        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "heartbeat-2")));
+        storage.AddVersion(VersionRead(1, "v1"));
+
+        var result = await CreateManager(storage).FindAllSiloEntries();
+
+        Assert.Equal("heartbeat-2", result.Single(entry => entry.Entity.RowKey == "silo-1").ETag);
+    }
+
+    private static OrleansSiloInstanceManager CreateManager(IMembershipTableReadStorage storage)
+        => new(
+            ClusterId,
+            NullLoggerFactory.Instance,
+            new AzureStorageClusteringOptions { TableName = TableName },
+            storage);
+
+    private static MembershipTableQueryResult Query(
+        bool isPaginated,
+        params (SiloInstanceTableEntry Entity, string ETag)[] entries)
+        => new([.. entries], isPaginated);
+
+    private static (SiloInstanceTableEntry Entity, string ETag) Version(int version, string etag)
+        => (new()
+        {
+            PartitionKey = ClusterId,
+            RowKey = SiloInstanceTableEntry.TABLE_VERSION_ROW,
+            DeploymentId = ClusterId,
+            MembershipVersion = version.ToString(),
+        }, etag);
+
+    private static (SiloInstanceTableEntry? Entity, string? ETag) VersionRead(int version, string etag)
+    {
+        var result = Version(version, etag);
+        return (result.Entity, result.ETag);
+    }
+
+    private static (SiloInstanceTableEntry Entity, string ETag) Silo(string rowKey, string etag)
+        => (new()
+        {
+            PartitionKey = ClusterId,
+            RowKey = rowKey,
+            DeploymentId = ClusterId,
+        }, etag);
+
+    private sealed class ScriptedMembershipTableReadStorage : IMembershipTableReadStorage
+    {
+        private readonly Queue<Func<MembershipTableQueryResult>> queries = new();
+        private readonly Queue<Func<(SiloInstanceTableEntry? Entity, string? ETag)>> versions = new();
+
+        public int QueryCount { get; private set; }
+
+        public int VersionReadCount { get; private set; }
+
+        public void AddQuery(MembershipTableQueryResult result) => AddQuery(() => result);
+
+        public void AddQuery(Func<MembershipTableQueryResult> query) => queries.Enqueue(query);
+
+        public void AddVersion((SiloInstanceTableEntry? Entity, string? ETag) result) => AddVersion(() => result);
+
+        public void AddVersion(Func<(SiloInstanceTableEntry? Entity, string? ETag)> version) => versions.Enqueue(version);
+
+        public Task<MembershipTableQueryResult> ReadAllTableEntriesForPartitionAsync(string partitionKey)
+        {
+            Assert.Equal(ClusterId, partitionKey);
+            QueryCount++;
+            return Task.FromResult(queries.Dequeue()());
+        }
+
+        public Task<(SiloInstanceTableEntry? Entity, string? ETag)> ReadTableVersionAsync(string partitionKey, string rowKey)
+        {
+            Assert.Equal(ClusterId, partitionKey);
+            Assert.Equal(SiloInstanceTableEntry.TABLE_VERSION_ROW, rowKey);
+            VersionReadCount++;
+            return Task.FromResult(versions.Dequeue()());
+        }
+    }
+}

--- a/test/Extensions/Orleans.Azure.Tests/AzureMembershipPaginationTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureMembershipPaginationTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
 using Orleans.AzureUtils;
 using Orleans.Clustering.AzureStorage;
@@ -22,131 +23,126 @@ public class AzureMembershipPaginationTests
 
         Assert.Equal(2, result.Count);
         Assert.Equal(1, storage.QueryCount);
-        Assert.Equal(0, storage.VersionReadCount);
     }
 
     [Fact]
-    public async Task StablePaginationSucceeds()
+    public async Task StablePaginatedReadUsesOneQuery()
     {
         var storage = new ScriptedMembershipTableReadStorage();
-        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
-        storage.AddVersion(VersionRead(1, "v1"));
-        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
-        storage.AddVersion(VersionRead(1, "v1"));
+        storage.AddQuery(FencedQuery(1, Silo("silo-1", "s1")));
 
         var result = await CreateManager(storage).FindAllSiloEntries();
 
         Assert.Equal(["silo-1", SiloInstanceTableEntry.TABLE_VERSION_ROW], result.Select(entry => entry.Entity.RowKey));
-        Assert.Equal(2, storage.QueryCount);
-        Assert.Equal(2, storage.VersionReadCount);
+        Assert.Equal(1, storage.QueryCount);
     }
 
     [Fact]
-    public async Task MutationBetweenPagesRetriesAndReturnsCoherentSnapshot()
+    public async Task TornPaginatedReadRetries()
     {
         var storage = new ScriptedMembershipTableReadStorage();
-        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
-
-        storage.AddVersion(VersionRead(1, "v1"));
-        storage.AddQuery(Query(true, Version(2, "v2"), Silo("silo-2", "s2")));
-        storage.AddVersion(VersionRead(2, "v2"));
-
-        storage.AddVersion(VersionRead(2, "v2"));
-        storage.AddQuery(Query(true, Version(2, "v2"), Silo("silo-2", "s2")));
-        storage.AddVersion(VersionRead(2, "v2"));
+        storage.AddQuery(Query(
+            true,
+            BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN, 1, "before-1"),
+            Silo("silo-1", "s1"),
+            Version(2, "legacy-2"),
+            BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, 2, "after-2")));
+        storage.AddQuery(FencedQuery(2, Silo("silo-2", "s2")));
 
         var result = await CreateManager(storage).FindAllSiloEntries();
 
         Assert.Equal(["silo-2", SiloInstanceTableEntry.TABLE_VERSION_ROW], result.Select(entry => entry.Entity.RowKey));
-        Assert.Equal("v2", result.Single(entry => entry.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW).ETag);
-        Assert.Equal(3, storage.QueryCount);
-        Assert.Equal(4, storage.VersionReadCount);
+        Assert.Equal(2, storage.QueryCount);
+    }
+
+    [Fact]
+    public async Task MultipleWritesDuringReadAreDetected()
+    {
+        var storage = new ScriptedMembershipTableReadStorage();
+        storage.AddQuery(Query(
+            true,
+            BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN, 1, "before-1"),
+            Silo("silo-1", "stale"),
+            Version(3, "legacy-3"),
+            BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, 3, "after-3")));
+        storage.AddQuery(FencedQuery(3, Silo("silo-1", "current")));
+
+        var result = await CreateManager(storage).FindAllSiloEntries();
+
+        Assert.Equal("current", result.Single(entry => entry.Entity.RowKey == "silo-1").ETag);
+        Assert.Equal(2, storage.QueryCount);
     }
 
     [Fact]
     public async Task PerpetualChurnFailsAfterBoundWithVersionContext()
     {
         var storage = new ScriptedMembershipTableReadStorage();
-        storage.AddQuery(Query(true, Version(0, "v0"), Silo("silo-0", "s0")));
-
         for (var attempt = 0; attempt < OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts; attempt++)
         {
-            storage.AddVersion(VersionRead(attempt, $"v{attempt}"));
-            storage.AddQuery(Query(true, Version(attempt, $"v{attempt}"), Silo($"silo-{attempt}", $"s{attempt}")));
-            storage.AddVersion(VersionRead(attempt + 1, $"v{attempt + 1}"));
+            storage.AddQuery(Query(
+                true,
+                BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN, attempt, $"before-{attempt}"),
+                Silo($"silo-{attempt}", $"s{attempt}"),
+                Version(attempt + 1, $"legacy-{attempt + 1}"),
+                BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, attempt + 1, $"after-{attempt + 1}")));
         }
 
         var exception = await Assert.ThrowsAsync<InconsistentStateException>(
             () => CreateManager(storage).FindAllSiloEntries());
 
-        Assert.Equal($"v{OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts - 1}", exception.StoredEtag);
-        Assert.Equal($"v{OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts}", exception.CurrentEtag);
-        Assert.Equal(OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts + 1, storage.QueryCount);
-        Assert.Equal(OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts * 2, storage.VersionReadCount);
+        Assert.Equal((OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts - 1).ToString(), exception.StoredEtag);
+        Assert.Equal(OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts.ToString(), exception.CurrentEtag);
+        Assert.Equal(OrleansSiloInstanceManager.MaxMembershipSnapshotAttempts, storage.QueryCount);
     }
 
     [Fact]
-    public async Task VersionRowAbsencePresenceTransitionRetries()
+    public async Task MissingBoundaryRowsSkipAtomicityCheck()
     {
         var storage = new ScriptedMembershipTableReadStorage();
-        storage.AddQuery(Query(true, Silo("silo-1", "s1")));
-
-        storage.AddVersion((null, null));
         storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
-        storage.AddVersion(VersionRead(1, "v1"));
-
-        storage.AddVersion(VersionRead(1, "v1"));
-        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
-        storage.AddVersion(VersionRead(1, "v1"));
 
         var result = await CreateManager(storage).FindAllSiloEntries();
 
         Assert.Equal("v1", result.Single(entry => entry.Entity.RowKey == SiloInstanceTableEntry.TABLE_VERSION_ROW).ETag);
-        Assert.Equal(3, storage.QueryCount);
-    }
-
-    [Fact]
-    public async Task PageEnumerationCompletesBeforeAfterFenceRead()
-    {
-        var events = new List<string>();
-        var storage = new ScriptedMembershipTableReadStorage();
-        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "s1")));
-        storage.AddVersion(() =>
-        {
-            events.Add("before");
-            return VersionRead(1, "v1");
-        });
-        storage.AddQuery(() =>
-        {
-            events.Add("page-1");
-            events.Add("page-2");
-            events.Add("query-complete");
-            return Query(true, Version(1, "v1"), Silo("silo-1", "s1"));
-        });
-        storage.AddVersion(() =>
-        {
-            Assert.Equal("query-complete", events[^1]);
-            events.Add("after");
-            return VersionRead(1, "v1");
-        });
-
-        await CreateManager(storage).FindAllSiloEntries();
-
-        Assert.Equal(["before", "page-1", "page-2", "query-complete", "after"], events);
+        Assert.Equal(1, storage.QueryCount);
     }
 
     [Fact]
     public async Task VersionFenceAllowsDirtyIAmAliveEtagUpdate()
     {
         var storage = new ScriptedMembershipTableReadStorage();
-        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "heartbeat-1")));
-        storage.AddVersion(VersionRead(1, "v1"));
-        storage.AddQuery(Query(true, Version(1, "v1"), Silo("silo-1", "heartbeat-2")));
-        storage.AddVersion(VersionRead(1, "v1"));
+        storage.AddQuery(FencedQuery(1, Silo("silo-1", "heartbeat-2")));
 
         var result = await CreateManager(storage).FindAllSiloEntries();
 
         Assert.Equal("heartbeat-2", result.Single(entry => entry.Entity.RowKey == "silo-1").ETag);
+        Assert.Equal(1, storage.QueryCount);
+    }
+
+    [Fact]
+    public async Task CancellationTokenFlowsThroughPaginatedRead()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var storage = new ScriptedMembershipTableReadStorage();
+        storage.AddQuery(FencedQuery(1, Silo("silo-1", "s1")));
+
+        await CreateManager(storage).FindAllSiloEntries(cancellation.Token);
+
+        var token = Assert.Single(storage.CancellationTokens);
+        Assert.Equal(cancellation.Token, token);
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("::1")]
+    [InlineData("fe80::1")]
+    public void BoundaryVersionRowsSortAroundMembershipRows(string address)
+    {
+        var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Parse(address), 11111), 1);
+        var rowKey = SiloInstanceTableEntry.ConstructRowKey(siloAddress);
+
+        Assert.True(string.CompareOrdinal(SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN, rowKey) < 0);
+        Assert.True(string.CompareOrdinal(rowKey, SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX) < 0);
     }
 
     private static OrleansSiloInstanceManager CreateManager(IMembershipTableReadStorage storage)
@@ -156,25 +152,37 @@ public class AzureMembershipPaginationTests
             new AzureStorageClusteringOptions { TableName = TableName },
             storage);
 
+    private static MembershipTableQueryResult FencedQuery(
+        int version,
+        params (SiloInstanceTableEntry Entity, string ETag)[] entries)
+        => Query(
+            true,
+            [
+                BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN, version, $"before-{version}"),
+                .. entries,
+                Version(version, $"legacy-{version}"),
+                BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX, version, $"after-{version}")
+            ]);
+
     private static MembershipTableQueryResult Query(
         bool isPaginated,
         params (SiloInstanceTableEntry Entity, string ETag)[] entries)
         => new([.. entries], isPaginated);
 
     private static (SiloInstanceTableEntry Entity, string ETag) Version(int version, string etag)
+        => BoundaryVersion(SiloInstanceTableEntry.TABLE_VERSION_ROW, version, etag);
+
+    private static (SiloInstanceTableEntry Entity, string ETag) BoundaryVersion(
+        string rowKey,
+        int version,
+        string etag)
         => (new()
         {
             PartitionKey = ClusterId,
-            RowKey = SiloInstanceTableEntry.TABLE_VERSION_ROW,
+            RowKey = rowKey,
             DeploymentId = ClusterId,
             MembershipVersion = version.ToString(),
         }, etag);
-
-    private static (SiloInstanceTableEntry? Entity, string? ETag) VersionRead(int version, string etag)
-    {
-        var result = Version(version, etag);
-        return (result.Entity, result.ETag);
-    }
 
     private static (SiloInstanceTableEntry Entity, string ETag) Silo(string rowKey, string etag)
         => (new()
@@ -186,34 +194,25 @@ public class AzureMembershipPaginationTests
 
     private sealed class ScriptedMembershipTableReadStorage : IMembershipTableReadStorage
     {
-        private readonly Queue<Func<MembershipTableQueryResult>> queries = new();
-        private readonly Queue<Func<(SiloInstanceTableEntry? Entity, string? ETag)>> versions = new();
+    private readonly Queue<Func<MembershipTableQueryResult>> queries = new();
+    private readonly List<CancellationToken> cancellationTokens = new();
 
-        public int QueryCount { get; private set; }
+    public int QueryCount { get; private set; }
 
-        public int VersionReadCount { get; private set; }
+    public IReadOnlyList<CancellationToken> CancellationTokens => cancellationTokens;
 
         public void AddQuery(MembershipTableQueryResult result) => AddQuery(() => result);
 
         public void AddQuery(Func<MembershipTableQueryResult> query) => queries.Enqueue(query);
 
-        public void AddVersion((SiloInstanceTableEntry? Entity, string? ETag) result) => AddVersion(() => result);
-
-        public void AddVersion(Func<(SiloInstanceTableEntry? Entity, string? ETag)> version) => versions.Enqueue(version);
-
-        public Task<MembershipTableQueryResult> ReadAllTableEntriesForPartitionAsync(string partitionKey)
+        public Task<MembershipTableQueryResult> ReadAllTableEntriesForPartitionAsync(
+            string partitionKey,
+            CancellationToken cancellationToken)
         {
             Assert.Equal(ClusterId, partitionKey);
+            cancellationTokens.Add(cancellationToken);
             QueryCount++;
             return Task.FromResult(queries.Dequeue()());
-        }
-
-        public Task<(SiloInstanceTableEntry? Entity, string? ETag)> ReadTableVersionAsync(string partitionKey, string rowKey)
-        {
-            Assert.Equal(ClusterId, partitionKey);
-            Assert.Equal(SiloInstanceTableEntry.TABLE_VERSION_ROW, rowKey);
-            VersionReadCount++;
-            return Task.FromResult(versions.Dequeue()());
         }
     }
 }

--- a/test/Extensions/Orleans.Azure.Tests/AzureTableDataManagerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureTableDataManagerTests.cs
@@ -217,7 +217,7 @@ namespace Tester.AzureUtils
         }
 
         [SkippableFact, TestCategory("Functional")]
-        public async Task AzureTableDataManager_InsertTwoTableEntriesConditionallyAsync()
+        public async Task AzureTableDataManager_CreateAndUpdateTableEntriesAsync()
         {
             StorageEmulatorUtilities.EnsureEmulatorIsNotUsed();
 
@@ -225,7 +225,7 @@ namespace Tester.AzureUtils
             var data2 = GenerateNewData();
             try
             {
-                await manager.InsertTwoTableEntriesConditionallyAsync(data1, data2, AzureTableUtils.ANY_ETAG);
+                await manager.CreateAndUpdateTableEntriesAsync(data1, (data2, AzureTableUtils.ANY_ETAG));
             }
             catch (RequestFailedException exc)
             {
@@ -238,10 +238,12 @@ namespace Tester.AzureUtils
             }
 
             string etag = await manager.CreateTableEntryAsync(data2.Clone());
-            var tuple = await manager.InsertTwoTableEntriesConditionallyAsync(data1, data2, etag);
+            var result = await manager.CreateAndUpdateTableEntriesAsync(data1, (data2, etag));
             try
             {
-                await manager.InsertTwoTableEntriesConditionallyAsync(data1.Clone(), data2.Clone(), tuple.Item2);
+                await manager.CreateAndUpdateTableEntriesAsync(
+                    data1.Clone(),
+                    (data2.Clone(), result.UpdatedEntryETag));
                 Assert.Fail("Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)
@@ -256,7 +258,9 @@ namespace Tester.AzureUtils
 
             try
             {
-                await manager.InsertTwoTableEntriesConditionallyAsync(data1.Clone(), data2.Clone(), AzureTableUtils.ANY_ETAG);
+                await manager.CreateAndUpdateTableEntriesAsync(
+                    data1.Clone(),
+                    (data2.Clone(), AzureTableUtils.ANY_ETAG));
                 Assert.Fail("Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)
@@ -271,7 +275,7 @@ namespace Tester.AzureUtils
         }
 
         [SkippableFact, TestCategory("Functional")]
-        public async Task AzureTableDataManager_UpdateTwoTableEntriesConditionallyAsync()
+        public async Task AzureTableDataManager_UpdateTableEntriesAsync()
         {
             StorageEmulatorUtilities.EnsureEmulatorIsNotUsed();
 
@@ -279,7 +283,9 @@ namespace Tester.AzureUtils
             var data2 = GenerateNewData();
             try
             {
-                await manager.UpdateTwoTableEntriesConditionallyAsync(data1, AzureTableUtils.ANY_ETAG, data2, AzureTableUtils.ANY_ETAG);
+                await manager.UpdateTableEntriesAsync(
+                    (data1, AzureTableUtils.ANY_ETAG),
+                    (data2, AzureTableUtils.ANY_ETAG));
                 Assert.Fail("Update should have failed since the data has not been created yet");
             }
             catch (RequestFailedException exc)
@@ -293,12 +299,16 @@ namespace Tester.AzureUtils
             }
 
             string etag = await manager.CreateTableEntryAsync(data2.Clone());
-            var tuple1 = await manager.InsertTwoTableEntriesConditionallyAsync(data1, data2, etag);
-            _ = await manager.UpdateTwoTableEntriesConditionallyAsync(data1, tuple1.Item1, data2, tuple1.Item2);
+            var createResult = await manager.CreateAndUpdateTableEntriesAsync(data1, (data2, etag));
+            _ = await manager.UpdateTableEntriesAsync(
+                (data1, createResult.CreatedEntryETag),
+                (data2, createResult.UpdatedEntryETag));
 
             try
             {
-                await manager.UpdateTwoTableEntriesConditionallyAsync(data1, tuple1.Item1, data2, tuple1.Item2);
+                await manager.UpdateTableEntriesAsync(
+                    (data1, createResult.CreatedEntryETag),
+                    (data2, createResult.UpdatedEntryETag));
                 Assert.Fail("Should have thrown RequestFailedException.");
             }
             catch (RequestFailedException exc)

--- a/test/Extensions/Orleans.Azure.Tests/SiloInstanceTableManagerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/SiloInstanceTableManagerTests.cs
@@ -147,8 +147,6 @@ namespace Tester.AzureUtils
             Assert.Equal("0", after.Entity?.MembershipVersion);
             Assert.Equal(SiloInstanceTableTestConstants.INSTANCE_STATUS_ACTIVE, before.Entity?.Status);
             Assert.Equal(SiloInstanceTableTestConstants.INSTANCE_STATUS_ACTIVE, after.Entity?.Status);
-            Assert.Equal("0", before.Entity?.ProxyPort);
-            Assert.Equal("0", after.Entity?.ProxyPort);
         }
 
         [SkippableFact, TestCategory("Functional")]

--- a/test/Extensions/Orleans.Azure.Tests/SiloInstanceTableManagerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/SiloInstanceTableManagerTests.cs
@@ -119,6 +119,14 @@ namespace Tester.AzureUtils
             var entries = await manager.FindAllSiloEntries();
             Assert.Equal(5, entries.Count);
             Assert.All(entries, e => Assert.NotEqual(SiloInstanceTableTestConstants.INSTANCE_STATUS_DEAD, e.Item1.Status));
+            var before = await manager.ReadSingleTableEntryAsync(
+                clusterId,
+                SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN);
+            var after = await manager.ReadSingleTableEntryAsync(
+                clusterId,
+                SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX);
+            Assert.NotNull(before.Entity);
+            Assert.NotNull(after.Entity);
         }
 
 
@@ -137,6 +145,10 @@ namespace Tester.AzureUtils
                 SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX);
             Assert.Equal("0", before.Entity?.MembershipVersion);
             Assert.Equal("0", after.Entity?.MembershipVersion);
+            Assert.Equal(SiloInstanceTableTestConstants.INSTANCE_STATUS_ACTIVE, before.Entity?.Status);
+            Assert.Equal(SiloInstanceTableTestConstants.INSTANCE_STATUS_ACTIVE, after.Entity?.Status);
+            Assert.Equal("0", before.Entity?.ProxyPort);
+            Assert.Equal("0", after.Entity?.ProxyPort);
         }
 
         [SkippableFact, TestCategory("Functional")]
@@ -203,6 +215,7 @@ namespace Tester.AzureUtils
         [SkippableFact, TestCategory("Functional")]
         public async Task SiloInstanceTable_FindAllGatewayProxyEndpoints()
         {
+            await manager.TryCreateTableVersionEntryAsync();
             RegisterSiloInstance();
 
             var gateways = await manager.FindAllGatewayProxyEndpoints();

--- a/test/Extensions/Orleans.Azure.Tests/SiloInstanceTableManagerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/SiloInstanceTableManagerTests.cs
@@ -129,6 +129,14 @@ namespace Tester.AzureUtils
                 .WaitAsync(new AzureStoragePolicyOptions().OperationTimeout);
 
             Assert.True(didInsert, "Did insert");
+            var before = await manager.ReadSingleTableEntryAsync(
+                clusterId,
+                SiloInstanceTableEntry.TABLE_VERSION_ROW_MIN);
+            var after = await manager.ReadSingleTableEntryAsync(
+                clusterId,
+                SiloInstanceTableEntry.TABLE_VERSION_ROW_MAX);
+            Assert.Equal("0", before.Entity?.MembershipVersion);
+            Assert.Equal("0", after.Entity?.MembershipVersion);
         }
 
         [SkippableFact, TestCategory("Functional")]


### PR DESCRIPTION
Azure Table continuation pages are separate Query Entities requests, so flattening them can combine membership rows from different topology versions even though `IMembershipTable.ReadAll` requires an atomic result.

This adds `!Start` and `~End`, whose keys sort before and after all IPv4 and IPv6 membership row keys. Membership inserts and updates atomically write the changed silo row, the legacy `VersionRow`, and both boundary rows in one Azure entity group transaction.

Paginated reads compare the boundary membership versions from the completed query. Matching values prove that no boundary-aware membership update committed while the pages were read, preserving the single-query non-conflict path. A mismatch retries the query up to a bounded limit before throwing `InconsistentStateException`.

During rolling upgrades, older silos update only `VersionRow`. If `VersionRow` is newer than both boundary versions, the reader accepts the potentially torn snapshot instead of retrying, preserving availability while the cluster transitions. Tables without boundary rows likewise retain legacy behavior and skip the atomicity check. `UpdateIAmAlive` and defunct-row cleanup remain intentionally outside the topology fence.

References:

- [Entity group transactions](https://learn.microsoft.com/azure/storage/tables/table-storage-design#entity-group-transactions)
- [Performing entity group transactions](https://learn.microsoft.com/rest/api/storageservices/performing-entity-group-transactions)
- [`TableTransactionActionType`](https://learn.microsoft.com/en-us/dotnet/api/azure.data.tables.tabletransactionactiontype?view=azure-dotnet)
- [Query Entities](https://learn.microsoft.com/rest/api/storageservices/query-entities)
- [Query timeout and pagination](https://learn.microsoft.com/rest/api/storageservices/query-timeout-and-pagination)

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10381)