### PR TITLE
docs: point package README links at the Orleans docs site

### DIFF
--- a/src/AWS/Orleans.Clustering.DynamoDB/README.md
+++ b/src/AWS/Orleans.Clustering.DynamoDB/README.md
@@ -67,9 +67,9 @@ await host.WaitForShutdownAsync();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Configuration Guide](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/)
-- [Orleans Clustering](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/cluster-management)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Configuration Guide](https://dotnet.github.io/orleans/docs/host/configuration-guide/)
+- [Orleans Clustering](https://dotnet.github.io/orleans/docs/implementation/cluster-management/)
 - [AWS SDK for .NET Documentation](https://docs.aws.amazon.com/sdk-for-net/index.html)
 
 ## Feedback & Contributing

--- a/src/AWS/Orleans.Persistence.DynamoDB/README.md
+++ b/src/AWS/Orleans.Persistence.DynamoDB/README.md
@@ -74,8 +74,8 @@ public class MyGrain : Grain, IMyGrain, IGrainWithStringKey
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Grain Persistence](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Grain Persistence](https://dotnet.github.io/orleans/docs/grains/grain-persistence/)
 - [AWS SDK for .NET Documentation](https://docs.aws.amazon.com/sdk-for-net/index.html)
 
 ## Feedback & Contributing

--- a/src/AWS/Orleans.Reminders.DynamoDB/README.md
+++ b/src/AWS/Orleans.Reminders.DynamoDB/README.md
@@ -101,8 +101,7 @@ public class ReminderGrain : Grain, IReminderGrain, IRemindable
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Reminders and Timers](https://learn.microsoft.com/en-us/dotnet/orleans/grains/timers-and-reminders)
-- [Reminder Services](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/reminder-services)
+- [Reminders and Timers](https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders)
 - [AWS SDK for .NET Documentation](https://docs.aws.amazon.com/sdk-for-net/index.html)
 
 ## Feedback & Contributing

--- a/src/AWS/Orleans.Reminders.DynamoDB/README.md
+++ b/src/AWS/Orleans.Reminders.DynamoDB/README.md
@@ -100,8 +100,8 @@ public class ReminderGrain : Grain, IReminderGrain, IRemindable
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Reminders and Timers](https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Reminders and Timers](https://dotnet.github.io/orleans/docs/grains/timers-and-reminders/)
 - [AWS SDK for .NET Documentation](https://docs.aws.amazon.com/sdk-for-net/index.html)
 
 ## Feedback & Contributing

--- a/src/AWS/Orleans.Streaming.Kinesis/README.md
+++ b/src/AWS/Orleans.Streaming.Kinesis/README.md
@@ -103,6 +103,6 @@ To provide a different checkpoint implementation, use the configurator overload 
 
 ## Documentation
 
-- [Microsoft Orleans documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans streaming](https://learn.microsoft.com/dotnet/orleans/streaming/)
+- [Microsoft Orleans documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans streaming](https://dotnet.github.io/orleans/docs/streaming/)
 - [Amazon Kinesis Data Streams documentation](https://docs.aws.amazon.com/streams/latest/dev/introduction.html)

--- a/src/AWS/Orleans.Streaming.SQS/README.md
+++ b/src/AWS/Orleans.Streaming.SQS/README.md
@@ -104,9 +104,9 @@ public class ConsumerGrain : Grain, IConsumerGrain, IAsyncObserver<string>
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans Streams](https://learn.microsoft.com/en-us/dotnet/orleans/streaming/index)
-- [Stream Providers](https://learn.microsoft.com/en-us/dotnet/orleans/streaming/stream-providers)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans Streams](https://dotnet.github.io/orleans/docs/streaming/)
+- [Stream Providers](https://dotnet.github.io/orleans/docs/streaming/stream-providers/)
 - [AWS SDK for .NET Documentation](https://docs.aws.amazon.com/sdk-for-net/index.html)
 
 ## Feedback & Contributing

--- a/src/AdoNet/Orleans.Clustering.AdoNet/README.md
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/README.md
@@ -126,8 +126,8 @@ namespace ExampleGrains;
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Clustering providers](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/cluster-management)
-- [Relational Database Provider](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/relational-storage-providers)
+- [Clustering providers](https://learn.microsoft.com/dotnet/orleans/implementation/cluster-management)
+- [ADO.NET database configuration](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/adonet-configuration)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/AdoNet/Orleans.Clustering.AdoNet/README.md
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/README.md
@@ -125,9 +125,9 @@ namespace ExampleGrains;
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Clustering providers](https://learn.microsoft.com/dotnet/orleans/implementation/cluster-management)
-- [ADO.NET database configuration](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/adonet-configuration)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Clustering providers](https://dotnet.github.io/orleans/docs/implementation/cluster-management/)
+- [ADO.NET database configuration](https://dotnet.github.io/orleans/docs/host/configuration-guide/adonet-configuration/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/AdoNet/Orleans.Persistence.AdoNet/README.md
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/README.md
@@ -96,9 +96,9 @@ Before using the ADO.NET provider, you need to set up the necessary database tab
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Grain Persistence](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence)
-- [Relational Database Persistence](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence/relational-storage)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Grain Persistence](https://dotnet.github.io/orleans/docs/grains/grain-persistence/)
+- [Relational Database Persistence](https://dotnet.github.io/orleans/docs/grains/grain-persistence/relational-storage/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/AdoNet/Orleans.Reminders.AdoNet/README.md
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/README.md
@@ -110,9 +110,8 @@ public class ReminderGrain : Grain, IReminderGrain, IRemindable
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Reminders and Timers](https://learn.microsoft.com/en-us/dotnet/orleans/grains/timers-and-reminders)
-- [Reminder Services](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/reminder-services)
-- [ADO.NET Database Setup](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/adonet-configuration)
+- [Reminders and Timers](https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders)
+- [ADO.NET Database Setup](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/adonet-configuration)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/AdoNet/Orleans.Reminders.AdoNet/README.md
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/README.md
@@ -109,9 +109,9 @@ public class ReminderGrain : Grain, IReminderGrain, IRemindable
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Reminders and Timers](https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders)
-- [ADO.NET Database Setup](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/adonet-configuration)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Reminders and Timers](https://dotnet.github.io/orleans/docs/grains/timers-and-reminders/)
+- [ADO.NET Database Setup](https://dotnet.github.io/orleans/docs/host/configuration-guide/adonet-configuration/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/AdoNet/Orleans.Streaming.AdoNet/README.md
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/README.md
@@ -110,10 +110,10 @@ public class ConsumerGrain : Grain, IConsumerGrain, IAsyncObserver<string>
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans Streams](https://learn.microsoft.com/en-us/dotnet/orleans/streaming/index)
-- [Stream Providers](https://learn.microsoft.com/en-us/dotnet/orleans/streaming/stream-providers)
-- [ADO.NET Database Setup](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/adonet-configuration)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans Streams](https://dotnet.github.io/orleans/docs/streaming/)
+- [Stream Providers](https://dotnet.github.io/orleans/docs/streaming/stream-providers/)
+- [ADO.NET Database Setup](https://dotnet.github.io/orleans/docs/host/configuration-guide/adonet-configuration/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Clustering.AzureStorage/README.md
+++ b/src/Azure/Orleans.Clustering.AzureStorage/README.md
@@ -108,9 +108,9 @@ await host.WaitForShutdownAsync();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Clustering providers](https://learn.microsoft.com/dotnet/orleans/implementation/cluster-management)
-- [Typical configurations](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/typical-configurations)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Clustering providers](https://dotnet.github.io/orleans/docs/implementation/cluster-management/)
+- [Typical configurations](https://dotnet.github.io/orleans/docs/host/configuration-guide/typical-configurations/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Clustering.AzureStorage/README.md
+++ b/src/Azure/Orleans.Clustering.AzureStorage/README.md
@@ -109,8 +109,8 @@ await host.WaitForShutdownAsync();
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Clustering providers](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/cluster-management)
-- [Azure Storage provider](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/azure-storage-providers)
+- [Clustering providers](https://learn.microsoft.com/dotnet/orleans/implementation/cluster-management)
+- [Typical configurations](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/typical-configurations)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Clustering.Cosmos/README.md
+++ b/src/Azure/Orleans.Clustering.Cosmos/README.md
@@ -34,9 +34,9 @@ await builder.RunAsync();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Configuration Guide](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/)
-- [Orleans Clustering](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/cluster-management)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Configuration Guide](https://dotnet.github.io/orleans/docs/host/configuration-guide/)
+- [Orleans Clustering](https://dotnet.github.io/orleans/docs/implementation/cluster-management/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.DurableJobs.AzureStorage/README.md
+++ b/src/Azure/Orleans.DurableJobs.AzureStorage/README.md
@@ -488,7 +488,7 @@ var blobServiceClient = new BlobServiceClient(storageAccountUri, credential);
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
 - [Azure Blob Storage Documentation](https://learn.microsoft.com/azure/storage/blobs/)
 - [Orleans Durable Jobs Core Package](../../../Orleans.DurableJobs/README.md)
 

--- a/src/Azure/Orleans.GrainDirectory.AzureStorage/README.md
+++ b/src/Azure/Orleans.GrainDirectory.AzureStorage/README.md
@@ -34,9 +34,9 @@ await builder.RunAsync();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Configuration Guide](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/)
-- [Implementation Details](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/index)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Configuration Guide](https://dotnet.github.io/orleans/docs/host/configuration-guide/)
+- [Implementation Details](https://dotnet.github.io/orleans/docs/implementation/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Journaling.AzureStorage/README.md
+++ b/src/Azure/Orleans.Journaling.AzureStorage/README.md
@@ -180,8 +180,8 @@ public class ShoppingCartGrain(
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Grain Persistence](https://learn.microsoft.com/dotnet/orleans/grains/grain-persistence)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Grain Persistence](https://dotnet.github.io/orleans/docs/grains/grain-persistence/)
 - [Azure Blob Storage Documentation](https://learn.microsoft.com/azure/storage/blobs/)
 
 ## Feedback & Contributing

--- a/src/Azure/Orleans.Persistence.AzureStorage/README.md
+++ b/src/Azure/Orleans.Persistence.AzureStorage/README.md
@@ -106,9 +106,9 @@ public class MyGrain : Grain, IMyGrain, IGrainWithStringKey
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Grain Persistence](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence)
-- [Azure Storage Persistence](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence/azure-storage)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Grain Persistence](https://dotnet.github.io/orleans/docs/grains/grain-persistence/)
+- [Azure Storage Persistence](https://dotnet.github.io/orleans/docs/grains/grain-persistence/azure-storage/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Persistence.Cosmos/README.md
+++ b/src/Azure/Orleans.Persistence.Cosmos/README.md
@@ -73,9 +73,9 @@ public class MyGrain : Grain, IMyGrain, IGrainWithStringKey
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Grain Persistence](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence)
-- [Azure Storage Providers](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence/azure-storage)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Grain Persistence](https://dotnet.github.io/orleans/docs/grains/grain-persistence/)
+- [Azure Storage Providers](https://dotnet.github.io/orleans/docs/grains/grain-persistence/azure-storage/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Reminders.AzureStorage/README.md
+++ b/src/Azure/Orleans.Reminders.AzureStorage/README.md
@@ -78,8 +78,7 @@ public class ReminderGrain : Grain, IReminderGrain, IRemindable
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Reminders and Timers](https://learn.microsoft.com/en-us/dotnet/orleans/grains/timers-and-reminders)
-- [Reminder Services](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/reminder-services)
+- [Reminders and Timers](https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Reminders.AzureStorage/README.md
+++ b/src/Azure/Orleans.Reminders.AzureStorage/README.md
@@ -77,8 +77,8 @@ public class ReminderGrain : Grain, IReminderGrain, IRemindable
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Reminders and Timers](https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Reminders and Timers](https://dotnet.github.io/orleans/docs/grains/timers-and-reminders/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Reminders.Cosmos/README.md
+++ b/src/Azure/Orleans.Reminders.Cosmos/README.md
@@ -79,8 +79,8 @@ public class ReminderGrain : Grain, IReminderGrain, IRemindable
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Reminders and Timers](https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Reminders and Timers](https://dotnet.github.io/orleans/docs/grains/timers-and-reminders/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Reminders.Cosmos/README.md
+++ b/src/Azure/Orleans.Reminders.Cosmos/README.md
@@ -80,8 +80,7 @@ public class ReminderGrain : Grain, IReminderGrain, IRemindable
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Reminders and Timers](https://learn.microsoft.com/en-us/dotnet/orleans/grains/timers-and-reminders)
-- [Reminder Services](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/reminder-services)
+- [Reminders and Timers](https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Streaming.AzureStorage/README.md
+++ b/src/Azure/Orleans.Streaming.AzureStorage/README.md
@@ -97,9 +97,9 @@ public class ConsumerGrain : Grain, IConsumerGrain, IAsyncObserver<string>
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans Streams](https://learn.microsoft.com/en-us/dotnet/orleans/streaming/index)
-- [Stream Providers](https://learn.microsoft.com/en-us/dotnet/orleans/streaming/stream-providers)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans Streams](https://dotnet.github.io/orleans/docs/streaming/)
+- [Stream Providers](https://dotnet.github.io/orleans/docs/streaming/stream-providers/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Streaming.EventHubs/README.md
+++ b/src/Azure/Orleans.Streaming.EventHubs/README.md
@@ -130,9 +130,9 @@ public class MyEvent
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans Streams](https://learn.microsoft.com/en-us/dotnet/orleans/streaming/)
-- [Event Hubs integration](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/streams-implementation)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans Streams](https://dotnet.github.io/orleans/docs/streaming/)
+- [Event Hubs integration](https://dotnet.github.io/orleans/docs/implementation/streams-implementation/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Transactions.AzureStorage/README.md
+++ b/src/Azure/Orleans.Transactions.AzureStorage/README.md
@@ -96,8 +96,8 @@ public class MyState
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Transactions](https://learn.microsoft.com/dotnet/orleans/grains/transactions)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Transactions](https://dotnet.github.io/orleans/docs/grains/transactions/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Azure/Orleans.Transactions.AzureStorage/README.md
+++ b/src/Azure/Orleans.Transactions.AzureStorage/README.md
@@ -97,8 +97,7 @@ public class MyState
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Transactions](https://learn.microsoft.com/en-us/dotnet/orleans/grains/transactions)
-- [Distributed ACID Transactions](https://learn.microsoft.com/en-us/dotnet/orleans/grains/transactions/acid-transactions)
+- [Transactions](https://learn.microsoft.com/dotnet/orleans/grains/transactions)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Dashboard/Orleans.Dashboard.Abstractions/README.md
+++ b/src/Dashboard/Orleans.Dashboard.Abstractions/README.md
@@ -21,8 +21,8 @@ This package provides:
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans observability](https://learn.microsoft.com/en-us/dotnet/orleans/host/monitoring/)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans observability](https://dotnet.github.io/orleans/docs/host/monitoring/)
 - [Orleans Dashboard package](https://www.nuget.org/packages/Microsoft.Orleans.Dashboard/)
 
 ## Feedback & Contributing

--- a/src/Dashboard/Orleans.Dashboard/README.md
+++ b/src/Dashboard/Orleans.Dashboard/README.md
@@ -107,9 +107,9 @@ For complete working examples, see the playground projects:
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans observability](https://learn.microsoft.com/en-us/dotnet/orleans/host/monitoring/)
-- [Server configuration](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/server-configuration)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans observability](https://dotnet.github.io/orleans/docs/host/monitoring/)
+- [Server configuration](https://dotnet.github.io/orleans/docs/host/configuration-guide/server-configuration/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Client/README.md
+++ b/src/Orleans.Client/README.md
@@ -52,10 +52,10 @@ await host.WaitForShutdownAsync();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans client configuration](https://learn.microsoft.com/en-us/dotnet/orleans/host/client)
-- [Grain references](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-references)
-- [Orleans request context](https://learn.microsoft.com/en-us/dotnet/orleans/grains/request-context)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans client configuration](https://dotnet.github.io/orleans/docs/host/client/)
+- [Grain references](https://dotnet.github.io/orleans/docs/grains/grain-references/)
+- [Orleans request context](https://dotnet.github.io/orleans/docs/grains/request-context/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Core.Abstractions/README.md
+++ b/src/Orleans.Core.Abstractions/README.md
@@ -27,8 +27,8 @@ public interface IHelloGrain : IGrainWithStringKey
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Grain interfaces](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-interfaces)
-- [Grain references](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-references)
+- [Develop grains](https://learn.microsoft.com/dotnet/orleans/grains/)
+- [Grain references](https://learn.microsoft.com/dotnet/orleans/grains/grain-references)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Core.Abstractions/README.md
+++ b/src/Orleans.Core.Abstractions/README.md
@@ -26,9 +26,9 @@ public interface IHelloGrain : IGrainWithStringKey
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Develop grains](https://learn.microsoft.com/dotnet/orleans/grains/)
-- [Grain references](https://learn.microsoft.com/dotnet/orleans/grains/grain-references)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Develop grains](https://dotnet.github.io/orleans/docs/grains/)
+- [Grain references](https://dotnet.github.io/orleans/docs/grains/grain-references/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Core/README.md
+++ b/src/Orleans.Core/README.md
@@ -62,8 +62,8 @@ await host.WaitForShutdownAsync();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Client Configuration](https://learn.microsoft.com/dotnet/orleans/host/client)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Client Configuration](https://dotnet.github.io/orleans/docs/host/client/)
 - [Dependency injection in .NET](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection)
 
 ## Feedback & Contributing

--- a/src/Orleans.Core/README.md
+++ b/src/Orleans.Core/README.md
@@ -63,8 +63,8 @@ await host.WaitForShutdownAsync();
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Client Configuration](https://learn.microsoft.com/en-us/dotnet/orleans/host/client)
-- [Dependency Injection](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/dependency-injection)
+- [Client Configuration](https://learn.microsoft.com/dotnet/orleans/host/client)
+- [Dependency injection in .NET](https://learn.microsoft.com/dotnet/core/extensions/dependency-injection)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.DurableJobs/README.md
+++ b/src/Orleans.DurableJobs/README.md
@@ -468,8 +468,8 @@ public class WorkflowGrain : Grain, IDurableJobHandler
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Timers and Reminders](https://learn.microsoft.com/en-us/dotnet/orleans/grains/timers-and-reminders)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Timers and Reminders](https://dotnet.github.io/orleans/docs/grains/timers-and-reminders/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.EventSourcing/README.md
+++ b/src/Orleans.EventSourcing/README.md
@@ -162,11 +162,11 @@ await host.WaitForShutdownAsync();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Event Sourcing Overview](https://learn.microsoft.com/dotnet/orleans/grains/event-sourcing)
-- [JournaledGrain Basics](https://learn.microsoft.com/dotnet/orleans/grains/event-sourcing/journaledgrain-basics)
-- [Replicated Instances](https://learn.microsoft.com/dotnet/orleans/grains/event-sourcing/replicated-instances)
-- [Log-Consistency Providers](https://learn.microsoft.com/dotnet/orleans/grains/event-sourcing/log-consistency-providers)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Event Sourcing Overview](https://dotnet.github.io/orleans/docs/grains/event-sourcing/)
+- [JournaledGrain Basics](https://dotnet.github.io/orleans/docs/grains/event-sourcing/journaledgrain-basics/)
+- [Replicated Instances](https://dotnet.github.io/orleans/docs/grains/event-sourcing/replicated-instances/)
+- [Log-Consistency Providers](https://dotnet.github.io/orleans/docs/grains/event-sourcing/log-consistency-providers/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Journaling/README.md
+++ b/src/Orleans.Journaling/README.md
@@ -110,8 +110,8 @@ Existing data is read using its stored format metadata, or as legacy OrleansBina
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Grain Persistence](https://learn.microsoft.com/dotnet/orleans/grains/grain-persistence)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Grain Persistence](https://dotnet.github.io/orleans/docs/grains/grain-persistence/)
 - [System.Text.Json Documentation](https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/overview)
 
 ## Feedback & Contributing

--- a/src/Orleans.Runtime/README.md
+++ b/src/Orleans.Runtime/README.md
@@ -31,10 +31,10 @@ await builder.Build().RunAsync();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Server configuration](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/server-configuration)
-- [Silo lifecycle](https://learn.microsoft.com/dotnet/orleans/host/silo-lifecycle)
-- [Clustering](https://learn.microsoft.com/dotnet/orleans/implementation/cluster-management)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Server configuration](https://dotnet.github.io/orleans/docs/host/configuration-guide/server-configuration/)
+- [Silo lifecycle](https://dotnet.github.io/orleans/docs/host/silo-lifecycle/)
+- [Clustering](https://dotnet.github.io/orleans/docs/implementation/cluster-management/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Runtime/README.md
+++ b/src/Orleans.Runtime/README.md
@@ -32,9 +32,9 @@ await builder.Build().RunAsync();
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Server configuration](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/server-configuration)
-- [Silo lifecycle](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/silo-lifecycle)
-- [Clustering](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/cluster-management)
+- [Server configuration](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/server-configuration)
+- [Silo lifecycle](https://learn.microsoft.com/dotnet/orleans/host/silo-lifecycle)
+- [Clustering](https://learn.microsoft.com/dotnet/orleans/implementation/cluster-management)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Sdk/README.md
+++ b/src/Orleans.Sdk/README.md
@@ -66,10 +66,10 @@ await host.WaitForShutdownAsync();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
 - [Getting started with Orleans](https://dotnet.github.io/orleans/docs/tutorials-and-samples/hello-world/)
-- [Grains](https://learn.microsoft.com/dotnet/orleans/grains/)
-- [Orleans configuration guide](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/)
+- [Grains](https://dotnet.github.io/orleans/docs/grains/)
+- [Orleans configuration guide](https://dotnet.github.io/orleans/docs/host/configuration-guide/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Sdk/README.md
+++ b/src/Orleans.Sdk/README.md
@@ -68,8 +68,8 @@ await host.WaitForShutdownAsync();
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
 - [Getting started with Orleans](https://dotnet.github.io/orleans/docs/tutorials-and-samples/hello-world/)
-- [Grains](https://learn.microsoft.com/en-us/dotnet/orleans/grains/)
-- [Hosting Orleans](https://learn.microsoft.com/en-us/dotnet/orleans/host/)
+- [Grains](https://learn.microsoft.com/dotnet/orleans/grains/)
+- [Orleans configuration guide](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Serialization.Abstractions/README.md
+++ b/src/Orleans.Serialization.Abstractions/README.md
@@ -34,9 +34,9 @@ public class MyData
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Serialization in Orleans](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/serialization)
-- [Configure serialization](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/serialization-configuration)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Serialization in Orleans](https://dotnet.github.io/orleans/docs/host/configuration-guide/serialization/)
+- [Configure serialization](https://dotnet.github.io/orleans/docs/host/configuration-guide/serialization-configuration/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Serialization.Abstractions/README.md
+++ b/src/Orleans.Serialization.Abstractions/README.md
@@ -35,8 +35,8 @@ public class MyData
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Serialization in Orleans](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization)
-- [Orleans type serialization](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization-attributes)
+- [Serialization in Orleans](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/serialization)
+- [Configure serialization](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/serialization-configuration)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Serialization.FSharp/README.md
+++ b/src/Orleans.Serialization.FSharp/README.md
@@ -85,9 +85,9 @@ let retrievedUser = grain.GetUser() |> Async.AwaitTask |> Async.RunSynchronously
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans Serialization](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization)
-- [F# Documentation](https://learn.microsoft.com/en-us/dotnet/fsharp/)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans Serialization](https://dotnet.github.io/orleans/docs/host/configuration-guide/serialization/)
+- [F# Documentation](https://learn.microsoft.com/dotnet/fsharp/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Serialization.MessagePack/README.md
+++ b/src/Orleans.Serialization.MessagePack/README.md
@@ -80,8 +80,8 @@ public class MyGrain : Grain, IMyGrain
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans Serialization](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans Serialization](https://dotnet.github.io/orleans/docs/host/configuration-guide/serialization/)
 - [MessagePack for C#](https://github.com/neuecc/MessagePack-CSharp)
 
 ## Feedback & Contributing

--- a/src/Orleans.Serialization.NewtonsoftJson/README.md
+++ b/src/Orleans.Serialization.NewtonsoftJson/README.md
@@ -78,8 +78,8 @@ public class MyGrain : Grain, IMyGrain
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans Serialization](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans Serialization](https://dotnet.github.io/orleans/docs/host/configuration-guide/serialization/)
 - [Newtonsoft.Json Documentation](https://www.newtonsoft.com/json/help/html/Introduction.htm)
 
 ## Feedback & Contributing

--- a/src/Orleans.Serialization.SystemTextJson/README.md
+++ b/src/Orleans.Serialization.SystemTextJson/README.md
@@ -78,9 +78,9 @@ public class MyGrain : Grain, IMyGrain
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans Serialization](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization)
-- [System.Text.Json Documentation](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/overview)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans Serialization](https://dotnet.github.io/orleans/docs/host/configuration-guide/serialization/)
+- [System.Text.Json Documentation](https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/overview)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Serialization.TestKit/README.md
+++ b/src/Orleans.Serialization.TestKit/README.md
@@ -72,9 +72,9 @@ var deserialized = specificSerializer.Deserialize(bytes);
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans Serialization](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization)
-- [Testing Orleans Applications](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/testing)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans Serialization](https://dotnet.github.io/orleans/docs/host/configuration-guide/serialization/)
+- [Testing Orleans Applications](https://dotnet.github.io/orleans/docs/implementation/testing/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Serialization/README.md
+++ b/src/Orleans.Serialization/README.md
@@ -49,8 +49,8 @@ When fail-closed type validation is enabled, additional types can be allowed by 
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Serialization in Orleans](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization)
-- [Orleans type serialization](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization-attributes)
+- [Serialization in Orleans](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/serialization)
+- [Configure serialization](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/serialization-configuration)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Serialization/README.md
+++ b/src/Orleans.Serialization/README.md
@@ -48,9 +48,9 @@ When fail-closed type validation is enabled, additional types can be allowed by 
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Serialization in Orleans](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/serialization)
-- [Configure serialization](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/serialization-configuration)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Serialization in Orleans](https://dotnet.github.io/orleans/docs/host/configuration-guide/serialization/)
+- [Configure serialization](https://dotnet.github.io/orleans/docs/host/configuration-guide/serialization-configuration/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Server/README.md
+++ b/src/Orleans.Server/README.md
@@ -64,10 +64,10 @@ await host.WaitForShutdownAsync();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans server (silo) configuration](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/server-configuration)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans server (silo) configuration](https://dotnet.github.io/orleans/docs/host/configuration-guide/server-configuration/)
 - [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host)
-- [Grain persistence](https://learn.microsoft.com/dotnet/orleans/grains/grain-persistence)
+- [Grain persistence](https://dotnet.github.io/orleans/docs/grains/grain-persistence/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Server/README.md
+++ b/src/Orleans.Server/README.md
@@ -65,9 +65,9 @@ await host.WaitForShutdownAsync();
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans server (silo) configuration](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/server-configuration)
-- [Hosting Orleans](https://learn.microsoft.com/en-us/dotnet/orleans/host/generic-host)
-- [Grain persistence](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence)
+- [Orleans server (silo) configuration](https://learn.microsoft.com/dotnet/orleans/host/configuration-guide/server-configuration)
+- [.NET Generic Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host)
+- [Grain persistence](https://learn.microsoft.com/dotnet/orleans/grains/grain-persistence)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)

--- a/src/Orleans.Streaming.NATS/README.md
+++ b/src/Orleans.Streaming.NATS/README.md
@@ -123,8 +123,8 @@ public class MyEvent
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans Streams](https://learn.microsoft.com/en-us/dotnet/orleans/streaming/)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans Streams](https://dotnet.github.io/orleans/docs/streaming/)
 - [NATS JetStream Documentation](https://docs.nats.io/nats-concepts/jetstream)
 
 ## Feedback & Contributing

--- a/src/Redis/Orleans.Clustering.Redis/README.md
+++ b/src/Redis/Orleans.Clustering.Redis/README.md
@@ -123,7 +123,7 @@ You can configure Orleans Redis clustering using `Microsoft.Extensions.Configura
 
 ### .NET Aspire Integration
 
-For applications using .NET Aspire, consider using the [.NET Aspire Redis integration](https://learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-integration) which provides simplified Redis configuration, automatic service discovery, health checks, and telemetry. The Aspire integration automatically configures connection strings that Orleans can consume via the configuration system.
+For applications using .NET Aspire, consider using the [.NET Aspire Redis integration](https://learn.microsoft.com/dotnet/aspire/caching/stackexchange-redis-integration) which provides simplified Redis configuration, automatic service discovery, health checks, and telemetry. The Aspire integration automatically configures connection strings that Orleans can consume via the configuration system.
 
 #### Example - Program.cs with Aspire Redis Integration
 ```csharp
@@ -172,9 +172,9 @@ builder.Build().Run();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Configuration Guide](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/)
-- [Orleans Clustering](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/cluster-management)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Configuration Guide](https://dotnet.github.io/orleans/docs/host/configuration-guide/)
+- [Orleans Clustering](https://dotnet.github.io/orleans/docs/implementation/cluster-management/)
 - [Redis Documentation](https://redis.io/documentation)
 
 ## Feedback & Contributing

--- a/src/Redis/Orleans.GrainDirectory.Redis/README.md
+++ b/src/Redis/Orleans.GrainDirectory.Redis/README.md
@@ -59,7 +59,7 @@ You can configure Orleans Redis grain directory using `Microsoft.Extensions.Conf
 
 ### .NET Aspire Integration
 
-For applications using .NET Aspire, consider using the [.NET Aspire Redis integration](https://learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-integration) which provides simplified Redis configuration, automatic service discovery, health checks, and telemetry. The Aspire integration automatically configures connection strings that Orleans can consume via the configuration system.
+For applications using .NET Aspire, consider using the [.NET Aspire Redis integration](https://learn.microsoft.com/dotnet/aspire/caching/stackexchange-redis-integration) which provides simplified Redis configuration, automatic service discovery, health checks, and telemetry. The Aspire integration automatically configures connection strings that Orleans can consume via the configuration system.
 
 #### Example - Program.cs with Aspire Redis Integration
 ```csharp
@@ -108,9 +108,9 @@ builder.Build().Run();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Configuration Guide](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/)
-- [Implementation Details](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/index)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Configuration Guide](https://dotnet.github.io/orleans/docs/host/configuration-guide/)
+- [Implementation Details](https://dotnet.github.io/orleans/docs/implementation/)
 - [Redis Documentation](https://redis.io/documentation)
 
 ## Feedback & Contributing

--- a/src/Redis/Orleans.Journaling.Redis/README.md
+++ b/src/Redis/Orleans.Journaling.Redis/README.md
@@ -35,8 +35,8 @@ If the Redis connection is already registered in dependency injection, configure
 
 ## Documentation
 
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Grain Persistence](https://learn.microsoft.com/dotnet/orleans/grains/grain-persistence)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Grain Persistence](https://dotnet.github.io/orleans/docs/grains/grain-persistence/)
 - [Redis Documentation](https://redis.io/docs/latest/)
 
 ## Feedback & Contributing

--- a/src/Redis/Orleans.Persistence.Redis/README.md
+++ b/src/Redis/Orleans.Persistence.Redis/README.md
@@ -98,7 +98,7 @@ You can configure Orleans Redis persistence using `Microsoft.Extensions.Configur
 
 ### .NET Aspire Integration
 
-For applications using .NET Aspire, consider using the [.NET Aspire Redis integration](https://learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-integration) which provides simplified Redis configuration, automatic service discovery, health checks, and telemetry. The Aspire integration automatically configures connection strings that Orleans can consume via the configuration system.
+For applications using .NET Aspire, consider using the [.NET Aspire Redis integration](https://learn.microsoft.com/dotnet/aspire/caching/stackexchange-redis-integration) which provides simplified Redis configuration, automatic service discovery, health checks, and telemetry. The Aspire integration automatically configures connection strings that Orleans can consume via the configuration system.
 
 #### Example - Program.cs with Aspire Redis Integration
 ```csharp
@@ -148,8 +148,8 @@ builder.Build().Run();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Grain Persistence](https://learn.microsoft.com/en-us/dotnet/orleans/grains/grain-persistence)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Grain Persistence](https://dotnet.github.io/orleans/docs/grains/grain-persistence/)
 - [Redis Documentation](https://redis.io/documentation)
 
 ## Feedback & Contributing

--- a/src/Redis/Orleans.Reminders.Redis/README.md
+++ b/src/Redis/Orleans.Reminders.Redis/README.md
@@ -97,7 +97,7 @@ You can configure Orleans Redis reminders using `Microsoft.Extensions.Configurat
 
 ### .NET Aspire Integration
 
-For applications using .NET Aspire, consider using the [.NET Aspire Redis integration](https://learn.microsoft.com/en-us/dotnet/aspire/caching/stackexchange-redis-integration) which provides simplified Redis configuration, automatic service discovery, health checks, and telemetry. The Aspire integration automatically configures connection strings that Orleans can consume via the configuration system.
+For applications using .NET Aspire, consider using the [.NET Aspire Redis integration](https://learn.microsoft.com/dotnet/aspire/caching/stackexchange-redis-integration) which provides simplified Redis configuration, automatic service discovery, health checks, and telemetry. The Aspire integration automatically configures connection strings that Orleans can consume via the configuration system.
 
 #### Example - Program.cs with Aspire Redis Integration
 ```csharp
@@ -147,8 +147,7 @@ builder.Build().Run();
 ## Documentation
 For more comprehensive documentation, please refer to:
 - [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Reminders and Timers](https://learn.microsoft.com/en-us/dotnet/orleans/grains/timers-and-reminders)
-- [Reminder Services](https://learn.microsoft.com/en-us/dotnet/orleans/implementation/reminder-services)
+- [Reminders and Timers](https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders)
 - [Redis Documentation](https://redis.io/documentation)
 
 ## Feedback & Contributing

--- a/src/Redis/Orleans.Reminders.Redis/README.md
+++ b/src/Redis/Orleans.Reminders.Redis/README.md
@@ -146,8 +146,8 @@ builder.Build().Run();
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Reminders and Timers](https://learn.microsoft.com/dotnet/orleans/grains/timers-and-reminders)
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Reminders and Timers](https://dotnet.github.io/orleans/docs/grains/timers-and-reminders/)
 - [Redis Documentation](https://redis.io/documentation)
 
 ## Feedback & Contributing

--- a/src/Serializers/Orleans.Serialization.Protobuf/README.md
+++ b/src/Serializers/Orleans.Serialization.Protobuf/README.md
@@ -31,7 +31,7 @@ await builder.RunAsync();
 ```
 
 ## Using Protobuf Types with Orleans
-This package supports types generated from `.proto` files using Google.Protobuf. For detailed information on creating Protobuf messages and configuring your project, see [Create Protobuf messages for .NET apps](https://learn.microsoft.com/en-us/aspnet/core/grpc/protobuf).
+This package supports types generated from `.proto` files using Google.Protobuf. For detailed information on creating Protobuf messages and configuring your project, see [Create Protobuf messages for .NET apps](https://learn.microsoft.com/aspnet/core/grpc/protobuf).
 
 Once you have defined your Protobuf messages and configured code generation, you can use them directly in your grain interfaces:
 
@@ -62,9 +62,9 @@ public class MyGrain : Grain, IMyGrain
 
 ## Documentation
 For more comprehensive documentation, please refer to:
-- [Create Protobuf messages for .NET apps](https://learn.microsoft.com/en-us/aspnet/core/grpc/protobuf) - Official guide for working with Protobuf in .NET
-- [Microsoft Orleans Documentation](https://learn.microsoft.com/dotnet/orleans/)
-- [Orleans Serialization](https://learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/serialization)
+- [Create Protobuf messages for .NET apps](https://learn.microsoft.com/aspnet/core/grpc/protobuf) - Official guide for working with Protobuf in .NET
+- [Microsoft Orleans Documentation](https://dotnet.github.io/orleans/docs/)
+- [Orleans Serialization](https://dotnet.github.io/orleans/docs/host/configuration-guide/serialization/)
 
 ## Feedback & Contributing
 - If you have any issues or would like to provide feedback, please [open an issue on GitHub](https://github.com/dotnet/orleans/issues)


### PR DESCRIPTION
Package READMEs linked to Orleans documentation on Microsoft Learn. Some of those links pointed at paths that were reorganized (`/dotnet/orleans/implementation/...`, `/host/...`, `/grains/...`) and returned HTTP 404. Because these READMEs ship inside the NuGet packages, the dead links were visible on the nuget.org package pages. Separately, Orleans documentation is migrating to https://dotnet.github.io/orleans, so these links should point at the docs site rather than the Learn copy.

This first repoints each dead link at its correct current topic, and removes bullets that had no matching page rather than sending readers somewhere misleading. It then rewrites every `learn.microsoft.com/dotnet/orleans` link across the package READMEs to its `dotnet.github.io/orleans/docs` equivalent, normalizing retired `index` suffixes and using the site's canonical trailing-slash form. Links to non-Orleans Microsoft documentation (.NET, Azure, ASP.NET Core, Aspire) stay on Microsoft Learn, with the hard-coded `/en-us/` locale segment removed per `docs/AGENTS.md`.

Every link in the modified files was checked and resolves.