### PR TITLE
test: make timed error grain test deterministic

### DIFF
--- a/test/Grains/TestGrainInterfaces/IErrorGrain.cs
+++ b/test/Grains/TestGrainInterfaces/IErrorGrain.cs
@@ -1,3 +1,5 @@
+using Orleans.Concurrency;
+
 namespace UnitTests.GrainInterfaces
 {
     public interface IErrorGrain : ISimpleGrain
@@ -8,6 +10,11 @@ namespace UnitTests.GrainInterfaces
         Task<int> GetAxBError();
         Task<int> GetAxBError(int a, int b);
         Task LongMethod(int waitTime);
+        Task LongMethodUntilReleased();
+        [AlwaysInterleave]
+        Task WaitForLongMethodToStart();
+        [AlwaysInterleave]
+        Task ReleaseLongMethod();
         Task LongMethodWithError(int waitTime);
         Task DelayMethod(int milliseconds);
         Task Dispose();

--- a/test/Grains/TestInternalGrains/ErrorGrain.cs
+++ b/test/Grains/TestInternalGrains/ErrorGrain.cs
@@ -10,6 +10,8 @@ namespace UnitTests.Grains
     public class ErrorGrain : SimpleGrain, IErrorGrain
     {
         private int counter;
+        private readonly TaskCompletionSource _longMethodStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _longMethodReleased = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public ErrorGrain(ILoggerFactory loggerFactory) : base(loggerFactory)
         {
@@ -52,6 +54,20 @@ namespace UnitTests.Grains
         public async Task LongMethod(int waitTime)
         {
             await Task.Delay(waitTime);
+        }
+
+        public Task LongMethodUntilReleased()
+        {
+            _longMethodStarted.TrySetResult();
+            return _longMethodReleased.Task;
+        }
+
+        public Task WaitForLongMethodToStart() => _longMethodStarted.Task;
+
+        public Task ReleaseLongMethod()
+        {
+            _longMethodReleased.TrySetResult();
+            return Task.CompletedTask;
         }
 
         public async Task LongMethodWithError(int waitTime)

--- a/test/Orleans.DefaultCluster.Tests/ErrorGrainTest.cs
+++ b/test/Orleans.DefaultCluster.Tests/ErrorGrainTest.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
 using Orleans.Internal;
@@ -111,30 +110,29 @@ namespace DefaultCluster.Tests
         /// Verifies that:
         /// - Tasks for long-running operations don't complete prematurely
         /// - The Task eventually completes successfully
-        /// - Timing assertions ensure proper async behavior
         /// This establishes baseline behavior for comparison with timeout scenarios.
         /// </summary>
-        [Fact(Skip = "https://github.com/dotnet/orleans/issues/9558"), TestCategory("BVT"), TestCategory("ErrorHandling")]
+        [Fact, TestCategory("BVT"), TestCategory("ErrorHandling")]
         public async Task ErrorHandlingTimedMethod()
         {
             var grainFullName = typeof(ErrorGrain).FullName;
             IErrorGrain grain = this.GrainFactory.GetGrain<IErrorGrain>(GetRandomGrainId(), grainFullName);
 
-            Task promise = grain.LongMethod(2000);
+            Task promise = grain.LongMethodUntilReleased();
+            try
+            {
+                await grain.WaitForLongMethodToStart().WaitAsync(timeout);
+                Assert.False(promise.IsCompleted, "The task shouldn't complete before the grain method is released.");
 
-            // there is a race in the test here. If run in debugger, the invocation can actually finish OK
-            Stopwatch stopwatch = Stopwatch.StartNew();
+                await grain.ReleaseLongMethod().WaitAsync(timeout);
+                await promise.WaitAsync(timeout);
 
-            await Task.Delay(1000);
-            Assert.False(promise.IsCompleted, "The task shouldn't have completed yet.");
-
-            // these asserts depend on timing issues and will be wrong for the sync version of OrleansTask
-            Assert.True(stopwatch.ElapsedMilliseconds >= 900, $"Waited less than 900ms: ({stopwatch.ElapsedMilliseconds}ms)"); // check that we waited at least 0.9 second
-            Assert.True(stopwatch.ElapsedMilliseconds <= 1300, $"Waited longer than 1300ms: ({stopwatch.ElapsedMilliseconds}ms)");
-
-            await promise; // just wait for the server side grain invocation to finish
-            
-            Assert.True(promise.Status == TaskStatus.RanToCompletion);
+                Assert.Equal(TaskStatus.RanToCompletion, promise.Status);
+            }
+            finally
+            {
+                await grain.ReleaseLongMethod().WaitAsync(timeout);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

`ErrorHandlingTimedMethod` was quarantined because it required a one-second delay to complete within a 900-1300 ms wall-clock window. Under CI load, scheduler pauses could violate that window or allow the two-second grain call to finish before the assertion.

## Solution

Replace the timing window with an explicit phase barrier in the test grain. The test now waits until the server invocation has started, verifies the client task remains incomplete, releases the invocation through interleavable control calls, and verifies successful completion. Cleanup releases the blocked call even when an assertion fails.

This preserves the behavior under test without relying on machine timing and re-enables the quarantined test.

Fixes #9558
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10448)