### PR TITLE
test(reminders): re-enable Azure list operations

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -69,7 +69,7 @@ namespace Tester.AzureUtils.TimerTests
             await Test_Reminders_UpdateReminder_DoesNotRestartLocalReminder();
         }
 
-        [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/9337"), TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task Rem_Azure_Basic_ListOps()
         {
             await Test_Reminders_Basic_ListOps();


### PR DESCRIPTION
Fixes #9337.

The test was quarantined because it expected all five Azure-backed reminders to complete two callbacks within a fixed wall-clock delay. Under CI callback and storage latency, one reminder could still report a count of 1.

Reminder tests now use a reminder-scoped fake clock and explicit ownership, armed-schedule, observed-tick, and grain-counter barriers before each exact period advance. Re-enable the Azure list-operations test to preserve that deterministic regression coverage for the Table provider.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10446)