### PR TITLE
fix(zookeeper): tolerate transient connection loss

### DIFF
--- a/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
+++ b/src/Orleans.Clustering.ZooKeeper/ZooKeeperBasedMembershipTable.cs
@@ -38,7 +38,7 @@ namespace Orleans.Runtime.Membership
     {
         private readonly ILogger logger;
 
-        private const int ZOOKEEPER_CONNECTION_TIMEOUT = 2000;
+        private const int ZOOKEEPER_SESSION_TIMEOUT = 10_000;
 
         private readonly ZooKeeperWatcher watcher;
 
@@ -297,12 +297,12 @@ namespace Orleans.Runtime.Membership
 
         private static Task<T> UsingZookeeper<T>(Func<ZooKeeper, Task<T>> zkMethod, string deploymentConnectionString, ZooKeeperWatcher watcher, bool canBeReadOnly = false)
         {
-            return ZooKeeper.Using(deploymentConnectionString, ZOOKEEPER_CONNECTION_TIMEOUT, watcher, zkMethod, canBeReadOnly);
+            return ZooKeeper.Using(deploymentConnectionString, ZOOKEEPER_SESSION_TIMEOUT, watcher, zkMethod, canBeReadOnly);
         }
 
         private Task UsingZookeeper(string connectString, Func<ZooKeeper, Task> zkMethod)
         {
-            return ZooKeeper.Using(connectString, ZOOKEEPER_CONNECTION_TIMEOUT, watcher, zkMethod);
+            return ZooKeeper.Using(connectString, ZOOKEEPER_SESSION_TIMEOUT, watcher, zkMethod);
         }
 
         private static string ConvertToRowPath(SiloAddress siloAddress)


### PR DESCRIPTION
The ZooKeeper provider configured a 2-second session timeout, which also bounded `ZooKeeper.Using` retries after a transient `ConnectionLossException`. The membership update test performs enough operations to intermittently exhaust that short window in CI.

Increase the session timeout to 10 seconds and name it according to the ZooKeeper client API semantics. This gives membership reads and writes time to reconnect without changing transaction behavior.

Fixes #10435
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10437)