### PR TITLE
docs: add connection middleware guide

### DIFF
--- a/docs/site/src/content/docs/host/connection-middleware.md
+++ b/docs/site/src/content/docs/host/connection-middleware.md
@@ -1,0 +1,116 @@
+---
+title: Connection middleware
+description: Plug custom logic, such as authentication or custom framing, into Orleans silo-to-silo and client-to-silo connections.
+ms.date: 08/10/2026
+ms.topic: how-to
+---
+
+# Connection middleware
+
+Orleans connections (silo-to-silo, client-to-gateway, and gateway-inbound) are built from a chain of middleware, similar to an ASP.NET Core request pipeline. <xref:Orleans.Runtime.Messaging.IConnectionMiddleware> lets you insert custom logic, such as authentication, custom framing, or connection-level diagnostics, into that pipeline without reimplementing connection setup.
+
+Orleans itself uses this abstraction for TLS. See [Secure Orleans connections with TLS](transport-layer-security.md) for the built-in TLS middleware.
+
+## The middleware interface
+
+```csharp
+public interface IConnectionMiddleware
+{
+    Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next);
+}
+```
+
+A middleware instance can be invoked concurrently for multiple connections, so store per-connection state in local variables or on the <xref:Microsoft.AspNetCore.Connections.ConnectionContext>, not on the middleware instance. Implementations should call `next(context)` to continue the pipeline after performing their work; not calling `next` terminates the connection.
+
+## Register middleware
+
+Use `UseMiddleware` on an <xref:Microsoft.AspNetCore.Connections.IConnectionBuilder> to add middleware to a connection pipeline:
+
+```csharp
+// Resolves T from the application's dependency injection container.
+// T must be registered as a singleton and must be safe for concurrent use.
+builder.UseMiddleware<MyMiddleware>();
+
+// Adds a shared instance. The caller owns the instance and is responsible for disposing it.
+builder.UseMiddleware(new MyMiddleware(...));
+```
+
+Connection pipelines are configured through <xref:Orleans.Configuration.SiloConnectionOptions> (silo) and <xref:Orleans.Configuration.ClientConnectionOptions> (client). A silo has three distinct pipelines:
+
+```csharp
+siloBuilder.Configure<SiloConnectionOptions>(options =>
+{
+    // Connections this silo makes to other silos.
+    options.ConfigureSiloOutboundConnection(connectionBuilder =>
+    {
+        connectionBuilder.UseMiddleware<MyClientSideMiddleware>();
+    });
+
+    // Connections this silo accepts from other silos.
+    options.ConfigureSiloInboundConnection(connectionBuilder =>
+    {
+        connectionBuilder.UseMiddleware<MyServerSideMiddleware>();
+    });
+
+    // Connections this silo accepts from Orleans clients through the gateway.
+    options.ConfigureGatewayInboundConnection(connectionBuilder =>
+    {
+        connectionBuilder.UseMiddleware<MyServerSideMiddleware>();
+    });
+});
+```
+
+An Orleans client has a single outbound pipeline, configured with <xref:Orleans.Configuration.ClientConnectionOptions>:
+
+```csharp
+clientBuilder.Configure<ClientConnectionOptions>(options =>
+{
+    options.ConfigureConnection(connectionBuilder =>
+    {
+        connectionBuilder.UseMiddleware<MyClientSideMiddleware>();
+    });
+});
+```
+
+Middleware added first runs first, wrapping every middleware added after it, matching the order `UseMiddleware` is called. Register the middleware type itself (for example `MyClientSideMiddleware`, `MyServerSideMiddleware`) as a singleton service when using the generic `UseMiddleware<T>()` overload.
+
+> [!NOTE]
+> Silo-to-silo and client-to-silo connections perform an Orleans-internal handshake after the connection pipeline runs. Middleware that terminates or replaces the transport (such as TLS) must leave a working `ConnectionContext` in place before calling `next`, because Orleans handshake and message framing execute afterward.
+
+## Read and write framed data
+
+Custom middleware that exchanges its own protocol data before calling `next` (for example, a handshake) can read and write directly from `context.Transport.Input`/`Output` (`PipeReader`/`PipeWriter`), or use <xref:Orleans.Runtime.Messaging.ConnectionFrameHelper> for structured, length-prefixed frames. `ConnectionFrameHelper` is optional; it exists to save middleware authors from re-implementing length-prefixed framing.
+
+The wire format per frame is `[4-byte little-endian length][1-byte frame type][payload]`, where the length equals `1 + payload.Length`.
+
+```csharp
+public class MyServerSideMiddleware : IConnectionMiddleware
+{
+    public async Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next)
+    {
+        // Read one frame of the custom handshake protocol.
+        var (frameType, payload) = await ConnectionFrameHelper.ReadFrameAsync(
+            context, context.ConnectionClosed);
+
+        // Validate the frame, e.g. an auth token, then respond.
+        var responsePayload = Encoding.UTF8.GetBytes("ok");
+        await ConnectionFrameHelper.WriteFrameAsync(
+            context, frameType: 0x01, responsePayload, context.ConnectionClosed);
+
+        // Continue the pipeline; Orleans's own handshake and framing run after this.
+        await next(context);
+    }
+}
+```
+
+`ConnectionFrameHelper` also provides `WriteLengthPrefixedString`/`ReadLengthPrefixedString` helpers for encoding UTF-8 strings inside a frame payload, and a zero-copy `WriteFrameAsync` overload that writes the payload directly into the transport pipe buffer via an `Action<IBufferWriter<byte>>` delegate, avoiding an intermediate `byte[]` allocation.
+
+`ReadFrameAsync` throws `InvalidOperationException` if the connection is closed mid-frame or if the declared frame length exceeds `maxFrameLength` (`ConnectionFrameHelper.DefaultMaxFrameLength`, 1 MB, by default). Pass a smaller `maxFrameLength` if your protocol's frames are bounded more tightly, to fail fast on malformed or hostile input.
+
+## See also
+
+- <xref:Orleans.Runtime.Messaging.IConnectionMiddleware>
+- <xref:Orleans.Runtime.Messaging.ConnectionFrameHelper>
+- [Secure Orleans connections with TLS](transport-layer-security.md)
+- [Server configuration](configuration-guide/server-configuration.md)
+- [Client configuration](configuration-guide/client-configuration.md)

