### PR TITLE
feat(streaming): flow cancellation through persistent streams

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/EventDataGeneratorStreamProvider/EventHubPartitionGeneratorReceiver.cs
@@ -3,6 +3,7 @@ using Azure.Messaging.EventHubs;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.Streaming.EventHubs.Testing
@@ -23,16 +24,23 @@ namespace Orleans.Streaming.EventHubs.Testing
         }
         /// <inheritdoc />
         public async Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime)
+            => await ReceiveAsync(maxCount, waitTime, CancellationToken.None);
+
+        /// <inheritdoc />
+        public async Task<IEnumerable<EventData>> ReceiveAsync(
+            int maxCount,
+            TimeSpan waitTime,
+            CancellationToken cancellationToken)
         {
             IEnumerable<EventData>? events;
             //mimic real life response time
-            await Task.Delay(TimeSpan.FromMilliseconds(30));
+            await Task.Delay(TimeSpan.FromMilliseconds(30), cancellationToken);
             if (generator.TryReadEvents(maxCount, out events))
             {
                 return events;
             }
             //if no events generated, wait for waitTime to pass
-            await Task.Delay(waitTime);
+            await Task.Delay(waitTime, cancellationToken);
             return new List<EventData>().AsEnumerable();
         }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterFactory.cs
@@ -288,7 +288,7 @@ namespace Orleans.Streaming.EventHubs
             return new EventHubAdapterReceiver(
                 config,
                 this.CacheFactory,
-                this.checkpointerFactory.Create,
+                (partition, cancellationToken) => this.checkpointerFactory.Create(partition, cancellationToken),
                 this.loggerFactory,
                 this.ReceiverMonitorFactory(receiverMonitorDimensions, this.loggerFactory),
                 this.serviceProvider.GetRequiredService<IOptions<LoadSheddingOptions>>().Value,

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -161,6 +161,7 @@ namespace Orleans.Streaming.EventHubs
             }
         }
 
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         public Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
             => GetQueueMessagesAsync(maxCount, CancellationToken.None);
 
@@ -267,7 +268,7 @@ namespace Orleans.Streaming.EventHubs
             if (earliestSubscriptionToken is IEventHubPartitionLocation location
                 && long.TryParse(location.EventHubOffset, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
             {
-                this.checkpointer?.Update(location.EventHubOffset, utcNow);
+                this.checkpointer?.Update(location.EventHubOffset, utcNow, CancellationToken.None);
             }
         }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubAdapterReceiver.cs
@@ -43,7 +43,7 @@ namespace Orleans.Streaming.EventHubs
 
         private readonly EventHubPartitionSettings settings;
         private readonly Func<string, IStreamQueueCheckpointer<string>, ILoggerFactory, IEventHubQueueCache> cacheFactory;
-        private readonly Func<string, Task<IStreamQueueCheckpointer<string>>> checkpointerFactory;
+        private readonly Func<string, CancellationToken, Task<IStreamQueueCheckpointer<string>>> checkpointerFactory;
         private readonly ILoggerFactory loggerFactory;
         private readonly ILogger logger;
         private readonly IQueueAdapterReceiverMonitor monitor;
@@ -77,6 +77,26 @@ namespace Orleans.Streaming.EventHubs
             LoadSheddingOptions loadSheddingOptions,
             IEnvironmentStatisticsProvider environmentStatisticsProvider,
             Func<EventHubPartitionSettings, string, ILogger, IEventHubReceiver>? eventHubReceiverFactory = null)
+            : this(
+                settings,
+                cacheFactory,
+                (partition, _) => checkpointerFactory(partition),
+                loggerFactory,
+                monitor,
+                loadSheddingOptions,
+                environmentStatisticsProvider,
+                eventHubReceiverFactory)
+        {
+        }
+
+        public EventHubAdapterReceiver(EventHubPartitionSettings settings,
+            Func<string, IStreamQueueCheckpointer<string>, ILoggerFactory, IEventHubQueueCache> cacheFactory,
+            Func<string, CancellationToken, Task<IStreamQueueCheckpointer<string>>> checkpointerFactory,
+            ILoggerFactory loggerFactory,
+            IQueueAdapterReceiverMonitor monitor,
+            LoadSheddingOptions loadSheddingOptions,
+            IEnvironmentStatisticsProvider environmentStatisticsProvider,
+            Func<EventHubPartitionSettings, string, ILogger, IEventHubReceiver>? eventHubReceiverFactory = null)
         {
             this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
             this.cacheFactory = cacheFactory ?? throw new ArgumentNullException(nameof(cacheFactory));
@@ -89,14 +109,18 @@ namespace Orleans.Streaming.EventHubs
             this.eventHubReceiverFactory = eventHubReceiverFactory == null ? EventHubAdapterReceiver.CreateReceiver : eventHubReceiverFactory;
         }
 
-        public Task Initialize(TimeSpan timeout)
+        public async Task Initialize(TimeSpan timeout)
         {
             LogInfoInitializingEventHubPartition(this.settings.Hub.EventHubName, this.settings.Partition);
 
             // if receiver was already running, do nothing
-            return ReceiverRunning == Interlocked.Exchange(ref this.receiverState, ReceiverRunning)
-                ? Task.CompletedTask
-                : Initialize();
+            if (ReceiverRunning == Interlocked.Exchange(ref this.receiverState, ReceiverRunning))
+            {
+                return;
+            }
+
+            using var cancellation = new CancellationTokenSource(timeout);
+            await Initialize(cancellation.Token);
         }
 
         /// <summary>
@@ -104,12 +128,14 @@ namespace Orleans.Streaming.EventHubs
         ///  it will be retried when messages are requested
         /// </summary>
         /// <returns></returns>
-        private async Task Initialize()
+        private async Task Initialize(CancellationToken cancellationToken)
         {
             var watch = Stopwatch.StartNew();
             try
             {
-                this.checkpointer = await this.checkpointerFactory(this.settings.Partition);
+                this.checkpointer = await this.checkpointerFactory(
+                    this.settings.Partition,
+                    cancellationToken);
                 if(this.cache != null)
                 {
                     this.cache.Dispose();
@@ -117,7 +143,7 @@ namespace Orleans.Streaming.EventHubs
                 }
                 this.cache = this.cacheFactory(this.settings.Partition, this.checkpointer, this.loggerFactory);
                 this.flowController = new AggregatedQueueFlowController(MaxMessagesPerRead) { this.cache, LoadShedQueueFlowController.CreateAsPercentOfLoadSheddingLimit(this.loadSheddingOptions, environmentStatisticsProvider) };
-                string offset = await this.checkpointer.Load();
+                string offset = await this.checkpointer.Load(cancellationToken);
                 if (!this.checkpointer.CheckpointExists)
                 {
                     offset = EventHubConstants.StartOfStream;
@@ -135,8 +161,14 @@ namespace Orleans.Streaming.EventHubs
             }
         }
 
-        public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
+        public Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
+            => GetQueueMessagesAsync(maxCount, CancellationToken.None);
+
+        public async Task<IList<IBatchContainer>> GetQueueMessagesAsync(
+            int maxCount,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (this.receiverState == ReceiverShutdown || maxCount <= 0)
             {
                 return new List<IBatchContainer>();
@@ -146,7 +178,7 @@ namespace Orleans.Streaming.EventHubs
             if (this.receiver == null)
             {
                 LogWarningRetryingInitializationOfEventHubPartition(this.settings.Hub.EventHubName, this.settings.Partition);
-                await Initialize();
+                await Initialize(cancellationToken);
                 if (this.receiver == null)
                 {
                     // should not get here, should throw instead, but just incase.
@@ -159,7 +191,10 @@ namespace Orleans.Streaming.EventHubs
             {
 
                 // Receivers built against older Orleans versions can still return null.
-                messages = (await this.receiver.ReceiveAsync(maxCount, ReceiveTimeout))?.ToList();
+                messages = (await this.receiver.ReceiveAsync(
+                    maxCount,
+                    ReceiveTimeout,
+                    cancellationToken))?.ToList();
                 watch.Stop();
 
                 this.monitor?.TrackRead(true, watch.Elapsed, null);

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubCheckpointer.cs
@@ -81,9 +81,17 @@ namespace Orleans.Streaming.EventHubs
         /// Loads a checkpoint
         /// </summary>
         /// <returns></returns>
-        public async Task<string> Load()
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
+        public Task<string> Load() => Load(CancellationToken.None);
+
+        /// <summary>
+        /// Loads a checkpoint.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The checkpoint.</returns>
+        public async Task<string> Load(CancellationToken cancellationToken)
         {
-            var checkpoint = await _inner.Load();
+            var checkpoint = await _inner.Load(cancellationToken);
             return CheckpointExists ? checkpoint : EventHubConstants.StartOfStream;
         }
 
@@ -93,7 +101,18 @@ namespace Orleans.Streaming.EventHubs
         /// </summary>
         /// <param name="offset"></param>
         /// <param name="utcNow"></param>
-        public void Update(string offset, DateTime utcNow) => _inner.Update(offset, utcNow);
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
+        public void Update(string offset, DateTime utcNow)
+            => Update(offset, utcNow, CancellationToken.None);
+
+        /// <summary>
+        /// Updates the checkpoint.
+        /// </summary>
+        /// <param name="offset">The checkpoint offset.</param>
+        /// <param name="utcNow">The current UTC time.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public void Update(string offset, DateTime utcNow, CancellationToken cancellationToken)
+            => _inner.Update(offset, utcNow, cancellationToken);
 
         /// <summary>
         /// Flushes any pending checkpoint to persistent storage.

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventHubQueueCache.cs
@@ -178,7 +178,10 @@ namespace Orleans.Streaming.EventHubs
             }
             if (lastItemPurged.HasValue)
             {
-                checkpointer.Update(this.dataAdapter.GetOffset(lastItemPurged.Value), DateTime.UtcNow);
+                checkpointer.Update(
+                    this.dataAdapter.GetOffset(lastItemPurged.Value),
+                    DateTime.UtcNow,
+                    CancellationToken.None);
             }
         }
 

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubReceiver.cs
@@ -21,6 +21,7 @@ namespace Orleans.Streaming.EventHubs
         /// <param name="maxCount">Max amount of message which should be delivered in this request</param>
         /// <param name="waitTime">Wait time of this request</param>
         /// <returns></returns>
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime);
 
         /// <summary>
@@ -30,19 +31,18 @@ namespace Orleans.Streaming.EventHubs
         /// <param name="waitTime">The maximum wait time.</param>
         /// <param name="cancellationToken">The token used to cancel the operation.</param>
         /// <returns>The received messages.</returns>
+#pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy overload.
         Task<IEnumerable<EventData>> ReceiveAsync(
             int maxCount,
             TimeSpan waitTime,
-            CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return ReceiveAsync(maxCount, waitTime).WaitAsync(cancellationToken);
-        }
+            CancellationToken cancellationToken) => ReceiveAsync(maxCount, waitTime);
+#pragma warning restore CS0618
 
         /// <summary>
         /// Send a clean up message
         /// </summary>
         /// <returns></returns>
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         Task CloseAsync();
 
         /// <summary>
@@ -50,7 +50,9 @@ namespace Orleans.Streaming.EventHubs
         /// </summary>
         /// <param name="cancellationToken">The token used to cancel the operation.</param>
         /// <returns>A task representing the operation.</returns>
+#pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy overload.
         Task CloseAsync(CancellationToken cancellationToken) => CloseAsync();
+#pragma warning restore CS0618
     }
 
     /// <summary>

--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubReceiver.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/IEventHubReceiver.cs
@@ -24,6 +24,22 @@ namespace Orleans.Streaming.EventHubs
         Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime);
 
         /// <summary>
