### PR TITLE
fix(ci): wait for SQL Server query readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,12 +330,14 @@ jobs:
           -p 1433:1433 \
           -e ACCEPT_EULA="$ACCEPT_EULA" \
           -e MSSQL_PID="$MSSQL_PID" \
-          -e SA_PASSWORD="$SA_PASSWORD" \
+          -e MSSQL_SA_PASSWORD="$SA_PASSWORD" \
+          --health-cmd '/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -Q "SELECT 1" -b -o /dev/null' \
+          --health-interval 2s \
+          --health-timeout 5s \
+          --health-retries 60 \
           "$MSSQL_IMAGE"
 
-        echo "Waiting for SQL Server to accept TCP connections..."
-        timeout 120 bash -c 'until nc -z localhost 1433; do sleep 2; done'
-        echo "SQL Server is accepting TCP connections"
+        bash .github/scripts/docker-wait-for-health.sh mssql 120
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:


### PR DESCRIPTION
SQL Server provider jobs currently treat the container as ready when Docker's published TCP port accepts a socket. The port opens well before the database engine can authenticate and execute queries, allowing provider tests to race SQL Server startup.

Replace the TCP probe with an authenticated `sqlcmd` health check and wait through the existing Docker health helper. This preserves the existing 120-second startup budget while requiring the service behavior the tests actually depend on. The container also uses the current `MSSQL_SA_PASSWORD` setting.

Fixes #10428
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10441)