### PR TITLE
fix(transactions): honor transaction timeout for participant locks

### DIFF
--- a/src/Orleans.Transactions.TestKit.xUnit/TOCGoldenPathTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TOCGoldenPathTestRunner.cs
@@ -8,7 +8,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         protected TocGoldenPathTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
         : base(grainFactory, output.WriteLine) { }
 
-        [Theory(Skip = "https://github.com/dotnet/orleans/issues/9556")]
+        [Theory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions / 2)]
         public override Task MultiGrainWriteTransaction(string grainStates, int grainCount)

--- a/src/Orleans.Transactions.TestKit.xUnit/TocFaultTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/TocFaultTransactionTestRunner.cs
@@ -8,7 +8,7 @@ namespace Orleans.Transactions.TestKit.xUnit
         protected TocFaultTransactionTestRunnerxUnit(IGrainFactory grainFactory, ITestOutputHelper output)
         : base(grainFactory, output.WriteLine) { }
 
-        [Theory(Skip = "https://github.com/dotnet/orleans/issues/9556")]
+        [Theory]
         [InlineData(TransactionTestConstants.SingleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions)]
         [InlineData(TransactionTestConstants.DoubleStateTransactionalGrain, TransactionTestConstants.MaxCoordinatedTransactions / 2)]
         [InlineData(TransactionTestConstants.MaxStateTransactionalGrain, 1)]

--- a/src/Orleans.Transactions/DistributedTM/TransactionAgent.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionAgent.cs
@@ -49,7 +49,10 @@ namespace Orleans.Transactions
 
             LogTraceStartTransaction(new(stopwatch), guid, new(ts));
             this.statistics.TrackTransactionStarted();
-            return Task.FromResult<TransactionInfo>(new TransactionInfo(guid, ts, ts, readOnly));
+            return Task.FromResult<TransactionInfo>(new TransactionInfo(guid, ts, ts, readOnly)
+            {
+                Timeout = timeout
+            });
         }
 
         public async Task<(TransactionalStatus, Exception?)> Resolve(TransactionInfo transactionInfo)

--- a/src/Orleans.Transactions/DistributedTM/TransactionInfo.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionInfo.cs
@@ -37,6 +37,7 @@ namespace Orleans.Transactions
             this.UseExclusiveLock = other.UseExclusiveLock;
             this.TimeStamp = other.TimeStamp;
             this.Priority = other.Priority;
+            this.Timeout = other.Timeout;
         }
 
         public string Id => TransactionId.ToString();
@@ -66,6 +67,9 @@ namespace Orleans.Transactions
 
         [Id(7)]
         public bool UseExclusiveLock { get; set; } = false;
+
+        [Id(8)]
+        internal TimeSpan Timeout { get; set; }
 
         [NonSerialized]
         public int PendingCalls;

--- a/src/Orleans.Transactions/DistributedTM/TransactionRecord.cs
+++ b/src/Orleans.Transactions/DistributedTM/TransactionRecord.cs
@@ -32,8 +32,11 @@ namespace Orleans.Transactions
         // the time at which this transaction was started on the TA
         public DateTime Priority;
 
-        // a deadline for the transaction to complete successfully, set by the TA
+        // the deadline for a queued transaction to acquire the lock
         public DateTime Deadline;
+
+        // the minimum time this participant must retain the lock after acquiring it
+        public TimeSpan LockTimeout;
 
         // the transaction timestamp as computed by the algorithm
         public DateTime Timestamp;

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -60,8 +60,14 @@ namespace Orleans.Transactions.State
             this.lockWorker = new BatchWorkerFromDelegate(LockWork, this.activationLifetime.OnDeactivating);
         }
 
-        public async Task<TResult> EnterLock<TResult>(Guid transactionId, DateTime priority,
-                                   AccessCounter counter, bool isRead, bool exclusiveLock, Func<TResult> task)
+        public async Task<TResult> EnterLock<TResult>(
+            Guid transactionId,
+            DateTime priority,
+            TimeSpan transactionTimeout,
+            AccessCounter counter,
+            bool isRead,
+            bool exclusiveLock,
+            Func<TResult> task)
         {
             bool rollbacksOccurred = false;
             List<Task> cleanup = new List<Task>();
@@ -108,10 +114,17 @@ namespace Orleans.Transactions.State
                     throw new OrleansBrokenTransactionLockException(transactionId.ToString(), "when trying to re-enter lock");
                 }
 
