### PR TITLE
fix(nats): preserve request context value types

### DIFF
--- a/src/Orleans.Streaming.NATS/Providers/NatsAdapter.cs
+++ b/src/Orleans.Streaming.NATS/Providers/NatsAdapter.cs
@@ -26,12 +26,19 @@ internal sealed class NatsAdapter(
     public async Task QueueMessageBatchAsync<T>(StreamId streamId, IEnumerable<T> events, StreamSequenceToken? token,
         Dictionary<string, object>? requestContext)
     {
+        await natsConnectionManager.EnqueueMessage(CreateMessage(serializer, streamId, events, requestContext));
+    }
+
+    internal static NatsStreamMessage CreateMessage<T>(Serializer serializer, StreamId streamId, IEnumerable<T> events,
+        Dictionary<string, object>? requestContext)
+    {
         var batchContainer = new NatsBatchContainer(streamId, events.Cast<object>().ToArray(), requestContext);
         var raw = serializer.GetSerializer<NatsBatchContainer>().SerializeToArray(batchContainer);
 
-        await natsConnectionManager.EnqueueMessage(new NatsStreamMessage
+        // Request context is carried in the Orleans-serialized payload, which preserves its value types.
+        return new NatsStreamMessage
         {
-            StreamId = streamId, Payload = raw, RequestContext = requestContext
-        });
+            StreamId = streamId, Payload = raw
+        };
     }
 }

--- a/src/Orleans.Streaming.NATS/Providers/NatsStreamMessage.cs
+++ b/src/Orleans.Streaming.NATS/Providers/NatsStreamMessage.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Orleans.Runtime;
 
@@ -13,10 +12,6 @@ internal class NatsStreamMessage
     [JsonConverter(typeof(StreamIdJsonConverter))]
     [JsonPropertyName("sid")]
     public StreamId StreamId { get; set; }
-
-    [Id(1)]
-    [JsonPropertyName("ctx")]
-    public Dictionary<string, object>? RequestContext { get; set; }
 
     [Id(2)]
     [JsonPropertyName("p")]

--- a/test/Extensions/Orleans.Streaming.NATS.Tests/NatsStreamMessageTests.cs
+++ b/test/Extensions/Orleans.Streaming.NATS.Tests/NatsStreamMessageTests.cs
@@ -1,0 +1,78 @@
+using System.Buffers;
+using System.Text.Json;
+using NATS.Client.Serializers.Json;
+using Orleans.Runtime;
+using Orleans.Streaming.NATS;
+using Orleans.Streams;
+using TestExtensions;
+using Xunit;
+
+namespace NATS.Tests;
+
+[TestCategory("NATS")]
+[Collection(TestEnvironmentFixture.DefaultCollection)]
+public sealed class NatsStreamMessageTests : IClassFixture<TestEnvironmentFixture>
+{
+    private const string ContextKey = "value";
+    private readonly TestEnvironmentFixture _fixture;
+
+    public NatsStreamMessageTests(TestEnvironmentFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public static IEnumerable<object[]> RequestContextValues()
+    {
+        yield return [true];
+        yield return [42];
+        yield return [long.MaxValue];
+        yield return [123.5];
+        yield return [79228162514264337593543950335m];
+        yield return [Guid.Parse("9b8219ed-9d58-4fe9-a5f4-51a17bd3d75d")];
+    }
+
+    [Theory]
+    [MemberData(nameof(RequestContextValues))]
+    public void RequestContextValuesRoundTripThroughNatsStreamSerialization(object value)
+    {
+        RequestContext.Clear();
+
+        try
+        {
+            RequestContext.Set(ContextKey, value);
+            var requestContext = RequestContextExtensions.Export(_fixture.DeepCopier);
+            var streamId = StreamId.Create("namespace", Guid.NewGuid());
+            var message = NatsAdapter.CreateMessage(_fixture.Serializer, streamId, ["event"], requestContext);
+
+            var receivedMessage = RoundTrip(message);
+            var receivedBatch = _fixture.Serializer.Deserialize<NatsBatchContainer>(receivedMessage.Payload);
+
+            RequestContext.Clear();
+
+            Assert.NotNull(receivedBatch);
+            Assert.True(receivedBatch.ImportRequestContext());
+            Assert.Equal(streamId, receivedMessage.StreamId);
+            Assert.Equal(streamId, receivedBatch.StreamId);
+            Assert.Equal(["event"], receivedBatch.GetEvents<string>().Select(tuple => tuple.Item1));
+            Assert.Equal(value, RequestContext.Get(ContextKey));
+            Assert.IsType(value.GetType(), RequestContext.Get(ContextKey));
+        }
+        finally
+        {
+            RequestContext.Clear();
+        }
+    }
+
+    private static NatsStreamMessage RoundTrip(NatsStreamMessage message)
+    {
+        var options = new JsonSerializerOptions();
+        options.TypeInfoResolverChain.Add(NatsSerializerContext.Default);
+        var registry = new NatsJsonContextOptionsSerializerRegistry(options);
+        var buffer = new ArrayBufferWriter<byte>();
+
+        registry.GetSerializer<NatsStreamMessage>().Serialize(buffer, message);
+
+        var sequence = new ReadOnlySequence<byte>(buffer.WrittenMemory);
+        return registry.GetDeserializer<NatsStreamMessage>().Deserialize(in sequence)!;
+    }
+}


### PR DESCRIPTION
The NATS stream provider failed when request context contained Boolean or other runtime values because its source-generated JSON envelope duplicated an object-valued context dictionary without metadata for those concrete types.

Keep request context exclusively in the Orleans-serialized batch payload, where runtime types are preserved and from which the receiver already imports context. Add focused round-trip coverage for common primitive and value types across the NATS JSON envelope and Orleans payload.

Fixes: #10244
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10422)