### PR TITLE
ci: cover omitted maintained tests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Test API data generator
+        run: dotnet test docs/tools/PackageJsonGenerator.Tests/PackageJsonGenerator.Tests.csproj
+
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
@@ -79,7 +82,7 @@ jobs:
           path: docs/site/dist
 
   snippets:
-    name: Build documentation snippets
+    name: Validate documentation snippets
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -91,7 +94,7 @@ jobs:
         with:
           global-json-file: global.json
 
-      - name: Build snippets
+      - name: Validate snippets
         shell: pwsh
         run: ./docs/site/src/content/docs/validate-snippets.ps1
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -118,9 +118,10 @@ tutorial into a reference or burying architecture detail inside a how-to.
 
 - Run the parser-backed link, include, redirect, navigation, and project-policy
   checks that cover the changed content.
-- Build every changed snippet project with `dotnet build`, and run
-  `docs/site/src/content/docs/validate-snippets.ps1` when snippet or project
-  policy changes.
+- Run `docs/site/src/content/docs/validate-snippets.ps1` for changed snippets
+  and snippet project policy changes. It builds ordinary snippet projects and
+  runs projects marked with `IsTestProject=true`, so executable testing examples
+  are validated behaviorally.
 - Run `samples/Validate-Samples.ps1` when maintained samples change.
 - When `docs/Docs.slnx` is present after integration, build it as the aggregate documentation project.
 - From `docs/site`, run `npm run validate`, including redirect and rendered

--- a/docs/site/src/content/docs/validate-snippets.ps1
+++ b/docs/site/src/content/docs/validate-snippets.ps1
@@ -1,31 +1,32 @@
 <#
 .SYNOPSIS
-    Validates that all Orleans documentation snippet projects compile successfully.
+    Validates all Orleans documentation snippet projects.
 
 .DESCRIPTION
-    This script finds all .csproj files in the snippets directories under docs/orleans/
-    and runs 'dotnet build' on each project to verify they compile.
+    This script finds all .csproj files in the documentation snippets directories
+    and runs 'dotnet build' on ordinary projects or 'dotnet test' on projects which
+    declare IsTestProject=true.
     
     Use this script to validate snippet code after making changes to ensure all
-    documentation examples remain buildable.
+    documentation examples remain buildable and executable test examples pass.
 
 .PARAMETER Parallel
-    Run builds in parallel (default: false for clearer output)
+    Run validations in parallel (default: false for clearer output)
 
 .EXAMPLE
     .\validate-snippets.ps1
     
-    Builds all snippet projects sequentially and reports results.
+    Validates all snippet projects sequentially and reports results.
 
 .EXAMPLE
     .\validate-snippets.ps1 -Parallel
     
-    Builds all snippet projects in parallel for faster validation.
+    Validates all snippet projects in parallel for faster validation.
 
 .NOTES
     Exit codes:
