### PR TITLE
fix(test): enforce async test lifetimes

### DIFF
--- a/test/Orleans.Core.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
+++ b/test/Orleans.Core.Tests/SchedulerTests/OrleansTaskSchedulerAdvancedTests_Set2.cs
@@ -454,21 +454,21 @@ namespace UnitTests.SchedulerTests
             Task join = null!;
             Task wrapper = new Task(() =>
             {
-                task1 = Task.Run(() =>
+                task1 = Task.Run(async () =>
                 {
                     this.output.WriteLine("Task-1 Started");
                     Assert.NotEqual(scheduler, TaskScheduler.Current);
-                    Task.Delay(1);
+                    await Task.Delay(1);
                     Assert.NotEqual(scheduler, TaskScheduler.Current);
                     pause1.WaitOne();
                     this.output.WriteLine("Task-1 Done");
                     return 1;
                 });
-                task2 = Task.Run(() =>
+                task2 = Task.Run(async () =>
                 {
                     this.output.WriteLine("Task-2 Started");
                     Assert.NotEqual(scheduler, TaskScheduler.Current);
-                    Task.Delay(1);
+                    await Task.Delay(1);
                     Assert.NotEqual(scheduler, TaskScheduler.Current);
                     pause2.WaitOne();
                     this.output.WriteLine("Task-2 Done");

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/DefaultToleranceTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/DefaultToleranceTests.cs
@@ -236,7 +236,7 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         await ResetCounters();
     }
 
-    [SkippableFact]
+    [Fact]
     public async Task Receivers_ShouldMoveCloseTo_PullingAgent()
     {
         var sp1 = GrainFactory.GetGrain<ISP>("s1");
@@ -282,21 +282,29 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         Assert.Equal(Silo1, sr2_host);
         Assert.Equal(Silo2, sr3_host);
 
+        await Silo1Repartitioner.FlushBuffers();
+        await Silo2Repartitioner.FlushBuffers();
         await Silo1Repartitioner.TriggerExchangeRequest();
-        await Task.Delay(100); // leave some breathing room - may not be enough though, thats why this test is skippable
 
         var allowedDuration = TimeSpan.FromSeconds(3);
-        Stopwatch stopwatch = new();
-        stopwatch.Start();
+        var stopwatch = Stopwatch.StartNew();
 
-        do
+        while (stopwatch.Elapsed < allowedDuration)
         {
             sr1_host = await sr1.GetAddress();
             sr2_host = await sr2.GetAddress();
 
-            Skip.If(stopwatch.Elapsed > allowedDuration);
+            if (sr1_host != Silo1 && sr2_host != Silo1)
+            {
+                break;
+            }
+
+            await Task.Delay(10);
         }
-        while (sr1_host == Silo1 || sr2_host == Silo1);
+
+        Assert.True(
+            sr1_host != Silo1 && sr2_host != Silo1,
+            $"Receivers did not move from {Silo1} within {allowedDuration}. SR1 was on {sr1_host}; SR2 was on {sr2_host}.");
 
         // refresh
         sr1_host = await sr1.GetAddress();

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/DefaultToleranceTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/DefaultToleranceTests.cs
@@ -324,12 +324,22 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         var sr2_GotHit = false;
         var sr3_GotHit = false;
 
-        while (!sr1_GotHit || !sr2_GotHit || !sr3_GotHit)
+        stopwatch.Restart();
+        while (stopwatch.Elapsed < allowedDuration && (!sr1_GotHit || !sr2_GotHit || !sr3_GotHit))
         {
             sr1_GotHit = await sr1.GotStreamHit();
             sr2_GotHit = await sr2.GotStreamHit();
             sr3_GotHit = await sr3.GotStreamHit();
+
+            if (!sr1_GotHit || !sr2_GotHit || !sr3_GotHit)
+            {
+                await Task.Delay(10);
+            }
         }
+
+        Assert.True(
+            sr1_GotHit && sr2_GotHit && sr3_GotHit,
+            $"Expected all stream receivers to observe a message within {allowedDuration}. SR1: {sr1_GotHit}; SR2: {sr2_GotHit}; SR3: {sr3_GotHit}.");
 
         var sr1_host = await sr1.GetAddress();
         var sr2_host = await sr2.GetAddress();

--- a/test/Orleans.Placement.Tests/ActivationRepartitioningTests/DefaultToleranceTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRepartitioningTests/DefaultToleranceTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Configuration;
 using Orleans.Placement;
+using Orleans.Providers.Streams.Common;
 using Orleans.Runtime.Placement;
 using Orleans.Runtime.Placement.Repartitioning;
 using Orleans.Streams;
@@ -239,15 +240,71 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
     [Fact]
     public async Task Receivers_ShouldMoveCloseTo_PullingAgent()
     {
+        var silo1Control = GrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlType, Silo1);
+        var silo2Control = GrainFactory.GetSystemTarget<ISiloControl>(Constants.SiloControlType, Silo2);
+        var allowedDuration = TimeSpan.FromSeconds(3);
+        var stopwatch = Stopwatch.StartNew();
+        var silo1AgentCount = 0;
+        var silo2AgentCount = 0;
+        var observedOwner = 0;
+        var stableObservationCount = 0;
+        const int requiredStableObservationCount = 5;
+        do
+        {
+            var agentCounts = await Task.WhenAll(
+                silo1Control.SendControlCommandToProvider<PersistentStreamProvider>(
+                    Fixture.StreamProviderName,
+                    (int)PersistentStreamProviderCommand.GetNumberRunningAgents,
+                    null),
+                silo2Control.SendControlCommandToProvider<PersistentStreamProvider>(
+                    Fixture.StreamProviderName,
+                    (int)PersistentStreamProviderCommand.GetNumberRunningAgents,
+                    null));
+            silo1AgentCount = Assert.IsType<int>(agentCounts[0]);
+            silo2AgentCount = Assert.IsType<int>(agentCounts[1]);
+
+            var currentOwner = (silo1AgentCount, silo2AgentCount) switch
+            {
+                (1, 0) => 1,
+                (0, 1) => 2,
+                _ => 0,
+            };
+            if (currentOwner != 0 && currentOwner == observedOwner)
+            {
+                stableObservationCount++;
+            }
+            else
+            {
+                observedOwner = currentOwner;
+                stableObservationCount = currentOwner == 0 ? 0 : 1;
+            }
+
+            if (stableObservationCount >= requiredStableObservationCount)
+            {
+                break;
+            }
+
+            await Task.Delay(50);
+        }
+        while (stopwatch.Elapsed < allowedDuration);
+
+        Assert.True(
+            stableObservationCount >= requiredStableObservationCount,
+            $"Expected a stable pulling-agent assignment within {allowedDuration}. Silo1 reported {silo1AgentCount}; Silo2 reported {silo2AgentCount}; stable observations: {stableObservationCount}.");
+        var pullingAgentSilo = observedOwner == 1 ? Silo1 : Silo2;
+        var receiverSilo = pullingAgentSilo == Silo1 ? Silo2 : Silo1;
+        var receiverRepartitioner = receiverSilo == Silo1 ? Silo1Repartitioner : Silo2Repartitioner;
+        var pullingAgentRepartitioner = pullingAgentSilo == Silo1 ? Silo1Repartitioner : Silo2Repartitioner;
+
         var sp1 = GrainFactory.GetGrain<ISP>("s1");
         var sp2 = GrainFactory.GetGrain<ISP>("s2");
         var sp3 = GrainFactory.GetGrain<ISP>("s3");
 
-        RequestContext.Set(IPlacementDirector.PlacementHintKey, Silo1);
+        RequestContext.Set(IPlacementDirector.PlacementHintKey, receiverSilo);
         await sp1.FirstPing();
         await sp2.FirstPing();
 
-        RequestContext.Set(IPlacementDirector.PlacementHintKey, Silo2);
+        RequestContext.Set(IPlacementDirector.PlacementHintKey, pullingAgentSilo);
         await sp3.FirstPing();
 
         var i = 0;
@@ -278,23 +335,22 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         var sr2_host = await sr2.GetAddress();
         var sr3_host = await sr3.GetAddress();
 
-        Assert.Equal(Silo1, sr1_host);
-        Assert.Equal(Silo1, sr2_host);
-        Assert.Equal(Silo2, sr3_host);
+        Assert.Equal(receiverSilo, sr1_host);
+        Assert.Equal(receiverSilo, sr2_host);
+        Assert.Equal(pullingAgentSilo, sr3_host);
 
-        await Silo1Repartitioner.FlushBuffers();
-        await Silo2Repartitioner.FlushBuffers();
-        await Silo1Repartitioner.TriggerExchangeRequest();
+        await receiverRepartitioner.FlushBuffers();
+        await pullingAgentRepartitioner.FlushBuffers();
+        await receiverRepartitioner.TriggerExchangeRequest();
 
-        var allowedDuration = TimeSpan.FromSeconds(3);
-        var stopwatch = Stopwatch.StartNew();
+        stopwatch.Restart();
 
         while (stopwatch.Elapsed < allowedDuration)
         {
             sr1_host = await sr1.GetAddress();
             sr2_host = await sr2.GetAddress();
 
-            if (sr1_host != Silo1 && sr2_host != Silo1)
+            if (sr1_host != receiverSilo && sr2_host != receiverSilo)
             {
                 break;
             }
@@ -303,17 +359,17 @@ public class DefaultToleranceTests(DefaultToleranceTests.Fixture fixture) : Repa
         }
 
         Assert.True(
-            sr1_host != Silo1 && sr2_host != Silo1,
-            $"Receivers did not move from {Silo1} within {allowedDuration}. SR1 was on {sr1_host}; SR2 was on {sr2_host}.");
+            sr1_host != receiverSilo && sr2_host != receiverSilo,
+            $"Receivers did not move from {receiverSilo} to pulling-agent silo {pullingAgentSilo} within {allowedDuration}. SR1 was on {sr1_host}; SR2 was on {sr2_host}.");
 
         // refresh
         sr1_host = await sr1.GetAddress();
         sr2_host = await sr2.GetAddress();
         sr3_host = await sr3.GetAddress();
 
-        Assert.Equal(Silo2, sr1_host);  // SR1 is now in silo 2, as there is 1 pulling agent (which is moved to silo 2 by the streaming runtime)
-        Assert.Equal(Silo2, sr2_host);  // SR2 is now in silo 2, as there is 1 pulling agent (which is moved to silo 2 by the streaming runtime)
-        Assert.Equal(Silo2, sr3_host);
+        Assert.Equal(pullingAgentSilo, sr1_host);
+        Assert.Equal(pullingAgentSilo, sr2_host);
+        Assert.Equal(pullingAgentSilo, sr3_host);
 
         await ResetCounters();
     }

--- a/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationCollectorTests.cs
+++ b/test/Orleans.Runtime.Internal.Tests/ActivationsLifeCycleTests/ActivationCollectorTests.cs
@@ -76,6 +76,18 @@ namespace UnitTests.ActivationsLifeCycleTests
             await Initialize(collectionAgeLimit, DEFAULT_COLLECTION_QUANTUM);
         }
 
+        private static async Task CancelWorkerAsync(CancellationTokenSource cancellation, Task worker)
+        {
+            cancellation.Cancel();
+            try
+            {
+                await worker;
+            }
+            catch (OperationCanceledException exception) when (exception.CancellationToken == cancellation.Token)
+            {
+            }
+        }
+
         public async Task DisposeAsync()
         {
             if (testCluster is null) return;
@@ -175,44 +187,49 @@ namespace UnitTests.ActivationsLifeCycleTests
                 tasks0.Add(g.Nop());
             }
             await Task.WhenAll(tasks0);
-            bool[] quit = new bool[]{ false };
-            async Task busyWorker()
+            using var workerCancellation = new CancellationTokenSource();
+            async Task busyWorker(CancellationToken cancellationToken)
             {
                 logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivations: busyWorker started");
-                while (!quit[0])
+                while (true)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     List<Task> tasks1 = new List<Task>(busyGrains.Count);
                     foreach (var g in busyGrains)
                         tasks1.Add(g.Nop());
                     await Task.WhenAll(tasks1);
                 }
             }
-            Task.Run(busyWorker).Ignore();
-
-            logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivations: activating {Count} idle grains.", idleGrainCount);
-            tasks0.Clear();
-            for (var i = 0; i < idleGrainCount; ++i)
+            var workerTask = Task.Run(() => busyWorker(workerCancellation.Token));
+            try
             {
-                IIdleActivationGcTestGrain1 g = this.testCluster.GrainFactory!.GetGrain<IIdleActivationGcTestGrain1>(Guid.NewGuid());
-                tasks0.Add(g.Nop());
+                logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivations: activating {Count} idle grains.", idleGrainCount);
+                tasks0.Clear();
+                for (var i = 0; i < idleGrainCount; ++i)
+                {
+                    IIdleActivationGcTestGrain1 g = this.testCluster.GrainFactory!.GetGrain<IIdleActivationGcTestGrain1>(Guid.NewGuid());
+                    tasks0.Add(g.Nop());
+                }
+                await Task.WhenAll(tasks0);
+
+                int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
+                Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
+
+                logger.LogInformation(
+                    "ActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
+                    DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+                await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
+
+                // we should have only collected grains from the idle category (IdleActivationGcTestGrain1).
+                int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName);
+                int busyActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
+                Assert.Equal(0, idleActivationsNotCollected);
+                Assert.Equal(busyGrainCount, busyActivationsNotCollected);
             }
-            await Task.WhenAll(tasks0);
-
-            int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
-            Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
-
-            logger.LogInformation(
-                "ActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
-                DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-            await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
-
-            // we should have only collected grains from the idle category (IdleActivationGcTestGrain1).
-            int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName);
-            int busyActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
-            Assert.Equal(0, idleActivationsNotCollected);
-            Assert.Equal(busyGrainCount, busyActivationsNotCollected);
-
-            quit[0] = true;
+            finally
+            {
+                await CancelWorkerAsync(workerCancellation, workerTask);
+            }
         }          
         
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
@@ -236,56 +253,60 @@ namespace UnitTests.ActivationsLifeCycleTests
                 tasks0.Add(g.Nop());
             }
             await Task.WhenAll(tasks0);
