### PR TITLE
fix(tests): synchronize timer delay in transactions tests

### DIFF
--- a/test/Transactions/Orleans.Transactions.Tests/TransactionQueueStorageWorkTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionQueueStorageWorkTests.cs
@@ -547,12 +547,8 @@ public class TransactionQueueStorageWorkTests
         private readonly Queue<TaskCompletionSource<bool>> delays = new();
         private readonly TaskCompletionSource<object?> delayRequested = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public int DelayCallCount { get; private set; }
-
         public Task<bool> Delay(TimeSpan timeSpan, CancellationToken cancellationToken = default)
         {
-            this.DelayCallCount++;
-
             if (cancellationToken.IsCancellationRequested)
             {
                 return Task.FromResult(false);
@@ -572,7 +568,7 @@ public class TransactionQueueStorageWorkTests
 
         public Task WaitForDelayAsync()
         {
-            return this.DelayCallCount > 0 ? Task.CompletedTask : this.delayRequested.Task;
+            return this.delayRequested.Task;
         }
 
         public void ReleaseNextDelay(bool result = true)


### PR DESCRIPTION
The transaction storage work test could observe its delay-call counter before the corresponding delay was added to the queue, causing an intermittent empty-queue failure in CI. Wait directly for the signal emitted after the delay is enqueued so releasing the delay is deterministic.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10384)