+        /// Sends an asynchronous request for more messages from the partition.
+        /// </summary>
+        /// <param name="maxCount">The maximum number of messages to return.</param>
+        /// <param name="waitTime">The maximum wait time.</param>
+        /// <param name="cancellationToken">The token used to cancel the operation.</param>
+        /// <returns>The received messages.</returns>
+        Task<IEnumerable<EventData>> ReceiveAsync(
+            int maxCount,
+            TimeSpan waitTime,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ReceiveAsync(maxCount, waitTime).WaitAsync(cancellationToken);
+        }
+
+        /// <summary>
         /// Send a clean up message
         /// </summary>
         /// <returns></returns>
@@ -85,8 +101,14 @@ namespace Orleans.Streaming.EventHubs
         }
 
         public async Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime)
+            => await ReceiveAsync(maxCount, waitTime, CancellationToken.None);
+
+        public async Task<IEnumerable<EventData>> ReceiveAsync(
+            int maxCount,
+            TimeSpan waitTime,
+            CancellationToken cancellationToken)
         {
-            return await client.ReceiveBatchAsync(maxCount, waitTime);
+            return await client.ReceiveBatchAsync(maxCount, waitTime, cancellationToken);
         }
 
         public Task CloseAsync() => CloseAsync(CancellationToken.None);

--- a/src/Orleans.Streaming/Checkpointers/GrainStreamQueueCheckpointer.cs
+++ b/src/Orleans.Streaming/Checkpointers/GrainStreamQueueCheckpointer.cs
@@ -74,6 +74,7 @@ namespace Orleans.Streams
         /// <summary>
         /// Creates and initializes a grain-based checkpointer with default options.
         /// </summary>
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         public static async Task<IStreamQueueCheckpointer<string>> Create(string providerName, string partition, string serviceId, IClusterClient clusterClient)
             => await Create(providerName, partition, serviceId, clusterClient, CancellationToken.None);
 
@@ -99,6 +100,7 @@ namespace Orleans.Streams
         /// <summary>
         /// Creates and initializes a grain-based checkpointer.
         /// </summary>
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         public static async Task<IStreamQueueCheckpointer<string>> Create(
             string providerName,
             string partition,
@@ -176,6 +178,7 @@ namespace Orleans.Streams
         }
 
         /// <inheritdoc />
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         public Task<string> Load() => Load(CancellationToken.None);
 
         /// <inheritdoc />
@@ -192,6 +195,7 @@ namespace Orleans.Streams
         }
 
         /// <inheritdoc />
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         public void Update(string offset, DateTime utcNow)
             => Update(offset, utcNow, CancellationToken.None);
 

--- a/src/Orleans.Streaming/Checkpointers/GrainStreamQueueCheckpointer.cs
+++ b/src/Orleans.Streaming/Checkpointers/GrainStreamQueueCheckpointer.cs
@@ -75,13 +75,25 @@ namespace Orleans.Streams
         /// Creates and initializes a grain-based checkpointer with default options.
         /// </summary>
         public static async Task<IStreamQueueCheckpointer<string>> Create(string providerName, string partition, string serviceId, IClusterClient clusterClient)
+            => await Create(providerName, partition, serviceId, clusterClient, CancellationToken.None);
+
+        /// <summary>
+        /// Creates and initializes a grain-based checkpointer with default options.
+        /// </summary>
+        public static async Task<IStreamQueueCheckpointer<string>> Create(
+            string providerName,
+            string partition,
+            string serviceId,
+            IClusterClient clusterClient,
+            CancellationToken cancellationToken)
         {
             return await Create(
                 providerName,
                 partition,
                 serviceId,
                 clusterClient,
-                new GrainStreamQueueCheckpointerOptions());
+                new GrainStreamQueueCheckpointerOptions(),
+                cancellationToken);
         }
 
         /// <summary>
@@ -93,6 +105,18 @@ namespace Orleans.Streams
             string serviceId,
             IClusterClient clusterClient,
             GrainStreamQueueCheckpointerOptions options)
+            => await Create(providerName, partition, serviceId, clusterClient, options, CancellationToken.None);
+
+        /// <summary>
+        /// Creates and initializes a grain-based checkpointer.
+        /// </summary>
+        public static async Task<IStreamQueueCheckpointer<string>> Create(
+            string providerName,
+            string partition,
+            string serviceId,
+            IClusterClient clusterClient,
+            GrainStreamQueueCheckpointerOptions options,
+            CancellationToken cancellationToken)
         {
             var grainKey = GetGrainKey(providerName, serviceId, partition, options.StorageProviderName);
             IStreamCheckpointerGrain grain = string.Equals(
@@ -103,7 +127,7 @@ namespace Orleans.Streams
                     : clusterClient.GetGrain<IConfiguredStreamCheckpointerGrain>(grainKey);
 
             var checkpoint = new GrainStreamQueueCheckpointer(grain, options);
-            _ = await checkpoint.Load();
+            _ = await checkpoint.Load(cancellationToken);
 
             return checkpoint;
         }
@@ -152,9 +176,12 @@ namespace Orleans.Streams
         }
 
         /// <inheritdoc />
-        public async Task<string> Load()
+        public Task<string> Load() => Load(CancellationToken.None);
+
+        /// <inheritdoc />
+        public async Task<string> Load(CancellationToken cancellationToken)
         {
-            var checkpoint = await _grain.Load(CancellationToken.None);
+            var checkpoint = await _grain.Load(cancellationToken);
             lock (_lock)
             {
                 _latestCheckpoint = checkpoint;
@@ -166,8 +193,13 @@ namespace Orleans.Streams
 
         /// <inheritdoc />
         public void Update(string offset, DateTime utcNow)
+            => Update(offset, utcNow, CancellationToken.None);
+
+        /// <inheritdoc />
+        public void Update(string offset, DateTime utcNow, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(offset);
+            cancellationToken.ThrowIfCancellationRequested();
 
             lock (_lock)
             {
@@ -186,7 +218,7 @@ namespace Orleans.Streams
                 }
 
                 _throttleSavesUntilUtc = utcNow + _options.PersistInterval;
-                _inProgressSave = Save(offset, CancellationToken.None);
+                _inProgressSave = Save(offset, cancellationToken);
                 _inProgressSave.Ignore();
             }
         }

--- a/src/Orleans.Streaming/Checkpointers/GrainStreamQueueCheckpointerFactory.cs
+++ b/src/Orleans.Streaming/Checkpointers/GrainStreamQueueCheckpointerFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -56,13 +57,18 @@ namespace Orleans.Streams
 
         /// <inheritdoc />
         public Task<IStreamQueueCheckpointer<string>> Create(string partition)
+            => Create(partition, CancellationToken.None);
+
+        /// <inheritdoc />
+        public Task<IStreamQueueCheckpointer<string>> Create(string partition, CancellationToken cancellationToken)
         {
             return GrainStreamQueueCheckpointer.Create(
                 _providerName,
                 partition,
                 _clusterOptions.ServiceId.ToString(),
                 _clusterClient,
-                _checkpointerOptions);
+                _checkpointerOptions,
+                cancellationToken);
         }
     }
 }

