### PR TITLE
feat(adonet): support DbDataSource

### DIFF
--- a/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
+++ b/docs/site/src/content/docs/host/configuration-guide/configuring-ado-dot-net-providers.md
@@ -1,7 +1,7 @@
 ---
 title: Configure ADO.NET providers
 description: Configure Orleans clustering, reminders, storage, and grain directories with ADO.NET.
-ms.date: 08/02/2026
+ms.date: 08/10/2026
 ms.topic: how-to
 ---
 
@@ -15,6 +15,7 @@ Orleans ADO.NET providers use a relational database for one or more runtime capa
 | Grain storage | [`Microsoft.Orleans.Persistence.AdoNet`](https://www.nuget.org/packages/Microsoft.Orleans.Persistence.AdoNet) | Silos |
 | Reminders | [`Microsoft.Orleans.Reminders.AdoNet`](https://www.nuget.org/packages/Microsoft.Orleans.Reminders.AdoNet) | Silos |
 | Grain directory | [`Microsoft.Orleans.GrainDirectory.AdoNet`](https://www.nuget.org/packages/Microsoft.Orleans.GrainDirectory.AdoNet) | Silos |
+| Streaming | [`Microsoft.Orleans.Streaming.AdoNet`](https://www.nuget.org/packages/Microsoft.Orleans.Streaming.AdoNet) | Silos and external clients |
 
 Install only the packages for the capabilities the application uses. Also reference the database driver package.
 
@@ -55,6 +56,14 @@ The Orleans configuration shape is the same for PostgreSQL, MySQL/MariaDB, and O
 | Oracle | `Oracle.ManagedDataAccess.Core` | `Oracle.DataAccess.Client` |
 
 Orleans also recognizes `MySqlConnector` for the MySqlConnector driver. Verify that the selected capability has a script for the chosen database.
+
+## Use a data source
+
+Each ADO.NET provider option type accepts either a connection string or a <xref:System.Data.Common.DbDataSource>. A data source is useful when the database driver needs configuration which can't be represented in a connection string, such as a periodically refreshed authentication token.
+
+Configure exactly one connection source. Orleans rejects configurations which supply both `ConnectionString` and `DataSource`, or neither. Continue to set `Invariant` because Orleans uses it to select database-specific queries and behavior.
+
+Register the data source as a singleton and resolve it through the provider's `OptionsBuilder` configuration overload. Named Orleans providers can resolve distinct keyed data sources. The dependency injection container or application owns the data source and must keep it alive for the Orleans provider's lifetime; Orleans opens and disposes individual connections but doesn't dispose the data source.
 
 ## Configure declaratively
 

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetClusteringTable.cs
@@ -35,7 +35,8 @@ namespace Orleans.Runtime.MembershipService
             //and assumes the database with appropriate definitions exists already.
             orleansQueries = await RelationalOrleansQueries.CreateInstance(
                 clusteringTableOptions.Invariant,
-                clusteringTableOptions.ConnectionString);
+                clusteringTableOptions.ConnectionString,
+                clusteringTableOptions.DataSource);
 
             // even if I am not the one who created the table,
             // try to insert an initial table version if it is not already there,

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Messaging/AdoNetGatewayListProvider.cs
@@ -45,7 +45,7 @@ namespace Orleans.Runtime.Membership
         public async Task InitializeGatewayListProvider()
         {
             LogTraceInitializeGatewayListProvider();
-            _orleansQueries = await RelationalOrleansQueries.CreateInstance(_options.Invariant, _options.ConnectionString);
+            _orleansQueries = await RelationalOrleansQueries.CreateInstance(_options.Invariant, _options.ConnectionString, _options.DataSource);
         }
 
         public async Task<IList<Uri>> GetGateways()

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringClientOptions.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringClientOptions.cs
@@ -1,3 +1,5 @@
+using System.Data.Common;
+
 namespace Orleans.Configuration
 {
     public class AdoNetClusteringClientOptions
@@ -6,7 +8,16 @@ namespace Orleans.Configuration
         /// Connection string for Sql
         /// </summary>
         [Redact]
-        public string ConnectionString { get; set; } = null!;
+        public string? ConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the data source used to open database connections.
+        /// </summary>
+        /// <remarks>
+        /// The data source is owned by the caller and is not disposed by Orleans.
+        /// </remarks>
+        [Redact]
+        public DbDataSource? DataSource { get; set; }
 
         /// <summary>
         /// The invariant name of the connector for gatewayProvider's database.

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringClientOptionsValidator.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringClientOptionsValidator.cs
@@ -24,9 +24,9 @@ namespace Orleans.Configuration
                 throw new OrleansConfigurationException($"Invalid {nameof(AdoNetClusteringClientOptions)} values for {nameof(AdoNetClusteringTable)}. {nameof(options.Invariant)} is required.");
             }
 
-            if (string.IsNullOrWhiteSpace(this.options.ConnectionString))
+            if (string.IsNullOrWhiteSpace(this.options.ConnectionString) == (this.options.DataSource is null))
             {
-                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetClusteringClientOptions)} values for {nameof(AdoNetClusteringTable)}. {nameof(options.ConnectionString)} is required.");
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetClusteringClientOptions)} values for {nameof(AdoNetClusteringTable)}. Configure exactly one of {nameof(options.ConnectionString)} or {nameof(options.DataSource)}.");
             }
         }
     }

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringSiloOptions.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetClusteringSiloOptions.cs
@@ -1,3 +1,5 @@
+using System.Data.Common;
+
 namespace Orleans.Configuration
 {
     /// <summary>
@@ -9,7 +11,16 @@ namespace Orleans.Configuration
         /// Connection string for AdoNet Storage
         /// </summary>
         [Redact]
-        public string ConnectionString { get; set; } = null!;
+        public string? ConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the data source used to open database connections.
+        /// </summary>
+        /// <remarks>
+        /// The data source is owned by the caller and is not disposed by Orleans.
+        /// </remarks>
+        [Redact]
+        public DbDataSource? DataSource { get; set; }
 
         /// <summary>
         /// The invariant name of the connector for membership's database.

--- a/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetReminderTableOptionsValidator.cs
+++ b/src/AdoNet/Orleans.Clustering.AdoNet/Options/AdoNetReminderTableOptionsValidator.cs
@@ -24,9 +24,9 @@ namespace Orleans.Configuration
                 throw new OrleansConfigurationException($"Invalid {nameof(AdoNetClusteringSiloOptions)} values for {nameof(AdoNetClusteringTable)}. {nameof(options.Invariant)} is required.");
             }
 
