### PR TITLE
docs: safely identify each contributor's fork remote

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,42 @@
 # Repository workflow
 
 - Open pull requests against `dotnet/orleans`.
-- Unless otherwise specified, create new branches from `main` in the upstream `dotnet/orleans` repository (`upstream/main`).
-- Do not push feature branches directly to `dotnet/orleans` or the `upstream` remote.
-- Push feature branches to your personal fork, which is configured as `origin`.
-- Create PRs using `dotnet/orleans` as the base repository and `origin`/personal fork branches as the head.
+- Unless otherwise specified, create new branches from `main` in the upstream `dotnet/orleans` repository. Branch from the remote-tracking ref of whichever remote points at `dotnet/orleans`, which is not necessarily named `upstream`.
+- Do not push feature branches directly to `dotnet/orleans`, under any remote name.
+- Push feature branches to your personal fork (`ReubenBond/orleans`).
+- Remote names are not reliable. Do not assume `origin` is the fork or that `upstream` is the only remote pointing at `dotnet/orleans` — in some checkouts `origin` *is* `dotnet/orleans` and the fork is under a different name such as `pr-ReubenBond-orleans`.
+- Before every push, run `git remote -v` and pick the remote by its URL, not its name. Push only to the remote whose URL is `https://github.com/ReubenBond/orleans.git`.
+- Never run `git push` against a remote whose URL is `https://github.com/dotnet/orleans.git`, and never hard-code `git push origin` without checking first.
+- If a branch does land on `dotnet/orleans` by mistake, delete it immediately with `git push <that-remote> --delete <branch>`, then re-push to the fork.
+- Create PRs using `dotnet/orleans` as the base repository and personal fork branches as the head.
 - Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages from now on.
 - PR titles must also follow Conventional Commits naming conventions because squash merges use the PR title as the resulting commit message.
 - When reviewing a PR, evaluate its title for Conventional Commits conformance and update it as appropriate.
 - When reviewing changes, check whether corresponding documentation or sample updates are needed in the `/docs` and `/samples` directories.
 - When creating PRs, keep the PR description simple: explain the problem it addresses and the solution it implements, including the rationale where helpful. Do not include a section describing what commands to run to test the PR.
 
-Example:
+Example. Resolve both remotes by URL first, then use those variables for every
+subsequent git command, so a checkout where `origin` is `dotnet/orleans` can't
+send a branch to the wrong repository:
 
 ```powershell
-git fetch upstream main
-git switch -c <branch> upstream/main
-git push --set-upstream origin <branch>
+# Inspect the remotes before doing anything else.
+git remote -v
+
+# Resolve remotes by URL, not by name.
+$fork = git remote -v | Select-String 'ReubenBond/orleans(\.git)?\s+\(push\)' | ForEach-Object { ($_ -split '\s+')[0] } | Select-Object -First 1
+$upstream = git remote -v | Select-String 'dotnet/orleans(\.git)?\s+\(fetch\)' | ForEach-Object { ($_ -split '\s+')[0] } | Select-Object -First 1
+if (-not $fork) { throw 'No remote points at the ReubenBond/orleans fork.' }
+if ($fork -eq $upstream) { throw 'Refusing to push: resolved fork remote points at dotnet/orleans.' }
+
+git fetch $upstream main
+git switch -c <branch> "$upstream/main"
+git push --set-upstream $fork <branch>
 gh pr create --repo dotnet/orleans --base main --head ReubenBond:<branch>
+```
+
+Recovery, if a branch reaches `dotnet/orleans` anyway:
+
+```powershell
+git push $upstream --delete <branch>
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,9 @@
 - Open pull requests against `dotnet/orleans`.
 - Unless otherwise specified, create new branches from `main` in the upstream `dotnet/orleans` repository. Branch from the remote-tracking ref of whichever remote points at `dotnet/orleans`, which is not necessarily named `upstream`.
 - Do not push feature branches directly to `dotnet/orleans`, under any remote name.
-- Push feature branches to your personal fork (`ReubenBond/orleans`).
-- Remote names are not reliable. Do not assume `origin` is the fork or that `upstream` is the only remote pointing at `dotnet/orleans` — in some checkouts `origin` *is* `dotnet/orleans` and the fork is under a different name such as `pr-ReubenBond-orleans`.
-- Before every push, run `git remote -v` and pick the remote by its URL, not its name. Push only to the remote whose URL is `https://github.com/ReubenBond/orleans.git`.
+- Push feature branches to your own fork of `dotnet/orleans`.
+- Remote names are not reliable. Do not assume `origin` is your fork or that `upstream` is the only remote pointing at `dotnet/orleans` — in some checkouts `origin` *is* `dotnet/orleans` and the fork is under a different name. A checkout may also carry remotes for other contributors' forks, so match on your own GitHub login rather than on any fork of this repository.
+- Before every push, run `git remote -v` and pick the remote by its URL, not its name. Push only to the remote whose URL is your own fork.
 - Never run `git push` against a remote whose URL is `https://github.com/dotnet/orleans.git`, and never hard-code `git push origin` without checking first.
 - If a branch does land on `dotnet/orleans` by mistake, delete it immediately with `git push <that-remote> --delete <branch>`, then re-push to the fork.
 - Create PRs using `dotnet/orleans` as the base repository and personal fork branches as the head.