--- a/docs/site/src/content/docs/host/connection-middleware.md
+++ b/docs/site/src/content/docs/host/connection-middleware.md
@@ -1,76 +1,33 @@
 ---
 title: Connection middleware
 description: Plug custom logic, such as authentication or custom framing, into Orleans silo-to-silo and client-to-silo connections.
-ms.date: 08/10/2026
+ms.date: 08/11/2026
 ms.topic: how-to
 ---
 
 # Connection middleware
 
-Orleans connections (silo-to-silo, client-to-gateway, and gateway-inbound) are built from a chain of middleware, similar to an ASP.NET Core request pipeline. <xref:Orleans.Runtime.Messaging.IConnectionMiddleware> lets you insert custom logic, such as authentication, custom framing, or connection-level diagnostics, into that pipeline without reimplementing connection setup.
+Orleans silo-to-silo and client-to-gateway connections are built from a chain of middleware, similar to an ASP.NET Core request pipeline. <xref:Orleans.Runtime.Messaging.IConnectionMiddleware> lets you insert custom logic, such as authentication, custom framing, or connection-level diagnostics, into that pipeline without reimplementing connection setup.
 
 Orleans itself uses this abstraction for TLS. See [Secure Orleans connections with TLS](transport-layer-security.md) for the built-in TLS middleware.
 
 ## The middleware interface
 
-```csharp
-public interface IConnectionMiddleware
-{
-    Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next);
-}
-```
-
-A middleware instance can be invoked concurrently for multiple connections, so store per-connection state in local variables or on the <xref:Microsoft.AspNetCore.Connections.ConnectionContext>, not on the middleware instance. Implementations should call `next(context)` to continue the pipeline after performing their work; not calling `next` terminates the connection.
+The interface defines `OnConnectionAsync(ConnectionContext, ConnectionDelegate)`. A middleware instance can be invoked concurrently for multiple connections, so store per-connection state in local variables or on the <xref:Microsoft.AspNetCore.Connections.ConnectionContext>, not on the middleware instance. Implementations should call `next(context)` to continue the pipeline after performing their work; not calling `next` terminates the connection.
 
 ## Register middleware
 
-Use `UseMiddleware` on an <xref:Microsoft.AspNetCore.Connections.IConnectionBuilder> to add middleware to a connection pipeline:
+Use <xref:Orleans.ConnectionMiddlewareExtensions.UseMiddleware*> on an <xref:Microsoft.AspNetCore.Connections.IConnectionBuilder> to add middleware to a connection pipeline:
 
-```csharp
-// Resolves T from the application's dependency injection container.
-// T must be registered as a singleton and must be safe for concurrent use.
-builder.UseMiddleware<MyMiddleware>();
-
-// Adds a shared instance. The caller owns the instance and is responsible for disposing it.
-builder.UseMiddleware(new MyMiddleware(...));
-```
+:::code language="csharp" source="./snippets/connection-middleware/ConnectionMiddlewareExamples.cs" id="RegisterMiddleware":::
 
 Connection pipelines are configured through <xref:Orleans.Configuration.SiloConnectionOptions> (silo) and <xref:Orleans.Configuration.ClientConnectionOptions> (client). A silo has three distinct pipelines:
 
