### PR TITLE
fix(transactions): harden confirmation recovery handling

### DIFF
--- a/src/Orleans.Transactions/State/ConfirmationWorker.cs
+++ b/src/Orleans.Transactions/State/ConfirmationWorker.cs
@@ -108,6 +108,7 @@ namespace Orleans.Transactions.State
                 using (this.activationLifetime.BlockDeactivation())
                 {
                     if (await TryCollect(transactionId)) break;
+                    if (ct.IsCancellationRequested) break;
 
                     await this.timerManager.Delay(this.options.ConfirmationRetryDelay, ct);
                 }
@@ -123,17 +124,25 @@ namespace Orleans.Transactions.State
                 // Now we can remove the commit record.
                 StorageBatch<TState> storageBatch = getStorageBatch();
                 storageBatch.Collect(transactionId);
-                storageBatch.FollowUpAction(() =>
+                storageBatch.CompletionAction(success =>
                 {
-                    LogTraceCollectionCompleted(transactionId);
-                    this.pending.Remove(transactionId);
-                    storeComplete.TrySetResult(true);
+                    if (success)
+                    {
+                        LogTraceCollectionCompleted(transactionId);
+                        this.pending.Remove(transactionId);
+                    }
+
+                    storeComplete.TrySetResult(success);
                 });
 
                 storageWorker.Notify();
 
                 // wait for storage call, so we don't free spin
-                return await storeComplete.Task;
+                return await storeComplete.Task.WaitAsync(this.activationLifetime.OnDeactivating);
+            }
+            catch (OperationCanceledException) when (this.activationLifetime.OnDeactivating.IsCancellationRequested)
+            {
+                return false;
             }
             catch(Exception ex)
             {

--- a/src/Orleans.Transactions/State/ConfirmationWorker.cs
+++ b/src/Orleans.Transactions/State/ConfirmationWorker.cs
@@ -124,7 +124,7 @@ namespace Orleans.Transactions.State
                 // Now we can remove the commit record.
                 StorageBatch<TState> storageBatch = getStorageBatch();
                 storageBatch.Collect(transactionId);
-                storageBatch.CompletionAction(success =>
+                storageBatch.FollowUpAction(success =>
                 {
                     if (success)
                     {

--- a/src/Orleans.Transactions/State/StorageBatch.cs
+++ b/src/Orleans.Transactions/State/StorageBatch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Orleans.Transactions.Abstractions;
 
@@ -41,7 +42,9 @@ namespace Orleans.Transactions
 
         // follow-up actions, to be executed after storing this batch
         private readonly List<Action> followUpActions;
+        private readonly List<Action<bool>> completionActions;
         private readonly List<Func<Task<bool>>> storeConditions;
+        private int completionInvoked;
         
         // counters for each type of event
         private int total = 0;
@@ -73,6 +76,7 @@ namespace Orleans.Transactions
             this.cancelAbove = cancelAbove;
             this.cancelAboveStart = cancelAbove;
             this.followUpActions = new List<Action>();
+            this.completionActions = new List<Action<bool>>();
             this.storeConditions = new List<Func<Task<bool>>>();
             this.prepares = new SortedDictionary<long, PendingTransactionState<TState>>();
         }
@@ -100,6 +104,19 @@ namespace Orleans.Transactions
             foreach (var action in followUpActions)
             {
                 action();
+            }
+        }
+
+        public void Complete(bool success)
+        {
+            if (Interlocked.Exchange(ref this.completionInvoked, 1) != 0)
+            {
+                return;
+            }
+
+            foreach (var action in completionActions)
+            {
+                action(success);
             }
         }
 
@@ -197,6 +214,11 @@ namespace Orleans.Transactions
         public void FollowUpAction(Action action)
         {
             followUpActions.Add(action);
+        }
+
+        public void CompletionAction(Action<bool> action)
+        {
+            completionActions.Add(action);
         }
 
         public void AddStorePreCondition(Func<Task<bool>> action)

--- a/src/Orleans.Transactions/State/StorageBatch.cs
+++ b/src/Orleans.Transactions/State/StorageBatch.cs
@@ -40,9 +40,8 @@ namespace Orleans.Transactions
         // prepare records
         private readonly SortedDictionary<long, PendingTransactionState<TState>> prepares;
 
-        // follow-up actions, to be executed after storing this batch
-        private readonly List<Action> followUpActions;
-        private readonly List<Action<bool>> completionActions;
+        // follow-up actions, to be executed when this batch completes
+        private readonly List<Action<bool>> followUpActions;
         private readonly List<Func<Task<bool>>> storeConditions;
         private int completionInvoked;
         
@@ -75,8 +74,7 @@ namespace Orleans.Transactions
             this.confirmUpTo = confirmUpTo;
             this.cancelAbove = cancelAbove;
             this.cancelAboveStart = cancelAbove;
-            this.followUpActions = new List<Action>();
-            this.completionActions = new List<Action<bool>>();
+            this.followUpActions = new List<Action<bool>>();
             this.storeConditions = new List<Func<Task<bool>>>();
             this.prepares = new SortedDictionary<long, PendingTransactionState<TState>>();
         }
@@ -99,14 +97,6 @@ namespace Orleans.Transactions
                 (cancelAbove < cancelAboveStart) ? cancelAbove : (long?)null);
         }
 
-        public void RunFollowUpActions()
-        {
-            foreach (var action in followUpActions)
-            {
-                action();
-            }
-        }
-
         public void Complete(bool success)
         {
             if (Interlocked.Exchange(ref this.completionInvoked, 1) != 0)
@@ -114,7 +104,7 @@ namespace Orleans.Transactions
                 return;
             }
 
-            foreach (var action in completionActions)
+            foreach (var action in followUpActions)
             {
                 action(success);
             }
@@ -211,14 +201,9 @@ namespace Orleans.Transactions
             MetaData.CommitRecords.Remove(transactionId);
         }
 
-        public void FollowUpAction(Action action)
+        public void FollowUpAction(Action<bool> action)
         {
             followUpActions.Add(action);
-        }
-
-        public void CompletionAction(Action<bool> action)
-        {
-            completionActions.Add(action);
         }
 
         public void AddStorePreCondition(Func<Task<bool>> action)

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -130,8 +130,13 @@ namespace Orleans.Transactions.State
                                 this.storageBatch.Read(record.Timestamp);
                             }
 
