### PR TITLE
fix(serialization): clarify type trust configuration

### DIFF
--- a/docs/site/src/content/docs/host/configuration-guide/serialization-configuration.md
+++ b/docs/site/src/content/docs/host/configuration-guide/serialization-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Serialization configuration in Orleans
 description: Learn how to configure serialization in .NET Orleans.
-ms.date: 05/23/2025
+ms.date: 08/10/2026
 ms.topic: how-to
 uid: orleans-serialization-configuration
 ---
@@ -42,3 +42,67 @@ siloBuilder.Services.AddSerializer(serializerBuilder =>
         isSupported: type => type.Namespace.StartsWith("Example.Namespace"));
 });
 ```
+
+## Authorize type-name resolution
+
+Registering an external serializer selects which codec can handle a value. It doesn't, by itself, authorize Orleans to resolve every CLR type name accepted by that serializer. Type-name resolution is a separate security boundary, and <xref:Orleans.Serialization.Configuration.TypeManifestOptions.AllowAllTypes?displayProperty=nameWithType> defaults to `false`.
+
+This distinction is especially visible for polymorphic signatures such as `IReadOnlyList<TriggerRule>`, where `TriggerRule` is abstract and values are handled by `System.Text.Json`. Register the JSON serializer and explicitly trust the application type:
+
+```csharp
+siloBuilder.Services.AddSerializer(serializerBuilder =>
+{
+    serializerBuilder.AddJsonSerializer(
+        isSupported: type => type.Namespace?.StartsWith("MyApp") == true);
+    serializerBuilder.Configure(options =>
+        options.AddAllowedType(typeof(TriggerRule)));
+});
+```
+
+<xref:Orleans.Serialization.Configuration.TypeManifestOptions.AddAllowedType*> uses Orleans' runtime type-name formatter, including for constructed and nested generic types. The <xref:Orleans.Serialization.Configuration.TypeManifestOptions.AllowedTypes> string set remains supported for compatibility and contains Orleans-formatted runtime type names. Prefer `AddAllowedType` instead of constructing those names manually.
+
+If every type in an application assembly is trusted, allow the assembly instead:
+
+```csharp
+siloBuilder.Services.AddSerializer(serializerBuilder =>
+{
+    serializerBuilder.Configure(options =>
+        options.AddAllowedAssembly(typeof(TriggerRule).Assembly));
+});
+```
+
+Assembly trust applies component by component. Allowing a generic type definition's assembly doesn't implicitly trust generic arguments from other assemblies.
+
+For policy-based trust, register <xref:Orleans.Serialization.ITypeNameFilter> to evaluate names before Orleans loads the corresponding type:
+
+```csharp
+public sealed class ApplicationTypeNameFilter : ITypeNameFilter
+{
+    public bool? IsTypeNameAllowed(string typeName, string assemblyName)
+    {
+        if (assemblyName == "MyApp.Contracts"
+            || assemblyName.StartsWith("MyApp.Contracts,", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return null;
+    }
+}
+
+siloBuilder.Services.AddSingleton<ITypeNameFilter, ApplicationTypeNameFilter>();
+```
+
+A filter returns `true` to allow, `false` to deny, or `null` when it has no opinion. Types explicitly added to `AllowedTypes` are authoritative. For other names, a denial from any `ITypeNameFilter` takes precedence over other type-name filters and assembly trust. <xref:Orleans.Serialization.ITypeFilter> provides a resolved-`Type` fallback when name-based checks have no affirmative result; a denial wins within that fallback. Both formatting and parsing apply these checks, including to constructed generic components and array element types.
+
+As a compatibility escape hatch, you can disable the boundary:
+
+```csharp
+siloBuilder.Services.AddSerializer(serializerBuilder =>
+{
+    serializerBuilder.Configure(options => options.AllowAllTypes = true);
+});
+```
+
+> [!WARNING]
+> `AllowAllTypes` bypasses type-name validation, including custom filters, and permits any resolvable type. Use it only when serialized input is fully trusted. Prefer allowing individual types or trusted assemblies.

--- a/src/Orleans.Core/Serialization/OrleansJsonSerializationBinder.cs
+++ b/src/Orleans.Core/Serialization/OrleansJsonSerializationBinder.cs
@@ -86,7 +86,8 @@ namespace Orleans.Serialization
 
         private static string BuildNotAllowedMessage(string fullName) =>
             $"Unable to resolve type \"{fullName}\". The type could not be found or is not permitted by the configured type allow-list. " +
-            $"To allow it, mark the type with [GenerateSerializer], add it to {nameof(Configuration.TypeManifestOptions)}.{nameof(Configuration.TypeManifestOptions.AllowedTypes)}, " +
-            $"register an {nameof(ITypeNameFilter)} or {nameof(ITypeFilter)} which allows it, or set {nameof(OrleansJsonSerializerOptions)}.{nameof(OrleansJsonSerializerOptions.AllowAllTypes)} to true to restore the previous behavior.";
+            $"To allow it, mark the type with [GenerateSerializer], call {nameof(Configuration.TypeManifestOptions)}.{nameof(Configuration.TypeManifestOptions.AddAllowedType)}, " +
+            $"call {nameof(Configuration.TypeManifestOptions)}.{nameof(Configuration.TypeManifestOptions.AddAllowedAssembly)}, add its Orleans-formatted name to {nameof(Configuration.TypeManifestOptions)}.{nameof(Configuration.TypeManifestOptions.AllowedTypes)}, " +
+            $"or register an {nameof(ITypeNameFilter)} or {nameof(ITypeFilter)} which allows it. Setting {nameof(OrleansJsonSerializerOptions)}.{nameof(OrleansJsonSerializerOptions.AllowAllTypes)} to true restores the previous behavior but is insecure when serialized input can be influenced by an untrusted party.";
     }
 }

--- a/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
+++ b/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
@@ -76,9 +76,31 @@ namespace Orleans.Serialization.Configuration
         /// Gets the set of allowed Orleans-formatted runtime type names.
         /// </summary>
         /// <remarks>
-        /// Prefer <see cref="AddAllowedType(Type)"/> when the type is available to avoid constructing
-        /// formatted names manually.
+        /// <para>
+        /// An Orleans-formatted runtime type name uses CLR type-name syntax, including namespace,
+        /// nesting, generic arguments, arrays, and optional assembly qualification. Use
+        /// <see cref="RuntimeTypeNameFormatter.Format(Type)"/> to produce this format.
+        /// </para>
+        /// <para>
+        /// Prefer <see cref="AddAllowedType(Type)"/> when the <see cref="Type"/> is available. It produces
+        /// the underlying CLR name without compound aliases so that later alias configuration does not
+        /// affect the allow-list entry. Unqualified names such as <see cref="Type.FullName"/> remain
+        /// supported for compatibility.
+        /// </para>
         /// </remarks>
+        /// <example>
+        /// <code>
+        /// services.AddSerializer(builder => builder.Configure(options =>
+        /// {
+        ///     // Preferred: let Orleans construct the entry.
+        ///     options.AddAllowedType(typeof(MyMessage));
+        ///
+        ///     // Supported when a string entry is required.
+        ///     options.AllowedTypes.Add(
+        ///         RuntimeTypeNameFormatter.Format(typeof(MyOtherMessage)));
+        /// }));
+        /// </code>
+        /// </example>
         public HashSet<string> AllowedTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
@@ -88,6 +110,12 @@ namespace Orleans.Serialization.Configuration
         /// Prefer <see cref="AddAllowedAssembly(Assembly)"/> when the assembly is available to avoid
         /// constructing assembly names manually.
         /// </remarks>
+        /// <example>
+        /// <code>
+        /// services.AddSerializer(builder => builder.Configure(options =>
+        ///     options.AddAllowedAssembly(typeof(MyMessage).Assembly)));
+        /// </code>
+        /// </example>
         public HashSet<string> AllowedAssemblies { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
@@ -112,8 +140,13 @@ namespace Orleans.Serialization.Configuration
         internal HashSet<object> TypeManifestProviders { get; } = new();
 
         /// <summary>
-        /// Adds the formatted type name for <paramref name="type"/> to <see cref="AllowedTypes"/>.
+        /// Adds the Orleans-formatted runtime type name for <paramref name="type"/> to
+        /// <see cref="AllowedTypes"/>.
         /// </summary>
+        /// <remarks>
+        /// This is the preferred way to allow an available <see cref="Type"/>. It formats the underlying
+        /// CLR type name without compound aliases and includes all constructed generic components.
+        /// </remarks>
         /// <param name="type">The type to allow.</param>
         public void AddAllowedType(Type type)
         {

--- a/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
+++ b/src/Orleans.Serialization/Configuration/TypeManifestOptions.cs
@@ -73,13 +73,21 @@ namespace Orleans.Serialization.Configuration
         public Dictionary<string, Type> WellKnownTypeAliases { get; } = new Dictionary<string, Type>();
 
         /// <summary>
-        /// Gets the mapping of allowed type names.
+        /// Gets the set of allowed Orleans-formatted runtime type names.
         /// </summary>
+        /// <remarks>
+        /// Prefer <see cref="AddAllowedType(Type)"/> when the type is available to avoid constructing
+        /// formatted names manually.
+        /// </remarks>
         public HashSet<string> AllowedTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets the set of assembly names whose types are allowed.
         /// </summary>
+        /// <remarks>
+        /// Prefer <see cref="AddAllowedAssembly(Assembly)"/> when the assembly is available to avoid
+        /// constructing assembly names manually.
+        /// </remarks>
         public HashSet<string> AllowedAssemblies { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
@@ -91,6 +99,11 @@ namespace Orleans.Serialization.Configuration
         /// Gets or sets a value indicating whether to allow all types by default.
         /// Default: <see langword="false"/>.
         /// </summary>
+        /// <remarks>
+        /// Setting this property to <see langword="true"/> bypasses type-name validation and permits any
+        /// resolvable type. This is insecure when serialized input can be influenced by an untrusted party.
+        /// Prefer allowing individual types or trusted assemblies.
+        /// </remarks>
         public bool AllowAllTypes { get; set; }
 
         /// <summary>

--- a/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
+++ b/src/Orleans.Serialization/TypeSystem/TypeConverter.cs
@@ -490,7 +490,7 @@ public class TypeConverter
     [DoesNotReturn]
     private static void ThrowTypeNotAllowed(string fullTypeName, List<QualifiedType> errors)
     {
-        const string allowListMessage = $"To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)}, add its assembly to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedAssemblies)}, or register an {nameof(ITypeNameFilter)} instance which allows it.";
+        const string allowListMessage = $"A registered {nameof(ITypeNameFilter)} denied it. Update that filter, or set {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowAllTypes)} to true to bypass type-name validation. Allowing all types is insecure when serialized input can be influenced by an untrusted party.";
         if (errors is { Count: 1 })
         {
             var value = errors[0];
@@ -524,7 +524,7 @@ public class TypeConverter
     [DoesNotReturn]
     private static void ThrowTypeNotAllowed(Type value)
     {
-        var message = $"Type \"{value.FullName}\" is not allowed. To allow it, add it to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)}, add its assembly to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedAssemblies)}, or register an {nameof(ITypeNameFilter)} or {nameof(ITypeFilter)} instance which allows it.";
+        var message = $"Type \"{value.FullName}\" is not allowed. To allow it, call {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AddAllowedType)}, call {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AddAllowedAssembly)}, add its Orleans-formatted name to {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowedTypes)}, register an {nameof(ITypeNameFilter)} or {nameof(ITypeFilter)} instance which allows it, or set {nameof(TypeManifestOptions)}.{nameof(TypeManifestOptions.AllowAllTypes)} to true. Allowing all types is insecure when serialized input can be influenced by an untrusted party.";
         throw new InvalidOperationException(message);
     }
 

--- a/test/Misc/TestSerializerExternalModels/Models.cs
+++ b/test/Misc/TestSerializerExternalModels/Models.cs
@@ -2,6 +2,10 @@ using Orleans;
 
 namespace UnitTests.SerializerExternalModels;
 
+public abstract class JsonPolymorphicBase
+{
+}
+
 [GenerateSerializer]
 public record struct Person2ExternalStruct(int Age, string Name)
 {

--- a/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
+++ b/test/Orleans.Serialization.UnitTests/TypeConverterTests.cs
@@ -1,10 +1,12 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Orleans.Serialization.Activators;
 using Orleans.Serialization.Configuration;
 using Orleans.Serialization.TypeSystem;
+using UnitTests.SerializerExternalModels;
 using Xunit;
 
 namespace Orleans.Serialization.UnitTests
@@ -20,11 +22,98 @@ namespace Orleans.Serialization.UnitTests
         }
 
         [Fact]
-        public void TypeConverter_DefaultsToAllowAllTypes_WhenAllFiltersHaveNoOpinion_AndAllowAllTypesIsTrue()
+        public void TypeConverter_AllowAllTypes_TakesPrecedenceOverDenyingFilters()
         {
-            var converter = CreateConverter(allowAllTypes: true);
+            var converter = CreateConverter(
+                allowAllTypes: true,
+                typeNameFilters: [new DelegateTypeNameFilter((_, _) => false)],
+                typeFilters: [new DelegateTypeFilter(_ => false)]);
 
             AssertRoundTrips(converter, typeof(TypeConverterTestsUnconfiguredType));
+        }
+
+        [Fact]
+        public void TypeConverter_JsonSerializerRegistration_DoesNotAuthorizeAbstractGenericArguments()
+        {
+            using var services = CreateJsonSerializerServices();
+            var converter = services.GetRequiredService<TypeConverter>();
+            var type = typeof(IReadOnlyList<JsonPolymorphicBase>);
+
+            AssertTypeNotAllowed(converter, type);
+
+            var exception = Assert.Throws<InvalidOperationException>(() => converter.Format(type));
+            Assert.Contains(nameof(TypeManifestOptions.AddAllowedType), exception.Message);
+            Assert.Contains(nameof(TypeManifestOptions.AddAllowedAssembly), exception.Message);
+            Assert.Contains(nameof(TypeManifestOptions.AllowAllTypes), exception.Message);
+        }
+
+        [Fact]
+        public void TypeConverter_JsonSerializer_AllowsAbstractGenericArgumentsAddedByType()
+        {
+            using var services = CreateJsonSerializerServices(
+                options => options.AddAllowedType(typeof(JsonPolymorphicBase)));
+
+            AssertRoundTrips(
+                services.GetRequiredService<TypeConverter>(),
+                typeof(IReadOnlyList<JsonPolymorphicBase>));
+        }
+
+        [Fact]
+        public void TypeConverter_JsonSerializer_AllowsAbstractGenericArgumentsAddedByFormattedName()
+        {
+            using var services = CreateJsonSerializerServices(
+                options => options.AllowedTypes.Add(typeof(JsonPolymorphicBase).FullName!));
+
+            AssertRoundTrips(
+                services.GetRequiredService<TypeConverter>(),
+                typeof(IReadOnlyList<JsonPolymorphicBase>));
+        }
+
+        [Fact]
+        public void TypeConverter_JsonSerializer_AllowsAbstractGenericArgumentsFromAllowedAssembly()
+        {
+            using var services = CreateJsonSerializerServices(
+                options => options.AddAllowedAssembly(typeof(JsonPolymorphicBase).Assembly));
+
+            AssertRoundTrips(
+                services.GetRequiredService<TypeConverter>(),
+                typeof(IReadOnlyList<JsonPolymorphicBase>));
+        }
+
+        [Fact]
+        public void TypeConverter_JsonSerializer_AllowsAbstractGenericArgumentsWhenAllTypesAreAllowed()
+        {
+            using var services = CreateJsonSerializerServices(options => options.AllowAllTypes = true);
+
+            AssertRoundTrips(
+                services.GetRequiredService<TypeConverter>(),
+                typeof(IReadOnlyList<JsonPolymorphicBase>));
+        }
+
+        [Fact]
+        public void TypeConverter_JsonSerializer_AllowsAbstractGenericArgumentsUsingTypeNameFilter()
+        {
+            using var services = CreateJsonSerializerServices(
+                configureServices: services => services.AddSingleton<ITypeNameFilter>(
+                    new DelegateTypeNameFilter((typeName, _) =>
+                        typeName == typeof(JsonPolymorphicBase).FullName ? true : null)));
+
+            AssertRoundTrips(
+                services.GetRequiredService<TypeConverter>(),
+                typeof(IReadOnlyList<JsonPolymorphicBase>));
+        }
+
+        [Fact]
+        public void TypeConverter_JsonSerializer_AllowsAbstractGenericArgumentsUsingTypeFilter()
+        {
+            using var services = CreateJsonSerializerServices(
+                configureServices: services => services.AddSingleton<ITypeFilter>(
+                    new DelegateTypeFilter(type =>
+                        type == typeof(JsonPolymorphicBase) ? true : null)));
+
+            AssertRoundTrips(
+                services.GetRequiredService<TypeConverter>(),
+                typeof(IReadOnlyList<JsonPolymorphicBase>));
         }
 
         [Fact]
@@ -101,6 +190,17 @@ namespace Orleans.Serialization.UnitTests
                 ]);
 
             AssertTypeNotAllowed(converter, typeof(TypeConverterTestsUnconfiguredType));
+        }
+
+        [Fact]
+        public void TypeConverter_ConfiguredAllowedTypes_TakePrecedenceOverDenyingFilters()
+        {
+            var converter = CreateConverter(
+                configureOptions: options => options.AddAllowedType(typeof(TypeConverterTestsUnconfiguredType)),
+                typeNameFilters: [new DelegateTypeNameFilter((_, _) => false)],
+                typeFilters: [new DelegateTypeFilter(_ => false)]);
+
+            AssertRoundTrips(converter, typeof(TypeConverterTestsUnconfiguredType));
         }
 
         [Fact]
@@ -409,6 +509,24 @@ namespace Orleans.Serialization.UnitTests
                 typeFilters ?? Array.Empty<ITypeFilter>(),
                 Options.Create(options),
                 new CachedTypeResolver());
+        }
+
+        private static ServiceProvider CreateJsonSerializerServices(
+            Action<TypeManifestOptions>? configureOptions = null,
+            Action<IServiceCollection>? configureServices = null)
+        {
+            var services = new ServiceCollection();
+            services.AddSerializer(builder =>
+            {
+                builder.AddJsonSerializer(isSupported: _ => true);
+                if (configureOptions is not null)
+                {
+                    builder.Configure(configureOptions);
+                }
+            });
+
+            configureServices?.Invoke(services);
+            return services.BuildServiceProvider();
         }
 
         private sealed class DelegateTypeNameFilter(Func<string, string, bool?> filter) : ITypeNameFilter


### PR DESCRIPTION
Orleans 10.2 intentionally requires affirmative trust for every component of a formatted type name, but the migration path for JSON-serialized abstract application types was not clearly documented or covered by the reporter's exact scenario.

This change adds focused `IReadOnlyList<TAbstract>` coverage for the fail-closed default and every supported trust route, including typed and string allow-list configuration, assembly trust, custom filters, and the broad opt-out. It also updates diagnostics and public API documentation to point to the typed helpers, explain filter precedence, distinguish serializer support from type authorization, and warn about the security implications of allowing all resolvable types.

The fail-closed default is preserved. Narrow type or assembly trust remains the recommended configuration.

Fixes: #10239
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10424)