-```csharp
-siloBuilder.Configure<SiloConnectionOptions>(options =>
-{
-    // Connections this silo makes to other silos.
-    options.ConfigureSiloOutboundConnection(connectionBuilder =>
-    {
-        connectionBuilder.UseMiddleware<MyClientSideMiddleware>();
-    });
-
-    // Connections this silo accepts from other silos.
-    options.ConfigureSiloInboundConnection(connectionBuilder =>
-    {
-        connectionBuilder.UseMiddleware<MyServerSideMiddleware>();
-    });
-
-    // Connections this silo accepts from Orleans clients through the gateway.
-    options.ConfigureGatewayInboundConnection(connectionBuilder =>
-    {
-        connectionBuilder.UseMiddleware<MyServerSideMiddleware>();
-    });
-});
-```
+:::code language="csharp" source="./snippets/connection-middleware/ConnectionMiddlewareExamples.cs" id="SiloPipelines":::
 
 An Orleans client has a single outbound pipeline, configured with <xref:Orleans.Configuration.ClientConnectionOptions>:
 
-```csharp
-clientBuilder.Configure<ClientConnectionOptions>(options =>
-{
-    options.ConfigureConnection(connectionBuilder =>
-    {
-        connectionBuilder.UseMiddleware<MyClientSideMiddleware>();
-    });
-});
-```
+:::code language="csharp" source="./snippets/connection-middleware/ConnectionMiddlewareExamples.cs" id="ClientPipeline":::
 
 Middleware added first runs first, wrapping every middleware added after it, matching the order `UseMiddleware` is called. Register the middleware type itself (for example `MyClientSideMiddleware`, `MyServerSideMiddleware`) as a singleton service when using the generic `UseMiddleware<T>()` overload.
 