--- a/src/Orleans.Streaming/Checkpointers/GrainStreamQueueCheckpointerFactory.cs
+++ b/src/Orleans.Streaming/Checkpointers/GrainStreamQueueCheckpointerFactory.cs
@@ -56,6 +56,7 @@ namespace Orleans.Streams
         }
 
         /// <inheritdoc />
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         public Task<IStreamQueueCheckpointer<string>> Create(string partition)
             => Create(partition, CancellationToken.None);
 

--- a/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
+++ b/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
@@ -15,6 +15,18 @@ namespace Orleans.Streams
         /// <param name="partition">The partition.</param>
         /// <returns>The stream checkpointer.</returns>
         Task<IStreamQueueCheckpointer<string>> Create(string partition);
+
+        /// <summary>
+        /// Creates a stream checkpointer for the specified partition.
+        /// </summary>
+        /// <param name="partition">The partition.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The stream checkpointer.</returns>
+        Task<IStreamQueueCheckpointer<string>> Create(string partition, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Create(partition).WaitAsync(cancellationToken);
+        }
     }
 
     /// <summary>
@@ -36,11 +48,34 @@ namespace Orleans.Streams
         Task<TCheckpoint> Load();
 
         /// <summary>
+        /// Loads the checkpoint.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The checkpoint.</returns>
+        Task<TCheckpoint> Load(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Load().WaitAsync(cancellationToken);
+        }
+
+        /// <summary>
         /// Updates the checkpoint.
         /// </summary>
         /// <param name="offset">The offset.</param>
         /// <param name="utcNow">The current UTC time.</param>
         void Update(TCheckpoint offset, DateTime utcNow);
+
+        /// <summary>
+        /// Updates the checkpoint.
+        /// </summary>
+        /// <param name="offset">The offset.</param>
+        /// <param name="utcNow">The current UTC time.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        void Update(TCheckpoint offset, DateTime utcNow, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Update(offset, utcNow);
+        }
 
         /// <summary>
         /// Flushes any pending checkpoint to persistent storage, ensuring the latest offset is durably saved.

--- a/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
+++ b/src/Orleans.Streaming/PersistentStreams/IStreamQueueCheckpointer.cs
@@ -14,6 +14,7 @@ namespace Orleans.Streams
         /// </summary>
         /// <param name="partition">The partition.</param>
         /// <returns>The stream checkpointer.</returns>
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         Task<IStreamQueueCheckpointer<string>> Create(string partition);
 
         /// <summary>
@@ -22,11 +23,10 @@ namespace Orleans.Streams
         /// <param name="partition">The partition.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The stream checkpointer.</returns>
+#pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy overload.
         Task<IStreamQueueCheckpointer<string>> Create(string partition, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Create(partition).WaitAsync(cancellationToken);
-        }
+            => Create(partition);
+#pragma warning restore CS0618
     }
 
     /// <summary>
@@ -45,6 +45,7 @@ namespace Orleans.Streams
         /// Loads the checkpoint.
         /// </summary>
         /// <returns>The checkpoint.</returns>
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         Task<TCheckpoint> Load();
 
         /// <summary>
@@ -52,17 +53,16 @@ namespace Orleans.Streams
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The checkpoint.</returns>
-        Task<TCheckpoint> Load(CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Load().WaitAsync(cancellationToken);
-        }
+#pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy overload.
+        Task<TCheckpoint> Load(CancellationToken cancellationToken) => Load();
+#pragma warning restore CS0618
 
         /// <summary>
         /// Updates the checkpoint.
         /// </summary>
         /// <param name="offset">The offset.</param>
         /// <param name="utcNow">The current UTC time.</param>
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         void Update(TCheckpoint offset, DateTime utcNow);
 
         /// <summary>
@@ -71,11 +71,10 @@ namespace Orleans.Streams
         /// <param name="offset">The offset.</param>
         /// <param name="utcNow">The current UTC time.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
+#pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy overload.
         void Update(TCheckpoint offset, DateTime utcNow, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            Update(offset, utcNow);
-        }
+            => Update(offset, utcNow);
+#pragma warning restore CS0618
 
         /// <summary>
         /// Flushes any pending checkpoint to persistent storage, ensuring the latest offset is durably saved.

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamProvider.cs
@@ -105,7 +105,7 @@ namespace Orleans.Providers.Streams.Common
         {
             if(!this.stateManager.PresetState(ProviderState.Initialized)) return;
             this.adapterFactory = this.runtime.ServiceProvider.GetRequiredKeyedService<IQueueAdapterFactory>(this.Name);
-            this.queueAdapter = await adapterFactory.CreateAdapter();
+            this.queueAdapter = await adapterFactory.CreateAdapter(token);
 
             if (this.pubsubOptions.PubSubType == StreamPubSubType.ExplicitGrainBasedAndImplicit
                 || this.pubsubOptions.PubSubType == StreamPubSubType.ExplicitGrainBasedOnly)

--- a/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
+++ b/src/Orleans.Streaming/PersistentStreams/PersistentStreamPullingAgent.cs
@@ -456,6 +456,10 @@ namespace Orleans.Streams
                         return;
                 }
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                receiverInitTask = null;
+            }
             catch (Exception exc)
             {
                 receiverInitTask = null;
@@ -505,7 +509,11 @@ namespace Orleans.Streams
                 {
                     try
                     {
-                        await rcvr.MessagesDeliveredAsync(purgedItems);
+                        await rcvr.MessagesDeliveredAsync(purgedItems, cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        return false;
                     }
                     catch (Exception exc)
                     {
@@ -527,7 +535,7 @@ namespace Orleans.Streams
             }
 
             // Retrieve one multiBatch from the queue. Every multiBatch has an IEnumerable of IBatchContainers, each IBatchContainer may have multiple events.
-            IList<IBatchContainer>? multiBatch = await rcvr.GetQueueMessagesAsync(maxCacheAddCount);
+            IList<IBatchContainer>? multiBatch = await rcvr.GetQueueMessagesAsync(maxCacheAddCount, cancellationToken);
 
             if (IsShutdown || cancellationToken.IsCancellationRequested)
             {

--- a/src/Orleans.Streaming/QueueAdapters/IQueueAdapterFactory.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueAdapterFactory.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.Streams
@@ -12,6 +13,17 @@ namespace Orleans.Streams
         /// </summary>
         /// <returns>The queue adapter</returns>
         Task<IQueueAdapter> CreateAdapter();
+
+        /// <summary>
+        /// Creates a queue adapter.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The queue adapter.</returns>
+        Task<IQueueAdapter> CreateAdapter(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return CreateAdapter().WaitAsync(cancellationToken);
+        }
 
         /// <summary>
         /// Creates queue message cache adapter.

--- a/src/Orleans.Streaming/QueueAdapters/IQueueAdapterFactory.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueAdapterFactory.cs
@@ -12,6 +12,7 @@ namespace Orleans.Streams
         /// Creates a queue adapter.
         /// </summary>
         /// <returns>The queue adapter</returns>
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         Task<IQueueAdapter> CreateAdapter();
 
         /// <summary>
@@ -19,11 +20,9 @@ namespace Orleans.Streams
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The queue adapter.</returns>
-        Task<IQueueAdapter> CreateAdapter(CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return CreateAdapter().WaitAsync(cancellationToken);
-        }
+#pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy overload.
+        Task<IQueueAdapter> CreateAdapter(CancellationToken cancellationToken) => CreateAdapter();
+#pragma warning restore CS0618
 
         /// <summary>
         /// Creates queue message cache adapter.

--- a/src/Orleans.Streaming/QueueAdapters/IQueueAdapterReceiver.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueAdapterReceiver.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Orleans.Streams
@@ -25,6 +26,18 @@ namespace Orleans.Streams
         Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount);
 
         /// <summary>
+        /// Retrieves batches from a message queue.
+        /// </summary>
+        /// <param name="maxCount">The maximum number of message batches to retrieve.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The message batches.</returns>
+        Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return GetQueueMessagesAsync(maxCount).WaitAsync(cancellationToken);
+        }
+
+        /// <summary>
         /// Notifies the adapter receiver that the messages were delivered to all consumers,
         /// so the receiver can take an appropriate action (e.g., delete the messages from a message queue).
         /// </summary>
@@ -33,6 +46,18 @@ namespace Orleans.Streams
         /// </param>
         /// <returns>A <see cref="Task"/> representing the operation.</returns>
         Task MessagesDeliveredAsync(IList<IBatchContainer> messages);
+
+        /// <summary>
+        /// Notifies the adapter receiver that the messages were delivered to all consumers.
+        /// </summary>
+        /// <param name="messages">The message batches.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A <see cref="Task"/> representing the operation.</returns>
+        Task MessagesDeliveredAsync(IList<IBatchContainer> messages, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return MessagesDeliveredAsync(messages).WaitAsync(cancellationToken);
+        }
 
         /// <summary>
         /// Receiver is no longer used. Shutdown and clean up.

--- a/src/Orleans.Streaming/QueueAdapters/IQueueAdapterReceiver.cs
+++ b/src/Orleans.Streaming/QueueAdapters/IQueueAdapterReceiver.cs
@@ -23,6 +23,7 @@ namespace Orleans.Streams
         /// The maximum number of message batches to retrieve.
         /// </param>
         /// <returns>The message batches.</returns>
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount);
 
         /// <summary>
@@ -31,11 +32,10 @@ namespace Orleans.Streams
         /// <param name="maxCount">The maximum number of message batches to retrieve.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The message batches.</returns>
+#pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy overload.
         Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return GetQueueMessagesAsync(maxCount).WaitAsync(cancellationToken);
-        }
+            => GetQueueMessagesAsync(maxCount);
+#pragma warning restore CS0618
 
         /// <summary>
         /// Notifies the adapter receiver that the messages were delivered to all consumers,