-    0 - All projects built successfully
-    1 - One or more projects failed to build
+    0 - All projects validated successfully
+    1 - One or more projects failed validation
 #>
 
 param(
@@ -39,10 +40,17 @@ Write-Host "Orleans Documentation Snippet Validator" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
-# Find all .csproj files in snippets directories
+# Find all .csproj files in snippets directories and identify executable test projects.
 $snippetProjects = Get-ChildItem -Path $scriptDir -Recurse -Filter "*.csproj" |
     Where-Object { $_.FullName -match "snippets" } |
-    Select-Object -ExpandProperty FullName
+    ForEach-Object {
+        [xml] $projectXml = Get-Content -Path $_.FullName -Raw
+        $isTestProject = $projectXml.Project.PropertyGroup.IsTestProject -contains "true"
+        [pscustomobject]@{
+            Path = $_.FullName
+            IsTestProject = $isTestProject
+        }
+    }
 
 if ($snippetProjects.Count -eq 0) {
     Write-Host "No snippet projects found!" -ForegroundColor Yellow
@@ -51,8 +59,9 @@ if ($snippetProjects.Count -eq 0) {
 
 Write-Host "Found $($snippetProjects.Count) snippet project(s) to validate:" -ForegroundColor Green
 $snippetProjects | ForEach-Object { 
-    $relativePath = $_.Replace($scriptDir, "").TrimStart("\", "/")
-    Write-Host "  - $relativePath" -ForegroundColor Gray
+    $relativePath = $_.Path.Replace($scriptDir, "").TrimStart("\", "/")
+    $action = if ($_.IsTestProject) { "test" } else { "build" }
+    Write-Host "  - $relativePath ($action)" -ForegroundColor Gray
 }
 Write-Host ""
 
@@ -60,21 +69,26 @@ $results = @()
 $failCount = 0
 $successCount = 0
 
-function Build-Project {
-    param([string]$ProjectPath)
+function Invoke-ProjectValidation {
+    param(
+        [string]$ProjectPath,
+        [bool]$IsTestProject
+    )
     
     $relativePath = $ProjectPath.Replace($scriptDir, "").TrimStart("\", "/")
-    $projectDir = Split-Path -Parent $ProjectPath
+    $command = if ($IsTestProject) { "test" } else { "build" }
+    $action = if ($IsTestProject) { "Testing" } else { "Building" }
     
-    Write-Host "Building: $relativePath" -ForegroundColor Yellow -NoNewline
+    Write-Host "${action}: $relativePath" -ForegroundColor Yellow -NoNewline
     
-    $output = & dotnet build $ProjectPath --nologo -v q 2>&1
+    $output = & dotnet $command $ProjectPath --nologo -v q 2>&1
     $exitCode = $LASTEXITCODE
     
     if ($exitCode -eq 0) {
         Write-Host " [OK]" -ForegroundColor Green
         return @{
             Project = $relativePath
+            Action = $command
             Success = $true
             Output = $output -join "`n"
         }
@@ -82,6 +96,7 @@ function Build-Project {
         Write-Host " [FAILED]" -ForegroundColor Red
         return @{
             Project = $relativePath
+            Action = $command
             Success = $false
             Output = $output -join "`n"
         }
@@ -89,24 +104,27 @@ function Build-Project {
 }
 
 if ($Parallel) {
-    Write-Host "Running builds in parallel..." -ForegroundColor Cyan
+    Write-Host "Running validations in parallel..." -ForegroundColor Cyan
     $results = $snippetProjects | ForEach-Object -Parallel {
-        $ProjectPath = $_
+        $ProjectPath = $_.Path
+        $IsTestProject = $_.IsTestProject
         $scriptDir = $using:scriptDir
         $relativePath = $ProjectPath.Replace($scriptDir, "").TrimStart("\", "/")
+        $command = if ($IsTestProject) { "test" } else { "build" }
         
-        $output = & dotnet build $ProjectPath --nologo -v q 2>&1
+        $output = & dotnet $command $ProjectPath --nologo -v q 2>&1
         $exitCode = $LASTEXITCODE
         
         @{
             Project = $relativePath
+            Action = $command
             Success = ($exitCode -eq 0)
             Output = $output -join "`n"
         }
     } -ThrottleLimit 4
 } else {
     foreach ($project in $snippetProjects) {
-        $result = Build-Project -ProjectPath $project
+        $result = Invoke-ProjectValidation -ProjectPath $project.Path -IsTestProject $project.IsTestProject
         $results += $result
     }
 }
@@ -123,14 +141,14 @@ Write-Host "Succeeded: $successCount" -ForegroundColor Green
 Write-Host "Failed:    $failCount" -ForegroundColor $(if ($failCount -gt 0) { "Red" } else { "Green" })
 Write-Host ""
 
-# Show details for failed builds
+# Show details for failed validations
 $failed = $results | Where-Object { -not $_.Success }
 if ($failed.Count -gt 0) {
     Write-Host "Failed Projects:" -ForegroundColor Red
     Write-Host "----------------" -ForegroundColor Red
     foreach ($f in $failed) {
         Write-Host ""
-        Write-Host "Project: $($f.Project)" -ForegroundColor Red
+        Write-Host "Project: $($f.Project) ($($f.Action))" -ForegroundColor Red
         Write-Host "Output:" -ForegroundColor Yellow
         Write-Host $f.Output
     }
@@ -138,5 +156,5 @@ if ($failed.Count -gt 0) {
     exit 1
 }
 
-Write-Host "All snippet projects built successfully!" -ForegroundColor Green
+Write-Host "All snippet projects validated successfully!" -ForegroundColor Green
 exit 0

--- a/test/Misc/TestSerializerExternalModels/TestSerializerExternalModels.csproj
+++ b/test/Misc/TestSerializerExternalModels/TestSerializerExternalModels.csproj
@@ -2,10 +2,9 @@
   <PropertyGroup>
     <RootNamespace>UnitTests.SerializerExternalModels</RootNamespace>
     <AssemblyName>SerializerExternalModels</AssemblyName>
-    <TargetFrameworks>$(TestTargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-    <SuppressTfmSupportBuildWarnings Condition="'$(TargetFramework)' == 'netcoreapp3.1'">true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Orleans.Serialization.Abstractions\Orleans.Serialization.Abstractions.csproj" />

--- a/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/BuiltInCodecTests.cs
@@ -2738,11 +2738,9 @@ namespace Orleans.Serialization.UnitTests
         private readonly IEqualityComparer<string>[] _comparers =
         [
             new CaseInsensitiveEqualityComparer(),
-#if NETCOREAPP3_1_OR_GREATER
             StringComparer.Ordinal,
             StringComparer.OrdinalIgnoreCase,
             EqualityComparer<string>.Default,
-#endif
 #if NET6_0_OR_GREATER
             StringComparer.InvariantCulture,
             StringComparer.InvariantCultureIgnoreCase,

--- a/test/Orleans.Serialization.UnitTests/GeneratedSerializerBitwiseCompatibilityTests.cs
+++ b/test/Orleans.Serialization.UnitTests/GeneratedSerializerBitwiseCompatibilityTests.cs
@@ -8,9 +8,7 @@ using Orleans.Serialization.Session;
 using Orleans.Serialization.Utilities;
 using UnitTests.SerializerExternalModels;
 using Xunit;
-#if !NETCOREAPP3_1
 using static VerifyXunit.Verifier;
-#endif
 
 namespace Orleans.Serialization.UnitTests;
 
@@ -34,51 +32,41 @@ public sealed class GeneratedSerializerBitwiseCompatibilityTests : IDisposable
     public void GeneratedClassSerializer_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreateBaselineClass()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task GeneratedClassSerializer_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreateBaselineClass())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void GeneratedRecordSerializer_UntypedRoot_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs<object>(CreateBaselinePerson()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task GeneratedRecordSerializer_UntypedRoot_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs<object>(CreateBaselinePerson())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void GeneratedAutoFieldIdSerializer_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreateBaselineAutoProperties()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task GeneratedAutoFieldIdSerializer_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreateBaselineAutoProperties())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void GeneratedPolymorphicSerializer_BaseType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs<BaselineBase>(CreateBaselineDerived()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task GeneratedPolymorphicSerializer_BaseType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs<BaselineBase>(CreateBaselineDerived())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void Person3_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreatePerson3()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task Person3_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreatePerson3())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void Person4_ExactType_MatchesBaseline()
@@ -88,11 +76,9 @@ public sealed class GeneratedSerializerBitwiseCompatibilityTests : IDisposable
     public void Person5_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreatePerson5()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task Person5_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreatePerson5())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void Person5_RecordAndClass_AreBitwiseEquivalent()
@@ -112,21 +98,17 @@ public sealed class GeneratedSerializerBitwiseCompatibilityTests : IDisposable
     public void Person2External_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreatePerson2External()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task Person2External_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreatePerson2External())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void GenericPersonExternalStruct_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreateGenericPersonExternalStruct()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task GenericPersonExternalStruct_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreateGenericPersonExternalStruct())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void ReadonlyGenericPersonExternalStruct_ExactType_MatchesBaseline()
@@ -137,11 +119,9 @@ public sealed class GeneratedSerializerBitwiseCompatibilityTests : IDisposable
     public void GenericPersonExternal_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreateGenericPersonExternal()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task GenericPersonExternal_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreateGenericPersonExternal())), extension: "txt").UseDirectory("snapshots");
-#endif
 #endif
 #endif
 
@@ -149,21 +129,17 @@ public sealed class GeneratedSerializerBitwiseCompatibilityTests : IDisposable
     public void GenericPocoString_Untyped_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs<object>(CreateGenericPocoString()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task GenericPocoString_Untyped_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs<object>(CreateGenericPocoString())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void NestedGenericPoco_Untyped_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs<object>(CreateNestedGenericPoco()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task NestedGenericPoco_Untyped_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs<object>(CreateNestedGenericPoco())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void OuterInnerGen_Untyped_MatchesBaseline()
@@ -181,11 +157,9 @@ public sealed class GeneratedSerializerBitwiseCompatibilityTests : IDisposable
     public void DerivedFromDictionary_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreateDerivedFromDictionary()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task DerivedFromDictionary_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreateDerivedFromDictionary())), extension: "txt").UseDirectory("snapshots");
-#endif
 
 #if NET6_0_OR_GREATER
     [Fact]
@@ -196,11 +170,9 @@ public sealed class GeneratedSerializerBitwiseCompatibilityTests : IDisposable
     public void SubClassWithRequiredMembersInBase_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreateSubClassWithRequiredMembersInBase()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task ClassWithRequiredMembers_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreateClassWithRequiredMembers())), extension: "txt").UseDirectory("snapshots");
-#endif
 #endif
 
     [Fact]
@@ -219,61 +191,49 @@ public sealed class GeneratedSerializerBitwiseCompatibilityTests : IDisposable
     public void DuplicateReferences_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs<object[]>(CreateDuplicateReferences()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task DuplicateReferences_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs<object[]>(CreateDuplicateReferences())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void DuplicateReferencesSuppressTracking_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs<object[]>(CreateDuplicateSuppressTrackingReferences()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task DuplicateReferencesSuppressTracking_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs<object[]>(CreateDuplicateSuppressTrackingReferences())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void ClassWithTypeFields_Untyped_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs<object>(CreateClassWithTypeFields()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task ClassWithTypeFields_Untyped_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs<object>(CreateClassWithTypeFields())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void WrapsMyForeignLibraryType_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreateWrapsMyForeignLibraryType()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task WrapsMyForeignLibraryType_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreateWrapsMyForeignLibraryType())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void MyFirstForeignLibraryType_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreateMyFirstForeignLibraryType()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task MyFirstForeignLibraryType_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreateMyFirstForeignLibraryType())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     [Fact]
     public void MySecondForeignLibraryType_ExactType_MatchesBaseline()
         => AssertBitwiseCompatibility(SerializeAs(CreateMySecondForeignLibraryType()));
 
-#if !NETCOREAPP3_1
     [Fact]
     public Task MySecondForeignLibraryType_ExactType_Formatted_MatchesSnapshot()
         => Verify(FormatSerializedPayload(SerializeAs(CreateMySecondForeignLibraryType())), extension: "txt").UseDirectory("snapshots");
-#endif
 
     public void Dispose() => _serviceProvider.Dispose();
 

--- a/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
+++ b/test/Orleans.Serialization.UnitTests/InterfaceCollectionCodecTests.cs
@@ -19,9 +19,7 @@ using Orleans.Serialization.TestKit;
 using Orleans.Serialization.Utilities;
 using Xunit;
 using Xunit.Abstractions;
-#if !NETCOREAPP3_1
 using static VerifyXunit.Verifier;
-#endif
 
 namespace Orleans.Serialization.UnitTests;
 
@@ -374,7 +372,6 @@ public class InterfaceCollectionRegressionTests
         Assert.Equal(4, readOnlyDictionary["d"]);
     }
 
-#if !NETCOREAPP3_1
     [Fact]
     public void CanDeserializeLegacyInterfaceCodecPayload()
     {
@@ -463,7 +460,6 @@ public class InterfaceCollectionRegressionTests
     [Fact]
     public Task ReadOnlyDictionaryInterfaceConcreteDictionary_Formatted_MatchesSnapshot()
         => VerifyConcreteRuntimeBitStream<IReadOnlyDictionary<string, int>>(new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 }, ReadOnlyDictionaryCodecAlias);
-#endif
 
     private static T RoundTrip<T>(T value)
     {
@@ -478,7 +474,6 @@ public class InterfaceCollectionRegressionTests
         return serviceProvider.GetRequiredService<DeepCopier<T>>().Copy(value)!;
     }
 
-#if !NETCOREAPP3_1
     private static Task VerifyFallbackBitStream<T>(T value, string codecAlias)
     {
         var formatted = FormatSerializedPayload(value);
@@ -505,7 +500,6 @@ public class InterfaceCollectionRegressionTests
         using var session = serviceProvider.GetRequiredService<SerializerSessionPool>().GetSession();
         return BitStreamFormatter.Format(payload, session);
     }
-#endif
 
     [GenerateSerializer]
     [Alias("Orleans.Serialization.UnitTests.InterfaceCollectionRegressionTests.ReadOnlyListContainer")]

--- a/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
+++ b/test/Orleans.Serialization.UnitTests/Orleans.Serialization.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks>$(TestTargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <OrleansBuildTimeCodeGen>true</OrleansBuildTimeCodeGen>
@@ -23,35 +23,21 @@
     <PackageReference Include="Grpc.Tools" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup>
     <PackageReference Include="Verify.Xunit" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Update="CsCheck" VersionOverride="2.14.1"/>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" VersionOverride="17.11.1"/>
-    <PackageReference Update="xunit.runner.visualstudio" VersionOverride="2.4.5"/>
-    <PackageReference Update="xunit" VersionOverride="2.4.2" />
-    <PackageReference Update="xunit.assert" VersionOverride="2.4.2" />
-    <PackageReference Update="xunit.core" VersionOverride="2.4.2" />
-    <PackageReference Update="xunit.extensibility.core" VersionOverride="2.4.2" />
-    <PackageReference Update="xunit.extensibility.execution" VersionOverride="2.4.2" />
-    <Compile Remove="SerializationTests.cs" />
-    <Compile Remove="JsonSerializerTests.cs" />
-    <Compile Remove="RoundTripSerializerTests.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.TestKit\Orleans.Serialization.TestKit.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.FSharp\Orleans.Serialization.FSharp.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization\Orleans.Serialization.csproj" />
-    <ProjectReference Include="$(SourceRoot)src\Orleans.Streaming\Orleans.Streaming.csproj" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
+    <ProjectReference Include="$(SourceRoot)src\Orleans.Streaming\Orleans.Streaming.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.SystemTextJson\Orleans.Serialization.SystemTextJson.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.NewtonsoftJson\Orleans.Serialization.NewtonsoftJson.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Orleans.Serialization.MessagePack\Orleans.Serialization.MessagePack.csproj" />
     <ProjectReference Include="$(SourceRoot)src\Serializers\Orleans.Serialization.Protobuf\Orleans.Serialization.Protobuf.csproj" />
     <ProjectReference Include="..\Misc\TestSerializerExternalModels\TestSerializerExternalModels.csproj" />
-    <ProjectReference Include="$(SourceRoot)test\Orleans.Runtime.Tests\Orleans.Runtime.Tests.csproj" Condition="'$(TargetFramework)' != 'netcoreapp3.1'" />
+    <ProjectReference Include="$(SourceRoot)test\Orleans.Runtime.Tests\Orleans.Runtime.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

Maintained tests could be silently skipped: the API data generator tests are outside the product solution, documentation snippets were only built even when they were test projects, and serialization still declared an end-of-life runtime target which CI no longer installed or selected.

## Solution

- Run `PackageJsonGenerator.Tests` in the documentation workflow, where the API generator is consumed, instead of coupling documentation tooling to the product solution.
- Treat snippet projects marked with `IsTestProject=true` as executable documentation and run them from the snippet validator. This makes the Orleans testing sample's behavior part of docs CI and documents that policy in `docs/AGENTS.md`.
- Remove the `netcoreapp3.1` serialization test target and its compatibility-only package, source, and project-reference branches. That target was introduced as a runtime proxy for netstandard 2.1 and originally depended on CI installing .NET Core 3.1; current supported runtime testing is net8.0 and net10.0, while package compatibility targets remain unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10416)