### PR TITLE
fix(codegen): release cached Roslyn symbols

### DIFF
--- a/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
+++ b/src/Orleans.CodeGenerator/SyntaxGeneration/SymbolExtensions.cs
@@ -1,8 +1,8 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -10,8 +10,8 @@ namespace Orleans.CodeGenerator.SyntaxGeneration;
 
 internal static class SymbolExtensions
 {
-    private static readonly ConcurrentDictionary<ITypeSymbol, TypeSyntax> TypeCache = new(SymbolEqualityComparer.Default);
-    private static readonly ConcurrentDictionary<ISymbol, string> NameCache = new(SymbolEqualityComparer.Default);
+    private static readonly ConditionalWeakTable<ITypeSymbol, TypeSyntax> TypeCache = new();
+    private static readonly ConditionalWeakTable<ISymbol, string> NameCache = new();
 
     public struct DisplayNameOptions
     {
@@ -64,12 +64,7 @@ internal static class SymbolExtensions
             return PredefinedType(Token(SyntaxKind.VoidKeyword));
         }
 
-        if (!TypeCache.TryGetValue(typeSymbol, out var result))
-        {
-            result = TypeCache[typeSymbol] = ParseTypeName(typeSymbol.ToDisplayName());
-        }
-
-        return result;
+        return TypeCache.GetValue(typeSymbol, static symbol => ParseTypeName(symbol.ToDisplayName()));
     }
 
     public static TypeSyntax ToTypeSyntax(this ITypeSymbol typeSymbol, Dictionary<ITypeParameterSymbol, string>? substitutions)
@@ -118,12 +113,7 @@ internal static class SymbolExtensions
             return "void";
         }
 
-        if (!NameCache.TryGetValue(typeSymbol, out var result))
-        {
-            result = NameCache[typeSymbol] = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        }
-
-        return result;
+        return NameCache.GetValue(typeSymbol, static symbol => symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
     }
 
     public static string ToDisplayName(this IAssemblySymbol? assemblySymbol)
@@ -133,12 +123,7 @@ internal static class SymbolExtensions
             return string.Empty;
         }
 
-        if (!NameCache.TryGetValue(assemblySymbol, out var result))
-        {
-            result = NameCache[assemblySymbol] = assemblySymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-        }
-
-        return result;
+        return NameCache.GetValue(assemblySymbol, static symbol => symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
     }
 
     private static void ToTypeSyntaxInner(ITypeSymbol typeSymbol, StringBuilder res, DisplayNameOptions options)

--- a/test/Orleans.CodeGenerator.Tests/GeneratorMemoryRetentionTests.cs
+++ b/test/Orleans.CodeGenerator.Tests/GeneratorMemoryRetentionTests.cs
@@ -1,0 +1,69 @@
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Orleans.CodeGenerator.Tests;
+
+public class GeneratorMemoryRetentionTests
+{
+    [Fact]
+    public async Task CompletedGeneratorRunsDoNotRetainCompilations()
+    {
+        const int compilationCount = 8;
+        var template = await TestCompilationHelper.CreateCompilation("internal sealed class Template { }");
+        var references = template.References.ToArray();
+        var weakReferences = await Task.WhenAll(
+            Enumerable.Range(0, compilationCount)
+                .Select(index => Task.Run(() => RunGenerator(index, references))));
+
+        ForceFullCollection();
+
+        Assert.Equal(0, weakReferences.Count(static references => references.Compilation.IsAlive));
+        Assert.Equal(0, weakReferences.Count(static references => references.Symbol.IsAlive));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference Compilation, WeakReference Symbol) RunGenerator(
+        int index,
+        MetadataReference[] references)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            $$"""
+            using Orleans;
+
+            namespace RetentionTest{{index}};
+
+            [GenerateSerializer]
+            public sealed class Payload
+            {
+                [Id(0)]
+                public Payload? Next { get; set; }
+            }
+            """);
+        var compilation = CSharpCompilation.Create(
+            $"RetentionTest{index}",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var symbol = compilation.GetTypeByMetadataName($"RetentionTest{index}.Payload");
+        Assert.NotNull(symbol);
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [new OrleansSerializationSourceGenerator().AsSourceGenerator()]);
+        driver = driver.RunGenerators(compilation);
+        var result = driver.GetRunResult();
+        Assert.Empty(result.Diagnostics);
+        Assert.NotEmpty(Assert.Single(result.Results).GeneratedSources);
+
+        return (new(compilation), new(symbol));
+    }
+
+    private static void ForceFullCollection()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+        }
+    }
+}


### PR DESCRIPTION
The source generator's process-static symbol caches retain entire Roslyn compilation graphs in long-lived compiler and IDE hosts. An in-process collectibility test confirmed that all 8 independent compilations remained alive after forced compacting collections.

Replace the strong-key dictionaries with thread-safe weak-key caches. This preserves repeated lookup reuse while symbols are live, without retaining completed compilations or introducing a global cache-clearing race. The regression test now observes 0 of 8 compilations retained and also exercises concurrent generator runs.

Fixes: #10202
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10426)