@@ -45,6 +45,7 @@ namespace Orleans.Streams
         /// The message batches.
         /// </param>
         /// <returns>A <see cref="Task"/> representing the operation.</returns>
+        [Obsolete("Use the overload which accepts a CancellationToken.")]
         Task MessagesDeliveredAsync(IList<IBatchContainer> messages);
 
         /// <summary>
@@ -53,11 +54,10 @@ namespace Orleans.Streams
         /// <param name="messages">The message batches.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the operation.</returns>
+#pragma warning disable CS0618 // Required for compatibility with providers which only implement the legacy overload.
         Task MessagesDeliveredAsync(IList<IBatchContainer> messages, CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return MessagesDeliveredAsync(messages).WaitAsync(cancellationToken);
-        }
+            => MessagesDeliveredAsync(messages);
+#pragma warning restore CS0618
 
         /// <summary>
         /// Receiver is no longer used. Shutdown and clean up.

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -365,9 +365,15 @@ namespace Orleans.Streaming.EventHubs
 
         public System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
 
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         public System.Threading.Tasks.Task<string> Load() { throw null; }
 
+        public System.Threading.Tasks.Task<string> Load(System.Threading.CancellationToken cancellationToken) { throw null; }
+
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         public void Update(string offset, System.DateTime utcNow) { }
+
+        public void Update(string offset, System.DateTime utcNow, System.Threading.CancellationToken cancellationToken) { }
     }
 
     public partial class EventHubCheckpointerFactory : Streams.IStreamQueueCheckpointerFactory
@@ -569,8 +575,10 @@ namespace Orleans.Streaming.EventHubs
 
     public partial interface IEventHubReceiver
     {
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         System.Threading.Tasks.Task CloseAsync();
         System.Threading.Tasks.Task CloseAsync(System.Threading.CancellationToken cancellationToken);
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData>> ReceiveAsync(int maxCount, System.TimeSpan waitTime);
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData>> ReceiveAsync(int maxCount, System.TimeSpan waitTime, System.Threading.CancellationToken cancellationToken);
     }

--- a/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
+++ b/src/api/Azure/Orleans.Streaming.EventHubs/Orleans.Streaming.EventHubs.cs
@@ -572,6 +572,7 @@ namespace Orleans.Streaming.EventHubs
         System.Threading.Tasks.Task CloseAsync();
         System.Threading.Tasks.Task CloseAsync(System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData>> ReceiveAsync(int maxCount, System.TimeSpan waitTime);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData>> ReceiveAsync(int maxCount, System.TimeSpan waitTime, System.Threading.CancellationToken cancellationToken);
     }
 
     public partial class SlowConsumingPressureMonitor : ICachePressureMonitor
@@ -668,6 +669,8 @@ namespace Orleans.Streaming.EventHubs.Testing
         public void ConfigureDataGeneratorForStream(Runtime.StreamId streamId) { }
 
         public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData>> ReceiveAsync(int maxCount, System.TimeSpan waitTime) { throw null; }
+
+        public System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Azure.Messaging.EventHubs.EventData>> ReceiveAsync(int maxCount, System.TimeSpan waitTime, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public void StopProducingOnStream(Runtime.StreamId streamId) { }
     }

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1371,20 +1371,24 @@ namespace Orleans.Streams
 
         public bool CheckpointExists { get { throw null; } }
 
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         public static System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string providerName, string partition, string serviceId, IClusterClient clusterClient, Configuration.GrainStreamQueueCheckpointerOptions options) { throw null; }
 
         public static System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string providerName, string partition, string serviceId, IClusterClient clusterClient, Configuration.GrainStreamQueueCheckpointerOptions options, System.Threading.CancellationToken cancellationToken) { throw null; }
 
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         public static System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string providerName, string partition, string serviceId, IClusterClient clusterClient) { throw null; }
 
         public static System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string providerName, string partition, string serviceId, IClusterClient clusterClient, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
 
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         public System.Threading.Tasks.Task<string> Load() { throw null; }
 
         public System.Threading.Tasks.Task<string> Load(System.Threading.CancellationToken cancellationToken) { throw null; }
 
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         public void Update(string offset, System.DateTime utcNow) { }
 
         public void Update(string offset, System.DateTime utcNow, System.Threading.CancellationToken cancellationToken) { }
@@ -1396,6 +1400,7 @@ namespace Orleans.Streams
 
         public GrainStreamQueueCheckpointerFactory(string providerName, Microsoft.Extensions.Options.IOptions<Configuration.ClusterOptions> clusterOptions, IClusterClient clusterClient) { }
 
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         public System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string partition) { throw null; }
 
         public System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string partition, System.Threading.CancellationToken cancellationToken) { throw null; }
@@ -1517,6 +1522,7 @@ namespace Orleans.Streams
 
     public partial interface IQueueAdapterFactory
     {
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         System.Threading.Tasks.Task<IQueueAdapter> CreateAdapter();
         System.Threading.Tasks.Task<IQueueAdapter> CreateAdapter(System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<IStreamFailureHandler> GetDeliveryFailureHandler(QueueId queueId);
@@ -1526,9 +1532,11 @@ namespace Orleans.Streams
 
     public partial interface IQueueAdapterReceiver
     {
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         System.Threading.Tasks.Task<System.Collections.Generic.IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount);
         System.Threading.Tasks.Task<System.Collections.Generic.IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task Initialize(System.TimeSpan timeout);
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         System.Threading.Tasks.Task MessagesDeliveredAsync(System.Collections.Generic.IList<IBatchContainer> messages);
         System.Threading.Tasks.Task MessagesDeliveredAsync(System.Collections.Generic.IList<IBatchContainer> messages, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task Shutdown(System.TimeSpan timeout);
@@ -1643,6 +1651,7 @@ namespace Orleans.Streams
 
     public partial interface IStreamQueueCheckpointerFactory
     {
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string partition);
         System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string partition, System.Threading.CancellationToken cancellationToken);
     }
@@ -1652,8 +1661,10 @@ namespace Orleans.Streams
         bool CheckpointExists { get; }
 
         System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken);
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         System.Threading.Tasks.Task<TCheckpoint> Load();
         System.Threading.Tasks.Task<TCheckpoint> Load(System.Threading.CancellationToken cancellationToken);
+        [System.Obsolete("Use the overload which accepts a CancellationToken.")]
         void Update(TCheckpoint offset, System.DateTime utcNow);
         void Update(TCheckpoint offset, System.DateTime utcNow, System.Threading.CancellationToken cancellationToken);
     }

--- a/src/api/Orleans.Streaming/Orleans.Streaming.cs
+++ b/src/api/Orleans.Streaming/Orleans.Streaming.cs
@@ -1373,13 +1373,21 @@ namespace Orleans.Streams
 
         public static System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string providerName, string partition, string serviceId, IClusterClient clusterClient, Configuration.GrainStreamQueueCheckpointerOptions options) { throw null; }
 
+        public static System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string providerName, string partition, string serviceId, IClusterClient clusterClient, Configuration.GrainStreamQueueCheckpointerOptions options, System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public static System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string providerName, string partition, string serviceId, IClusterClient clusterClient) { throw null; }
+
+        public static System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string providerName, string partition, string serviceId, IClusterClient clusterClient, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public System.Threading.Tasks.Task<string> Load() { throw null; }
 
+        public System.Threading.Tasks.Task<string> Load(System.Threading.CancellationToken cancellationToken) { throw null; }
+
         public void Update(string offset, System.DateTime utcNow) { }
+
+        public void Update(string offset, System.DateTime utcNow, System.Threading.CancellationToken cancellationToken) { }
     }
 
     public partial class GrainStreamQueueCheckpointerFactory : IStreamQueueCheckpointerFactory
@@ -1389,6 +1397,8 @@ namespace Orleans.Streams
         public GrainStreamQueueCheckpointerFactory(string providerName, Microsoft.Extensions.Options.IOptions<Configuration.ClusterOptions> clusterOptions, IClusterClient clusterClient) { }
 
         public System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string partition) { throw null; }
+
+        public System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string partition, System.Threading.CancellationToken cancellationToken) { throw null; }
 
         public static IStreamQueueCheckpointerFactory CreateFactory(System.IServiceProvider services, string providerName) { throw null; }
     }
