### PR TITLE
fix(transactions): remove aborted queued lock operations

### DIFF
--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -283,26 +283,13 @@ namespace Orleans.Transactions.State
 
         public void Rollback(Guid guid)
         {
-            var group = currentGroup;
-            while (group != null)
-            {
-                if (group.Remove(guid))
-                {
-                    if (group != currentGroup)
-                    {
-                        AbortPendingOperations(group, guid);
-                    }
-                    return;
-                }
-
-                group = group.Next;
-            }
+            TryRemove(guid, out _);
         }
 
         public Task Rollback(Guid guid, bool notify, TransactionDiagnosticEvents.LockBreakReason reason)
         {
             // no-op if the transaction never happened or already rolled back
-            if (currentGroup == null || !currentGroup.Remove(guid, out var record))
+            if (!TryRemove(guid, out var record))
             {
                 return Task.CompletedTask;
             }
@@ -319,6 +306,28 @@ namespace Orleans.Transactions.State
                 reason,
                 queue.DiagnosticIdentity);
             return queue.NotifyOfAbort(record, TransactionalStatus.BrokenLock, exception: null);
+        }
+
+        private bool TryRemove(Guid transactionId, [NotNullWhen(true)] out TransactionRecord<TState>? record)
+        {
+            var group = currentGroup;
+            while (group != null)
+            {
+                if (group.Remove(transactionId, out record))
+                {
+                    if (group != currentGroup)
+                    {
+                        AbortPendingOperations(group, transactionId);
+                    }
+
+                    return true;
+                }
+
+                group = group.Next;
+            }
+
+            record = null;
+            return false;
         }
 
         private async Task LockWork()

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -33,17 +33,19 @@ namespace Orleans.Transactions.State
         private class LockGroup : Dictionary<Guid, TransactionRecord<TState>>
         {
             public int FillCount;
-            public List<Action>? Tasks; // the tasks for executing the waiting operations
+            public List<PendingOperation>? PendingOperations;
             public LockGroup? Next; // queued-up transactions waiting to acquire lock
             public DateTime? Deadline;
             public void Reset()
             {
                 FillCount = 0;
-                Tasks = null;
+                PendingOperations = null;
                 Deadline = null;
                 Clear();
             }
         }
+
+        private readonly record struct PendingOperation(Guid TransactionId, Action Execute, Action Abort);
 
         public ReadWriteLock(
             IOptions<TransactionalStateOptions> options,
@@ -159,15 +161,16 @@ namespace Orleans.Transactions.State
                     result.TrySetException(exception);
                 }
             }
