### PR TITLE
test: repair provider test traits

### DIFF
--- a/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TransactionalStateStorageTestRunner.cs
@@ -28,25 +28,25 @@ namespace Orleans.Transactions.TestKit.xUnit
         {
         }
 
-        [Fact]
+        [SkippableFact]
         public override Task FirstTime_Load_ShouldReturnEmptyLoadResponse()
         {
             return base.FirstTime_Load_ShouldReturnEmptyLoadResponse();
         }
 
-        [Fact]
+        [SkippableFact]
         public override Task StoreWithoutChanges()
         {
             return base.StoreWithoutChanges();
         }
 
-        [Fact]
+        [SkippableFact]
         public override Task WrongEtags()
         {
             return base.WrongEtags();
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(true)]
         [InlineData(false)]
         public override Task ConfirmOne(bool useTwoSteps)
@@ -54,19 +54,19 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.ConfirmOne(useTwoSteps);
         }
 
-        [Fact]
+        [SkippableFact]
         public override Task CancelOne()
         {
             return base.CancelOne();
         }
 
-        [Fact]
+        [SkippableFact]
         public override Task ReplaceOne()
         {
             return base.ReplaceOne();
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(false, false)]
         [InlineData(true, true)]
         [InlineData(true, false)]
@@ -75,19 +75,19 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.ConfirmOneAndCancelOne(useTwoSteps, reverseOrder);
         }
 
-        [Fact]
+        [SkippableFact]
         public override Task GrowingBatch()
         {
             return base.GrowingBatch();
         }
 
-        [Fact]
+        [SkippableFact]
         public override Task ShrinkingBatch()
         {
             return base.ShrinkingBatch();
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(99)]
         [InlineData(100)]
         [InlineData(200)]
@@ -96,7 +96,7 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.PrepareMany(count);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(99, true)]
         [InlineData(99, false)]
         [InlineData(100, true)]
@@ -108,7 +108,7 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.ConfirmMany(count, useTwoSteps);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(99)]
         [InlineData(100)]
         [InlineData(200)]
@@ -117,7 +117,7 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.CancelMany(count);
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(99)]
         [InlineData(100)]
         [InlineData(200)]

--- a/test/Extensions/Orleans.Azure.Tests/AzureClientOptionsTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureClientOptionsTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace Tester.AzureUtils;
 
+[TestCategory("AzureStorage"), TestCategory("BVT")]
 public class AzureClientOptionsTests
 {
     [Fact]

--- a/test/Extensions/Orleans.Azure.Tests/AzureMembershipPaginationTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureMembershipPaginationTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Tester.AzureUtils;
 
-[TestCategory("AzureStorage"), TestCategory("Storage")]
+[TestCategory("AzureStorage"), TestCategory("Storage"), TestCategory("BVT")]
 public class AzureMembershipPaginationTests
 {
     private const string ClusterId = "membership-pagination-tests";

--- a/test/Extensions/Orleans.Azure.Tests/AzureRemindersTableTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/AzureRemindersTableTests.cs
@@ -49,7 +49,7 @@ namespace UnitTests.RemindersTest
             return Task.FromResult("not used");
         }
 
-        [SkippableFact]
+        [SkippableFact, TestCategory("Functional")]
         public void RemindersTable_Azure_Init()
         {
         }

--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_Azure_Standalone.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_Azure_Standalone.cs
@@ -52,7 +52,7 @@ namespace Tester.AzureUtils.TimerTests
             await TestTableInsertRate(table, 500);
         }
 
