### PR TITLE
test(reminders): make failover tests deterministic

### DIFF
--- a/src/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/src/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -257,6 +257,21 @@ public sealed class ReminderDiagnosticObserver : IDisposable
     }
 
     /// <summary>
+    /// Gets the silos which currently host local owners for a reminder.
+    /// </summary>
+    public SiloAddress[] GetActiveReminderSilos(GrainId grainId, string reminderName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(reminderName);
+
+        lock (_lock)
+        {
+            return _activeLocalReminders.TryGetValue(new ReminderTickKey(grainId, reminderName), out var instances)
+                ? instances.Values.Select(instance => instance.SiloAddress).OfType<SiloAddress>().Distinct().ToArray()
+                : [];
+        }
+    }
+
+    /// <summary>
     /// Waits for a specific number of active local reminder owners for a reminder.
     /// </summary>
     public Task WaitForActiveReminderCountAsync(GrainId grainId, int expectedCount, CancellationToken cancellationToken, string reminderName)

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -152,27 +152,24 @@ namespace Tester.AzureUtils.TimerTests
             IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             using var cts = new CancellationTokenSource(CHURN_ENDWAIT);
 
-            Task<bool>[] tasks =
-            {
-                Task.Run(() => PerGrainMultiReminderTestChurn(g1, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTestChurn(g2, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTestChurn(g3, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTestChurn(g4, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTestChurn(g5, cts.Token), cts.Token),
-            };
-
-            await WaitForInitialReminderTicksAsync(cts.Token, g1, g2, g3, g4, g5);
-
-            // start two extra silos ... although it will take it a while before they stabilize
-            await using (await PauseReminderTimeAsync(cts.Token))
-            {
-                log.LogInformation("Starting 2 extra silos");
-                await this.StartAdditionalSilosAsync(2, true).WaitAsync(cts.Token);
-                await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
-            }
-
-            //Block until all tasks complete.
-            await Task.WhenAll(tasks).WaitAsync(cts.Token);
+            await Test_Reminders_MultiGrainMultiReminders(
+                async cancellationToken =>
+                {
+                    await using (await PauseReminderTimeAsync(cancellationToken))
+                    {
+                        log.LogInformation("Starting 2 extra silos");
+                        await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
+                            2,
+                            cancellationToken,
+                            startAdditionalSiloOnNewPort: true);
+                    }
+                },
+                cts.Token,
+                g1,
+                g2,
+                g3,
+                g4,
+                g5);
         }
 
         [SkippableFact, TestCategory("Functional")]
@@ -185,17 +182,14 @@ namespace Tester.AzureUtils.TimerTests
             IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             using var cts = new CancellationTokenSource(ENDWAIT);
 
-            Task<bool>[] tasks =
-            {
-                Task.Run(() => PerGrainMultiReminderTest(g1, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTest(g2, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTest(g3, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTest(g4, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTest(g5, cts.Token), cts.Token),
-            };
-
-            //Block until all tasks complete.
-            await Task.WhenAll(tasks).WaitAsync(cts.Token);
+            await Test_Reminders_MultiGrainMultiReminders(
+                afterFirstTick: null,
+                cts.Token,
+                g1,
+                g2,
+                g3,
+                g4,
+                g5);
         }
 
         [SkippableFact, TestCategory("Functional")]
@@ -204,95 +198,80 @@ namespace Tester.AzureUtils.TimerTests
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             using var cts = new CancellationTokenSource(ENDWAIT);
 
-            Task<bool> test = Task.Run(() => PerGrainFailureTest(g1, cts.Token), cts.Token);
+            await PrepareForGrainFailureAsync(cts.Token, g1);
 
-            await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), failAfter, cts.Token);
-                // stop the secondary silo
-                await using (await PauseReminderTimeAsync(cts.Token))
-                {
-                    log.LogInformation("Stopping secondary silo");
-                    await this.StopSiloAsync(this.GetSecondarySilo());
-                    await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
-                }
+            // stop the secondary silo
+            await using (await PauseReminderTimeAsync(cts.Token))
+            {
+                log.LogInformation("Stopping secondary silo");
+                await this.StopSiloAsync(this.GetSecondarySilo());
+                await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
+            }
 
-            await test.WaitAsync(cts.Token); // Block until test completes.
+            await CompleteGrainFailureTestAsync(cts.Token, g1);
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task Rem_Azure_2F_MultiGrain()
         {
-            var silos = await this.StartAdditionalSilosAsync(2, true);
+            using var cts = new CancellationTokenSource(ENDWAIT);
+            var silos = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
+                2,
+                cts.Token,
+                startAdditionalSiloOnNewPort: true);
 
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g2 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g3 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g4 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            using var cts = new CancellationTokenSource(ENDWAIT);
 
-            Task[] tasks =
-            {
-                Task.Run(() => PerGrainFailureTest(g1, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g2, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g3, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g4, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g5, cts.Token), cts.Token),
-            };
-
-            await WaitForInitialReminderTicksAsync(cts.Token, g1, g2, g3, g4, g5);
-            await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), failAfter, cts.Token);
+            IAddressable[] grains = [g1, g2, g3, g4, g5];
+            await PrepareForGrainFailureAsync(cts.Token, grains);
 
             // stop a couple of silos
             await using (await PauseReminderTimeAsync(cts.Token))
             {
                 log.LogInformation("Stopping 2 silos");
                 int i = Random.Shared.Next(silos.Count);
-                    await this.StopSiloAsync(silos[i]);
-                    silos.RemoveAt(i);
-                    await this.StopSiloAsync(silos[Random.Shared.Next(silos.Count)]);
-                    await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
-                }
+                await this.StopSiloAsync(silos[i]);
+                silos.RemoveAt(i);
+                await this.StopSiloAsync(silos[Random.Shared.Next(silos.Count)]);
+                await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
+            }
 
-            await Task.WhenAll(tasks).WaitAsync(cts.Token); // Block until all tasks complete.
+            await CompleteGrainFailureTestAsync(cts.Token, grains);
         }
 
         [SkippableFact, TestCategory("Functional")]
         public async Task Rem_Azure_1F1J_MultiGrain()
         {
-            var silos = await this.StartAdditionalSilosAsync(1);
-            await this.WaitForLivenessToStabilizeAsync();
+            using var cts = new CancellationTokenSource(ENDWAIT);
+            var silos = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g2 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g3 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g4 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            using var cts = new CancellationTokenSource(ENDWAIT);
 
-            Task[] tasks =
-            {
-                Task.Run(() => PerGrainFailureTest(g1, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g2, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g3, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g4, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g5, cts.Token), cts.Token),
-            };
-
-            await WaitForInitialReminderTicksAsync(cts.Token, g1, g2, g3, g4, g5);
-            await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), failAfter, cts.Token);
+            IAddressable[] grains = [g1, g2, g3, g4, g5];
+            await PrepareForGrainFailureAsync(cts.Token, grains);
 
             var siloToKill = silos[Random.Shared.Next(silos.Count)];
-                // stop a silo and join a new one in parallel
-                await using (await PauseReminderTimeAsync(cts.Token))
-                {
-                    log.LogInformation("Stopping a silo and joining a silo");
-                    Task t1 = this.StopSiloAsync(siloToKill);
-                    Task t2 = this.StartAdditionalSilosAsync(1, true);
-                    await Task.WhenAll(new[] { t1, t2 }).WaitAsync(cts.Token);
-                    await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
-                }
+            // stop a silo and join a new one
+            await using (await PauseReminderTimeAsync(cts.Token))
+            {
+                log.LogInformation("Stopping a silo and joining a silo");
+                await this.StopSiloAsync(siloToKill);
+                await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
+                await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
+                    1,
+                    cts.Token,
+                    startAdditionalSiloOnNewPort: true);
+            }
 
-            await Task.WhenAll(tasks).WaitAsync(cts.Token); // Block until all tasks complete.
+            await CompleteGrainFailureTestAsync(cts.Token, grains);
             log.LogInformation("\n\n\nReminderTest_1F1J_MultiGrain passed OK.\n\n\n");
         }
 
@@ -336,36 +315,28 @@ namespace Tester.AzureUtils.TimerTests
         [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/4319"), TestCategory("Functional")]
         public async Task Rem_Azure_GT_1F1J_MultiGrain()
         {
-            var silos = await this.StartAdditionalSilosAsync(1);
-            await this.WaitForLivenessToStabilizeAsync();
+            using var cts = new CancellationTokenSource(ENDWAIT);
+            var silos = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g2 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestCopyGrain g3 = this.GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
             IReminderTestCopyGrain g4 = this.GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
-            using var cts = new CancellationTokenSource(ENDWAIT);
 
-            Task[] tasks =
-            {
-                Task.Run(() => PerGrainFailureTest(g1, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g2, cts.Token), cts.Token),
-                Task.Run(() => PerCopyGrainFailureTest(g3, cts.Token), cts.Token),
-                Task.Run(() => PerCopyGrainFailureTest(g4, cts.Token), cts.Token),
-            };
-
-            await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), failAfter, cts.Token);
+            IAddressable[] grains = [g1, g2, g3, g4];
+            await PrepareForGrainFailureAsync(cts.Token, grains);
 
             var siloToKill = silos[Random.Shared.Next(silos.Count)];
-            // stop a silo and join a new one in parallel
+            // stop a silo and join a new one
             await using (await PauseReminderTimeAsync(cts.Token))
             {
                 log.LogInformation("Stopping a silo and joining a silo");
-                Task t1 = this.StopSiloAsync(siloToKill);
-                Task t2 = this.StartAdditionalSilosAsync(1);
-                await Task.WhenAll(new[] { t1, t2 }).WaitAsync(cts.Token);
+                await this.StopSiloAsync(siloToKill);
+                await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
+                await this.StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
             }
 
