### PR TITLE
test(transactions): re-enable GoldenPath coverage

### DIFF
--- a/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/GoldenPathTransactionTestRunner.cs
@@ -9,7 +9,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         protected GoldenPathTransactionTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
         : base(grainFactory, output.WriteLine) { }
 
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain)]
@@ -18,7 +18,7 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.SingleGrainReadTransaction(grainStates);
         }
 
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain)]
@@ -27,7 +27,7 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.SingleGrainWriteTransaction(grainStates);
         }
 
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions / 2)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain, 1)]
@@ -36,7 +36,7 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.MultiGrainWriteTransaction(grainStates, grainCount);
         }
 
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions / 2)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain, 1)]
@@ -45,7 +45,7 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.MultiGrainReadWriteTransaction(grainStates, grainCount);
         }
 
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions / 2)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain, 1)]
@@ -54,7 +54,7 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.RepeatGrainReadWriteTransaction(grainStates, grainCount);
         }
 
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain)]
@@ -63,7 +63,7 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.MultiWriteToSingleGrainTransaction(grainStates);
         }
 
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions / 2)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain, 1)]
@@ -72,7 +72,7 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.RWRWTest(grainStates, grainCount);
         }
 
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions / 2)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain, 1)]

--- a/src/api/Orleans.Transactions.TestKit.xUnit/Orleans.Transactions.TestKit.xUnit.cs
+++ b/src/api/Orleans.Transactions.TestKit.xUnit/Orleans.Transactions.TestKit.xUnit.cs
@@ -155,49 +155,49 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         protected GoldenPathTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.Abstractions.ITestOutputHelper output) : base(default!, default!) { }
 
-        [SkippableTheory(new[] { }, Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory(new[] { })]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task MultiGrainReadWriteTransaction(string grainStates, int grainCount) { throw null; }
 
-        [SkippableTheory(new[] { }, Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory(new[] { })]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task MultiGrainWriteTransaction(string grainStates, int grainCount) { throw null; }
 
-        [SkippableTheory(new[] { }, Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory(new[] { })]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task MultiWriteToSingleGrainTransaction(string grainStates) { throw null; }
 
-        [SkippableTheory(new[] { }, Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory(new[] { })]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task RepeatGrainReadWriteTransaction(string grainStates, int grainCount) { throw null; }
 
-        [SkippableTheory(new[] { }, Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory(new[] { })]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]
         public override System.Threading.Tasks.Task RWRWTest(string grainStates, int grainCount) { throw null; }
 
-        [SkippableTheory(new[] { }, Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory(new[] { })]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task SingleGrainReadTransaction(string grainStates) { throw null; }
 
-        [SkippableTheory(new[] { }, Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory(new[] { })]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain" })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain" })]
         public override System.Threading.Tasks.Task SingleGrainWriteTransaction(string grainStates) { throw null; }
 
-        [SkippableTheory(new[] { }, Skip = "https://github.com/dotnet/orleans/issues/9553")]
+        [SkippableTheory(new[] { })]
         [Xunit.InlineData(new[] { "SingleStateTransactionalGrain", 8 })]
         [Xunit.InlineData(new[] { "DoubleStateTransactionalGrain", 4 })]
         [Xunit.InlineData(new[] { "MaxStateTransactionalGrain", 1 })]


### PR DESCRIPTION
Fixes #9553

The GoldenPath transaction matrix was quarantined on the shared xUnit runner, disabling the affected Azure Storage tests as well as the in-memory, skewed-clock, and subsequently added DynamoDB coverage. Issue history and repository searches found no open repair; only the original quarantine referenced the issue.

Since that quarantine, the transaction recovery and Azure Table storage paths received durable conflict, failed-write isolation, snapshot-fencing, and recovery-ordering fixes in #10374, #10375, #10376, and #10382. Remove the issue-level `Skip` values from all eight GoldenPath theories and update the generated API surface while retaining `SkippableTheory` for legitimate missing-provider preconditions.

The restored Azure matrix completed 10 consecutive Azurite runs (240 cases) on .NET 10 and all 24 cases on .NET 8; the shared in-memory matrix also passes on both target frameworks.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10443)