### PR TITLE
docs: deepen runtime architecture internals

### DIFF
--- a/docs/site/src/content/docs/implementation/index.md
+++ b/docs/site/src/content/docs/implementation/index.md
@@ -11,6 +11,28 @@ The implementation track explains how Orleans realizes the virtual actor model. 
 
 The pages in this track use Orleans source and tests as the specification. Internal types are named so that readers can follow an operation through the repository, but those types are not public compatibility contracts unless the page explicitly identifies an extension point.
 
+## A runtime map
+
+An application call enters through generated proxy code, becomes a `Message`, and is routed by the grain directory and placement services. `MessageCenter` delivers it locally or through a `Connection` managed by `ConnectionManager`. The target `Catalog` resolves an activation, where `ActivationData` admits the request and `WorkItemGroup` executes one synchronous turn at a time. Responses travel back through the same messaging and callback pipeline.
+
+The runtime is intentionally layered:
+
+```mermaid
+flowchart LR
+    Proxy[Generated proxy and invokable] --> Factory[MessageFactory]
+    Factory --> Center[MessageCenter]
+    Center --> Directory[Grain directory and placement]
+    Center --> Network[ConnectionManager and transport]
+    Directory --> Activation[Catalog and ActivationData]
+    Activation --> Admission[Request admission]
+    Admission --> Scheduler[WorkItemGroup]
+    Scheduler --> Grain[Grain turn]
+    Grain --> Serialization[Generated codecs and wire format]
+    Serialization --> Network
+```
+
+Use the map below to choose the right depth. The [runtime architecture](runtime-architecture.md) page follows the normal call path; the messaging, serialization, reminder, transaction, and version-skew pages explain the boundaries where failure, persistence, and rolling upgrades change the guarantees.
+
 ## Runtime core
 
 - [Runtime architecture](runtime-architecture.md) follows a call through client, messaging, placement, directory, activation, and scheduling components.
@@ -19,12 +41,16 @@ The pages in this track use Orleans source and tests as the specification. Inter
 - [Grain directory](grain-directory.md) distinguishes the default `LocalGrainDirectory` DHT from the experimental distributed directory.
 - [Scheduling and turn execution](scheduler.md) explains `WorkItemGroup`, continuations, interleaving, and single-threaded execution.
 - [Messaging and delivery semantics](messaging-delivery-guarantees.md) traces requests and explains why a timeout has an unknown outcome.
+- [Transport and networking internals](messaging-networking.md) explains connection establishment, framing, backpressure, and shutdown behavior.
 - [Placement and activation balancing](load-balancing.md) covers the default resource-optimized policy and the opt-in movement protocols.
 
 ## Runtime services and extensibility
 
 - [Lifecycle implementation](orleans-lifecycle.md) describes ordered startup and shutdown.
 - [Serialization and code generation](serialization.md) covers generated codecs, proxies, manifests, wire identity, and custom components.
+- [Reminders](reminders.md) explains ring ownership, durable reminder rows, refresh, and tick delivery.
+- [Transactions](transactions.md) explains transaction agents, managers, participant queues, and recovery decisions.
+- [Rolling version skew](rolling-version-skew.md) connects interface version manifests, compatibility directors, selectors, and wire compatibility during mixed-version operation.
 - [Persistent streams](streams-implementation/index.md) explains pulling agents, queue ownership, caches, cursors, pub-sub, and recovery.
 - [Provider authoring](provider-authoring.md) describes named providers, configuration binding, lifecycle participation, and validation.
 - [TestingHost architecture](testing.md) explains the in-process cluster harness and its substitutions for production services.

