### PR TITLE
test: exercise distributed grain directory in CI

### DIFF
--- a/docs/site/src/content/docs/implementation/testing.md
+++ b/docs/site/src/content/docs/implementation/testing.md
@@ -50,6 +50,7 @@ API: <xref:Orleans.TestingHost.InProcessTestClusterBuilder>, <xref:Orleans.Testi
 | <xref:Orleans.TestingHost.InProcessTestClusterOptions.InitializeClientOnDeploy?displayProperty=nameWithType> | `true` |
 | Test-cluster membership | `true` |
 | Test-cluster grain directory | `true` |
+| <xref:Orleans.TestingHost.InProcessTestClusterOptions.UseDistributedGrainDirectory?displayProperty=nameWithType> | `false` |
 | <xref:Orleans.TestingHost.InProcessTestClusterOptions.GatewayPerSilo?displayProperty=nameWithType> | `true` |
 | <xref:Orleans.TestingHost.InProcessTestClusterOptions.UseRealEnvironmentStatistics?displayProperty=nameWithType> | `false` |
 | Connection transport | In-memory |

--- a/src/Orleans.TestingHost/ConfigureDistributedGrainDirectory.cs
+++ b/src/Orleans.TestingHost/ConfigureDistributedGrainDirectory.cs
@@ -1,10 +1,28 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.GrainDirectory;
 using Orleans.Hosting;
