### PR TITLE
test(reminders): stabilize Azure Table reminder tests

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -110,29 +110,26 @@ namespace Tester.AzureUtils.TimerTests
             Assert.Equal(last, curr);
         }
 
-        [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/9557"), TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task Rem_Azure_Basic_Restart()
         {
             IReminderTestGrain2 grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             TimeSpan period = await grain.GetReminderPeriod(DR);
-            await grain.StartReminder(DR);
-            await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 2);
-            long last = await grain.GetCounter(DR);
-            Assert.Equal(2, last);
+            using var cts = new CancellationTokenSource(ENDWAIT);
 
-            await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder);
-            TimeSpan sleepFor = period.Multiply(1) + LEEWAY;
-            await AdvanceReminderTimeAsync(sleepFor);
-            long curr = await grain.GetCounter(DR);
-            Assert.Equal(last, curr);
-            AssertIsInRange(curr, last, last + 1, grain, DR, sleepFor);
+            await grain.StartReminder(DR);
+            await AdvanceRemindersByTicksAsync(2, cts.Token, (grain, DR));
+            await AssertReminderCountersAsync([grain], (DR, 2));
+
+            await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder, cts.Token);
+            await AdvanceReminderTimeAsync(period, cts.Token);
+            await AssertReminderCountersAsync([grain], (DR, 2));
 
             // start the same reminder again
             await grain.StartReminder(DR);
-            sleepFor = period.Multiply(2) + LEEWAY;
-            curr = await WaitForAdditionalReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 1);
-            AssertIsInRange(curr, 2, 3, grain, DR, sleepFor);
-            await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder); // cleanup
+            await AdvanceRemindersByTicksAsync(2, cts.Token, (grain, DR));
+            await AssertReminderCountersAsync([grain], (DR, 2));
+            await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder, cts.Token);
         }
 
         [SkippableFact, TestCategory("Functional")]
@@ -286,29 +283,26 @@ namespace Tester.AzureUtils.TimerTests
             // TODO: write tests where period of a reminder is changed
         }
 
-        [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/9557"), TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task Rem_Azure_GT_Basic()
         {
             IReminderTestGrain2 g1 = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
             IReminderTestCopyGrain g2 = this.GrainFactory.GetGrain<IReminderTestCopyGrain>(Guid.NewGuid());
+            using var cts = new CancellationTokenSource(ENDWAIT);
 
             await g1.StartReminder(DR);
-            await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), 2);
-            await g2.StartReminder(DR);
-            await WaitForReminderCounterAsync(g1, DR, () => g1.GetCounter(DR), 4);
-            await WaitForReminderCounterAsync(g2, DR, () => g2.GetCounter(DR), 2);
-            long last1 = await g1.GetCounter(DR);
-            Assert.Equal(4, last1);
-            long last2 = await g2.GetCounter(DR);
-            Assert.Equal(2, last2); // CopyGrain fault
+            await AdvanceRemindersByTicksAsync(2, cts.Token, (g1, DR));
+            await AssertReminderCountersAsync([g1], (DR, 2));
 
