### PR TITLE
fix(testing): stabilize reminder diagnostic waiters

### DIFF
--- a/src/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
+++ b/src/Orleans.Testing.Reminders/ReminderDiagnosticObserver.cs
@@ -56,7 +56,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
 
     private void StoreEvent(ReminderEvents.ReminderEvent value)
     {
-        List<TaskCompletionSource<bool>> ready = [];
+        List<Waiter> ready = [];
         lock (_lock)
         {
             switch (value)
@@ -136,9 +136,9 @@ public sealed class ReminderDiagnosticObserver : IDisposable
             }
         }
 
-        foreach (var taskSource in ready)
+        foreach (var waiter in ready)
         {
-            taskSource.TrySetResult(true);
+            waiter.Complete();
         }
     }
 
@@ -307,9 +307,10 @@ public sealed class ReminderDiagnosticObserver : IDisposable
 
             waiter = new TickCountWaiter(grainId, reminderName, targetCount);
             _tickCountWaiters.Add(waiter);
+            RegisterCancellation(waiter, _tickCountWaiters, cancellationToken);
         }
 
-        return WaitAsync(waiter, cancellationToken);
+        return waiter.TaskSource.Task;
     }
 
     private Task WaitForActiveReminderCountCoreAsync(GrainId grainId, int targetCount, string reminderName, CancellationToken cancellationToken)
@@ -329,9 +330,10 @@ public sealed class ReminderDiagnosticObserver : IDisposable
 
             waiter = new ActiveReminderCountWaiter(grainId, reminderName, targetCount);
             _activeReminderCountWaiters.Add(waiter);
+            RegisterCancellation(waiter, _activeReminderCountWaiters, cancellationToken);
         }
 
-        return WaitAsync(waiter, cancellationToken);
+        return waiter.TaskSource.Task;
     }
 
     private Task WaitForLocalReminderScheduleCoreAsync(GrainId grainId, string reminderName, CancellationToken cancellationToken)
@@ -351,69 +353,29 @@ public sealed class ReminderDiagnosticObserver : IDisposable
 
             waiter = new LocalReminderScheduleWaiter(grainId, reminderName);
             _localReminderScheduleWaiters.Add(waiter);
+            RegisterCancellation(waiter, _localReminderScheduleWaiters, cancellationToken);
         }
 
-        return WaitAsync(waiter, cancellationToken);
+        return waiter.TaskSource.Task;
     }
 
-    private async Task WaitAsync(TickCountWaiter waiter, CancellationToken cancellationToken)
+    private void RegisterCancellation<TWaiter>(TWaiter waiter, List<TWaiter> waiters, CancellationToken cancellationToken)
+        where TWaiter : Waiter
     {
-        using var registration = cancellationToken.Register(static state =>
+        waiter.CancellationRegistration = cancellationToken.Register(static state =>
         {
-            var (observer, pendingWaiter, token) = ((ReminderDiagnosticObserver Observer, TickCountWaiter Waiter, CancellationToken Token))state!;
-            observer.CancelWaiter(pendingWaiter, token);
-        }, (this, waiter, cancellationToken));
-
-        await waiter.TaskSource.Task.ConfigureAwait(false);
+            var (observer, pendingWaiter, pendingWaiters, token) =
+                ((ReminderDiagnosticObserver Observer, TWaiter Waiter, List<TWaiter> Waiters, CancellationToken Token))state!;
+            observer.CancelWaiter(pendingWaiter, pendingWaiters, token);
+        }, (this, waiter, waiters, cancellationToken));
     }
 
-    private async Task WaitAsync(LocalReminderScheduleWaiter waiter, CancellationToken cancellationToken)
-    {
-        using var registration = cancellationToken.Register(static state =>
-        {
-            var (observer, pendingWaiter, token) = ((ReminderDiagnosticObserver Observer, LocalReminderScheduleWaiter Waiter, CancellationToken Token))state!;
-            observer.CancelWaiter(pendingWaiter, token);
-        }, (this, waiter, cancellationToken));
-
-        await waiter.TaskSource.Task.ConfigureAwait(false);
-    }
-
-    private async Task WaitAsync(ActiveReminderCountWaiter waiter, CancellationToken cancellationToken)
-    {
-        using var registration = cancellationToken.Register(static state =>
-        {
-            var (observer, pendingWaiter, token) = ((ReminderDiagnosticObserver Observer, ActiveReminderCountWaiter Waiter, CancellationToken Token))state!;
-            observer.CancelWaiter(pendingWaiter, token);
-        }, (this, waiter, cancellationToken));
-
-        await waiter.TaskSource.Task.ConfigureAwait(false);
-    }
-
-    private void CancelWaiter(TickCountWaiter waiter, CancellationToken cancellationToken)
+    private void CancelWaiter<TWaiter>(TWaiter waiter, List<TWaiter> waiters, CancellationToken cancellationToken)
+        where TWaiter : Waiter
     {
         lock (_lock)
         {
-            _tickCountWaiters.Remove(waiter);
-        }
-
-        waiter.TaskSource.TrySetCanceled(cancellationToken);
-    }
-
-    private void CancelWaiter(LocalReminderScheduleWaiter waiter, CancellationToken cancellationToken)
-    {
-        lock (_lock)
-        {
-            _localReminderScheduleWaiters.Remove(waiter);
-        }
-
-        waiter.TaskSource.TrySetCanceled(cancellationToken);
-    }
-
-    private void CancelWaiter(ActiveReminderCountWaiter waiter, CancellationToken cancellationToken)
-    {
-        lock (_lock)
-        {
-            _activeReminderCountWaiters.Remove(waiter);
+            waiters.Remove(waiter);
         }
 
         waiter.TaskSource.TrySetCanceled(cancellationToken);
@@ -470,7 +432,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         return false;
     }
 