-            await Task.WhenAll(tasks).WaitAsync(cts.Token); // Block until all tasks complete.
+            await CompleteGrainFailureTestAsync(cts.Token, grains);
         }
 
         [SkippableFact, TestCategory("Functional")]

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -203,8 +203,9 @@ namespace Tester.AzureUtils.TimerTests
             // stop the secondary silo
             await using (await PauseReminderTimeAsync(cts.Token))
             {
-                log.LogInformation("Stopping secondary silo");
-                await this.StopSiloAsync(this.GetSecondarySilo());
+                var reminderOwner = this.GetReminderOwner(g1, DR);
+                log.LogInformation("Stopping reminder owner {SiloAddress}", reminderOwner.SiloAddress);
+                await this.StopSiloAsync(reminderOwner);
                 await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
             }
 
@@ -215,7 +216,7 @@ namespace Tester.AzureUtils.TimerTests
         public async Task Rem_Azure_2F_MultiGrain()
         {
             using var cts = new CancellationTokenSource(ENDWAIT);
-            var silos = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
+            _ = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
                 2,
                 cts.Token,
                 startAdditionalSiloOnNewPort: true);
@@ -233,10 +234,10 @@ namespace Tester.AzureUtils.TimerTests
             await using (await PauseReminderTimeAsync(cts.Token))
             {
                 log.LogInformation("Stopping 2 silos");
-                int i = Random.Shared.Next(silos.Count);
-                await this.StopSiloAsync(silos[i]);
-                silos.RemoveAt(i);
-                await this.StopSiloAsync(silos[Random.Shared.Next(silos.Count)]);
+                var reminderOwner = this.GetReminderOwner(g1, DR);
+                var otherSilo = this.HostedCluster.GetActiveSilos().First(silo => !silo.SiloAddress.Equals(reminderOwner.SiloAddress));
+                await this.StopSiloAsync(reminderOwner);
+                await this.StopSiloAsync(otherSilo);
                 await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
             }
 
