### PR TITLE
test(transactions): make fault injection deterministic

### DIFF
--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionReource.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionReource.cs
@@ -30,23 +30,38 @@ namespace Orleans.Transactions.TestKit
         public async Task<TransactionalStatus> PrepareAndCommit(Guid transactionId, AccessCounter accessCount, DateTime timeStamp, List<ParticipantId> writeParticipants, int totalParticipants)
         {
             LogInformationStartedPrepareAndCommit(this.logger, context.GrainInstance, transactionId);
-            if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.BeforePrepareAndCommit)
+            var injectBeforeStore = this.faultInjectionControl.TryConsume(
+                TransactionFaultInjectPhase.BeforePrepareAndCommit,
+                out var injectionType);
+            if (injectBeforeStore)
             {
-                if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.ExceptionBeforeStore)
+                if (injectionType == FaultInjectionType.ExceptionBeforeStore)
                     this.faultInjector.InjectBeforeStore = true;
-                if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.ExceptionAfterStore)
+                if (injectionType == FaultInjectionType.ExceptionAfterStore)
                     this.faultInjector.InjectAfterStore = true;
-                if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.GenericExceptionAfterStore)
+                if (injectionType == FaultInjectionType.GenericExceptionAfterStore)
                     this.faultInjector.InjectGenericAfterStore = true;
-                LogInformationInjectedFaultBeforePrepareAndCommit(this.logger, context.GrainInstance, transactionId, faultInjectionControl.FaultInjectionType);
+                LogInformationInjectedFaultBeforePrepareAndCommit(this.logger, context.GrainInstance, transactionId, injectionType);
+                FaultInjectionDiagnosticEvents.Emit(new(
+                    this.context.GrainId,
+                    transactionId,
+                    TransactionFaultInjectPhase.BeforePrepareAndCommit,
+                    injectionType));
             }
             var result = await this.tm.PrepareAndCommit(transactionId, accessCount, timeStamp, writeParticipants, totalParticipants);
-            if (this.faultInjectionControl?.FaultInjectionPhase == TransactionFaultInjectPhase.AfterPrepareAndCommit && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
+            if (this.faultInjectionControl.TryConsume(
+                    TransactionFaultInjectPhase.AfterPrepareAndCommit,
+                    out injectionType)
+                && injectionType == FaultInjectionType.Deactivation)
             {
+                FaultInjectionDiagnosticEvents.Emit(new(
+                    this.context.GrainId,
+                    transactionId,
+                    TransactionFaultInjectPhase.AfterPrepareAndCommit,
+                    injectionType));
                 this.grainRuntime.DeactivateOnIdle(context);
                 LogInformationDeactivatingAfterPrepareAndCommit(this.logger, context.GrainInstance, transactionId);
             }
-            this.faultInjectionControl!.Reset();
             return result;
         }
 
@@ -54,26 +69,38 @@ namespace Orleans.Transactions.TestKit
         {
             LogInformationStartedPrepared(this.logger, context.GrainInstance, transactionId);
             await this.tm.Prepared(transactionId, timeStamp, participant, status);
-            if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterPrepared
-                && this.faultInjectionControl?.FaultInjectionType == FaultInjectionType.Deactivation)
+            if (this.faultInjectionControl.TryConsume(
+                    TransactionFaultInjectPhase.AfterPrepared,
+                    out var injectionType)
+                && injectionType == FaultInjectionType.Deactivation)
             {
+                FaultInjectionDiagnosticEvents.Emit(new(
+                    this.context.GrainId,
+                    transactionId,
+                    TransactionFaultInjectPhase.AfterPrepared,
+                    injectionType));
                 this.grainRuntime.DeactivateOnIdle(context);
                 LogInformationDeactivatingAfterPrepared(this.logger, context.GrainInstance, transactionId);
             }