@@ -1508,6 +1518,7 @@ namespace Orleans.Streams
     public partial interface IQueueAdapterFactory
     {
         System.Threading.Tasks.Task<IQueueAdapter> CreateAdapter();
+        System.Threading.Tasks.Task<IQueueAdapter> CreateAdapter(System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<IStreamFailureHandler> GetDeliveryFailureHandler(QueueId queueId);
         IQueueAdapterCache GetQueueAdapterCache();
         IStreamQueueMapper GetStreamQueueMapper();
@@ -1516,8 +1527,10 @@ namespace Orleans.Streams
     public partial interface IQueueAdapterReceiver
     {
         System.Threading.Tasks.Task<System.Collections.Generic.IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount);
+        System.Threading.Tasks.Task<System.Collections.Generic.IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task Initialize(System.TimeSpan timeout);
         System.Threading.Tasks.Task MessagesDeliveredAsync(System.Collections.Generic.IList<IBatchContainer> messages);
+        System.Threading.Tasks.Task MessagesDeliveredAsync(System.Collections.Generic.IList<IBatchContainer> messages, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task Shutdown(System.TimeSpan timeout);
     }
 
@@ -1631,6 +1644,7 @@ namespace Orleans.Streams
     public partial interface IStreamQueueCheckpointerFactory
     {
         System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string partition);
+        System.Threading.Tasks.Task<IStreamQueueCheckpointer<string>> Create(string partition, System.Threading.CancellationToken cancellationToken);
     }
 
     public partial interface IStreamQueueCheckpointer<TCheckpoint>
@@ -1639,7 +1653,9 @@ namespace Orleans.Streams
 
         System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task<TCheckpoint> Load();
+        System.Threading.Tasks.Task<TCheckpoint> Load(System.Threading.CancellationToken cancellationToken);
         void Update(TCheckpoint offset, System.DateTime utcNow);
+        void Update(TCheckpoint offset, System.DateTime utcNow, System.Threading.CancellationToken cancellationToken);
     }
 
     public partial interface IStreamQueueMapper

