### PR TITLE
test: categorize ordinary tests for CI

### DIFF
--- a/src/Orleans.TestingHost/Utils/TestingUtils.cs
+++ b/src/Orleans.TestingHost/Utils/TestingUtils.cs
@@ -149,7 +149,7 @@ namespace Orleans.TestingHost.Utils
             using var deadlineCancellation = new CancellationTokenSource(timeout);
             using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deadlineCancellation.Token);
             var finalAttempt = false;
-            var lastAttemptDuration = TimeSpan.Zero;
+            var finalAttemptWindow = retryDelay > TimeSpan.Zero ? retryDelay : TimeSpan.FromMilliseconds(10);
 
             while (Stopwatch.GetElapsedTime(startedAt) < timeout)
             {
@@ -159,7 +159,6 @@ namespace Orleans.TestingHost.Utils
                 }
 
                 bool succeeded;
-                var attemptStartedAt = Stopwatch.GetTimestamp();
                 try
                 {
                     succeeded = await predicate(finalAttempt, linkedCancellation.Token);
@@ -169,7 +168,6 @@ namespace Orleans.TestingHost.Utils
                     return false;
                 }
 
-                lastAttemptDuration = Stopwatch.GetElapsedTime(attemptStartedAt);
                 cancellationToken.ThrowIfCancellationRequested();
                 var elapsed = Stopwatch.GetElapsedTime(startedAt);
                 if (elapsed >= timeout)
@@ -197,33 +195,22 @@ namespace Orleans.TestingHost.Utils
                     continue;
                 }
 