-            this.faultInjectionControl!.Reset();
         }
 
         public async Task Ping(Guid transactionId, DateTime timeStamp, ParticipantId participant)
         {
             LogInformationStartedPing(this.logger, context.GrainInstance, transactionId);
             await this.tm.Ping(transactionId, timeStamp, participant);
-            if (this.faultInjectionControl?.FaultInjectionPhase == TransactionFaultInjectPhase.AfterPing
-                && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
+            if (this.faultInjectionControl.TryConsume(
+                    TransactionFaultInjectPhase.AfterPing,
+                    out var injectionType)
+                && injectionType == FaultInjectionType.Deactivation)
             {
+                FaultInjectionDiagnosticEvents.Emit(new(
+                    this.context.GrainId,
+                    transactionId,
+                    TransactionFaultInjectPhase.AfterPing,
+                    injectionType));
                 this.grainRuntime.DeactivateOnIdle(context);
                 LogInformationDeactivatingAfterPing(this.logger, context.GrainInstance, transactionId);
             }
-            this.faultInjectionControl!.Reset();
         }
 
         [LoggerMessage(
@@ -145,14 +172,20 @@ namespace Orleans.Transactions.TestKit
         {
             LogInformationStartedCommitReadOnly(this.logger, context.GrainInstance, transactionId);
             var result = await this.tResource.CommitReadOnly(transactionId, accessCount, timeStamp);
-            if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterCommitReadOnly
-                && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
+            if (this.faultInjectionControl.TryConsume(
+                    TransactionFaultInjectPhase.AfterCommitReadOnly,
+                    out var injectionType)
+                && injectionType == FaultInjectionType.Deactivation)
             {
+                FaultInjectionDiagnosticEvents.Emit(new(
+                    this.context.GrainId,
+                    transactionId,
+                    TransactionFaultInjectPhase.AfterCommitReadOnly,
+                    injectionType));
                 this.grainRuntime.DeactivateOnIdle(context);
                 LogInformationDeactivatingAfterCommitReadOnly(this.logger, context.GrainInstance, transactionId);
             }
 
-            this.faultInjectionControl.Reset();
             return result;
         }
 
@@ -160,74 +193,114 @@ namespace Orleans.Transactions.TestKit
         {
             LogInformationAborting(this.logger, context.GrainInstance, transactionId);
             await this.tResource.Abort(transactionId);
-            if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterAbort
-                && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
+            if (this.faultInjectionControl.TryConsume(
+                    TransactionFaultInjectPhase.AfterAbort,
+                    out var injectionType)
+                && injectionType == FaultInjectionType.Deactivation)
             {
+                FaultInjectionDiagnosticEvents.Emit(new(
+                    this.context.GrainId,
+                    transactionId,
+                    TransactionFaultInjectPhase.AfterAbort,
+                    injectionType));
                 this.grainRuntime.DeactivateOnIdle(context);
                 LogInformationDeactivatingAfterAbort(this.logger, context.GrainInstance, transactionId);
             }
-            this.faultInjectionControl.Reset();
         }
 
         public async Task Cancel(Guid transactionId, DateTime timeStamp, TransactionalStatus status)
         {
             LogInformationCancelling(this.logger, context.GrainInstance, transactionId);
             await this.tResource.Cancel(transactionId, timeStamp, status);
-            if (this.faultInjectionControl.FaultInjectionPhase == TransactionFaultInjectPhase.AfterCancel
-                && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
+            if (this.faultInjectionControl.TryConsume(
+                    TransactionFaultInjectPhase.AfterCancel,
+                    out var injectionType)
+                && injectionType == FaultInjectionType.Deactivation)
             {
+                FaultInjectionDiagnosticEvents.Emit(new(
+                    this.context.GrainId,
+                    transactionId,
+                    TransactionFaultInjectPhase.AfterCancel,
+                    injectionType));
                 this.grainRuntime.DeactivateOnIdle(context);
                 LogInformationDeactivatingAfterCancel(this.logger, context.GrainInstance, transactionId);
             }
-            this.faultInjectionControl.Reset();
         }
 
         public async Task Confirm(Guid transactionId, DateTime timeStamp)
         {
             LogInformationStartedConfirm(this.logger, context.GrainInstance, transactionId);
-            if (this.faultInjectionControl?.FaultInjectionPhase == TransactionFaultInjectPhase.BeforeConfirm)
+            var injectBeforeStore = this.faultInjectionControl.TryConsume(
+                TransactionFaultInjectPhase.BeforeConfirm,
+                out var injectionType);
+            if (injectBeforeStore)
             {
-                if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.ExceptionBeforeStore)
+                if (injectionType == FaultInjectionType.ExceptionBeforeStore)
                     this.faultInjector.InjectBeforeStore = true;
-                if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.ExceptionAfterStore)
+                if (injectionType == FaultInjectionType.ExceptionAfterStore)
                     this.faultInjector.InjectAfterStore = true;
-                if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.GenericExceptionAfterStore)
+                if (injectionType == FaultInjectionType.GenericExceptionAfterStore)
                     this.faultInjector.InjectGenericAfterStore = true;
-                LogInformationInjectedFaultBeforeConfirm(this.logger, context.GrainInstance, transactionId, faultInjectionControl.FaultInjectionType);
+                LogInformationInjectedFaultBeforeConfirm(this.logger, context.GrainInstance, transactionId, injectionType);
+                FaultInjectionDiagnosticEvents.Emit(new(
+                    this.context.GrainId,
+                    transactionId,
+                    TransactionFaultInjectPhase.BeforeConfirm,
+                    injectionType));
             }
             await this.tResource.Confirm(transactionId, timeStamp);
-            if (this.faultInjectionControl!.FaultInjectionPhase == TransactionFaultInjectPhase.AfterConfirm
-                && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
+            if (this.faultInjectionControl.TryConsume(
+                    TransactionFaultInjectPhase.AfterConfirm,
+                    out injectionType)
+                && injectionType == FaultInjectionType.Deactivation)
             {
+                FaultInjectionDiagnosticEvents.Emit(new(
+                    this.context.GrainId,
+                    transactionId,
+                    TransactionFaultInjectPhase.AfterConfirm,
+                    injectionType));
                 this.grainRuntime.DeactivateOnIdle(context);
                 LogInformationDeactivatingAfterConfirm(this.logger, context.GrainInstance, transactionId);
             }
-            this.faultInjectionControl.Reset();
         }
 
         public async Task Prepare(Guid transactionId, AccessCounter accessCount, DateTime timeStamp, ParticipantId transactionManager)
         {
             LogInformationStartedPrepare(this.logger, context.GrainInstance, transactionId);
 
-            if (this.faultInjectionControl?.FaultInjectionPhase == TransactionFaultInjectPhase.BeforePrepare)
+            var injectBeforeStore = this.faultInjectionControl.TryConsume(
+                TransactionFaultInjectPhase.BeforePrepare,
+                out var injectionType);
+            if (injectBeforeStore)
             {
-                if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.ExceptionBeforeStore)
+                if (injectionType == FaultInjectionType.ExceptionBeforeStore)
                     this.faultInjector.InjectBeforeStore = true;
-                if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.ExceptionAfterStore)
+                if (injectionType == FaultInjectionType.ExceptionAfterStore)
                     this.faultInjector.InjectAfterStore = true;
-                if (this.faultInjectionControl.FaultInjectionType == FaultInjectionType.GenericExceptionAfterStore)
+                if (injectionType == FaultInjectionType.GenericExceptionAfterStore)
                     this.faultInjector.InjectGenericAfterStore = true;
-                LogInformationInjectedFaultBeforePrepare(this.logger, this.context.GrainInstance, transactionId, faultInjectionControl.FaultInjectionType);
+                LogInformationInjectedFaultBeforePrepare(this.logger, this.context.GrainInstance, transactionId, injectionType);
+                FaultInjectionDiagnosticEvents.Emit(new(
+                    this.context.GrainId,
+                    transactionId,
+                    TransactionFaultInjectPhase.BeforePrepare,
+                    injectionType));
             }
 
             await this.tResource.Prepare(transactionId, accessCount, timeStamp, transactionManager);
-            if (this.faultInjectionControl!.FaultInjectionPhase == TransactionFaultInjectPhase.AfterPrepare
-                && this.faultInjectionControl.FaultInjectionType == FaultInjectionType.Deactivation)
+            if (this.faultInjectionControl.TryConsume(
+                    TransactionFaultInjectPhase.AfterPrepare,
+                    out injectionType)
+                && injectionType == FaultInjectionType.Deactivation)
             {
+                FaultInjectionDiagnosticEvents.Emit(new(
+                    this.context.GrainId,
+                    transactionId,
+                    TransactionFaultInjectPhase.AfterPrepare,
+                    injectionType));
                 this.grainRuntime.DeactivateOnIdle(context);
                 LogInformationDeactivatingAfterPrepare(this.logger, this.context.GrainInstance, transactionId);
             }
-            this.faultInjectionControl.Reset();
         }
 
         [LoggerMessage(

--- a/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionState.cs
+++ b/src/Orleans.Transactions.TestKit.Base/FaultInjection/ControlledInjection/FaultInjectionTransactionState.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
@@ -20,6 +22,74 @@ namespace Orleans.Transactions.TestKit
         {
             this.FaultInjectionType = FaultInjectionType.None;
             this.FaultInjectionPhase = TransactionFaultInjectPhase.None;
+        }
+
+        internal bool TryConsume(TransactionFaultInjectPhase phase, out FaultInjectionType injectionType)
+        {
+            if (this.FaultInjectionPhase != phase)
+            {
+                injectionType = FaultInjectionType.None;
+                return false;
+            }
+
+            injectionType = this.FaultInjectionType;
+            this.Reset();
+            return true;
+        }
+    }
+
+    internal readonly record struct FaultInjectionEvent(
+        GrainId GrainId,
+        Guid TransactionId,
+        TransactionFaultInjectPhase Phase,
+        FaultInjectionType Type);
+
+    internal static class FaultInjectionDiagnosticEvents
+    {
+        private static readonly object LockObj = new();
+        private static ImmutableArray<Action<FaultInjectionEvent>> observers = [];
+
+        public static IDisposable Subscribe(Action<FaultInjectionEvent> observer)
+        {
+            lock (LockObj)
+            {
+                observers = observers.Add(observer);
+            }
+
+            return new Subscription(observer);
+        }
+
+        public static void Emit(FaultInjectionEvent evt)
+        {
+            ImmutableArray<Action<FaultInjectionEvent>> snapshot;
+            lock (LockObj)
+            {
+                snapshot = observers;
+            }
+
+            foreach (var observer in snapshot)
+            {
+                observer(evt);
+            }
+        }
+
+        private sealed class Subscription(Action<FaultInjectionEvent> observer) : IDisposable
+        {
+            private Action<FaultInjectionEvent>? observer = observer;
+
+            public void Dispose()
+            {
+                var value = Interlocked.Exchange(ref this.observer, null);
+                if (value is null)
+                {
+                    return;
+                }
+
+                lock (LockObj)
+                {
+                    observers = observers.Remove(value);
+                }
+            }
         }
     }
 

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/ControlledFaultInjectionTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/ControlledFaultInjectionTransactionTestRunner.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using Orleans.Configuration;
+using Orleans.Runtime;
 
 namespace Orleans.Transactions.TestKit
 {
@@ -76,6 +77,7 @@ namespace Orleans.Transactions.TestKit
                 grains.Count,
                 recoveryEvents,
                 GetDeadline());
+            var faultAttemptSequence = recoveryEvents.LatestRelevantSequence;
             try
             {
                 await this.ExecuteAndWaitForCommit(
@@ -88,6 +90,18 @@ namespace Orleans.Transactions.TestKit
             {
                 this.testOutput($"Fault-injected transaction aborted: {exception}");
                 var deadline = GetDeadline();
+                var fault = await this.ObserveFaultInjection(
+                    faultObserved.Task,
+                    injectionPhase,
+                    injectionType,
+                    recoveryEvents,
+                    deadline);
+                await this.WaitForRecoveryCompletion(
+                    fault.TransactionId,
+                    fault.GrainId,
+                    faultAttemptSequence,
+                    recoveryEvents,
+                    deadline);
                 await this.RetryAfterRecovery(
                     () => this.ExecuteAndWaitForCommit(
                         () => coordinator.MultiGrainAddAndFaultInjection(grains, addval),
@@ -101,6 +115,18 @@ namespace Orleans.Transactions.TestKit
             {
                 this.testOutput($"Fault-injected transaction failed with an ambiguous outcome: {exception}");
                 var deadline = GetDeadline();
+                var fault = await this.ObserveFaultInjection(
+                    faultObserved.Task,
+                    injectionPhase,
+                    injectionType,
+                    recoveryEvents,
+                    deadline);
+                await this.WaitForRecoveryCompletion(
+                    fault.TransactionId,
+                    fault.GrainId,
+                    faultAttemptSequence,
+                    recoveryEvents,
+                    deadline);
                 expected = await this.RetryAfterRecovery(
                     async () =>
                     {
@@ -116,7 +142,7 @@ namespace Orleans.Transactions.TestKit
                     deadline);
             }
 
-            await this.VerifyFaultWasInjected(
+            await this.ObserveFaultInjection(
                 faultObserved.Task,
                 injectionPhase,
                 injectionType,
@@ -190,7 +216,7 @@ namespace Orleans.Transactions.TestKit
                 + recoveryEvents.FormatTimeline());
         }
 
-        private async Task VerifyFaultWasInjected(
+        private async Task<FaultInjectionEvent> ObserveFaultInjection(
             Task<FaultInjectionEvent> observation,
             TransactionFaultInjectPhase phase,
             FaultInjectionType type,
@@ -207,8 +233,10 @@ namespace Orleans.Transactions.TestKit
                         throw new TimeoutException();
                     }
 
-                    await observation.WaitAsync(Stopwatch.GetElapsedTime(now, deadline));
+                    return await observation.WaitAsync(Stopwatch.GetElapsedTime(now, deadline));
                 }
+
+                return await observation;
             }
             catch (TimeoutException)
             {
@@ -218,6 +246,23 @@ namespace Orleans.Transactions.TestKit
                     + Environment.NewLine
                     + recoveryEvents.FormatTimeline());
             }
+        }
+
+        private async Task WaitForRecoveryCompletion(
+            Guid transactionId,
+            GrainId faultingGrainId,
+            long afterSequence,
+            TransactionRecoveryEventObserver recoveryEvents,
+            long deadline)
+        {
+            var transition = await recoveryEvents.WaitForRecoveryCompletionAsync(
+                transactionId,
+                faultingGrainId,
+                afterSequence,
+                deadline);
+            this.testOutput(
+                $"Fault-injected transaction recovery completed. "
+                + TransactionRecoveryEventObserver.FormatTransition(transition).Trim());
         }
 
         private static long GetDeadline()

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/ControlledFaultInjectionTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/ControlledFaultInjectionTransactionTestRunner.cs
@@ -1,13 +1,21 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using AwesomeAssertions;
+using Orleans.Configuration;
 
 namespace Orleans.Transactions.TestKit
 {
     public class ControlledFaultInjectionTransactionTestRunner : TransactionTestRunnerBase
     {
+        private static readonly TimeSpan RecoveryWatchdog =
+            new ClientMessagingOptions().ResponseTimeout
+            + TransactionalStateOptions.DefaultPrepareTimeout
+            + TransactionalStateOptions.DefaultRemoteTransactionPingFrequency
+            + TransactionalStateOptions.DefaultLockTimeout;
+
         public ControlledFaultInjectionTransactionTestRunner(IGrainFactory grainFactory, Action<string> output)
          : base(grainFactory, output)
         { }
@@ -51,49 +59,69 @@ namespace Orleans.Transactions.TestKit
 
             IFaultInjectionTransactionCoordinatorGrain coordinator = this.grainFactory.GetGrain<IFaultInjectionTransactionCoordinatorGrain>(Guid.NewGuid());
 
-            await coordinator.MultiGrainSet(grains, setval);
-            // add delay between transactions so confirmation errors don't bleed into neighboring transactions
-            if (injectionPhase == TransactionFaultInjectPhase.BeforeConfirm || injectionPhase == TransactionFaultInjectPhase.AfterConfirm)
-                await Task.Delay(TimeSpan.FromSeconds(30));
+            var grainIds = grains.Select(grain => grain.GetGrainId()).ToHashSet();
+            using var recoveryEvents = new TransactionRecoveryEventObserver(grainIds);
+            var faultObserved = new TaskCompletionSource<FaultInjectionEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var faultSubscription = FaultInjectionDiagnosticEvents.Subscribe(evt =>
+            {
+                if (grainIds.Contains(evt.GrainId)
+                    && evt.Phase == injectionPhase
+                    && evt.Type == injectionType)
+                {
+                    faultObserved.TrySetResult(evt);
+                }
+            });
+            await this.ExecuteAndWaitForCommit(
+                () => coordinator.MultiGrainSet(grains, setval),
+                grains.Count,
+                recoveryEvents,
+                GetDeadline());
             try
             {
-                await coordinator.MultiGrainAddAndFaultInjection(grains, addval, faultInjectionControl);
-                // add delay between transactions so confirmation errors don't bleed into neighboring transactions
-                if (injectionPhase == TransactionFaultInjectPhase.BeforeConfirm || injectionPhase == TransactionFaultInjectPhase.AfterConfirm)
-                    await Task.Delay(TimeSpan.FromSeconds(30));
+                await this.ExecuteAndWaitForCommit(
+                    () => coordinator.MultiGrainAddAndFaultInjection(grains, addval, faultInjectionControl),
+                    grains.Count,
+                    recoveryEvents,
+                    GetDeadline());
             }
-            catch (OrleansTransactionAbortedException)
+            catch (OrleansTransactionAbortedException exception)
             {
-                // add delay between transactions so errors don't bleed into neighboring transactions
-                await coordinator.MultiGrainAddAndFaultInjection(grains, addval);
+                this.testOutput($"Fault-injected transaction aborted: {exception}");
+                var deadline = GetDeadline();
+                await this.RetryAfterRecovery(
+                    () => this.ExecuteAndWaitForCommit(
+                        () => coordinator.MultiGrainAddAndFaultInjection(grains, addval),
+                        grains.Count,
+                        recoveryEvents,
+                        deadline),
+                    recoveryEvents,
+                    deadline);
             }
-            catch (OrleansTransactionException e)
+            catch (OrleansTransactionException exception)
             {
-                this.testOutput($"Call failed with exception: {e}, retrying without fault");
-                bool cascadingAbort = false;
-                bool firstAttempt = true;
+                this.testOutput($"Fault-injected transaction failed with an ambiguous outcome: {exception}");
+                var deadline = GetDeadline();
+                expected = await this.RetryAfterRecovery(
+                    async () =>
+                    {
+                        var result = await grains[0].Get() + addval;
+                        await this.ExecuteAndWaitForCommit(
+                            () => coordinator.MultiGrainAddAndFaultInjection(grains, addval),
+                            grains.Count,
+                            recoveryEvents,
+                            deadline);
+                        return result;
+                    },
+                    recoveryEvents,
+                    deadline);
+            }
 
-                do
-                {
-                    cascadingAbort = false;
-                    try
-                    {
-                        expected = await grains[0].Get() + addval;
-                        await coordinator.MultiGrainAddAndFaultInjection(grains, addval);
-                    }
-                    catch (OrleansCascadingAbortException)
-                    {
-                        this.testOutput($"Retry failed with OrleansCascadingAbortException: {e}, retrying without fault");
-                        // should only encounter this when faulting after storage write
-                        injectionType.Should().Be(FaultInjectionType.ExceptionAfterStore);
-                        // only allow one retry
-                        firstAttempt.Should().BeTrue();
-                        // add delay prevent castcading abort.
-                        cascadingAbort = true;
-                        firstAttempt = false;
-                    }
-                } while (cascadingAbort);
-            }
+            await this.VerifyFaultWasInjected(
+                faultObserved.Task,
+                injectionPhase,
+                injectionType,
+                recoveryEvents,
+                GetDeadline());
 
             //if transactional state loaded correctly after reactivation, then following should pass
             foreach (var grain in grains)
@@ -102,5 +130,97 @@ namespace Orleans.Transactions.TestKit
                 actual.Should().Be(expected);
             }
         }
+
+        private async Task ExecuteAndWaitForCommit(
+            Func<Task> transaction,
+            int participantCount,
+            TransactionRecoveryEventObserver recoveryEvents,
+            long deadline)
+        {
+            var sequence = recoveryEvents.LatestRelevantSequence;
+            await transaction();
+            var commit = await recoveryEvents.WaitForCommitConfirmationAsync(sequence, participantCount, deadline);
+            this.testOutput(
+                $"Transaction commit and participant confirmations completed. "
+                + TransactionRecoveryEventObserver.FormatTransition(commit).Trim());
+        }
+
+        private async Task RetryAfterRecovery(
+            Func<Task> transaction,
+            TransactionRecoveryEventObserver recoveryEvents,
+            long deadline)
+            => await this.RetryAfterRecovery(
+                async () =>
+                {
+                    await transaction();
+                    return true;
+                },
+                recoveryEvents,
+                deadline);
+
+        private async Task<TResult> RetryAfterRecovery<TResult>(
+            Func<Task<TResult>> transaction,
+            TransactionRecoveryEventObserver recoveryEvents,
+            long deadline)
+        {
+            var attempt = 0;
+            while (Stopwatch.GetTimestamp() < deadline)
+            {
+                attempt++;
+                var sequence = recoveryEvents.LatestRelevantSequence;
+                try
+                {
+                    return await transaction();
+                }
+                catch (OrleansCascadingAbortException exception)
+                {
+                    this.testOutput(
+                        $"Recovery retry {attempt} observed a cascading abort for transaction "
+                        + $"{exception.TransactionId}; waiting for transaction recovery progress.");
+                    var transition = await recoveryEvents.WaitForNextTransitionAsync(sequence, deadline);
+                    this.testOutput(
+                        $"Recovery retry {attempt} observed progress. "
+                        + TransactionRecoveryEventObserver.FormatTransition(transition).Trim());
+                }
+            }
+
+            throw new TimeoutException(
+                $"The fault-injected transaction did not recover within the protocol-derived {RecoveryWatchdog} watchdog."
+                + Environment.NewLine
+                + recoveryEvents.FormatTimeline());
+        }
+
+        private async Task VerifyFaultWasInjected(
+            Task<FaultInjectionEvent> observation,
+            TransactionFaultInjectPhase phase,
+            FaultInjectionType type,
+            TransactionRecoveryEventObserver recoveryEvents,
+            long deadline)
+        {
+            try
+            {
+                if (!observation.IsCompleted)
+                {
+                    var now = Stopwatch.GetTimestamp();
+                    if (now >= deadline)
+                    {
+                        throw new TimeoutException();
+                    }
+
+                    await observation.WaitAsync(Stopwatch.GetElapsedTime(now, deadline));
+                }
+            }
+            catch (TimeoutException)
+            {
+                throw new TimeoutException(
+                    $"The configured {type} fault at {phase} was not observed before the "
+                    + $"{RecoveryWatchdog} watchdog expired."
+                    + Environment.NewLine
+                    + recoveryEvents.FormatTimeline());
+            }
+        }
+
+        private static long GetDeadline()
+            => Stopwatch.GetTimestamp() + (long)(RecoveryWatchdog.TotalSeconds * Stopwatch.Frequency);
     }
 }

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/ControlledFaultInjectionTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/ControlledFaultInjectionTransactionTestRunner.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using Orleans.Configuration;
-using Orleans.Runtime;
 
 namespace Orleans.Transactions.TestKit
 {
@@ -50,7 +49,7 @@ namespace Orleans.Transactions.TestKit
         {
             const int setval = 5;
             const int addval = 7;
-            int expected = setval + addval;
+            int? expected = setval + addval;
             const int grainCount = TransactionTestConstants.MaxCoordinatedTransactions;
             var faultInjectionControl = new FaultInjectionControl() { FaultInjectionPhase = injectionPhase, FaultInjectionType = injectionType };
             List<IFaultInjectionTransactionTestGrain> grains =
@@ -77,7 +76,6 @@ namespace Orleans.Transactions.TestKit
                 grains.Count,
                 recoveryEvents,
                 GetDeadline());
-            var faultAttemptSequence = recoveryEvents.LatestRelevantSequence;
             try
             {
                 await this.ExecuteAndWaitForCommit(
@@ -89,57 +87,12 @@ namespace Orleans.Transactions.TestKit
             catch (OrleansTransactionAbortedException exception)
             {
                 this.testOutput($"Fault-injected transaction aborted: {exception}");
-                var deadline = GetDeadline();
-                var fault = await this.ObserveFaultInjection(
-                    faultObserved.Task,
-                    injectionPhase,
-                    injectionType,
-                    recoveryEvents,
-                    deadline);
-                await this.WaitForRecoveryCompletion(
-                    fault.TransactionId,
-                    fault.GrainId,
-                    faultAttemptSequence,
-                    recoveryEvents,
-                    deadline);
-                await this.RetryAfterRecovery(
-                    () => this.ExecuteAndWaitForCommit(
-                        () => coordinator.MultiGrainAddAndFaultInjection(grains, addval),
-                        grains.Count,
-                        recoveryEvents,
-                        deadline),
-                    recoveryEvents,
-                    deadline);
+                expected = setval;
             }
             catch (OrleansTransactionException exception)
             {
                 this.testOutput($"Fault-injected transaction failed with an ambiguous outcome: {exception}");
-                var deadline = GetDeadline();
-                var fault = await this.ObserveFaultInjection(
-                    faultObserved.Task,
-                    injectionPhase,
-                    injectionType,
-                    recoveryEvents,
-                    deadline);
-                await this.WaitForRecoveryCompletion(
-                    fault.TransactionId,
-                    fault.GrainId,
-                    faultAttemptSequence,
-                    recoveryEvents,
-                    deadline);
-                expected = await this.RetryAfterRecovery(
-                    async () =>
-                    {
-                        var result = await grains[0].Get() + addval;
-                        await this.ExecuteAndWaitForCommit(
-                            () => coordinator.MultiGrainAddAndFaultInjection(grains, addval),
-                            grains.Count,
-                            recoveryEvents,
-                            deadline);
-                        return result;
-                    },
-                    recoveryEvents,
-                    deadline);
+                expected = null;
             }
 
             await this.ObserveFaultInjection(
@@ -149,11 +102,15 @@ namespace Orleans.Transactions.TestKit
                 recoveryEvents,
                 GetDeadline());
 
-            //if transactional state loaded correctly after reactivation, then following should pass
-            foreach (var grain in grains)
+            var actualValues = await this.ReadAfterRecovery(grains, recoveryEvents, GetDeadline());
+            actualValues.Should().OnlyContain(value => value == actualValues[0]);
+            if (expected is { } expectedValue)
             {
-                int actual = await grain.Get();
-                actual.Should().Be(expected);
+                actualValues.Should().OnlyContain(value => value == expectedValue);
+            }
+            else
+            {
+                actualValues.Should().OnlyContain(value => value == setval || value == setval + addval);
             }
         }
 
@@ -171,21 +128,8 @@ namespace Orleans.Transactions.TestKit
                 + TransactionRecoveryEventObserver.FormatTransition(commit).Trim());
         }
 
-        private async Task RetryAfterRecovery(
-            Func<Task> transaction,
-            TransactionRecoveryEventObserver recoveryEvents,
-            long deadline)
-            => await this.RetryAfterRecovery(
-                async () =>
-                {
-                    await transaction();
-                    return true;
-                },
-                recoveryEvents,
-                deadline);
-
-        private async Task<TResult> RetryAfterRecovery<TResult>(
-            Func<Task<TResult>> transaction,
+        private async Task<int[]> ReadAfterRecovery(
+            List<IFaultInjectionTransactionTestGrain> grains,
             TransactionRecoveryEventObserver recoveryEvents,
             long deadline)
         {
@@ -196,22 +140,25 @@ namespace Orleans.Transactions.TestKit
                 var sequence = recoveryEvents.LatestRelevantSequence;
                 try
                 {
-                    return await transaction();
+                    return await Task.WhenAll(grains.Select(grain => grain.Get()));
                 }
-                catch (OrleansCascadingAbortException exception)
+                catch (Exception exception) when (exception is OrleansTransactionTransientFailureException
+                    or OrleansTransactionInDoubtException
+                    or TimeoutException)
                 {
                     this.testOutput(
-                        $"Recovery retry {attempt} observed a cascading abort for transaction "
-                        + $"{exception.TransactionId}; waiting for transaction recovery progress.");
+                        $"Recovery read {attempt} failed with {exception.GetType().Name}; "
+                        + "waiting for transaction recovery progress.");
                     var transition = await recoveryEvents.WaitForNextTransitionAsync(sequence, deadline);
                     this.testOutput(
-                        $"Recovery retry {attempt} observed progress. "
+                        $"Recovery read {attempt} observed progress. "
                         + TransactionRecoveryEventObserver.FormatTransition(transition).Trim());
                 }
             }
 
             throw new TimeoutException(
-                $"The fault-injected transaction did not recover within the protocol-derived {RecoveryWatchdog} watchdog."
+                $"The fault-injected transaction did not become readable within the protocol-derived "
+                + $"{RecoveryWatchdog} watchdog."
                 + Environment.NewLine
                 + recoveryEvents.FormatTimeline());
         }