--- a/test/Extensions/Orleans.AWS.Tests/Streaming/SQSAdapterTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/Streaming/SQSAdapterTests.cs
@@ -78,7 +78,7 @@ namespace AWSUtils.Tests.Streaming
 
         private async Task SendAndReceiveFromQueueAdapter(IQueueAdapterFactory adapterFactory)
         {
-            IQueueAdapter adapter = await adapterFactory.CreateAdapter();
+            IQueueAdapter adapter = await adapterFactory.CreateAdapter(CancellationToken.None);
             IQueueAdapterCache cache = adapterFactory.GetQueueAdapterCache();
 
             // Create receiver per queue
@@ -106,7 +106,9 @@ namespace AWSUtils.Tests.Streaming
                 {
                     while (receivedBatches < NumBatches)
                     {
-                        var messages = receiver.GetQueueMessagesAsync(SQSStorage.MAX_NUMBER_OF_MESSAGE_TO_PEEK).Result.ToArray();
+                        var messages = receiver.GetQueueMessagesAsync(
+                            SQSStorage.MAX_NUMBER_OF_MESSAGE_TO_PEEK,
+                            CancellationToken.None).Result.ToArray();
                         if (!messages.Any())
                         {
                             continue;

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterTests.cs
@@ -199,7 +199,7 @@ public abstract class AdoNetQueueAdapterTests(string invariant, TestEnvironmentF
         var receiver = adapter.CreateReceiver(queueId);
         await receiver.Initialize(TimeSpan.FromSeconds(10));
         var beforeDequeued = DateTime.UtcNow;
-        var messages = await receiver.GetQueueMessagesAsync(10);
+        var messages = await receiver.GetQueueMessagesAsync(10, CancellationToken.None);
         var afterDequeued = DateTime.UtcNow;
 
         // assert - dequeued messages are as expected

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueAdapterTests.cs
@@ -69,7 +69,7 @@ namespace Tester.AzureUtils.Streaming
 
         private async Task SendAndReceiveFromQueueAdapter(IQueueAdapterFactory adapterFactory)
         {
-            IQueueAdapter adapter = await adapterFactory.CreateAdapter();
+            IQueueAdapter adapter = await adapterFactory.CreateAdapter(CancellationToken.None);
             IQueueAdapterCache cache = adapterFactory.GetQueueAdapterCache();
 
             // Create receiver per queue
@@ -97,7 +97,9 @@ namespace Tester.AzureUtils.Streaming
                 {
                     while (receivedBatches < NumBatches)
                     {
-                        var receivedMessages = receiver.GetQueueMessagesAsync(QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG).Result;
+                        var receivedMessages = receiver.GetQueueMessagesAsync(
+                            QueueAdapterConstants.UNLIMITED_GET_QUEUE_MSG,
+                            CancellationToken.None).Result;
                         Assert.NotNull(receivedMessages);
                         var messages = receivedMessages.ToArray();
                         if (!messages.Any())

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -108,7 +108,7 @@ public class EventHubCheckpointerTests
         {
             if (PurgeOffsetToReport is not null)
             {
-                checkpointer?.Update(PurgeOffsetToReport, DateTime.UtcNow);
+                checkpointer?.Update(PurgeOffsetToReport, DateTime.UtcNow, CancellationToken.None);
             }
         }
 
@@ -269,7 +269,7 @@ public class EventHubCheckpointerTests
         var eventHubReceiver = new NullReturningEventHubReceiver();
         var receiver = await CreateReceiver(new TestCheckpointer(), cache, eventHubReceiver);
 
-        var messages = await receiver.GetQueueMessagesAsync(10);
+        var messages = await receiver.GetQueueMessagesAsync(10, CancellationToken.None);
 
         Assert.Empty(messages);
         Assert.Equal(1, eventHubReceiver.ReceiveCount);
@@ -291,6 +291,19 @@ public class EventHubCheckpointerTests
 
         var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
         Assert.Equal(cancellation.Token, exception.CancellationToken);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task CancellationOverloads_FallBackToLegacyReceiver()
+    {
+        IEventHubReceiver receiver = new TestEventHubReceiver();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        Assert.Empty(await receiver.ReceiveAsync(10, TimeSpan.Zero, cancellation.Token));
+        await receiver.CloseAsync(cancellation.Token);
+
+        Assert.Equal(1, ((TestEventHubReceiver)receiver).CloseCount);
     }
 
     [Fact, TestCategory("BVT")]
@@ -442,7 +455,7 @@ public class EventHubCheckpointerTests
         Assert.NotNull(constructor);
         var checkpointer = (EventHubCheckpointer)constructor.Invoke([inner]);
 
-        Assert.Equal(expected, await checkpointer.Load());
+        Assert.Equal(expected, await checkpointer.Load(CancellationToken.None));
     }
 
     [Fact, TestCategory("BVT")]

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/CheckpointerTests/EventHubCheckpointerTests.cs
@@ -148,6 +148,27 @@ public class EventHubCheckpointerTests
         public Task CloseAsync() => Task.CompletedTask;
     }
 
+    private sealed class CancellableEventHubReceiver : IEventHubReceiver
+    {
+        public TaskCompletionSource<CancellationToken> ReceiveStarted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<IEnumerable<EventData>> ReceiveAsync(int maxCount, TimeSpan waitTime)
+            => Task.FromResult<IEnumerable<EventData>>([]);
+
+        public async Task<IEnumerable<EventData>> ReceiveAsync(
+            int maxCount,
+            TimeSpan waitTime,
+            CancellationToken cancellationToken)
+        {
+            ReceiveStarted.SetResult(cancellationToken);
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return [];
+        }
+
+        public Task CloseAsync() => Task.CompletedTask;
+    }
+
     private sealed class BlockingEventHubReceiver : IEventHubReceiver
     {
         public int CloseCount { get; private set; }
@@ -253,6 +274,23 @@ public class EventHubCheckpointerTests
         Assert.Empty(messages);
         Assert.Equal(1, eventHubReceiver.ReceiveCount);
         Assert.Equal(0, cache.AddCount);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task GetQueueMessagesAsync_ForwardsCancellationToken()
+    {
+        var eventHubReceiver = new CancellableEventHubReceiver();
+        var receiver = await CreateReceiver(
+            new TestCheckpointer(),
+            eventHubReceiver: eventHubReceiver);
+        using var cancellation = new CancellationTokenSource();
+
+        var operation = receiver.GetQueueMessagesAsync(10, cancellation.Token);
+        Assert.Equal(cancellation.Token, await eventHubReceiver.ReceiveStarted.Task);
+        cancellation.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
     }
 
     [Fact, TestCategory("BVT")]

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsAdapterTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsAdapterTests.cs
@@ -89,7 +89,7 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
 
     private async Task SendAndReceiveFromQueueAdapter(IQueueAdapterFactory adapterFactory)
     {
-        IQueueAdapter adapter = await adapterFactory.CreateAdapter();
+        IQueueAdapter adapter = await adapterFactory.CreateAdapter(CancellationToken.None);
         IQueueAdapterCache cache = adapterFactory.GetQueueAdapterCache();
 
         // Create receiver per queue
@@ -120,7 +120,7 @@ public class NatsAdapterTests : IAsyncLifetime, IClassFixture<TestEnvironmentFix
             {
                 while (receivedBatches < NumBatches)
                 {
-                    var receivedMessages = receiver.GetQueueMessagesAsync(50).Result;
+                    var receivedMessages = receiver.GetQueueMessagesAsync(50, CancellationToken.None).Result;
                     Assert.NotNull(receivedMessages);
                     var messages = receivedMessages.ToArray();
                     if (!messages.Any())

--- a/test/Orleans.Streaming.Tests/Checkpointers/GrainStreamQueueCheckpointerTests.cs
+++ b/test/Orleans.Streaming.Tests/Checkpointers/GrainStreamQueueCheckpointerTests.cs
@@ -108,6 +108,68 @@ public sealed class GrainStreamQueueCheckpointerTests : StreamQueueCheckpointerT
     }
 
     [Fact]
+    public async Task Update_ForwardsCancellationTokenToGrainWrite()
+    {
+        var grain = Substitute.For<IStreamCheckpointerGrain>();
+        grain.Load(Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult("10"));
+        grain.Update(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(call => ValueTask.FromResult(call.ArgAt<string>(0)));
+        var checkpointer = new GrainStreamQueueCheckpointer(grain);
+        await checkpointer.Load();
+        using var cancellation = new CancellationTokenSource();
+
+        checkpointer.Update("20", DateTime.UtcNow, cancellation.Token);
+        await checkpointer.FlushAsync(CancellationToken.None);
+
+        await grain.Received(1).Update("20", "10", cancellation.Token);
+    }
+
+    [Fact]
+    public async Task FlushAsync_RetriesSaveCanceledByUpdateToken()
+    {
+        var grain = Substitute.For<IStreamCheckpointerGrain>();
+        grain.Load(Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult("10"));
+        using var updateCancellation = new CancellationTokenSource();
+        using var flushCancellation = new CancellationTokenSource();
+        var writeStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstWrite = new TaskCompletionSource<string>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellationRegistration = updateCancellation.Token.Register(
+            () => firstWrite.TrySetCanceled(updateCancellation.Token));
+        grain.Update("20", "10", updateCancellation.Token)
+            .Returns(_ =>
+            {
+                writeStarted.SetResult();
+                return new ValueTask<string>(firstWrite.Task);
+            });
+        grain.Update("20", "10", flushCancellation.Token).Returns(ValueTask.FromResult("20"));
+        var checkpointer = new GrainStreamQueueCheckpointer(grain);
+        await checkpointer.Load();
+        checkpointer.Update("20", DateTime.UtcNow, updateCancellation.Token);
+        await writeStarted.Task;
+
+        updateCancellation.Cancel();
+        await checkpointer.FlushAsync(flushCancellation.Token);
+
+        await grain.Received(1).Update("20", "10", updateCancellation.Token);
+        await grain.Received(1).Update("20", "10", flushCancellation.Token);
+    }
+
+    [Fact]
+    public async Task Load_ForwardsCancellationTokenToGrain()
+    {
+        var grain = Substitute.For<IStreamCheckpointerGrain>();
+        grain.Load(Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult("10"));
+        var checkpointer = new GrainStreamQueueCheckpointer(grain);
+        using var cancellation = new CancellationTokenSource();
+
+        Assert.Equal("10", await checkpointer.Load(cancellation.Token));
+
+        _ = await grain.Received(1).Load(cancellation.Token);
+    }
+
+    [Fact]
     public async Task GrainMethods_WhenCanceled_DoNotReadOrWriteState()
     {
         var state = new StreamCheckpointerGrainState { Checkpoint = "10" };
@@ -317,13 +379,15 @@ public sealed class GrainStreamQueueCheckpointerTests : StreamQueueCheckpointerT
         clusterClient
             .GetGrain<IStreamCheckpointerGrain>(Arg.Any<string>())
             .Returns(grain);
+        using var cancellation = new CancellationTokenSource();
 
         _ = await GrainStreamQueueCheckpointer.Create(
             providerName,
             "partition",
             "service",
             clusterClient,
-            new GrainStreamQueueCheckpointerOptions());
+            new GrainStreamQueueCheckpointerOptions(),
+            cancellation.Token);
 
         _ = clusterClient.Received(1).GetGrain<IStreamCheckpointerGrain>(
             GrainStreamQueueCheckpointer.GetGrainKey(
@@ -331,6 +395,7 @@ public sealed class GrainStreamQueueCheckpointerTests : StreamQueueCheckpointerT
                 "service",
                 "partition",
                 ProviderConstants.DEFAULT_PUBSUB_PROVIDER_NAME));
+        _ = await grain.Received(1).Load(cancellation.Token);
     }
 
     [Fact]

--- a/test/Orleans.Streaming.Tests/Checkpointers/GrainStreamQueueCheckpointerTests.cs
+++ b/test/Orleans.Streaming.Tests/Checkpointers/GrainStreamQueueCheckpointerTests.cs
@@ -51,10 +51,10 @@ public sealed class GrainStreamQueueCheckpointerTests : StreamQueueCheckpointerT
     {
         var store = new ControllableCheckpointStore("10");
         var checkpointer = await CreateCheckpointer(store);
-        Assert.Equal("10", await checkpointer.Load());
+        Assert.Equal("10", await checkpointer.Load(CancellationToken.None));
 
         Assert.Throws<ArgumentNullException>(
-            () => checkpointer.Update(null!, DateTime.UtcNow));
+            () => checkpointer.Update(null!, DateTime.UtcNow, CancellationToken.None));
 
         Assert.Empty(store.WriteAttempts);
         Assert.Equal("10", store.PersistedCheckpoint);
@@ -95,10 +95,10 @@ public sealed class GrainStreamQueueCheckpointerTests : StreamQueueCheckpointerT
         grain.Update(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(call => ValueTask.FromResult(call.ArgAt<string>(0)));
         var checkpointer = new GrainStreamQueueCheckpointer(grain);
-        await checkpointer.Load();
+        await checkpointer.Load(CancellationToken.None);
         var utcNow = DateTime.UtcNow;
-        checkpointer.Update("20", utcNow);
-        checkpointer.Update("30", utcNow);
+        checkpointer.Update("20", utcNow, CancellationToken.None);
+        checkpointer.Update("30", utcNow, CancellationToken.None);
         using var cancellation = new CancellationTokenSource();
 
         await checkpointer.FlushAsync(cancellation.Token);
@@ -115,7 +115,7 @@ public sealed class GrainStreamQueueCheckpointerTests : StreamQueueCheckpointerT
         grain.Update(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(call => ValueTask.FromResult(call.ArgAt<string>(0)));
         var checkpointer = new GrainStreamQueueCheckpointer(grain);
-        await checkpointer.Load();
+        await checkpointer.Load(CancellationToken.None);
         using var cancellation = new CancellationTokenSource();
 
         checkpointer.Update("20", DateTime.UtcNow, cancellation.Token);
@@ -145,7 +145,7 @@ public sealed class GrainStreamQueueCheckpointerTests : StreamQueueCheckpointerT
             });
         grain.Update("20", "10", flushCancellation.Token).Returns(ValueTask.FromResult("20"));
         var checkpointer = new GrainStreamQueueCheckpointer(grain);
-        await checkpointer.Load();
+        await checkpointer.Load(CancellationToken.None);
         checkpointer.Update("20", DateTime.UtcNow, updateCancellation.Token);
         await writeStarted.Task;
 
@@ -249,12 +249,12 @@ public sealed class GrainStreamQueueCheckpointerTests : StreamQueueCheckpointerT
         };
         var first = new GrainStreamQueueCheckpointer(grain, options);
         var second = new GrainStreamQueueCheckpointer(grain, options);
-        await first.Load();
-        await second.Load();
+        await first.Load(CancellationToken.None);
+        await second.Load(CancellationToken.None);
 
-        first.Update("40", DateTime.UtcNow);
+        first.Update("40", DateTime.UtcNow, CancellationToken.None);
         await first.FlushAsync(CancellationToken.None);
-        second.Update("30", DateTime.UtcNow);
+        second.Update("30", DateTime.UtcNow, CancellationToken.None);
         await second.FlushAsync(CancellationToken.None);
 
         Assert.Equal("40", state.Checkpoint);
@@ -270,16 +270,16 @@ public sealed class GrainStreamQueueCheckpointerTests : StreamQueueCheckpointerT
         var grain = CreateGrain(storage);
         var first = new GrainStreamQueueCheckpointer(grain);
         var second = new GrainStreamQueueCheckpointer(grain);
-        await first.Load();
-        await second.Load();
+        await first.Load(CancellationToken.None);
+        await second.Load(CancellationToken.None);
 
-        first.Update("opaque-40", DateTime.UtcNow);
+        first.Update("opaque-40", DateTime.UtcNow, CancellationToken.None);
         await first.FlushAsync(CancellationToken.None);
-        second.Update("opaque-30", DateTime.UtcNow);
+        second.Update("opaque-30", DateTime.UtcNow, CancellationToken.None);
         await second.FlushAsync(CancellationToken.None);
 
         Assert.Equal("opaque-40", state.Checkpoint);
-        Assert.Equal("opaque-40", await second.Load());
+        Assert.Equal("opaque-40", await second.Load(CancellationToken.None));
         await storage.Received(1).WriteStateAsync(Arg.Any<CancellationToken>());
     }
 
@@ -292,8 +292,8 @@ public sealed class GrainStreamQueueCheckpointerTests : StreamQueueCheckpointerT
         grain.Update(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromException<string>(expected));
         var checkpointer = new GrainStreamQueueCheckpointer(grain);
-        await checkpointer.Load();
-        checkpointer.Update("20", DateTime.UtcNow);
+        await checkpointer.Load(CancellationToken.None);
+        checkpointer.Update("20", DateTime.UtcNow, CancellationToken.None);
 
         var actual = await Assert.ThrowsAsync<InvalidOperationException>(
             () => checkpointer.FlushAsync(CancellationToken.None));
@@ -322,7 +322,7 @@ public sealed class GrainStreamQueueCheckpointerTests : StreamQueueCheckpointerT
             .BuildServiceProvider();
 
         var factory = GrainStreamQueueCheckpointerFactory.CreateFactory(services, providerName);
-        _ = await factory.Create("partition");
+        _ = await factory.Create("partition", CancellationToken.None);
 
         _ = clusterClient.Received(1).GetGrain<IStreamCheckpointerGrain>(
             GrainStreamQueueCheckpointer.GetGrainKey(
@@ -474,10 +474,10 @@ public sealed class OrderedGrainStreamQueueCheckpointerTests : StreamQueueCheckp
         const string advanced = "100000000000000000000000000000000000000000000000000";
         var store = new ControllableCheckpointStore(initial);
         var checkpointer = await CreateCheckpointer(store);
-        Assert.Equal(initial, await checkpointer.Load());
+        Assert.Equal(initial, await checkpointer.Load(CancellationToken.None));
 
-        checkpointer.Update(regressed, TestTimeUtc);
-        checkpointer.Update(advanced, TestTimeUtc);
+        checkpointer.Update(regressed, TestTimeUtc, CancellationToken.None);
+        checkpointer.Update(advanced, TestTimeUtc, CancellationToken.None);
         await store.WaitForCompletedWrites(1);
         await checkpointer.FlushAsync(CancellationToken.None);
 
@@ -495,9 +495,9 @@ public sealed class OrderedGrainStreamQueueCheckpointerTests : StreamQueueCheckp
     {
         var store = new ControllableCheckpointStore(initial);
         var checkpointer = await CreateCheckpointer(store);
-        Assert.Equal(initial, await checkpointer.Load());
+        Assert.Equal(initial, await checkpointer.Load(CancellationToken.None));
 
-        checkpointer.Update(candidate, TestTimeUtc);
+        checkpointer.Update(candidate, TestTimeUtc, CancellationToken.None);
         await checkpointer.FlushAsync(CancellationToken.None);
 
         Assert.Empty(store.WriteAttempts);

--- a/test/Orleans.Streaming.Tests/Checkpointers/StreamQueueCheckpointerTests.cs
+++ b/test/Orleans.Streaming.Tests/Checkpointers/StreamQueueCheckpointerTests.cs
@@ -39,7 +39,7 @@ public abstract class StreamQueueCheckpointerTests
     {
         var (checkpointer, store) = await CreateSubject(NoCheckpoint);
 
-        var checkpoint = await checkpointer.Load();
+        var checkpoint = await checkpointer.Load(CancellationToken.None);
 
         Assert.Equal(NoCheckpoint, checkpoint);
         Assert.False(checkpointer.CheckpointExists);
@@ -52,7 +52,7 @@ public abstract class StreamQueueCheckpointerTests
     {
         var (checkpointer, store) = await CreateSubject("10");
 
-        var checkpoint = await checkpointer.Load();
+        var checkpoint = await checkpointer.Load(CancellationToken.None);
 
         Assert.Equal("10", checkpoint);
         Assert.True(checkpointer.CheckpointExists);
@@ -65,7 +65,7 @@ public abstract class StreamQueueCheckpointerTests
     {
         var (checkpointer, store) = await CreateLoadedSubject("10");
 
-        checkpointer.Update("20", TestTimeUtc);
+        checkpointer.Update("20", TestTimeUtc, CancellationToken.None);
         await store.WaitForCompletedWrites(1);
         await checkpointer.FlushAsync(CancellationToken.None);
 
@@ -78,10 +78,10 @@ public abstract class StreamQueueCheckpointerTests
     public async Task Update_WithinPersistInterval_ThrottlesWriteUntilFlush()
     {
         var (checkpointer, store) = await CreateLoadedSubject("10");
-        checkpointer.Update("20", TestTimeUtc);
+        checkpointer.Update("20", TestTimeUtc, CancellationToken.None);
         await store.WaitForCompletedWrites(1);
 
-        checkpointer.Update("30", TestTimeUtc + PersistInterval - TimeSpan.FromTicks(1));
+        checkpointer.Update("30", TestTimeUtc + PersistInterval - TimeSpan.FromTicks(1), CancellationToken.None);
 
         Assert.Equal(["20"], store.WriteAttempts);
         Assert.Equal("20", store.PersistedCheckpoint);
@@ -96,10 +96,10 @@ public abstract class StreamQueueCheckpointerTests
     public async Task Update_AtPersistIntervalBoundary_PersistsWithoutFlush()
     {
         var (checkpointer, store) = await CreateLoadedSubject("10");
-        checkpointer.Update("20", TestTimeUtc);
+        checkpointer.Update("20", TestTimeUtc, CancellationToken.None);
         await store.WaitForCompletedWrites(1);
 
-        checkpointer.Update("30", TestTimeUtc + PersistInterval);
+        checkpointer.Update("30", TestTimeUtc + PersistInterval, CancellationToken.None);
         await store.WaitForCompletedWrites(2);
 
         Assert.Equal(["20", "30"], store.WriteAttempts);
@@ -111,11 +111,11 @@ public abstract class StreamQueueCheckpointerTests
     public async Task FlushAsync_AfterMultipleThrottledUpdates_PersistsOnlyLatestCheckpoint()
     {
         var (checkpointer, store) = await CreateLoadedSubject("10");
-        checkpointer.Update("20", TestTimeUtc);
+        checkpointer.Update("20", TestTimeUtc, CancellationToken.None);
         await store.WaitForCompletedWrites(1);
 
-        checkpointer.Update("30", TestTimeUtc);
-        checkpointer.Update("40", TestTimeUtc);
+        checkpointer.Update("30", TestTimeUtc, CancellationToken.None);
+        checkpointer.Update("40", TestTimeUtc, CancellationToken.None);
         await checkpointer.FlushAsync(CancellationToken.None);
 
         Assert.Equal(["20", "40"], store.WriteAttempts);
@@ -128,9 +128,9 @@ public abstract class StreamQueueCheckpointerTests
     {
         var (checkpointer, store) = await CreateLoadedSubject("10");
         var blockedWrite = store.BlockNextWrite();
-        checkpointer.Update("20", TestTimeUtc);
+        checkpointer.Update("20", TestTimeUtc, CancellationToken.None);
         await store.WaitForWriteAttempts(1);
-        checkpointer.Update("30", TestTimeUtc + PersistInterval + PersistInterval);
+        checkpointer.Update("30", TestTimeUtc + PersistInterval + PersistInterval, CancellationToken.None);
 
         var flush = checkpointer.FlushAsync(CancellationToken.None);
 
@@ -155,7 +155,7 @@ public abstract class StreamQueueCheckpointerTests
         Task flush;
         using (context.Activate())
         {
-            checkpointer.Update("20", TestTimeUtc);
+            checkpointer.Update("20", TestTimeUtc, CancellationToken.None);
             flush = checkpointer.FlushAsync(CancellationToken.None);
         }
 
@@ -168,7 +168,7 @@ public abstract class StreamQueueCheckpointerTests
         var secondWrite = store.BlockNextWrite();
         using (context.Activate())
         {
-            checkpointer.Update("30", TestTimeUtc + PersistInterval);
+            checkpointer.Update("30", TestTimeUtc + PersistInterval, CancellationToken.None);
         }
 
         await store.WaitForWriteAttempts(2);
@@ -194,7 +194,7 @@ public abstract class StreamQueueCheckpointerTests
         var (checkpointer, store) = await CreateLoadedSubject("10");
         var expected = new InvalidOperationException("checkpoint write failed");
         store.FailNextWrite(expected);
-        checkpointer.Update("20", TestTimeUtc);
+        checkpointer.Update("20", TestTimeUtc, CancellationToken.None);
 
         await checkpointer.FlushAsync(CancellationToken.None);
 
@@ -208,7 +208,7 @@ public abstract class StreamQueueCheckpointerTests
     {
         var (checkpointer, store) = await CreateLoadedSubject("10");
         var blockedWrite = store.BlockNextWrite();
-        checkpointer.Update("20", TestTimeUtc);
+        checkpointer.Update("20", TestTimeUtc, CancellationToken.None);
         await store.WaitForWriteAttempts(1);
         using var cancellation = new CancellationTokenSource();
 
@@ -231,7 +231,7 @@ public abstract class StreamQueueCheckpointerTests
     {
         var (checkpointer, store) = await CreateLoadedSubject("20");
 
-        checkpointer.Update(EquivalentCheckpoint, TestTimeUtc);
+        checkpointer.Update(EquivalentCheckpoint, TestTimeUtc, CancellationToken.None);
         await checkpointer.FlushAsync(CancellationToken.None);
 
         Assert.Empty(store.WriteAttempts);
@@ -244,7 +244,7 @@ public abstract class StreamQueueCheckpointerTests
     {
         var (checkpointer, store) = await CreateLoadedSubject("20");
 
-        checkpointer.Update("10", TestTimeUtc);
+        checkpointer.Update("10", TestTimeUtc, CancellationToken.None);
         await checkpointer.FlushAsync(CancellationToken.None);
 
         if (RegressionPolicy is OffsetRegressionPolicy.Ignore)
@@ -270,7 +270,7 @@ public abstract class StreamQueueCheckpointerTests
         CreateLoadedSubject(string persistedCheckpoint)
     {
         var subject = await CreateSubject(persistedCheckpoint);
-        Assert.Equal(persistedCheckpoint, await subject.Checkpointer.Load());
+        Assert.Equal(persistedCheckpoint, await subject.Checkpointer.Load(CancellationToken.None));
         return subject;
     }
 

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamCancellationCompatibilityTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamCancellationCompatibilityTests.cs
@@ -1,0 +1,83 @@
+using NSubstitute;
+using Orleans.Streams;
+using TestExtensions;
+using Xunit;
+
+namespace UnitTests.StreamingTests;
+
+public class PersistentStreamCancellationCompatibilityTests
+{
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public async Task CancellationOverloads_FallBackToLegacyImplementations()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var adapter = Substitute.For<IQueueAdapter>();
+        IQueueAdapterFactory adapterFactory = new LegacyQueueAdapterFactory(adapter);
+        Assert.Same(adapter, await adapterFactory.CreateAdapter(cancellation.Token));
+
+        IQueueAdapterReceiver receiver = new LegacyQueueAdapterReceiver();
+        Assert.Empty(await receiver.GetQueueMessagesAsync(10, cancellation.Token));
+        await receiver.MessagesDeliveredAsync([], cancellation.Token);
+        Assert.True(((LegacyQueueAdapterReceiver)receiver).MessagesDelivered);
+
+        IStreamQueueCheckpointer<string> checkpointer = new LegacyStreamQueueCheckpointer();
+        IStreamQueueCheckpointerFactory checkpointerFactory = new LegacyStreamQueueCheckpointerFactory(checkpointer);
+        Assert.Same(checkpointer, await checkpointerFactory.Create("partition", cancellation.Token));
+        Assert.Equal("10", await checkpointer.Load(cancellation.Token));
+
+        checkpointer.Update("20", DateTime.UtcNow, cancellation.Token);
+        Assert.Equal("20", ((LegacyStreamQueueCheckpointer)checkpointer).Checkpoint);
+    }
+
+    private sealed class LegacyQueueAdapterFactory(IQueueAdapter adapter) : IQueueAdapterFactory
+    {
+        public Task<IQueueAdapter> CreateAdapter() => Task.FromResult(adapter);
+
+        public IQueueAdapterCache GetQueueAdapterCache() => null!;
+
+        public IStreamQueueMapper GetStreamQueueMapper() => null!;
+
+        public Task<IStreamFailureHandler> GetDeliveryFailureHandler(QueueId queueId)
+            => Task.FromResult<IStreamFailureHandler>(null!);
+    }
+
+    private sealed class LegacyQueueAdapterReceiver : IQueueAdapterReceiver
+    {
+        public bool MessagesDelivered { get; private set; }
+
+        public Task Initialize(TimeSpan timeout) => Task.CompletedTask;
+
+        public Task<IList<IBatchContainer>> GetQueueMessagesAsync(int maxCount)
+            => Task.FromResult<IList<IBatchContainer>>([]);
+
+        public Task MessagesDeliveredAsync(IList<IBatchContainer> messages)
+        {
+            MessagesDelivered = true;
+            return Task.CompletedTask;
+        }
+
+        public Task Shutdown(TimeSpan timeout) => Task.CompletedTask;
+    }
+
+    private sealed class LegacyStreamQueueCheckpointerFactory(
+        IStreamQueueCheckpointer<string> checkpointer) : IStreamQueueCheckpointerFactory
+    {
+        public Task<IStreamQueueCheckpointer<string>> Create(string partition)
+            => Task.FromResult(checkpointer);
+    }
+
+    private sealed class LegacyStreamQueueCheckpointer : IStreamQueueCheckpointer<string>
+    {
+        public string Checkpoint { get; private set; } = "10";
+
+        public bool CheckpointExists => true;
+
+        public Task<string> Load() => Task.FromResult(Checkpoint);
+
+        public void Update(string offset, DateTime utcNow) => Checkpoint = offset;
+
+        public Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PersistentStreamPullingAgentTests.cs
@@ -32,7 +32,7 @@ namespace UnitTests.StreamingTests
             var streamId = StreamId.Create("namespace", Guid.NewGuid());
             var receiver = Substitute.For<IQueueAdapterReceiver>();
             // Use Arg.Any<int>() to match regardless of the maxCacheAddCount value.
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(
                 [
                     new GeneratedBatchContainer(streamId, 1, new EventSequenceTokenV2(1)),
@@ -72,7 +72,7 @@ namespace UnitTests.StreamingTests
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);
             var streamId = StreamId.Create("namespace", Guid.NewGuid());
             var receiver = Substitute.For<IQueueAdapterReceiver>();
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(
                 [
                     new GeneratedBatchContainer(streamId, 1, new EventSequenceTokenV2(1)),
@@ -122,7 +122,7 @@ namespace UnitTests.StreamingTests
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);
             var receiver = Substitute.For<IQueueAdapterReceiver>();
             // Simulate a receiver binary compiled before the return value was annotated as non-null.
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(null!));
             var agent = CreateAgent(pubSub: null, queueId);
             var testAccessor = (PersistentStreamPullingAgent.ITestAccessor)agent;
@@ -131,7 +131,7 @@ namespace UnitTests.StreamingTests
             var readResult = await testAccessor.ReadFromQueue(queueId, receiver, 1);
 
             Assert.False(readResult);
-            await receiver.Received(1).GetQueueMessagesAsync(1);
+            await receiver.Received(1).GetQueueMessagesAsync(1, CancellationToken.None);
             Assert.Empty(await testAccessor.GetPubSubCache());
         }
 
@@ -493,7 +493,7 @@ namespace UnitTests.StreamingTests
             Assert.False(cursor.MoveNext());
 
             var receiver = Substitute.For<IQueueAdapterReceiver>();
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>([new TestBatchContainer(streamId, newToken)]));
             var queueAdapterCache = Substitute.For<IQueueAdapterCache>();
             queueAdapterCache.CreateQueueCache(Arg.Any<QueueId>()).Returns(queueCache);
@@ -545,7 +545,7 @@ namespace UnitTests.StreamingTests
             var consumer = new RewindConsumer(rewindToken);
 
             var receiver = Substitute.For<IQueueAdapterReceiver>();
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(
                     Task.FromResult<IList<IBatchContainer>>([new TestBatchContainer(streamId, attemptedToken)]),
                     Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
@@ -667,7 +667,7 @@ namespace UnitTests.StreamingTests
             var queueReadReleased = new TaskCompletionSource<IList<IBatchContainer>>(TaskCreationOptions.RunContinuationsAsynchronously);
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);
             var receiver = Substitute.For<IQueueAdapterReceiver>();
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(async _ =>
                 {
                     queueReadStarted.TrySetResult(true);
@@ -713,7 +713,7 @@ namespace UnitTests.StreamingTests
         {
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);
             var receiver = Substitute.For<IQueueAdapterReceiver>();
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
             receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
@@ -726,7 +726,7 @@ namespace UnitTests.StreamingTests
 
             await testAccessor.RunQueuePump(queueId, CancellationToken.None);
 
-            await receiver.Received(1).GetQueueMessagesAsync(Arg.Any<int>());
+            await receiver.Received(1).GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
         }
 
         [Fact, TestCategory("BVT"), TestCategory("Streaming")]
@@ -738,7 +738,7 @@ namespace UnitTests.StreamingTests
 
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);
             var receiver = Substitute.For<IQueueAdapterReceiver>();
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
             receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
@@ -788,7 +788,7 @@ namespace UnitTests.StreamingTests
 
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);
             var receiver = Substitute.For<IQueueAdapterReceiver>();
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
             receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 
@@ -841,7 +841,7 @@ namespace UnitTests.StreamingTests
             var streamId = StreamId.Create("namespace", Guid.NewGuid());
             var receiver = Substitute.For<IQueueAdapterReceiver>();
             var receiverShutdownStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(
                     Task.FromResult<IList<IBatchContainer>>([
                         new GeneratedBatchContainer(streamId, 1, new EventSequenceTokenV2(1)),
@@ -892,7 +892,7 @@ namespace UnitTests.StreamingTests
 
             var queueId = QueueId.GetQueueId("queue", 0u, 0u);
             var receiver = Substitute.For<IQueueAdapterReceiver>();
-            receiver.GetQueueMessagesAsync(Arg.Any<int>())
+            receiver.GetQueueMessagesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(Task.FromResult<IList<IBatchContainer>>(new List<IBatchContainer>()));
             receiver.Shutdown(Arg.Any<TimeSpan>()).Returns(Task.CompletedTask);
 


### PR DESCRIPTION
Flows cancellation through persistent stream adapter and checkpointer creation, queue reads, delivery notifications, and checkpoint operations.

Cancellation-aware default interface overloads preserve compatibility by calling legacy provider implementations, while providers can opt in to cancellation by overriding them. Legacy non-cancellable APIs are marked obsolete. The runtime, grain checkpointer, and Event Hubs integration adopt the new overloads with focused coverage.