-            if (string.IsNullOrWhiteSpace(this.options.ConnectionString))
+            if (string.IsNullOrWhiteSpace(this.options.ConnectionString) == (this.options.DataSource is null))
             {
-                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetClusteringSiloOptions)} values for {nameof(AdoNetClusteringTable)}. {nameof(options.ConnectionString)} is required.");
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetClusteringSiloOptions)} values for {nameof(AdoNetClusteringTable)}. Configure exactly one of {nameof(options.ConnectionString)} or {nameof(options.DataSource)}.");
             }
         }
     }

--- a/src/AdoNet/Orleans.GrainDirectory.AdoNet/AdoNetGrainDirectory.cs
+++ b/src/AdoNet/Orleans.GrainDirectory.AdoNet/AdoNetGrainDirectory.cs
@@ -152,7 +152,7 @@ internal sealed partial class AdoNetGrainDirectory(string name, AdoNetGrainDirec
 
                 // slow path - the member variable will only be set if the call succeeds
                 return _queries = await RelationalOrleansQueries
-                    .CreateInstance(options.Invariant, options.ConnectionString)
+                    .CreateInstance(options.Invariant, options.ConnectionString, options.DataSource)
                     .WaitAsync(lifetime.ApplicationStopping);
             }
             finally

--- a/src/AdoNet/Orleans.GrainDirectory.AdoNet/AdoNetGrainDirectoryOptions.cs
+++ b/src/AdoNet/Orleans.GrainDirectory.AdoNet/AdoNetGrainDirectoryOptions.cs
@@ -1,3 +1,5 @@
+using System.Data.Common;
+
 namespace Orleans.GrainDirectory.AdoNet;
 
 /// <summary>
@@ -15,6 +17,14 @@ public class AdoNetGrainDirectoryOptions
     /// Gets or sets the connection string.
     /// </summary>
     [Redact]
-    [Required]
-    public string ConnectionString { get; set; } = "";
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the data source used to open database connections.
+    /// </summary>
+    /// <remarks>
+    /// The data source is owned by the caller and is not disposed by Orleans.
+    /// </remarks>
+    [Redact]
+    public DbDataSource? DataSource { get; set; }
 }

--- a/src/AdoNet/Orleans.GrainDirectory.AdoNet/Options/AdoNetGrainDirectoryOptionsValidator.cs
+++ b/src/AdoNet/Orleans.GrainDirectory.AdoNet/Options/AdoNetGrainDirectoryOptionsValidator.cs
@@ -20,9 +20,9 @@ public class AdoNetGrainDirectoryOptionsValidator(AdoNetGrainDirectoryOptions op
             throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainDirectoryOptions)} values for {nameof(AdoNetGrainDirectory)}|{name}. {nameof(options.Invariant)} is required.");
         }
 
-        if (IsNullOrWhiteSpace(options.ConnectionString))
+        if (IsNullOrWhiteSpace(options.ConnectionString) == (options.DataSource is null))
         {
-            throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainDirectoryOptions)} values for {nameof(AdoNetGrainDirectory)}|{name}. {nameof(options.ConnectionString)} is required.");
+            throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainDirectoryOptions)} values for {nameof(AdoNetGrainDirectory)}|{name}. Configure exactly one of {nameof(options.ConnectionString)} or {nameof(options.DataSource)}.");
         }
     }
 }

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Options/AdoNetGrainStorageOptions.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Options;
 using Orleans.Persistence.AdoNet.Storage;
 using Orleans.Runtime;
 using Orleans.Storage;
+using System.Data.Common;
 
 namespace Orleans.Configuration
 {
@@ -14,7 +15,16 @@ namespace Orleans.Configuration
         /// Connection string for AdoNet storage.
         /// </summary>
         [Redact]
-        public string ConnectionString { get; set; } = null!;
+        public string? ConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the data source used to open database connections.
+        /// </summary>
+        /// <remarks>
+        /// The data source is owned by the caller and is not disposed by Orleans.
+        /// </remarks>
+        [Redact]
+        public DbDataSource? DataSource { get; set; }
 
         /// <summary>
         /// Stage of silo lifecycle where storage should be initialized.  Storage must be initialized prior to use.
@@ -87,9 +97,9 @@ namespace Orleans.Configuration
                 throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainStorageOptions)} values for {nameof(AdoNetGrainStorage)} \"{name}\". {nameof(options.Invariant)} is required.");
             }
 
-            if (string.IsNullOrWhiteSpace(this.options.ConnectionString))
+            if (string.IsNullOrWhiteSpace(this.options.ConnectionString) == (this.options.DataSource is null))
             {
-                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainStorageOptions)} values for {nameof(AdoNetGrainStorage)} \"{name}\". {nameof(options.ConnectionString)} is required.");
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetGrainStorageOptions)} values for {nameof(AdoNetGrainStorage)} \"{name}\". Configure exactly one of {nameof(options.ConnectionString)} or {nameof(options.DataSource)}.");
             }
 
             if (this.options.HashPicker == null)