@@ -246,23 +193,6 @@ namespace Orleans.Transactions.TestKit
                     + Environment.NewLine
                     + recoveryEvents.FormatTimeline());
             }
-        }
-
-        private async Task WaitForRecoveryCompletion(
-            Guid transactionId,
-            GrainId faultingGrainId,
-            long afterSequence,
-            TransactionRecoveryEventObserver recoveryEvents,
-            long deadline)
-        {
-            var transition = await recoveryEvents.WaitForRecoveryCompletionAsync(
-                transactionId,
-                faultingGrainId,
-                afterSequence,
-                deadline);
-            this.testOutput(
-                $"Fault-injected transaction recovery completed. "
-                + TransactionRecoveryEventObserver.FormatTransition(transition).Trim());
         }
 
         private static long GetDeadline()

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
@@ -163,37 +163,6 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
         }
     }
 
-    public async Task<RecoveryTransition> WaitForRecoveryCompletionAsync(
-        Guid transactionId,
-        GrainId faultingGrainId,
-        long afterSequence,
-        long deadline,
-        CancellationToken cancellationToken = default)
-    {
-        while (true)
-        {
-            long observedThrough;
-            lock (this.lockObj)
-            {
-                this.ThrowIfDisposed();
-                var completed = this.timeline.FirstOrDefault(transition =>
-                    transition.Sequence > afterSequence
-                    && this.IsCurrentlyRelevant(transition)
-                    && transition.GrainId == faultingGrainId
-                    && transition.TransactionIds.Contains(transactionId)
-                    && IsRecoveryCompletion(transition));
-                if (completed is not null)
-                {
-                    return completed;
-                }
-
-                observedThrough = this.nextSequence;
-            }
-
-            await this.WaitForNextTransitionAsync(observedThrough, deadline, cancellationToken);
-        }
-    }
-
     public IReadOnlyList<RecoveryTransition> GetTimeline()
     {
         lock (this.lockObj)
@@ -447,13 +416,6 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
 
     private static string FormatTransactionIds(ImmutableArray<Guid> transactionIds)
         => transactionIds.IsDefaultOrEmpty ? "<none>" : $"[{string.Join(",", transactionIds)}]";
-
-    private static bool IsRecoveryCompletion(RecoveryTransition transition)
-        => transition.Kind is RecoveryTransitionKind.AbortAndRestoreCompleted
-            or RecoveryTransitionKind.QueueRestoreCompleted
-            || transition.Kind is RecoveryTransitionKind.TransactionCancelCompleted
-                or RecoveryTransitionKind.TransactionConfirmCompleted
-                && transition.Succeeded == true;
 
     private bool IsCurrentlyRelevant(RecoveryTransition transition)
         => this.relevantGrains is null

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
@@ -136,6 +136,33 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
         }
     }
 