-                            this.storageBatch.FollowUpAction(() =>
+                            this.storageBatch.FollowUpAction(success =>
                             {
+                                if (!success)
+                                {
+                                    return;
+                                }
+
                                 LogTracePersisted(record);
                                 record.PrepareIsPersisted = true;
 
@@ -610,7 +615,6 @@ namespace Orleans.Transactions.State
 
                     if (batchBeingSentToStorage != null)
                     {
-                        batchBeingSentToStorage.RunFollowUpActions();
                         batchBeingSentToStorage.Complete(success: true);
                         batchCompletedSuccessfully = true;
                         storageWorker.Notify();  // we have to re-check for work
@@ -809,8 +813,13 @@ namespace Orleans.Transactions.State
                             {
                                 // we must confirm in storage, and then respond to TM so it can collect
                                 this.storageBatch.Confirm(entry.SequenceNumber);
-                                this.storageBatch.FollowUpAction(() =>
+                                this.storageBatch.FollowUpAction(success =>
                                 {
+                                    if (!success)
+                                    {
+                                        return;
+                                    }
+
                                     entry.ConfirmationResponsePromise.TrySetResult(true);
                                     LogTraceConfirmedRemoteCommit(entry.SequenceNumber, entry.TransactionId, new(entry.Timestamp), entry.TransactionManager);
                                 });
@@ -823,8 +832,13 @@ namespace Orleans.Transactions.State
                         {
                             // we are a participant of a read-only transaction. Must store timestamp and then respond.
                             this.storageBatch.Read(entry.Timestamp);
-                            this.storageBatch.FollowUpAction(() =>
+                            this.storageBatch.FollowUpAction(success =>
                             {
+                                if (!success)
+                                {
+                                    return;
+                                }
+
                                 entry.PromiseForTA.TrySetResult(TransactionalStatus.Ok);
                             });
 
@@ -847,8 +861,13 @@ namespace Orleans.Transactions.State
             this.storageBatch.Confirm(entry.SequenceNumber);
 
             // after store, send response back to TA
-            this.storageBatch.FollowUpAction(() =>
+            this.storageBatch.FollowUpAction(success =>
             {
+                if (!success)
+                {
+                    return;
+                }
+
                 LogTraceLocallyCommitted(entry.TransactionId, new(entry.Timestamp));
                 entry.PromiseForTA.TrySetResult(TransactionalStatus.Ok);
             });
@@ -856,8 +875,13 @@ namespace Orleans.Transactions.State
             if (entry.WriteParticipants.Count > 1)
             {
                 // after committing, we need to run a task to confirm and collect
-                this.storageBatch.FollowUpAction(() =>
+                this.storageBatch.FollowUpAction(success =>
                 {
+                    if (!success)
+                    {
+                        return;
+                    }
+
                     LogTraceAddingConfirmationToWorker(entry.TransactionId, new(entry.Timestamp));
                     this.confirmationWorker.Add(entry.TransactionId, entry.Timestamp, entry.WriteParticipants);
                 });

--- a/src/Orleans.Transactions/State/TransactionQueue.cs
+++ b/src/Orleans.Transactions/State/TransactionQueue.cs
@@ -507,6 +507,10 @@ namespace Orleans.Transactions.State
             // Stop if this activation is stopping/stopped.
             if (this.activationLifetime.OnDeactivating.IsCancellationRequested) return;
 
+            StorageBatch<TState>? batchBeingSentToStorage = null;
+            var batchCompletedSuccessfully = false;
+            var recoveryInitiated = false;
+
             using (this.activationLifetime.BlockDeactivation())
             {
                 var writeAttempted = false;
@@ -534,7 +538,6 @@ namespace Orleans.Transactions.State
                     }
 
                     // store the current storage batch, if it is not empty
-                    StorageBatch<TState>? batchBeingSentToStorage = null;
                     if (this.storageBatch.BatchSize > 0)
                     {
                         // get the next batch in place so it can be filled while we store the old one
@@ -556,12 +559,18 @@ namespace Orleans.Transactions.State
                             else
                             {
                                 LogWarningStorePreConditionsNotMet();
+                                recoveryInitiated = true;
                                 await AbortAndRestore(TransactionalStatus.CommitFailure, exception: null, storageOutcomeInDoubt: false);
                                 return;
                             }
                         }
                         catch (Exception exception)
                         {
+                            if (recoveryInitiated)
+                            {
+                                throw;
+                            }
+
                             TransactionalStatus status;
                             if (exception is InconsistentStateException)
                             {
@@ -574,6 +583,7 @@ namespace Orleans.Transactions.State
                                 LogWarningStorageExceptionInStorageWorker(exception);
                             }
 
+                            recoveryInitiated = true;
                             await AbortAndRestore(status, exception, storageOutcomeInDoubt: writeAttempted);
                             return;
                         }
@@ -601,6 +611,8 @@ namespace Orleans.Transactions.State
                     if (batchBeingSentToStorage != null)
                     {
                         batchBeingSentToStorage.RunFollowUpActions();
+                        batchBeingSentToStorage.Complete(success: true);
+                        batchCompletedSuccessfully = true;
                         storageWorker.Notify();  // we have to re-check for work
                     }
                 }
@@ -608,8 +620,21 @@ namespace Orleans.Transactions.State
                 {
                     LogWarningExceptionInStorageWorker(failCounter, exception);
 
+                    if (recoveryInitiated)
+                    {
+                        throw;
+                    }
+
                     // If a write was attempted, the durable outcome is unknown and recovery must resolve it.
+                    recoveryInitiated = true;
                     await AbortAndRestore(TransactionalStatus.UnknownException, exception, storageOutcomeInDoubt: writeAttempted);
+                }
+                finally
+                {
+                    if (batchBeingSentToStorage != null && !batchCompletedSuccessfully)
+                    {
+                        batchBeingSentToStorage.Complete(success: false);
+                    }
                 }
             }
         }
@@ -647,7 +672,12 @@ namespace Orleans.Transactions.State
                     LogDebugStorageWorkerTriggeringGrainDeactivation();
                     this.deactivate();
                 }
+                StorageBatch<TState>? discardedBatch = this.storageBatch;
                 await this.Restore();
+                if (discardedBatch is not null && !ReferenceEquals(discardedBatch, this.storageBatch))
+                {
+                    discardedBatch.Complete(success: false);
+                }
             }
         }
 

--- a/test/Transactions/Orleans.Transactions.Tests/ConfirmationWorkerTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/ConfirmationWorkerTests.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.Timers.Internal;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.State;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class ConfirmationWorkerTests
+{
+    [Fact]
+    public async Task CollectionFailure_CompletesAfterRestoreAndRetryUsesRestoredBatch()
+    {
+        var transactionId = Guid.NewGuid();
+        var timestamp = DateTime.UtcNow;
+        var timerManager = new TestTimerManager();
+        var activationLifetime = new TestActivationLifetime();
+        var participant = new ParticipantId("me", null!, ParticipantId.Role.Resource);
+        var speculativeBatch = CreateBatch(transactionId, timestamp, participant, includeCommitRecord: true);
+        var restoredBatch = CreateBatch(transactionId, timestamp, participant, includeCommitRecord: true);
+        StorageBatch<TestState> currentBatch = CreateBatch(transactionId, timestamp, participant, includeCommitRecord: true);
+
+        var recoveryStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var finishRecovery = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondAttempt = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var workerCycleCount = 0;
+
+        var storageWorker = new BatchWorkerFromDelegate(async () =>
+        {
+            var batch = currentBatch;
+            var cycle = Interlocked.Increment(ref workerCycleCount);
+
+            if (cycle == 1)
+            {
+                currentBatch = speculativeBatch;
+                recoveryStarted.TrySetResult(null);
+                await finishRecovery.Task;
+                currentBatch = restoredBatch;
+                batch.Complete(success: false);
+            }
+            else if (cycle == 2)
+            {
+                Assert.Same(restoredBatch, batch);
+                batch.RunFollowUpActions();
+                batch.Complete(success: true);
+                secondAttempt.TrySetResult(null);
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unexpected storage cycle {cycle}.");
+            }
+        }, activationLifetime.OnDeactivating);
+
+        var worker = CreateWorker(storageWorker, () => currentBatch, participant, timerManager, activationLifetime);
+
+        worker.Add(transactionId, timestamp, new List<ParticipantId> { participant });
+
+        await recoveryStarted.Task;
+        Assert.True(worker.IsConfirmed(transactionId));
+        Assert.Equal(1, workerCycleCount);
+        Assert.Same(speculativeBatch, currentBatch);
+        Assert.Equal(0, timerManager.DelayCallCount);
+
+        finishRecovery.TrySetResult(null);
+
+        await timerManager.WaitForDelayAsync();
+        Assert.Equal(1, timerManager.DelayCallCount);
+        timerManager.ReleaseNextDelay();
+
+        await secondAttempt.Task;
+        await storageWorker.WaitForCurrentWorkToBeServiced();
+
+        Assert.Equal(2, workerCycleCount);
+        Assert.False(worker.IsConfirmed(transactionId));
+    }
+
+    [Fact]
+    public async Task CollectionOutcomeInDoubt_RetriesAgainstRestoredBatchAndClearsPending()
+    {
+        var transactionId = Guid.NewGuid();
+        var timestamp = DateTime.UtcNow;
+        var timerManager = new TestTimerManager();
+        var activationLifetime = new TestActivationLifetime();
+        var participant = new ParticipantId("me", null!, ParticipantId.Role.Resource);
+        StorageBatch<TestState> currentBatch = CreateBatch(transactionId, timestamp, participant, includeCommitRecord: true);
+
+        var firstAttempt = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondAttempt = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var workerCycleCount = 0;
+
+        var storageWorker = new BatchWorkerFromDelegate(() =>
+        {
+            var batch = currentBatch;
+            var cycle = Interlocked.Increment(ref workerCycleCount);
+
+            if (cycle == 1)
+            {
+                currentBatch = CreateBatch(transactionId, timestamp, participant, includeCommitRecord: false);
+                batch.Complete(success: false);
+                firstAttempt.TrySetResult(null);
+            }
+            else if (cycle == 2)
+            {
+                Assert.DoesNotContain(transactionId, batch.MetaData.CommitRecords.Keys);
+                batch.RunFollowUpActions();
+                batch.Complete(success: true);
+                secondAttempt.TrySetResult(null);
+            }
+            else
+            {
+                throw new InvalidOperationException($"Unexpected storage cycle {cycle}.");
+            }
+
+            return Task.CompletedTask;
+        }, activationLifetime.OnDeactivating);
+
+        var worker = CreateWorker(storageWorker, () => currentBatch, participant, timerManager, activationLifetime);
+
+        worker.Add(transactionId, timestamp, new List<ParticipantId> { participant });
+
+        await firstAttempt.Task;
+        Assert.True(worker.IsConfirmed(transactionId));
+
+        await timerManager.WaitForDelayAsync();
+        timerManager.ReleaseNextDelay();
+
+        await secondAttempt.Task;
+        await storageWorker.WaitForCurrentWorkToBeServiced();
+
+        Assert.Equal(2, workerCycleCount);
+        Assert.False(worker.IsConfirmed(transactionId));
+    }
+
+    [Fact]
+    public void StorageBatch_CompletionRunsExactlyOnce()
+    {
+        var transactionId = Guid.NewGuid();
+        var timestamp = DateTime.UtcNow;
+        var participant = new ParticipantId("me", null!, ParticipantId.Role.Resource);
+        var batch = CreateBatch(transactionId, timestamp, participant, includeCommitRecord: true);
+        var callbacks = 0;
+
+        batch.CompletionAction(_ => callbacks++);
+
+        batch.Complete(success: false);
+        batch.Complete(success: false);
+        batch.Complete(success: true);
+
+        Assert.Equal(1, callbacks);
+    }
+
+    [Fact]
+    public async Task Deactivation_UnblocksOutstandingCollectionWait()
+    {
+        var transactionId = Guid.NewGuid();
+        var timestamp = DateTime.UtcNow;
+        var timerManager = new TestTimerManager();
+        var activationLifetime = new TestActivationLifetime();
+        var participant = new ParticipantId("me", null!, ParticipantId.Role.Resource);
+        StorageBatch<TestState> currentBatch = CreateBatch(transactionId, timestamp, participant, includeCommitRecord: true);
+
+        var workStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var finishWork = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var storageWorker = new BatchWorkerFromDelegate(async () =>
+        {
+            workStarted.TrySetResult(null);
+            await finishWork.Task;
+        }, activationLifetime.OnDeactivating);
+
+        var worker = CreateWorker(storageWorker, () => currentBatch, participant, timerManager, activationLifetime);
+
+        worker.Add(transactionId, timestamp, new List<ParticipantId> { participant });
+
+        await workStarted.Task;
+        Assert.True(worker.IsConfirmed(transactionId));
+        Assert.Equal(1, activationLifetime.PendingBlockCount);
+
+        activationLifetime.Deactivate();
+        await activationLifetime.WaitForPendingBlocksToDrainAsync();
+
+        Assert.Equal(0, activationLifetime.PendingBlockCount);
+        Assert.Equal(0, timerManager.DelayCallCount);
+        Assert.True(worker.IsConfirmed(transactionId));
+
+        finishWork.TrySetResult(null);
+        await storageWorker.WaitForCurrentWorkToBeServiced();
+    }
+
+    private static ConfirmationWorker<TestState> CreateWorker(
+        BatchWorker storageWorker,
+        Func<StorageBatch<TestState>> getStorageBatch,
+        ParticipantId participant,
+        ITimerManager timerManager,
+        IActivationLifetime activationLifetime)
+    {
+        return new ConfirmationWorker<TestState>(
+            Options.Create(new TransactionalStateOptions { ConfirmationRetryDelay = TimeSpan.FromHours(1) }),
+            participant,
+            storageWorker,
+            getStorageBatch,
+            NullLogger<ConfirmationWorker<TestState>>.Instance,
+            timerManager,
+            activationLifetime);
+    }
+
+    private static StorageBatch<TestState> CreateBatch(Guid transactionId, DateTime timestamp, ParticipantId participant, bool includeCommitRecord)
+    {
+        var metadata = new TransactionalStateMetaData();
+        if (includeCommitRecord)
+        {
+            metadata.CommitRecords.Add(transactionId, new CommitRecord
+            {
+                Timestamp = timestamp,
+                WriteParticipants = new List<ParticipantId> { participant }
+            });
+        }
+
+        return new StorageBatch<TestState>(metadata, etag: "etag", confirmUpTo: 0, cancelAbove: 0);
+    }
+
+    private sealed class TestState
+    {
+    }
+
+    private sealed class TestTimerManager : ITimerManager
+    {
+        private readonly Queue<TaskCompletionSource<bool>> delays = new();
+        private readonly TaskCompletionSource<object?> delayRequested = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int DelayCallCount { get; private set; }
+
+        public Task<bool> Delay(TimeSpan timeSpan, CancellationToken cancellationToken = default)
+        {
+            this.DelayCallCount++;
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromResult(false);
+            }
+
+            var delay = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            cancellationToken.Register(static state => ((TaskCompletionSource<bool>)state!).TrySetResult(false), delay);
+
+            lock (this.delays)
+            {
+                this.delays.Enqueue(delay);
+            }
+
+            this.delayRequested.TrySetResult(null);
+            return delay.Task;
+        }
+
+        public Task WaitForDelayAsync()
+        {
+            return this.DelayCallCount > 0 ? Task.CompletedTask : this.delayRequested.Task;
+        }
+
+        public void ReleaseNextDelay(bool result = true)
+        {
+            TaskCompletionSource<bool> delay;
+            lock (this.delays)
+            {
+                delay = this.delays.Dequeue();
+            }
+
+            delay.TrySetResult(result);
+        }
+    }
+
+    private sealed class TestActivationLifetime : IActivationLifetime
+    {
+        private readonly CancellationTokenSource cancellation = new();
+        private readonly TaskCompletionSource<object?> pendingBlocksDrained = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int pendingBlockCount;
+
+        public CancellationToken OnDeactivating => this.cancellation.Token;
+
+        public int PendingBlockCount => this.pendingBlockCount;
+
+        public IDisposable BlockDeactivation()
+        {
+            Interlocked.Increment(ref this.pendingBlockCount);
+            return new Releaser(this);
+        }
+
+        public void Deactivate()
+        {
+            this.cancellation.Cancel();
+            if (this.PendingBlockCount == 0)
+            {
+                this.pendingBlocksDrained.TrySetResult(null);
+            }
+        }
+
+        public Task WaitForPendingBlocksToDrainAsync()
+        {
+            return this.PendingBlockCount == 0 ? Task.CompletedTask : this.pendingBlocksDrained.Task;
+        }
+
+        private void Release()
+        {
+            if (Interlocked.Decrement(ref this.pendingBlockCount) == 0 && this.cancellation.IsCancellationRequested)
+            {
+                this.pendingBlocksDrained.TrySetResult(null);
+            }
+        }
+
+        private sealed class Releaser : IDisposable
+        {
+            private readonly TestActivationLifetime owner;
+            private bool disposed;
+
+            public Releaser(TestActivationLifetime owner)
+            {
+                this.owner = owner;
+            }
+
+            public void Dispose()
+            {
+                if (this.disposed)
+                {
+                    return;
+                }
+
+                this.disposed = true;
+                this.owner.Release();
+            }
+        }
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/ConfirmationWorkerTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/ConfirmationWorkerTests.cs
@@ -49,7 +49,6 @@ public class ConfirmationWorkerTests
             else if (cycle == 2)
             {
                 Assert.Same(restoredBatch, batch);
-                batch.RunFollowUpActions();
                 batch.Complete(success: true);
                 secondAttempt.TrySetResult(null);
             }
@@ -110,7 +109,6 @@ public class ConfirmationWorkerTests
             else if (cycle == 2)
             {
                 Assert.DoesNotContain(transactionId, batch.MetaData.CommitRecords.Keys);
-                batch.RunFollowUpActions();
                 batch.Complete(success: true);
                 secondAttempt.TrySetResult(null);
             }
@@ -140,7 +138,7 @@ public class ConfirmationWorkerTests
     }
 
     [Fact]
-    public void StorageBatch_CompletionRunsExactlyOnce()
+    public void StorageBatch_FollowUpRunsExactlyOnce()
     {
         var transactionId = Guid.NewGuid();
         var timestamp = DateTime.UtcNow;
@@ -148,7 +146,7 @@ public class ConfirmationWorkerTests
         var batch = CreateBatch(transactionId, timestamp, participant, includeCommitRecord: true);
         var callbacks = 0;
 
-        batch.CompletionAction(_ => callbacks++);
+        batch.FollowUpAction(_ => callbacks++);
 
         batch.Complete(success: false);
         batch.Complete(success: false);

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionQueueStorageWorkTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionQueueStorageWorkTests.cs
@@ -195,7 +195,7 @@ public class TransactionQueueStorageWorkTests
         Assert.NotSame(initialBatch, replacementBatch);
 
         var replacementCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        replacementBatch.CompletionAction(success => replacementCompleted.TrySetResult(success));
+        replacementBatch.FollowUpAction(success => replacementCompleted.TrySetResult(success));
 
         queue.AddConfirmation(transactionId, timestamp, new List<ParticipantId> { participant });
 
@@ -217,7 +217,7 @@ public class TransactionQueueStorageWorkTests
         Assert.Equal("restored-etag", restoredBatch.ETag);
 
         var restoredCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        restoredBatch.CompletionAction(success => restoredCompleted.TrySetResult(success));
+        restoredBatch.FollowUpAction(success => restoredCompleted.TrySetResult(success));
 
         await timerManager.WaitForDelayAsync();
         timerManager.ReleaseNextDelay();
@@ -268,7 +268,7 @@ public class TransactionQueueStorageWorkTests
         Assert.NotSame(initialBatch, replacementBatch);
 
         var replacementCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        replacementBatch.CompletionAction(success => replacementCompleted.TrySetResult(success));
+        replacementBatch.FollowUpAction(success => replacementCompleted.TrySetResult(success));
 
         failFirstStore.TrySetResult(null);
         await firstRestoreStarted.Task;

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionQueueStorageWorkTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionQueueStorageWorkTests.cs
@@ -1,0 +1,609 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Storage;
+using Orleans.Timers.Internal;
+using Orleans.Transactions.Abstractions;
+using Orleans.Transactions.State;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class TransactionQueueStorageWorkTests
+{
+    [Fact]
+    public async Task StoreFailureAndFailedRestore_CountsOneFailurePerCycle_AndLoadsOncePerCycle()
+    {
+        var storage = new ScriptedTransactionalStateStorage();
+        storage.EnqueueStoreFailures(10, () => new InvalidOperationException("store failed"));
+        storage.EnqueueLoadFailures(10, () => new InvalidOperationException("load failed"));
+
+        var deactivateCount = 0;
+        var queue = CreateQueue(storage, () => deactivateCount++);
+
+        for (var attempt = 1; attempt <= 9; attempt++)
+        {
+            queue.SetStorageBatch(CreateDirtyBatch());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(queue.InvokeStorageWorkAsync);
+
+            Assert.Equal(attempt, storage.StoreCallCount);
+            Assert.Equal(attempt, storage.LoadCallCount);
+            Assert.Equal(0, deactivateCount);
+        }
+
+        queue.SetStorageBatch(CreateDirtyBatch());
+        await Assert.ThrowsAsync<InvalidOperationException>(queue.InvokeStorageWorkAsync);
+
+        Assert.Equal(10, storage.StoreCallCount);
+        Assert.Equal(10, storage.LoadCallCount);
+        Assert.Equal(1, deactivateCount);
+    }
+
+    [Fact]
+    public async Task FailedStorePreconditionAndFailedRestore_CountsOneFailurePerCycle_AndLoadsOncePerCycle()
+    {
+        var storage = new ScriptedTransactionalStateStorage();
+        storage.EnqueueLoadFailures(10, () => new InvalidOperationException("load failed"));
+
+        var deactivateCount = 0;
+        var queue = CreateQueue(storage, () => deactivateCount++);
+
+        for (var attempt = 1; attempt <= 9; attempt++)
+        {
+            queue.SetStorageBatch(CreateDirtyBatchWithFailedStorePrecondition());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(queue.InvokeStorageWorkAsync);
+
+            Assert.Equal(0, storage.StoreCallCount);
+            Assert.Equal(attempt, storage.LoadCallCount);
+            Assert.Equal(0, deactivateCount);
+        }
+
+        queue.SetStorageBatch(CreateDirtyBatchWithFailedStorePrecondition());
+        await Assert.ThrowsAsync<InvalidOperationException>(queue.InvokeStorageWorkAsync);
+
+        Assert.Equal(0, storage.StoreCallCount);
+        Assert.Equal(10, storage.LoadCallCount);
+        Assert.Equal(1, deactivateCount);
+    }
+
+    [Fact]
+    public async Task SuccessfulStore_ResetsConsecutiveFailureCount()
+    {
+        var storage = new ScriptedTransactionalStateStorage();
+        storage.EnqueueStoreFailures(9, () => new InvalidOperationException("store failed"));
+        storage.EnqueueLoadSuccesses(9);
+        storage.EnqueueStoreSuccesses(1);
+        storage.EnqueueStoreFailures(10, () => new InvalidOperationException("store failed"));
+        storage.EnqueueLoadSuccesses(10);
+
+        var deactivateCount = 0;
+        var queue = CreateQueue(storage, () => deactivateCount++);
+
+        await RunStoreFailureCyclesAsync(queue, storage, 9, deactivateCount, startingStoreCount: 1, startingLoadCount: 1);
+
+        queue.SetStorageBatch(CreateDirtyBatch());
+        await queue.InvokeStorageWorkAsync();
+        await queue.WaitForBackgroundWorkAsync();
+
+        Assert.Equal(10, storage.StoreCallCount);
+        Assert.Equal(9, storage.LoadCallCount);
+        Assert.Equal(0, deactivateCount);
+
+        await RunStoreFailureCyclesAsync(queue, storage, 9, deactivateCount, startingStoreCount: 11, startingLoadCount: 10);
+
+        queue.SetStorageBatch(CreateDirtyBatch());
+        await queue.InvokeStorageWorkAsync();
+        await queue.WaitForBackgroundWorkAsync();
+
+        Assert.Equal(20, storage.StoreCallCount);
+        Assert.Equal(19, storage.LoadCallCount);
+        Assert.Equal(1, deactivateCount);
+    }
+
+    [Fact]
+    public async Task SuccessfulRestoreAfterStoreFailure_DoesNotResetConsecutiveFailureCount()
+    {
+        var storage = new ScriptedTransactionalStateStorage();
+        storage.EnqueueStoreFailures(10, () => new InvalidOperationException("store failed"));
+        storage.EnqueueLoadSuccesses(10);
+
+        var deactivateCount = 0;
+        var queue = CreateQueue(storage, () => deactivateCount++);
+
+        await RunStoreFailureCyclesAsync(queue, storage, 9, deactivateCount, startingStoreCount: 1, startingLoadCount: 1);
+
+        queue.SetStorageBatch(CreateDirtyBatch());
+        await queue.InvokeStorageWorkAsync();
+        await queue.WaitForBackgroundWorkAsync();
+
+        Assert.Equal(10, storage.StoreCallCount);
+        Assert.Equal(10, storage.LoadCallCount);
+        Assert.Equal(1, deactivateCount);
+    }
+
+    [Fact]
+    public async Task StorageConflict_DeactivatesOnFirstCycle()
+    {
+        var storage = new ScriptedTransactionalStateStorage();
+        storage.EnqueueStoreFailures(1, () => new InconsistentStateException("etag mismatch"));
+        storage.EnqueueLoadSuccesses(1);
+
+        var deactivateCount = 0;
+        var queue = CreateQueue(storage, () => deactivateCount++);
+        queue.SetStorageBatch(CreateDirtyBatch());
+
+        await queue.InvokeStorageWorkAsync();
+        await queue.WaitForBackgroundWorkAsync();
+
+        Assert.Equal(1, storage.StoreCallCount);
+        Assert.Equal(1, storage.LoadCallCount);
+        Assert.Equal(1, deactivateCount);
+    }
+
+    [Fact]
+    public async Task StoreFailureDuringCollection_RestoreCompletesReplacementBatchAndRetryUsesRestoredBatch()
+    {
+        var transactionId = Guid.NewGuid();
+        var timestamp = DateTime.UtcNow;
+        var participant = new ParticipantId("resource", null!, ParticipantId.Role.Resource);
+        var timerManager = new TestTimerManager();
+        var storage = new CoordinatedTransactionalStateStorage();
+        var failFirstStore = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRestore = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completeRetryStore = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstStoreStarted = new TaskCompletionSource<CoordinatedTransactionalStateStorage.StoreCall>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var restoreStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var retryStoreStarted = new TaskCompletionSource<CoordinatedTransactionalStateStorage.StoreCall>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        storage.EnqueueStore(async call =>
+        {
+            firstStoreStarted.TrySetResult(call);
+            await failFirstStore.Task;
+            throw new InvalidOperationException("store failed");
+        });
+        storage.EnqueueLoad(async () =>
+        {
+            restoreStarted.TrySetResult(null);
+            await releaseRestore.Task;
+            return CreateLoadResponse(transactionId, timestamp, participant, etag: "restored-etag");
+        });
+        storage.EnqueueStore(async call =>
+        {
+            retryStoreStarted.TrySetResult(call);
+            await completeRetryStore.Task;
+            return "collected-etag";
+        });
+
+        var queue = CreateQueue(storage, deactivate: static () => { }, participant, timerManager);
+        var initialBatch = CreateDirtyBatchWithCommitRecord(transactionId, timestamp, participant);
+        queue.SetStorageBatch(initialBatch);
+
+        queue.NotifyStorageWorker();
+        await firstStoreStarted.Task;
+
+        var replacementBatch = queue.CurrentStorageBatch;
+        Assert.NotSame(initialBatch, replacementBatch);
+
+        var replacementCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        replacementBatch.CompletionAction(success => replacementCompleted.TrySetResult(success));
+
+        queue.AddConfirmation(transactionId, timestamp, new List<ParticipantId> { participant });
+
+        Assert.True(queue.IsConfirmationPending(transactionId));
+        Assert.Equal(1, replacementBatch.BatchSize);
+
+        failFirstStore.TrySetResult(null);
+        await restoreStarted.Task;
+
+        Assert.Same(replacementBatch, queue.CurrentStorageBatch);
+        Assert.False(replacementCompleted.Task.IsCompleted);
+
+        releaseRestore.TrySetResult(null);
+
+        Assert.False(await replacementCompleted.Task);
+
+        var restoredBatch = queue.CurrentStorageBatch;
+        Assert.NotSame(replacementBatch, restoredBatch);
+        Assert.Equal("restored-etag", restoredBatch.ETag);
+
+        var restoredCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        restoredBatch.CompletionAction(success => restoredCompleted.TrySetResult(success));
+
+        await timerManager.WaitForDelayAsync();
+        timerManager.ReleaseNextDelay();
+
+        var retryStore = await retryStoreStarted.Task;
+        Assert.Equal("restored-etag", retryStore.ExpectedETag);
+        Assert.DoesNotContain(transactionId, retryStore.Metadata.CommitRecords.Keys);
+
+        completeRetryStore.TrySetResult(null);
+        await queue.WaitForBackgroundWorkAsync();
+
+        Assert.True(await restoredCompleted.Task);
+        Assert.False(queue.IsConfirmationPending(transactionId));
+    }
+
+    [Fact]
+    public async Task FailedRestore_LeavesReplacementBatchPendingUntilLaterSuccessfulRestoreReplacesIt()
+    {
+        var timestamp = DateTime.UtcNow;
+        var storage = new CoordinatedTransactionalStateStorage();
+        var failFirstStore = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var failFirstRestore = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstStoreStarted = new TaskCompletionSource<CoordinatedTransactionalStateStorage.StoreCall>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstRestoreStarted = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        storage.EnqueueStore(async call =>
+        {
+            firstStoreStarted.TrySetResult(call);
+            await failFirstStore.Task;
+            throw new InvalidOperationException("store failed");
+        });
+        storage.EnqueueLoad(async () =>
+        {
+            firstRestoreStarted.TrySetResult(null);
+            await failFirstRestore.Task;
+            throw new InvalidOperationException("restore failed");
+        });
+        storage.EnqueueLoad(() => Task.FromResult(CreateLoadResponse(Guid.NewGuid(), timestamp, new ParticipantId("resource", null!, ParticipantId.Role.Resource), etag: "restored-etag-2", includeCommitRecord: false)));
+
+        var queue = CreateQueue(storage, deactivate: static () => { });
+        var initialBatch = CreateDirtyBatch();
+        queue.SetStorageBatch(initialBatch);
+
+        queue.NotifyStorageWorker();
+        await firstStoreStarted.Task;
+
+        var replacementBatch = queue.CurrentStorageBatch;
+        Assert.NotSame(initialBatch, replacementBatch);
+
+        var replacementCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        replacementBatch.CompletionAction(success => replacementCompleted.TrySetResult(success));
+
+        failFirstStore.TrySetResult(null);
+        await firstRestoreStarted.Task;
+        failFirstRestore.TrySetResult(null);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(queue.WaitForBackgroundWorkAsync);
+        Assert.Equal("restore failed", exception.Message);
+        Assert.Same(replacementBatch, queue.CurrentStorageBatch);
+        Assert.False(replacementCompleted.Task.IsCompleted);
+
+        await queue.InvokeAbortAndRestoreAsync(TransactionalStatus.UnknownException, new InvalidOperationException("retry"), storageOutcomeInDoubt: false);
+
+        Assert.False(await replacementCompleted.Task);
+        Assert.NotSame(replacementBatch, queue.CurrentStorageBatch);
+        Assert.Equal("restored-etag-2", queue.CurrentStorageBatch.ETag);
+    }
+
+    [Fact]
+    public async Task FailedInitialRestore_AllowsLaterRecoveryWhenNoBatchWasEverInstalled()
+    {
+        var transactionId = Guid.NewGuid();
+        var timestamp = DateTime.UtcNow;
+        var participant = new ParticipantId("resource", null!, ParticipantId.Role.Resource);
+        var storage = new CoordinatedTransactionalStateStorage();
+        storage.EnqueueLoad(() => Task.FromException<TransactionalStorageLoadResponse<TestState>>(new InvalidOperationException("initial restore failed")));
+        storage.EnqueueLoad(() => Task.FromResult(CreateLoadResponse(transactionId, timestamp, participant, etag: "restored-etag-3", includeCommitRecord: false)));
+
+        var queue = CreateQueue(storage, deactivate: static () => { });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(queue.NotifyOfRestore);
+        Assert.Equal("initial restore failed", exception.Message);
+        Assert.Null(queue.CurrentStorageBatchOrNull);
+
+        await queue.Ready();
+
+        var restoredBatch = queue.CurrentStorageBatchOrNull;
+        Assert.NotNull(restoredBatch);
+        Assert.Equal("restored-etag-3", restoredBatch.ETag);
+    }
+
+    private static async Task RunStoreFailureCyclesAsync(
+        TestTransactionQueue queue,
+        ScriptedTransactionalStateStorage storage,
+        int cycles,
+        int deactivateCount,
+        int startingStoreCount,
+        int startingLoadCount)
+    {
+        for (var offset = 0; offset < cycles; offset++)
+        {
+            var expectedStoreCount = startingStoreCount + offset;
+            var expectedLoadCount = startingLoadCount + offset;
+            queue.SetStorageBatch(CreateDirtyBatch());
+
+            await queue.InvokeStorageWorkAsync();
+            await queue.WaitForBackgroundWorkAsync();
+
+            Assert.Equal(expectedStoreCount, storage.StoreCallCount);
+            Assert.Equal(expectedLoadCount, storage.LoadCallCount);
+            Assert.Equal(0, deactivateCount);
+        }
+    }
+
+    private static TestTransactionQueue CreateQueue(ITransactionalStateStorage<TestState> storage, Action deactivate)
+        => CreateQueue(
+            storage,
+            deactivate,
+            new ParticipantId("resource", null!, ParticipantId.Role.Resource),
+            new NoOpTimerManager(),
+            new TestActivationLifetime());
+
+    private static TestTransactionQueue CreateQueue(
+        ITransactionalStateStorage<TestState> storage,
+        Action deactivate,
+        ParticipantId resource,
+        ITimerManager timerManager)
+        => CreateQueue(storage, deactivate, resource, timerManager, new TestActivationLifetime());
+
+    private static TestTransactionQueue CreateQueue(
+        ITransactionalStateStorage<TestState> storage,
+        Action deactivate,
+        ParticipantId resource,
+        ITimerManager timerManager,
+        IActivationLifetime activationLifetime)
+    {
+        return new TestTransactionQueue(
+            Options.Create(new TransactionalStateOptions()),
+            resource,
+            deactivate,
+            storage,
+            new Clock(),
+            NullLogger.Instance,
+            timerManager,
+            activationLifetime);
+    }
+
+    private static StorageBatch<TestState> CreateDirtyBatch()
+    {
+        var batch = new StorageBatch<TestState>(new TransactionalStateMetaData(), etag: "etag", confirmUpTo: 0, cancelAbove: 0);
+        batch.Read(DateTime.UtcNow);
+        return batch;
+    }
+
+    private static StorageBatch<TestState> CreateDirtyBatchWithFailedStorePrecondition()
+    {
+        var batch = CreateDirtyBatch();
+        batch.AddStorePreCondition(() => Task.FromResult(false));
+        return batch;
+    }
+
+    private static StorageBatch<TestState> CreateDirtyBatchWithCommitRecord(Guid transactionId, DateTime timestamp, ParticipantId participant)
+    {
+        var metadata = new TransactionalStateMetaData();
+        metadata.CommitRecords.Add(transactionId, new CommitRecord
+        {
+            Timestamp = timestamp,
+            WriteParticipants = new List<ParticipantId> { participant }
+        });
+
+        var batch = new StorageBatch<TestState>(metadata, etag: "etag", confirmUpTo: 0, cancelAbove: 0);
+        batch.Read(timestamp);
+        return batch;
+    }
+
+    private static TransactionalStorageLoadResponse<TestState> CreateLoadResponse(Guid transactionId, DateTime timestamp, ParticipantId participant, string etag, bool includeCommitRecord = true)
+    {
+        var metadata = new TransactionalStateMetaData();
+        if (includeCommitRecord)
+        {
+            metadata.CommitRecords.Add(transactionId, new CommitRecord
+            {
+                Timestamp = timestamp,
+                WriteParticipants = new List<ParticipantId> { participant }
+            });
+        }
+
+        return new TransactionalStorageLoadResponse<TestState>(
+            etag,
+            committedState: new TestState(),
+            committedSequenceId: 0,
+            metadata,
+            pendingStates: Array.Empty<PendingTransactionState<TestState>>());
+    }
+
+    private sealed class TestTransactionQueue : TransactionQueue<TestState>
+    {
+        private static readonly MethodInfo StorageWorkMethod = typeof(TransactionQueue<TestState>).GetMethod("StorageWork", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        private static readonly MethodInfo AbortAndRestoreMethod = typeof(TransactionQueue<TestState>).GetMethod("AbortAndRestore", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        private static readonly FieldInfo ConfirmationWorkerField = typeof(TransactionQueue<TestState>).GetField("confirmationWorker", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        private static readonly FieldInfo StorageWorkerField = typeof(TransactionQueue<TestState>).GetField("storageWorker", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        public TestTransactionQueue(
+            IOptions<TransactionalStateOptions> options,
+            ParticipantId resource,
+            Action deactivate,
+            ITransactionalStateStorage<TestState> storage,
+            IClock clock,
+            Microsoft.Extensions.Logging.ILogger logger,
+            ITimerManager timerManager,
+            IActivationLifetime activationLifetime)
+            : base(options, resource, deactivate, storage, clock, logger, timerManager, activationLifetime)
+        {
+        }
+
+        public Task InvokeStorageWorkAsync() => (Task)StorageWorkMethod.Invoke(this, null)!;
+
+        public void SetStorageBatch(StorageBatch<TestState> batch) => this.storageBatch = batch;
+
+        public StorageBatch<TestState> CurrentStorageBatch => this.storageBatch;
+
+        public StorageBatch<TestState>? CurrentStorageBatchOrNull => this.storageBatch;
+
+        public void NotifyStorageWorker() => ((BatchWorker)StorageWorkerField.GetValue(this)!).Notify();
+
+        public void AddConfirmation(Guid transactionId, DateTime timestamp, List<ParticipantId> participants)
+            => ((ConfirmationWorker<TestState>)ConfirmationWorkerField.GetValue(this)!).Add(transactionId, timestamp, participants);
+
+        public bool IsConfirmationPending(Guid transactionId)
+            => ((ConfirmationWorker<TestState>)ConfirmationWorkerField.GetValue(this)!).IsConfirmed(transactionId);
+
+        public Task InvokeAbortAndRestoreAsync(TransactionalStatus status, Exception? exception, bool storageOutcomeInDoubt)
+            => (Task)AbortAndRestoreMethod.Invoke(this, new object?[] { status, exception, storageOutcomeInDoubt })!;
+
+        public Task WaitForBackgroundWorkAsync() => ((BatchWorker)StorageWorkerField.GetValue(this)!).WaitForCurrentWorkToBeServiced();
+    }
+
+    private sealed class ScriptedTransactionalStateStorage : ITransactionalStateStorage<TestState>
+    {
+        private readonly Queue<Func<Task<TransactionalStorageLoadResponse<TestState>>>> loads = new();
+        private readonly Queue<Func<Task<string>>> stores = new();
+
+        public int LoadCallCount { get; private set; }
+
+        public int StoreCallCount { get; private set; }
+
+        public void EnqueueStoreFailures(int count, Func<Exception> exceptionFactory)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                this.stores.Enqueue(() => Task.FromException<string>(exceptionFactory()));
+            }
+        }
+
+        public void EnqueueStoreSuccesses(int count)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                var value = $"etag-{this.stores.Count + 1}";
+                this.stores.Enqueue(() => Task.FromResult(value));
+            }
+        }
+
+        public void EnqueueLoadFailures(int count, Func<Exception> exceptionFactory)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                this.loads.Enqueue(() => Task.FromException<TransactionalStorageLoadResponse<TestState>>(exceptionFactory()));
+            }
+        }
+
+        public void EnqueueLoadSuccesses(int count)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                this.loads.Enqueue(() => Task.FromResult(CreateLoadResponse()));
+            }
+        }
+
+        public Task<TransactionalStorageLoadResponse<TestState>> Load()
+        {
+            this.LoadCallCount++;
+            return this.loads.Dequeue().Invoke();
+        }
+
+        public Task<string> Store(string? expectedETag, TransactionalStateMetaData metadata, List<PendingTransactionState<TestState>>? statesToPrepare, long? commitUpTo, long? abortAfter)
+        {
+            this.StoreCallCount++;
+            return this.stores.Dequeue().Invoke();
+        }
+
+        private static TransactionalStorageLoadResponse<TestState> CreateLoadResponse()
+        {
+            return new TransactionalStorageLoadResponse<TestState>(etag: "loaded-etag", committedState: new TestState(), committedSequenceId: 0, metadata: new TransactionalStateMetaData(), pendingStates: Array.Empty<PendingTransactionState<TestState>>());
+        }
+    }
+
+    private sealed class CoordinatedTransactionalStateStorage : ITransactionalStateStorage<TestState>
+    {
+        private readonly Queue<Func<Task<TransactionalStorageLoadResponse<TestState>>>> loads = new();
+        private readonly Queue<Func<StoreCall, Task<string>>> stores = new();
+
+        public void EnqueueLoad(Func<Task<TransactionalStorageLoadResponse<TestState>>> load) => this.loads.Enqueue(load);
+
+        public void EnqueueStore(Func<StoreCall, Task<string>> store) => this.stores.Enqueue(store);
+
+        public Task<TransactionalStorageLoadResponse<TestState>> Load() => this.loads.Dequeue().Invoke();
+
+        public Task<string> Store(string? expectedETag, TransactionalStateMetaData metadata, List<PendingTransactionState<TestState>>? statesToPrepare, long? commitUpTo, long? abortAfter)
+            => this.stores.Dequeue().Invoke(new StoreCall(expectedETag, metadata, statesToPrepare, commitUpTo, abortAfter));
+
+        public sealed record StoreCall(
+            string? ExpectedETag,
+            TransactionalStateMetaData Metadata,
+            List<PendingTransactionState<TestState>>? StatesToPrepare,
+            long? CommitUpTo,
+            long? AbortAfter);
+    }
+
+    private sealed class NoOpTimerManager : ITimerManager
+    {
+        public Task<bool> Delay(TimeSpan timeSpan, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    }
+
+    private sealed class TestTimerManager : ITimerManager
+    {
+        private readonly Queue<TaskCompletionSource<bool>> delays = new();
+        private readonly TaskCompletionSource<object?> delayRequested = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int DelayCallCount { get; private set; }
+
+        public Task<bool> Delay(TimeSpan timeSpan, CancellationToken cancellationToken = default)
+        {
+            this.DelayCallCount++;
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromResult(false);
+            }
+
+            var delay = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            cancellationToken.Register(static state => ((TaskCompletionSource<bool>)state!).TrySetResult(false), delay);
+
+            lock (this.delays)
+            {
+                this.delays.Enqueue(delay);
+            }
+
+            this.delayRequested.TrySetResult(null);
+            return delay.Task;
+        }
+
+        public Task WaitForDelayAsync()
+        {
+            return this.DelayCallCount > 0 ? Task.CompletedTask : this.delayRequested.Task;
+        }
+
+        public void ReleaseNextDelay(bool result = true)
+        {
+            TaskCompletionSource<bool> delay;
+            lock (this.delays)
+            {
+                delay = this.delays.Dequeue();
+            }
+
+            delay.TrySetResult(result);
+        }
+    }
+
+    private sealed class TestActivationLifetime : IActivationLifetime
+    {
+        public CancellationToken OnDeactivating => CancellationToken.None;
+
+        public IDisposable BlockDeactivation() => NoOpDisposable.Instance;
+
+        private sealed class NoOpDisposable : IDisposable
+        {
+            public static NoOpDisposable Instance { get; } = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+
+    private sealed class TestState
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- complete failed confirmation-collection batches only after recovery installs the authoritative storage batch so retries bind to the restored batch
- prevent duplicate recovery within a single `StorageWork` cycle so consecutive failure counting and deactivation thresholds stay correct
- use one failure-aware follow-up callback path for storage-batch completion
- add deterministic tests covering confirmation retry ordering, exact-once batch completion, and direct `TransactionQueue` storage-work recovery behavior
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10382)