### PR TITLE
test(streaming): stabilize memory resume startup

### DIFF
--- a/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
+++ b/test/Orleans.Streaming.Tests/StreamingTests/MemoryStreamResumeTests.cs
@@ -1,6 +1,11 @@
 using Microsoft.Extensions.Configuration;
+using Orleans.Configuration;
 using Orleans.Providers;
+using Orleans.Providers.Streams.Common;
+using Orleans.Runtime;
 using Orleans.TestingHost;
+using Orleans.TestingHost.Utils;
+using Xunit;
 
 namespace Tester.StreamingTests
 {
@@ -14,6 +19,53 @@ namespace Tester.StreamingTests
         {
             builder.AddSiloBuilderConfigurator<MySiloBuilderConfigurator>();
             builder.AddClientBuilderConfigurator<MyClientBuilderConfigurator>();
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+            await this.HostedCluster.WaitForLivenessToStabilizeAsync();
+
+            var managementGrain = this.Client.GetGrain<IManagementGrain>(0);
+            var expectedSiloCount = this.HostedCluster.GetActiveSilos().Count();
+            await managementGrain.SendControlCommandToProvider<PersistentStreamProvider>(
+                StreamProviderName,
+                (int)PersistentStreamProviderCommand.StartAgents);
+
+            // Guard against a subsequent membership notification racing the serialized StartAgents command.
+            var consecutiveReadyObservations = 0;
+            const int requiredReadyObservations = 3;
+            await TestingUtils.WaitUntilAsync(
+                async lastTry =>
+                {
+                    var states = await managementGrain.SendControlCommandToProvider<PersistentStreamProvider>(
+                        StreamProviderName,
+                        (int)PersistentStreamProviderCommand.GetAgentsState);
+                    var agentCounts = await managementGrain.SendControlCommandToProvider<PersistentStreamProvider>(
+                        StreamProviderName,
+                        (int)PersistentStreamProviderCommand.GetNumberRunningAgents);
+                    var runningAgentCounts = agentCounts.Select(Convert.ToInt32).ToArray();
+                    var ready = states.Length == expectedSiloCount
+                        && runningAgentCounts.Length == expectedSiloCount
+                        && states.All(state => Convert.ToInt32(state) == (int)StreamLifecycleOptions.RunState.AgentsStarted)
+                        && runningAgentCounts.Sum() == HashRingStreamQueueMapperOptions.DEFAULT_NUM_QUEUES;
+                    consecutiveReadyObservations = ready ? consecutiveReadyObservations + 1 : 0;
+
+                    if (lastTry)
+                    {
+                        Assert.Equal(expectedSiloCount, states.Length);
+                        Assert.Equal(expectedSiloCount, runningAgentCounts.Length);
+                        Assert.All(states, state => Assert.Equal((int)StreamLifecycleOptions.RunState.AgentsStarted, Convert.ToInt32(state)));
+                        Assert.Equal(HashRingStreamQueueMapperOptions.DEFAULT_NUM_QUEUES, runningAgentCounts.Sum());
+                        Assert.True(
+                            consecutiveReadyObservations >= requiredReadyObservations,
+                            $"Stream provider readiness was observed {consecutiveReadyObservations} consecutive time(s), but {requiredReadyObservations} were required.");
+                    }
+
+                    return consecutiveReadyObservations >= requiredReadyObservations;
+                },
+                TimeSpan.FromSeconds(30),
+                delayOnFail: TimeSpan.FromMilliseconds(100));
         }
 
         #region Configuration stuff


### PR DESCRIPTION
## Problem

`MemoryStreamResumeTests.ResumeAfterSlowSubscriber` can begin publishing while the consistent-ring queue balancer is still transferring pulling-agent ownership to the second silo. A retiring in-memory pulling agent can dequeue the first batch before subscriptions attach, then discard it during shutdown, leaving the fast subscriber at zero.

## Solution

Synchronize fixture initialization with the provider lifecycle before any test publishes:

- wait for cluster liveness to stabilize
- send the idempotent `StartAgents` control command, serialized behind pending queue-distribution work
- require every provider manager to be started and the cluster-wide pulling-agent count to match all configured queues for consecutive observations

This removes the startup race without skipping the test or increasing its behavioral timeouts.

Fixes #10436
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10466)