-            bool[] quit = new bool[]{ false };
-            async Task busyWorker()
+            using var workerCancellation = new CancellationTokenSource();
+            async Task busyWorker(CancellationToken cancellationToken)
             {
                 logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: busyWorker started");
-                while (!quit[0])
+                while (true)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     List<Task> tasks1 = new List<Task>(busyGrains.Count);
                     foreach (var g in busyGrains)
                         tasks1.Add(g.Nop());
                     await Task.WhenAll(tasks1);
                 }
             }
-            Task.Run(busyWorker).Ignore();
-
-            logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: activating {Count} idle grains.", idleGrainCount);
-            tasks0.Clear();
-            for (var i = 0; i < idleGrainCount; ++i)
+            var workerTask = Task.Run(() => busyWorker(workerCancellation.Token));
+            try
             {
-                IIdleActivationGcTestGrain1 g = this.testCluster.GrainFactory!.GetGrain<IIdleActivationGcTestGrain1>(Guid.NewGuid());
-                tasks0.Add(g.Nop());
+                logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: activating {Count} idle grains.", idleGrainCount);
+                tasks0.Clear();
+                for (var i = 0; i < idleGrainCount; ++i)
+                {
+                    IIdleActivationGcTestGrain1 g = this.testCluster.GrainFactory!.GetGrain<IIdleActivationGcTestGrain1>(Guid.NewGuid());
+                    tasks0.Add(g.Nop());
+                }
+                await Task.WhenAll(tasks0);
+
+                int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
+                Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
+
+                logger.LogInformation(
+                    "ManualCollectionShouldNotCollectBusyActivations: grains activated; waiting {TotalSeconds} sec (activation GC idle timeout is {DefaultIdleTime} sec).",
+                    shortIdleTimeout.TotalSeconds,
+                    DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+                await Task.Delay(shortIdleTimeout);
+
+                TimeSpan everything = TimeSpan.FromMinutes(10);
+                logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: triggering manual collection (timespan is {TotalSeconds} sec).",  everything.TotalSeconds);
+                IManagementGrain mgmtGrain = this.testCluster.GrainFactory!.GetGrain<IManagementGrain>(0);
+                await mgmtGrain.ForceActivationCollection(everything);
+
+                logger.LogInformation(
+                    "ManualCollectionShouldNotCollectBusyActivations: waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
+                    DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+                await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
+
+                // we should have only collected grains from the idle category (IdleActivationGcTestGrain).
+                int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName);
+                int busyActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
+                Assert.Equal(0, idleActivationsNotCollected);
+                Assert.Equal(busyGrainCount, busyActivationsNotCollected);
             }
-            await Task.WhenAll(tasks0);
-
-            int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
-            Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
-
-            logger.LogInformation(
-                "ManualCollectionShouldNotCollectBusyActivations: grains activated; waiting {TotalSeconds} sec (activation GC idle timeout is {DefaultIdleTime} sec).",
-                shortIdleTimeout.TotalSeconds,
-                DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-            await Task.Delay(shortIdleTimeout);
-
-            TimeSpan everything = TimeSpan.FromMinutes(10);
-            logger.LogInformation("ManualCollectionShouldNotCollectBusyActivations: triggering manual collection (timespan is {TotalSeconds} sec).",  everything.TotalSeconds);
-            IManagementGrain mgmtGrain = this.testCluster.GrainFactory!.GetGrain<IManagementGrain>(0);
-            await mgmtGrain.ForceActivationCollection(everything);
-
-
-            logger.LogInformation(
-                "ManualCollectionShouldNotCollectBusyActivations: waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
-                DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-            await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
-
-            // we should have only collected grains from the idle category (IdleActivationGcTestGrain).
-            int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName);
-            int busyActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
-            Assert.Equal(0, idleActivationsNotCollected);
-            Assert.Equal(busyGrainCount, busyActivationsNotCollected);
-
-            quit[0] = true;
+            finally
+            {
+                await CancelWorkerAsync(workerCancellation, workerTask);
+            }
         }    
         
         [Fact, TestCategory("ActivationCollector"), TestCategory("Functional")]
@@ -341,44 +362,49 @@ namespace UnitTests.ActivationsLifeCycleTests
                 tasks0.Add(g.Nop());
             }
             await Task.WhenAll(tasks0);