-            await StopReminderAndWaitForQuiescenceAsync(g1, DR, g1.StopReminder);
-            await WaitForReminderCounterAsync(g2, DR, () => g2.GetCounter(DR), 4);
-            await StopReminderAndWaitForQuiescenceAsync(g2, DR, g2.StopReminder);
-            long curr1 = await g1.GetCounter(DR);
-            Assert.Equal(last1, curr1);
-            long curr2 = await g2.GetCounter(DR);
-            Assert.Equal(4, curr2); // CopyGrain fault
+            await g2.StartReminder(DR);
+            await AdvanceRemindersByTicksAsync(2, cts.Token, (g1, DR), (g2, DR));
+            await AssertReminderCountersAsync([g1], (DR, 4));
+            await AssertReminderCountersAsync([g2], (DR, 2));
+
+            await StopReminderAndWaitForQuiescenceAsync(g1, DR, g1.StopReminder, cts.Token);
+            await AdvanceRemindersByTicksAsync(2, cts.Token, (g2, DR));
+            await AssertReminderCountersAsync([g1, g2], (DR, 4));
+            await StopReminderAndWaitForQuiescenceAsync(g2, DR, g2.StopReminder, cts.Token);
         }
 
         [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/4319"), TestCategory("Functional")]

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Microsoft.Extensions.Logging;
 using Orleans.Internal;
 using Orleans.Runtime;
+using Orleans.Runtime.Messaging;
 using Orleans.Testing.Reminders;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
@@ -334,6 +335,9 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
     protected async Task PrepareForGrainFailureAsync(CancellationToken cancellationToken, params IAddressable[] grains)
     {
         ArgumentNullException.ThrowIfNull(grains);
+        Assert.NotEmpty(grains);
+
+        await WaitForGrainsReachableAsync(cancellationToken, grains);
 
         foreach (var grain in grains)
         {
@@ -351,12 +355,59 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
         ArgumentNullException.ThrowIfNull(grains);
         Assert.NotEmpty(grains);
 
+        await WaitForGrainsReachableAsync(cancellationToken, grains);
         await AdvanceRemindersByTicksAsync((int)(failCheckAfter - failAfter), cancellationToken, GetReminderIdentities(grains, DR));
         await AssertReminderCountersAsync(grains, (DR, failCheckAfter));
 
         await StopRemindersAsync(grains, DR, cancellationToken);
         await AdvanceReminderTimeAsync(await GetReminderPeriodAsync(grains[0], DR), cancellationToken);
         await AssertReminderCountersAsync(grains, (DR, failCheckAfter));
+    }
+
+    private async Task WaitForGrainsReachableAsync(CancellationToken cancellationToken, params IAddressable[] grains)
+    {
+        Exception? lastException = null;
+        try
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    await Task.WhenAll(grains.Select(grain => GetReminderPeriodAsync(grain, DR))).WaitAsync(cancellationToken);
+                    return;
+                }
+                catch (Exception exception) when (IsTransientLifecycleException(exception))
+                {
+                    lastException = exception;
+                    log.LogInformation(
+                        exception,
+                        "Waiting for reminder grains to become reachable after topology change: {Grains}",
+                        string.Join(", ", grains.Select(grain => grain.GetGrainId())));
+                }
+
+                try
+                {
+                    await WaitForLivenessToStabilizeAsync().WaitAsync(cancellationToken);
+                }
+                catch (Exception exception) when (IsTransientLifecycleException(exception))
+                {
+                    lastException = exception;
+                }
+            }
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new InvalidOperationException(
+                $"Timed out waiting for reminder grains to become reachable after a topology change: {string.Join(", ", grains.Select(grain => grain.GetGrainId()))}.",
+                lastException ?? exception);
+        }
+    }
+
+    private static bool IsTransientLifecycleException(Exception exception)
+    {
+        return exception is SiloUnavailableException or OrleansMessageRejectionException or ConnectionFailedException
+            || exception.InnerException is not null && IsTransientLifecycleException(exception.InnerException);
     }
 
     protected async Task AdvanceRemindersByTicksAsync(


### PR DESCRIPTION
## Problem
Azure Table reminder tests still had three independent race conditions after the broader reminder-clock work: the restart test waited for one post-reset tick while asserting two, the cross-grain test let independent waits advance one shared fake clock, and failover tests resumed after best-effort liveness stabilization without proving that the shared client could route grain calls through the replacement gateways.

## Existing repairs reviewed
Recent merged work addressed adjacent reminder races: #9989, #9997, #10033, #10159, #10296, #10312, #10317, #10400, #10421, and #10430. Current `main` still skips both #9557 methods and retains the mismatched restart wait and independent cross-grain clock drivers. The latest stale-gateway failure occurred on a head containing #10400; #10430 merged afterward but only changes exact-due reminder recovery and does not affect the failing client `GetCounter` route.

## Solution
Use the single reminder-clock orchestrator and exact counter assertions for the restart and cross-grain scenarios, then re-enable both quarantined tests. Add an explicit grain-reachability phase before and after failover: only expected lifecycle transport failures are retried, each retry re-runs liveness stabilization, and the existing test cancellation deadline remains authoritative.

This preserves the failover coverage without sleeps, test skips, or increased timeouts, and makes failures report the affected grain set and last transport error.

Fixes #9557