--- a/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
+++ b/src/AdoNet/Orleans.Persistence.AdoNet/Storage/Provider/AdoNetGrainStorage.cs
@@ -333,7 +333,7 @@ namespace Orleans.Storage
         /// <summary> Initialization function for this storage provider. </summary>
         private async Task Init(CancellationToken cancellationToken)
         {
-            Storage = RelationalStorage.CreateInstance(options.Invariant, options.ConnectionString);
+            Storage = RelationalStorage.CreateInstance(options.Invariant, options.ConnectionString, options.DataSource);
             var queries = await Storage.ReadAsync(DefaultInitializationQuery, command => { }, (selector, resultSetCount, token) =>
             {
                 return Task.FromResult(Tuple.Create(selector.GetValue<string>("QueryKey"), selector.GetValue<string>("QueryText")));

--- a/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTable.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTable.cs
@@ -22,7 +22,7 @@ namespace Orleans.Runtime.ReminderService
 
         public async Task Init()
         {
-            this.orleansQueries = await RelationalOrleansQueries.CreateInstance(this.options.Invariant, this.options.ConnectionString);
+            this.orleansQueries = await RelationalOrleansQueries.CreateInstance(this.options.Invariant, this.options.ConnectionString, this.options.DataSource);
         }
 
         public Task<ReminderTableData> ReadRows(GrainId grainId)

--- a/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTableOptions.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTableOptions.cs
@@ -1,3 +1,5 @@
+using System.Data.Common;
+
 namespace Orleans.Configuration
 {
     /// <summary>
@@ -14,6 +16,15 @@ namespace Orleans.Configuration
         /// Gets or sets the connection string.
         /// </summary>
         [Redact]
-        public string ConnectionString { get; set; } = null!;
+        public string? ConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the data source used to open database connections.
+        /// </summary>
+        /// <remarks>
+        /// The data source is owned by the caller and is not disposed by Orleans.
+        /// </remarks>
+        [Redact]
+        public DbDataSource? DataSource { get; set; }
     }
 }

--- a/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTableOptionsValidator.cs
+++ b/src/AdoNet/Orleans.Reminders.AdoNet/ReminderService/AdoNetReminderTableOptionsValidator.cs
@@ -24,9 +24,9 @@ namespace Orleans.Configuration
                 throw new OrleansConfigurationException($"Invalid {nameof(AdoNetReminderTableOptions)} values for {nameof(AdoNetReminderTable)}. {nameof(options.Invariant)} is required.");
             }
 
-            if (string.IsNullOrWhiteSpace(this.options.ConnectionString))
+            if (string.IsNullOrWhiteSpace(this.options.ConnectionString) == (this.options.DataSource is null))
             {
-                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetReminderTableOptions)} values for {nameof(AdoNetReminderTable)}. {nameof(options.ConnectionString)} is required.");
+                throw new OrleansConfigurationException($"Invalid {nameof(AdoNetReminderTableOptions)} values for {nameof(AdoNetReminderTable)}. Configure exactly one of {nameof(options.ConnectionString)} or {nameof(options.DataSource)}.");
             }
         }
     }

--- a/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetQueueAdapterFactory.cs
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetQueueAdapterFactory.cs
@@ -60,7 +60,7 @@ internal class AdoNetQueueAdapterFactory : IQueueAdapterFactory
 
                 // slow path - the member variable will only be set if the call succeeds
                 return _queries = await RelationalOrleansQueries
-                    .CreateInstance(_streamOptions.Invariant, _streamOptions.ConnectionString)
+                    .CreateInstance(_streamOptions.Invariant, _streamOptions.ConnectionString, _streamOptions.DataSource)
                     .WaitAsync(_streamOptions.InitializationTimeout);
             }
             finally

--- a/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetStreamOptions.cs
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetStreamOptions.cs
@@ -1,3 +1,5 @@
+using System.Data.Common;
+
 namespace Orleans.Configuration;
 
 /// <summary>
@@ -14,7 +16,16 @@ public class AdoNetStreamOptions
     /// Gets or sets the connection string.
     /// </summary>
     [Redact]
-    public string ConnectionString { get; set; } = default!;
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Gets or sets the data source used to open database connections.
+    /// </summary>
+    /// <remarks>
+    /// The data source is owned by the caller and is not disposed by Orleans.
+    /// </remarks>
+    [Redact]
+    public DbDataSource? DataSource { get; set; }
 
     /// <summary>
     /// The maximum number of attempts to deliver a message.

--- a/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetStreamOptionsValidator.cs
+++ b/src/AdoNet/Orleans.Streaming.AdoNet/AdoNetStreamOptionsValidator.cs
@@ -15,9 +15,9 @@ public class AdoNetStreamOptionsValidator(AdoNetStreamOptions options, string na
             throw new OrleansConfigurationException($"Invalid {nameof(AdoNetStreamOptions)} values for ADO.NET Streaming Provider '{name}': {nameof(options.Invariant)} is required.");
         }
 
-        if (IsNullOrWhiteSpace(options.ConnectionString))
+        if (IsNullOrWhiteSpace(options.ConnectionString) == (options.DataSource is null))
         {
-            throw new OrleansConfigurationException($"Invalid {nameof(AdoNetStreamOptions)} values for ADO.NET Streaming Provider '{name}': {nameof(options.ConnectionString)} is required.");
+            throw new OrleansConfigurationException($"Invalid {nameof(AdoNetStreamOptions)} values for ADO.NET Streaming Provider '{name}': configure exactly one of {nameof(options.ConnectionString)} or {nameof(options.DataSource)}.");
         }
 
         if (options.MaxAttempts < 0)

--- a/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
+++ b/src/AdoNet/Shared/Storage/DbConnectionFactory.cs
@@ -124,6 +124,25 @@ namespace Orleans.Tests.SqlUtils
             return connection;
         }
 