+                var now = DateTime.UtcNow;
+                var lockTimeout = GetEffectiveLockTimeout(transactionTimeout, this.options.LockTimeout);
+
                 // update the lock deadline
                 if (group == currentGroup)
                 {
-                    group.Deadline = DateTime.UtcNow + this.options.LockTimeout;
+                    var deadline = AddTimeout(now, lockTimeout);
+                    if (!group.Deadline.HasValue || group.Deadline.Value < deadline)
+                    {
+                        group.Deadline = deadline;
+                    }
                     LogTraceSetLockExpiration(new(group.Deadline));
                 }
 
@@ -120,7 +133,8 @@ namespace Orleans.Transactions.State
                 {
                     TransactionId = transactionId,
                     Priority = priority,
-                    Deadline = DateTime.UtcNow + this.options.LockAcquireTimeout
+                    Deadline = AddTimeout(now, this.options.LockAcquireTimeout),
+                    LockTimeout = lockTimeout
                 };
 
                 group.Add(transactionId, record);
@@ -362,8 +376,6 @@ namespace Orleans.Transactions.State
 
                         if (currentGroup != null)
                         {
-                            currentGroup.Deadline = now + this.options.LockTimeout;
-
                             // discard expired waiters that have no chance to succeed
                             // because they have been waiting for the lock for a longer timespan than the
                             // total transaction timeout
@@ -382,6 +394,10 @@ namespace Orleans.Transactions.State
                                     LogTraceExpireLockWaiter(kvp.Key);
                                 }
                             }
+
+                            currentGroup.Deadline = currentGroup.Count == 0
+                                ? null
+                                : AddTimeout(now, currentGroup.Values.Max(record => record.LockTimeout));
 
                             LogTraceLockGroupSize(currentGroup.Count, new(currentGroup.Deadline));
                             if (logger.IsEnabled(LogLevel.Trace))
@@ -405,6 +421,14 @@ namespace Orleans.Transactions.State
                 }
             }
         }
