### PR TITLE
fix(transactions): retry TOC verification after transient abort

### DIFF
--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TocFaultTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TocFaultTransactionTestRunner.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using AwesomeAssertions;
@@ -9,6 +10,9 @@ namespace Orleans.Transactions.TestKit
 {
     public abstract class TocFaultTransactionTestRunner : TransactionTestRunnerBase
     {
+        private static readonly TimeSpan VerificationRetryTimeout = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan VerificationRetryDelay = TimeSpan.FromMilliseconds(100);
+
         protected TocFaultTransactionTestRunner(IGrainFactory grainFactory, Action<string> output)
         : base(grainFactory, output) { }
 
@@ -31,7 +35,7 @@ namespace Orleans.Transactions.TestKit
 
             foreach (var grain in grains)
             {
-                var actualValues = await grain.Get();
+                var actualValues = await GetWithTransientFailureRetry(grain);
                 foreach (var actual in actualValues)
                 {
                     actual.Should().Be(expected);
@@ -60,7 +64,7 @@ namespace Orleans.Transactions.TestKit
 
             foreach (var grain in grains)
             {
-                var actualValues = await grain.Get();
+                var actualValues = await GetWithTransientFailureRetry(grain);
                 foreach (var actual in actualValues)
                 {
                     actual.Should().Be(expected);
@@ -68,6 +72,27 @@ namespace Orleans.Transactions.TestKit
             }
 
             // TODO : Add verification that commit service receive call with proper args.
+        }
+
+        private async Task<int[]> GetWithTransientFailureRetry(ITransactionTestGrain grain)
+        {
+            var retryStart = Stopwatch.GetTimestamp();
+
+            while (true)
+            {
+                try
+                {
+                    return await grain.Get();
+                }
+                // The commit result can arrive before cancellation reaches every participant. A verification read
+                // which overlaps that cleanup is intentionally aborted and is safe to retry.
+                catch (OrleansTransactionTransientFailureException exception)
+                    when (Stopwatch.GetElapsedTime(retryStart) < VerificationRetryTimeout)
+                {
+                    this.testOutput($"State verification failed transiently: {exception.Message}. Retrying.");
+                    await Task.Delay(VerificationRetryDelay);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
TOC fault tests can begin state verification before cancellation from the intentionally aborted transaction reaches every participant. A verification transaction which overlaps that cleanup is correctly aborted as a transient failure, causing provider-dependent flakes such as the DynamoDB failure in #10384.

Retry only transient verification failures for a bounded period in both commit-failure scenarios. This preserves transaction ordering while continuing to surface persistent and non-transient failures.

Related to #9556 and #9825.