### PR TITLE
test(streaming): re-enable lease balancer crash recovery

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/Lease/LeaseBasedQueueBalancerTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Lease/LeaseBasedQueueBalancerTests.cs
@@ -74,7 +74,7 @@ namespace Tester.AzureUtils.Lease
             await WaitUntilAgentManagersOwnCorrectAmountOfAgents(2, 2, mgmtGrain);
         }
 
-        [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/9559")]
+        [SkippableFact]
         public async Task LeaseBalancedQueueBalancer_SupportUnexpectedNodeFailureScenerio()
         {
             var mgmtGrain = this.GrainFactory.GetGrain<IManagementGrain>(0);


### PR DESCRIPTION
## Problem

The Azure Blob lease balancer's unexpected-node failure scenario remained quarantined after its timing-sensitive polling was replaced. That left abrupt silo-loss recovery without CI coverage.

## Solution

PR #10212 replaced fixed-interval polling with queue-ownership change signals and immediate state checks, preventing the test from missing the transition it was waiting for. This change removes the stale quarantine so the existing scenario again validates lease expiry, reacquisition, and redistribution after two silo crashes and a replacement silo start.

Fixes #9559
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10444)