+
+        internal DateTime? CurrentGroupDeadline => currentGroup?.Deadline;
+
+        internal static TimeSpan GetEffectiveLockTimeout(TimeSpan transactionTimeout, TimeSpan configuredLockTimeout)
+            => transactionTimeout > configuredLockTimeout ? transactionTimeout : configuredLockTimeout;
+
+        private static DateTime AddTimeout(DateTime now, TimeSpan timeout)
+            => timeout >= DateTime.MaxValue - now ? DateTime.MaxValue : now + timeout;
 
         private bool Find(Guid guid, bool isRead, out LockGroup group, [NotNullWhen(true)] out TransactionRecord<TState>? record)
         {

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -379,7 +379,7 @@ namespace Orleans.Transactions.State
                             // discard expired waiters that have no chance to succeed
                             // because they have been waiting for the lock for a longer timespan than the
                             // total transaction timeout
-                            foreach (var kvp in currentGroup.ToArray())
+                            foreach (var kvp in currentGroup)
                             {
                                 if (now > kvp.Value.Deadline)
                                 {

--- a/src/Orleans.Transactions/State/ReaderWriterLock.cs
+++ b/src/Orleans.Transactions/State/ReaderWriterLock.cs
@@ -379,7 +379,7 @@ namespace Orleans.Transactions.State
                             // discard expired waiters that have no chance to succeed
                             // because they have been waiting for the lock for a longer timespan than the
                             // total transaction timeout
-                            foreach (var kvp in currentGroup)
+                            foreach (var kvp in currentGroup.ToArray())
                             {
                                 if (now > kvp.Value.Deadline)
                                 {

--- a/src/Orleans.Transactions/State/TransactionalState.cs
+++ b/src/Orleans.Transactions/State/TransactionalState.cs
@@ -67,7 +67,7 @@ namespace Orleans.Transactions
             info.Participants.TryGetValue(this.participantId, out var recordedaccesses);
 
             // schedule read access to happen under the lock
-            return this.queue.RWLock.EnterLock<TResult>(info.TransactionId, info.Priority, recordedaccesses, true, info.UseExclusiveLock,
+            return this.queue.RWLock.EnterLock<TResult>(info.TransactionId, info.Priority, info.Timeout, recordedaccesses, true, info.UseExclusiveLock,
                 () =>
                 {
                     // check if our record is gone because we expired while waiting
@@ -127,7 +127,7 @@ namespace Orleans.Transactions
 
             info.Participants.TryGetValue(this.participantId, out var recordedaccesses);
 
-            return this.queue.RWLock.EnterLock<TResult>(info.TransactionId, info.Priority, recordedaccesses, false, info.UseExclusiveLock,
+            return this.queue.RWLock.EnterLock<TResult>(info.TransactionId, info.Priority, info.Timeout, recordedaccesses, false, info.UseExclusiveLock,
                 () =>
                 {
                     // check if we expired while waiting

--- a/src/Orleans.Transactions/TOC/TransactionCommitter.cs
+++ b/src/Orleans.Transactions/TOC/TransactionCommitter.cs
@@ -62,7 +62,7 @@ namespace Orleans.Transactions
 
             info.Participants.TryGetValue(this.participantId, out var recordedaccesses);
 
-            return this.queue.RWLock.EnterLock<bool>(info.TransactionId, info.Priority, recordedaccesses, false, info.UseExclusiveLock,
+            return this.queue.RWLock.EnterLock<bool>(info.TransactionId, info.Priority, info.Timeout, recordedaccesses, false, info.UseExclusiveLock,
                 () =>
                 {
                     // check if we expired while waiting

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -19,6 +19,55 @@ namespace Orleans.Transactions.Tests;
 public class TransactionRecoveryLatencyTests
 {
     [Fact]
+    public async Task TransactionTimeoutIsPreservedAcrossForks()
+    {
+        var timeout = TimeSpan.FromSeconds(30);
+
+        var transaction = await CreateTransactionAgent(protocol: null!).StartTransaction(readOnly: false, timeout);
+        var fork = transaction.Fork();
+
+        Assert.Equal(timeout, transaction.Timeout);
+        Assert.Equal(timeout, fork.Timeout);
+    }
+
+    [Fact]
+    public async Task ParticipantLockUsesTransactionTimeoutWhenItExceedsConfiguredLockTimeout()
+    {
+        var resource = CreateParticipant("resource", ParticipantId.Role.Resource);
+        var activationLifetime = new TestActivationLifetime();
+        var configuredLockTimeout = TimeSpan.FromSeconds(8);
+        var transactionTimeout = TimeSpan.FromSeconds(30);
+        var queue = new GatedCancelTransactionQueue(
+            resource,
+            activationLifetime,
+            options: new TransactionalStateOptions { LockTimeout = configuredLockTimeout });
+        var transactionId = Guid.NewGuid();
+        var before = DateTime.UtcNow + transactionTimeout;
+
+        await queue.RWLock.EnterLock(
+            transactionId,
+            DateTime.UtcNow,
+            transactionTimeout,
+            default,
+            isRead: true,
+            exclusiveLock: false,
+            static () => true);
+
+        var after = DateTime.UtcNow + transactionTimeout;
+        var deadline = Assert.IsType<DateTime>(queue.RWLock.CurrentGroupDeadline);
+        Assert.InRange(deadline, before, after);
+        Assert.Equal(
+            transactionTimeout,
+            ReadWriteLock<TestState>.GetEffectiveLockTimeout(transactionTimeout, configuredLockTimeout));
+        Assert.Equal(
+            configuredLockTimeout,
+            ReadWriteLock<TestState>.GetEffectiveLockTimeout(TimeSpan.Zero, configuredLockTimeout));
+
+        queue.RWLock.Rollback(transactionId);
+        activationLifetime.Cancel();
+    }
+
+    [Fact]
     public void RestoredRemoteCommitUsesBoundedExponentialPingRetry()
     {
         var frequency = TimeSpan.FromSeconds(60);

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -23,7 +23,7 @@ public class TransactionRecoveryLatencyTests
     {
         var timeout = TimeSpan.FromSeconds(30);
 
-        var transaction = await CreateTransactionAgent(protocol: null!).StartTransaction(readOnly: false, timeout);
+        var transaction = await CreateTransactionAgent(TransactionAgentProtocol.Instance).StartTransaction(readOnly: false, timeout);
         var fork = transaction.Fork();
 
         Assert.Equal(timeout, transaction.Timeout);

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionRecoveryLatencyTests.cs
@@ -123,6 +123,7 @@ public class TransactionRecoveryLatencyTests
         await queue.RWLock.EnterLock(
             transactionId,
             timeStamp,
+            TimeSpan.FromMinutes(1),
             default,
             isRead: false,
             exclusiveLock: false,


### PR DESCRIPTION
## Problem

TOC can acquire its priority-committer lock before Azure-backed participants finish joining a transaction. Transactions request a 10-second execution timeout, but participant locks were independently expired after the configured 8-second lock timeout. Under storage latency, that allowed the committer lock to break before prepare and surfaced `OrleansBrokenTransactionLockException`.

## Solution

Propagate the requested transaction timeout through `TransactionInfo` and its forks, then retain acquired participant locks for the greater of that timeout and the configured lock timeout. Queued lock groups receive the same effective lease when promoted, with the duration applied against each participant's local clock. Regression coverage verifies propagation, fork behavior, fallback behavior, and the held-lock deadline, and the affected TOC theories are re-enabled.

Fixes #9556
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10457)