--- a/docs/site/src/content/docs/implementation/messaging-delivery-guarantees.md
+++ b/docs/site/src/content/docs/implementation/messaging-delivery-guarantees.md
@@ -35,6 +35,12 @@ The source generator emits a proxy and an invokable request type. `GrainReferenc
 
 Source: [`GrainReferenceRuntime`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Runtime/GrainReferenceRuntime.cs), [`MessageFactory`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Messaging/MessageFactory.cs), [`MessageCenter`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Messaging/MessageCenter.cs), and [`InsideRuntimeClient`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Core/InsideRuntimeClient.cs).
 
+## Address repair and dispatch boundaries
+
+The target grain address is a routing hint, not a lease. `MessageCenter` checks for a local delivery, a proxied client, a usable remote connection, and a known-dead target. At the target, `Catalog` and `ActivationData` validate the grain address and interface version before admitting the request. A stale activation can therefore be invalidated and the request forwarded or rerouted without changing its logical message identity.
+
+The dispatch boundary is also where shutdown policy applies. When application messages are blocked, responses and membership traffic remain eligible while new application requests are rejected or dropped. This allows the lifecycle protocol to drain without pretending that a stopping silo can accept arbitrary new work.
+
 ## Routing repair is not call retry
 
 A message can encounter a stale activation address because an activation deactivated, moved, or its silo failed. The runtime can reject, invalidate, forward, or reroute that same logical request while locating the current activation. Forwarding is bounded by silo messaging options.
@@ -77,6 +83,8 @@ Repeated retry can approximate at-least-once delivery only while the cluster and
 The runtime can return a rejection when it knows that it cannot process a request, for example because of invalid routing or overload. A rejection is stronger evidence than a timeout, but application code must still interpret the rejection type.
 
 Messages have expiration metadata derived from the response timeout. With <xref:Orleans.Configuration.MessagingOptions.DropExpiredMessages?displayProperty=nameWithType> set to `true` (the default), an expired request or response can be dropped instead of consuming work which can no longer complete the original callback.
+
+Rejections carry more information than a timeout because the runtime has made an explicit decision not to process the message. They still do not imply that a prior attempt did not execute: a rejection can be generated after forwarding, activation lookup, or a transport failure. Treat the rejection type as a routing or availability signal, not as a universal rollback.
 
 ## Designing callers
 

--- a/docs/site/src/content/docs/implementation/messaging-networking.md
+++ b/docs/site/src/content/docs/implementation/messaging-networking.md
@@ -1,0 +1,40 @@
+---
+title: Transport and networking internals
+description: Explain how Orleans maintains silo connections, frames messages, and handles transport failure and shutdown.
+ms.date: 08/11/2026
+ms.topic: concept-article
+---
+
+# Transport and networking internals
+
+Orleans separates message routing from transport management. `MessageCenter` decides where a message should go; `ConnectionManager` obtains a usable connection to the target silo; the connection implementation frames, queues, and writes messages to a socket. This separation lets routing repair an activation address without making the transport responsible for grain placement.
+
+## Connection lifecycle
+
+For each remote `SiloAddress`, `ConnectionManager` keeps a `ConnectionEntry` containing active connections, a pending connection attempt, and the last failure time. `GetConnection` reuses an existing connection when one is suitable and starts at most one new attempt per endpoint when none is available. Concurrent senders await the same pending attempt instead of opening an unbounded connection storm.
+
+Connection establishment has a bounded `OpenConnectionTimeout`. A failed attempt clears the pending task, removes defunct connections, records the failure, and applies the configured retry delay before another attempt. A timeout is therefore a transport failure, not evidence that the application message was processed.
+
+Source: [`ConnectionManager`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Networking/ConnectionManager.cs), [`Connection`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Networking/Connection.cs), and [`SiloConnection`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Networking/SiloConnection.cs).
+
+## Message path and framing
+
+When `MessageCenter.SendMessage` has a target silo, it first uses an existing connection, otherwise it asks `ConnectionManager` for one. A local target loops back through receive processing without a socket. A known-dead target is rejected for requests and one-way messages rather than triggering a new connection attempt. Expired messages are dropped before they consume transport work.
+
+The connection pipeline performs the protocol preamble and then exchanges framed payloads. `MessageSerializer` encodes the message header and body using Orleans serialization; the frame helper validates lengths and rejects malformed input before dispatch. TLS, when configured, is middleware around the connection rather than a different message protocol.
+
+The transport queues writes and applies its own flow control. A successful socket write means the frame was handed to the transport, not that the target grain completed the request. Disconnects remove the connection from the endpoint entry and cause later sends to establish a replacement.
+
+## Failure and shutdown
+
+Transport retries repair a connection attempt or a failed write; they do not intentionally invoke a grain method a second time. Application-level response timeouts remain ambiguous because a request can have reached the target before a connection failed.
+
+Shutdown first blocks new application traffic while allowing responses and membership traffic needed to complete the stop protocol. `MessageCenter` rejects or drops blocked messages, stops accepting client messages, and then closes connections. Inbound requests arriving at a stopping silo are rejected or dropped according to message direction, so callers must still handle a rejection or timeout.
+
+## Design trade-offs
+
+- Per-endpoint connection state avoids global coordination but means every silo must observe and repair its own broken paths.
+- Reusing connections reduces handshake and allocation cost, while multiple connections can improve throughput and avoid head-of-line blocking.
+- Dropping expired messages protects a saturated runtime from work whose callback can no longer complete, at the cost of losing a late response that might have been useful to an application retry.
+
+For end-to-end semantics, see [messaging and delivery semantics](messaging-delivery-guarantees.md). Network endpoint selection and firewall requirements belong in [topology, networking, and clustering](../deployment/networking.md).

--- a/docs/site/src/content/docs/implementation/reminders.md
+++ b/docs/site/src/content/docs/implementation/reminders.md
@@ -1,0 +1,36 @@
+---
+title: Reminder implementation
+description: Explain reminder ownership, durable table reconciliation, scheduling, and delivery behavior inside Orleans.
+ms.date: 08/11/2026
+ms.topic: concept-article
+---
+
+# Reminder implementation
+
+Reminders are durable schedules with volatile local execution. A reminder row is stored in an `IReminderTable`; the silo responsible for the grain's consistent-ring range loads that row into `LocalReminderService` and runs the schedule locally. The table is the source of truth for registration, while the local `ReminderData` state is a cache and timer.
+
+## Registration and ownership
+
+`ReminderRegistry` validates names, due times, periods, and the configured minimum period before forwarding the operation to the grain service for the grain's current owner. `LocalReminderService` performs a responsibility check, upserts the row, and reconciles its local entry using the returned ETag. Conditional removal uses the ETag as a concurrency check, so a stale unregister cannot silently delete a newer registration.
+
+The reminder service is a grain service attached to the consistent ring. Ownership changes when membership changes; a new owner discovers the row on its next table read rather than relying on the old silo to transfer an in-memory timer.
+
+## Refresh and reconciliation
+
+After the reminder table starts successfully, the service refreshes the ring range periodically. Reads are staggered and retried during initialization. Each refresh reads the range, compares the table sequence with local mutations, starts or updates entries which are now owned, and stops entries which disappeared or moved elsewhere. A local sequence prevents a concurrent registration or removal from being overwritten by an older refresh result.
+
+This is deliberately reconciliation, not a distributed lock around every tick. A brief ownership overlap during membership convergence is possible; ETags, responsibility checks, and the service's delivery state prevent a stale owner from continuing indefinitely.
+
+## Tick delivery
+
+Each local reminder has a small state machine: stopped, runnable, running, and stopping. Its loop computes the next due time from the stored start time and period, waits using the reminder `TimeProvider`, and invokes the target grain through the normal messaging path. The service counts active deliveries and refuses new ticks after shutdown begins, then waits for active deliveries to quiesce.
+
+A tick is not a durable queue item. If the owner or process fails, the next owner reconstructs the schedule from the row. A slow or unavailable grain can therefore delay a tick, and a process failure can result in a later delivery without a durable record of every missed occurrence. Reminder callbacks should be idempotent and should not assume exactly-once execution.
+
+## Storage and operational boundaries
+
+The in-memory table is suitable for development only. Production tables provide the durability and concurrency behavior required for ownership changes, but their consistency and availability characteristics remain provider-specific. Table startup is part of silo lifecycle initialization; failure to open the configured table prevents normal reminder service startup.
+
+The [timers and reminders guide](../grains/timers-and-reminders.md) owns registration usage. This page explains why reminder persistence, ring movement, refresh intervals, and callback failures affect observed behavior.
+
+Source: [`LocalReminderService`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Reminders/ReminderService/LocalReminderService.cs), [`ReminderRegistry`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Reminders/ReminderService/ReminderRegistry.cs), and [`IReminderTable`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Reminders/SystemTargetInterfaces/IReminderTable.cs).

--- a/docs/site/src/content/docs/implementation/rolling-version-skew.md
+++ b/docs/site/src/content/docs/implementation/rolling-version-skew.md
@@ -1,0 +1,48 @@
+---
+title: Rolling version skew
+description: Explain how Orleans routes grain interface versions and preserves compatibility while silos run different builds.
+ms.date: 08/11/2026
+ms.topic: concept-article
+---
+
+# Rolling version skew
+
+During a rolling deployment, silos can advertise different versions of the same grain interface. Orleans separates two questions: **compatibility** asks whether a requested version can be served by a candidate version, and **selection** chooses which compatible candidate to use. The grain version manifest, compatibility directors, selectors, and placement service answer those questions together.
+
+## Version discovery and selection
+
+Each silo contributes supported interface versions to `GrainVersionManifest`. The cached selector manager keys its result by grain type, interface, and requested version. It obtains available versions, filters them through the configured compatibility director, selects one or more versions, and maps those versions to suitable silos. The cache is invalidated when version or compatibility strategies change.
+
+The built-in strategies have intentionally different upgrade behavior:
+
+| Strategy | Effect |
+| --- | --- |
+| Strict compatibility | Only the same interface version is eligible. |
+| Backward compatibility | A newer implementation may serve an older request when the director says it is compatible. |
+| All versions compatible | Every advertised version is eligible. |
+| Latest selector | Choose the highest compatible version. |
+| Minimum selector | Choose the lowest compatible version. |
+| All compatible selector | Keep all compatible versions as placement candidates. |
+
+The selector does not make an incompatible contract safe. It only turns the compatibility decision into a placement set.
+
+## Activation checks
+
+Placement chooses a suitable silo, but an activation also validates the incoming interface version against its local implementation. If the activation's version is not compatible, the runtime invalidates the stale route and returns the message to routing rather than executing the method against an incompatible implementation. This is why a version change can cause activation movement or a retry of routing without being an application-level call retry.
+
+## Wire compatibility is a separate contract
+
+Version routing cannot repair incompatible bytes. Request and response types must remain readable by both old and new builds for as long as mixed traffic, queued messages, reminders, streams, or persisted state can cross the boundary. Keep serialization IDs stable, add fields instead of reusing IDs, retain aliases when CLR names move, and ensure custom codecs skip fields they do not understand. See [serialization and code generation internals](serialization.md) for the wire-level rules.
+
+Interface versioning also does not version grain state. Both implementations must read the stored representation and tolerate writes from the other while rollback or mixed placement remains possible.
+
+## Failure modes and rollout implications
+
+- If no compatible silo is available, placement cannot complete the request and the caller receives a rejection or eventually a timeout.
+- If a stale activation receives a request, cache invalidation and routing repair can locate a compatible activation; this is not an automatic duplicate invocation policy.
+- Changing a selector or compatibility strategy resets the suitable-silo cache, so subsequent placements reflect the new policy.
+- Removing the old implementation before all callers and durable data are compatible can turn a planned rolling deployment into an outage.
+
+The [interface versioning guide](../grains/grain-versioning/grain-versioning.md) and [deployment and rollback guidance](../migration/deployment-and-rollback.md) own configuration and rollout procedures. This page documents the runtime decision chain.
+
+Source: [`GrainVersionManifest`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Core/Manifest/GrainVersionManifest.cs), [`CachedVersionSelectorManager`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Versions/CachedVersionSelectorManager.cs), [`AllCompatibleVersionsSelector`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Versions/Selector/AllCompatibleVersionsSelector.cs), and [`ActivationData`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Runtime/Catalog/ActivationData.cs).

--- a/docs/site/src/content/docs/implementation/scheduler.md
+++ b/docs/site/src/content/docs/implementation/scheduler.md
@@ -61,6 +61,10 @@ Therefore, grain state is protected from parallel access by the scheduler but ca
 
 The user-facing rules are documented in [request scheduling](../grains/request-scheduling.md). Internally, request admission and task serialization remain separate layers.
 
+Admission is a state machine, not a second thread pool. `ActivationData` keeps pending requests and running requests, evaluates the current interleaving policy, and starts an eligible request by enqueueing its work on the activation scheduler. Completion signals admission to reevaluate the queue. A request which is waiting on an incomplete task therefore occupies a logical slot according to the request policy, while its executing thread returns to the pool.
+
+Call-chain reentrancy is narrower than grain-wide reentrancy: it permits progress for calls which belong to the current chain while preserving the non-interleaving default for unrelated calls. `AlwaysInterleave` and `MayInterleave` are explicit opt-ins because they trade simpler invariants for throughput or avoidance of dependency cycles.
+
 ## Runtime context and inline execution
 
 `ActivationTaskScheduler.TryExecuteTaskInline` permits inline execution only when the current `RuntimeContext` belongs to the same `WorkItemGroup` and the task was not already queued. Runtime helpers follow the same rule: execute inline in the matching grain context, otherwise enqueue.
@@ -78,3 +82,5 @@ Blocking a turn prevents every queued continuation and admitted request for that
 `WorkItemGroup` drains work subject to runtime scheduling limits so one busy activation does not permanently own a thread-pool worker. Long synchronous turns still delay other work and are reported by runtime scheduling diagnostics. The [.NET diagnostics tools](https://learn.microsoft.com/dotnet/core/diagnostics/) provide the underlying runtime traces, counters, and dumps used alongside Orleans telemetry.
 
 Scheduling guarantees are local to an activation. They do not order calls across grains, create a distributed lock, or provide message exactly-once behavior.
+
+The scheduler also does not provide fairness across activations. A long synchronous turn consumes a thread-pool worker and delays that activation's requests; a burst of work across many activations competes for the process-wide pool. Queue length and turn-duration diagnostics are therefore capacity signals, not proof that a grain is deadlocked.

--- a/docs/site/src/content/docs/implementation/serialization.md
+++ b/docs/site/src/content/docs/implementation/serialization.md
@@ -58,11 +58,17 @@ The wire protocol uses writer and reader sessions to track references and type i
 
 Deep copying is a separate operation used when Orleans must preserve isolation without crossing a transport boundary. Immutable values can bypass copying; mutable values require a generated or custom copier. Declaring a mutable type immutable trades safety for speed and must be justified by the type's actual behavior.
 
+Field headers carry an ID and wire type, so readers can consume fields in a different source order. Generated readers dispatch known IDs and call `ConsumeUnknownField` for fields introduced by a newer writer. This is the mechanism which makes additive evolution possible; it is not safe to change the wire type or reuse an ID for a different meaning.
+
+Reference tracking is scoped to a writer/reader session. It preserves repeated references and cycles within a payload, but it is not a distributed identity mechanism and does not deduplicate requests across retries. A deep copier uses a corresponding session so a copied graph has the same aliasing relationships as the serialized graph.
+
 ## RPC generation
 
 For each grain interface method, generated code captures arguments in an invokable object. The generated proxy submits that object through its proxy base. On the target, generated dispatch metadata invokes the concrete implementation and encodes the response.
 
 The request object is serializable like any other Orleans value. Stable method and interface metadata allow caller and target assemblies to evolve independently within the supported versioning rules. Outgoing and incoming call filters wrap the generated invocation; they do not replace serialization or dispatch.
+
+The generated request type and response envelope are part of the rolling-upgrade boundary. Old code must be able to skip fields it does not know, and new code must supply compatible defaults when an old sender omits fields. Method identity and interface version routing are separate from value wire identity: a compatible interface can still fail if its argument or result types cannot be decoded.
 
 ## Runtime manifest and type safety
 

--- a/docs/site/src/content/docs/implementation/transactions.md
+++ b/docs/site/src/content/docs/implementation/transactions.md
@@ -1,0 +1,51 @@
+---
+title: Transaction implementation
+description: Explain Orleans transaction coordination, participant queues, commit decisions, and recovery behavior.
+ms.date: 08/11/2026
+ms.topic: concept-article
+---
+
+# Transaction implementation
+
+Orleans transactions coordinate transactional state across grains. The runtime uses a transaction agent to collect participants and choose a commit path, a transaction manager to make the durable decision, and a `TransactionQueue` at each participant to serialize versions and apply or restore state.
+
+## Coordination model
+
+`TransactionAgent.StartTransaction` creates a transaction ID and causal timestamp, rejecting new work when the overload detector reports that the silo cannot safely admit more transactions. As grain calls access transactional resources, the transaction context records read and write counters and identifies a manager. Read-only transactions can contact resources directly. Read-write transactions send prepare messages to other resources and ask the manager to prepare and commit.
+
+The manager is selected from the participants, with an explicit priority manager taking precedence. The agent sends one-way prepare notifications to non-manager resources, then waits for the manager's result. This reduces coordination round trips while keeping one authoritative decision for write transactions.
+
+```mermaid
+sequenceDiagram
+    participant Agent as TransactionAgent
+    participant Resource as Participant queues
+    participant Manager as Transaction manager
+    participant Store as Transactional storage
+    Agent->>Resource: prepare reads and writes
+    Agent->>Manager: prepare and commit
+    Manager->>Store: persist decision/record
+    Manager-->>Resource: commit or abort
+    Resource->>Store: apply or restore state
+```
+
+## Participant queues and isolation
+
+`TransactionQueue` keeps pending transaction records, commit records, and a stable sequence for a transactional state. It uses access counters to determine whether a transaction read or wrote a resource, holds the required locks while a transaction is unresolved, and applies the committed state in order. A participant can therefore reject a conflicting access before the manager has committed.
+
+Transactional storage is not just ordinary grain persistence with a transaction ID attached. The provider wrapper must support the queue's load, commit, restore, and recovery operations. A storage failure can leave a transaction in a prepared or uncertain state, which is why the queue persists enough information to recover after activation or process restart.
+
+## Decisions and failure behavior
+
+The agent distinguishes a successful decision, a participant response timeout, a transaction-manager response timeout, and a presumed abort. A timeout does not mean that no participant changed: the manager may have durably committed while its response was lost. When the result is definitely aborted and the manager has not taken ownership of notifications, the agent sends cancel messages to release participant locks.
+
+The manager's durable decision owns later participant notification. Recovery replays commit confirmations and aborts from the manager or participant queue records. If a participant cannot be reached, the transaction remains observable as recovering or failed rather than being treated as successfully committed by the caller.
+
+Disabled transactions use a separate agent which rejects transactional operations instead of silently providing weaker semantics. Overload throttling is also explicit: callers receive a transaction-start failure rather than an unbounded queue.
+
+## Trade-offs and boundaries
+
+The protocol favors serializable state transitions and recovery over low latency. Read-only work avoids the manager's write path, while write transactions pay for coordination and durable records. Transaction atomicity applies to registered transactional resources; unrelated side effects such as an external HTTP call are not rolled back.
+
+Application guidance belongs in [transactions](../grains/transactions.md). Provider implementations and fault-injection tests are useful source authorities when evaluating a storage provider's recovery behavior.
+
+Source: [`TransactionAgent`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Transactions/DistributedTM/TransactionAgent.cs), [`TransactionManager`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Transactions/State/TransactionManager.cs), and [`TransactionQueue`](https://github.com/dotnet/orleans/blob/main/src/Orleans.Transactions/State/TransactionQueue.cs).

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -275,10 +275,18 @@ items:
         href: implementation/scheduler.md
       - name: Messaging and delivery semantics
         href: implementation/messaging-delivery-guarantees.md
+      - name: Transport and networking internals
+        href: implementation/messaging-networking.md
       - name: Placement and activation balancing
         href: implementation/load-balancing.md
       - name: Serialization and code generation
         href: implementation/serialization.md
+      - name: Reminders
+        href: implementation/reminders.md
+      - name: Transactions
+        href: implementation/transactions.md
+      - name: Rolling version skew
+        href: implementation/rolling-version-skew.md
       - name: Persistent streams
         items:
           - name: Architecture


### PR DESCRIPTION
## Problem
Issue #10390 identified a shallow and incomplete implementation documentation track, making it difficult to trace runtime behavior and reason about failure, persistence, and rolling-version boundaries.

## Solution
Turn the implementation overview into a runtime map, deepen messaging, scheduling, and serialization internals, and add focused pages for transport networking, reminders, transactions, and rolling version skew. Register all pages in the site navigation and cross-link implementation detail to task-oriented guidance.

## Rationale
The content is grounded in current Orleans source code and preserves existing implementation URLs and anchors while giving contributors and operators a coherent map of the runtime and its guarantees.

Fixes #10390
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10479)