### PR TITLE
test(streaming): retire stale queue balancer skips

### DIFF
--- a/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventDataGeneratorStreamConfigurator.cs
+++ b/src/Azure/Orleans.Streaming.EventHubs/Providers/Streams/EventHub/EventDataGeneratorStreamConfigurator.cs
@@ -32,7 +32,6 @@ namespace Orleans.Hosting.Developer
             this.ConfigureDelegate(services => services.ConfigureNamedOptionForLogging<EventHubOptions>(name)
                 .ConfigureNamedOptionForLogging<EventHubReceiverOptions>(name)
                 .ConfigureNamedOptionForLogging<EventHubStreamCachePressureOptions>(name)
-                .AddTransient<IConfigurationValidator>(sp => new EventHubOptionsValidator(sp.GetOptionsByName<EventHubOptions>(name), name))
                 .AddTransient<IConfigurationValidator>(sp => new StreamCheckpointerConfigurationValidator(sp, name)));
         }
     }

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/PluggableQueueBalancerTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/PluggableQueueBalancerTests.cs
@@ -1,5 +1,7 @@
 using Orleans.Configuration;
 using Orleans.Hosting.Developer;
+using Orleans.Streaming.EventHubs.Testing;
+using Orleans.Streams;
 using Orleans.TestingHost;
 using Tester.StreamingTests;
 using TestExtensions;
@@ -24,7 +26,6 @@ namespace ServiceBus.Tests
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
                 builder.Options.InitialSilosCount = SiloCount;
-                builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
                 builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
             }
 
@@ -43,7 +44,8 @@ namespace ServiceBus.Tests
                                 {
                                     options.EventHubPartitionCount = TotalQueueCount;
                                 }));
-                                b.ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s, n));
+                                b.ConfigureComponent<IStreamQueueCheckpointerFactory>((s, n) => NoOpCheckpointerFactory.Instance);
+                                b.ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s, n, TotalQueueCount / SiloCount));
                             });
                 }
             }
@@ -54,7 +56,7 @@ namespace ServiceBus.Tests
             this.fixture = fixture;
         }
 
-        [Fact(Skip = "https://github.com/dotnet/orleans/issues/4317"), TestCategory("BVT")]
+        [Fact, TestCategory("BVT")]
         public Task PluggableQueueBalancerTest_ShouldUseInjectedQueueBalancerAndBalanceCorrectly()
         {
             return base.ShouldUseInjectedQueueBalancerAndBalanceCorrectly(this.fixture, StreamProviderName, SiloCount, TotalQueueCount);

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
@@ -70,7 +70,7 @@ namespace ServiceBus.Tests.MonitorTests
             seed = new Random();
         }
 
-        [Fact(Skip = "https://github.com/dotnet/orleans/issues/4594"), TestCategory("Functional")]
+        [Fact, TestCategory("Functional")]
         public async Task EHStatistics_MonitorCalledAccordingly()
         {
             var streamId = new FullStreamIdentity(Guid.NewGuid(), StreamNamespace, StreamProviderName);

--- a/test/Extensions/Orleans.Streaming.EventHubs.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
+++ b/test/Extensions/Orleans.Streaming.EventHubs.Tests/StatisticMonitorTests/EHStatisticMonitorTests.cs
@@ -1,6 +1,7 @@
 using Orleans.Runtime;
 using Orleans.Streams;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
 using ServiceBus.Tests.TestStreamProviders;
 using TestExtensions;
 using UnitTests.Grains.ProgrammaticSubscribe;
@@ -21,7 +22,7 @@ namespace ServiceBus.Tests.MonitorTests
     {
         private const string StreamProviderName = "EventHubStreamProvider";
         private const string StreamNamespace = "EHTestsNamespace";
-        private static readonly TimeSpan timeout = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan timeout = TimeSpan.FromSeconds(30);
         private static readonly TimeSpan monitorWriteInterval = TimeSpan.FromSeconds(2);
         private static readonly int ehPartitionCountPerSilo = 4;
 
@@ -80,45 +81,115 @@ namespace ServiceBus.Tests.MonitorTests
 
             //configure data generator for stream and start producing
             var mgmtGrain = this.fixture.GrainFactory.GetGrain<IManagementGrain>(0);
+            await TestingUtils.WaitUntilAsync(
+                (lastTry, cancellationToken) => CheckReceiversInitialized(mgmtGrain, lastTry, cancellationToken),
+                timeout);
             var randomStreamPlacementArg = new EHStreamProviderForMonitorTestsAdapterFactory.StreamRandomPlacementArg(streamId, this.seed.Next(100));
             await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
                 (int)EHStreamProviderForMonitorTestsAdapterFactory.Commands.Randomly_Place_Stream_To_Queue, randomStreamPlacementArg);
+            await TestingUtils.WaitUntilAsync(
+                (lastTry, cancellationToken) => CheckMonitorCounters(mgmtGrain, requireCachePressure: false, lastTry, cancellationToken),
+                timeout);
 
-            // let the test to run for a while to build up some streaming traffic
-            await Task.Delay(timeout);
-            //wait sometime after cache pressure changing, for the system to notice it and trigger cache monitor to track it
             await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
                 (int)EHStreamProviderForMonitorTestsAdapterFactory.QueryCommands.ChangeCachePressure, null);