+    public async Task<RecoveryTransition> WaitForCommitConfirmationAsync(
+        long afterSequence,
+        int participantCount,
+        long deadline,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(participantCount, 1);
+
+        while (true)
+        {
+            long observedThrough;
+            lock (this.lockObj)
+            {
+                this.ThrowIfDisposed();
+                var completed = this.FindConfirmedCommitAfter(afterSequence, participantCount);
+                if (completed is not null)
+                {
+                    return completed;
+                }
+
+                observedThrough = this.nextSequence;
+            }
+
+            await this.WaitForNextTransitionAsync(observedThrough, deadline, cancellationToken);
+        }
+    }
+
     public IReadOnlyList<RecoveryTransition> GetTimeline()
     {
         lock (this.lockObj)
@@ -377,7 +404,13 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
             evt.SiloAddress,
             evt.ActivationId,
             status,
-            evt is TransactionDiagnosticEvents.StorageWriteCompleted storageWrite ? storageWrite.CommitCount : null);
+            evt is TransactionDiagnosticEvents.StorageWriteCompleted storageWrite ? storageWrite.CommitCount : null,
+            evt switch
+            {
+                TransactionDiagnosticEvents.TransactionConfirmCompleted confirmed => confirmed.Succeeded,
+                TransactionDiagnosticEvents.TransactionCancelCompleted canceled => canceled.Succeeded,
+                _ => null,
+            });
         return true;
     }
 
