### PR TITLE
fix(directory): arm lease retry before notification

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
+++ b/src/Orleans.Runtime/GrainDirectory/DistributedGrainDirectory.cs
@@ -291,9 +291,10 @@ internal sealed partial class DistributedGrainDirectory : SystemTarget, IGrainDi
             if (invokeResult.RetryAfterDelay > TimeSpan.Zero)
             {
                 // A safety lease hold is active for this grain or range.
-                // Wait for the suggested duration before retrying.
+                // Arm the delay before notifying observers so the event can be used as a synchronization barrier.
+                var retryDelay = Task.Delay(invokeResult.RetryAfterDelay, _timeProvider, cancellationToken);
                 GrainDirectoryEvents.EmitOperationDelayedByLeaseHold(Silo, grainId, operation, invokeResult.RetryAfterDelay);
-                await Task.Delay(invokeResult.RetryAfterDelay, _timeProvider, cancellationToken);
+                await retryDelay;
                 continue;
             }
 

--- a/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
+++ b/test/Orleans.GrainDirectory.Tests/GrainDirectory/GrainDirectoryLeaseTests.cs
@@ -61,12 +61,12 @@ public class GrainDirectoryLeaseTests
             await directory.Unregister(fakeAddress);
 
             // The registration should block while the lease hold is active.
-            var registrationBlocked = WaitForRegistrationDelayedByLeaseAsync(events, primary.SiloAddress, leaseGrain.GetGrainId());
+            var retryDelayScheduled = WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, leaseGrain.GetGrainId());
             var registerTask = directory.Register(fakeAddress);
-            await registrationBlocked;
+            await retryDelayScheduled;
             Assert.False(registerTask.IsCompleted, "Registration should be blocked by the lease hold.");
 
-            // Advance time past the lease duration so the retry succeeds.
+            // The diagnostic event is emitted after the retry delay is armed, so advancing time cannot race timer creation.
             timeProvider.Advance(RangeLeaseDuration);
             var result = await registerTask.WaitAsync(EventTimeout);
             Assert.NotNull(result);
@@ -105,9 +105,9 @@ public class GrainDirectoryLeaseTests
             var fakeAddress = GrainAddress.NewActivationAddress(primary.SiloAddress, leaseGrain.GetGrainId());
             using var cancellation = new CancellationTokenSource();
 
-            var registrationBlocked = WaitForRegistrationDelayedByLeaseAsync(events, primary.SiloAddress, leaseGrain.GetGrainId());
+            var retryDelayScheduled = WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, leaseGrain.GetGrainId());
             var registerTask = grainLocator.Register(fakeAddress, null, cancellation.Token);
-            await registrationBlocked;
+            await retryDelayScheduled;
             cancellation.Cancel();
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => registerTask);
@@ -352,9 +352,9 @@ public class GrainDirectoryLeaseTests
             // All grains on the dead silo should be blocked by the lease hold.
             var blockedTasks = new[]
             {
-                WaitForRegistrationDelayedByLeaseAsync(events, primary.SiloAddress, grain1.GetGrainId()),
-                WaitForRegistrationDelayedByLeaseAsync(events, primary.SiloAddress, grain2.GetGrainId()),
-                WaitForRegistrationDelayedByLeaseAsync(events, primary.SiloAddress, grain3.GetGrainId())
+                WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, grain1.GetGrainId()),
+                WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, grain2.GetGrainId()),
+                WaitForLeaseRetryScheduledAsync(events, primary.SiloAddress, grain3.GetGrainId())
             };
 
             var task1 = directory.Register(GrainAddress.NewActivationAddress(primary.SiloAddress, grain1.GetGrainId()));
@@ -490,7 +490,7 @@ public class GrainDirectoryLeaseTests
         && created.ObserverSiloAddress.Equals(observerSiloAddress)
         && created.DeadSiloAddress.Equals(deadSiloAddress);
 
-    private static Task<DiagnosticEvent> WaitForRegistrationDelayedByLeaseAsync(
+    private static Task<DiagnosticEvent> WaitForLeaseRetryScheduledAsync(
         DiagnosticEventCollector events,
         SiloAddress observerSiloAddress,
         GrainId grainId) =>


### PR DESCRIPTION
A fake-time race remained in the grain-directory lease tests introduced by #9958. The diagnostic event could wake the test before the retry delay was registered, so advancing fake time sometimes happened too early and left registration blocked until timeout.

Create the retry delay before emitting the diagnostic event, making that event a reliable synchronization barrier. Rename the test helper to document the stronger ordering guarantee.

Fixes #10431
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10447)