### PR TITLE
test(reminders): stabilize Azure basic reminder test

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Reminder/ReminderTests_AzureTable.cs
@@ -89,24 +89,21 @@ namespace Tester.AzureUtils.TimerTests
             await Test_Reminders_ReminderNotFound();
         }
 
-        [SkippableFact(Skip = "https://github.com/dotnet/orleans/issues/9344"), TestCategory("Functional")]
+        [SkippableFact, TestCategory("Functional")]
         public async Task Rem_Azure_Basic()
         {
-            // start up a test grain and get the period that it's programmed to use.
-            IReminderTestGrain2 grain = this.GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
-            TimeSpan period = await grain.GetReminderPeriod(DR);
-            // start up the 'DR' reminder and wait for two ticks to pass.
+            using var cts = new CancellationTokenSource(ENDWAIT);
+            var grain = GrainFactory.GetGrain<IReminderTestGrain2>(Guid.NewGuid());
+            var period = await grain.GetReminderPeriod(DR);
+
             await grain.StartReminder(DR);
-            await WaitForReminderCounterAsync(grain, DR, () => grain.GetCounter(DR), 2);
-            // retrieve the value of the counter-- it should match the sequence number which is the number of periods
-            // we've waited.
-            long last = await grain.GetCounter(DR);
+            await AdvanceRemindersByTicksAsync(2, cts.Token, GetReminderIdentities([grain], DR));
+            var last = await grain.GetCounter(DR);
             Assert.Equal(2, last);
-            // stop the timer and wait for a whole period.
-            await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder);
-            await AdvanceReminderTimeAsync(period);
-            // the counter should not have changed.
-            long curr = await grain.GetCounter(DR);
+
+            await StopReminderAndWaitForQuiescenceAsync(grain, DR, grain.StopReminder, cts.Token);
+            await AdvanceReminderTimeAsync(period, cts.Token);
+            var curr = await grain.GetCounter(DR);
             Assert.Equal(last, curr);
         }
 

--- a/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
+++ b/test/Orleans.Reminders.Tests/TimerTests/ReminderTestsBase.cs
@@ -2,10 +2,12 @@
 
 using System.Collections.Concurrent;
 using System.Text;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Orleans.Internal;
 using Orleans.Runtime;
 using Orleans.Runtime.Messaging;
+using Orleans.Runtime.ReminderService;
 using Orleans.Testing.Reminders;
 using Orleans.TestingHost;
 using Orleans.TestingHost.Utils;
@@ -744,24 +746,26 @@ public class ReminderTestsBase : OrleansTestingBase, IDisposable
     {
         while (true)
         {
-            while (observer.GetActiveReminderCount(grain.GetGrainId(), reminderName) > 0)
+            if (observer.GetActiveReminderCount(grain.GetGrainId(), reminderName) > 0)
             {
                 var quiescenceTask = observer.WaitForReminderQuiescenceAsync(grain, reminderName, cancellationToken);
-                if (quiescenceTask.IsCompleted)
-                {
-                    await quiescenceTask;
-                    break;
-                }
-
-                await AdvanceReminderTimeAsync(ReminderClock.RefreshReminderListPeriod, cancellationToken);
+                await RefreshReminderServicesAsync(cancellationToken);
+                await quiescenceTask;
             }
 
-            await AdvanceReminderTimeAsync(ReminderClock.RefreshReminderListPeriod, cancellationToken);
+            await RefreshReminderServicesAsync(cancellationToken);
             if (observer.GetActiveReminderCount(grain.GetGrainId(), reminderName) == 0)
             {
                 return;
             }
         }
+    }
+
+    private async Task RefreshReminderServicesAsync(CancellationToken cancellationToken)
+    {
+        var refreshTasks = HostedCluster.Silos.Select(silo =>
+            silo.ServiceProvider.GetRequiredService<LocalReminderService>().TestOnlyRefresh());
+        await Task.WhenAll(refreshTasks).WaitAsync(cancellationToken);
     }
 
     private async Task<bool> HandleError(Exception ex, long i)


### PR DESCRIPTION
Fixes #9344.

`Rem_Azure_Basic` remained skipped after reminder tests moved to deterministic fake time. Its stop synchronization could repeatedly advance the reminder clock while an Azure-backed unregister refresh was still in flight, allowing the counter to jump by multiple periods before quiescence.

Re-enable the test using the single-clock tick orchestrator, and make reminder shutdown reconciliation explicit by awaiting a refresh on each reminder service instead of advancing fake time. This preserves exact counter assertions without adding sleeps or timeout allowances.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10456)