### PR TITLE
chore: add repository code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ReubenBond


### PR DESCRIPTION
Establishes explicit review ownership so GitHub can automatically request the appropriate reviewer for changes across the repository.

Adds a repository-wide CODEOWNERS rule assigning all paths to @ReubenBond.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10419)