### PR TITLE
fix(testing): prevent fatal errors from terminating test hosts

### DIFF
--- a/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
+++ b/src/Orleans.Runtime/MembershipService/MembershipTableManager.cs
@@ -627,7 +627,10 @@ namespace Orleans.Runtime.MembershipService
         {
             LogErrorKillMyselfLocally(this.log, reason);
             this.CurrentStatus = SiloStatus.Dead;
-            this.fatalErrorHandler.OnFatalException(this, $"I have been told I am dead, so this silo will stop! Reason: {reason}", null);
+            if (!this.IsStopping)
+            {
+                this.fatalErrorHandler.OnFatalException(this, $"I have been told I am dead, so this silo will stop! Reason: {reason}", null);
+            }
         }
 
         private async Task GossipToOthers(SiloAddress updatedSilo, SiloStatus updatedStatus)

--- a/src/Orleans.TestingHost/InProcTestCluster.cs
+++ b/src/Orleans.TestingHost/InProcTestCluster.cs
@@ -781,6 +781,7 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
 
                 siloBuilder.Services
                     .Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(30));
+                TestClusterFatalErrorHandler.Configure(siloBuilder.Services);
 
                 if (Options.UseTestClusterMembership)
                 {
@@ -811,6 +812,7 @@ public sealed class InProcessTestCluster : IDisposable, IAsyncDisposable
             });
 
             var host = appBuilder.Build();
+            TestClusterFatalErrorHandler.Attach(host);
             InitializeTestHooksSystemTarget(host);
             await host.StartAsync();
             return host;

--- a/src/Orleans.TestingHost/StandaloneSiloHost.cs
+++ b/src/Orleans.TestingHost/StandaloneSiloHost.cs
@@ -4,6 +4,8 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Orleans.Runtime;
 
 namespace Orleans.TestingHost
@@ -38,6 +40,9 @@ namespace Orleans.TestingHost
             try
             {
                 var cts = new CancellationTokenSource();
+                using var stoppedRegistration = host.Services
+                    .GetRequiredService<IHostApplicationLifetime>()
+                    .ApplicationStopped.Register(cts.Cancel);
                 Console.CancelKeyPress += (sender, eventArgs) => cts.Cancel();
 
                 ListenForShutdownCommand(cts);

--- a/src/Orleans.TestingHost/TestClusterFatalErrorHandler.cs
+++ b/src/Orleans.TestingHost/TestClusterFatalErrorHandler.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+
+namespace Orleans.TestingHost;
+
+internal sealed class TestClusterFatalErrorHandler(
+    ILogger<TestClusterFatalErrorHandler> logger,
+    TestClusterHostTerminator hostTerminator) : IFatalErrorHandler
+{
+    public bool IsUnexpected(Exception exception) => exception is not ThreadAbortException;
+
+    public void OnFatalException(object? sender = null, string? context = null, Exception? exception = null)
+    {
+        logger.LogError(
+            exception,
+            "Fatal error from {Sender}. Context: {Context}. The affected test silo will stop without terminating the test host.",
+            sender,
+            context);
+        hostTerminator.Stop();
+    }
+
+    public static void Configure(IServiceCollection services)
+    {
+        services.AddSingleton<TestClusterHostTerminator>();
+        services.Replace(ServiceDescriptor.Singleton<IFatalErrorHandler, TestClusterFatalErrorHandler>());
+    }
+
+    public static void Attach(IHost host) =>
+        host.Services.GetRequiredService<TestClusterHostTerminator>().Attach(host);
+}
+
+internal sealed class TestClusterHostTerminator(ILogger<TestClusterHostTerminator> logger)
+{
+    private IHost? _host;
+    private int _stopping;
+
+    public void Attach(IHost host) => _host = host;
+
+    public void Stop()
+    {
+        var host = _host ?? throw new InvalidOperationException("The test silo host has not been attached.");
+        if (Interlocked.Exchange(ref _stopping, 1) != 0)
+        {
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await host.StopAsync();
+            }
+            catch (Exception exception)
+            {
+                logger.LogError(exception, "Failed to stop a test silo after a fatal error.");
+            }
+        });
+    }
+}