+        public static void ValidateDataSource(string invariantName, DbDataSource dataSource)
+        {
+            ArgumentNullException.ThrowIfNull(dataSource);
+
+            var factory = factoryCache.GetOrAdd(invariantName, GetFactory).Factory;
+            using var expectedConnection = factory.CreateConnection()
+                ?? throw new InvalidOperationException($"Database provider factory: '{invariantName}' did not return a connection object.");
+            using var actualConnection = dataSource.CreateConnection();
+
+            var expectedType = expectedConnection.GetType();
+            var actualType = actualConnection.GetType();
+            if (!expectedType.IsAssignableFrom(actualType))
+            {
+                throw new ArgumentException(
+                    $"The configured data source creates connections of type '{actualType.FullName}', but invariant '{invariantName}' uses '{expectedType.FullName}'.",
+                    nameof(dataSource));
+            }
+        }
+
         private class CachedFactory
         {
             public CachedFactory(DbProviderFactory factory, string factoryName, string factoryDescription, string factoryAssemblyQualifiedNameKey)

--- a/src/AdoNet/Shared/Storage/RelationalOrleansQueries.cs
+++ b/src/AdoNet/Shared/Storage/RelationalOrleansQueries.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -66,10 +67,17 @@ namespace Orleans.Tests.SqlUtils
         /// </summary>
         /// <param name="invariantName">The invariant name of the connector for this database.</param>
         /// <param name="connectionString">The connection string this database should use for database operations.</param>
-        internal static async Task<RelationalOrleansQueries> CreateInstance(string invariantName, string connectionString)
-        {
-            var storage = RelationalStorage.CreateInstance(invariantName, connectionString);
+        internal static Task<RelationalOrleansQueries> CreateInstance(string invariantName, string connectionString) =>
+            CreateInstance(RelationalStorage.CreateInstance(invariantName, connectionString));
 
+        /// <summary>
+        /// Creates an instance using exactly one configured connection source and initializes Orleans queries from the database.
+        /// </summary>
+        internal static Task<RelationalOrleansQueries> CreateInstance(string invariantName, string? connectionString, DbDataSource? dataSource) =>
+            CreateInstance(RelationalStorage.CreateInstance(invariantName, connectionString, dataSource));
+
+        private static async Task<RelationalOrleansQueries> CreateInstance(IRelationalStorage storage)
+        {
             var queries = await storage.ReadAsync(DbStoredQueries.GetQueriesKey, DbStoredQueries.Converters.GetQueryKeyAndValue, null);
 
             return new RelationalOrleansQueries(storage, new DbStoredQueries(queries.ToDictionary(q => q.Key, q => q.Value)));

--- a/src/AdoNet/Shared/Storage/RelationalStorage.cs
+++ b/src/AdoNet/Shared/Storage/RelationalStorage.cs
@@ -35,6 +35,11 @@ namespace Orleans.Tests.SqlUtils
         private readonly string _connectionString;
 
         /// <summary>
+        /// The optional data source used to open connections.
+        /// </summary>
+        private readonly DbDataSource? _dataSource;
+
+        /// <summary>
         /// The invariant name of the connector for this database.
         /// </summary>
         private readonly string _invariantName;
@@ -99,6 +104,39 @@ namespace Orleans.Tests.SqlUtils
             }
 
             return new RelationalStorage(invariantName, connectionString);
+        }
+
+        /// <summary>
+        /// Creates an instance of a database of type <see cref="IRelationalStorage"/>.
+        /// </summary>
+        /// <param name="invariantName">The invariant name of the connector for this database.</param>
+        /// <param name="dataSource">The data source used to open database connections.</param>
+        /// <returns>A relational storage instance.</returns>
+        public static IRelationalStorage CreateInstance(string invariantName, DbDataSource dataSource)
+        {
+            if (string.IsNullOrWhiteSpace(invariantName))
+            {
+                throw new ArgumentException("The name of invariant must contain characters", nameof(invariantName));
+            }
+
+            ArgumentNullException.ThrowIfNull(dataSource);
+            DbConnectionFactory.ValidateDataSource(invariantName, dataSource);
+            return new RelationalStorage(invariantName, dataSource);
+        }
+
+        /// <summary>
+        /// Creates an instance using exactly one configured connection source.
+        /// </summary>
+        public static IRelationalStorage CreateInstance(string invariantName, string? connectionString, DbDataSource? dataSource)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString) == (dataSource is null))
+            {
+                throw new ArgumentException($"Configure exactly one of {nameof(connectionString)} or {nameof(dataSource)}.");
+            }
+
+            return dataSource is null
+                ? CreateInstance(invariantName, connectionString!)
+                : CreateInstance(invariantName, dataSource);
         }
 
 
@@ -214,6 +252,16 @@ namespace Orleans.Tests.SqlUtils
             this._databaseCommandInterceptor = DbConstantsStore.GetDatabaseCommandInterceptor(InvariantName);
         }
 