-                var finalAttemptWindow = retryDelay > TimeSpan.Zero ? retryDelay : TimeSpan.FromMilliseconds(10);
                 if (invokeFinalAttempt && remaining <= finalAttemptWindow)
                 {
-                    var minimumBudget = TimeSpan.FromMilliseconds(100);
-                    var finalAttemptBudget = lastAttemptDuration > minimumBudget
-                        ? lastAttemptDuration.Ticks >= remaining.Ticks / 2
-                            ? remaining
-                            : TimeSpan.FromTicks(lastAttemptDuration.Ticks * 2)
-                        : minimumBudget;
-                    var delayBeforeFinalAttempt = remaining - finalAttemptBudget;
-                    if (delayBeforeFinalAttempt > TimeSpan.Zero)
-                    {
-                        try
-                        {
-                            await Task.Delay(delayBeforeFinalAttempt, linkedCancellation.Token);
-                        }
-                        catch (OperationCanceledException) when (deadlineCancellation.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-                        {
-                            return false;
-                        }
-                    }
-
                     finalAttempt = true;
                     continue;
                 }
 
                 var delay = retryDelay < remaining ? retryDelay : remaining;
+                if (invokeFinalAttempt)
+                {
+                    var delayUntilFinalAttempt = remaining - finalAttemptWindow;
+                    if (delayUntilFinalAttempt < delay)
+                    {
+                        delay = delayUntilFinalAttempt;
+                    }
+                }
+
                 try
                 {
                     await Task.Delay(delay, linkedCancellation.Token);

--- a/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreDataManagerCancellationTests.cs
+++ b/test/Extensions/Orleans.Clustering.Firestore.Tests/FirestoreDataManagerCancellationTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Orleans.Clustering.Firestore.Tests;
 
+[TestCategory("BVT")]
 public class FirestoreDataManagerCancellationTests
 {
     [Fact]

--- a/test/Extensions/Orleans.Clustering.Firestore.Tests/SiloInstanceEntityTests.cs
+++ b/test/Extensions/Orleans.Clustering.Firestore.Tests/SiloInstanceEntityTests.cs
@@ -3,6 +3,7 @@ using TestExtensions;
 
 namespace Orleans.Clustering.Firestore.Tests;
 
+[TestCategory("BVT")]
 public class SiloInstanceEntityTests
 {
     public static TheoryData<SiloStatus> SiloStatuses => new(Enum.GetValues<SiloStatus>());

--- a/test/Extensions/Orleans.Clustering.Firestore.Tests/UtilsTests.cs
+++ b/test/Extensions/Orleans.Clustering.Firestore.Tests/UtilsTests.cs
@@ -3,6 +3,7 @@ using FirestoreUtils = Orleans.Clustering.Firestore.Utils;
 
 namespace Orleans.Clustering.Firestore.Tests;
 
+[TestCategory("BVT")]
 public class UtilsTests
 {
     [Theory]

--- a/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/DurableJobReceiverExtensionTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace NonSilo.Tests.ScheduledJobs;
 
-[TestCategory("DurableJobs")]
+[TestCategory("BVT"), TestCategory("DurableJobs")]
 public class DurableJobReceiverExtensionTests
 {
     [Fact]

--- a/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/InMemoryJobQueueTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace NonSilo.Tests.DurableJobs;
 
-[TestCategory("DurableJobs")]
+[TestCategory("BVT"), TestCategory("DurableJobs")]
 public class InMemoryJobQueueTests
 {
     [Fact]

--- a/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
+++ b/test/Orleans.Core.Tests/DurableJobs/ShardExecutorTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace NonSilo.Tests.ScheduledJobs;
 
-[TestCategory("DurableJobs")]
+[TestCategory("BVT"), TestCategory("DurableJobs")]
 public class ShardExecutorTests
 {
     [Fact]

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/EmbeddedAssetTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/EmbeddedAssetTests.cs
@@ -169,19 +169,16 @@ namespace UnitTests
         {
             var provider = new EmbeddedAssetProvider();
             var httpContext = new DefaultHttpContext();
-            var assembly = typeof(EmbeddedAssetProvider).GetTypeInfo().Assembly;
-            var fontResourceName = assembly
+            var fontResourceName = DashboardAssembly
                 .GetManifestResourceNames()
                 .FirstOrDefault(name =>
-                    name.EndsWith(".woff2", StringComparison.Ordinal) ||
-                    name.EndsWith(".woff", StringComparison.Ordinal));
+                    name.StartsWith(ResourcePrefix, StringComparison.Ordinal) &&
+                    (name.EndsWith(".woff2", StringComparison.Ordinal) ||
+                     name.EndsWith(".woff", StringComparison.Ordinal)));
 
             Assert.NotNull(fontResourceName);
 
-            var resourcePrefix = typeof(EmbeddedAssetProvider).Namespace + ".";
-            var assetName = fontResourceName.StartsWith(resourcePrefix, StringComparison.Ordinal)
-                ? fontResourceName.Substring(resourcePrefix.Length)
-                : fontResourceName;
+            var assetName = fontResourceName.Substring(ResourcePrefix.Length);
 
             var result = provider.ServeAsset(assetName, httpContext);
             Assert.IsNotType<NotFound>(result);

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/EmbeddedAssetTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/EmbeddedAssetTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace UnitTests
 {
+    [TestCategory("BVT")]
     public class EmbeddedAssetTests
     {
         private static readonly Assembly DashboardAssembly = typeof(DashboardOptions).Assembly;

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/GrainStateTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/GrainStateTests.cs
@@ -13,6 +13,7 @@ using Orleans.Dashboard.Core;
 
 namespace UnitTests
 {
+    [TestCategory("Functional")]
     public class GrainStateTests : IDisposable
     {
         private readonly TestCluster _cluster;

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/LifecycleStageInspectorTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/LifecycleStageInspectorTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace UnitTests;
 
+[TestCategory("BVT")]
 public class LifecycleStageInspectorTests
 {
     [Fact]

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/Orleans.Dashboard.UnitTests.csproj
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/Orleans.Dashboard.UnitTests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Dashboard\Orleans.Dashboard\Orleans.Dashboard.csproj" />
     <ProjectReference Include="..\..\..\src\Orleans.TestingHost\Orleans.TestingHost.csproj" />
+    <ProjectReference Include="..\..\TestInfrastructure\TestExtensions\TestExtensions.csproj" />
     <ProjectReference Include="..\Orleans.Dashboard.TestGrains\Orleans.Dashboard.TestGrains.csproj" />
   </ItemGroup>
 

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/RingBufferTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/RingBufferTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace UnitTests
 {
+    [TestCategory("BVT")]
     public class RingBufferTests
     {
         [Fact]

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/TraceHistoryTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/TraceHistoryTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace UnitTests;
 
+[TestCategory("BVT")]
 public class TraceHistoryTests
 {
     private readonly DateTime _startTime = DateTime.UtcNow;

--- a/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/TypeFormatterTests.cs
+++ b/test/Orleans.Dashboard.Tests/Orleans.Dashboard.UnitTests/TypeFormatterTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace UnitTests
 {
+    [TestCategory("BVT")]
     public class TypeFormatterTests
     {
         [Fact]

--- a/test/Orleans.Serialization.UnitTests/Buffers/Adaptors/PooledBufferStreamTests.cs
+++ b/test/Orleans.Serialization.UnitTests/Buffers/Adaptors/PooledBufferStreamTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions;
@@ -16,7 +15,7 @@ namespace Orleans.Serialization.Buffers.Adaptors.UnitTests;
 /// <summary>
 /// Unit tests for the PooledBufferStream constructor.
 /// </summary>
-[Category("BVT")]
+[Trait("Category", "BVT")]
 public class PooledBufferStreamTests
 {
     /// <summary>
@@ -861,6 +860,7 @@ public class PooledBufferStreamTests
 /// <summary>
 /// Unit tests for the BufferSegment class.
 /// </summary>
+[Trait("Category", "BVT")]
 public class BufferSegmentTests
 {
     /// <summary>

--- a/test/Orleans.Serialization.UnitTests/RecordSerializationTests.cs
+++ b/test/Orleans.Serialization.UnitTests/RecordSerializationTests.cs
@@ -28,6 +28,7 @@ namespace Orleans.Serialization.UnitTests;
 /// - Functional programming patterns
 /// - Clean API contracts
 /// </summary>
+[Trait("Category", "BVT")]
 public class RecordSerializationTests
 {
     private readonly ServiceProvider _services;

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Orleans.Serialization.UnitTests
 {
+    [Trait("Category", "BVT")]
     public class TypeConverterTests
     {
         [Fact]

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/TestingUtilsTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace Orleans.TestingHost.Tests;
 
+[TestCategory("BVT")]
 public class TestingUtilsTests
 {
     [Fact]


### PR DESCRIPTION
Several ordinary test groups had no standard CI category, so they were not selected by the existing BVT or Functional filters.

This adds BVT to fast serialization, Durable Jobs, TestingHost, Dashboard, and Firestore unit tests; adds Functional to the cluster-backed grain-directory lease and Dashboard grain-state tests; preserves existing domain categories; and replaces an ineffective ComponentModel Category attribute with TestCategory. The Dashboard test project now references TestExtensions directly so its traits are discoverable.

Targeted discovery selects 132 serialization, 44 Durable Jobs, 14 grain-directory lease, 11 TestingHost, 38 Dashboard, and 18 Firestore test cases.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10407)