--- a/src/Orleans.TestingHost/TestClusterHostFactory.cs
+++ b/src/Orleans.TestingHost/TestClusterHostFactory.cs
@@ -45,6 +45,7 @@ namespace Orleans.TestingHost
             {
                 siloBuilder.Services
                     .Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(30));
+                TestClusterFatalErrorHandler.Configure(siloBuilder.Services);
             });
 
             ConfigureAppServices(configuration, hostBuilder);
@@ -66,6 +67,7 @@ namespace Orleans.TestingHost
 
             postConfigureHostBuilder?.Invoke(hostBuilder);
             var host = hostBuilder.Build();
+            TestClusterFatalErrorHandler.Attach(host);
             InitializeTestHooksSystemTarget(host);
             return host;
         }

--- a/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
+++ b/test/Orleans.Core.Tests/Membership/MembershipTableManagerTests.cs
@@ -434,6 +434,30 @@ namespace NonSilo.Tests.Membership
         }
 
         [Fact]
+        public async Task MembershipTableManager_DeclaredDead_DuringShutdown_DoesNotTerminate()
+        {
+            var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));
+            var manager = this.CreateMembershipTableManager(membershipTable);
+            ((ILifecycleParticipant<ISiloLifecycle>)manager).Participate(this.lifecycle);
+            await this.lifecycle.OnStart();
+            await manager.UpdateStatus(SiloStatus.Joining);
+            await this.lifecycle.OnStop();
+
+            while (true)
+            {
+                var table = await membershipTable.ReadAll();
+                var row = table.Members.Single(e => e.Item1.SiloAddress.Equals(this.localSilo));
+                if (await membershipTable.UpdateRow(row.Item1.WithStatus(SiloStatus.Dead), row.Item2, table.Version.Next()))
+                {
+                    break;
+                }
+            }
+
+            await manager.Refresh();
+            this.fatalErrorHandler.DidNotReceiveWithAnyArgs().OnFatalException(default, default, default);
+        }
+
+        [Fact]
         public async Task MembershipTableManager_ExplicitDeadSnapshot_Terminates()
         {
             var membershipTable = new InMemoryMembershipTable(new TableVersion(123, "123"));

--- a/test/Orleans.DefaultCluster.Tests/AsyncEnumerableGrainCallTests.cs
+++ b/test/Orleans.DefaultCluster.Tests/AsyncEnumerableGrainCallTests.cs
@@ -688,7 +688,7 @@ public class AsyncEnumerableGrainCallTests
         var cleanupCount = listener.CleanupCount + 1;
         var timer = listener.Timer;
         var timerChangeCount = _fixture.GetTimerChangeCount(timer);
-        _fixture.AdvanceTimeByResponseTimeout();
+        await _fixture.AdvanceTimeByResponseTimeoutAsync();
         await listener.WaitForCleanupCountAsync(cleanupCount, cancellationToken);
 
         // Cleanup is reported from inside the callback, before the one-shot timer is rearmed.
@@ -717,8 +717,8 @@ public class AsyncEnumerableGrainCallTests
             });
         }
 
-        public void AdvanceTimeByResponseTimeout() =>
-            FakeTimeSilo.Advance(_timeProvider, HostedCluster.GetSiloServiceProvider().GetRequiredService<IOptions<SiloMessagingOptions>>().Value.ResponseTimeout);
+        public Task AdvanceTimeByResponseTimeoutAsync() =>
+            FakeTimeSilo.AdvanceAsync(_timeProvider, HostedCluster.GetSiloServiceProvider().GetRequiredService<IOptions<SiloMessagingOptions>>().Value.ResponseTimeout);
 
         public int GetTimerChangeCount(object timer) => _timeProvider.GetTimerChangeCount(timer);
 

--- a/test/Orleans.DefaultCluster.Tests/FakeTimeSilo.cs
+++ b/test/Orleans.DefaultCluster.Tests/FakeTimeSilo.cs
@@ -55,43 +55,23 @@ internal static class FakeTimeSilo
     }
 
     /// <summary>