+using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.Hosting;
 
 namespace Orleans.TestingHost;
 
 internal class ConfigureDistributedGrainDirectory : ISiloConfigurator
 {
 #pragma warning disable ORLEANSEXP003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    public void Configure(ISiloBuilder siloBuilder) => siloBuilder.AddDistributedGrainDirectory();
+    public void Configure(ISiloBuilder siloBuilder)
+    {
+        if (siloBuilder.Services.Any(static service => service.ServiceType == typeof(DistributedGrainDirectory)))
+        {
+            siloBuilder.Services.AddSingleton(
+                static _ => new NamedService<IGrainDirectory>(GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY));
+            siloBuilder.Services.AddKeyedSingleton<IGrainDirectory>(
+                GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY,
+                static (services, _) => services.GetRequiredService<DistributedGrainDirectory>());
+        }
+        else
+        {
+            siloBuilder.AddDistributedGrainDirectory();
+        }
+    }
 #pragma warning restore ORLEANSEXP003 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 }

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -785,10 +785,15 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
                 if (Options.UseTestClusterMembership)
                 {
                     services.AddSingleton<IMembershipTable>(_membershipTable);
-                    if (Options.UseTestClusterGrainDirectory)
+                    if (!Options.UseDistributedGrainDirectory && Options.UseTestClusterGrainDirectory)
                     {
                         siloBuilder.AddGrainDirectory(GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY, (_, _) => _grainDirectory);
                     }
+                }
+
+                if (Options.UseDistributedGrainDirectory)
+                {
+                    new ConfigureDistributedGrainDirectory().Configure(siloBuilder);
                 }
 
                 siloBuilder.UseInMemoryConnectionTransport(_transportHub);

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -785,13 +785,17 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
                 if (Options.UseTestClusterMembership)
                 {
                     services.AddSingleton<IMembershipTable>(_membershipTable);
+#pragma warning disable ORLEANSEXP003
                     if (!Options.UseDistributedGrainDirectory && Options.UseTestClusterGrainDirectory)
+#pragma warning restore ORLEANSEXP003
                     {
                         siloBuilder.AddGrainDirectory(GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY, (_, _) => _grainDirectory);
                     }
                 }
 
+#pragma warning disable ORLEANSEXP003
                 if (Options.UseDistributedGrainDirectory)
+#pragma warning restore ORLEANSEXP003
                 {
                     new ConfigureDistributedGrainDirectory().Configure(siloBuilder);
                 }

--- a/src/Orleans.TestingHost/InProcTestClusterOptions.cs
+++ b/src/Orleans.TestingHost/InProcTestClusterOptions.cs
@@ -50,6 +50,12 @@ public sealed class InProcessTestClusterOptions
     internal bool UseTestClusterGrainDirectory { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to use the experimental distributed grain directory.
+    /// </summary>
+    /// <value><see langword="true" /> if the distributed grain directory should be used; otherwise, <see langword="false" />.</value>
+    public bool UseDistributedGrainDirectory { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether to use the real environment statistics.
     /// </summary>
     public bool UseRealEnvironmentStatistics { get; set; }

--- a/src/Orleans.TestingHost/InProcTestClusterOptions.cs
+++ b/src/Orleans.TestingHost/InProcTestClusterOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Hosting;
 using Orleans.Configuration;
 using Orleans.Hosting;
@@ -53,6 +54,7 @@ public sealed class InProcessTestClusterOptions
     /// Gets or sets a value indicating whether to use the experimental distributed grain directory.
     /// </summary>
     /// <value><see langword="true" /> if the distributed grain directory should be used; otherwise, <see langword="false" />.</value>
+    [Experimental("ORLEANSEXP003")]
     public bool UseDistributedGrainDirectory { get; set; }
 
     /// <summary>

--- a/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
+++ b/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
@@ -216,6 +216,7 @@ namespace Orleans.TestingHost
 
         public System.Collections.Generic.List<System.Action<InProcessTestSiloSpecificOptions, Microsoft.Extensions.Hosting.IHostApplicationBuilder>> SiloHostConfigurationDelegates { get { throw null; } }
 
+        [System.Diagnostics.CodeAnalysis.Experimental("ORLEANSEXP003")]
         public bool UseDistributedGrainDirectory { get { throw null; } set { } }
 
         public bool UseRealEnvironmentStatistics { get { throw null; } set { } }

--- a/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
+++ b/src/api/Orleans.TestingHost/Orleans.TestingHost.cs
@@ -216,6 +216,8 @@ namespace Orleans.TestingHost
 
         public System.Collections.Generic.List<System.Action<InProcessTestSiloSpecificOptions, Microsoft.Extensions.Hosting.IHostApplicationBuilder>> SiloHostConfigurationDelegates { get { throw null; } }
 
+        public bool UseDistributedGrainDirectory { get { throw null; } set { } }
+
         public bool UseRealEnvironmentStatistics { get { throw null; } set { } }
     }
 

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
@@ -386,7 +386,9 @@ public class GrainDirectoryLeaseTests
     {
         var timeProvider = new FakeTimeProvider(InitialTime);
         var builder = new InProcessTestClusterBuilder(2);
+#pragma warning disable ORLEANSEXP003
         builder.Options.UseDistributedGrainDirectory = true;
+#pragma warning restore ORLEANSEXP003
         builder.ConfigureSilo((_, siloBuilder) =>
         {
             siloBuilder.Services.AddSingleton<MembershipTableManager>();

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
 using Orleans.Configuration;
 using Orleans.Runtime.Diagnostics;
 using Orleans.Runtime.GrainDirectory;
+using Orleans.Runtime.MembershipService;
 using Orleans.Runtime.Placement;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Diagnostics;
@@ -23,7 +25,7 @@ public class LeaseTestGrain : Grain, ILeaseTestGrain
     public Task<SiloAddress> GetAddress() => Task.FromResult(Runtime.SiloAddress);
 }
 
-[TestCategory("Lease"), TestCategory("Directory")]
+[TestCategory("BVT"), TestCategory("Lease"), TestCategory("Directory")]
 public class GrainDirectoryLeaseTests
 {
     private static readonly DateTimeOffset InitialTime = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
@@ -48,7 +50,7 @@ public class GrainDirectoryLeaseTests
             Assert.Equal(secondary.SiloAddress, await leaseGrain.GetAddress());
 
             var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(events, primary.SiloAddress, secondary.SiloAddress);
-            await cluster.KillSiloAsync(secondary);
+            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary);
             await leaseCreated;
             var directory = primary.ServiceProvider.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
 
@@ -95,7 +97,7 @@ public class GrainDirectoryLeaseTests
             Assert.Equal(secondary.SiloAddress, await leaseGrain.GetAddress());
 
             var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(events, primary.SiloAddress, secondary.SiloAddress);
-            await cluster.KillSiloAsync(secondary);
+            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary);
             await leaseCreated;
 
             var grainLocator = primary.ServiceProvider.GetRequiredService<CachedGrainLocator>();
@@ -269,7 +271,7 @@ public class GrainDirectoryLeaseTests
             Assert.Equal(secondary.SiloAddress, await leaseGrain.GetAddress());
 
             // Ungraceful kill, but leases are disabled (duration = Zero).
-            await cluster.KillSiloAsync(secondary);
+            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary);
 
             var directory = primary.ServiceProvider.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
             var fakeAddress = GrainAddress.NewActivationAddress(primary.SiloAddress, leaseGrain.GetGrainId());
@@ -304,7 +306,7 @@ public class GrainDirectoryLeaseTests
             Assert.Equal(secondary.SiloAddress, await leaseGrain.GetAddress());
 
             var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(events, primary.SiloAddress, secondary.SiloAddress);
-            await cluster.KillSiloAsync(secondary);
+            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary);
             await leaseCreated;
 
             var directory = primary.ServiceProvider.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
@@ -342,7 +344,7 @@ public class GrainDirectoryLeaseTests
             Assert.Equal(secondary.SiloAddress, await grain3.GetAddress());
 
             var leaseCreated = WaitForSiloLeaseHoldCreatedAsync(events, primary.SiloAddress, secondary.SiloAddress);
-            await cluster.KillSiloAsync(secondary);
+            await KillSiloAndWaitForDirectoryMembershipAsync(cluster, primary, secondary);
             await leaseCreated;
 
             var directory = primary.ServiceProvider.GetRequiredService<GrainDirectoryResolver>().DefaultGrainDirectory!;
@@ -384,20 +386,19 @@ public class GrainDirectoryLeaseTests
     {
         var timeProvider = new FakeTimeProvider(InitialTime);
         var builder = new InProcessTestClusterBuilder(2);
-        builder.Options.UseTestClusterGrainDirectory = false;
+        builder.Options.UseDistributedGrainDirectory = true;
         builder.ConfigureSilo((_, siloBuilder) =>
         {
+            siloBuilder.Services.AddSingleton<MembershipTableManager>();
+            siloBuilder.Services.AddSingleton<IMembershipManager, LeaseTestMembershipManager>();
             siloBuilder.Services.AddSingleton<TimeProvider>(timeProvider);
+            siloBuilder.Services.AddKeyedSingleton(TimeProviderNames.Membership, TimeProvider.System);
             siloBuilder.Services.Configure<ClusterMembershipOptions>(options =>
             {
                 options.ProbeTimeout = TimeSpan.FromSeconds(1);
                 options.NumMissedProbesLimit = 1;
             });
             siloBuilder.Services.PostConfigure<GrainDirectoryOptions>(o => o.RangeLeaseDuration = rangeLeaseDuration ?? RangeLeaseDuration);
-
-#pragma warning disable ORLEANSEXP003
-            siloBuilder.AddDistributedGrainDirectory();
-#pragma warning restore ORLEANSEXP003
         });
 
         return (builder.Build(), timeProvider);
@@ -413,6 +414,61 @@ public class GrainDirectoryLeaseTests
         {
             await cluster.DisposeAsync();
         }
+    }
+
+    private static async Task KillSiloAndWaitForDirectoryMembershipAsync(
+        InProcessTestCluster cluster,
+        InProcessSiloHandle observer,
+        InProcessSiloHandle victim)
+    {
+        using var timeout = new CancellationTokenSource(EventTimeout);
+        var membership = observer.ServiceProvider.GetRequiredService<ClusterMembershipService>();
+        var directoryMembership = observer.ServiceProvider.GetRequiredService<DirectoryMembershipService>();
+
+        var initialView = await WaitForDirectoryMembershipAsync(
+            cluster,
+            observer,
+            directoryMembership,
+            membership.CurrentSnapshot.Version,
+            timeout.Token);
+        Assert.Equal(SiloStatus.Active, initialView.ClusterMembershipSnapshot.GetSiloStatus(victim.SiloAddress));
+
+        await cluster.KillSiloAsync(victim);
+        await cluster.WaitForLivenessToStabilizeAsync(didKill: true);
+        var deadMembership = membership.CurrentSnapshot;
+        Assert.Equal(SiloStatus.Dead, deadMembership.GetSiloStatus(victim.SiloAddress));
+
+        var deadView = await WaitForDirectoryMembershipAsync(
+            cluster,
+            observer,
+            directoryMembership,
+            deadMembership.Version,
+            timeout.Token);
+        Assert.Equal(SiloStatus.Dead, deadView.ClusterMembershipSnapshot.GetSiloStatus(victim.SiloAddress));
+        Assert.True(deadView.ClusterMembershipSnapshot.Members[victim.SiloAddress].WasDeclaredDead);
+    }
+
+    private static async Task<DirectoryMembershipSnapshot> WaitForDirectoryMembershipAsync(
+        InProcessTestCluster cluster,
+        InProcessSiloHandle silo,
+        DirectoryMembershipService membership,
+        MembershipVersion targetVersion,
+        CancellationToken cancellationToken)
+    {
+        var view = membership.CurrentView.Version >= targetVersion
+            ? membership.CurrentView
+            : await membership.RefreshViewAsync(targetVersion, cancellationToken);
+
+        var partitionWaits = new Task[membership.PartitionsPerSilo];
+        for (var partitionIndex = 0; partitionIndex < partitionWaits.Length; partitionIndex++)
+        {
+            var partition = cluster.InternalClient!.GetSystemTarget<IGrainDirectoryTestHooks>(
+                GrainDirectoryPartition.CreateGrainId(silo.SiloAddress, partitionIndex).GrainId);
+            partitionWaits[partitionIndex] = partition.WaitForMembershipVersionAsync(view.Version).AsTask();
+        }
+
+        await Task.WhenAll(partitionWaits).WaitAsync(cancellationToken);
+        return view;
     }
 
     private static Task<DiagnosticEvent> WaitForSiloLeaseHoldCreatedAsync(
@@ -444,4 +500,50 @@ public class GrainDirectoryLeaseTests
                 && delayed.Operation == "RegisterAsync",
             EventTimeout);
 
+}
+
+internal sealed class LeaseTestMembershipManager(MembershipTableManager inner) : IMembershipManager
+{
+    private bool _gracefulShutdown;
+
+    public MembershipTableSnapshot CurrentSnapshot => ((IMembershipManager)inner).CurrentSnapshot;
+
+    public IAsyncEnumerable<MembershipTableSnapshot> MembershipUpdates => ((IMembershipManager)inner).MembershipUpdates;
+
+    public SiloStatus LocalSiloStatus => ((IMembershipManager)inner).LocalSiloStatus;
+
+    public bool CheckHealth(DateTime lastCheckTime, [NotNullWhen(false)] out string? reason) =>
+        ((IHealthCheckable)inner).CheckHealth(lastCheckTime, out reason);
+
+    public void Participate(ISiloLifecycle lifecycle) => ((ILifecycleParticipant<ISiloLifecycle>)inner).Participate(lifecycle);
+
+    public Task ProcessGossipSnapshot(MembershipTableSnapshot snapshot, CancellationToken cancellationToken) =>
+        ((IMembershipManager)inner).ProcessGossipSnapshot(snapshot, cancellationToken);
+
+    public Task Refresh(MembershipVersion? targetVersion, CancellationToken cancellationToken) =>
+        ((IMembershipManager)inner).Refresh(targetVersion, cancellationToken);
+
+    public Task<bool> TryKillSilo(SiloAddress silo, CancellationToken cancellationToken) =>
+        ((IMembershipManager)inner).TryKillSilo(silo, cancellationToken);
+
+    public Task<bool> TrySuspectSilo(SiloAddress silo, SiloAddress? indirectProbingSilo, CancellationToken cancellationToken) =>
+        ((IMembershipManager)inner).TrySuspectSilo(silo, indirectProbingSilo, cancellationToken);
+
+    public Task UpdateIAmAlive(CancellationToken cancellationToken) =>
+        ((IMembershipManager)inner).UpdateIAmAlive(cancellationToken);
+
+    public Task UpdateLocalStatus(SiloStatus status, CancellationToken cancellationToken)
+    {
+        if (status is SiloStatus.ShuttingDown)
+        {
+            _gracefulShutdown = true;
+        }
+
+        if (!_gracefulShutdown && status is SiloStatus.Stopping or SiloStatus.Dead)
+        {
+            return Task.CompletedTask;
+        }
+
+        return ((IMembershipManager)inner).UpdateLocalStatus(status, cancellationToken);
+    }
 }

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterDirectoryTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterDirectoryTests.cs
@@ -22,12 +22,34 @@ public sealed class InProcessTestClusterDirectoryTests
     public async Task DistributedDirectoryCanBeEnabled()
     {
         var builder = new InProcessTestClusterBuilder(1);
+#pragma warning disable ORLEANSEXP003
         builder.Options.UseDistributedGrainDirectory = true;
+#pragma warning restore ORLEANSEXP003
 
         await using var cluster = builder.Build();
         await cluster.DeployAsync();
 
         Assert.Equal("DistributedGrainDirectory", GetDefaultDirectory(cluster).GetType().Name);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task DistributedDirectoryCanBeEnabledWhenNamedDirectoryExists()
+    {
+        var builder = new InProcessTestClusterBuilder(1);
+#pragma warning disable ORLEANSEXP003
+        builder.Options.UseDistributedGrainDirectory = true;
+        builder.ConfigureSilo(static (_, siloBuilder) => siloBuilder.AddDistributedGrainDirectory("named"));
+#pragma warning restore ORLEANSEXP003
+
+        await using var cluster = builder.Build();
+        await cluster.DeployAsync();
+
+        var defaultDirectory = GetDefaultDirectory(cluster);
+        var namedDirectory = cluster.Silos[0].ServiceProvider.GetRequiredKeyedService<IGrainDirectory>("named");
+        Assert.Same(namedDirectory, defaultDirectory);
+        Assert.Single(
+            cluster.Silos[0].ServiceProvider.GetServices<ILifecycleParticipant<ISiloLifecycle>>(),
+            static participant => participant.GetType().Name == "DistributedGrainDirectory");
     }
 
     private static IGrainDirectory GetDefaultDirectory(InProcessTestCluster cluster) =>

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterDirectoryTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/InProcessTestClusterDirectoryTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.GrainDirectory;
+using TestExtensions;
+using Xunit;
+
+namespace Orleans.TestingHost.Tests;
+
+public sealed class InProcessTestClusterDirectoryTests
+{
+    [Fact, TestCategory("BVT")]
+    public async Task DefaultUsesTestDirectory()
+    {
+        var builder = new InProcessTestClusterBuilder(1);
+
+        await using var cluster = builder.Build();
+        await cluster.DeployAsync();
+
+        Assert.Equal("InProcessGrainDirectory", GetDefaultDirectory(cluster).GetType().Name);
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task DistributedDirectoryCanBeEnabled()
+    {
+        var builder = new InProcessTestClusterBuilder(1);
+        builder.Options.UseDistributedGrainDirectory = true;
+
+        await using var cluster = builder.Build();
+        await cluster.DeployAsync();
+
+        Assert.Equal("DistributedGrainDirectory", GetDefaultDirectory(cluster).GetType().Name);
+    }
+
+    private static IGrainDirectory GetDefaultDirectory(InProcessTestCluster cluster) =>
+        cluster.Silos[0].ServiceProvider.GetRequiredKeyedService<IGrainDirectory>(
+            GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY);
+}
+
+public sealed class OrleansInProcessTestClusterDirectoryTests(
+    OrleansInProcessTestClusterFixture fixture) : IClassFixture<OrleansInProcessTestClusterFixture>
+{
+    [Fact, TestCategory("BVT")]
+    public void OrleansFixtureUsesDistributedDirectory()
+    {
+        var registeredDirectory = fixture.HostedCluster.Silos[0].ServiceProvider.GetRequiredKeyedService<IGrainDirectory>(
+            GrainDirectoryAttribute.DEFAULT_GRAIN_DIRECTORY);
+        Assert.Equal("DistributedGrainDirectory", registeredDirectory.GetType().Name);
+    }
+}
+
+public sealed class OrleansInProcessTestClusterFixture : BaseInProcessTestClusterFixture;

--- a/test/TestInfrastructure/TestExtensions/BaseInProcessTestClusterFixture.cs
+++ b/test/TestInfrastructure/TestExtensions/BaseInProcessTestClusterFixture.cs
@@ -54,7 +54,9 @@ public abstract class BaseInProcessTestClusterFixture : Xunit.IAsyncLifetime
     {
         EnsurePreconditionsMet();
         var builder = new InProcessTestClusterBuilder();
+#pragma warning disable ORLEANSEXP003 // Distributed grain directory is enabled by default for Orleans tests.
         builder.Options.UseDistributedGrainDirectory = true;
+#pragma warning restore ORLEANSEXP003
         builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
         ConfigureTestCluster(builder);
 

--- a/test/TestInfrastructure/TestExtensions/BaseInProcessTestClusterFixture.cs
+++ b/test/TestInfrastructure/TestExtensions/BaseInProcessTestClusterFixture.cs
@@ -54,6 +54,7 @@ public abstract class BaseInProcessTestClusterFixture : Xunit.IAsyncLifetime
     {
         EnsurePreconditionsMet();
         var builder = new InProcessTestClusterBuilder();
+        builder.Options.UseDistributedGrainDirectory = true;
         builder.ConfigureHost(hostBuilder => TestDefaultConfiguration.ConfigureHostConfiguration(hostBuilder.Configuration));
         ConfigureTestCluster(builder);
 


### PR DESCRIPTION
Orleans' in-process test fixtures defaulted to the simplified test directory, limiting routine coverage of the experimental distributed grain directory.

This adds an explicit `UseDistributedGrainDirectory` TestingHost option while preserving the existing external default. Orleans' shared in-process fixture opts into the distributed directory, and the directory lease suite now participates in BVT with deterministic hard-kill membership and directory-view synchronization. Regression coverage verifies both the unchanged external default and the Orleans CI opt-in.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10399)