@@ -83,25 +40,7 @@ Custom middleware that exchanges its own protocol data before calling `next` (fo
 
 The wire format per frame is `[4-byte little-endian length][1-byte frame type][payload]`, where the length equals `1 + payload.Length`.
 
-```csharp
-public class MyServerSideMiddleware : IConnectionMiddleware
-{
-    public async Task OnConnectionAsync(ConnectionContext context, ConnectionDelegate next)
-    {
-        // Read one frame of the custom handshake protocol.
-        var (frameType, payload) = await ConnectionFrameHelper.ReadFrameAsync(
-            context, context.ConnectionClosed);
-
-        // Validate the frame, e.g. an auth token, then respond.
-        var responsePayload = Encoding.UTF8.GetBytes("ok");
-        await ConnectionFrameHelper.WriteFrameAsync(
-            context, frameType: 0x01, responsePayload, context.ConnectionClosed);
-
-        // Continue the pipeline; Orleans's own handshake and framing run after this.
-        await next(context);
-    }
-}
-```
+:::code language="csharp" source="./snippets/connection-middleware/ConnectionMiddlewareExamples.cs" id="ServerMiddleware":::
 
 `ConnectionFrameHelper` also provides `WriteLengthPrefixedString`/`ReadLengthPrefixedString` helpers for encoding UTF-8 strings inside a frame payload, and a zero-copy `WriteFrameAsync` overload that writes the payload directly into the transport pipe buffer via an `Action<IBufferWriter<byte>>` delegate, avoiding an intermediate `byte[]` allocation.
 

--- a/docs/site/src/content/docs/host/snippets/connection-middleware/ConnectionMiddleware.csproj
+++ b/docs/site/src/content/docs/host/snippets/connection-middleware/ConnectionMiddleware.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <RepositoryRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\..\..\..\..\..\'))</RepositoryRoot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepositoryRoot)src\Orleans.Client\Orleans.Client.csproj" />
+    <ProjectReference Include="$(RepositoryRoot)src\Orleans.Server\Orleans.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/site/src/content/docs/host/snippets/connection-middleware/ConnectionMiddlewareExamples.cs
+++ b/docs/site/src/content/docs/host/snippets/connection-middleware/ConnectionMiddlewareExamples.cs
@@ -1,0 +1,128 @@
+using System.Text;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Orleans.Configuration;
+using Orleans.Hosting;
+using Orleans.Runtime.Messaging;
+
+namespace ConnectionMiddlewareSnippets;
+
+internal static class ConnectionMiddlewareExamples
+{
+    // <RegisterMiddleware>
+    public static void RegisterFromDependencyInjection(
+        IServiceCollection services,
+        IConnectionBuilder connectionBuilder)
+    {
+        services.AddSingleton<MyClientSideMiddleware>();
+        connectionBuilder.UseMiddleware<MyClientSideMiddleware>();
+    }
+
+    public static void RegisterInstance(IConnectionBuilder connectionBuilder)
+    {
+        // The caller owns this shared instance and is responsible for disposing it.
+        connectionBuilder.UseMiddleware(new MyClientSideMiddleware());
+    }
+    // </RegisterMiddleware>
+
+    // <SiloPipelines>
+    public static void ConfigureSilo(ISiloBuilder siloBuilder)
+    {
+        siloBuilder.Services.AddSingleton<MyClientSideMiddleware>();
+        siloBuilder.Services.AddSingleton<MyServerSideMiddleware>();
+
+        siloBuilder.Configure<SiloConnectionOptions>(options =>
+        {
+            // Connections this silo makes to other silos.
+            options.ConfigureSiloOutboundConnection(connectionBuilder =>
+            {
+                connectionBuilder.UseMiddleware<MyClientSideMiddleware>();
+            });
+
+            // Connections this silo accepts from other silos.
+            options.ConfigureSiloInboundConnection(connectionBuilder =>
+            {
+                connectionBuilder.UseMiddleware<MyServerSideMiddleware>();
+            });
+
+            // Connections this silo accepts from Orleans clients through the gateway.
+            options.ConfigureGatewayInboundConnection(connectionBuilder =>
+            {
+                connectionBuilder.UseMiddleware<MyServerSideMiddleware>();
+            });
+        });
+    }
+    // </SiloPipelines>
+
+    // <ClientPipeline>
+    public static void ConfigureClient(IClientBuilder clientBuilder)
+    {
+        clientBuilder.Services.AddSingleton<MyClientSideMiddleware>();
+
+        clientBuilder.Configure<ClientConnectionOptions>(options =>
+        {
+            options.ConfigureConnection(connectionBuilder =>
+            {
+                connectionBuilder.UseMiddleware<MyClientSideMiddleware>();
+            });
+        });
+    }
+    // </ClientPipeline>
+}
+
+internal sealed class MyClientSideMiddleware : IConnectionMiddleware
+{
+    public async Task OnConnectionAsync(
+        ConnectionContext context,
+        ConnectionDelegate next)
+    {
+        var requestPayload = Encoding.UTF8.GetBytes("hello");
+        await ConnectionFrameHelper.WriteFrameAsync(
+            context, frameType: 0x01, requestPayload, context.ConnectionClosed);
+
+        var (frameType, payload) = await ConnectionFrameHelper.ReadFrameAsync(
+            context, context.ConnectionClosed);
+
+        if (frameType != 0x02
+            || !string.Equals(
+                Encoding.UTF8.GetString(payload),
+                "ok",
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Unexpected handshake response.");
+        }
+
+        await next(context);
+    }
+}
+
+// <ServerMiddleware>
+internal sealed class MyServerSideMiddleware : IConnectionMiddleware
+{
+    public async Task OnConnectionAsync(
+        ConnectionContext context,
+        ConnectionDelegate next)
+    {
+        // Read one frame of the custom handshake protocol.
+        var (frameType, payload) = await ConnectionFrameHelper.ReadFrameAsync(
+            context, context.ConnectionClosed);
+
+        if (frameType != 0x01
+            || !string.Equals(
+                Encoding.UTF8.GetString(payload),
+                "hello",
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Unexpected handshake request.");
+        }
+
+        var responsePayload = Encoding.UTF8.GetBytes("ok");
+        await ConnectionFrameHelper.WriteFrameAsync(
+            context, frameType: 0x02, responsePayload, context.ConnectionClosed);
+
+        // Continue the pipeline; Orleans's own handshake and framing run after this.
+        await next(context);
+    }
+}
+// </ServerMiddleware>

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -160,6 +160,8 @@ items:
             href: host/grain-directory.md
           - name: Transport Layer Security (TLS)
             href: host/transport-layer-security.md
+          - name: Connection middleware
+            href: host/connection-middleware.md
       - name: Configuration
         items:
           - name: Overview


### PR DESCRIPTION
Adds a documentation page covering the connection middleware abstractions introduced in #10136 (IConnectionMiddleware, registration via UseMiddleware/UseMiddleware<T> on silo and client connection pipelines, and ConnectionFrameHelper for custom framing).

The new page cross-links with the existing TLS documentation, since Orleans's own TLS middleware is built on this same abstraction. Code examples are plain fenced blocks rather than compile-checked snippets for now, since the feature isn't in a published NuGet package yet; they can be converted to compile-checked snippets once a package containing this feature ships.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10433)