### PR TITLE
test(adonet): fix provider trait coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,8 @@ jobs:
           --health-interval 10s \
           --health-timeout 5s \
           --health-retries 5 \
-          "$POSTGRES_IMAGE"
+          "$POSTGRES_IMAGE" \
+          -c max_connections=200
 
         bash .github/scripts/docker-wait-for-health.sh postgres
     - name: Setup .NET

--- a/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/AdoNetGrainDirectoryClusterTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/AdoNetGrainDirectoryClusterTests.cs
@@ -12,7 +12,7 @@ namespace Tester.AdoNet.GrainDirectory;
 /// <summary>
 /// Cluster tests for ADO.NET Grain Directory against SQL Server.
 /// </summary>
-[TestCategory("SqlServer")]
+[TestCategory("SqlServer"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("GrainDirectory")]
 public class SqlServerAdoNetGrainDirectoryClusterTests() : AdoNetGrainDirectoryClusterTests(AdoNetInvariants.InvariantNameSqlServer)
 {
 }
@@ -20,7 +20,7 @@ public class SqlServerAdoNetGrainDirectoryClusterTests() : AdoNetGrainDirectoryC
 /// <summary>
 /// Cluster tests for ADO.NET Grain Directory against PostgreSQL.
 /// </summary>
-[TestCategory("PostgreSql")]
+[TestCategory("PostgreSql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("GrainDirectory")]
 public class PostgreSqlAdoNetGrainDirectoryClusterTests : AdoNetGrainDirectoryClusterTests
 {
     public PostgreSqlAdoNetGrainDirectoryClusterTests() : base(AdoNetInvariants.InvariantNamePostgreSql)
@@ -32,7 +32,7 @@ public class PostgreSqlAdoNetGrainDirectoryClusterTests : AdoNetGrainDirectoryCl
 /// <summary>
 /// Cluster tests for ADO.NET Grain Directory against MySQL.
 /// </summary>
-[TestCategory("MySql")]
+[TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("GrainDirectory")]
 public class MySqlAdoNetGrainDirectoryClusterTests : AdoNetGrainDirectoryClusterTests
 {
     public MySqlAdoNetGrainDirectoryClusterTests() : base(AdoNetInvariants.InvariantNameMySql)

--- a/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/AdoNetGrainDirectoryTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/AdoNetGrainDirectoryTests.cs
@@ -16,7 +16,7 @@ namespace Tester.AdoNet.GrainDirectory;
 /// <summary>
 /// Tests for <see cref="AdoNetGrainDirectory"/> against SQL Server.
 /// </summary>
-[TestCategory("SqlServer")]
+[TestCategory("SqlServer"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("GrainDirectory")]
 public class SqlServerAdoNetGrainDirectoryTests() : AdoNetGrainDirectoryTests(AdoNetInvariants.InvariantNameSqlServer, 90)
 {
 }
@@ -24,7 +24,7 @@ public class SqlServerAdoNetGrainDirectoryTests() : AdoNetGrainDirectoryTests(Ad
 /// <summary>
 /// Tests for <see cref="AdoNetGrainDirectory"/> against PostgreSQL.
 /// </summary>
-[TestCategory("PostgreSql")]
+[TestCategory("PostgreSql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("GrainDirectory")]
 public class PostgreSqlAdoNetGrainDirectoryTests : AdoNetGrainDirectoryTests
 {
     public PostgreSqlAdoNetGrainDirectoryTests() : base(AdoNetInvariants.InvariantNamePostgreSql, 90)
@@ -36,7 +36,7 @@ public class PostgreSqlAdoNetGrainDirectoryTests : AdoNetGrainDirectoryTests
 /// <summary>
 /// Tests for <see cref="AdoNetGrainDirectory"/> against MySQL.
 /// </summary>
-[TestCategory("MySql")]
+[TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("GrainDirectory")]
 public class MySqlAdoNetGrainDirectoryTests : AdoNetGrainDirectoryTests
 {
     public MySqlAdoNetGrainDirectoryTests() : base(AdoNetInvariants.InvariantNameMySql, 90)

--- a/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/AdoNetGrainDirectoryTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/AdoNetGrainDirectoryTests.cs
@@ -39,7 +39,7 @@ public class PostgreSqlAdoNetGrainDirectoryTests : AdoNetGrainDirectoryTests
 [TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("GrainDirectory")]
 public class MySqlAdoNetGrainDirectoryTests : AdoNetGrainDirectoryTests
 {
-    public MySqlAdoNetGrainDirectoryTests() : base(AdoNetInvariants.InvariantNameMySql, 90)
+    public MySqlAdoNetGrainDirectoryTests() : base(AdoNetInvariants.InvariantNameMySql, 20)
     {
         MySqlConnection.ClearAllPools();
     }

--- a/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/RelationalOrleansQueriesTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/RelationalOrleansQueriesTests.cs
@@ -10,7 +10,7 @@ namespace Tester.AdoNet.GrainDirectory;
 /// <summary>
 /// Tests the relational storage layer via <see cref="RelationalOrleansQueries"/> against Sql Server.
 /// </summary>
-[TestCategory("SqlServer")]
+[TestCategory("SqlServer"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("GrainDirectory")]
 public class SqlServerRelationalOrleansQueriesTests() : RelationalOrleansQueriesTests(AdoNetInvariants.InvariantNameSqlServer, 90)
 {
 }
@@ -18,7 +18,7 @@ public class SqlServerRelationalOrleansQueriesTests() : RelationalOrleansQueries
 /// <summary>
 /// Tests the relational storage layer via <see cref="RelationalOrleansQueries"/> against PostgreSQL.
 /// </summary>
-[TestCategory("PostgreSql")]
+[TestCategory("PostgreSql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("GrainDirectory")]
 public class PostgreSqlRelationalOrleansQueriesTests : RelationalOrleansQueriesTests
 {
     public PostgreSqlRelationalOrleansQueriesTests() : base(AdoNetInvariants.InvariantNamePostgreSql, 90)
@@ -30,7 +30,7 @@ public class PostgreSqlRelationalOrleansQueriesTests : RelationalOrleansQueriesT
 /// <summary>
 /// Tests the relational storage layer via <see cref="RelationalOrleansQueries"/> against MySQL.
 /// </summary>
-[TestCategory("MySql")]
+[TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("GrainDirectory")]
 public class MySqlRelationalOrleansQueriesTests : RelationalOrleansQueriesTests
 {
     public MySqlRelationalOrleansQueriesTests() : base(AdoNetInvariants.InvariantNameMySql, 90)

--- a/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/RelationalOrleansQueriesTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/GrainDirectory/RelationalOrleansQueriesTests.cs
@@ -33,7 +33,7 @@ public class PostgreSqlRelationalOrleansQueriesTests : RelationalOrleansQueriesT
 [TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("GrainDirectory")]
 public class MySqlRelationalOrleansQueriesTests : RelationalOrleansQueriesTests
 {
-    public MySqlRelationalOrleansQueriesTests() : base(AdoNetInvariants.InvariantNameMySql, 90)
+    public MySqlRelationalOrleansQueriesTests() : base(AdoNetInvariants.InvariantNameMySql, 20)
     {
         MySqlConnection.ClearAllPools();
     }

--- a/test/Extensions/Orleans.AdoNet.Tests/Properties/AssemblyInfo.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using Xunit;
 
-// Disable XUnit concurrency limit
-[assembly: CollectionBehavior(MaxParallelThreads = -1)]
+// ADO.NET tests recreate shared provider databases and cannot safely run in parallel.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/PostgreSqlStorageForTesting.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/RelationalUtilities/PostgreSqlStorageForTesting.cs
@@ -10,8 +10,24 @@ namespace Tester.RelationalUtilities
         protected override string ProviderMoniker => "PostgreSQL";
 
         public PostgreSqlStorageForTesting(string connectionString)
-            : base(AdoNetInvariants.InvariantNamePostgreSql, connectionString ?? TestDefaultConfiguration.PostgresConnectionString)
+            : base(AdoNetInvariants.InvariantNamePostgreSql, EnablePooling(connectionString ?? TestDefaultConfiguration.PostgresConnectionString))
         {
+        }
+
+        private static string EnablePooling(string? connectionString)
+        {
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new SkipException("ConnectionString not provided.");
+            }
+
+            var builder = new NpgsqlConnectionStringBuilder(connectionString)
+            {
+                Pooling = true
+            };
+
+            NpgsqlConnection.ClearAllPools();
+            return builder.ConnectionString;
         }
 
         public override string CancellationTestQuery { get { return "SELECT pg_sleep(10); SELECT 1; "; } }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetBatchContainerTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetBatchContainerTests.cs
@@ -9,7 +9,7 @@ namespace Tester.AdoNet.Streaming;
 /// Tests for <see cref="AdoNetBatchContainer"/>.
 /// </summary>
 [Collection(TestEnvironmentFixture.DefaultCollection)]
-[TestCategory("AdoNet"), TestCategory("Streaming")]
+[TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class AdoNetBatchContainerTests(TestEnvironmentFixture fixture)
 {
     [Fact]

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetClientStreamTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetClientStreamTests.cs
@@ -14,6 +14,7 @@ namespace Tester.AdoNet.Streaming;
 /// <summary>
 /// Tests for SQL Server ADO.NET client stream functionality.
 /// </summary>
+[TestCategory("SqlServer"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class SqlServerAdoNetClientStreamTests(ITestOutputHelper output) : AdoNetClientStreamTests(AdoNetInvariants.InvariantNameSqlServer, output)
 {
 }
@@ -21,6 +22,7 @@ public class SqlServerAdoNetClientStreamTests(ITestOutputHelper output) : AdoNet
 /// <summary>
 /// Tests for MySQL ADO.NET client stream functionality.
 /// </summary>
+[TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlAdoNetClientStreamTests : AdoNetClientStreamTests
 {
     public MySqlAdoNetClientStreamTests(ITestOutputHelper output) : base(AdoNetInvariants.InvariantNameMySql, output)
@@ -32,6 +34,7 @@ public class MySqlAdoNetClientStreamTests : AdoNetClientStreamTests
 /// <summary>
 /// Tests for PostgreSQL ADO.NET client stream functionality.
 /// </summary>
+[TestCategory("PostgreSql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class PostgreSqlAdoNetClientStreamTests(ITestOutputHelper output) : AdoNetClientStreamTests(AdoNetInvariants.InvariantNamePostgreSql, output)
 {
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterFactoryTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterFactoryTests.cs
@@ -15,6 +15,7 @@ namespace Tester.AdoNet.Streaming;
 /// <summary>
 /// Tests for <see cref="AdoNetQueueAdapterFactory"/> against SQL Server.
 /// </summary>
+[TestCategory("SqlServer"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class SqlServerAdoNetQueueAdapterFactoryTests(TestEnvironmentFixture fixture) : AdoNetQueueAdapterFactoryTests(AdoNetInvariants.InvariantNameSqlServer, fixture)
 {
 }
@@ -22,6 +23,7 @@ public class SqlServerAdoNetQueueAdapterFactoryTests(TestEnvironmentFixture fixt
 /// <summary>
 /// Tests for <see cref="AdoNetQueueAdapterFactory"/> against MySQL.
 /// </summary>
+[TestCategory("MySql"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlAdoNetQueueAdapterFactoryTests : AdoNetQueueAdapterFactoryTests
 {
     public MySqlAdoNetQueueAdapterFactoryTests(TestEnvironmentFixture fixture) : base(AdoNetInvariants.InvariantNameMySql, fixture)
@@ -33,6 +35,7 @@ public class MySqlAdoNetQueueAdapterFactoryTests : AdoNetQueueAdapterFactoryTest
 /// <summary>
 /// Tests for <see cref="AdoNetQueueAdapterFactory"/> against PostgreSQL.
 /// </summary>
+[TestCategory("PostgreSql"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class PostgreSqlAdoNetQueueAdapterFactoryTests(TestEnvironmentFixture fixture) : AdoNetQueueAdapterFactoryTests(AdoNetInvariants.InvariantNamePostgreSql, fixture)
 {
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterReceiverTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterReceiverTests.cs
@@ -13,6 +13,7 @@ namespace Tester.AdoNet.Streaming;
 /// <summary>
 /// Tests for <see cref="AdoNetQueueAdapterReceiverTests"/> against SQL Server.
 /// </summary>
+[TestCategory("SqlServer"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class SqlServerAdoNetQueueAdapterReceiverTests(TestEnvironmentFixture fixture) : AdoNetQueueAdapterReceiverTests(AdoNetInvariants.InvariantNameSqlServer, fixture)
 {
 }
@@ -20,6 +21,7 @@ public class SqlServerAdoNetQueueAdapterReceiverTests(TestEnvironmentFixture fix
 /// <summary>
 /// Tests for <see cref="AdoNetQueueAdapterReceiverTests"/> against MySQL.
 /// </summary>
+[TestCategory("MySql"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlAdoNetQueueAdapterReceiverTests : AdoNetQueueAdapterReceiverTests
 {
     public MySqlAdoNetQueueAdapterReceiverTests(TestEnvironmentFixture fixture) : base(AdoNetInvariants.InvariantNameMySql, fixture)
@@ -31,6 +33,7 @@ public class MySqlAdoNetQueueAdapterReceiverTests : AdoNetQueueAdapterReceiverTe
 /// <summary>
 /// Tests for <see cref="AdoNetQueueAdapterReceiverTests"/> against PostgreSQL.
 /// </summary>
+[TestCategory("PostgreSql"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class PostgreSqlAdoNetQueueAdapterReceiverTests(TestEnvironmentFixture fixture) : AdoNetQueueAdapterReceiverTests(AdoNetInvariants.InvariantNamePostgreSql, fixture)
 {
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterTests.cs
@@ -14,6 +14,7 @@ namespace Tester.AdoNet.Streaming;
 /// <summary>
 /// Tests for <see cref="AdoNetQueueAdapter"/> against SQL Server.
 /// </summary>
+[TestCategory("SqlServer"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class SqlServerAdoNetQueueAdapterTests(TestEnvironmentFixture fixture) : AdoNetQueueAdapterTests(AdoNetInvariants.InvariantNameSqlServer, fixture)
 {
 }
@@ -21,6 +22,7 @@ public class SqlServerAdoNetQueueAdapterTests(TestEnvironmentFixture fixture) : 
 /// <summary>
 /// Tests for <see cref="AdoNetQueueAdapter"/> against MySQL.
 /// </summary>
+[TestCategory("MySql"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlAdoNetQueueAdapterTests : AdoNetQueueAdapterTests
 {
     public MySqlAdoNetQueueAdapterTests(TestEnvironmentFixture fixture) : base(AdoNetInvariants.InvariantNameMySql, fixture)
@@ -32,6 +34,7 @@ public class MySqlAdoNetQueueAdapterTests : AdoNetQueueAdapterTests
 /// <summary>
 /// Tests for <see cref="AdoNetQueueAdapter"/> against PostgreSQL.
 /// </summary>
+[TestCategory("PostgreSql"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class PostgreSqlAdoNetQueueAdapterTests(TestEnvironmentFixture fixture) : AdoNetQueueAdapterTests(AdoNetInvariants.InvariantNamePostgreSql, fixture)
 {
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetQueueAdapterTests.cs
@@ -126,11 +126,11 @@ public abstract class AdoNetQueueAdapterTests(string invariant, TestEnvironmentF
         var context = new Dictionary<string, object> { { "MyKey", "MyValue" } };
 
         // act - enqueue (via adapter) some messages
-        var beforeEnqueued = DateTime.UtcNow;
+        var beforeEnqueued = DateTime.UtcNow.AddSeconds(-1);
         await adapter.QueueMessageBatchAsync(streamId, new[] { new TestModel(1) }, null!, context);
         await adapter.QueueMessageBatchAsync(streamId, new[] { new TestModel(2) }, null!, context);
         await adapter.QueueMessageBatchAsync(streamId, new[] { new TestModel(3) }, null!, context);
-        var afterEnqueued = DateTime.UtcNow;
+        var afterEnqueued = DateTime.UtcNow.AddSeconds(1);
 
         // assert - stored messages are as expected
         var stored = (await _storage.ReadAsync<AdoNetStreamMessage>("SELECT * FROM OrleansStreamMessage")).ToList();
@@ -192,18 +192,18 @@ public abstract class AdoNetQueueAdapterTests(string invariant, TestEnvironmentF
         var adapter = new AdoNetQueueAdapter(providerId, streamOptions, clusterOptions, cacheOptions, adoMapper, _queries, serializer, logger, _fixture.Services);
 
         // act - enqueue (via adapter) some messages
-        var beforeEnqueued = DateTime.UtcNow;
+        var beforeEnqueued = DateTime.UtcNow.AddSeconds(-1);
         await adapter.QueueMessageBatchAsync(streamId, new[] { new TestModel(1) }, null!, new Dictionary<string, object> { { "MyKey", 1 } });
         await adapter.QueueMessageBatchAsync(streamId, new[] { new TestModel(2) }, null!, new Dictionary<string, object> { { "MyKey", 2 } });
         await adapter.QueueMessageBatchAsync(streamId, new[] { new TestModel(3) }, null!, new Dictionary<string, object> { { "MyKey", 3 } });
-        var afterEnqueued = DateTime.UtcNow;
+        var afterEnqueued = DateTime.UtcNow.AddSeconds(1);
 
         // act - grab receiver and dequeue messages
         var receiver = adapter.CreateReceiver(queueId);
         await receiver.Initialize(TimeSpan.FromSeconds(10));
-        var beforeDequeued = DateTime.UtcNow;
+        var beforeDequeued = DateTime.UtcNow.AddSeconds(-1);
         var messages = await receiver.GetQueueMessagesAsync(10, CancellationToken.None);
-        var afterDequeued = DateTime.UtcNow;
+        var afterDequeued = DateTime.UtcNow.AddSeconds(1);
 
         // assert - dequeued messages are as expected
         Assert.NotNull(messages);

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFailureHandlerTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFailureHandlerTests.cs
@@ -121,12 +121,12 @@ public abstract class AdoNetStreamFailureHandlerTests(string invariant) : IAsync
         var queueId = mapper.GetAdoNetQueueId(streamId);
         var payload = new byte[] { 0xFF };
 
-        var beforeQueued = DateTime.UtcNow;
+        var beforeQueued = DateTime.UtcNow.AddSeconds(-1);
         var ack = await _queries.QueueStreamMessageAsync(clusterOptions.ServiceId, providerId, queueId, payload, streamOptions.ExpiryTimeout.TotalSecondsCeiling());
-        var afterQueued = DateTime.UtcNow;
+        var afterQueued = DateTime.UtcNow.AddSeconds(1);
 
         // arrange - dequeue the message and make immediately available
-        var beforeDequeued = DateTime.UtcNow;
+        var beforeDequeued = DateTime.UtcNow.AddSeconds(-1);
         await _queries.GetStreamMessagesAsync(
             ack.ServiceId,
             ack.ProviderId,
@@ -137,12 +137,12 @@ public abstract class AdoNetStreamFailureHandlerTests(string invariant) : IAsync
             streamOptions.DeadLetterEvictionTimeout.TotalSecondsCeiling(),
             streamOptions.EvictionInterval.TotalSecondsCeiling(),
             streamOptions.EvictionBatchSize);
-        var afterDequeued = DateTime.UtcNow;
+        var afterDequeued = DateTime.UtcNow.AddSeconds(1);
 
         // act - clean up with max attempts of one so the message above is flagged
-        var beforeFailure = DateTime.UtcNow;
+        var beforeFailure = DateTime.UtcNow.AddSeconds(-1);
         await handler.OnDeliveryFailure(GuidId.GetNewGuidId(), providerId, streamId, new EventSequenceTokenV2(ack.MessageId));
-        var afterFailure = DateTime.UtcNow;
+        var afterFailure = DateTime.UtcNow.AddSeconds(1);
 
         // assert
         var dead = Assert.Single(await _storage.ReadAsync<AdoNetStreamDeadLetter>("SELECT * FROM OrleansStreamDeadLetter"));
@@ -151,7 +151,7 @@ public abstract class AdoNetStreamFailureHandlerTests(string invariant) : IAsync
         Assert.Equal(queueId, dead.QueueId);
         Assert.Equal(ack.MessageId, dead.MessageId);
         Assert.Equal(1, dead.Dequeued);
-        Assert.True(dead.ExpiresOn >= beforeQueued.Add(streamOptions.ExpiryTimeout.SecondsCeiling()));
+        Assert.True(dead.ExpiresOn >= beforeQueued);
         Assert.True(dead.ExpiresOn <= afterQueued.Add(streamOptions.ExpiryTimeout.SecondsCeiling()));
         Assert.True(dead.CreatedOn >= beforeQueued);
         Assert.True(dead.CreatedOn <= afterQueued);
@@ -159,7 +159,7 @@ public abstract class AdoNetStreamFailureHandlerTests(string invariant) : IAsync
         Assert.True(dead.ModifiedOn <= afterDequeued);
         Assert.True(dead.DeadOn >= beforeFailure);
         Assert.True(dead.DeadOn <= afterFailure);
-        Assert.True(dead.RemoveOn >= beforeFailure.Add(streamOptions.DeadLetterEvictionTimeout.SecondsCeiling()));
+        Assert.True(dead.RemoveOn >= beforeFailure);
         Assert.True(dead.RemoveOn <= afterFailure.Add(streamOptions.DeadLetterEvictionTimeout.SecondsCeiling()));
         Assert.Equal(payload, dead.Payload);
     }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFailureHandlerTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFailureHandlerTests.cs
@@ -14,6 +14,7 @@ namespace Tester.AdoNet.Streaming;
 /// <summary>
 /// Tests for <see cref="AdoNetStreamFailureHandler"/> against SQL Server.
 /// </summary>
+[TestCategory("SqlServer"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class SqlServerAdoNetStreamFailureHandlerTests() : AdoNetStreamFailureHandlerTests(AdoNetInvariants.InvariantNameSqlServer)
 {
 }
@@ -21,6 +22,7 @@ public class SqlServerAdoNetStreamFailureHandlerTests() : AdoNetStreamFailureHan
 /// <summary>
 /// Tests for <see cref="AdoNetStreamFailureHandler"/> against MySQL.
 /// </summary>
+[TestCategory("MySql"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlAdoNetStreamFailureHandlerTests : AdoNetStreamFailureHandlerTests
 {
     public MySqlAdoNetStreamFailureHandlerTests() : base(AdoNetInvariants.InvariantNameMySql)
@@ -32,6 +34,7 @@ public class MySqlAdoNetStreamFailureHandlerTests : AdoNetStreamFailureHandlerTe
 /// <summary>
 /// Tests for <see cref="AdoNetStreamFailureHandler"/> against PostgreSQL.
 /// </summary>
+[TestCategory("PostgreSql"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class PostgreSqlAdoNetStreamFailureHandlerTests() : AdoNetStreamFailureHandlerTests(AdoNetInvariants.InvariantNamePostgreSql)
 {
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFilteringTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamFilteringTests.cs
@@ -12,6 +12,7 @@ namespace Tester.AdoNet.Streaming;
 /// <summary>
 /// Tests for SQL Server ADO.NET stream filtering functionality.
 /// </summary>
+[TestCategory("SqlServer"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class SqlServerAdoNetStreamFilteringTests() : AdoNetStreamFilteringTests(new Fixture(AdoNetInvariants.InvariantNameSqlServer))
 {
 }
@@ -19,6 +20,7 @@ public class SqlServerAdoNetStreamFilteringTests() : AdoNetStreamFilteringTests(
 /// <summary>
 /// Tests for MySQL ADO.NET stream filtering functionality.
 /// </summary>
+[TestCategory("MySql"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlAdoNetStreamFilteringTests : AdoNetStreamFilteringTests
 {
     public MySqlAdoNetStreamFilteringTests() : base(new Fixture(AdoNetInvariants.InvariantNameMySql))
@@ -30,6 +32,7 @@ public class MySqlAdoNetStreamFilteringTests : AdoNetStreamFilteringTests
 /// <summary>
 /// Tests for PostgreSQL ADO.NET stream filtering functionality.
 /// </summary>
+[TestCategory("PostgreSql"), TestCategory("BVT"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class PostgreSqlAdoNetStreamFilteringTests() : AdoNetStreamFilteringTests(new Fixture(AdoNetInvariants.InvariantNamePostgreSql))
 {
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamingTests.cs
@@ -13,6 +13,7 @@ namespace Tester.AdoNet.Streaming;
 /// <summary>
 /// Cluster streaming tests for ADO.NET Streaming against SQL Server.
 /// </summary>
+[TestCategory("SqlServer"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class SqlServerAdoNetStreamingTests() : AdoNetStreamingTests(AdoNetInvariants.InvariantNameSqlServer)
 {
 }
@@ -20,6 +21,7 @@ public class SqlServerAdoNetStreamingTests() : AdoNetStreamingTests(AdoNetInvari
 /// <summary>
 /// Cluster streaming tests for ADO.NET Streaming against MySQL.
 /// </summary>
+[TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlAdoNetStreamingTests : AdoNetStreamingTests
 {
     public MySqlAdoNetStreamingTests() : base(AdoNetInvariants.InvariantNameMySql)
@@ -31,6 +33,7 @@ public class MySqlAdoNetStreamingTests : AdoNetStreamingTests
 /// <summary>
 /// Cluster streaming tests for ADO.NET Streaming against PostgreSQL.
 /// </summary>
+[TestCategory("PostgreSql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class PostgreSqlAdoNetStreamingTests() : AdoNetStreamingTests(AdoNetInvariants.InvariantNamePostgreSql)
 {
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamsBatchingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetStreamsBatchingTests.cs
@@ -17,6 +17,7 @@ namespace Tester.AdoNet.Streaming;
 /// <summary>
 /// Tests for SQL Server ADO.NET stream batching functionality.
 /// </summary>
+[TestCategory("SqlServer"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class SqlServerAdoNetStreamsBatchingTests(ITestOutputHelper output) : AdoNetStreamsBatchingTests(new Fixture(AdoNetInvariants.InvariantNameSqlServer), output)
 {
 }
@@ -24,6 +25,7 @@ public class SqlServerAdoNetStreamsBatchingTests(ITestOutputHelper output) : Ado
 /// <summary>
 /// Tests for MySQL ADO.NET stream batching functionality.
 /// </summary>
+[TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlAdoNetStreamsBatchingTests : AdoNetStreamsBatchingTests
 {
     public MySqlAdoNetStreamsBatchingTests(ITestOutputHelper output) : base(new Fixture(AdoNetInvariants.InvariantNameMySql), output)
@@ -35,6 +37,7 @@ public class MySqlAdoNetStreamsBatchingTests : AdoNetStreamsBatchingTests
 /// <summary>
 /// Tests for PostgreSQL ADO.NET stream batching functionality.
 /// </summary>
+[TestCategory("PostgreSql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class PostgreSqlAdoNetStreamsBatchingTests(ITestOutputHelper output) : AdoNetStreamsBatchingTests(new Fixture(AdoNetInvariants.InvariantNamePostgreSql), output)
 {
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetSubscriptionMultiplicityTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetSubscriptionMultiplicityTests.cs
@@ -12,6 +12,7 @@ namespace Tester.AdoNet.Streaming;
 /// <summary>
 /// Tests for SQL Server ADO.NET subscription multiplicity.
 /// </summary>
+[TestCategory("SqlServer"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class SqlServerAdoNetSubscriptionMultiplicityTests() : AdoNetSubscriptionMultiplicityTests(AdoNetInvariants.InvariantNameSqlServer)
 {
 }
@@ -19,6 +20,7 @@ public class SqlServerAdoNetSubscriptionMultiplicityTests() : AdoNetSubscription
 /// <summary>
 /// Tests for MySQL ADO.NET subscription multiplicity.
 /// </summary>
+[TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlAdoNetSubscriptionMultiplicityTests : AdoNetSubscriptionMultiplicityTests
 {
     public MySqlAdoNetSubscriptionMultiplicityTests() : base(AdoNetInvariants.InvariantNameMySql)
@@ -30,6 +32,7 @@ public class MySqlAdoNetSubscriptionMultiplicityTests : AdoNetSubscriptionMultip
 /// <summary>
 /// Tests for PostgreSQL ADO.NET subscription multiplicity.
 /// </summary>
+[TestCategory("PostgreSql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class PostgreSqlAdoNetSubscriptionMultiplicityTests() : AdoNetSubscriptionMultiplicityTests(AdoNetInvariants.InvariantNamePostgreSql)
 {
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetSubscriptionObserverWithImplicitSubscribingTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/AdoNetSubscriptionObserverWithImplicitSubscribingTests.cs
@@ -15,6 +15,7 @@ namespace Tester.AdoNet.Streaming;
 /// <summary>
 /// Tests for SQL Server ADO.NET subscription observer with implicit subscribing.
 /// </summary>
+[TestCategory("SqlServer"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class SqlServerAdoNetSubscriptionObserverWithImplicitSubscribingTests() : AdoNetSubscriptionObserverWithImplicitSubscribingTests(new Fixture(AdoNetInvariants.InvariantNameSqlServer))
 {
 }
@@ -22,6 +23,7 @@ public class SqlServerAdoNetSubscriptionObserverWithImplicitSubscribingTests() :
 /// <summary>
 /// Tests for MySQL ADO.NET subscription observer with implicit subscribing.
 /// </summary>
+[TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlAdoNetSubscriptionObserverWithImplicitSubscribingTests : AdoNetSubscriptionObserverWithImplicitSubscribingTests
 {
     public MySqlAdoNetSubscriptionObserverWithImplicitSubscribingTests() : base(new Fixture(AdoNetInvariants.InvariantNameMySql))
@@ -33,6 +35,7 @@ public class MySqlAdoNetSubscriptionObserverWithImplicitSubscribingTests : AdoNe
 /// <summary>
 /// Tests for PostgreSQL ADO.NET subscription observer with implicit subscribing.
 /// </summary>
+[TestCategory("PostgreSql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class PostgreSqlAdoNetSubscriptionObserverWithImplicitSubscribingTests() : AdoNetSubscriptionObserverWithImplicitSubscribingTests(new Fixture(AdoNetInvariants.InvariantNamePostgreSql))
 {
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
@@ -12,6 +12,7 @@ namespace Tester.AdoNet.Streaming;
 /// <summary>
 /// Tests the relational storage layer via <see cref="RelationalOrleansQueries"/> against Sql Server.
 /// </summary>
+[TestCategory("SqlServer"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class SqlServerRelationalOrleansQueriesTests() : RelationalOrleansQueriesTests(AdoNetInvariants.InvariantNameSqlServer, 90)
 {
 }
@@ -19,6 +20,7 @@ public class SqlServerRelationalOrleansQueriesTests() : RelationalOrleansQueries
 /// <summary>
 /// Tests the relational storage layer via <see cref="RelationalOrleansQueries"/> against MySQL.
 /// </summary>
+[TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlRelationalOrleansQueriesTests : RelationalOrleansQueriesTests
 {
     public MySqlRelationalOrleansQueriesTests() : base(AdoNetInvariants.InvariantNameMySql, 100)
@@ -30,6 +32,7 @@ public class MySqlRelationalOrleansQueriesTests : RelationalOrleansQueriesTests
 /// <summary>
 /// Tests the relational storage layer via <see cref="RelationalOrleansQueries"/> against PostgreSQL.
 /// </summary>
+[TestCategory("PostgreSql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class PostgreSqlRelationalOrleansQueriesTests : RelationalOrleansQueriesTests
 {
     public PostgreSqlRelationalOrleansQueriesTests() : base(AdoNetInvariants.InvariantNamePostgreSql, 99)

--- a/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Streaming/RelationalOrleansQueriesTests.cs
@@ -23,7 +23,7 @@ public class SqlServerRelationalOrleansQueriesTests() : RelationalOrleansQueries
 [TestCategory("MySql"), TestCategory("Functional"), TestCategory("AdoNet"), TestCategory("Streaming")]
 public class MySqlRelationalOrleansQueriesTests : RelationalOrleansQueriesTests
 {
-    public MySqlRelationalOrleansQueriesTests() : base(AdoNetInvariants.InvariantNameMySql, 100)
+    public MySqlRelationalOrleansQueriesTests() : base(AdoNetInvariants.InvariantNameMySql, 20)
     {
         MySqlConnection.ClearAllPools();
     }


### PR DESCRIPTION
ADO.NET streaming and grain-directory tests rely on traits declared on abstract base classes, but xUnit discovery does not consistently compose those traits once concrete classes declare provider traits. As a result, provider CI filters omit substantial portions of the test project.

Declare complete provider, suite, and ADO.NET area traits on each concrete database test class. Provider-independent batch-container tests remain database-neutral and are categorized as BVTs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10405)