### PR TITLE
fix(tests): initialize Azure shard fixture services

### DIFF
--- a/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureBlobJournaledJobShardManagerTests.cs
+++ b/test/Extensions/Orleans.DurableJobs.AzureStorage.Tests/DurableJobs/AzureBlobJournaledJobShardManagerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.DurableJobs.Tests;
 using Orleans.Hosting;
+using Orleans.Journaling;
 using Orleans.Runtime;
 using Tester;
 using TestExtensions;
@@ -25,7 +26,10 @@ public sealed class AzureBlobJournaledJobShardManagerTestFixture : IJobShardMana
         var containerName = "durablejobs-shard-tests-" + Guid.NewGuid().ToString("N");
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddMetrics();
+        services.AddSingleton<OrleansInstruments>();
         services.AddSingleton(TimeProvider.System);
+        services.AddKeyedSingleton<TimeProvider>(KeyedService.AnyKey, static (sp, _) => sp.GetRequiredService<TimeProvider>());
         services.UseAzureBlobDurableJobs(options =>
         {
             options.ConfigureTestDefaults();
@@ -34,10 +38,8 @@ public sealed class AzureBlobJournaledJobShardManagerTestFixture : IJobShardMana
 
         var serviceProvider = services.BuildServiceProvider();
         var lifecycle = new SiloLifecycleSubject(serviceProvider.GetRequiredService<ILogger<SiloLifecycleSubject>>());
-        foreach (var participant in serviceProvider.GetServices<ILifecycleParticipant<ISiloLifecycle>>())
-        {
-            participant.Participate(lifecycle);
-        }
+        var storageProvider = serviceProvider.GetRequiredService<IJournalStorageProvider>();
+        Assert.IsAssignableFrom<ILifecycleParticipant<ISiloLifecycle>>(storageProvider).Participate(lifecycle);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         await lifecycle.OnStart(cts.Token);


### PR DESCRIPTION
`AzureBlobJournaledJobShardManagerTests` built a standalone service provider and activated every registered silo lifecycle participant. That pulled in the full Durable Jobs runtime graph and failed while constructing `ShardExecutor` because no Orleans host had registered `IInternalGrainFactory`.

Register the real metrics and time-provider defaults needed by the Azure journal provider, then initialize only that storage provider in the fixture lifecycle. This keeps the direct component tests lightweight without faking runtime internals or changing production DI.

Fixes: #10411
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10420)