-        [SkippableFact, TestCategory("Reminders")]
+        [SkippableFact, TestCategory("Reminders"), TestCategory("Functional")]
         public async Task Reminders_AzureTable_InsertNewRowAndReadBack()
         {
             string clusterId = NewClusterId();

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AQProgrammaticSubscribeTest.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AQProgrammaticSubscribeTest.cs
@@ -14,7 +14,7 @@ namespace Tester.AzureUtils.Streaming
     /// <summary>
     /// Tests for programmatic subscription functionality with Azure Queue streaming providers.
     /// </summary>
-    [TestCategory("BVT"), TestCategory("Streaming"), TestCategory("AQStreaming")]
+    [TestCategory("BVT"), TestCategory("Streaming"), TestCategory("AQStreaming"), TestCategory("AzureStorage")]
     public class AQProgrammaticSubscribeTest : ProgrammaticSubscribeTestsRunner, IClassFixture<AQProgrammaticSubscribeTest.Fixture>
     {
         private const int queueCount = 8;

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AQSubscriptionObserverWithImplicitSubscribingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AQSubscriptionObserverWithImplicitSubscribingTests.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 
 namespace Tester.AzureUtils.Streaming
 {
-    [TestCategory("Functional"), TestCategory("AzureStorage")]
+    [TestCategory("Functional"), TestCategory("AzureStorage"), TestCategory("Streaming")]
     public class AQSubscriptionObserverWithImplicitSubscribingTests : SubscriptionObserverWithImplicitSubscribingTestRunner, IClassFixture<AQSubscriptionObserverWithImplicitSubscribingTests.Fixture>
     {
         private const int queueCount = 8;

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AQSubscriptionObserverWithImplicitSubscribingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AQSubscriptionObserverWithImplicitSubscribingTests.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 
 namespace Tester.AzureUtils.Streaming
 {
-    [TestCategory("Functional")]
+    [TestCategory("Functional"), TestCategory("AzureStorage")]
     public class AQSubscriptionObserverWithImplicitSubscribingTests : SubscriptionObserverWithImplicitSubscribingTestRunner, IClassFixture<AQSubscriptionObserverWithImplicitSubscribingTests.Fixture>
     {
         private const int queueCount = 8;

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueStreamProviderBuilderTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueStreamProviderBuilderTests.cs
@@ -9,6 +9,7 @@ namespace Tester.AzureUtils;
 /// <summary>
 /// Tests for Azure Queue Stream Provider configuration builder, validating various configuration scenarios.
 /// </summary>
+[TestCategory("AzureStorage"), TestCategory("BVT")]
 public class AzureQueueStreamProviderBuilderTests
 {
 	/// <summary>

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueStreamProviderBuilderTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/AzureQueueStreamProviderBuilderTests.cs
@@ -9,7 +9,7 @@ namespace Tester.AzureUtils;
 /// <summary>
 /// Tests for Azure Queue Stream Provider configuration builder, validating various configuration scenarios.
 /// </summary>
-[TestCategory("AzureStorage"), TestCategory("BVT")]
+[TestCategory("AzureStorage"), TestCategory("Streaming"), TestCategory("BVT")]
 public class AzureQueueStreamProviderBuilderTests
 {
 	/// <summary>

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/DelayedQueueRebalancingTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Tester.AzureUtils.Streaming
 {
-    [TestCategory("Streaming")]
+    [TestCategory("Streaming"), TestCategory("AzureStorage")]
     public class DelayedQueueRebalancingTests : TestClusterPerTest
     {
         private const string adapterName = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/HaloStreamSubscribeTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace UnitTests.HaloTests.Streaming
 {
-    [TestCategory("Streaming"), TestCategory("Halo")]
+    [TestCategory("Streaming"), TestCategory("Halo"), TestCategory("AzureStorage")]
     public class HaloStreamSubscribeTests : OrleansTestingBase, IClassFixture<HaloStreamSubscribeTests.Fixture>
     {
         private readonly Fixture fixture;

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/PullingAgentManagementTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/PullingAgentManagementTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace UnitTests.StreamingTests
 {
+    [TestCategory("AzureStorage")]
     public class PullingAgentManagementTests : OrleansTestingBase, IClassFixture<PullingAgentManagementTests.Fixture>
     {
         private readonly Fixture fixture;

--- a/test/Extensions/Orleans.Azure.Tests/Streaming/SampleAzureQueueStreamingTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/SampleAzureQueueStreamingTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Tester.AzureUtils.Streaming
 {
-    [TestCategory("Streaming")]
+    [TestCategory("Streaming"), TestCategory("AzureStorage")]
     public class SampleAzureQueueStreamingTests : TestClusterPerTest
     {
         private const string StreamProvider = StreamTestsConstants.AZURE_QUEUE_STREAM_PROVIDER_NAME;

--- a/test/Extensions/Orleans.Cosmos.Tests/CosmosHostingExtensionsTests.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/CosmosHostingExtensionsTests.cs
@@ -9,6 +9,7 @@ using Orleans.Runtime;
 
 namespace Tester.Cosmos.Persistence;
 
+[TestCategory("Cosmos"), TestCategory("BVT")]
 public class CosmosHostingExtensionsTests
 {
     [Fact]

--- a/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos_Standalone.cs
+++ b/test/Extensions/Orleans.Cosmos.Tests/ReminderTests_Cosmos_Standalone.cs
@@ -50,7 +50,7 @@ public class ReminderTests_Cosmos_Standalone
         await TestTableInsertRate(table, 500);
     }
 
-    [SkippableFact, TestCategory("Reminders")]
+    [SkippableFact, TestCategory("Reminders"), TestCategory("Functional")]
     public async Task Reminders_AzureTable_InsertNewRowAndReadBack()
     {
         string clusterId = NewClusterId();

--- a/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
@@ -31,6 +31,7 @@ namespace Orleans.Transactions.Azure.Tests
     /// <summary>
     /// Tests for Azure Table Storage implementation of transactional state storage.
     /// </summary>
+    [TestCategory("AzureStorage"), TestCategory("Functional")]
     public class AzureTransactionalStateStorageTests : TransactionalStateStorageTestRunnerxUnit<TestState>, IClassFixture<TestFixture>
     {
         private const string tableName = "StateStorageTests";

--- a/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
@@ -31,7 +31,7 @@ namespace Orleans.Transactions.Azure.Tests
     /// <summary>
     /// Tests for Azure Table Storage implementation of transactional state storage.
     /// </summary>
-    [TestCategory("AzureStorage"), TestCategory("Functional")]
+    [TestCategory("AzureStorage"), TestCategory("Transactions"), TestCategory("Functional")]
     public class AzureTransactionalStateStorageTests : TransactionalStateStorageTestRunnerxUnit<TestState>, IClassFixture<TestFixture>
     {
         private const string tableName = "StateStorageTests";

--- a/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.Azure.Test/AzureTransactionalStateStorageTests.cs
@@ -51,7 +51,7 @@ namespace Orleans.Transactions.Azure.Tests
             return CreateStorage(table, $"{partition}{DateTime.UtcNow.Ticks}", jsonSettings);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task NoChangeStoreUsesStrictETag()
         {
             var (writer, staleWriter, writerLoad, staleLoad) = await CreateInitializedWriters();
@@ -63,7 +63,7 @@ namespace Orleans.Transactions.Azure.Tests
                 () => staleWriter.Store(staleLoad.ETag, staleLoad.Metadata, [], null, null));
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task StaleWriterConvergesAfterLoad()
         {
             var (writer, staleWriter, writerLoad, staleLoad) = await CreateInitializedWriters();
@@ -97,7 +97,7 @@ namespace Orleans.Transactions.Azure.Tests
             Assert.Equal(staleWriterTimestamp, converged.Metadata.TimeStamp);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task FailedStoreRequiresSuccessfulLoadBeforeReuse()
         {
             var (writer, staleWriter, writerLoad, staleLoad) = await CreateInitializedWriters();
@@ -114,7 +114,7 @@ namespace Orleans.Transactions.Azure.Tests
             await staleWriter.Store(refreshed.ETag, refreshed.Metadata, [], null, null);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task ConflictDiagnosticsExcludePayloads()
         {
             var table = await InitTableAsync(NullLogger.Instance);
@@ -250,7 +250,7 @@ namespace Orleans.Transactions.Azure.Tests
         }
     }
 
-    [TestCategory("BVT")]
+    [TestCategory("AzureStorage"), TestCategory("Transactions"), TestCategory("BVT")]
     public class AzureTransactionalStateStorageSnapshotTests
     {
         private const string Partition = "test-partition";

--- a/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateStorageTests.cs
@@ -35,7 +35,7 @@ namespace Orleans.Transactions.DynamoDB.Tests
     /// <summary>
     /// Tests for DynamoDB implementation of transactional state storage.
     /// </summary>
-    [TestCategory("DynamoDB"), TestCategory("Functional")]
+    [TestCategory("DynamoDB"), TestCategory("Transactions"), TestCategory("Functional")]
     public class DynamoDBTransactionalStateStorageTests : TransactionalStateStorageTestRunnerxUnit<TestState>, IClassFixture<TestFixture>
     {
         private const string tableName = "StateStorageTests";

--- a/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateStorageTests.cs
@@ -45,10 +45,10 @@ namespace Orleans.Transactions.DynamoDB.Tests
         {
         }
 
-        [Fact]
+        [SkippableFact]
         public override Task StoreWithoutChanges() => base.StoreWithoutChanges();
 
-        [Fact]
+        [SkippableFact]
         public override async Task WrongEtags()
         {
             var storage = await this.stateStorageFactory();
@@ -87,7 +87,7 @@ namespace Orleans.Transactions.DynamoDB.Tests
             return stateStorage;
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task Store_NewRowConflict_ReportsOperationsAndRequiresLoadBeforeReuse()
         {
             var partitionKey = $"{partition}-{Guid.NewGuid():N}";
@@ -141,7 +141,7 @@ namespace Orleans.Transactions.DynamoDB.Tests
             Assert.Equal(202, recovered.CommittedState.State);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task Store_ExistingRowETagConflict_MapsCancellationReasonsInOperationOrder()
         {
             var partitionKey = $"{partition}-{Guid.NewGuid():N}";
@@ -201,7 +201,7 @@ namespace Orleans.Transactions.DynamoDB.Tests
             Assert.Equal(40, recovered.CommittedState.State);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task Store_StaleDeleteConflict_ReportsDeleteOperation()
         {
             var partitionKey = $"{partition}-{Guid.NewGuid():N}";
@@ -246,7 +246,7 @@ namespace Orleans.Transactions.DynamoDB.Tests
             Assert.Equal(21, durableWinner.CommittedState.State);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task Store_DuplicateSequenceInSingleBatch_IsRejectedAndRequiresLoad()
         {
             var partitionKey = $"{partition}-{Guid.NewGuid():N}";
@@ -282,7 +282,7 @@ namespace Orleans.Transactions.DynamoDB.Tests
             Assert.Equal(40, recovered.CommittedState.State);
         }
 
-        [Fact]
+        [SkippableFact]
         public async Task TransactWriteItems_ExplicitClientRequestToken_ReplaysIdenticalRequest()
         {
             _ = await InitTableAsync(NullLogger.Instance);
@@ -327,7 +327,7 @@ namespace Orleans.Transactions.DynamoDB.Tests
             Assert.Equal("1", response.Item["Value"].N);
         }
 
-        [Fact]
+        [SkippableFact]
         public void TransactionConflictCancellation_IsNotClassifiedAsStorageConflict()
         {
             var batchOperation = typeof(DynamoDBTransactionalStateStorage<TestState>).GetNestedType(

--- a/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateStorageTests.cs
+++ b/test/Transactions/Orleans.Transactions.DynamoDB.Test/DynamoDBTransactionalStateStorageTests.cs
@@ -35,6 +35,7 @@ namespace Orleans.Transactions.DynamoDB.Tests
     /// <summary>
     /// Tests for DynamoDB implementation of transactional state storage.
     /// </summary>
+    [TestCategory("DynamoDB"), TestCategory("Functional")]
     public class DynamoDBTransactionalStateStorageTests : TransactionalStateStorageTestRunnerxUnit<TestState>, IClassFixture<TestFixture>
     {
         private const string tableName = "StateStorageTests";

--- a/test/Transactions/Orleans.Transactions.DynamoDB.Test/SkewedClockGoldenPathTransactionTests.cs
+++ b/test/Transactions/Orleans.Transactions.DynamoDB.Test/SkewedClockGoldenPathTransactionTests.cs
@@ -7,7 +7,7 @@ namespace Orleans.Transactions.DynamoDB.Tests
     /// <summary>
     /// Tests for transaction golden path scenarios with skewed clocks using DynamoDB.
     /// </summary>
-    [TestCategory("DynamoDB"), TestCategory("Transactions")]
+    [TestCategory("DynamoDB"), TestCategory("Transactions"), TestCategory("Functional")]
     public class SkewedClockGoldenPathTransactionTests : GoldenPathTransactionTestRunnerxUnit, IClassFixture<SkewedClockTestFixture>
     {
         public SkewedClockGoldenPathTransactionTests(SkewedClockTestFixture fixture, ITestOutputHelper output)


### PR DESCRIPTION
Provider CI filters were missing ordinary tests because several transaction, Azure Storage, DynamoDB, and Cosmos classes lacked provider or suite traits.

This adds provider and BVT/Functional traits only where the tests are ordinary and compatible with the provisioned emulator jobs. Discovery changes are Azure Storage 249→289, Azure transactions 66→97, DynamoDB transactions 55→96, and Cosmos 65→70. A sixth Cosmos test gains Functional qualification for suite-based filtering.

Intentional boundaries remain unchanged: 243 `Transactions-dev` cases in each transaction provider, 32 Azure Storage stress/performance cases, 7 Cosmos stress/performance cases, 7 real-Azure-only grain-directory cases, and 4 known-failure Azure Queue cases remain excluded.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10410)