-    /// Advances the fake clock, guarded by a watchdog which fails fast if the call does not return
-    /// promptly. Advancing the fake clock should complete near-instantaneously; if infrastructure timers
-    /// are ever driven by the fake clock again (see <see cref="UseFakeTimeProviderForGrainTimers"/>),
-    /// they spin the CPU inline and never return. The watchdog converts that regression into an
-    /// immediate, diagnosable failure instead of a multi-minute CI hang.
+    /// Advances the fake clock, failing the test if the call does not return promptly.
     /// </summary>
-    public static void Advance(FakeTimeProvider timeProvider, TimeSpan duration)
+    public static async Task AdvanceAsync(FakeTimeProvider timeProvider, TimeSpan duration)
     {
-        using var watchdog = new AdvanceWatchdog(duration);
-        timeProvider.Advance(duration);
-    }
-
-    private sealed class AdvanceWatchdog : IDisposable
-    {
-        // Advancing the fake clock is a synchronous, in-memory operation and completes in well under a
-        // second in practice. This limit is generous while remaining far below CI's 10-minute blame-hang
-        // timeout, so a genuine spin surfaces quickly.
-        private static readonly TimeSpan Limit = TimeSpan.FromSeconds(60);
-
-        private readonly TimeSpan _duration;
-
-        // Uses the real system timer queue (not the fake provider), so it still fires while the calling
-        // thread is spinning inside Advance.
-        private readonly Timer _timer;
-
-        public AdvanceWatchdog(TimeSpan duration)
+        var advanceTask = Task.Run(() => timeProvider.Advance(duration));
+        try
         {
-            _duration = duration;
-            _timer = new Timer(static state => ((AdvanceWatchdog)state!).OnElapsed(), this, Limit, Timeout.InfiniteTimeSpan);
+            await advanceTask.WaitAsync(TimeSpan.FromSeconds(60));
         }
-
-        private void OnElapsed() => Environment.FailFast(
-            $"FakeTimeProvider.Advance({_duration}) did not return within {Limit}. This indicates that silo " +
-            "infrastructure timers are being driven by the test's fake clock and are spinning inline during " +
-            "Advance. Ensure infrastructure timers use TimeProvider.System (see FakeTimeSilo.UseFakeTimeProviderForGrainTimers).");
-
-        public void Dispose() => _timer.Dispose();
+        catch (TimeoutException exception)
+        {
+            throw new TimeoutException(
+                $"FakeTimeProvider.Advance({duration}) did not return within 00:01:00. This indicates that silo " +
+                "infrastructure timers are being driven by the test's fake clock and are spinning inline during " +
+                "Advance. Ensure infrastructure timers use TimeProvider.System (see FakeTimeSilo.UseFakeTimeProviderForGrainTimers).",
+                exception);
+        }
     }
 }
 

--- a/test/Orleans.DefaultCluster.Tests/TimerOrleansTest.cs
+++ b/test/Orleans.DefaultCluster.Tests/TimerOrleansTest.cs
@@ -67,7 +67,7 @@ namespace DefaultCluster.Tests.TimerTests
             for (var expectedTickCount = 1; expectedTickCount <= ExpectedDefaultTimerTicks; expectedTickCount++)
             {
                 var waitForTicks = Task.WhenAll(grains.Select(g => timerObserver.WaitForTickCountAsync(g, expectedTickCount, TimerDiagnosticTimeout)));
-                fixture.AdvanceTime(period);
+                await fixture.AdvanceTimeAsync(period);
                 await waitForTicks;
                 await Task.WhenAll(grains.Select(g => g.GetCounter()));
             }
@@ -76,7 +76,7 @@ namespace DefaultCluster.Tests.TimerTests
         private async Task AdvanceTimerToTickCountAsync(IAddressable grain, TimerDiagnosticObserver timerObserver, TimeSpan dueTime, int expectedTickCount)
         {
             var waitForTick = timerObserver.WaitForTickCountAsync(grain, expectedTickCount, TimerDiagnosticTimeout);
-            fixture.AdvanceTime(dueTime);
+            await fixture.AdvanceTimeAsync(dueTime);
             await waitForTick;
         }
 