@@ -390,6 +423,42 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
 
     private RecoveryTransition? FindTransitionAfter(long sequence)
         => this.timeline.FirstOrDefault(transition => transition.Sequence > sequence && this.IsCurrentlyRelevant(transition));
+
+    private RecoveryTransition? FindConfirmedCommitAfter(long sequence, int participantCount)
+    {
+        foreach (var commit in this.timeline)
+        {
+            if (commit.Sequence <= sequence
+                || !this.IsCurrentlyRelevant(commit)
+                || commit.Kind != RecoveryTransitionKind.StorageWriteCompleted
+                || commit.CommitCount <= 0)
+            {
+                continue;
+            }
+
+            foreach (var transactionId in commit.TransactionIds)
+            {
+                var confirmedParticipants = this.timeline
+                    .Where(transition =>
+                        transition.Sequence > commit.Sequence
+                        && this.IsCurrentlyRelevant(transition)
+                        && transition.Kind == RecoveryTransitionKind.TransactionConfirmCompleted
+                        && transition.TransactionId == transactionId
+                        && transition.Succeeded == true
+                        && transition.GrainId != commit.GrainId)
+                    .Select(transition => transition.GrainId)
+                    .Where(grainId => grainId is not null)
+                    .Distinct()
+                    .Count();
+                if (confirmedParticipants >= participantCount - 1)
+                {
+                    return commit;
+                }
+            }
+        }
+
+        return null;
+    }
 
     private void RemoveWaiter(Waiter waiter)
     {
@@ -464,7 +533,8 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
         SiloAddress? SiloAddress,
         ActivationId ActivationId,
         string? Status,
-        int? CommitCount)
+        int? CommitCount,
+        bool? Succeeded)
     {
         public Guid? TransactionId => this.TransactionIds.Length == 1 ? this.TransactionIds[0] : null;
     }

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
@@ -163,6 +163,37 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
         }
     }
 
