### PR TITLE
ci: enforce build and test results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
   build:
     name: Build
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -59,7 +58,6 @@ jobs:
   test-redis:
     name: Redis provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
     strategy:
@@ -116,7 +114,6 @@ jobs:
   test-cassandra:
     name: Cassandra provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
       CASSANDRA_IMAGE: cassandra:${{ matrix.dbversion }}
@@ -163,7 +160,6 @@ jobs:
   test-postgres:
     name: PostgreSQL provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
@@ -224,7 +220,6 @@ jobs:
   test-mariadb:
     name: MariaDB/MySQL provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
       # The official MariaDB 10.6 image is not published to GHCR. Use Google's Docker Hub mirror
@@ -306,7 +301,6 @@ jobs:
   test-sqlserver:
     name: Microsoft SQL Server provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
       ACCEPT_EULA: "Y"
@@ -369,7 +363,6 @@ jobs:
   test-azure-storage:
     name: Azure Storage provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
     strategy:
@@ -430,7 +423,6 @@ jobs:
   test-azure-eventhubs:
     name: Azure Event Hubs provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
     strategy:
@@ -515,7 +507,6 @@ jobs:
   test-azure-cosmosdb:
     name: Azure Cosmos DB provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
     strategy:
@@ -608,7 +599,6 @@ jobs:
   test-consul:
     name: Consul provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
     strategy:
@@ -651,7 +641,6 @@ jobs:
   test-zookeeper:
     name: ZooKeeper provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
     strategy:
@@ -706,7 +695,6 @@ jobs:
   test-dynamodb:
     name: AWS DynamoDB provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
@@ -773,7 +761,6 @@ jobs:
   test-sqs:
     name: AWS SQS provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
@@ -856,7 +843,6 @@ jobs:
   test-nats:
     name: NATS stream provider tests
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BuildExternalAssets: "false"
     strategy:
@@ -1008,7 +994,6 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       matrix:
         suite: [BVT, SlowBVT, Functional]
@@ -1049,7 +1034,6 @@ jobs:
   test-codegenerator:
     name: Test Code Generator
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
@@ -61,6 +62,7 @@ jobs:
     env:
       BuildExternalAssets: "false"
     strategy:
+      fail-fast: false
       matrix:
         provider: ["Redis"]
         framework: ["net8.0", "net10.0"]
@@ -118,6 +120,7 @@ jobs:
       BuildExternalAssets: "false"
       CASSANDRA_IMAGE: cassandra:${{ matrix.dbversion }}
     strategy:
+      fail-fast: false
       matrix:
         provider: ["Cassandra"]
         dbversion: ["4.0", "4.1", "5.0"]
@@ -165,6 +168,7 @@ jobs:
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
       POSTGRES_PASSWORD: postgres
     strategy:
+      fail-fast: false
       matrix:
         provider: ["PostgreSql"]
         framework: ["net8.0", "net10.0"]
@@ -228,6 +232,7 @@ jobs:
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
       MARIADB_ROOT_PASSWORD: "mariadb"
     strategy:
+      fail-fast: false
       matrix:
         provider: ["MySql"]
         framework: ["net8.0", "net10.0"]
@@ -308,6 +313,7 @@ jobs:
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
       SA_PASSWORD: "yourWeak(!)Password"
     strategy:
+      fail-fast: false
       matrix:
         provider: ["SqlServer"]
         framework: ["net8.0", "net10.0"]
@@ -366,6 +372,7 @@ jobs:
     env:
       BuildExternalAssets: "false"
     strategy:
+      fail-fast: false
       matrix:
         framework: ["net8.0", "net10.0"]
         provider: ["AzureStorage"]
@@ -426,6 +433,7 @@ jobs:
     env:
       BuildExternalAssets: "false"
     strategy:
+      fail-fast: false
       matrix:
         framework: ["net8.0", "net10.0"]
         provider: ["EventHub"]
@@ -510,6 +518,7 @@ jobs:
     env:
       BuildExternalAssets: "false"
     strategy:
+      fail-fast: false
       matrix:
         framework: ["net8.0", "net10.0"]
         provider: ["Cosmos"]
@@ -602,6 +611,7 @@ jobs:
     env:
       BuildExternalAssets: "false"
     strategy:
+      fail-fast: false
       matrix:
         provider: ["Consul"]
         framework: ["net8.0", "net10.0"]
@@ -644,6 +654,7 @@ jobs:
     env:
       BuildExternalAssets: "false"
     strategy:
+      fail-fast: false
       matrix:
         provider: ["ZooKeeper"]
         framework: ["net8.0", "net10.0"]
@@ -703,6 +714,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: pass
       AWS_REGION: us-east-1
     strategy:
+      fail-fast: false
       matrix:
         provider: ["DynamoDB"]
         framework: ["net8.0", "net10.0"]
@@ -769,6 +781,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: pass
       AWS_REGION: us-east-1
     strategy:
+      fail-fast: false
       matrix:
         provider: ["SQS"]
         framework: ["net8.0", "net10.0"]
@@ -846,6 +859,7 @@ jobs:
     env:
       BuildExternalAssets: "false"
     strategy:
+      fail-fast: false
       matrix:
         provider: ["NATS"]
         framework: ["net8.0", "net10.0"]
@@ -995,6 +1009,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         suite: [BVT, SlowBVT, Functional]
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -1035,6 +1050,7 @@ jobs:
     name: Test Code Generator
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         framework: ["net8.0", "net10.0"]
@@ -1068,6 +1084,7 @@ jobs:
     name: Google Cloud providers tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         provider: ["GoogleCloud"]
         framework: ["net8.0", "net10.0"]
@@ -1141,3 +1158,31 @@ jobs:
         path: |
           **/TestResults/*
           **/logs/*
+  ci:
+    name: CI
+    if: always()
+    needs:
+      - build
+      - test-redis
+      - test-cassandra
+      - test-postgres
+      - test-mariadb
+      - test-sqlserver
+      - test-azure-storage
+      - test-azure-eventhubs
+      - test-azure-cosmosdb
+      - test-consul
+      - test-zookeeper
+      - test-dynamodb
+      - test-sqs
+      - test-nats
+      - test-kinesis
+      - test
+      - test-codegenerator
+      - test-google
+    runs-on: ubuntu-latest
+    steps:
+    - name: Verify all CI jobs succeeded
+      env:
+        JOB_RESULTS: ${{ toJSON(needs) }}
+      run: jq --exit-status 'all(.[]; .result == "success")' <<< "$JOB_RESULTS"


### PR DESCRIPTION
Standard CI build and test jobs currently use job-level `continue-on-error`, so failures do not fail the workflow and cannot be enforced as required checks.

Remove those job-level exemptions from the build, provider-test, general-test, and code-generator-test jobs. Artifact-upload steps remain non-blocking so diagnostic upload failures do not mask the underlying result.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10402)