@@ -247,7 +248,7 @@ namespace Tester.AzureUtils.TimerTests
         public async Task Rem_Azure_1F1J_MultiGrain()
         {
             using var cts = new CancellationTokenSource(ENDWAIT);
-            var silos = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
+            _ = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g2 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -258,15 +259,13 @@ namespace Tester.AzureUtils.TimerTests
             IAddressable[] grains = [g1, g2, g3, g4, g5];
             await PrepareForGrainFailureAsync(cts.Token, grains);
 
-            var siloToKill = silos[Random.Shared.Next(silos.Count)];
-            // stop a silo and join a new one
+            var siloToKill = this.GetReminderOwner(g1, DR);
+            // stop a silo and join a new one in parallel
             await using (await PauseReminderTimeAsync(cts.Token))
             {
                 log.LogInformation("Stopping a silo and joining a silo");
-                await this.StopSiloAsync(siloToKill);
-                await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
-                await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
-                    1,
+                await this.StopSiloAndStartAdditionalSiloAsync(
+                    siloToKill,
                     cts.Token,
                     startAdditionalSiloOnNewPort: true);
             }
@@ -316,7 +315,7 @@ namespace Tester.AzureUtils.TimerTests
         public async Task Rem_Azure_GT_1F1J_MultiGrain()
         {
             using var cts = new CancellationTokenSource(ENDWAIT);
-            var silos = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
+            _ = await this.StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestGrain2 g2 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -326,14 +325,12 @@ namespace Tester.AzureUtils.TimerTests
             IAddressable[] grains = [g1, g2, g3, g4];
             await PrepareForGrainFailureAsync(cts.Token, grains);
 
-            var siloToKill = silos[Random.Shared.Next(silos.Count)];
-            // stop a silo and join a new one
+            var siloToKill = this.GetReminderOwner(g1, DR);
+            // stop a silo and join a new one in parallel
             await using (await PauseReminderTimeAsync(cts.Token))
             {
                 log.LogInformation("Stopping a silo and joining a silo");
-                await this.StopSiloAsync(siloToKill);
-                await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
-                await this.StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
+                await this.StopSiloAndStartAdditionalSiloAsync(siloToKill, cts.Token);
             }
 
             await CompleteGrainFailureTestAsync(cts.Token, grains);

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
@@ -197,8 +197,9 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         // stop the secondary silo
         await using (await PauseReminderTimeAsync(cts.Token))
         {
-            log.LogInformation("Stopping secondary silo");
-            await StopSiloAsync(GetSecondarySilo());
+            var reminderOwner = GetReminderOwner(g1, DR);
+            log.LogInformation("Stopping reminder owner {SiloAddress}", reminderOwner.SiloAddress);
+            await StopSiloAsync(reminderOwner);
             await WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
         }
 
@@ -209,7 +210,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     public async Task Rem_Azure_2F_MultiGrain()
     {
         using var cts = new CancellationTokenSource(ENDWAIT);
-        var silos = await StartAdditionalSilosAndWaitForReminderServicesAsync(
+        _ = await StartAdditionalSilosAndWaitForReminderServicesAsync(
             2,
             cts.Token,
             startAdditionalSiloOnNewPort: true);
@@ -227,10 +228,10 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         await using (await PauseReminderTimeAsync(cts.Token))
         {
             log.LogInformation("Stopping 2 silos");
-            int i = Random.Shared.Next(silos.Count);
-            await StopSiloAsync(silos[i]);
-            silos.RemoveAt(i);
-            await StopSiloAsync(silos[Random.Shared.Next(silos.Count)]);
+            var reminderOwner = GetReminderOwner(g1, DR);
+            var otherSilo = HostedCluster.GetActiveSilos().First(silo => !silo.SiloAddress.Equals(reminderOwner.SiloAddress));
+            await StopSiloAsync(reminderOwner);
+            await StopSiloAsync(otherSilo);
             await WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
         }
 
@@ -241,7 +242,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     public async Task Rem_Azure_1F1J_MultiGrain()
     {
         using var cts = new CancellationTokenSource(ENDWAIT);
-        var silos = await StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
+        _ = await StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
         IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g2 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -252,15 +253,13 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         IAddressable[] grains = [g1, g2, g3, g4, g5];
         await PrepareForGrainFailureAsync(cts.Token, grains);
 
-        var siloToKill = silos[Random.Shared.Next(silos.Count)];
-        // stop a silo and join a new one
+        var siloToKill = GetReminderOwner(g1, DR);
+        // stop a silo and join a new one in parallel
         await using (await PauseReminderTimeAsync(cts.Token))
         {
             log.LogInformation("Stopping a silo and joining a silo");
-            await StopSiloAsync(siloToKill);
-            await WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
-            await StartAdditionalSilosAndWaitForReminderServicesAsync(
-                1,
+            await StopSiloAndStartAdditionalSiloAsync(
+                siloToKill,
                 cts.Token,
                 startAdditionalSiloOnNewPort: true);
         }
@@ -330,7 +329,7 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     public async Task Rem_Azure_GT_1F1J_MultiGrain()
     {
         using var cts = new CancellationTokenSource(ENDWAIT);
-        var silos = await StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
+        _ = await StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
         IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g2 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
@@ -340,14 +339,12 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         IAddressable[] grains = [g1, g2, g3, g4];
         await PrepareForGrainFailureAsync(cts.Token, grains);
 
-        var siloToKill = silos[Random.Shared.Next(silos.Count)];
-        // stop a silo and join a new one
+        var siloToKill = GetReminderOwner(g1, DR);
+        // stop a silo and join a new one in parallel
         await using (await PauseReminderTimeAsync(cts.Token))
         {
             log.LogInformation("Stopping a silo and joining a silo");
-            await StopSiloAsync(siloToKill);
-            await WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
-            await StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
+            await StopSiloAndStartAdditionalSiloAsync(siloToKill, cts.Token);
         }
 
         await CompleteGrainFailureTestAsync(cts.Token, grains);

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos.cs
@@ -146,27 +146,24 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         IReminderTestGrain2 g5 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         using var cts = new CancellationTokenSource(CHURN_ENDWAIT);
 
-        Task<bool>[] tasks =
-        {
-                Task.Run(() => PerGrainMultiReminderTestChurn(g1, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTestChurn(g2, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTestChurn(g3, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTestChurn(g4, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTestChurn(g5, cts.Token), cts.Token),
-            };
-
-        await WaitForInitialReminderTicksAsync(cts.Token, g1, g2, g3, g4, g5);
-
-        // start two extra silos ... although it will take it a while before they stabilize
-        await using (await PauseReminderTimeAsync(cts.Token))
-        {
-            log.LogInformation("Starting 2 extra silos");
-            await StartAdditionalSilosAsync(2, true).WaitAsync(cts.Token);
-            await WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
-        }
-
-        //Block until all tasks complete.
-        await Task.WhenAll(tasks).WaitAsync(cts.Token);
+        await Test_Reminders_MultiGrainMultiReminders(
+            async cancellationToken =>
+            {
+                await using (await PauseReminderTimeAsync(cancellationToken))
+                {
+                    log.LogInformation("Starting 2 extra silos");
+                    await StartAdditionalSilosAndWaitForReminderServicesAsync(
+                        2,
+                        cancellationToken,
+                        startAdditionalSiloOnNewPort: true);
+                }
+            },
+            cts.Token,
+            g1,
+            g2,
+            g3,
+            g4,
+            g5);
     }
 
     [SkippableFact, TestCategory("Functional")]
@@ -179,17 +176,14 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         IReminderTestGrain2 g5 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         using var cts = new CancellationTokenSource(ENDWAIT);
 
-        Task<bool>[] tasks =
-        {
-                Task.Run(() => PerGrainMultiReminderTest(g1, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTest(g2, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTest(g3, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTest(g4, cts.Token), cts.Token),
-                Task.Run(() => PerGrainMultiReminderTest(g5, cts.Token), cts.Token),
-            };
-
-        //Block until all tasks complete.
-        await Task.WhenAll(tasks).WaitAsync(cts.Token);
+        await Test_Reminders_MultiGrainMultiReminders(
+            afterFirstTick: null,
+            cts.Token,
+            g1,
+            g2,
+            g3,
+            g4,
+            g5);
     }
 
     [SkippableFact, TestCategory("Functional")]
@@ -198,9 +192,8 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
         IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         using var cts = new CancellationTokenSource(ENDWAIT);
 
-        Task<bool> test = Task.Run(() => PerGrainFailureTest(g1, cts.Token), cts.Token);
+        await PrepareForGrainFailureAsync(cts.Token, g1);
 
-        await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), failAfter, cts.Token);
         // stop the secondary silo
         await using (await PauseReminderTimeAsync(cts.Token))
         {
@@ -209,32 +202,26 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
             await WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
         }
 
-        await test.WaitAsync(cts.Token); // Block until test completes.
+        await CompleteGrainFailureTestAsync(cts.Token, g1);
     }
 
     [SkippableFact, TestCategory("Functional")]
     public async Task Rem_Azure_2F_MultiGrain()
     {
-        var silos = await StartAdditionalSilosAsync(2, true);
+        using var cts = new CancellationTokenSource(ENDWAIT);
+        var silos = await StartAdditionalSilosAndWaitForReminderServicesAsync(
+            2,
+            cts.Token,
+            startAdditionalSiloOnNewPort: true);
 
         IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g2 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g3 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g4 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g5 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        using var cts = new CancellationTokenSource(ENDWAIT);
 
-        Task[] tasks =
-        {
-                Task.Run(() => PerGrainFailureTest(g1, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g2, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g3, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g4, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g5, cts.Token), cts.Token),
-            };
-
-        await WaitForInitialReminderTicksAsync(cts.Token, g1, g2, g3, g4, g5);
-        await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), failAfter, cts.Token);
+        IAddressable[] grains = [g1, g2, g3, g4, g5];
+        await PrepareForGrainFailureAsync(cts.Token, grains);
 
         // stop a couple of silos
         await using (await PauseReminderTimeAsync(cts.Token))
@@ -247,46 +234,38 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
             await WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
         }
 
-        await Task.WhenAll(tasks).WaitAsync(cts.Token); // Block until all tasks complete.
+        await CompleteGrainFailureTestAsync(cts.Token, grains);
     }
 
     [SkippableFact, TestCategory("Functional")]
     public async Task Rem_Azure_1F1J_MultiGrain()
     {
-        var silos = await StartAdditionalSilosAsync(1);
-        await WaitForLivenessToStabilizeAsync();
+        using var cts = new CancellationTokenSource(ENDWAIT);
+        var silos = await StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
         IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g2 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g3 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g4 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g5 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-        using var cts = new CancellationTokenSource(ENDWAIT);
 
-        Task[] tasks =
-        {
-                Task.Run(() => PerGrainFailureTest(g1, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g2, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g3, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g4, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g5, cts.Token), cts.Token),
-            };
-
-        await WaitForInitialReminderTicksAsync(cts.Token, g1, g2, g3, g4, g5);
-        await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), failAfter, cts.Token);
+        IAddressable[] grains = [g1, g2, g3, g4, g5];
+        await PrepareForGrainFailureAsync(cts.Token, grains);
 
         var siloToKill = silos[Random.Shared.Next(silos.Count)];
-        // stop a silo and join a new one in parallel
+        // stop a silo and join a new one
         await using (await PauseReminderTimeAsync(cts.Token))
         {
             log.LogInformation("Stopping a silo and joining a silo");
-            Task t1 = StopSiloAsync(siloToKill);
-            Task t2 = StartAdditionalSilosAsync(1, true);
-            await Task.WhenAll(new[] { t1, t2 }).WaitAsync(cts.Token);
+            await StopSiloAsync(siloToKill);
             await WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
+            await StartAdditionalSilosAndWaitForReminderServicesAsync(
+                1,
+                cts.Token,
+                startAdditionalSiloOnNewPort: true);
         }
 
-        await Task.WhenAll(tasks).WaitAsync(cts.Token); // Block until all tasks complete.
+        await CompleteGrainFailureTestAsync(cts.Token, grains);
         log.LogInformation("\n\n\nReminderTest_1F1J_MultiGrain passed OK.\n\n\n");
     }
 
@@ -350,35 +329,28 @@ public class ReminderTests_Cosmos : ReminderTestsBase, IClassFixture<ReminderTes
     [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/4319"), TestCategory("Functional")]
     public async Task Rem_Azure_GT_1F1J_MultiGrain()
     {
-        var silos = await StartAdditionalSilosAsync(1);
-        await WaitForLivenessToStabilizeAsync();
+        using var cts = new CancellationTokenSource(ENDWAIT);
+        var silos = await StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
 
         IReminderTestGrain2 g1 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestGrain2 g2 = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         IReminderTestCopyGrain g3 = GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
         IReminderTestCopyGrain g4 = GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
-        using var cts = new CancellationTokenSource(ENDWAIT);
 
-        TimeSpan period = await g1.GetReminderPeriod(DR);
-
-        Task[] tasks =
-        {
-                Task.Run(() => PerGrainFailureTest(g1, cts.Token), cts.Token),
-                Task.Run(() => PerGrainFailureTest(g2, cts.Token), cts.Token),
-                Task.Run(() => PerCopyGrainFailureTest(g3, cts.Token), cts.Token),
-                Task.Run(() => PerCopyGrainFailureTest(g4, cts.Token), cts.Token),
-            };
-
-        Thread.Sleep(period.Multiply(failAfter));
+        IAddressable[] grains = [g1, g2, g3, g4];
+        await PrepareForGrainFailureAsync(cts.Token, grains);
 
         var siloToKill = silos[Random.Shared.Next(silos.Count)];
-        // stop a silo and join a new one in parallel
-        log.LogInformation("Stopping a silo and joining a silo");
-        Task t1 = StopSiloAsync(siloToKill);
-        Task t2 = StartAdditionalSilosAsync(1);
-        await Task.WhenAll(new[] { t1, t2 }).WaitAsync(cts.Token);
+        // stop a silo and join a new one
+        await using (await PauseReminderTimeAsync(cts.Token))
+        {
+            log.LogInformation("Stopping a silo and joining a silo");
+            await StopSiloAsync(siloToKill);
+            await WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
+            await StartAdditionalSilosAndWaitForReminderServicesAsync(1, cts.Token);
+        }
 
-        await Task.WhenAll(tasks).WaitAsync(cts.Token); // Block until all tasks complete.
+        await CompleteGrainFailureTestAsync(cts.Token, grains);
     }
 
     [SkippableFact, TestCategory("Functional")]

--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -26,6 +26,7 @@ namespace UnitTests.Grains
         private readonly IOptions<ReminderOptions> reminderOptions;
 
         private readonly ILogger logger;
+        private readonly ReminderCounterWaiter counterWaiter = new();
         private string _id = null!; // used to distinguish during debugging between multiple activations of the same grain
 
         private string filePrefix = null!;
@@ -52,6 +53,7 @@ namespace UnitTests.Grains
         public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             this.logger.LogInformation("OnDeactivateAsync");
+            counterWaiter.Deactivate(this.GrainId);
             return Task.CompletedTask;
         }
 
@@ -85,6 +87,7 @@ namespace UnitTests.Grains
 
             string fileName = GetFileName(reminderName);
             File.Delete(fileName); // if successfully started, then remove any old data
+            counterWaiter.Reset(reminderName);
             this.logger.LogInformation("Started reminder {Reminder}", r);
             return r;
         }
@@ -136,6 +139,7 @@ namespace UnitTests.Grains
             string fileName = GetFileName(reminderName);
             string counterValue = this.sequence[reminderName].ToString(CultureInfo.InvariantCulture);
             File.WriteAllText(fileName, counterValue);
+            counterWaiter.Signal(reminderName, sequenceNumber);
 
             return;
         }
@@ -213,6 +217,21 @@ namespace UnitTests.Grains
             return Task.FromResult(counterValue);
         }
 
+        public Task WaitForCounterForTestAsync(string reminderName, long target, CancellationToken cancellationToken)
+        {
+            long current;
+            try
+            {
+                current = long.Parse(File.ReadAllText(GetFileName(reminderName)), CultureInfo.InvariantCulture);
+            }
+            catch (FileNotFoundException)
+            {
+                current = 0;
+            }
+
+            return counterWaiter.WaitAsync(reminderName, target, current, cancellationToken);
+        }
+
         public Task<IGrainReminder?> GetReminderObject(string reminderName)
         {
             return this.GetReminder(reminderName);
@@ -256,6 +275,7 @@ namespace UnitTests.Grains
         private static readonly long aCCURACY = 50 * TimeSpan.TicksPerMillisecond; // when we use ticks to compute sequence numbers, we might get wrong results as timeouts don't happen with precision of ticks  ... we keep this as a leeway
 
         private readonly ILogger logger;
+        private readonly ReminderCounterWaiter counterWaiter = new();
         private long myId; // used to distinguish during debugging between multiple activations of the same grain
 
         private string filePrefix = null!;
@@ -280,6 +300,7 @@ namespace UnitTests.Grains
         public override Task OnDeactivateAsync(DeactivationReason reason, CancellationToken cancellationToken)
         {
             this.logger.LogInformation("OnDeactivateAsync.");
+            counterWaiter.Deactivate(this.GrainId);
             return Task.CompletedTask;
         }
 
@@ -308,6 +329,7 @@ namespace UnitTests.Grains
             }
 
             File.Delete(GetFileName(reminderName)); // if successfully started, then remove any old data
+            counterWaiter.Reset(reminderName);
             this.logger.LogInformation("Started reminder {Reminder}.", r);
             return r;
         }
