### PR TITLE
fix(tests): wait for gateways after silo restart

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/Streaming/StreamReliabilityTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/StreamReliabilityTests.cs
@@ -943,8 +943,7 @@ namespace UnitTests.Streaming.Reliability
                 await this.HostedCluster.RestartSiloAsync(silo);
             }
 
-            // Note: Needed to reinitialize client in this test case to connect to new silos
-            // this.HostedCluster.InitializeClient();
+            await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
             var newSilos = this.HostedCluster.GetActiveSilos().Select(silo => silo.SiloAddress).ToArray();
             _output.WriteLine("\n\n\n\n-----------------------------------------------------\n" +


### PR DESCRIPTION
`AQ_StreamRel_AllSilosRestart` could issue its first post-restart grain call while the client still cached gateway endpoints from the stopped silos, causing an in-memory transport connection failure.

Wait for the test cluster's liveness and gateway views to stabilize after replacing all silos. This uses the existing event-driven convergence barrier, which refreshes the client gateway snapshot and verifies that it exactly matches the active silos before the test continues.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10427)