+            void abort() => result.TrySetException(new OrleansCascadingAbortException(transactionId.ToString()));
 
             if (group != currentGroup)
             {
                 // task will be executed once its group acquires the lock
 
-                if (group.Tasks == null)
-                    group.Tasks = new List<Action>();
+                if (group.PendingOperations == null)
+                    group.PendingOperations = new List<PendingOperation>();
 
-                group.Tasks.Add(completion);
+                group.PendingOperations.Add(new PendingOperation(transactionId, completion, abort));
             }
             else
             {
@@ -263,13 +266,13 @@ namespace Orleans.Transactions.State
             var pos = currentGroup?.Next;
             while (pos != null)
             {
-                if (pos.Tasks != null)
+                if (pos.PendingOperations != null)
                 {
-                    foreach (var t in pos.Tasks)
+                    foreach (var operation in pos.PendingOperations)
                     {
-                        // running the task will abort the transaction because it is not in currentGroup
-                        t();
+                        operation.Abort();
                     }
+                    pos.PendingOperations = null;
                 }
                 pos.Clear();
                 pos = pos.Next;
@@ -278,7 +281,23 @@ namespace Orleans.Transactions.State
                 currentGroup.Next = null;
         }
 
-        public void Rollback(Guid guid) => currentGroup?.Remove(guid);
+        public void Rollback(Guid guid)
+        {
+            var group = currentGroup;
+            while (group != null)
+            {
+                if (group.Remove(guid))
+                {
+                    if (group != currentGroup)
+                    {
+                        AbortPendingOperations(group, guid);
+                    }
+                    return;
+                }
+
+                group = group.Next;
+            }
+        }
 
         public Task Rollback(Guid guid, bool notify, TransactionDiagnosticEvents.LockBreakReason reason)
         {
@@ -379,20 +398,23 @@ namespace Orleans.Transactions.State
                             // discard expired waiters that have no chance to succeed
                             // because they have been waiting for the lock for a longer timespan than the
                             // total transaction timeout
-                            foreach (var kvp in currentGroup)
+                            var expiredWaiters = currentGroup
+                                .Where(kvp => now > kvp.Value.Deadline)
+                                .Select(kvp => kvp.Key)
+                                .ToList();
+                            foreach (var transactionId in expiredWaiters)
                             {
-                                if (now > kvp.Value.Deadline)
-                                {
-                                    TransactionDiagnosticEvents.EmitLockExpired(
-                                        queue.Resource,
-                                        kvp.Key,
-                                        kvp.Value.Deadline,
-                                        now,
-                                        TransactionDiagnosticEvents.LockExpirationKind.QueuedWaiter,
-                                        queue.DiagnosticIdentity);
-                                    currentGroup.Remove(kvp.Key);
-                                    LogTraceExpireLockWaiter(kvp.Key);
-                                }
+                                var deadline = currentGroup[transactionId].Deadline;
+                                TransactionDiagnosticEvents.EmitLockExpired(
+                                    queue.Resource,
+                                    transactionId,
+                                    deadline,
+                                    now,
+                                    TransactionDiagnosticEvents.LockExpirationKind.QueuedWaiter,
+                                    queue.DiagnosticIdentity);
+                                currentGroup.Remove(transactionId);
+                                AbortPendingOperations(currentGroup, transactionId);
+                                LogTraceExpireLockWaiter(transactionId);
                             }
 
                             currentGroup.Deadline = currentGroup.Count == 0
@@ -407,11 +429,13 @@ namespace Orleans.Transactions.State
                             }
 
                             // execute all the read and update tasks
-                            if (currentGroup.Tasks != null)
+                            if (currentGroup.PendingOperations != null)
                             {
-                                foreach (var t in currentGroup.Tasks)
+                                var pendingOperations = currentGroup.PendingOperations;
+                                currentGroup.PendingOperations = null;
+                                foreach (var operation in pendingOperations)
                                 {
-                                    t();
+                                    operation.Execute();
                                 }
                             }
 
@@ -429,6 +453,29 @@ namespace Orleans.Transactions.State
 
         private static DateTime AddTimeout(DateTime now, TimeSpan timeout)
             => timeout >= DateTime.MaxValue - now ? DateTime.MaxValue : now + timeout;
+
+        private static void AbortPendingOperations(LockGroup group, Guid transactionId)
+        {
+            if (group.PendingOperations == null)
+            {
+                return;
+            }
+
+            for (var i = group.PendingOperations.Count - 1; i >= 0; i--)
+            {
+                var operation = group.PendingOperations[i];
+                if (operation.TransactionId == transactionId)
+                {
+                    group.PendingOperations.RemoveAt(i);
+                    operation.Abort();
+                }
+            }
+
+            if (group.PendingOperations.Count == 0)
+            {
+                group.PendingOperations = null;
+            }
+        }
 
         private bool Find(Guid guid, bool isRead, out LockGroup group, [NotNullWhen(true)] out TransactionRecord<TState>? record)
         {

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -90,6 +90,8 @@ namespace Orleans.Transactions.State
                 {
                     if (!resolvable)
                     {
+                        Rollback(transactionId);
+                        lockWorker.Notify();
                         throw new OrleansTransactionLockUpgradeException(transactionId.ToString());
                     }
                     else

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -309,6 +309,68 @@ public class TransactionRecoveryLatencyTests
     }
 
     [Fact]
+    public async Task UnresolvableQueuedWriteUpgradeAbortsItsPendingOperations()
+    {
+        var queue = new GatedCancelTransactionQueue(
+            CreateParticipant("resource", ParticipantId.Role.Resource),
+            new TestActivationLifetime());
+        var currentTransactionId = Guid.NewGuid();
+        var upgradingTransactionId = Guid.NewGuid();
+        var conflictingTransactionId = Guid.NewGuid();
+        var higherPriority = new DateTime(2026, 8, 21, 12, 0, 0, DateTimeKind.Utc);
+        var lowerPriority = higherPriority.AddTicks(1);
+        var transactionTimeout = TimeSpan.FromMinutes(1);
+        var upgradingOperationCount = 0;
+        var conflictingOperationCount = 0;
+
+        await queue.RWLock.EnterLock(
+            currentTransactionId,
+            higherPriority,
+            transactionTimeout,
+            new AccessCounter(),
+            isRead: false,
+            exclusiveLock: false,
+            static () => 0);
+        var queuedRead = queue.RWLock.EnterLock(
+            upgradingTransactionId,
+            lowerPriority,
+            transactionTimeout,
+            new AccessCounter(),
+            isRead: true,
+            exclusiveLock: false,
+            () => ++upgradingOperationCount);
+        var conflictingRead = queue.RWLock.EnterLock(
+            conflictingTransactionId,
+            higherPriority,
+            transactionTimeout,
+            new AccessCounter(),
+            isRead: true,
+            exclusiveLock: false,
+            () => ++conflictingOperationCount);
+
+        await Assert.ThrowsAsync<OrleansTransactionLockUpgradeException>(
+            () => queue.RWLock.EnterLock(
+                upgradingTransactionId,
+                lowerPriority,
+                transactionTimeout,
+                new AccessCounter { Reads = 1 },
+                isRead: false,
+                exclusiveLock: false,
+                static () => 0));
+        await Assert.ThrowsAsync<OrleansCascadingAbortException>(
+            () => queuedRead.WaitAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(0, upgradingOperationCount);
+        Assert.False(conflictingRead.IsCompleted);
+
+        queue.RWLock.Rollback(currentTransactionId);
+        queue.RWLock.Notify();
+
+        Assert.Equal(1, await conflictingRead.WaitAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(0, upgradingOperationCount);
+        Assert.Equal(1, conflictingOperationCount);
+    }
+
+    [Fact]
     public async Task LocalAbortCompletesManagerDecisionAfterDispatchAndBeforeCleanupSettles()
     {
         var manager = CreateParticipant(

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -191,11 +191,13 @@ public class TransactionRecoveryLatencyTests
         var abortedTransactionId = Guid.NewGuid();
         var nextTransactionId = Guid.NewGuid();
         var priority = DateTime.UtcNow;
+        var transactionTimeout = TimeSpan.FromMinutes(1);
         var abortedOperationCount = 0;
 
         await queue.RWLock.EnterLock(
             currentTransactionId,
             priority,
+            transactionTimeout,
             new AccessCounter(),
             isRead: false,
             exclusiveLock: false,
@@ -203,6 +205,7 @@ public class TransactionRecoveryLatencyTests
         var firstAbortedOperation = queue.RWLock.EnterLock(
             abortedTransactionId,
             priority,
+            transactionTimeout,
             new AccessCounter(),
             isRead: false,
             exclusiveLock: false,
@@ -210,6 +213,7 @@ public class TransactionRecoveryLatencyTests
         var secondAbortedOperation = queue.RWLock.EnterLock(
             abortedTransactionId,
             priority,
+            transactionTimeout,
             new AccessCounter { Writes = 1 },
             isRead: false,
             exclusiveLock: false,
@@ -229,6 +233,7 @@ public class TransactionRecoveryLatencyTests
         var nextOperation = queue.RWLock.EnterLock(
             nextTransactionId,
             priority,
+            transactionTimeout,
             new AccessCounter(),
             isRead: false,
             exclusiveLock: false,
@@ -253,11 +258,13 @@ public class TransactionRecoveryLatencyTests
         var upgradingTransactionId = Guid.NewGuid();
         var conflictingTransactionId = Guid.NewGuid();
         var priority = new DateTime(2026, 8, 21, 12, 0, 0, DateTimeKind.Utc);
+        var transactionTimeout = TimeSpan.FromMinutes(1);
         var conflictingOperationCount = 0;
 
         await queue.RWLock.EnterLock(
             currentTransactionId,
             priority,
+            transactionTimeout,
             new AccessCounter(),
             isRead: false,
             exclusiveLock: false,
@@ -265,6 +272,7 @@ public class TransactionRecoveryLatencyTests
         var queuedRead = queue.RWLock.EnterLock(
             upgradingTransactionId,
             priority,
+            transactionTimeout,
             new AccessCounter(),
             isRead: true,
             exclusiveLock: false,
@@ -272,6 +280,7 @@ public class TransactionRecoveryLatencyTests
         var conflictingRead = queue.RWLock.EnterLock(
             conflictingTransactionId,
             priority,
+            transactionTimeout,
             new AccessCounter(),
             isRead: true,
             exclusiveLock: false,
@@ -279,6 +288,7 @@ public class TransactionRecoveryLatencyTests
         var queuedWrite = queue.RWLock.EnterLock(
             upgradingTransactionId,
             priority,
+            transactionTimeout,
             new AccessCounter { Reads = 1 },
             isRead: false,
             exclusiveLock: false,

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -221,9 +221,9 @@ public class TransactionRecoveryLatencyTests
         queue.RWLock.Rollback(abortedTransactionId);
 
         await Assert.ThrowsAsync<OrleansCascadingAbortException>(
-            () => firstAbortedOperation.WaitAsync(TimeSpan.FromSeconds(1)));
+            () => firstAbortedOperation.WaitAsync(TestContext.Current.CancellationToken));
         await Assert.ThrowsAsync<OrleansCascadingAbortException>(
-            () => secondAbortedOperation.WaitAsync(TimeSpan.FromSeconds(1)));
+            () => secondAbortedOperation.WaitAsync(TestContext.Current.CancellationToken));
         Assert.Equal(0, abortedOperationCount);
 
         var nextOperation = queue.RWLock.EnterLock(
@@ -239,7 +239,7 @@ public class TransactionRecoveryLatencyTests
         queue.RWLock.Rollback(currentTransactionId);
         queue.RWLock.Notify();
 
-        Assert.Equal(42, await nextOperation.WaitAsync(TimeSpan.FromSeconds(1)));
+        Assert.Equal(42, await nextOperation.WaitAsync(TestContext.Current.CancellationToken));
         Assert.Equal(0, abortedOperationCount);
     }
 
@@ -285,7 +285,7 @@ public class TransactionRecoveryLatencyTests
             static () => 2);
 
         await Assert.ThrowsAsync<OrleansCascadingAbortException>(
-            () => conflictingRead.WaitAsync(TimeSpan.FromSeconds(1)));
+            () => conflictingRead.WaitAsync(TestContext.Current.CancellationToken));
         Assert.Equal(0, conflictingOperationCount);
         Assert.False(queuedRead.IsCompleted);
         Assert.False(queuedWrite.IsCompleted);
@@ -293,8 +293,8 @@ public class TransactionRecoveryLatencyTests
         queue.RWLock.Rollback(currentTransactionId);
         queue.RWLock.Notify();
 
-        Assert.Equal(1, await queuedRead.WaitAsync(TimeSpan.FromSeconds(1)));
-        Assert.Equal(2, await queuedWrite.WaitAsync(TimeSpan.FromSeconds(1)));
+        Assert.Equal(1, await queuedRead.WaitAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(2, await queuedWrite.WaitAsync(TestContext.Current.CancellationToken));
         Assert.Equal(0, conflictingOperationCount);
     }
 

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -182,6 +182,68 @@ public class TransactionRecoveryLatencyTests
     }
 
     [Fact]
+    public async Task AbortingQueuedTransactionRemovesAllPendingOperations()
+    {
+        var queue = new GatedCancelTransactionQueue(
+            CreateParticipant("resource", ParticipantId.Role.Resource),
+            new TestActivationLifetime());
+        var currentTransactionId = Guid.NewGuid();
+        var abortedTransactionId = Guid.NewGuid();
+        var nextTransactionId = Guid.NewGuid();
+        var priority = DateTime.UtcNow;
+        var abortedOperationCount = 0;
+
+        await queue.RWLock.EnterLock(
+            currentTransactionId,
+            priority,
+            new AccessCounter(),
+            isRead: false,
+            exclusiveLock: false,
+            static () => 0);
+        var firstAbortedOperation = queue.RWLock.EnterLock(
+            abortedTransactionId,
+            priority,
+            new AccessCounter(),
+            isRead: false,
+            exclusiveLock: false,
+            () => ++abortedOperationCount);
+        var secondAbortedOperation = queue.RWLock.EnterLock(
+            abortedTransactionId,
+            priority,
+            new AccessCounter { Writes = 1 },
+            isRead: false,
+            exclusiveLock: false,
+            () => ++abortedOperationCount);
+
+        Assert.False(firstAbortedOperation.IsCompleted);
+        Assert.False(secondAbortedOperation.IsCompleted);
+
+        queue.RWLock.Rollback(abortedTransactionId);
+
+        await Assert.ThrowsAsync<OrleansCascadingAbortException>(
+            () => firstAbortedOperation.WaitAsync(TimeSpan.FromSeconds(1)));
+        await Assert.ThrowsAsync<OrleansCascadingAbortException>(
+            () => secondAbortedOperation.WaitAsync(TimeSpan.FromSeconds(1)));
+        Assert.Equal(0, abortedOperationCount);
+
+        var nextOperation = queue.RWLock.EnterLock(
+            nextTransactionId,
+            priority,
+            new AccessCounter(),
+            isRead: false,
+            exclusiveLock: false,
+            static () => 42);
+
+        Assert.False(nextOperation.IsCompleted);
+
+        queue.RWLock.Rollback(currentTransactionId);
+        queue.RWLock.Notify();
+
+        Assert.Equal(42, await nextOperation.WaitAsync(TimeSpan.FromSeconds(1)));
+        Assert.Equal(0, abortedOperationCount);
+    }
+
+    [Fact]
     public async Task LocalAbortCompletesManagerDecisionAfterDispatchAndBeforeCleanupSettles()
     {
         var manager = CreateParticipant(

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -244,6 +244,61 @@ public class TransactionRecoveryLatencyTests
     }
 
     [Fact]
+    public async Task QueuedWriteUpgradeAbortsConflictingTransactionOperations()
+    {
+        var queue = new GatedCancelTransactionQueue(
+            CreateParticipant("resource", ParticipantId.Role.Resource),
+            new TestActivationLifetime());
+        var currentTransactionId = Guid.NewGuid();
+        var upgradingTransactionId = Guid.NewGuid();
+        var conflictingTransactionId = Guid.NewGuid();
+        var priority = new DateTime(2026, 8, 21, 12, 0, 0, DateTimeKind.Utc);
+        var conflictingOperationCount = 0;
+
+        await queue.RWLock.EnterLock(
+            currentTransactionId,
+            priority,
+            new AccessCounter(),
+            isRead: false,
+            exclusiveLock: false,
+            static () => 0);
+        var queuedRead = queue.RWLock.EnterLock(
+            upgradingTransactionId,
+            priority,
+            new AccessCounter(),
+            isRead: true,
+            exclusiveLock: false,
+            static () => 1);
+        var conflictingRead = queue.RWLock.EnterLock(
+            conflictingTransactionId,
+            priority,
+            new AccessCounter(),
+            isRead: true,
+            exclusiveLock: false,
+            () => ++conflictingOperationCount);
+        var queuedWrite = queue.RWLock.EnterLock(
+            upgradingTransactionId,
+            priority,
+            new AccessCounter { Reads = 1 },
+            isRead: false,
+            exclusiveLock: false,
+            static () => 2);
+
+        await Assert.ThrowsAsync<OrleansCascadingAbortException>(
+            () => conflictingRead.WaitAsync(TimeSpan.FromSeconds(1)));
+        Assert.Equal(0, conflictingOperationCount);
+        Assert.False(queuedRead.IsCompleted);
+        Assert.False(queuedWrite.IsCompleted);
+
+        queue.RWLock.Rollback(currentTransactionId);
+        queue.RWLock.Notify();
+
+        Assert.Equal(1, await queuedRead.WaitAsync(TimeSpan.FromSeconds(1)));
+        Assert.Equal(2, await queuedWrite.WaitAsync(TimeSpan.FromSeconds(1)));
+        Assert.Equal(0, conflictingOperationCount);
+    }
+
+    [Fact]
     public async Task LocalAbortCompletesManagerDecisionAfterDispatchAndBeforeCleanupSettles()
     {
         var manager = CreateParticipant(


### PR DESCRIPTION
## Summary

A transaction aborted while waiting for a transactional-state lock remained in its queued lock group because rollback only searched the active group. When that queued group was later promoted, the stale transaction still appeared valid and its pending operations executed, producing cascading aborts and prepare timeouts that could prevent recovery from settling.

A rejected queued write upgrade had the same lifetime gap: the upgrade threw before the participant callback executed, so the transaction agent did not yet know about that participant and could not reliably release its earlier queued operations.

This change associates pending lock operations with their transaction and removes them whenever that transaction is rolled back, expires, loses a conflict, fails a lock upgrade, or its queued group is reset. Each removed operation completes with the existing cascading-abort semantics before the group can be promoted, while unaffected transactions continue through the queue.

Fixes #5211.