@@ -358,6 +380,7 @@ namespace UnitTests.Grains
             this.logger.LogInformation("{ReminderName} Sequence # {SequenceNumber} with status {Status}.", reminderName, this.sequence[reminderName], status);
 
             File.WriteAllText(GetFileName(reminderName), this.sequence[reminderName].ToString());
+            counterWaiter.Signal(reminderName, sequenceNumber);
 
             return;
         }
@@ -410,6 +433,21 @@ namespace UnitTests.Grains
             return Task.FromResult(long.Parse(File.ReadAllText(GetFileName(name))));
         }
 
+        public Task WaitForCounterForTestAsync(string reminderName, long target, CancellationToken cancellationToken)
+        {
+            long current;
+            try
+            {
+                current = long.Parse(File.ReadAllText(GetFileName(reminderName)), CultureInfo.InvariantCulture);
+            }
+            catch (FileNotFoundException)
+            {
+                current = 0;
+            }
+
+            return counterWaiter.WaitAsync(reminderName, target, current, cancellationToken);
+        }
+
         public async Task<IGrainReminder?> GetReminderObject(string reminderName)
         {
             return await this.GetReminder(reminderName);
@@ -422,6 +460,107 @@ namespace UnitTests.Grains
         private string GetFileName(string reminderName)
         {
             return string.Format("{0}{1}", this.filePrefix, reminderName);
+        }
+    }
+
+    internal sealed class ReminderCounterWaiter
+    {
+        private readonly object lockObject = new();
+        private readonly Dictionary<string, long> counters = new();
+        private readonly Dictionary<string, List<(long Target, TaskCompletionSource Completion)>> waiters = new();
+
+        public async Task WaitAsync(string reminderName, long target, long current, CancellationToken cancellationToken)
+        {
+            TaskCompletionSource completion;
+            lock (lockObject)
+            {
+                current = Math.Max(current, counters.GetValueOrDefault(reminderName));
+                if (current >= target)
+                {
+                    return;
+                }
+
+                if (!waiters.TryGetValue(reminderName, out var reminderWaiters))
+                {
+                    reminderWaiters = [];
+                    waiters.Add(reminderName, reminderWaiters);
+                }
+
+                completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                reminderWaiters.Add((target, completion));
+            }
+
+            using var registration = cancellationToken.Register(
+                static state =>
+                {
+                    var (source, token) = ((TaskCompletionSource Source, CancellationToken Token))state!;
+                    source.TrySetCanceled(token);
+                },
+                (completion, cancellationToken));
+            await completion.Task.ConfigureAwait(false);
+        }
+
+        public void Signal(string reminderName, long current)
+        {
+            List<TaskCompletionSource>? completed = null;
+            lock (lockObject)
+            {
+                counters[reminderName] = current;
+                if (!waiters.TryGetValue(reminderName, out var reminderWaiters))
+                {
+                    return;
+                }
+
+                for (var i = reminderWaiters.Count - 1; i >= 0; i--)
+                {
+                    var waiter = reminderWaiters[i];
+                    if (waiter.Completion.Task.IsCompleted || current >= waiter.Target)
+                    {
+                        reminderWaiters.RemoveAt(i);
+                        if (!waiter.Completion.Task.IsCompleted)
+                        {
+                            (completed ??= []).Add(waiter.Completion);
+                        }
+                    }
+                }
+
+                if (reminderWaiters.Count == 0)
+                {
+                    waiters.Remove(reminderName);
+                }
+            }
+
+            if (completed is not null)
+            {
+                foreach (var completion in completed)
+                {
+                    completion.TrySetResult();
+                }
+            }
+        }
+
+        public void Reset(string reminderName)
+        {
+            lock (lockObject)
+            {
+                counters[reminderName] = 0;
+            }
+        }
+
+        public void Deactivate(GrainId grainId)
+        {
+            List<TaskCompletionSource> pending;
+            lock (lockObject)
+            {
+                pending = waiters.Values.SelectMany(static value => value.Select(static waiter => waiter.Completion)).ToList();
+                waiters.Clear();
+                counters.Clear();
+            }
+
+            foreach (var completion in pending)
+            {
+                completion.TrySetException(new InvalidOperationException($"Grain {grainId} deactivated while waiting for a reminder counter."));
+            }
         }
     }
 

--- a/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
+++ b/test/Grains/TestInternalGrains/ReminderTestGrain2.cs
@@ -217,20 +217,8 @@ namespace UnitTests.Grains
             return Task.FromResult(counterValue);
         }
 
-        public Task WaitForCounterForTestAsync(string reminderName, long target, CancellationToken cancellationToken)
-        {
-            long current;
-            try
-            {
-                current = long.Parse(File.ReadAllText(GetFileName(reminderName)), CultureInfo.InvariantCulture);
-            }
-            catch (FileNotFoundException)
-            {
-                current = 0;
-            }
-
-            return counterWaiter.WaitAsync(reminderName, target, current, cancellationToken);
-        }
+        public Task<bool> WaitForCounterForTestAsync(string reminderName, long target, long current, CancellationToken cancellationToken)
+            => counterWaiter.WaitAsync(reminderName, target, current, cancellationToken);
 
         public Task<IGrainReminder?> GetReminderObject(string reminderName)
         {
@@ -433,20 +421,8 @@ namespace UnitTests.Grains
             return Task.FromResult(long.Parse(File.ReadAllText(GetFileName(name))));
         }
 
-        public Task WaitForCounterForTestAsync(string reminderName, long target, CancellationToken cancellationToken)
-        {
-            long current;
-            try
-            {
-                current = long.Parse(File.ReadAllText(GetFileName(reminderName)), CultureInfo.InvariantCulture);
-            }
-            catch (FileNotFoundException)
-            {
-                current = 0;
-            }
-
-            return counterWaiter.WaitAsync(reminderName, target, current, cancellationToken);
-        }
+        public Task<bool> WaitForCounterForTestAsync(string reminderName, long target, long current, CancellationToken cancellationToken)
+            => counterWaiter.WaitAsync(reminderName, target, current, cancellationToken);
 
         public async Task<IGrainReminder?> GetReminderObject(string reminderName)
         {
@@ -467,17 +443,23 @@ namespace UnitTests.Grains
     {
         private readonly object lockObject = new();
         private readonly Dictionary<string, long> counters = new();
-        private readonly Dictionary<string, List<(long Target, TaskCompletionSource Completion)>> waiters = new();
+        private readonly Dictionary<string, List<(long Target, TaskCompletionSource<bool> Completion)>> waiters = new();
+        private bool deactivated;
 
-        public async Task WaitAsync(string reminderName, long target, long current, CancellationToken cancellationToken)
+        public async Task<bool> WaitAsync(string reminderName, long target, long current, CancellationToken cancellationToken)
         {
-            TaskCompletionSource completion;
+            TaskCompletionSource<bool> completion;
             lock (lockObject)
             {
+                if (deactivated)
+                {
+                    return false;
+                }
+
                 current = Math.Max(current, counters.GetValueOrDefault(reminderName));
                 if (current >= target)
                 {
-                    return;
+                    return true;
                 }
 
                 if (!waiters.TryGetValue(reminderName, out var reminderWaiters))
@@ -493,16 +475,33 @@ namespace UnitTests.Grains
             using var registration = cancellationToken.Register(
                 static state =>
                 {
-                    var (source, token) = ((TaskCompletionSource Source, CancellationToken Token))state!;
+                    var (source, token) = ((TaskCompletionSource<bool> Source, CancellationToken Token))state!;
                     source.TrySetCanceled(token);
                 },
                 (completion, cancellationToken));
-            await completion.Task.ConfigureAwait(false);
+            try
+            {
+                return await completion.Task.ConfigureAwait(false);
+            }
+            finally
+            {
+                lock (lockObject)
+                {
+                    if (waiters.TryGetValue(reminderName, out var reminderWaiters))
+                    {
+                        reminderWaiters.RemoveAll(waiter => ReferenceEquals(waiter.Completion, completion));
+                        if (reminderWaiters.Count == 0)
+                        {
+                            waiters.Remove(reminderName);
+                        }
+                    }
+                }
+            }
         }
 
         public void Signal(string reminderName, long current)
         {
-            List<TaskCompletionSource>? completed = null;
+            List<TaskCompletionSource<bool>>? completed = null;
             lock (lockObject)
             {
                 counters[reminderName] = current;
@@ -534,7 +533,7 @@ namespace UnitTests.Grains
             {
                 foreach (var completion in completed)
                 {
-                    completion.TrySetResult();
+                    completion.TrySetResult(true);
                 }
             }
         }
@@ -549,9 +548,10 @@ namespace UnitTests.Grains
 
         public void Deactivate(GrainId grainId)
         {
-            List<TaskCompletionSource> pending;
+            List<TaskCompletionSource<bool>> pending;
             lock (lockObject)
             {
+                deactivated = true;
                 pending = waiters.Values.SelectMany(static value => value.Select(static waiter => waiter.Completion)).ToList();
                 waiters.Clear();
                 counters.Clear();
@@ -559,7 +559,7 @@ namespace UnitTests.Grains
 
             foreach (var completion in pending)
             {
-                completion.TrySetException(new InvalidOperationException($"Grain {grainId} deactivated while waiting for a reminder counter."));
+                completion.TrySetResult(false);
             }
         }
     }

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -235,32 +235,36 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         CancellationToken cancellationToken,
         bool startAdditionalSiloOnNewPort = false)
     {
-        var result = new List<InProcessSiloHandle>(silosToStart);
-        for (var i = 0; i < silosToStart; i++)
-        {
-            var started = await StartAdditionalSilosAsync(1, startAdditionalSiloOnNewPort).WaitAsync(cancellationToken);
-            var silo = Assert.Single(started);
-            var reminderServiceStarted = observer.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress);
-            await Task.WhenAll(
-                reminderServiceStarted,
-                WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken));
-            result.Add(silo);
-        }
-
+        var result = await StartAdditionalSilosAsync(silosToStart, startAdditionalSiloOnNewPort).WaitAsync(cancellationToken);
+        var reminderServicesStarted = result.Select(silo =>
+            observer.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress));
+        await Task.WhenAll(
+            Task.WhenAll(reminderServicesStarted),
+            WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken));
         return result;
     }
 
