### PR TITLE
test(transactions): retry transient concurrency aborts

### DIFF
--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionConcurrencyTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionConcurrencyTestRunner.cs
@@ -28,9 +28,9 @@ namespace Orleans.Transactions.TestKit
             
             ITransactionCoordinatorGrain coordinator1 = this.grainFactory.GetGrain<ITransactionCoordinatorGrain>(Guid.NewGuid());
             ITransactionCoordinatorGrain coordinator2 = this.grainFactory.GetGrain<ITransactionCoordinatorGrain>(Guid.NewGuid());
-            await Task.WhenAll(
-                coordinator1.MultiGrainAdd(transaction1Members, expected),
-                coordinator2.MultiGrainAdd(transaction2Members, expected));
+            await RunConcurrentTransactions(
+                () => coordinator1.MultiGrainAdd(transaction1Members, expected),
+                () => coordinator2.MultiGrainAdd(transaction2Members, expected));
 
             int[] actual = await grain1.Get();
             expected.Should().Be(actual.FirstOrDefault());
@@ -63,11 +63,11 @@ namespace Orleans.Transactions.TestKit
             ITransactionCoordinatorGrain coordinator2 = this.grainFactory.GetGrain<ITransactionCoordinatorGrain>(Guid.NewGuid());
             ITransactionCoordinatorGrain coordinator3 = this.grainFactory.GetGrain<ITransactionCoordinatorGrain>(Guid.NewGuid());
             ITransactionCoordinatorGrain coordinator4 = this.grainFactory.GetGrain<ITransactionCoordinatorGrain>(Guid.NewGuid());
-            await Task.WhenAll(
-                coordinator1.MultiGrainAdd(transaction1Members, expected),
-                coordinator2.MultiGrainAdd(transaction2Members, expected),
-                coordinator3.MultiGrainAdd(transaction3Members, expected),
-                coordinator4.MultiGrainAdd(transaction4Members, expected));
+            await RunConcurrentTransactions(
+                () => coordinator1.MultiGrainAdd(transaction1Members, expected),
+                () => coordinator2.MultiGrainAdd(transaction2Members, expected),
+                () => coordinator3.MultiGrainAdd(transaction3Members, expected),
+                () => coordinator4.MultiGrainAdd(transaction4Members, expected));
 
             int[] actual = await grain1.Get();
             actual.FirstOrDefault().Should().Be(expected);
@@ -101,10 +101,10 @@ namespace Orleans.Transactions.TestKit
             ITransactionCoordinatorGrain coordinator1 = this.grainFactory.GetGrain<ITransactionCoordinatorGrain>(Guid.NewGuid());
             ITransactionCoordinatorGrain coordinator2 = this.grainFactory.GetGrain<ITransactionCoordinatorGrain>(Guid.NewGuid());
             ITransactionCoordinatorGrain coordinator3 = this.grainFactory.GetGrain<ITransactionCoordinatorGrain>(Guid.NewGuid());
-            await Task.WhenAll(
-                coordinator1.MultiGrainAdd(transaction1Members, expected),
-                coordinator2.MultiGrainAdd(transaction2Members, expected),
-                coordinator3.MultiGrainAdd(transaction3Members, expected));
+            await RunConcurrentTransactions(
+                () => coordinator1.MultiGrainAdd(transaction1Members, expected),
+                () => coordinator2.MultiGrainAdd(transaction2Members, expected),
+                () => coordinator3.MultiGrainAdd(transaction3Members, expected));
 
             int[] actual = await grain1.Get();
             actual.FirstOrDefault().Should().Be(expected);
@@ -114,6 +114,33 @@ namespace Orleans.Transactions.TestKit
             actual.FirstOrDefault().Should().Be(expected*2);
             actual = await grain4.Get();
             actual.FirstOrDefault().Should().Be(expected);
+        }
+
+        private async Task RunConcurrentTransactions(params Func<Task>[] transactions)
+        {
+            var completed = await Task.WhenAll(transactions.Select(TryRunTransaction));
+            // Preserve contention in the first attempt, then serialize retries so aborted operations can make progress.
+            for (var i = 0; i < transactions.Length; i++)
+            {
+                while (!completed[i])
+                {
+                    completed[i] = await TryRunTransaction(transactions[i]);
+                }
+            }
+        }
+
+        private async Task<bool> TryRunTransaction(Func<Task> transaction)
+        {
+            try
+            {
+                await transaction();
+                return true;
+            }
+            catch (OrleansTransactionTransientFailureException exception)
+            {
+                this.testOutput($"Transaction aborted transiently: {exception.Message}. Retrying.");
+                return false;
+            }
         }
     }
 }

--- a/src/Orleans.Transactions.TestKit.xUnit/TransactionConcurrencyTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TransactionConcurrencyTestRunner.cs
@@ -14,7 +14,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// </summary>
         /// <param name="grainStates"></param>
         /// <returns></returns>
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9554")]
+        [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain)]
@@ -28,7 +28,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// </summary>
         /// <param name="grainStates"></param>
         /// <returns></returns>
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9554")]
+        [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain)]
@@ -42,7 +42,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         /// </summary>
         /// <param name="grainStates"></param>
         /// <returns></returns>
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9554")]
+        [SkippableTheory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain)]


### PR DESCRIPTION
Fixes #9554

The concurrency scenarios treated every transaction abort as a permanent failure. Under storage latency and intentional contention, a lock lease can expire and produce an OrleansTransactionTransientFailureException even though the transaction was atomically aborted and is safe to retry.

Preserve the initial concurrent attempt, then retry only definitely-aborted operations serially so they make progress without changing lock timeouts or adding timing delays. Ambiguous outcomes still fail immediately. Re-enable all shared concurrency theories across the memory, Azure Table, and DynamoDB providers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10449)