### PR TITLE
fix(tests): surface provider async failures

### DIFF
--- a/test/Extensions/Orleans.AWS.Tests/StorageTests/DynamoDBStorageStressTests.cs
+++ b/test/Extensions/Orleans.AWS.Tests/StorageTests/DynamoDBStorageStressTests.cs
@@ -30,7 +30,7 @@ namespace AWSUtils.Tests.StorageTests
         }
 
         [SkippableFact]
-        public void DynamoDBDataManagerStressTests_WriteAlot_SinglePartition()
+        public async Task DynamoDBDataManagerStressTests_WriteAlot_SinglePartition()
         {
             const string testName = "DynamoDBDataManagerStressTests_WriteAlot_SinglePartition";
             const int iterations = 2000;
@@ -38,11 +38,11 @@ namespace AWSUtils.Tests.StorageTests
             const int numPartitions = 1;
 
             // Write some data
-            WriteAlot_Async(testName, numPartitions, iterations, batchSize);
+            await WriteAlot_Async(testName, numPartitions, iterations, batchSize);
         }
 
         [SkippableFact]
-        public void DynamoDBDataManagerStressTests_WriteAlot_MultiPartition()
+        public async Task DynamoDBDataManagerStressTests_WriteAlot_MultiPartition()
         {
             const string testName = "DynamoDBDataManagerStressTests_WriteAlot_MultiPartition";
             const int iterations = 2000;
@@ -50,31 +50,31 @@ namespace AWSUtils.Tests.StorageTests
             const int numPartitions = 100;
 
             // Write some data
-            WriteAlot_Async(testName, numPartitions, iterations, batchSize);
+            await WriteAlot_Async(testName, numPartitions, iterations, batchSize);
         }
 
         [SkippableFact]
-        public void DynamoDBDataManagerStressTests_ReadAll_SinglePartition()
+        public async Task DynamoDBDataManagerStressTests_ReadAll_SinglePartition()
         {
             const string testName = "DynamoDBDataManagerStressTests_ReadAll";
             const int iterations = 1000;
 
             // Write some data
-            WriteAlot_Async(testName, 1, iterations, iterations);
+            await WriteAlot_Async(testName, 1, iterations, iterations);
 
             Stopwatch sw = Stopwatch.StartNew();
 
             var keys = new Dictionary<string, AttributeValue> { { ":PK", new AttributeValue(PartitionKey) } };
-            var data = manager.QueryAsync(UnitTestDynamoDBStorage.INSTANCE_TABLE_NAME, keys, $"PartitionKey = :PK", item => new UnitTestDynamoDBTableData(item)).Result;
+            var data = await manager.QueryAsync(UnitTestDynamoDBStorage.INSTANCE_TABLE_NAME, keys, $"PartitionKey = :PK", item => new UnitTestDynamoDBTableData(item));
 
             sw.Stop();
             int count = data.results.Count;
             output.WriteLine("DynamoDBDataManagerStressTests_ReadAll completed. ReadAll {0} entries in {1} at {2} RPS", count, sw.Elapsed, count / sw.Elapsed.TotalSeconds);
 
-            //Assert.True(count >= iterations, $"ReadAllshould return some data: Found={count}");
+            Assert.Equal(iterations, count);
         }
 
-        private void WriteAlot_Async(string testName, int numPartitions, int iterations, int batchSize)
+        private async Task WriteAlot_Async(string testName, int numPartitions, int iterations, int batchSize)
         {
             output.WriteLine("Iterations={0}, Batch={1}, Partitions={2}", iterations, batchSize, numPartitions);
             List<Task> promises = new List<Task>();
@@ -93,13 +93,13 @@ namespace AWSUtils.Tests.StorageTests
                 promises.Add(promise);
                 if ((i % batchSize) == 0 && i > 0)
                 {
-                    Task.WhenAll(promises);
+                    await Task.WhenAll(promises);
                     promises.Clear();
                     output.WriteLine("{0} has written {1} rows in {2} at {3} RPS",
                         testName, i, sw.Elapsed, i / sw.Elapsed.TotalSeconds);
                 }
             }