-    protected InProcessSiloHandle GetSecondarySilo()
+    protected async Task<InProcessSiloHandle> StopSiloAndStartAdditionalSiloAsync(
+        InProcessSiloHandle siloToStop,
+        CancellationToken cancellationToken,
+        bool startAdditionalSiloOnNewPort = false)
     {
-        foreach (var silo in HostedCluster.GetActiveSilos())
-        {
-            if (silo.InstanceNumber != 0)
-            {
-                return silo;
-            }
-        }
+        var stopTask = StopSiloAsync(siloToStop);
+        var startTask = StartAdditionalSilosAsync(1, startAdditionalSiloOnNewPort);
+        await Task.WhenAll(stopTask, startTask).WaitAsync(cancellationToken);
 
-        throw new InvalidOperationException("Expected at least one non-primary silo.");
+        var silo = Assert.Single(await startTask);
+        await Task.WhenAll(
+            observer.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress),
+            WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken));
+        return silo;
+    }
+
+    protected InProcessSiloHandle GetReminderOwner(IAddressable grain, string reminderName)
+    {
+        var siloAddress = Assert.Single(observer.GetActiveReminderSilos(grain.GetGrainId(), reminderName));
+        return HostedCluster.GetSiloForAddress(siloAddress)
+            ?? throw new InvalidOperationException($"Could not find reminder owner {siloAddress} in the active test silos.");
     }
 
     protected Task StopSiloAsync(InProcessSiloHandle silo)
@@ -378,6 +382,21 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
             }));
 
             var counterWaitTasks = new List<Task>(reminders.Length);
+            var previousTickCounts = new int[reminders.Length];
+            var tickTasks = new Task[reminders.Length];
+            for (var reminderIndex = 0; reminderIndex < reminders.Length; reminderIndex++)
+            {
+                var reminder = reminders[reminderIndex];
+                previousTickCounts[reminderIndex] = observer.GetTickCount(
+                    reminder.Grain.GetGrainId(),
+                    reminder.ReminderName);
+                tickTasks[reminderIndex] = observer.WaitForTickCountAsync(
+                    reminder.Grain,
+                    previousTickCounts[reminderIndex] + 1,
+                    cancellationToken,
+                    reminder.ReminderName);
+            }
+
             foreach (var reminder in reminders)
             {
                 var current = await GetReminderCounterOrZeroAsync(reminder.Grain, reminder.ReminderName);
@@ -399,7 +418,27 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                 tickCount,
                 reminders.Length);
             await AdvanceReminderTimeAsync(period, cancellationToken);
-            await Task.WhenAll(counterWaitTasks);
+            await Task.WhenAll(Task.WhenAll(counterWaitTasks), Task.WhenAll(tickTasks));
+
+            await Task.WhenAll(reminders.Select(reminder =>
+                observer.WaitForLocalReminderScheduleAsync(
+                    reminder.Grain,
+                    reminder.ReminderName,
+                    cancellationToken)));
+            for (var reminderIndex = 0; reminderIndex < reminders.Length; reminderIndex++)
+            {
+                var reminder = reminders[reminderIndex];
+                Assert.Equal(
+                    1,
+                    observer.GetActiveReminderCount(
+                        reminder.Grain.GetGrainId(),
+                        reminder.ReminderName));
+                Assert.Equal(
+                    previousTickCounts[reminderIndex] + 1,
+                    observer.GetTickCount(
+                        reminder.Grain.GetGrainId(),
+                        reminder.ReminderName));
+            }
         }
     }
 
@@ -737,22 +776,30 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         long target,
         CancellationToken cancellationToken)
     {
-        if (!HostedCluster.TryGetGrainContext(grain.GetGrainId(), out var grainContext))
-        {
-            throw new InvalidOperationException($"Could not find an activation for grain {grain.GetGrainId()}.");
-        }
-
-        var waitTask = grainContext.GrainInstance switch
-        {
-            ReminderTestGrain2 reminderTestGrain => reminderTestGrain.WaitForCounterForTestAsync(reminderName, target, cancellationToken),
-            ReminderTestCopyGrain reminderTestCopyGrain => reminderTestCopyGrain.WaitForCounterForTestAsync(reminderName, target, cancellationToken),
-            { } instance => throw new InvalidOperationException($"Unexpected grain instance type {instance.GetType()} for grain {grain.GetGrainId()}."),
-            null => throw new InvalidOperationException($"Grain {grain.GetGrainId()} does not have an instance.")
-        };
-
         try
         {
-            await waitTask;
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var current = await GetReminderCounterOrZeroAsync(grain, reminderName);
+                if (!HostedCluster.TryGetGrainContext(grain.GetGrainId(), out var grainContext))
+                {
+                    await Task.Yield();
+                    continue;
+                }
+
+                var completed = grainContext.GrainInstance switch
+                {
+                    ReminderTestGrain2 reminderTestGrain => await reminderTestGrain.WaitForCounterForTestAsync(reminderName, target, current, cancellationToken),
+                    ReminderTestCopyGrain reminderTestCopyGrain => await reminderTestCopyGrain.WaitForCounterForTestAsync(reminderName, target, current, cancellationToken),
+                    { } instance => throw new InvalidOperationException($"Unexpected grain instance type {instance.GetType()} for grain {grain.GetGrainId()}."),
+                    null => false
+                };
+                if (completed)
+                {
+                    return;
+                }
+            }
         }
         catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
         {

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -9,6 +9,7 @@ using Orleans.Testing.Reminders;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
 using TestExtensions;
+using UnitTests.Grains;
 using UnitTests.GrainInterfaces;
 using Xunit;
 using ReminderEvents = Orleans.Reminders.Diagnostics.ReminderEvents;
@@ -35,8 +36,8 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
 
     protected const long retries = 3;
 
-    protected const long failAfter = 2; // NOTE: match this sleep with 'failCheckAfter' used in PerGrainFailureTest() so you dont try to get counter immediately after failure as new activation may not have the reminder statistics
-    protected const long failCheckAfter = 6; // safe value: 9
+    protected const long failAfter = 2;
+    protected const long failCheckAfter = 6;
     protected ILogger log;
     protected ReminderDiagnosticObserver observer;
     private ReminderTestClock ReminderClock { get; }
@@ -142,16 +143,13 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         // Wait for each reminder to tick twice using the observer
         log.LogInformation("Time tests");
         using var cts = new CancellationTokenSource(ENDWAIT);
-        for (int i = 0; i < count; i++)
-        {
-            await WaitForReminderCounterAsync(grain, DR + "_" + i, () => grain.GetCounter(DR + "_" + i), 2, cts.Token);
-        }
+        var reminderNames = Enumerable.Range(0, count).Select(i => DR + "_" + i).ToArray();
+        await AdvanceRemindersByTicksAsync(2, cts.Token, GetReminderIdentities([grain], reminderNames));
 
         // Verify via grain counters
-        for (int i = 0; i < count; i++)
+        foreach (var reminderName in reminderNames)
         {
-            long curr = await grain.GetCounter(DR + "_" + i);
-            Assert.True(curr >= 2, $"Reminder {DR}_{i} should have fired at least 2 times, but fired {curr}");
+            Assert.Equal(2, await grain.GetCounter(reminderName));
         }
     }
 
@@ -164,28 +162,24 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         IReminderTestGrain2 g5 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
         using var cts = new CancellationTokenSource(CHURN_ENDWAIT);
 