-            bool[] quit = new bool[]{ false };
-            async Task busyWorker()
+            using var workerCancellation = new CancellationTokenSource();
+            async Task busyWorker(CancellationToken cancellationToken)
             {
                 logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: busyWorker started");
-                while (!quit[0])
+                while (true)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     List<Task> tasks1 = new List<Task>(busyGrains.Count);
                     foreach (var g in busyGrains)
                         tasks1.Add(g.Nop());
                     await Task.WhenAll(tasks1);
                 }
             }
-            Task.Run(busyWorker).Ignore();
-
-            logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: activating {Count} idle grains.", idleGrainCount);
-            tasks0.Clear();
-            for (var i = 0; i < idleGrainCount; ++i)
+            var workerTask = Task.Run(() => busyWorker(workerCancellation.Token));
+            try
             {
-                IIdleActivationGcTestGrain2 g = this.testCluster.GrainFactory!.GetGrain<IIdleActivationGcTestGrain2>(Guid.NewGuid());
-                tasks0.Add(g.Nop());
+                logger.LogInformation("ActivationCollectorShouldNotCollectBusyActivationsSpecifiedInPerTypeConfiguration: activating {Count} idle grains.", idleGrainCount);
+                tasks0.Clear();
+                for (var i = 0; i < idleGrainCount; ++i)
+                {
+                    IIdleActivationGcTestGrain2 g = this.testCluster.GrainFactory!.GetGrain<IIdleActivationGcTestGrain2>(Guid.NewGuid());
+                    tasks0.Add(g.Nop());
+                }
+                await Task.WhenAll(tasks0);
+
+                int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
+                Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
+
+                logger.LogInformation(
+                    "IdleActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
+                    DEFAULT_IDLE_TIMEOUT.TotalSeconds);
+                await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
+
+                // we should have only collected grains from the idle category (IdleActivationGcTestGrain2).
+                int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName);
+                int busyActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
+                Assert.Equal(0, idleActivationsNotCollected);
+                Assert.Equal(busyGrainCount, busyActivationsNotCollected);
             }
