### PR TITLE
fix(streaming): restore Redis implicit subscriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Test
       run: dotnet test
         --framework ${{ matrix.framework }}
-        --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional)"
+        --filter "Category=${{ matrix.provider }}&(Category=BVT|Category=SlowBVT|Category=Functional|Category=Streaming)"
         --blame-hang-timeout 10m
         --blame-crash-dump-type full
         --blame-hang-dump-type full

--- a/test/Extensions/Orleans.Redis.Tests/Streaming/RedisStreamBatchContainerTests.cs
+++ b/test/Extensions/Orleans.Redis.Tests/Streaming/RedisStreamBatchContainerTests.cs
@@ -12,18 +12,23 @@ namespace Tester.Redis.Streaming;
 public sealed class RedisStreamBatchContainerTests
 {
     [Fact]
-    public void RedisStreamBatchContainer_FromStreamEntry_CreatesRedisSequenceTokens()
+    public void RedisStreamBatchContainer_FromStreamEntry_PreservesStreamIdAndCreatesRedisSequenceTokens()
     {
         using var serviceProvider = new ServiceCollection().AddSerializer().BuildServiceProvider();
         var serializer = serviceProvider.GetRequiredService<Serializer<RedisStreamBatchContainer>>();
+        var streamId = StreamId.Create(nameof(RedisStreamBatchContainerTests), Guid.NewGuid());
         var payload = RedisStreamBatchContainer.ToRedisValue(
             serializer,
-            StreamId.Create(nameof(RedisStreamBatchContainerTests), "stream"),
+            streamId,
             new object[] { 1, 2 },
             new Dictionary<string, object>());
         var entry = new StreamEntry("1735790000000-3", [new NameValueEntry(RedisStreamReceiverOptions.DefaultFieldName, payload)]);
 
         var container = RedisStreamBatchContainer.FromStreamEntry(serializer, entry, RedisStreamReceiverOptions.DefaultFieldName);
+
+        Assert.Equal(streamId, container.StreamId);
+        Assert.Equal(streamId.GetNamespace(), container.StreamId.GetNamespace());
+        Assert.Equal(streamId.GetKeyAsString(), container.StreamId.GetKeyAsString());
 
         var batchToken = Assert.IsType<RedisStreamSequenceToken>(container.SequenceToken);
         Assert.Equal("1735790000000-3", batchToken.EntryId);

--- a/test/Grains/TestInternalGrains/StreamingGrain.cs
+++ b/test/Grains/TestInternalGrains/StreamingGrain.cs
@@ -967,7 +967,9 @@ namespace UnitTests.Grains
 
         public async Task OnSubscribed(IStreamSubscriptionHandleFactory handleFactory)
         {
-            await BecomeConsumer(Guid.Parse(handleFactory.StreamId.Key.ToString()), handleFactory.ProviderName, handleFactory.StreamId.Namespace.ToString());
+            var streamNamespace = handleFactory.StreamId.GetNamespace()
+                ?? throw new InvalidOperationException("Implicit stream subscriptions require a stream namespace.");
+            await BecomeConsumer(Guid.Parse(handleFactory.StreamId.GetKeyAsString()), handleFactory.ProviderName, streamNamespace);
         }
     }
 


### PR DESCRIPTION
Redis implicit-subscription tests consistently timed out because the shared test consumer converted `StreamId` byte components using `ReadOnlyMemory<byte>.ToString()`. That caused a GUID format exception after Redis had already discovered and activated the implicit subscriber, so delivery retried until the test timeout.

Use the canonical `StreamId` key and namespace accessors, verify that GUID-backed stream IDs survive the Redis batch round trip, and include the Redis streaming category in provider CI so this behavior remains covered on both target frameworks.

Fixes: #10412
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10423)