### PR TITLE
docs: enforce Conventional Commit PR titles during reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Create PRs using `dotnet/orleans` as the base repository and `origin`/personal fork branches as the head.
 - Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages from now on.
 - PR titles must also follow Conventional Commits naming conventions because squash merges use the PR title as the resulting commit message.
+- When reviewing a PR, evaluate its title for Conventional Commits conformance and update it as appropriate.
 - When reviewing changes, check whether corresponding documentation or sample updates are needed in the `/docs` and `/samples` directories.
 - When creating PRs, keep the PR description simple: explain the problem it addresses and the solution it implements, including the rationale where helpful. Do not include a section describing what commands to run to test the PR.
 


### PR DESCRIPTION
Updates the repository workflow guidance to require reviewers to evaluate PR titles for Conventional Commits conformance and update them when appropriate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10387)