+        private RelationalStorage(string invariantName, DbDataSource dataSource)
+        {
+            _connectionString = dataSource.ConnectionString;
+            _dataSource = dataSource;
+            _invariantName = invariantName;
+            _supportsCommandCancellation = DbConstantsStore.SupportsCommandCancellation(InvariantName);
+            _isSynchronousAdoNetImplementation = DbConstantsStore.IsSynchronousAdoNetImplementation(InvariantName);
+            _databaseCommandInterceptor = DbConstantsStore.GetDatabaseCommandInterceptor(InvariantName);
+        }
+
         private static async Task<Tuple<IEnumerable<TResult>, int>> SelectAsync<TResult>(DbDataReader reader, Func<IDataReader, int, CancellationToken, Task<TResult>> selector, CancellationToken cancellationToken)
         {
             var results = new List<TResult>();
@@ -263,9 +311,8 @@ namespace Orleans.Tests.SqlUtils
             CommandBehavior commandBehavior,
             CancellationToken cancellationToken)
         {
-            using (var connection = DbConnectionFactory.CreateConnection(_invariantName, _connectionString))
+            using (var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(continueOnCapturedContext: false))
             {
-                await connection.OpenAsync(cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
                 using (var command = connection.CreateCommand())
                 {
                     parameterProvider?.Invoke(command);
@@ -285,6 +332,26 @@ namespace Orleans.Tests.SqlUtils
 
                     return await ret.ConfigureAwait(continueOnCapturedContext: false);
                 }
+            }
+        }
+
+        private async ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+        {
+            if (_dataSource is not null)
+            {
+                return await _dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+            }
+
+            var connection = DbConnectionFactory.CreateConnection(_invariantName, _connectionString);
+            try
+            {
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(continueOnCapturedContext: false);
+                return connection;
+            }
+            catch
+            {
+                connection.Dispose();
+                throw;
             }
         }
 

--- a/src/api/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.cs
+++ b/src/api/AdoNet/Orleans.Clustering.AdoNet/Orleans.Clustering.AdoNet.cs
@@ -11,7 +11,10 @@ namespace Orleans.Configuration
     public partial class AdoNetClusteringClientOptions
     {
         [Redact]
-        public string ConnectionString { get { throw null; } set { } }
+        public string? ConnectionString { get { throw null; } set { } }
+
+        [Redact]
+        public System.Data.Common.DbDataSource? DataSource { get { throw null; } set { } }
 
         public string Invariant { get { throw null; } set { } }
     }
@@ -26,7 +29,10 @@ namespace Orleans.Configuration
     public partial class AdoNetClusteringSiloOptions
     {
         [Redact]
-        public string ConnectionString { get { throw null; } set { } }
+        public string? ConnectionString { get { throw null; } set { } }
+
+        [Redact]
+        public System.Data.Common.DbDataSource? DataSource { get { throw null; } set { } }
 
         public string Invariant { get { throw null; } set { } }
     }

--- a/src/api/AdoNet/Orleans.GrainDirectory.AdoNet/Orleans.GrainDirectory.AdoNet.cs
+++ b/src/api/AdoNet/Orleans.GrainDirectory.AdoNet/Orleans.GrainDirectory.AdoNet.cs
@@ -21,8 +21,10 @@ namespace Orleans.GrainDirectory.AdoNet
     public partial class AdoNetGrainDirectoryOptions
     {
         [Redact]
-        [System.ComponentModel.DataAnnotations.Required]
-        public string ConnectionString { get { throw null; } set { } }
+        public string? ConnectionString { get { throw null; } set { } }
+
+        [Redact]
+        public System.Data.Common.DbDataSource? DataSource { get { throw null; } set { } }
 
         [System.ComponentModel.DataAnnotations.Required]
         public string Invariant { get { throw null; } set { } }

--- a/src/api/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.cs
+++ b/src/api/AdoNet/Orleans.Persistence.AdoNet/Orleans.Persistence.AdoNet.cs
@@ -13,7 +13,10 @@ namespace Orleans.Configuration
         public const string DEFAULT_ADONET_INVARIANT = "Microsoft.Data.SqlClient";
         public const int DEFAULT_INIT_STAGE = 10000;
         [Redact]
-        public string ConnectionString { get { throw null; } set { } }
+        public string? ConnectionString { get { throw null; } set { } }
+
+        [Redact]
+        public System.Data.Common.DbDataSource? DataSource { get { throw null; } set { } }
 
         public bool DeleteStateOnClear { get { throw null; } set { } }
 

--- a/src/api/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.cs
+++ b/src/api/AdoNet/Orleans.Reminders.AdoNet/Orleans.Reminders.AdoNet.cs
@@ -11,7 +11,10 @@ namespace Orleans.Configuration
     public partial class AdoNetReminderTableOptions
     {
         [Redact]
-        public string ConnectionString { get { throw null; } set { } }
+        public string? ConnectionString { get { throw null; } set { } }
+
+        [Redact]
+        public System.Data.Common.DbDataSource? DataSource { get { throw null; } set { } }
 
         public string Invariant { get { throw null; } set { } }
     }

--- a/src/api/AdoNet/Orleans.Streaming.AdoNet/Orleans.Streaming.AdoNet.cs
+++ b/src/api/AdoNet/Orleans.Streaming.AdoNet/Orleans.Streaming.AdoNet.cs
@@ -11,7 +11,10 @@ namespace Orleans.Configuration
     public partial class AdoNetStreamOptions
     {
         [Redact]
-        public string ConnectionString { get { throw null; } set { } }
+        public string? ConnectionString { get { throw null; } set { } }
+
+        [Redact]
+        public System.Data.Common.DbDataSource? DataSource { get { throw null; } set { } }
 
         public System.TimeSpan DeadLetterEvictionTimeout { get { throw null; } set { } }
 

--- a/test/Extensions/Orleans.AdoNet.Tests/AdoNetOptionsValidatorTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/AdoNetOptionsValidatorTests.cs
@@ -1,0 +1,224 @@
+using System.Data.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using Orleans.GrainDirectory.AdoNet;
+using Orleans.Runtime;
+using Orleans.Storage;
+using Orleans.Tests.SqlUtils;
+using UnitTests.StorageTests.Relational;
+
+namespace UnitTests.AdoNet;
+
+[TestCategory("AdoNet")]
+public sealed class AdoNetOptionsValidatorTests
+{
+    [Fact]
+    public void NamedOptions_ResolveKeyedDataSources()
+    {
+        using var first = new TrackingSqliteDataSource("Data Source=first.db");
+        using var second = new TrackingSqliteDataSource("Data Source=second.db");
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<DbDataSource>("first", first);
+        services.AddKeyedSingleton<DbDataSource>("second", second);
+        Configure("first");
+        Configure("second");
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var options = serviceProvider.GetRequiredService<IOptionsMonitor<AdoNetStreamOptions>>();
+
+        Assert.Same(first, options.Get("first").DataSource);
+        Assert.Same(second, options.Get("second").DataSource);
+
+        void Configure(string name)
+        {
+            services.AddOptions<AdoNetStreamOptions>(name).Configure<IServiceProvider>((value, provider) =>
+            {
+                value.Invariant = AdoNetInvariants.InvariantNameSqlLite;
+                value.DataSource = provider.GetRequiredKeyedService<DbDataSource>(name);
+            });
+        }
+    }
+
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, false)]
+    [InlineData(true, true, false)]
+    public void ClusteringClient_ValidatesConnectionSource(bool connectionString, bool dataSource, bool valid)
+    {
+        using var source = new TrackingSqliteDataSource("Data Source=:memory:");
+        var options = new AdoNetClusteringClientOptions
+        {
+            Invariant = AdoNetInvariants.InvariantNameSqlLite,
+            ConnectionString = connectionString ? source.ConnectionString : null,
+            DataSource = dataSource ? source : null
+        };
+
+        AssertValidation(valid, new AdoNetClusteringClientOptionsValidator(Options.Create(options)).ValidateConfiguration);
+    }
+
+    [Fact]
+    public void ClusteringClient_RequiresInvariant()
+    {
+        var options = new AdoNetClusteringClientOptions { ConnectionString = "configured", Invariant = " " };
+
+        AssertInvariantRequired(new AdoNetClusteringClientOptionsValidator(Options.Create(options)).ValidateConfiguration);
+    }
+
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, false)]
+    [InlineData(true, true, false)]
+    public void ClusteringSilo_ValidatesConnectionSource(bool connectionString, bool dataSource, bool valid)
+    {
+        using var source = new TrackingSqliteDataSource("Data Source=:memory:");
+        var options = new AdoNetClusteringSiloOptions
+        {
+            Invariant = AdoNetInvariants.InvariantNameSqlLite,
+            ConnectionString = connectionString ? source.ConnectionString : null,
+            DataSource = dataSource ? source : null
+        };
+
+        AssertValidation(valid, new AdoNetClusteringSiloOptionsValidator(Options.Create(options)).ValidateConfiguration);
+    }
+
+    [Fact]
+    public void ClusteringSilo_RequiresInvariant()
+    {
+        var options = new AdoNetClusteringSiloOptions { ConnectionString = "configured", Invariant = " " };
+
+        AssertInvariantRequired(new AdoNetClusteringSiloOptionsValidator(Options.Create(options)).ValidateConfiguration);
+    }
+
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, false)]
+    [InlineData(true, true, false)]
+    public void ReminderTable_ValidatesConnectionSource(bool connectionString, bool dataSource, bool valid)
+    {
+        using var source = new TrackingSqliteDataSource("Data Source=:memory:");
+        var options = new AdoNetReminderTableOptions
+        {
+            Invariant = AdoNetInvariants.InvariantNameSqlLite,
+            ConnectionString = connectionString ? source.ConnectionString : null,
+            DataSource = dataSource ? source : null
+        };
+
+        AssertValidation(valid, new AdoNetReminderTableOptionsValidator(Options.Create(options)).ValidateConfiguration);
+    }
+
+    [Fact]
+    public void ReminderTable_RequiresInvariant()
+    {
+        var options = new AdoNetReminderTableOptions { ConnectionString = "configured", Invariant = " " };
+
+        AssertInvariantRequired(new AdoNetReminderTableOptionsValidator(Options.Create(options)).ValidateConfiguration);
+    }
+
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, false)]
+    [InlineData(true, true, false)]
+    public void GrainDirectory_ValidatesConnectionSource(bool connectionString, bool dataSource, bool valid)
+    {
+        using var source = new TrackingSqliteDataSource("Data Source=:memory:");
+        var options = new AdoNetGrainDirectoryOptions
+        {
+            Invariant = AdoNetInvariants.InvariantNameSqlLite,
+            ConnectionString = connectionString ? source.ConnectionString : null,
+            DataSource = dataSource ? source : null
+        };
+
+        AssertValidation(valid, new AdoNetGrainDirectoryOptionsValidator(options, "directory").ValidateConfiguration);
+    }
+
+    [Fact]
+    public void GrainDirectory_RequiresInvariant()
+    {
+        var options = new AdoNetGrainDirectoryOptions { ConnectionString = "configured", Invariant = " " };
+
+        AssertInvariantRequired(new AdoNetGrainDirectoryOptionsValidator(options, "directory").ValidateConfiguration);
+    }
+
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, false)]
+    [InlineData(true, true, false)]
+    public void GrainStorage_ValidatesConnectionSource(bool connectionString, bool dataSource, bool valid)
+    {
+        using var source = new TrackingSqliteDataSource("Data Source=:memory:");
+        var options = new AdoNetGrainStorageOptions
+        {
+            Invariant = AdoNetInvariants.InvariantNameSqlLite,
+            ConnectionString = connectionString ? source.ConnectionString : null,
+            DataSource = dataSource ? source : null,
+            HashPicker = new StorageHasherPicker([new ConstantHasher()])
+        };
+
+        AssertValidation(valid, new AdoNetGrainStorageOptionsValidator(options, "storage").ValidateConfiguration);
+    }
+
+    [Fact]
+    public void GrainStorage_RequiresInvariant()
+    {
+        var options = new AdoNetGrainStorageOptions
+        {
+            ConnectionString = "configured",
+            Invariant = " ",
+            HashPicker = new StorageHasherPicker([new ConstantHasher()])
+        };
+
+        AssertInvariantRequired(new AdoNetGrainStorageOptionsValidator(options, "storage").ValidateConfiguration);
+    }
+
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, false)]
+    [InlineData(true, true, false)]
+    public void Streaming_ValidatesConnectionSource(bool connectionString, bool dataSource, bool valid)
+    {
+        using var source = new TrackingSqliteDataSource("Data Source=:memory:");
+        var options = new AdoNetStreamOptions
+        {
+            Invariant = AdoNetInvariants.InvariantNameSqlLite,
+            ConnectionString = connectionString ? source.ConnectionString : null,
+            DataSource = dataSource ? source : null
+        };
+
+        AssertValidation(valid, new AdoNetStreamOptionsValidator(options, "stream").ValidateConfiguration);
+    }
+
+    [Fact]
+    public void Streaming_RequiresInvariant()
+    {
+        var options = new AdoNetStreamOptions { ConnectionString = "configured", Invariant = " " };
+
+        AssertInvariantRequired(new AdoNetStreamOptionsValidator(options, "stream").ValidateConfiguration);
+    }
+
+    private static void AssertValidation(bool valid, Action validate)
+    {
+        if (valid)
+        {
+            validate();
+        }
+        else
+        {
+            var exception = Assert.Throws<OrleansConfigurationException>(validate);
+            Assert.Contains("exactly one", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static void AssertInvariantRequired(Action validate)
+    {
+        var exception = Assert.Throws<OrleansConfigurationException>(validate);
+        Assert.Contains("Invariant", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("required", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageFixture.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageFixture.cs
@@ -88,5 +88,34 @@ namespace Tester.AdoNet.Persistence
 
             return await File.ReadAllTextAsync(scriptPath).ConfigureAwait(false);
         }
+
+        public async Task<AdoNetGrainStorage> CreateGrainStorageAsync(
+            System.Data.Common.DbDataSource dataSource,
+            string storageName = "SqliteDataSourceGrainStorageForTest")
+        {
+            var providerRuntime = new ClientProviderRuntime(
+                this.InternalGrainFactory,
+                this.Services,
+                this.Services.GetRequiredService<ClientGrainContext>());
+
+            var options = new AdoNetGrainStorageOptions
+            {
+                DataSource = dataSource,
+                Invariant = AdoInvariant,
+                GrainStorageSerializer = new JsonGrainStorageSerializer(providerRuntime.ServiceProvider.GetService<OrleansJsonSerializer>()!)
+            };
+
+            var storageProvider = new AdoNetGrainStorage(
+                providerRuntime.ServiceProvider.GetRequiredService<IActivatorProvider>(),
+                providerRuntime.ServiceProvider.GetRequiredService<ILogger<AdoNetGrainStorage>>(),
+                Options.Create(options),
+                Options.Create(new ClusterOptions { ServiceId = Guid.NewGuid().ToString() }),
+                storageName);
+
+            ISiloLifecycleSubject siloLifeCycle = new SiloLifecycleSubject(NullLoggerFactory.Instance.CreateLogger<SiloLifecycleSubject>());
+            storageProvider.Participate(siloLifeCycle);
+            await siloLifeCycle.OnStart(CancellationToken.None).ConfigureAwait(false);
+            return storageProvider;
+        }
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/Persistence/SqlitePersistenceGrainStorageTests.cs
@@ -173,5 +173,41 @@ namespace Tester.AdoNet.Persistence
             var versionAfterWritePostClear = int.Parse(Assert.IsType<string>(grainState.ETag), CultureInfo.InvariantCulture);
             Assert.Equal(versionAfterClear + 1, versionAfterWritePostClear);
         }
+
+        [Fact]
+        public async Task DataSource_WriteReadClear_LeavesCallerOwnedDataSourceUsable()
+        {
+            using var dataSource = new TrackingSqliteDataSource(this.fixture.ConnectionString);
+            var storage = await this.fixture.CreateGrainStorageAsync(dataSource, $"SqliteDataSource-{Guid.NewGuid():N}");
+            const string grainType = "sqlite-data-source-grain";
+            var grainId = GrainId.Create(GrainType.Create(grainType), GrainIdKeyExtensions.CreateIntegerKey(Random.Shared.NextInt64()));
+            var written = new GrainState<TestState1> { State = new TestState1 { A = "from-data-source", B = 17, C = 29 } };
+
+            await storage.WriteStateAsync(grainType, grainId, written);
+            var read = new GrainState<TestState1> { State = new TestState1() };
+            await storage.ReadStateAsync(grainType, grainId, read);
+
+            Assert.True(read.RecordExists);
+            Assert.Equal(written.State, read.State);
+            Assert.NotNull(read.ETag);
+
+            var etagBeforeClear = read.ETag;
+            await storage.ClearStateAsync(grainType, grainId, read);
+
+            Assert.False(read.RecordExists);
+            Assert.NotEqual(etagBeforeClear, read.ETag);
+            Assert.False(dataSource.IsDisposed);
+
+            await using (var connection = await dataSource.OpenConnectionAsync())
+            await using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT 43;";
+                Assert.Equal(43L, await command.ExecuteScalarAsync());
+            }
+
+            Assert.True(dataSource.OpenConnectionAsyncCallCount >= 5);
+            Assert.All(dataSource.Connections, connection => Assert.True(connection.IsDisposed));
+            Assert.False(dataSource.IsDisposed);
+        }
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/MySqlRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/MySqlRelationalStoreTests.cs
@@ -1,7 +1,9 @@
 using System.Runtime.ExceptionServices;
+using MySql.Data.MySqlClient;
 using Orleans.Tests.SqlUtils;
 using TestExtensions;
 using UnitTests.General;
+using UnitTests.StorageTests.Relational;
 using Xunit;
 
 namespace UnitTests.StorageTests.AdoNet
@@ -62,6 +64,22 @@ namespace UnitTests.StorageTests.AdoNet
         public async Task CancellationToken_MySql_Test()
         {
             await CancellationTokenTest(_storage, CancellationTestTimeoutLimit);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task DataSource_MySql_Test()
+        {
+            using var dataSource = new ProviderDbDataSource(
+                _storage.CurrentConnectionString,
+                () => new MySqlConnection(_storage.CurrentConnectionString));
+            var storage = RelationalStorage.CreateInstance(AdoNetInvariantName, dataSource);
+
+            var values = await storage.ReadAsync(
+                "SELECT 47;",
+                parameterProvider: null,
+                (record, _, _) => Task.FromResult(record.GetInt32(0)));
+
+            Assert.Equal([47], values);
         }
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/PostgreSqlRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/PostgreSqlRelationalStoreTests.cs
@@ -52,5 +52,20 @@ namespace UnitTests.StorageTests.AdoNet
         {
             await CancellationTokenTest(_storage, CancellationTestTimeoutLimit);
         }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task NativeDataSource_PostgreSql_Test()
+        {
+            Skip.If(_storage is null || string.IsNullOrWhiteSpace(_storage.CurrentConnectionString), "Connection string not provided.");
+            await using var dataSource = Npgsql.NpgsqlDataSource.Create(_storage.CurrentConnectionString);
+            var storage = RelationalStorage.CreateInstance(AdoNetInvariantName, dataSource);
+
+            var values = await storage.ReadAsync(
+                "SELECT 47;",
+                parameterProvider: null,
+                (record, _, _) => Task.FromResult(record.GetInt32(0)));
+
+            Assert.Equal([47], values);
+        }
     }
 }

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageDataSourceTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/Relational/RelationalStorageDataSourceTests.cs
@@ -1,0 +1,188 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.Sqlite;
+using MySql.Data.MySqlClient;
+using Npgsql;
+using Orleans.Tests.SqlUtils;
+
+namespace UnitTests.StorageTests.Relational;
+
+[TestCategory("AdoNet"), TestCategory("Persistence"), TestCategory("Sqlite")]
+public sealed class RelationalStorageDataSourceTests
+{
+    [Fact]
+    public async Task DataSource_ExecutesQueryWithCancellationAndDisposesConnections()
+    {
+        using var dataSource = new TrackingSqliteDataSource("Data Source=:memory:");
+        var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNameSqlLite, dataSource);
+        using var cancellation = new CancellationTokenSource();
+
+        var values = await storage.ReadAsync(
+            "SELECT 42;",
+            parameterProvider: null,
+            (record, _, _) => Task.FromResult(record.GetInt32(0)),
+            cancellationToken: cancellation.Token);
+
+        Assert.Equal([42], values);
+        Assert.Equal(1, dataSource.OpenConnectionAsyncCallCount);
+        Assert.Equal(cancellation.Token, dataSource.LastOpenCancellationToken);
+        Assert.Equal(2, dataSource.Connections.Count);
+        Assert.All(dataSource.Connections, connection => Assert.True(connection.IsDisposed));
+        Assert.False(dataSource.IsDisposed);
+    }
+
+    [Fact]
+    public async Task RelationalOrleansQueries_UsesDataSource()
+    {
+        using var dataSource = new TrackingSqliteDataSource("Data Source=:memory:");
+
+        var exception = await Assert.ThrowsAsync<SqliteException>(() =>
+            RelationalOrleansQueries.CreateInstance(
+                AdoNetInvariants.InvariantNameSqlLite,
+                connectionString: null,
+                dataSource));
+
+        Assert.Contains("OrleansQuery", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(1, dataSource.OpenConnectionAsyncCallCount);
+        Assert.All(dataSource.Connections, connection => Assert.True(connection.IsDisposed));
+        Assert.False(dataSource.IsDisposed);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CreateInstance_RequiresExactlyOneConnectionSource(bool configureBoth)
+    {
+        using var dataSource = new TrackingSqliteDataSource("Data Source=:memory:");
+
+        var exception = Assert.Throws<ArgumentException>(() => RelationalStorage.CreateInstance(
+            AdoNetInvariants.InvariantNameSqlLite,
+            configureBoth ? dataSource.ConnectionString : null,
+            configureBoth ? dataSource : null));
+
+        Assert.Contains("exactly one", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(dataSource.Connections);
+        Assert.Equal(0, dataSource.OpenConnectionAsyncCallCount);
+    }
+
+    [Fact]
+    public void CreateInstance_RejectsProviderMismatchWithoutOpeningConnection()
+    {
+        using var dataSource = new TrackingSqliteDataSource("Data Source=:memory:");
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNamePostgreSql, dataSource));
+
+        Assert.Contains(typeof(SqliteConnection).FullName!, exception.Message, StringComparison.Ordinal);
+        Assert.Contains(typeof(NpgsqlConnection).FullName!, exception.Message, StringComparison.Ordinal);
+        Assert.Equal(0, dataSource.OpenConnectionAsyncCallCount);
+        var validationConnection = Assert.Single(dataSource.Connections);
+        Assert.True(validationConnection.IsDisposed);
+        Assert.False(dataSource.IsDisposed);
+    }
+
+    [Fact]
+    public void CreateInstance_AcceptsNativeNpgsqlDataSourceWithoutOpeningConnection()
+    {
+        const string connectionString = "Host=127.0.0.1;Port=1;Database=unused;Username=unused;Password=unused";
+        using var dataSource = NpgsqlDataSource.Create(connectionString);
+
+        var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNamePostgreSql, dataSource);
+
+        Assert.Equal(AdoNetInvariants.InvariantNamePostgreSql, storage.InvariantName);
+        Assert.Equal(dataSource.ConnectionString, storage.ConnectionString);
+    }
+
+    [Fact]
+    public void CreateInstance_AcceptsSqlServerDataSourceWithoutOpeningConnection()
+    {
+        const string connectionString = "Server=127.0.0.1,1;Database=unused;User Id=unused;******;TrustServerCertificate=True";
+        using var dataSource = new ProviderDbDataSource(
+            connectionString,
+            () => new SqlConnection("Server=127.0.0.1,1;Database=unused;Integrated Security=True;TrustServerCertificate=True"));
+
+        var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNameSqlServer, dataSource);
+
+        Assert.Equal(AdoNetInvariants.InvariantNameSqlServer, storage.InvariantName);
+        Assert.Equal(dataSource.ConnectionString, storage.ConnectionString);
+    }
+
+    [Fact]
+    public void CreateInstance_AcceptsMySqlDataSourceWithoutOpeningConnection()
+    {
+        const string connectionString = "Server=127.0.0.1;Port=1;Database=unused;User Id=unused;******";
+        using var dataSource = new ProviderDbDataSource(
+            connectionString,
+            () => new MySqlConnection("Server=127.0.0.1;Port=1;Database=unused;User Id=unused"));
+
+        var storage = RelationalStorage.CreateInstance(AdoNetInvariants.InvariantNameMySql, dataSource);
+
+        Assert.Equal(AdoNetInvariants.InvariantNameMySql, storage.InvariantName);
+        Assert.Equal(dataSource.ConnectionString, storage.ConnectionString);
+    }
+}
+
+internal sealed class TrackingSqliteDataSource(string connectionString) : DbDataSource
+{
+    private readonly List<TrackedSqliteConnection> _connections = [];
+
+    public override string ConnectionString { get; } = connectionString;
+
+    public IReadOnlyList<TrackedSqliteConnection> Connections => _connections;
+
+    public int OpenConnectionAsyncCallCount { get; private set; }
+
+    public CancellationToken LastOpenCancellationToken { get; private set; }
+
+    public bool IsDisposed { get; private set; }
+
+    protected override DbConnection CreateDbConnection()
+    {
+        var connection = new SqliteConnection(ConnectionString);
+        var tracked = new TrackedSqliteConnection(connection);
+        connection.Disposed += (_, _) => tracked.IsDisposed = true;
+        _connections.Add(tracked);
+        return connection;
+    }
+
+    protected override async ValueTask<DbConnection> OpenDbConnectionAsync(CancellationToken cancellationToken)
+    {
+        OpenConnectionAsyncCallCount++;
+        LastOpenCancellationToken = cancellationToken;
+        var connection = CreateDbConnection();
+        try
+        {
+            await connection.OpenAsync(cancellationToken);
+            return connection;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            IsDisposed = true;
+        }
+
+        base.Dispose(disposing);
+    }
+}
+
+internal sealed class TrackedSqliteConnection(SqliteConnection connection)
+{
+    public SqliteConnection Connection { get; } = connection;
+
+    public bool IsDisposed { get; set; }
+}
+
+internal sealed class ProviderDbDataSource(string connectionString, Func<DbConnection> createConnection) : DbDataSource
+{
+    public override string ConnectionString { get; } = connectionString;
+
+    protected override DbConnection CreateDbConnection() => createConnection();
+}