-        Task<bool>[] tasks =
-        [
-            Task.Run(() => this.PerGrainMultiReminderTestChurn(g1, cts.Token), cts.Token),
-            Task.Run(() => this.PerGrainMultiReminderTestChurn(g2, cts.Token), cts.Token),
-            Task.Run(() => this.PerGrainMultiReminderTestChurn(g3, cts.Token), cts.Token),
-            Task.Run(() => this.PerGrainMultiReminderTestChurn(g4, cts.Token), cts.Token),
-            Task.Run(() => this.PerGrainMultiReminderTestChurn(g5, cts.Token), cts.Token),
-        ];
-
-        // Wait for all grains to have at least one reminder tick before adding a silo
-        await WaitForInitialReminderTicksAsync(cts.Token, g1, g2, g3, g4, g5);
-
-        // start another silo ... although it will take it a while before it stabilizes
-        await using (await PauseReminderTimeAsync(cts.Token))
-        {
-            log.LogInformation("Starting another silo");
-            await this.StartAdditionalSilosAsync(1, true).WaitAsync(cts.Token);
-            await this.WaitForLivenessToStabilizeAsync().WaitAsync(cts.Token);
-        }
-
-        //Block until all tasks complete.
-        await Task.WhenAll(tasks).WaitAsync(cts.Token);
+        await Test_Reminders_MultiGrainMultiReminders(
+            async cancellationToken =>
+            {
+                await using (await PauseReminderTimeAsync(cancellationToken))
+                {
+                    log.LogInformation("Starting another silo");
+                    await this.StartAdditionalSilosAndWaitForReminderServicesAsync(
+                        1,
+                        cancellationToken,
+                        startAdditionalSiloOnNewPort: true);
+                }
+            },
+            cts.Token,
+            g1,
+            g2,
+            g3,
+            g4,
+            g5);
     }
 
     public async Task Test_Reminders_ReminderNotFound()
@@ -236,6 +230,26 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         return HostedCluster.WaitForLivenessToStabilizeAsync(didKill);
     }
 
+    protected async Task<List<InProcessSiloHandle>> StartAdditionalSilosAndWaitForReminderServicesAsync(
+        int silosToStart,
+        CancellationToken cancellationToken,
+        bool startAdditionalSiloOnNewPort = false)
+    {
+        var result = new List<InProcessSiloHandle>(silosToStart);
+        for (var i = 0; i < silosToStart; i++)
+        {
+            var started = await StartAdditionalSilosAsync(1, startAdditionalSiloOnNewPort).WaitAsync(cancellationToken);
+            var silo = Assert.Single(started);
+            var reminderServiceStarted = observer.WaitForReminderServiceStartedAsync(cancellationToken, silo.SiloAddress);
+            await Task.WhenAll(
+                reminderServiceStarted,
+                WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken));
+            result.Add(silo);
+        }
+
+        return result;
+    }
+
     protected InProcessSiloHandle GetSecondarySilo()
     {
         foreach (var silo in HostedCluster.GetActiveSilos())
@@ -254,93 +268,214 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         return HostedCluster.StopSiloAsync(silo);
     }
 
-    protected async Task WaitForInitialReminderTicksAsync(CancellationToken cancellationToken, params IReminderTestGrain2[] grains)
+    protected async Task Test_Reminders_MultiGrainMultiReminders(
+        Func<CancellationToken, Task>? afterFirstTick,
+        CancellationToken cancellationToken,
+        params IReminderTestGrain2[] grains)
+    {
+        ArgumentNullException.ThrowIfNull(grains);
+        Assert.NotEmpty(grains);
+
+        foreach (var grain in grains)
+        {
+            ArgumentNullException.ThrowIfNull(grain);
+            await ExecuteWithRetries(grain.StartReminder, DR);
+        }
+
+        await AdvanceRemindersByTicksAsync(1, cancellationToken, GetReminderIdentities(grains, DR));
+        await AssertReminderCountersAsync(grains, (DR, 1));
+
+        if (afterFirstTick is not null)
+        {
+            await afterFirstTick(cancellationToken);
+        }
+
+        await AdvanceRemindersByTicksAsync(1, cancellationToken, GetReminderIdentities(grains, DR));
+        await AssertReminderCountersAsync(grains, (DR, 2));
+
+        foreach (var grain in grains)
+        {
+            await ExecuteWithRetries(grain.StartReminder, R1);
+        }
+
+        await AdvanceRemindersByTicksAsync(2, cancellationToken, GetReminderIdentities(grains, DR, R1));
+        await AssertReminderCountersAsync(grains, (DR, 4), (R1, 2));
+
+        foreach (var grain in grains)
+        {
+            await ExecuteWithRetries(grain.StartReminder, R2);
+        }
+
+        await AdvanceRemindersByTicksAsync(2, cancellationToken, GetReminderIdentities(grains, DR, R1, R2));
+        await AssertReminderCountersAsync(grains, (DR, 6), (R1, 4), (R2, 2));
+
+        await AdvanceRemindersByTicksAsync(1, cancellationToken, GetReminderIdentities(grains, DR, R1, R2));
+        await AssertReminderCountersAsync(grains, (DR, 7), (R1, 5), (R2, 3));
+
+        await StopRemindersAsync(grains, R1, cancellationToken);
+        await AdvanceRemindersByTicksAsync(2, cancellationToken, GetReminderIdentities(grains, DR, R2));
+        await AssertReminderCountersAsync(grains, (DR, 9), (R1, 5), (R2, 5));
+
+        await StopRemindersAsync(grains, R2, cancellationToken);
+        await AdvanceRemindersByTicksAsync(1, cancellationToken, GetReminderIdentities(grains, DR));
+        await AssertReminderCountersAsync(grains, (DR, 10), (R1, 5), (R2, 5));
+
+        await StopRemindersAsync(grains, DR, cancellationToken);
+        await AdvanceReminderTimeAsync(await grains[0].GetReminderPeriod(DR), cancellationToken);
+        await AssertReminderCountersAsync(grains, (DR, 10), (R1, 5), (R2, 5));
+    }
+
+    protected async Task PrepareForGrainFailureAsync(CancellationToken cancellationToken, params IAddressable[] grains)
     {
         ArgumentNullException.ThrowIfNull(grains);
 
         foreach (var grain in grains)
         {
             ArgumentNullException.ThrowIfNull(grain);
-            await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 1, cancellationToken);
+            this.log.LogInformation("Preparing grain failure test for Grain={Grain}", grain);
+            await StartReminderAsync(grain, DR);
+        }
+
+        await AdvanceRemindersByTicksAsync((int)failAfter, cancellationToken, GetReminderIdentities(grains, DR));
+        await AssertReminderCountersAsync(grains, (DR, failAfter));
+    }
+
+    protected async Task CompleteGrainFailureTestAsync(CancellationToken cancellationToken, params IAddressable[] grains)
+    {
+        ArgumentNullException.ThrowIfNull(grains);
+        Assert.NotEmpty(grains);
+
+        await AdvanceRemindersByTicksAsync((int)(failCheckAfter - failAfter), cancellationToken, GetReminderIdentities(grains, DR));
+        await AssertReminderCountersAsync(grains, (DR, failCheckAfter));
+
+        await StopRemindersAsync(grains, DR, cancellationToken);
+        await AdvanceReminderTimeAsync(await GetReminderPeriodAsync(grains[0], DR), cancellationToken);
+        await AssertReminderCountersAsync(grains, (DR, failCheckAfter));
+    }
+
+    protected async Task AdvanceRemindersByTicksAsync(
+        int tickCount,
+        CancellationToken cancellationToken,
+        params (IAddressable Grain, string ReminderName)[] reminders)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(tickCount);
+        ArgumentNullException.ThrowIfNull(reminders);
+        Assert.NotEmpty(reminders);
+
+        for (var i = 0; i < tickCount; i++)
+        {
+            await Task.WhenAll(reminders.Select(async reminder =>
+            {
+                await observer.WaitForActiveReminderCountAsync(
+                    reminder.Grain,
+                    1,
+                    cancellationToken,
+                    reminder.ReminderName);
+                await observer.WaitForLocalReminderScheduleAsync(
+                    reminder.Grain,
+                    reminder.ReminderName,
+                    cancellationToken);
+            }));
+
+            var counterWaitTasks = new List<Task>(reminders.Length);
+            foreach (var reminder in reminders)
+            {
+                var current = await GetReminderCounterOrZeroAsync(reminder.Grain, reminder.ReminderName);
+                counterWaitTasks.Add(GetReminderCounterWaitTask(
+                    reminder.Grain,
+                    reminder.ReminderName,
+                    current + 1,
+                    cancellationToken));
+            }
+
+            var periods = await Task.WhenAll(reminders.Select(reminder =>
+                GetReminderPeriodAsync(reminder.Grain, reminder.ReminderName)));
+            var period = Assert.Single(periods.Distinct());
+
+            log.LogInformation(
+                "Advancing reminder time by {Period} for tick {TickNumber}/{TickCount} across {ReminderCount} reminders",
+                period,
+                i + 1,
+                tickCount,
+                reminders.Length);
+            await AdvanceReminderTimeAsync(period, cancellationToken);
+            await Task.WhenAll(counterWaitTasks);
         }
     }
 