-    private void ReleaseReadyTickWaiters(List<TaskCompletionSource<bool>> ready)
+    private void ReleaseReadyTickWaiters(List<Waiter> ready)
     {
         for (var i = _tickCountWaiters.Count - 1; i >= 0; i--)
         {
@@ -481,11 +443,11 @@ public sealed class ReminderDiagnosticObserver : IDisposable
             }
 
             _tickCountWaiters.RemoveAt(i);
-            ready.Add(waiter.TaskSource);
+            ready.Add(waiter);
         }
     }
 
-    private void ReleaseReadyActiveReminderWaiters(List<TaskCompletionSource<bool>> ready)
+    private void ReleaseReadyActiveReminderWaiters(List<Waiter> ready)
     {
         for (var i = _activeReminderCountWaiters.Count - 1; i >= 0; i--)
         {
@@ -496,11 +458,11 @@ public sealed class ReminderDiagnosticObserver : IDisposable
             }
 
             _activeReminderCountWaiters.RemoveAt(i);
-            ready.Add(waiter.TaskSource);
+            ready.Add(waiter);
         }
     }
 
-    private void ReleaseReadyLocalReminderScheduleWaiters(List<TaskCompletionSource<bool>> ready)
+    private void ReleaseReadyLocalReminderScheduleWaiters(List<Waiter> ready)
     {
         for (var i = _localReminderScheduleWaiters.Count - 1; i >= 0; i--)
         {
@@ -511,7 +473,7 @@ public sealed class ReminderDiagnosticObserver : IDisposable
             }
 
             _localReminderScheduleWaiters.RemoveAt(i);
-            ready.Add(waiter.TaskSource);
+            ready.Add(waiter);
         }
     }
 
@@ -532,27 +494,36 @@ public sealed class ReminderDiagnosticObserver : IDisposable
         public long TickWaitArmedVersion { get; set; } = -1;
     }
 