--- a/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
+++ b/test/Extensions/Orleans.AdoNet.Tests/StorageTests/SqlServerRelationalStoreTests.cs
@@ -1,4 +1,6 @@
+using Microsoft.Data.SqlClient;
 using Orleans.Tests.SqlUtils;
+using UnitTests.StorageTests.Relational;
 using UnitTests.General;
 using Xunit;
 
@@ -50,6 +52,23 @@ namespace UnitTests.StorageTests.AdoNet
         public async Task CancellationToken_SqlServer_Test()
         {
             await CancellationTokenTest(_storage, CancellationTestTimeoutLimit);
+        }
+
+        [SkippableFact, TestCategory("Functional")]
+        public async Task DataSource_SqlServer_Test()
+        {
+            Skip.If(_storage is null || string.IsNullOrWhiteSpace(_storage.CurrentConnectionString), "Connection string not provided.");
+            using var dataSource = new ProviderDbDataSource(
+                _storage.CurrentConnectionString,
+                () => new SqlConnection(_storage.CurrentConnectionString));
+            var storage = RelationalStorage.CreateInstance(AdoNetInvariantName, dataSource);
+
+            var values = await storage.ReadAsync(
+                "SELECT 47;",
+                parameterProvider: null,
+                (record, _, _) => Task.FromResult(record.GetInt32(0)));
+
+            Assert.Equal([47], values);
         }
     }
 }


### PR DESCRIPTION
ADO.NET providers currently require connection strings, which prevents applications from using provider features such as Npgsql's managed-identity token refresh. This adds a provider-neutral `System.Data.Common.DbDataSource` alternative across clustering, gateway discovery, persistence, reminders, grain directories, and streaming.

Each provider now requires exactly one of `ConnectionString` or `DataSource`. Orleans validates that the data source matches the configured invariant, opens connections asynchronously, disposes each connection after use, and leaves data-source lifetime ownership with the caller or DI container. Existing connection-string configuration remains compatible, including named providers through keyed DI.

The change also updates public API baselines and documentation, and adds coverage for validation, ownership, named DI, SQLite persistence, and SQL Server, PostgreSQL, MySQL, and SQLite driver compatibility.

Fixes: #10247
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10429)