-    protected async Task<bool> PerGrainMultiReminderTestChurn(IReminderTestGrain2 g, CancellationToken cancellationToken = default)
+    protected async Task AssertReminderCountersAsync(
+        IEnumerable<IAddressable> grains,
+        params (string ReminderName, long ExpectedCount)[] expectedCounters)
     {
-        // for churn cases, we do execute start and stop reminders with retries as we don't have the queue-ing
-        // functionality implemented on the LocalReminderService yet
-        this.log.LogInformation("PerGrainMultiReminderTestChurn Grain={Grain}", g);
+        ArgumentNullException.ThrowIfNull(grains);
+        ArgumentNullException.ThrowIfNull(expectedCounters);
 
-        // Start Default Reminder and wait for 2 persisted counter increments.
-        await ExecuteWithRetries(g.StartReminder, DR);
-        await WaitForAdditionalReminderCounterAsync(g, DR, () => g.GetCounter(DR), 2, cancellationToken);
-
-        // Start R1 and wait for 2 persisted counter increments.
-        await ExecuteWithRetries(g.StartReminder, R1);
-        await WaitForAdditionalReminderCounterAsync(g, R1, () => g.GetCounter(R1), 2, cancellationToken);
-
-        // Start R2 and wait for 2 persisted counter increments.
-        await ExecuteWithRetries(g.StartReminder, R2);
-        await WaitForAdditionalReminderCounterAsync(g, R2, () => g.GetCounter(R2), 2, cancellationToken);
-
-        // Wait for 1 more DR counter increment to verify all reminders are still running.
-        await WaitForAdditionalReminderCounterAsync(g, DR, () => g.GetCounter(DR), 1, cancellationToken);
-
-        // If this test asserts that R1 reached 4 ticks, wait on R1 itself rather than
-        // inferring progress from DR. This turns the old flaky floor into an explicit contract.
-        await WaitForReminderCounterAsync(g, R1, () => g.GetCounter(R1), 4, cancellationToken);
-
-        // Stop R1
-        await StopReminderAndWaitForQuiescenceAsync(g, R1, g.StopReminder, cancellationToken);
-        // Wait for 2 more DR counter increments to let things settle after R1 stop.
-        await WaitForAdditionalReminderCounterAsync(g, DR, () => g.GetCounter(DR), 2, cancellationToken);
-
-        // Stop R2
-        await StopReminderAndWaitForQuiescenceAsync(g, R2, g.StopReminder, cancellationToken);
-        // Wait for 1 more DR counter increment.
-        await WaitForAdditionalReminderCounterAsync(g, DR, () => g.GetCounter(DR), 1, cancellationToken);
-
-        // Stop Default reminder
-        await StopReminderAndWaitForQuiescenceAsync(g, DR, g.StopReminder, cancellationToken);
-
-        long lastR1 = await g.GetCounter(R1);
-        const long minimumReminder1Ticks = 4;
-        Assert.True(lastR1 >= minimumReminder1Ticks, $"R1 should have at least {minimumReminder1Ticks} ticks, got {lastR1}");
-
-        long lastR2 = await g.GetCounter(R2);
-        // R2 only gets its initial two observed ticks plus the DR-based settle window after R1 stops,
-        // so the observer-driven sequence guarantees 3 ticks here instead of the old 4-tick floor.
-        const long minimumReminder2Ticks = 3;
-        Assert.True(lastR2 >= minimumReminder2Ticks, $"R2 should have at least {minimumReminder2Ticks} ticks, got {lastR2}");
-
-        long lastDR = await g.GetCounter(DR);
-        // The observer-driven waits no longer spend two full periods between each step, so
-        // DEFAULT_REMINDER is guaranteed to reach 8 ticks here instead of the old 9-tick floor.
-        const long minimumDefaultReminderTicks = 8;
-        Assert.True(lastDR >= minimumDefaultReminderTicks, $"DR should have at least {minimumDefaultReminderTicks} ticks, got {lastDR}");
-
-        return true;
+        foreach (var grain in grains)
+        {
+            ArgumentNullException.ThrowIfNull(grain);
+            foreach (var expected in expectedCounters)
+            {
+                Assert.Equal(
+                    expected.ExpectedCount,
+                    await GetReminderCounterAsync(grain, expected.ReminderName));
+            }
+        }
     }
 
-    protected async Task<bool> PerGrainFailureTest(IReminderTestGrain2 grain, CancellationToken cancellationToken = default)
+    protected static (IAddressable Grain, string ReminderName)[] GetReminderIdentities(
+        IEnumerable<IAddressable> grains,
+        params string[] reminderNames)
     {
-        this.log.LogInformation("PerGrainFailureTest Grain={Grain}", grain);
-
-        await grain.StartReminder(DR);
-        long last = await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), failCheckAfter, cancellationToken);
-        Assert.True(last >= failCheckAfter, $"Expected at least {failCheckAfter} ticks, got {last}");
-
-        await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder, cancellationToken);
-        var stoppedCount = await grain.GetCounter(DR);
-        await AdvanceReminderTimeAsync(await GetReminderPeriodAsync(grain, DR), cancellationToken);
-
-        long curr = await grain.GetCounter(DR);
-        Assert.Equal(stoppedCount, curr);
-
-        return true;
+        ArgumentNullException.ThrowIfNull(grains);
+        ArgumentNullException.ThrowIfNull(reminderNames);
+        return
+        [
+            .. from grain in grains
+               from reminderName in reminderNames
+               select (grain, reminderName)
+        ];
     }
 
-    protected async Task<long> WaitForReminderCounterAsync(IAddressable grain, string reminderName, Func<Task<long>> getCounter, long minimumCount, CancellationToken cancellationToken = default)
+    protected async Task StopRemindersAsync(
+        IEnumerable<IAddressable> grains,
+        string reminderName,
+        CancellationToken cancellationToken)
+    {
+        var grainArray = grains.ToArray();
+        var unregisteredTasks = grainArray.Select(grain =>
+            observer.WaitForReminderUnregisteredAsync(grain, reminderName, cancellationToken)).ToArray();
+        var quiescenceTasks = grainArray.Select(grain =>
+            observer.WaitForReminderQuiescenceAsync(grain, reminderName, cancellationToken)).ToArray();
+
+        foreach (var grain in grainArray)
+        {
+            await ExecuteWithRetriesStop(
+                name => StopReminderAsync(grain, name),
+                reminderName);
+        }
+
+        await Task.WhenAll(unregisteredTasks);
+        await AdvanceReminderTimeAsync(ReminderClock.RefreshReminderListPeriod, cancellationToken);
+        try
+        {
+            await Task.WhenAll(quiescenceTasks);
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            var activeOwners = grainArray.Select(grain =>
+                $"{grain.GetGrainId()}={observer.GetActiveReminderCount(grain.GetGrainId(), reminderName)}");
+            throw new InvalidOperationException(
+                $"Timed out waiting for reminder '{reminderName}' owners to stop: {string.Join(", ", activeOwners)}",
+                exception);
+        }
+    }
+
+    protected async Task<long> WaitForReminderCounterAsync(
+        IAddressable grain,
+        string reminderName,
+        Func<Task<long>> getCounter,
+        long minimumCount,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(grain);
         ArgumentNullException.ThrowIfNull(getCounter);
@@ -369,16 +504,21 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
                 return result;
             }
 
-            await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cancellationToken);
             var nextTickTarget = observer.GetTickCount(grainId, reminderName) + 1;
             var waitTask = observer.WaitForTickCountAsync(grainId, nextTickTarget, cancellationToken, reminderName);
+            await observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cancellationToken);
             var reminderPeriod = await GetReminderPeriodAsync(grain, reminderName);
             await AdvanceReminderTimeAsync(reminderPeriod, cancellationToken);
             await waitTask;
         }
     }
 
-    protected async Task<long> WaitForAdditionalReminderCounterAsync(IAddressable grain, string reminderName, Func<Task<long>> getCounter, long additionalCount, CancellationToken cancellationToken = default)
+    protected async Task<long> WaitForAdditionalReminderCounterAsync(
+        IAddressable grain,
+        string reminderName,
+        Func<Task<long>> getCounter,
+        long additionalCount,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(grain);
         ArgumentNullException.ThrowIfNull(getCounter);
@@ -393,84 +533,20 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         {
         }
 
-        return await WaitForReminderCounterAsync(grain, reminderName, getCounter, currentCount + additionalCount, cancellationToken);
+        return await WaitForReminderCounterAsync(
+            grain,
+            reminderName,
+            getCounter,
+            currentCount + additionalCount,
+            cancellationToken);
     }
 
     protected async Task<bool> PerGrainMultiReminderTest(IReminderTestGrain2 g, CancellationToken cancellationToken = default)
     {
-        this.log.LogInformation("PerGrainMultiReminderTest Grain={Grain}", g);
-
-        // Each reminder is started then verified via observer ticks.
-        // Once all reminders have been started, stop them one at a time
-        // and verify stopped reminders no longer fire.
-
-        // Start Default Reminder and wait for first tick
-        await g.StartReminder(DR);
-        await WaitForReminderCounterAsync(g, DR, () => g.GetCounter(DR), 1, cancellationToken);
-        var reminders = await g.GetReminderStates();
-        Assert.True(reminders[DR].Fired.Count >= 1, $"DR should have fired at least 1 time, got {reminders[DR].Fired.Count}");
-
-        // Start R1 and wait for first tick
-        await g.StartReminder(R1);
-        await WaitForReminderCounterAsync(g, R1, () => g.GetCounter(R1), 1, cancellationToken);
-        reminders = await g.GetReminderStates();
-        Assert.True(reminders[R1].Fired.Count >= 1, $"R1 should have fired at least 1 time, got {reminders[R1].Fired.Count}");
-
-        // Start R2 and wait for first tick
-        await g.StartReminder(R2);
-        await WaitForReminderCounterAsync(g, R2, () => g.GetCounter(R2), 1, cancellationToken);
-        reminders = await g.GetReminderStates();
-        Assert.True(reminders[R2].Fired.Count >= 1, $"R2 should have fired at least 1 time, got {reminders[R2].Fired.Count}");
-        Assert.True(reminders[R1].Fired.Count >= 1, $"R1 should still be running, got {reminders[R1].Fired.Count}");
-        Assert.True(reminders[DR].Fired.Count >= 1, $"DR should still be running, got {reminders[DR].Fired.Count}");
-
-        // Stop R1, wait for quiescence, then confirm R2/DR continue while R1 remains stable.
-        await StopReminderAndWaitForQuiescenceAsync(g, R1, g.StopReminder, cancellationToken);
-        reminders = await g.GetReminderStates();
-        int r1CountAtStop = reminders[R1].Fired.Count;
-        await WaitForAdditionalReminderCounterAsync(g, R2, () => g.GetCounter(R2), 1, cancellationToken);
-        reminders = await g.GetReminderStates();
-        Assert.Equal(r1CountAtStop, reminders[R1].Fired.Count);
-        Assert.True(reminders[R2].Fired.Count >= 2, $"R2 should still be running, got {reminders[R2].Fired.Count}");
-
-        // Stop R2, wait for quiescence, then confirm DR continues while R1/R2 remain stable.
-        await StopReminderAndWaitForQuiescenceAsync(g, R2, g.StopReminder, cancellationToken);
-        reminders = await g.GetReminderStates();
-        int r2CountAtStop = reminders[R2].Fired.Count;
-        await WaitForAdditionalReminderCounterAsync(g, DR, () => g.GetCounter(DR), 1, cancellationToken);
-        reminders = await g.GetReminderStates();
-        Assert.Equal(r2CountAtStop, reminders[R2].Fired.Count);
-        Assert.Equal(r1CountAtStop, reminders[R1].Fired.Count);
-
-        // Stop Default reminder
-        await StopReminderAndWaitForQuiescenceAsync(g, DR, g.StopReminder, cancellationToken);
-        reminders = await g.GetReminderStates();
-        int drCountAtStop = reminders[DR].Fired.Count;
-        await AdvanceReminderTimeAsync(await GetReminderPeriodAsync(g, DR), cancellationToken);
-
-        reminders = await g.GetReminderStates();
-        Assert.Equal(drCountAtStop, reminders[DR].Fired.Count);
-        Assert.Equal(r1CountAtStop, reminders[R1].Fired.Count);
-        Assert.Equal(r2CountAtStop, reminders[R2].Fired.Count);
-
-        return true;
-    }
-
-    protected async Task<bool> PerCopyGrainFailureTest(IReminderTestCopyGrain grain, CancellationToken cancellationToken = default)
-    {
-        this.log.LogInformation("PerCopyGrainFailureTest Grain={Grain}", grain);
-
-        await grain.StartReminder(DR);
-        long last = await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), failCheckAfter, cancellationToken);
-        Assert.True(last >= failCheckAfter, $"Expected at least {failCheckAfter} ticks, got {last}");
-
-        await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder, cancellationToken);
-        var stoppedCount = await grain.GetCounter(DR);
-        await AdvanceReminderTimeAsync(await GetReminderPeriodAsync(grain, DR), cancellationToken);
-
-        long curr = await grain.GetCounter(DR);
-        Assert.Equal(stoppedCount, curr);
-
+        await Test_Reminders_MultiGrainMultiReminders(
+            afterFirstTick: null,
+            cancellationToken,
+            g);
         return true;
     }
 