@@ -91,14 +91,14 @@ namespace DefaultCluster.Tests.TimerTests
             var grainId = grain.GetGrainId();
             var delayScheduledCount = callbackObserver.GetDelayScheduledCount(grainId);
 
-            fixture.AdvanceTime(dueTime);
+            await fixture.AdvanceTimeAsync(dueTime);
             for (var tickCount = timerObserver.GetTickCount(grain.GetGrainId()) + 1; tickCount <= expectedTickCount; tickCount++)
             {
                 await timerObserver.WaitForTickStartCountAsync(grain, tickCount, TimerDiagnosticTimeout);
                 await callbackObserver.WaitForDelayScheduledCountAsync(grainId, ++delayScheduledCount, TimerDiagnosticTimeout);
 
                 var waitForTickStop = timerObserver.WaitForTickCountAsync(grain, tickCount, TimerDiagnosticTimeout);
-                fixture.AdvanceTime(callbackDelay);
+                await fixture.AdvanceTimeAsync(callbackDelay);
                 await waitForTickStop;
             }
         }
@@ -109,7 +109,7 @@ namespace DefaultCluster.Tests.TimerTests
             var grainId = grain.GetGrainId();
             var externalTick = grain.ExternalTick("external");
             await callbackObserver.WaitForDelayScheduledCountAsync(grainId, callbackObserver.GetDelayScheduledCount(grainId) + 1, TimerDiagnosticTimeout);
-            fixture.AdvanceTime(TimerCallbackDelay);
+            await fixture.AdvanceTimeAsync(TimerCallbackDelay);
             await externalTick;
             await AdvanceTimerToTickCountAsync(grain, timerObserver, dueTime, TimerCallbackDelay, expectedTimerTicks);
             return 1;
@@ -238,7 +238,7 @@ namespace DefaultCluster.Tests.TimerTests
                 });
             }
 
-            public void AdvanceTime(TimeSpan duration) => FakeTimeSilo.Advance(timeProvider, duration);
+            public Task AdvanceTimeAsync(TimeSpan duration) => FakeTimeSilo.AdvanceAsync(timeProvider, duration);
 
             public Task WaitForTimerChangeAsync(object timer, int changeCount, CancellationToken cancellationToken) =>
                 timeProvider.WaitForTimerChangeAsync(timer, changeCount, cancellationToken);
@@ -263,7 +263,7 @@ namespace DefaultCluster.Tests.TimerTests
                 Assert.Equal(ExpectedDefaultTimerTicks, last);
 
                 await grain.StopDefaultTimer();
-                fixture.AdvanceTime(period.Multiply(2));
+                await fixture.AdvanceTimeAsync(period.Multiply(2));
                 var curr = await grain.GetCounter();
                 Assert.Equal(last, curr);
             }
@@ -396,7 +396,7 @@ namespace DefaultCluster.Tests.TimerTests
             using var timerObserver = TimerDiagnosticObserver.Create();
             var numTimers = await grain.TestAllTimerOverloads();
             var waitForTimers = timerObserver.WaitForTickCountAsync(grain, numTimers, TimerDiagnosticTimeout);
-            fixture.AdvanceTime(TimerOverloadDueTime);
+            await fixture.AdvanceTimeAsync(TimerOverloadDueTime);
             await waitForTimers;
             await grain.TestCompletedTimerResults();
         }
@@ -526,7 +526,7 @@ namespace DefaultCluster.Tests.TimerTests
                 Assert.Equal(ExpectedDefaultTimerTicks, last);
 
                 await grain.StopDefaultTimer();
-                fixture.AdvanceTime(period.Multiply(2));
+                await fixture.AdvanceTimeAsync(period.Multiply(2));
                 var curr = await grain.GetCounter();
                 Assert.Equal(last, curr);
             }