-            Task.WhenAll(promises);
+            await Task.WhenAll(promises);
             sw.Stop();
             output.WriteLine("{0} completed. Wrote {1} entries to {2} partition(s) in {3} at {4} RPS",
                 testName, iterations, numPartitions, sw.Elapsed, iterations / sw.Elapsed.TotalSeconds);

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_Azure_Standalone.cs
@@ -83,40 +83,34 @@ namespace Tester.AzureUtils.TimerTests
         {
             DateTime startedAt = DateTime.UtcNow;
 
-            try
+            List<Task<bool>> promises = new List<Task<bool>>();
+            for (int i = 0; i < numOfInserts; i++)
             {
-                List<Task<bool>> promises = new List<Task<bool>>();
-                for (int i = 0; i < numOfInserts; i++)
+                //"177BF46E-D06D-44C0-943B-C12F26DF5373"
+                string s = string.Format("177BF46E-D06D-44C0-943B-C12F26D{0:d5}", i);
+
+                var e = new ReminderEntry
                 {
-                    //"177BF46E-D06D-44C0-943B-C12F26DF5373"
-                    string s = string.Format("177BF46E-D06D-44C0-943B-C12F26D{0:d5}", i);
+                    //GrainId = LegacyGrainId.GetGrainId(new Guid(s)),
+                    GrainId = fixture.InternalGrainFactory.GetGrain(LegacyGrainId.NewId()).GetGrainId(),
+                    ReminderName = "MY_REMINDER_" + i,
+                    Period = TimeSpan.FromSeconds(5),
+                    StartAt = DateTime.UtcNow
+                };
 
-                    var e = new ReminderEntry
-                    {
-                        //GrainId = LegacyGrainId.GetGrainId(new Guid(s)),
-                        GrainId = fixture.InternalGrainFactory.GetGrain(LegacyGrainId.NewId()).GetGrainId(),
-                        ReminderName = "MY_REMINDER_" + i,
-                        Period = TimeSpan.FromSeconds(5),
-                        StartAt = DateTime.UtcNow
-                    };
+                int capture = i;
+                Task<bool> promise = Task.Run(async () =>
+                {
+                    await reminderTable.UpsertRow(e);
+                    this.output.WriteLine("Done " + capture);
+                    return true;
+                });
+                promises.Add(promise);
+                this.log.LogInformation("Started {Capture}", capture);
+            }
+            this.log.LogInformation("Started all, now waiting...");
+            await Task.WhenAll(promises).WaitAsync(TimeSpan.FromSeconds(500));
 
-                    int capture = i;
-                    Task<bool> promise = Task.Run(async () =>
-                    {
-                        await reminderTable.UpsertRow(e);
-                        this.output.WriteLine("Done " + capture);
-                        return true;
-                    });
-                    promises.Add(promise);
-                    this.log.LogInformation("Started {Capture}", capture);
-                }
-                this.log.LogInformation("Started all, now waiting...");
-                await Task.WhenAll(promises).WaitAsync(TimeSpan.FromSeconds(500));
-            }
-            catch (Exception exc)
-            {
-                this.log.LogInformation(exc, "Exception caught");
-            }
             TimeSpan dur = DateTime.UtcNow - startedAt;
             this.log.LogInformation(
                 "Inserted {InsertCount} rows in {Duration}, i.e., {Rate} upserts/sec",

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos_Standalone.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos_Standalone.cs
@@ -82,40 +82,34 @@ public class ReminderTests_Cosmos_Standalone
     {
         DateTime startedAt = DateTime.UtcNow;
 
-        try
+        List<Task<bool>> promises = new List<Task<bool>>();
+        for (int i = 0; i < numOfInserts; i++)
         {
-            List<Task<bool>> promises = new List<Task<bool>>();
-            for (int i = 0; i < numOfInserts; i++)
+            //"177BF46E-D06D-44C0-943B-C12F26DF5373"
+            string s = string.Format("177BF46E-D06D-44C0-943B-C12F26D{0:d5}", i);
+
+            var e = new ReminderEntry
             {
-                //"177BF46E-D06D-44C0-943B-C12F26DF5373"
-                string s = string.Format("177BF46E-D06D-44C0-943B-C12F26D{0:d5}", i);
+                //GrainId = LegacyGrainId.GetGrainId(new Guid(s)),
+                GrainId = _fixture.InternalGrainFactory.GetGrain(LegacyGrainId.NewId()).GetGrainId(),
+                ReminderName = "MY_REMINDER_" + i,
+                Period = TimeSpan.FromSeconds(5),
+                StartAt = DateTime.UtcNow
+            };
 
-                var e = new ReminderEntry
-                {
-                    //GrainId = LegacyGrainId.GetGrainId(new Guid(s)),
-                    GrainId = _fixture.InternalGrainFactory.GetGrain(LegacyGrainId.NewId()).GetGrainId(),
-                    ReminderName = "MY_REMINDER_" + i,
-                    Period = TimeSpan.FromSeconds(5),
-                    StartAt = DateTime.UtcNow
-                };
+            int capture = i;
+            Task<bool> promise = Task.Run(async () =>
+            {
+                await reminderTable.UpsertRow(e);
+                _output.WriteLine("Done " + capture);
+                return true;
+            });
+            promises.Add(promise);
+            _log.LogInformation("Started {Capture}", capture);
+        }
+        _log.LogInformation("Started all, now waiting...");
+        await Task.WhenAll(promises).WaitAsync(TimeSpan.FromSeconds(500));
 
-                int capture = i;
-                Task<bool> promise = Task.Run(async () =>
-                {
-                    await reminderTable.UpsertRow(e);
-                    _output.WriteLine("Done " + capture);
-                    return true;
-                });
-                promises.Add(promise);
-                _log.LogInformation("Started {Capture}", capture);
-            }
-            _log.LogInformation("Started all, now waiting...");
-            await Task.WhenAll(promises).WaitAsync(TimeSpan.FromSeconds(500));
-        }
-        catch (Exception exc)
-        {
-            _log.LogInformation(exc, "Exception caught");
-        }
         TimeSpan dur = DateTime.UtcNow - startedAt;
         _log.LogInformation(
             "Inserted {InsertCount} rows in {Duration}, i.e., {Rate} upserts/sec",


### PR DESCRIPTION
Provider stress and reminder tests could report success after asynchronous storage operations failed because tasks were discarded, blocked synchronously, or caught without rethrowing. Await the DynamoDB write batches and reads, assert the expected read count, and let Azure Storage and Cosmos reminder operation failures propagate while retaining the existing explicit environment-availability skips.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10406)