@@ -507,7 +583,11 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         }
     }
 
-    protected async Task ExecuteWithRetries(Func<string, TimeSpan?, bool, Task> function, string reminderName, TimeSpan? period = null, bool validate = false)
+    protected async Task ExecuteWithRetries(
+        Func<string, TimeSpan?, bool, Task> function,
+        string reminderName,
+        TimeSpan? period = null,
+        bool validate = false)
     {
         for (long i = 1; i <= retries; i++)
         {
@@ -553,7 +633,11 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         await function(reminderName).WaitAsync(TestConstants.InitTimeout);
     }
 
-    protected async Task StopReminderAndWaitForQuiescenceAsync(IAddressable grain, string reminderName, Func<string, Task> stopReminder, CancellationToken cancellationToken = default)
+    protected async Task StopReminderAndWaitForQuiescenceAsync(
+        IAddressable grain,
+        string reminderName,
+        Func<string, Task> stopReminder,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(grain);
         ArgumentNullException.ThrowIfNull(stopReminder);
@@ -598,7 +682,7 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         if (ex is ReminderException)
         {
             this.log.LogInformation(ex, "Retryable operation failed on attempt {Attempt}", i);
-            await AdvanceReminderTimeAsync(TimeSpan.FromMilliseconds(10));
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
             return true;
         }
 
@@ -611,6 +695,81 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         {
             IReminderTestGrain2 reminderTestGrain2 => reminderTestGrain2.GetReminderPeriod(reminderName),
             IReminderTestCopyGrain reminderTestCopyGrain => reminderTestCopyGrain.GetReminderPeriod(reminderName),
+            _ => throw new InvalidOperationException($"Unsupported reminder test grain type: {grain.GetType().FullName}")
+        };
+    }
+
+    private static Task<IGrainReminder> StartReminderAsync(IAddressable grain, string reminderName)
+    {
+        return grain switch
+        {
+            IReminderTestGrain2 reminderTestGrain2 => reminderTestGrain2.StartReminder(reminderName),
+            IReminderTestCopyGrain reminderTestCopyGrain => reminderTestCopyGrain.StartReminder(reminderName),
+            _ => throw new InvalidOperationException($"Unsupported reminder test grain type: {grain.GetType().FullName}")
+        };
+    }
+
+    private static Task<long> GetReminderCounterAsync(IAddressable grain, string reminderName)
+    {
+        return grain switch
+        {
+            IReminderTestGrain2 reminderTestGrain2 => reminderTestGrain2.GetCounter(reminderName),
+            IReminderTestCopyGrain reminderTestCopyGrain => reminderTestCopyGrain.GetCounter(reminderName),
+            _ => throw new InvalidOperationException($"Unsupported reminder test grain type: {grain.GetType().FullName}")
+        };
+    }
+
+    private static async Task<long> GetReminderCounterOrZeroAsync(IAddressable grain, string reminderName)
+    {
+        try
+        {
+            return await GetReminderCounterAsync(grain, reminderName);
+        }
+        catch (FileNotFoundException)
+        {
+            return 0;
+        }
+    }
+
+    private async Task GetReminderCounterWaitTask(
+        IAddressable grain,
+        string reminderName,
+        long target,
+        CancellationToken cancellationToken)
+    {
+        if (!HostedCluster.TryGetGrainContext(grain.GetGrainId(), out var grainContext))
+        {
+            throw new InvalidOperationException($"Could not find an activation for grain {grain.GetGrainId()}.");
+        }
+
+        var waitTask = grainContext.GrainInstance switch
+        {
+            ReminderTestGrain2 reminderTestGrain => reminderTestGrain.WaitForCounterForTestAsync(reminderName, target, cancellationToken),
+            ReminderTestCopyGrain reminderTestCopyGrain => reminderTestCopyGrain.WaitForCounterForTestAsync(reminderName, target, cancellationToken),
+            { } instance => throw new InvalidOperationException($"Unexpected grain instance type {instance.GetType()} for grain {grain.GetGrainId()}."),
+            null => throw new InvalidOperationException($"Grain {grain.GetGrainId()} does not have an instance.")
+        };
+
+        try
+        {
+            await waitTask;
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            var current = await GetReminderCounterOrZeroAsync(grain, reminderName);
+            var activeOwners = observer.GetActiveReminderCount(grain.GetGrainId(), reminderName);
+            throw new InvalidOperationException(
+                $"Timed out waiting for reminder '{reminderName}' on grain {grain.GetGrainId()} to reach counter {target}. Current counter: {current}. Active owners: {activeOwners}.",
+                exception);
+        }
+    }
+
+    private static Task StopReminderAsync(IAddressable grain, string reminderName)
+    {
+        return grain switch
+        {
+            IReminderTestGrain2 reminderTestGrain2 => reminderTestGrain2.StopReminder(reminderName),
+            IReminderTestCopyGrain reminderTestCopyGrain => reminderTestCopyGrain.StopReminder(reminderName),
             _ => throw new InvalidOperationException($"Unsupported reminder test grain type: {grain.GetType().FullName}")
         };
     }

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTests_TableGrain.cs
@@ -129,6 +129,20 @@ namespace UnitTests.TimerTests
         }
 
         [Fact]
+        public async Task Rem_Grain_ConcurrentCounterWaitersUseSingleClockDriver()
+        {
+            using var cts = new CancellationTokenSource(TestConstants.InitTimeout);
+            var grains = Enumerable.Range(0, 16)
+                .Select(_ => this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid()))
+                .ToArray();
+
+            await Task.WhenAll(grains.Select(grain => grain.StartReminder(DR)));
+            await AdvanceRemindersByTicksAsync(1, cts.Token, GetReminderIdentities(grains, DR));
+            await AssertReminderCountersAsync(grains, (DR, 1));
+            await StopRemindersAsync(grains, DR, cts.Token);
+        }
+
+        [Fact]
         public async Task Rem_Grain_CanRestartBeforeRemovedReminderIsPurged()
         {
             using var cts = new CancellationTokenSource(TestConstants.InitTimeout);


### PR DESCRIPTION
Reminder failover and churn tests intermittently timed out because multiple workers advanced the same fake clock and topology tests resumed before newly joined silos completed reminder-service initialization. This could skip an armed schedule or advance time while reminder ownership was still moving.

This change replaces independent clock drivers with deterministic phases. A single orchestrator waits for exactly one local owner and an armed schedule, materializes direct grain counter barriers, advances exactly one reminder period, and asserts exact persisted counters. Joined silos must emit `ReminderServiceStarted` and reach liveness stability before reminder time resumes.

The test grains now expose test-only counter synchronization for in-process access through `TryGetGrainContext`. Stop/join operations are serialized, cleanup waits for quiescence after an exact refresh step, and timeout failures include the affected grain, reminder, expected counter, current counter, and owner state.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10400)