+    public async Task<RecoveryTransition> WaitForRecoveryCompletionAsync(
+        Guid transactionId,
+        GrainId faultingGrainId,
+        long afterSequence,
+        long deadline,
+        CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            long observedThrough;
+            lock (this.lockObj)
+            {
+                this.ThrowIfDisposed();
+                var completed = this.timeline.FirstOrDefault(transition =>
+                    transition.Sequence > afterSequence
+                    && this.IsCurrentlyRelevant(transition)
+                    && transition.GrainId == faultingGrainId
+                    && transition.TransactionIds.Contains(transactionId)
+                    && IsRecoveryCompletion(transition));
+                if (completed is not null)
+                {
+                    return completed;
+                }
+
+                observedThrough = this.nextSequence;
+            }
+
+            await this.WaitForNextTransitionAsync(observedThrough, deadline, cancellationToken);
+        }
+    }
+
     public IReadOnlyList<RecoveryTransition> GetTimeline()
     {
         lock (this.lockObj)
@@ -416,6 +447,13 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
 
     private static string FormatTransactionIds(ImmutableArray<Guid> transactionIds)
         => transactionIds.IsDefaultOrEmpty ? "<none>" : $"[{string.Join(",", transactionIds)}]";
+
+    private static bool IsRecoveryCompletion(RecoveryTransition transition)
+        => transition.Kind is RecoveryTransitionKind.AbortAndRestoreCompleted
+            or RecoveryTransitionKind.QueueRestoreCompleted
+            || transition.Kind is RecoveryTransitionKind.TransactionCancelCompleted
+                or RecoveryTransitionKind.TransactionConfirmCompleted
+                && transition.Succeeded == true;
 
     private bool IsCurrentlyRelevant(RecoveryTransition transition)
         => this.relevantGrains is null

--- a/src/Orleans.Transactions.TestKit.xUnit/ControlledFaultInjectionTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.xUnit/ControlledFaultInjectionTransactionTestRunner.cs
@@ -22,7 +22,7 @@ namespace Orleans.Transactions.TestKit.xUnit
             return base.SingleGrainWriteTransaction();
         }
 
