### PR TITLE
fix(ci): include omitted provider tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,7 @@ jobs:
         global-json-file: global.json
     - name: Test
       run: dotnet test
-        --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)"
+        --filter "(Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional))|(Category=Azure&Category=DurableJobs)"
         --framework ${{ matrix.framework }}
         --blame-hang-timeout 10m
         --blame-crash-dump-type full
@@ -681,7 +681,7 @@ jobs:
     - name: Test
       run: dotnet test
         --framework ${{ matrix.framework }}
-        --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)"
+        --filter "Category=${{ matrix.provider }}"
         --blame-hang-timeout 10m
         --blame-crash-dump-type full
         --blame-hang-dump-type full

--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureStorageDurableJobsConfigurationTests.cs
@@ -4,12 +4,14 @@ using Microsoft.Extensions.Options;
 using Orleans.DurableJobs;
 using Orleans.Journaling.Json;
 using Orleans.Hosting;
+using TestExtensions;
 using Xunit;
 
 namespace Tester.AzureUtils.DurableJobs;
 
 #pragma warning disable ORLEANSEXP005
 
+[TestCategory("Azure"), TestCategory("DurableJobs")]
 public class AzureStorageDurableJobsConfigurationTests
 {
     [Fact]


### PR DESCRIPTION
Azure Durable Jobs and ZooKeeper provider jobs currently select no tests because their traits do not include the generic suite categories required by the workflow filters. Redis streaming tests are likewise omitted because the Redis job excludes the Streaming category.

This broadens each provider job only to its intended provider-specific cases, tags the previously categoryless Azure Durable Jobs configuration test, and aligns Redis with the existing Event Hubs streaming filter. On net10.0, affected project discovery changes from 0 to 24 Azure Durable Jobs tests, 0 to 14 ZooKeeper tests, and 137 to 190 Redis tests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10403)