-    private sealed class TickCountWaiter(GrainId grainId, string? reminderName, int targetCount)
+    private abstract class Waiter
+    {
+        public TaskCompletionSource<bool> TaskSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public CancellationTokenRegistration CancellationRegistration { get; set; }
+
+        public void Complete()
+        {
+            CancellationRegistration.Dispose();
+            TaskSource.TrySetResult(true);
+        }
+    }
+
+    private sealed class TickCountWaiter(GrainId grainId, string? reminderName, int targetCount) : Waiter
     {
         public GrainId GrainId { get; } = grainId;
         public string? ReminderName { get; } = reminderName;
         public int TargetCount { get; } = targetCount;
-        public TaskCompletionSource<bool> TaskSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
-    private sealed class ActiveReminderCountWaiter(GrainId grainId, string reminderName, int targetCount)
+    private sealed class ActiveReminderCountWaiter(GrainId grainId, string reminderName, int targetCount) : Waiter
     {
         public GrainId GrainId { get; } = grainId;
         public string ReminderName { get; } = reminderName;
         public int TargetCount { get; } = targetCount;
-        public TaskCompletionSource<bool> TaskSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
-    private sealed class LocalReminderScheduleWaiter(GrainId grainId, string reminderName)
+    private sealed class LocalReminderScheduleWaiter(GrainId grainId, string reminderName) : Waiter
     {
         public GrainId GrainId { get; } = grainId;
         public string ReminderName { get; } = reminderName;
-        public TaskCompletionSource<bool> TaskSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
     /// <inheritdoc/>

--- a/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
+++ b/test/Orleans.Reminders.Tests/Diagnostics/ReminderEventsTests.cs
@@ -51,7 +51,6 @@ public class ReminderEventsTests
     public async Task ReminderDiagnosticObserver_WaitsForAdditionalTickCount_FromCurrentState()
     {
         using var observer = ReminderDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var now = DateTime.UtcNow;
@@ -63,7 +62,7 @@ public class ReminderEventsTests
             new TickStatus(now, TimeSpan.FromSeconds(5), now),
             siloAddress);
 
-        var waitTask = observer.WaitForAdditionalTickCountAsync(grainId, 1, cts.Token, reminderName);
+        var waitTask = observer.WaitForAdditionalTickCountAsync(grainId, 1, CancellationToken.None, reminderName);
         Assert.False(waitTask.IsCompleted);
 
         ReminderEvents.EmitTickCompleted(
@@ -72,7 +71,8 @@ public class ReminderEventsTests
             new TickStatus(now, TimeSpan.FromSeconds(5), now.AddSeconds(5)),
             siloAddress);
 
-        await waitTask.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.True(waitTask.IsCompletedSuccessfully);
+        await waitTask;
     }
 
     [Fact, TestCategory("BVT")]
@@ -143,7 +143,6 @@ public class ReminderEventsTests
     public async Task ReminderDiagnosticObserver_WaitsForReminderQuiescence_FromLifecycleEvents()
     {
         using var observer = ReminderDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var identity1 = new object();
@@ -155,7 +154,7 @@ public class ReminderEventsTests
         ReminderEvents.EmitLocalReminderStarted(grainId, reminderName, identity2, siloAddress2);
         Assert.Equal(2, observer.GetActiveReminderCount(grainId, reminderName));
 
-        var waitTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, cts.Token);
+        var waitTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, CancellationToken.None);
         Assert.False(waitTask.IsCompleted);
 
         ReminderEvents.EmitLocalReminderStopped(grainId, reminderName, identity1, ReminderEvents.LocalReminderStopReason.RemovedFromTable, siloAddress1);
@@ -164,21 +163,52 @@ public class ReminderEventsTests
 
         ReminderEvents.EmitLocalReminderStopped(grainId, reminderName, identity2, ReminderEvents.LocalReminderStopReason.Unregistered, siloAddress2);
 
-        await waitTask.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.True(waitTask.IsCompletedSuccessfully);
+        await waitTask;
         Assert.Equal(0, observer.GetActiveReminderCount(grainId, reminderName));
+    }
+
+    [Fact, TestCategory("BVT")]
+    public async Task ReminderDiagnosticObserver_CanceledQuiescenceWait_RemainsCanceled()
+    {
+        using var observer = ReminderDiagnosticObserver.Create();
+        using var cts = new CancellationTokenSource();
+        var grainId = GrainId.Create("test", "grain");
+        const string reminderName = "reminder";
+        var identity = new object();
+        var siloAddress = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14007), 8);
+
+        ReminderEvents.EmitLocalReminderStarted(grainId, reminderName, identity, siloAddress);
+        var canceledWaitTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, cts.Token);
+
+        cts.Cancel();
+
+        Assert.True(canceledWaitTask.IsCanceled);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledWaitTask);
+
+        var currentWaitTask = observer.WaitForReminderQuiescenceAsync(grainId, reminderName, CancellationToken.None);
+        ReminderEvents.EmitLocalReminderStopped(
+            grainId,
+            reminderName,
+            identity,
+            ReminderEvents.LocalReminderStopReason.Unregistered,
+            siloAddress);
+
+        Assert.True(currentWaitTask.IsCompletedSuccessfully);
+        await currentWaitTask;
+        Assert.True(canceledWaitTask.IsCanceled);
     }
 
     [Fact, TestCategory("BVT")]
     public async Task ReminderDiagnosticObserver_WaitsForCurrentOwnerSchedule_AfterOwnershipChange()
     {
         using var observer = ReminderDiagnosticObserver.Create();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         var grainId = GrainId.Create("test", "grain");
         const string reminderName = "reminder";
         var previousOwner = new object();
         var currentOwner = new object();
-        var previousSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14007), 8);
-        var currentSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14008), 9);
+        var previousSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14008), 9);
+        var currentSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 14009), 10);
         var now = DateTime.UtcNow;
 
         ReminderEvents.EmitLocalReminderStarted(grainId, reminderName, previousOwner, previousSilo);
@@ -192,7 +222,7 @@ public class ReminderEventsTests
             new TickStatus(now, TimeSpan.FromSeconds(5), now),
             previousSilo);
 
-        var waitTask = observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, cts.Token);
+        var waitTask = observer.WaitForLocalReminderScheduleAsync(grainId, reminderName, CancellationToken.None);
         Assert.False(waitTask.IsCompleted);
 
         ReminderEvents.EmitLocalReminderStopped(
@@ -202,7 +232,8 @@ public class ReminderEventsTests
             ReminderEvents.LocalReminderStopReason.RemovedFromRange,
             previousSilo);
 
-        await waitTask.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.True(waitTask.IsCompletedSuccessfully);
+        await waitTask;
     }
 
     private sealed class Observer : IObserver<ReminderEvents.ReminderEvent>, IDisposable


### PR DESCRIPTION
Fixes #10413.

Reminder diagnostic wait helpers completed an internal task source and then exposed it through an additional async wrapper. Under scheduler pressure, the lifecycle event could be recorded while completion of the returned task remained queued long enough to lose to the test timeout.

Return waiter task-source tasks directly while retaining asynchronous caller continuations, and keep cancellation registration cleanup with each waiter. The regression tests now assert completion when synchronous lifecycle emission returns and cover canceled-waiter cleanup without extending timeouts or adding retries.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10421)