@@ -659,7 +659,7 @@ namespace DefaultCluster.Tests.TimerTests
             using var timerObserver = TimerDiagnosticObserver.Create();
             var numTimers = await grain.TestAllTimerOverloads();
             var waitForTimers = timerObserver.WaitForTickCountAsync(grain, numTimers, TimerDiagnosticTimeout);
-            fixture.AdvanceTime(TimerOverloadDueTime);
+            await fixture.AdvanceTimeAsync(TimerOverloadDueTime);
             await waitForTimers;
             await grain.TestCompletedTimerResults();
         }

--- a/test/Orleans.Runtime.Tests/MembershipTests/LivenessTests.cs
+++ b/test/Orleans.Runtime.Tests/MembershipTests/LivenessTests.cs
@@ -31,6 +31,7 @@ namespace UnitTests.MembershipTests
             output.WriteLine("ClusterId= {0}", this.HostedCluster.Options.ClusterId);
 
             SiloHandle silo3 = await this.HostedCluster.StartAdditionalSiloAsync();
+            await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
             IManagementGrain mgmtGrain = this.GrainFactory.GetGrain<IManagementGrain>(0);
 
@@ -45,8 +46,7 @@ namespace UnitTests.MembershipTests
             IPEndPoint address = silo3.SiloAddress.Endpoint;
             output.WriteLine("About to stop {0}", address);
             await this.HostedCluster.StopSiloAsync(silo3);
-
-            // TODO: Should we be allowing time for changes to percolate?
+            await this.HostedCluster.WaitForLivenessToStabilizeAsync();
 
             output.WriteLine("----------------");
 

--- a/test/TestInfrastructure/Orleans.TestingHost.Tests/TestClusterTests.cs
+++ b/test/TestInfrastructure/Orleans.TestingHost.Tests/TestClusterTests.cs
@@ -1,6 +1,8 @@
 using AwesomeAssertions;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Orleans.Runtime;
 using Orleans.TestingHost.Tests.Grains;
 using TestExtensions;
 using Xunit;
@@ -34,6 +36,27 @@ namespace Orleans.TestingHost.Tests
             await using var testCluster = builder.Build();
 
             await testCluster.DeployAsync();
+            var primary = Assert.IsType<InProcessSiloHandle>(testCluster.Primary);
+            Assert.Equal("TestClusterFatalErrorHandler", primary.ServiceProvider.GetRequiredService<IFatalErrorHandler>().GetType().Name);
+        }
+
+        [Fact, TestCategory("Functional")]
+        public async Task FatalErrorStopsSiloWithoutTerminatingTestHost()
+        {
+            var builder = new TestClusterBuilder(1);
+            builder.Options.ServiceId = Guid.NewGuid().ToString();
+            builder.ConfigureHostConfiguration(TestDefaultConfiguration.ConfigureHostConfiguration);
+            await using var testCluster = builder.Build();
+            await testCluster.DeployAsync();
+
+            var primary = Assert.IsType<InProcessSiloHandle>(testCluster.Primary);
+            var applicationLifetime = primary.ServiceProvider.GetRequiredService<IHostApplicationLifetime>();
+            var stopped = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var registration = applicationLifetime.ApplicationStopped.Register(stopped.SetResult);
+
+            primary.ServiceProvider.GetRequiredService<IFatalErrorHandler>().OnFatalException(context: "Test");
+
+            await stopped.Task.WaitAsync(TimeSpan.FromSeconds(30));
         }
     }
 


### PR DESCRIPTION
Fixes #10409.

A graceful silo shutdown can publish the local membership row as `Dead` before `MembershipTableManager.CurrentStatus` is updated. A concurrent refresh then treats the expected shutdown transition as remote eviction and invokes the production fatal handler, terminating the entire shared test process.

This change suppresses fatal handling when the silo lifecycle is already stopping, adds explicit membership convergence barriers to the liveness test, and replaces the production fatal handler in `Orleans.TestingHost` so unexpected fatal errors stop only the affected silo. It also removes the remaining test-only `Environment.FailFast` watchdog in fake-time tests in favor of an ordinary asynchronous timeout.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10438)