### PR TITLE
fix(testing): isolate streaming readiness by silo

### DIFF
--- a/test/Extensions/Orleans.Azure.Tests/Streaming/StreamingDiagnosticEventRecorderTests.cs
+++ b/test/Extensions/Orleans.Azure.Tests/Streaming/StreamingDiagnosticEventRecorderTests.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using Orleans.Runtime;
+using Orleans.Streaming.Diagnostics;
+using Orleans.Streams;
+using UnitTests.Grains;
+using Xunit;
+
+namespace UnitTests.Streaming.Reliability;
+
+public class StreamingDiagnosticEventRecorderTests
+{
+    [Fact, TestCategory("BVT"), TestCategory("Streaming")]
+    public async Task ProviderReadinessIgnoresQueueEventsFromOtherSilos()
+    {
+        const string providerName = "provider";
+        var localSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13000), 1);
+        var otherSilo = SiloAddress.New(new IPEndPoint(IPAddress.Loopback, 13001), 1);
+        var queue = QueueId.GetQueueId("queue", 1, 1);
+        using var recorder = new StreamingDiagnosticEventRecorder(new TestLocalSiloDetails(localSilo));
+
+        recorder.OnEvent(new StreamingEvents.PullingAgentStarted(
+            providerName,
+            localSilo,
+            queue,
+            TimeSpan.Zero,
+            TimeSpan.FromSeconds(1)));
+        recorder.OnEvent(new StreamingEvents.QueueReceiverInitialized(providerName, localSilo, queue));
+        recorder.OnEvent(new StreamingEvents.BalancerChanged(
+            providerName,
+            otherSilo,
+            [queue],
+            [],
+            new TestQueueBalancer()));
+
+        await recorder.WaitForProviderReady(providerName, expectedQueueCount: 1, TimeSpan.FromSeconds(1));
+    }
+
+    private sealed class TestLocalSiloDetails(SiloAddress siloAddress) : ILocalSiloDetails
+    {
+        public string Name => "Test";
+        public string ClusterId => "Test";
+        public string DnsHostName => "localhost";
+        public SiloAddress SiloAddress { get; } = siloAddress;
+        public SiloAddress GatewayAddress => SiloAddress;
+    }
+
+    private sealed class TestQueueBalancer : IStreamQueueBalancer
+    {
+        public IEnumerable<QueueId> GetMyQueues() => [];
+        public Task Initialize(IStreamQueueMapper queueMapper) => Task.CompletedTask;
+        public Task Shutdown() => Task.CompletedTask;
+        public bool SubscribeToQueueDistributionChangeEvents(IStreamQueueBalanceListener observer) => true;
+        public bool UnSubscribeFromQueueDistributionChangeEvents(IStreamQueueBalanceListener observer) => true;
+    }
+}

--- a/test/Grains/TestInternalGrains/StreamingDiagnosticsProbeSystemTarget.cs
+++ b/test/Grains/TestInternalGrains/StreamingDiagnosticsProbeSystemTarget.cs
@@ -54,7 +54,8 @@ internal sealed class StreamingDiagnosticsProbeSystemTarget : SystemTarget, IStr
     public Task<string> GetRecentStreamingDiagnostics() => Task.FromResult(_recorder.GetSummary());
 }
 
-public sealed class StreamingDiagnosticEventRecorder : IStartupTask, IDisposable
+public sealed class StreamingDiagnosticEventRecorder(
+    ILocalSiloDetails localSiloDetails) : IStartupTask, IDisposable
 {
     private const int MaxRecentEvents = 64;
     private const int MaxSummaryItems = 8;
@@ -70,6 +71,7 @@ public sealed class StreamingDiagnosticEventRecorder : IStartupTask, IDisposable
     private readonly HashSet<SubscriptionKey> _cursorDrains = [];
     private readonly Queue<string> _recentEvents = new();
     private readonly List<Waiter> _waiters = [];
+    private readonly SiloAddress _localSiloAddress = localSiloDetails.SiloAddress;
 
     private IDisposable? _subscription;
 
@@ -177,8 +179,13 @@ public sealed class StreamingDiagnosticEventRecorder : IStartupTask, IDisposable
         }
     }
 
-    private void OnEvent(StreamingEvents.StreamingEvent evt)
+    internal void OnEvent(StreamingEvents.StreamingEvent evt)
     {
+        if (evt.SiloAddress is { } siloAddress && !siloAddress.Equals(_localSiloAddress))
+        {
+            return;
+        }
+
         List<Waiter>? completedWaiters = null;
 
         lock (_lock)


### PR DESCRIPTION
Streaming diagnostic readiness currently observes process-wide diagnostic events. In multi-silo test hosts, a queue-balancer event from another silo can overwrite the local provider state and make readiness synchronization nondeterministic.

Filter silo-addressed streaming events against the recorder's local silo before updating readiness state. Add a deterministic regression which combines local pulling-agent and receiver events with a foreign-silo balancer event.

This preserves the shared diagnostic subscription while aligning each recorder's readiness state with local queue ownership.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10463)