-        [SkippableTheory(Skip = "https://github.com/dotnet/orleans/issues/9551")]
+        [SkippableTheory]
         [InlineData(TransactionFaultInjectPhase.AfterPrepare, FaultInjectionType.Deactivation)]
         [InlineData(TransactionFaultInjectPhase.AfterConfirm, FaultInjectionType.Deactivation)]
         [InlineData(TransactionFaultInjectPhase.AfterPrepared, FaultInjectionType.Deactivation)]

--- a/src/api/Orleans.Transactions.TestKit.xUnit/Orleans.Transactions.TestKit.xUnit.cs
+++ b/src/api/Orleans.Transactions.TestKit.xUnit/Orleans.Transactions.TestKit.xUnit.cs
@@ -105,7 +105,7 @@ namespace Orleans.Transactions.TestKit.xUnit
     {
         public ControlledFaultInjectionTransactionTestRunnerxUnit(IGrainFactory grainFactory, Xunit.Abstractions.ITestOutputHelper output) : base(default!, default!) { }
 
-        [SkippableTheory(new[] { }, Skip = "https://github.com/dotnet/orleans/issues/9551")]
+        [SkippableTheory(new[] { })]
         [Xunit.InlineData(new[] { TransactionFaultInjectPhase.AfterPrepare, FaultInjectionType.Deactivation })]
         [Xunit.InlineData(new[] { TransactionFaultInjectPhase.AfterConfirm, FaultInjectionType.Deactivation })]
         [Xunit.InlineData(new[] { TransactionFaultInjectPhase.AfterPrepared, FaultInjectionType.Deactivation })]

--- a/test/Transactions/Orleans.Transactions.Tests/FaultInjectionControlTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/FaultInjectionControlTests.cs
@@ -1,0 +1,45 @@
+using Orleans.Transactions.TestKit;
+using Xunit;
+
+namespace Orleans.Transactions.Tests;
+
+[TestCategory("BVT"), TestCategory("Transactions")]
+public class FaultInjectionControlTests
+{
+    [Theory]
+    [InlineData(TransactionFaultInjectPhase.BeforePrepare, FaultInjectionType.ExceptionBeforeStore)]
+    [InlineData(TransactionFaultInjectPhase.BeforeConfirm, FaultInjectionType.ExceptionAfterStore)]
+    [InlineData(TransactionFaultInjectPhase.AfterPrepare, FaultInjectionType.Deactivation)]
+    public void MatchingPhaseIsConsumedOnce(
+        TransactionFaultInjectPhase phase,
+        FaultInjectionType injectionType)
+    {
+        var control = new FaultInjectionControl
+        {
+            FaultInjectionPhase = phase,
+            FaultInjectionType = injectionType,
+        };
+
+        Assert.True(control.TryConsume(phase, out var consumedType));
+        Assert.Equal(injectionType, consumedType);
+        Assert.Equal(TransactionFaultInjectPhase.None, control.FaultInjectionPhase);
+        Assert.Equal(FaultInjectionType.None, control.FaultInjectionType);
+        Assert.False(control.TryConsume(phase, out consumedType));
+        Assert.Equal(FaultInjectionType.None, consumedType);
+    }
+
+    [Fact]
+    public void NonMatchingPhaseDoesNotConsumeFault()
+    {
+        var control = new FaultInjectionControl
+        {
+            FaultInjectionPhase = TransactionFaultInjectPhase.BeforePrepareAndCommit,
+            FaultInjectionType = FaultInjectionType.ExceptionAfterStore,
+        };
+
+        Assert.False(control.TryConsume(TransactionFaultInjectPhase.BeforePrepare, out var consumedType));
+        Assert.Equal(FaultInjectionType.None, consumedType);
+        Assert.Equal(TransactionFaultInjectPhase.BeforePrepareAndCommit, control.FaultInjectionPhase);
+        Assert.Equal(FaultInjectionType.ExceptionAfterStore, control.FaultInjectionType);
+    }
+}

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionDiagnosticEventsTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionDiagnosticEventsTests.cs
@@ -500,6 +500,55 @@ public class TransactionDiagnosticEventsTests
     }
 
     [Fact]
+    public async Task RecoveryObserverWaitsForMatchingTransactionRecoveryCompletion()
+    {
+        var resource = CreateParticipant(
+            "resource",
+            CreateGrainReference("resource"),
+            ParticipantId.Role.Resource | ParticipantId.Role.Manager);
+        var otherResource = CreateParticipant(
+            "other-resource",
+            CreateGrainReference("other-resource"),
+            ParticipantId.Role.Resource);
+        var transactionId = Guid.NewGuid();
+        var unrelatedTransactionId = Guid.NewGuid();
+        using var observer = new TransactionRecoveryEventObserver(_ => true);
+        var recovery = observer.WaitForRecoveryCompletionAsync(
+            transactionId,
+            resource.Reference.GrainId,
+            afterSequence: 0,
+            GetDeadline(RecoveryObservationTimeout));
+
+        TransactionDiagnosticEvents.EmitAbortAndRestoreCompleted(
+            resource,
+            TransactionalStatus.UnknownException,
+            storageOutcomeInDoubt: false,
+            ImmutableArray.Create(unrelatedTransactionId));
+
+        await Task.Yield();
+        Assert.False(recovery.IsCompleted);
+
+        TransactionDiagnosticEvents.EmitAbortAndRestoreCompleted(
+            otherResource,
+            TransactionalStatus.UnknownException,
+            storageOutcomeInDoubt: false,
+            ImmutableArray.Create(transactionId));
+
+        await Task.Yield();
+        Assert.False(recovery.IsCompleted);
+
+        TransactionDiagnosticEvents.EmitAbortAndRestoreCompleted(
+            resource,
+            TransactionalStatus.UnknownException,
+            storageOutcomeInDoubt: false,
+            ImmutableArray.Create(transactionId));
+
+        var transition = await recovery;
+        Assert.Equal(TransactionRecoveryEventObserver.RecoveryTransitionKind.AbortAndRestoreCompleted, transition.Kind);
+        Assert.Equal(transactionId, Assert.Single(transition.TransactionIds));
+    }
+
+    [Fact]
     public async Task RecoveryObserverLockExpiredTransitionContainsTransactionId()
     {
         var resource = CreateParticipant("resource", ParticipantId.Role.Resource);

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionDiagnosticEventsTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionDiagnosticEventsTests.cs
@@ -418,6 +418,88 @@ public class TransactionDiagnosticEventsTests
     }
 
     [Fact]