-            await Task.Delay(timeout);
-
-            //assert EventHubReceiverMonitor call counters
-            var receiverMonitorCounters = await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
-                (int)EHStreamProviderForMonitorTestsAdapterFactory.QueryCommands.GetReceiverMonitorCallCounters, null);
-            foreach (var callCounter in receiverMonitorCounters)
-            {
-                AssertReceiverMonitorCallCounters((callCounter as EventHubReceiverMonitorCounters)!);
-            }
-
-            var cacheMonitorCounters = await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
-                (int)EHStreamProviderForMonitorTestsAdapterFactory.QueryCommands.GetCacheMonitorCallCounters, null);
-            foreach (var callCounter in cacheMonitorCounters)
-            {
-                AssertCacheMonitorCallCounters((callCounter as CacheMonitorCounters)!);
-            }
-
-            var objectPoolMonitorCounters = await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
-             (int)EHStreamProviderForMonitorTestsAdapterFactory.QueryCommands.GetObjectPoolMonitorCallCounters, null);
-            foreach (var callCounter in objectPoolMonitorCounters)
-            {
-                AssertObjectPoolMonitorCallCounters((callCounter as ObjectPoolMonitorCounters)!);
-            }
+            await TestingUtils.WaitUntilAsync(
+                (lastTry, cancellationToken) => CheckMonitorCounters(mgmtGrain, requireCachePressure: true, lastTry, cancellationToken),
+                timeout);
         }
 