-            await Task.WhenAll(tasks0);
-
-            int activationsCreated = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName) + await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
-            Assert.Equal(idleGrainCount + busyGrainCount, activationsCreated);
-
-            logger.LogInformation(
-                "IdleActivationCollectorShouldNotCollectBusyActivations: grains activated; waiting for idle activation count to converge to zero (activation GC idle timeout is {DefaultIdleTime} sec).",
-                DEFAULT_IDLE_TIMEOUT.TotalSeconds);
-            await WaitForActivationCountToConverge(idleGrainTypeName, expectedCount: 0);
-
-            // we should have only collected grains from the idle category (IdleActivationGcTestGrain2).
-            int idleActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, idleGrainTypeName);
-            int busyActivationsNotCollected = await TestUtils.GetActivationCount(this.testCluster.GrainFactory!, busyGrainTypeName);
-            Assert.Equal(0, idleActivationsNotCollected);
-            Assert.Equal(busyGrainCount, busyActivationsNotCollected);
-
-            quit[0] = true;
+            finally
+            {
+                await CancelWorkerAsync(workerCancellation, workerTask);
+            }
         } 
   
         [Fact(Skip = "Flaky test. Needs to be investigated."), TestCategory("ActivationCollector"), TestCategory("Functional")]


### PR DESCRIPTION
Fixes three test-semantics defects which could hide failures or let work escape the xUnit test lifetime. Activation collector workers are now cancelled and awaited with only their own cancellation treated as expected, and scheduler delay tests now exercise asynchronous continuations.

The repartitioning test previously assumed its single stream pulling agent always ran on Silo2, but consistent-ring ownership depends on randomized silo addresses. It now waits for a stable observed owner, places receivers on the opposite silo, flushes sampled edges, and uses bounded polling that reports migration timeouts as failures instead of skips.