+    public async Task RecoveryObserverWaitsForSuccessfulConfirmationFromEveryRemoteParticipant()
+    {
+        var manager = CreateParticipant(
+            "manager",
+            CreateGrainReference("manager"),
+            ParticipantId.Role.Resource | ParticipantId.Role.Manager);
+        var remoteOne = CreateParticipant(
+            "remote-one",
+            CreateGrainReference("remote-one"),
+            ParticipantId.Role.Resource);
+        var remoteTwo = CreateParticipant(
+            "remote-two",
+            CreateGrainReference("remote-two"),
+            ParticipantId.Role.Resource);
+        var transactionId = Guid.NewGuid();
+        var unrelatedTransactionId = Guid.NewGuid();
+        var timestamp = DateTime.UtcNow;
+        using var observer = new TransactionRecoveryEventObserver(_ => true);
+        var confirmation = observer.WaitForCommitConfirmationAsync(
+            afterSequence: 0,
+            participantCount: 3,
+            GetDeadline(RecoveryObservationTimeout));
+
+        TransactionDiagnosticEvents.EmitStorageWriteCompleted(
+            manager,
+            "etag",
+            batchSize: 1,
+            commitCount: 1,
+            ImmutableArray.Create(transactionId));
+        TransactionDiagnosticEvents.EmitTransactionConfirmCompleted(
+            remoteOne,
+            transactionId,
+            timestamp,
+            TransactionalStatus.Ok,
+            queueEntryFound: true,
+            succeeded: true);
+        TransactionDiagnosticEvents.EmitTransactionConfirmCompleted(
+            remoteOne,
+            transactionId,
+            timestamp,
+            TransactionalStatus.Ok,
+            queueEntryFound: true,
+            succeeded: true);
+        TransactionDiagnosticEvents.EmitTransactionConfirmCompleted(
+            manager,
+            transactionId,
+            timestamp,
+            TransactionalStatus.Ok,
+            queueEntryFound: true,
+            succeeded: true);
+        TransactionDiagnosticEvents.EmitTransactionConfirmCompleted(
+            remoteTwo,
+            transactionId,
+            timestamp,
+            TransactionalStatus.UnknownException,
+            queueEntryFound: true,
+            succeeded: false);
+        TransactionDiagnosticEvents.EmitTransactionConfirmCompleted(
+            remoteTwo,
+            unrelatedTransactionId,
+            timestamp,
+            TransactionalStatus.Ok,
+            queueEntryFound: true,
+            succeeded: true);
+
+        await Task.Yield();
+        Assert.False(confirmation.IsCompleted);
+
+        TransactionDiagnosticEvents.EmitTransactionConfirmCompleted(
+            remoteTwo,
+            transactionId,
+            timestamp,
+            TransactionalStatus.Ok,
+            queueEntryFound: true,
+            succeeded: true);
+
+        var commit = await confirmation;
+        Assert.Equal(transactionId, Assert.Single(commit.TransactionIds));
+        Assert.Equal(manager.Reference.GrainId, commit.GrainId);
+    }
+
+    [Fact]
     public async Task RecoveryObserverLockExpiredTransitionContainsTransactionId()
     {
         var resource = CreateParticipant("resource", ParticipantId.Role.Resource);

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionDiagnosticEventsTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionDiagnosticEventsTests.cs
@@ -500,55 +500,6 @@ public class TransactionDiagnosticEventsTests
     }
 
     [Fact]
-    public async Task RecoveryObserverWaitsForMatchingTransactionRecoveryCompletion()
-    {
-        var resource = CreateParticipant(
-            "resource",
-            CreateGrainReference("resource"),
-            ParticipantId.Role.Resource | ParticipantId.Role.Manager);
-        var otherResource = CreateParticipant(
-            "other-resource",
-            CreateGrainReference("other-resource"),
-            ParticipantId.Role.Resource);
-        var transactionId = Guid.NewGuid();
-        var unrelatedTransactionId = Guid.NewGuid();
-        using var observer = new TransactionRecoveryEventObserver(_ => true);
-        var recovery = observer.WaitForRecoveryCompletionAsync(
-            transactionId,
-            resource.Reference.GrainId,
-            afterSequence: 0,
-            GetDeadline(RecoveryObservationTimeout));
-
-        TransactionDiagnosticEvents.EmitAbortAndRestoreCompleted(
-            resource,
-            TransactionalStatus.UnknownException,
-            storageOutcomeInDoubt: false,
-            ImmutableArray.Create(unrelatedTransactionId));
-
-        await Task.Yield();
-        Assert.False(recovery.IsCompleted);
-
-        TransactionDiagnosticEvents.EmitAbortAndRestoreCompleted(
-            otherResource,
-            TransactionalStatus.UnknownException,
-            storageOutcomeInDoubt: false,
-            ImmutableArray.Create(transactionId));
-
-        await Task.Yield();
-        Assert.False(recovery.IsCompleted);
-
-        TransactionDiagnosticEvents.EmitAbortAndRestoreCompleted(
-            resource,
-            TransactionalStatus.UnknownException,
-            storageOutcomeInDoubt: false,
-            ImmutableArray.Create(transactionId));
-
-        var transition = await recovery;
-        Assert.Equal(TransactionRecoveryEventObserver.RecoveryTransitionKind.AbortAndRestoreCompleted, transition.Kind);
-        Assert.Equal(transactionId, Assert.Single(transition.TransactionIds));
-    }
-
-    [Fact]
     public async Task RecoveryObserverLockExpiredTransitionContainsTransactionId()
     {
         var resource = CreateParticipant("resource", ParticipantId.Role.Resource);


### PR DESCRIPTION
The controlled fault injector reset its phase/type only after the wrapped transaction protocol call completed successfully. An injected storage exception therefore left the control armed, so recovery retries could repeatedly inject the same supposedly one-shot fault.

Consume `Before*` faults before entering the wrapped call and preserve `After*` faults until the phase succeeds. Replace fixed delays and unsafe write retries with transaction diagnostics plus read-only recovery probes, verifying that every participant converges atomically to either the pre-transaction or committed value before the protocol-derived watchdog expires. Re-enable the full Azure/DynamoDB theory matrix and cover one-shot fault consumption and commit-confirmation filtering.

Fixes #9551