-        private static void AssertCacheMonitorCallCounters(CacheMonitorCounters totalCacheMonitorCallCounters)
+        private static async Task<bool> CheckReceiversInitialized(IManagementGrain mgmtGrain, bool lastTry, CancellationToken cancellationToken)
+        {
+            var receiverMonitorCounters = await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
+                (int)EHStreamProviderForMonitorTestsAdapterFactory.QueryCommands.GetReceiverMonitorCallCounters, null).WaitAsync(cancellationToken);
+            var ready = receiverMonitorCounters.Length > 0
+                && receiverMonitorCounters.All(callCounter =>
+                    ((EventHubReceiverMonitorCounters)callCounter!).TrackInitializationCallCounter == ehPartitionCountPerSilo);
+
+            if (ready || lastTry)
+            {
+                Assert.NotEmpty(receiverMonitorCounters);
+                foreach (var callCounter in receiverMonitorCounters)
+                {
+                    var c = (EventHubReceiverMonitorCounters)callCounter!;
+                    Assert.True(c.TrackInitializationCallCounter == ehPartitionCountPerSilo,
+                        $"Expected {nameof(c.TrackInitializationCallCounter)} == {ehPartitionCountPerSilo}, got {c.TrackInitializationCallCounter}");
+                }
+            }
+
+            return ready;
+        }
+
+        private static async Task<bool> CheckMonitorCounters(
+            IManagementGrain mgmtGrain,
+            bool requireCachePressure,
+            bool lastTry,
+            CancellationToken cancellationToken)
+        {
+            var receiverMonitorCounters = await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
+                (int)EHStreamProviderForMonitorTestsAdapterFactory.QueryCommands.GetReceiverMonitorCallCounters, null).WaitAsync(cancellationToken);
+            var cacheMonitorCounters = await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
+                (int)EHStreamProviderForMonitorTestsAdapterFactory.QueryCommands.GetCacheMonitorCallCounters, null).WaitAsync(cancellationToken);
+            var objectPoolMonitorCounters = await mgmtGrain.SendControlCommandToProvider<PersistentStreamProvider>(StreamProviderName,
+                (int)EHStreamProviderForMonitorTestsAdapterFactory.QueryCommands.GetObjectPoolMonitorCallCounters, null).WaitAsync(cancellationToken);
+
+            var ready = receiverMonitorCounters.Length > 0
+                && receiverMonitorCounters.All(callCounter => ReceiverMonitorCallCountersAreExpected((EventHubReceiverMonitorCounters)callCounter!))
+                && cacheMonitorCounters.Length > 0
+                && cacheMonitorCounters.All(callCounter => CacheMonitorCallCountersAreExpected((CacheMonitorCounters)callCounter!, requireCachePressure))
+                && objectPoolMonitorCounters.Length > 0
+                && objectPoolMonitorCounters.All(callCounter => ObjectPoolMonitorCallCountersAreExpected((ObjectPoolMonitorCounters)callCounter!));
+
+            if (ready || lastTry)
+            {
+                Assert.NotEmpty(receiverMonitorCounters);
+                foreach (var callCounter in receiverMonitorCounters)
+                {
+                    AssertReceiverMonitorCallCounters((EventHubReceiverMonitorCounters)callCounter!);
+                }
+
+                Assert.NotEmpty(cacheMonitorCounters);
+                foreach (var callCounter in cacheMonitorCounters)
+                {
+                    AssertCacheMonitorCallCounters((CacheMonitorCounters)callCounter!, requireCachePressure);
+                }
+
+                Assert.NotEmpty(objectPoolMonitorCounters);
+                foreach (var callCounter in objectPoolMonitorCounters)
+                {
+                    AssertObjectPoolMonitorCallCounters((ObjectPoolMonitorCounters)callCounter!);
+                }
+            }
+
+            return ready;
+        }
+
+        private static bool CacheMonitorCallCountersAreExpected(CacheMonitorCounters c, bool requireCachePressure) =>
+            (!requireCachePressure || c.TrackCachePressureMonitorStatusChangeCallCounter > 0)
+            && c.TrackMemoryAllocatedCallCounter > 0
+            && c.TrackMemoryReleasedCallCounter == 0
+            && c.TrackMessageAddedCounter > 0
+            && c.TrackMessagePurgedCounter == 0;
+
+        private static bool ReceiverMonitorCallCountersAreExpected(EventHubReceiverMonitorCounters c) =>
+            c.TrackInitializationCallCounter == ehPartitionCountPerSilo
+            && c.TrackMessagesReceivedCallCounter > 0
+            && c.TrackReadCallCounter > 0
+            && c.TrackShutdownCallCounter == 0;
+
+        private static bool ObjectPoolMonitorCallCountersAreExpected(ObjectPoolMonitorCounters c) =>
+            c.TrackObjectAllocatedByCacheCallCounter > 0
+            && c.TrackObjectReleasedFromCacheCallCounter == 0;
+
+        private static void AssertCacheMonitorCallCounters(CacheMonitorCounters totalCacheMonitorCallCounters, bool requireCachePressure)
         {
             var c = totalCacheMonitorCallCounters;
-            Assert.True(c.TrackCachePressureMonitorStatusChangeCallCounter > 0,
-                $"Expected {nameof(c.TrackCachePressureMonitorStatusChangeCallCounter)} > 0, got {c.TrackCachePressureMonitorStatusChangeCallCounter}");
+            if (requireCachePressure)
+            {
+                Assert.True(c.TrackCachePressureMonitorStatusChangeCallCounter > 0,
+                    $"Expected {nameof(c.TrackCachePressureMonitorStatusChangeCallCounter)} > 0, got {c.TrackCachePressureMonitorStatusChangeCallCounter}");
+            }
+
             Assert.True(c.TrackMemoryAllocatedCallCounter > 0, $"Expected {nameof(c.TrackMemoryAllocatedCallCounter)} > 0, got {c.TrackMemoryAllocatedCallCounter}");
             Assert.True(0 == c.TrackMemoryReleasedCallCounter, $"Expected {nameof(c.TrackMemoryReleasedCallCounter)} == 0, got {c.TrackMemoryReleasedCallCounter}");
             Assert.True(c.TrackMessageAddedCounter > 0, $"Expected {nameof(c.TrackMessageAddedCounter)} > 0, got {c.TrackMessageAddedCounter}");

--- a/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/LeaseBasedQueueBalancer.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/LeaseBasedQueueBalancer.cs
@@ -7,12 +7,14 @@ namespace Tester.StreamingTests
     {
         private readonly string id;
         private readonly ILeaseManagerGrain leaseManagerGrain;
+        private readonly int _expectedResponsibility;
         private List<QueueId> ownedQueues = null!;
 
-        public LeaseBasedQueueBalancerForTest(string name, IGrainFactory grainFactory)
+        public LeaseBasedQueueBalancerForTest(string name, int expectedResponsibility, IGrainFactory grainFactory)
         {
             this.leaseManagerGrain = grainFactory.GetGrain<ILeaseManagerGrain>(name);
             this.id = $"{name}-{Guid.NewGuid()}";
+            _expectedResponsibility = expectedResponsibility;
         }
 
         public async Task Initialize(IStreamQueueMapper queueMapper)
@@ -33,9 +35,8 @@ namespace Tester.StreamingTests
 
         private async Task GetInitialLease()
         {
-            var responsibilty = await this.leaseManagerGrain.GetLeaseResposibility();
-            this.ownedQueues = new List<QueueId>(responsibilty);
-            for(int i = 0; i < responsibilty; i++)
+            this.ownedQueues = new List<QueueId>(_expectedResponsibility);
+            for(int i = 0; i < _expectedResponsibility; i++)
             {
                 try
                 {

--- a/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/LeaseManagerGrain.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/LeaseManagerGrain.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
-using Orleans.Runtime;
 using Orleans.Streams;
 
 namespace Tester.StreamingTests
@@ -10,7 +8,6 @@ namespace Tester.StreamingTests
         Task<QueueId> Acquire();
         Task<bool> Renew(QueueId leaseNumber);
         Task Release(QueueId leaseNumber);
-        Task<int> GetLeaseResposibility();
         Task SetQueuesAsLeases(IEnumerable<QueueId> queues);
         //methods used in test asserts
         Task RecordBalancerResponsibility(string balancerId, int ownedQueues);
@@ -23,19 +20,11 @@ namespace Tester.StreamingTests
         //queueId is the lease id here
         private static readonly DateTime UnAssignedLeaseTime = DateTime.MinValue;
         private Dictionary<QueueId, DateTime> queueLeaseToRenewTimeMap = null!;
-        private ISiloStatusOracle siloStatusOracle = null!;
         public override Task OnActivateAsync(CancellationToken cancellationToken)
         {
-            this.siloStatusOracle = base.ServiceProvider.GetRequiredService<ISiloStatusOracle>();
             this.queueLeaseToRenewTimeMap = new Dictionary<QueueId, DateTime>();
             this.responsibilityMap = new Dictionary<string, int>();
             return Task.CompletedTask;
-        }
-        public Task<int> GetLeaseResposibility()
-        {
-            var siloCount = this.siloStatusOracle.GetApproximateSiloStatuses(onlyActive: true).Count;
-            var resposibity = this.queueLeaseToRenewTimeMap.Count / siloCount;
-            return Task.FromResult(resposibity);
         }
 
         public Task<QueueId> Acquire()

--- a/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestBase.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Xunit;
+﻿using Xunit;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
 using TestExtensions;
@@ -9,21 +8,11 @@ namespace Tester.StreamingTests
     public class PluggableQueueBalancerTestBase : OrleansTestingBase
     {
         private readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
-        private static readonly Type QueueBalancerType = typeof(LeaseBasedQueueBalancerForTest);
-
         public virtual async Task ShouldUseInjectedQueueBalancerAndBalanceCorrectly(BaseTestClusterFixture fixture, string streamProviderName, int siloCount, int totalQueueCount)
         {
             var leaseManager = fixture.GrainFactory.GetGrain<ILeaseManagerGrain>(streamProviderName);
             var expectedResponsibilityPerBalancer = totalQueueCount / siloCount;
             await TestingUtils.WaitUntilAsync((lastTry, cancellationToken) => CheckLeases(leaseManager, siloCount, expectedResponsibilityPerBalancer, lastTry, cancellationToken), Timeout);
-        }
-
-        public class SiloBuilderConfigurator : ISiloConfigurator
-        {
-            public void Configure(ISiloBuilder hostBuilder)
-            {
-                hostBuilder.ConfigureServices(services => services.AddTransient<LeaseBasedQueueBalancerForTest>());
-            }
         }
 
         private async Task<bool> CheckLeases(ILeaseManagerGrain leaseManager, int siloCount, int expectedResponsibilityPerBalancer, bool lastTry, CancellationToken cancellationToken)

--- a/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestsWithMemoryStreamProvider.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/PlugableQueueBalancerTests/PluggableQueueBalancerTestsWithMemoryStreamProvider.cs
@@ -23,7 +23,6 @@ namespace Tester.StreamingTests.PlugableQueueBalancerTests
             protected override void ConfigureTestCluster(TestClusterBuilder builder)
             {
                 builder.Options.InitialSilosCount = siloCount;
-                builder.AddSiloBuilderConfigurator<SiloBuilderConfigurator>();
                 builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
                 builder.AddClientBuilderConfigurator<MyClientBuilderConfigurator>();
             }
@@ -39,7 +38,7 @@ namespace Tester.StreamingTests.PlugableQueueBalancerTests
                             b=>
                             {
                                 b.ConfigurePartitioning(totalQueueCount);
-                                b.ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s, n));
+                                b.ConfigurePartitionBalancing((s, n) => ActivatorUtilities.CreateInstance<LeaseBasedQueueBalancerForTest>(s, n, totalQueueCount / siloCount));
                             });
                         
                 }
@@ -61,7 +60,7 @@ namespace Tester.StreamingTests.PlugableQueueBalancerTests
             this.fixture = fixture;
         }
 
-        [Fact(Skip = "https://github.com/dotnet/orleans/issues/4317"), TestCategory("BVT")]
+        [Fact, TestCategory("BVT")]
         public Task PluggableQueueBalancerTest_ShouldUseInjectedQueueBalancerAndBalanceCorrectly()
         {
             return base.ShouldUseInjectedQueueBalancerAndBalanceCorrectly(this.fixture, StreamProviderName, siloCount, totalQueueCount);


### PR DESCRIPTION
The pluggable queue balancer tests and EventHub statistics monitor remained disabled after their linked reliability issues were closed. The skips hid stale setup: the test balancer was registered through an invalid unkeyed DI path, derived its responsibility before cluster membership converged, and the in-memory event-data generator applied validation intended for real Event Hub connections.

This removes three stale skips, passes the expected queue responsibility directly to the test balancer, configures the generator test with its no-op checkpointer, and stops requiring a real Event Hub connection for the generator adapter. Provider-backed skips which could not be executed against their required services are intentionally left unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10417)