@@ -23,16 +23,18 @@ send a branch to the wrong repository:
 # Inspect the remotes before doing anything else.
 git remote -v
 
-# Resolve remotes by URL, not by name.
-$fork = git remote -v | Select-String 'ReubenBond/orleans(\.git)?\s+\(push\)' | ForEach-Object { ($_ -split '\s+')[0] } | Select-Object -First 1
-$upstream = git remote -v | Select-String 'dotnet/orleans(\.git)?\s+\(fetch\)' | ForEach-Object { ($_ -split '\s+')[0] } | Select-Object -First 1
-if (-not $fork) { throw 'No remote points at the ReubenBond/orleans fork.' }
+# Resolve remotes by URL, not by name. Derive your own login so the lookup
+# doesn't match another contributor's fork remote.
+$login = gh api user --jq .login
+$fork = git remote -v | Select-String "github\.com[:/]$login/[^\s]+\s+\(push\)$" | ForEach-Object { ($_ -split '\s+')[0] } | Select-Object -First 1
+$upstream = git remote -v | Select-String 'github\.com[:/]dotnet/orleans(\.git)?\s+\(fetch\)$' | ForEach-Object { ($_ -split '\s+')[0] } | Select-Object -First 1
+if (-not $fork) { throw "No remote points at a fork owned by $login." }
 if ($fork -eq $upstream) { throw 'Refusing to push: resolved fork remote points at dotnet/orleans.' }
 
 git fetch $upstream main
 git switch -c <branch> "$upstream/main"
 git push --set-upstream $fork <branch>
-gh pr create --repo dotnet/orleans --base main --head ReubenBond:<branch>
+gh pr create --repo dotnet/orleans --base main --head "${login}:<branch>"
 ```
 
 Recovery, if a branch reaches `dotnet/orleans` anyway:


### PR DESCRIPTION
## Problem

The workflow guidance in `AGENTS.md` identified remotes by *name* and identified the fork by a specific *person*. Neither holds generally.

The name assumption said the fork "is configured as `origin`" and told contributors not to push to `dotnet/orleans` "or the `upstream` remote". In a checkout where `origin` points at `dotnet/orleans` and the fork sits under a different name, following the documented example literally pushes a feature branch straight to the upstream repository. That happened while working on #10394 and had to be undone by hand.

The person assumption hard-coded a single maintainer's GitHub account, including in `gh pr create --head`. This repository has many contributors, and a checkout can carry remotes for several contributors' forks, so a hard-coded account is wrong for everyone else and risks matching the wrong remote.

## Solution

Identify remotes by URL, and identify the fork by the current user:

- Forbid pushing to `dotnet/orleans` under *any* remote name, rather than singling out `upstream`.
- State that remote names are unreliable and that `origin` may be `dotnet/orleans`.
- Require `git remote -v` before every push, selecting the target by URL.
- Derive the current user's login from `gh api user` and match the fork remote on that login, so the lookup resolves each contributor's own fork and can't select another contributor's fork remote.
- Rework the example to resolve `$fork` and `$upstream` from remote URLs and use those variables throughout, with guard clauses that fail if no fork remote is found or if the resolved fork turns out to be `dotnet/orleans`.
- Document the recovery step for deleting a branch that reaches upstream by mistake.

The resolution snippet is verified against a checkout with the problematic layout — `origin` pointing at `dotnet/orleans`, alongside fork remotes for many other contributors — where it correctly selects the current user's fork.
