### PR TITLE
docs: add end-to-end Orleans walkthroughs

### DIFF
--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -22,6 +22,14 @@ items:
         href: tutorials-and-samples/adventure.md
       - name: Build custom grain storage
         href: tutorials-and-samples/custom-grain-storage.md
+      - name: Build and deploy a production-shaped application
+        href: tutorials-and-samples/production-application.md
+      - name: Test an Orleans application end to end
+        href: tutorials-and-samples/testing-walkthrough.md
+      - name: Build and recover a streaming application
+        href: tutorials-and-samples/streaming-walkthrough.md
+      - name: Perform a rolling upgrade
+        href: tutorials-and-samples/rolling-upgrade.md
   - name: Develop applications
     items:
       - name: Grains

--- a/docs/site/src/content/docs/tutorials-and-samples/index.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/index.md
@@ -24,6 +24,10 @@ For a more typical project structure, [Build your first Orleans app](../quicksta
 
 | Tutorial | What it teaches |
 | --- | --- |
+| [Build and deploy a production-shaped application](production-application.md) | Run, deploy, observe, and verify a multi-process Orleans application. |
+| [Test an Orleans application end to end](testing-walkthrough.md) | Progress from a first cluster test to reusable fixtures and topology changes. |
+| [Build and recover a streaming application](streaming-walkthrough.md) | Follow events through a real provider and verify recovery from checkpoints. |
+| [Perform a rolling upgrade](rolling-upgrade.md) | Evolve grain contracts and state while mixed versions remain online. |
 | [Custom grain storage](custom-grain-storage.md) | Implement and register an <xref:Orleans.Storage.IGrainStorage> provider. |
 | [Deploy and scale on Azure](../quickstarts/deploy-scale-orleans-on-azure.md) | Deploy an Orleans app to Azure Container Apps and configure shared providers. |
 

--- a/docs/site/src/content/docs/tutorials-and-samples/production-application.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/production-application.md
@@ -1,0 +1,91 @@
+---
+title: Build and deploy a production-shaped Orleans application
+description: Run, inspect, deploy, and verify a multi-process Orleans application on Azure Container Apps.
+ms.date: 08/11/2026
+ms.topic: tutorial
+---
+
+# Build and deploy a production-shaped Orleans application
+
+This walkthrough takes you from an empty directory to a deployed, observable Orleans cluster. You use the maintained [Azure Container Apps sample](https://github.com/dotnet/orleans/tree/main/samples/Deployment/AzureContainerApps) so that the application, infrastructure, and deployment workflow stay buildable together.
+
+The finished system has dedicated silos, an HTTP API and worker client, Azure Table Storage clustering, managed identity, health probes, Application Insights, and an Orleans Dashboard. Grain state isn't persisted in this sample; add a grain-storage provider before storing application state.
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- [Git](https://git-scm.com/downloads)
+- [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite) for local clustering
+- An Azure subscription and [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) for deployment
+
+## Get the application
+
+From an empty working directory:
+
+```powershell
+git clone https://github.com/dotnet/orleans.git
+cd orleans
+dotnet build .\samples\Deployment\AzureContainerApps\HelloOrleans.sln -c Release
+```
+
+Explore the projects before running them:
+
+| Project | Responsibility |
+| --- | --- |
+| `Abstractions` | Grain interfaces and serialized contracts shared by callers and silos. |
+| `Grains` | Grain implementations and placement policy. |
+| `Silo` | A dedicated Orleans server process. |
+| `Clients.MinimalApi` | An HTTP API which calls grains through an Orleans client. |
+| `Clients.WorkerService` | A background client which sends simulated sensor updates. |
+| `Dashboard` | A separately deployed dashboard silo. |
+| `Infrastructure` | Shared identity, clustering, endpoint, and telemetry configuration. |
+
+This separation lets clients and silos scale and deploy independently. It also keeps contracts independent from implementations.
+
+## Run the system locally
+
+Start Azurite, then open four terminals at the repository root:
+
+```powershell
+dotnet run --project .\samples\Deployment\AzureContainerApps\Silo
+dotnet run --project .\samples\Deployment\AzureContainerApps\Dashboard
+dotnet run --project .\samples\Deployment\AzureContainerApps\Clients.MinimalApi
+dotnet run --project .\samples\Deployment\AzureContainerApps\Clients.WorkerService
+```
+
+Each launch profile selects the Development environment and connects to Azurite. Verify the system before deploying:
+
+1. Open the dashboard URL printed by the `Dashboard` process and confirm that its silo and the dedicated silo are active.
+1. Call `GET /hello/0` on the Minimal API and confirm that it returns a greeting.
+1. Call `GET /providers` and confirm that grain key `0` appears.
+1. Stop the worker and confirm that API calls continue; clients aren't cluster members and can restart independently.
+
+## Understand the production configuration
+
+Development uses a storage emulator. Deployed processes instead use <xref:Azure.Identity.DefaultAzureCredential> with a user-assigned managed identity and an Azure Table service URI. The deployment grants data-plane access without distributing storage keys.
+
+Every deployed silo has a unique advertised silo and gateway endpoint. Azure Container Apps replicas within one app don't provide Orleans with unique, documented replica addresses, so the sample deploys each silo as a separate one-replica Container App. Add capacity by adding another silo app with unused ports, not by increasing a silo app's replica count.
+
+Review the sample's [deployment README](https://github.com/dotnet/orleans/blob/main/samples/Deployment/AzureContainerApps/README.md) and `Azure/bootstrap.bicep` before assigning roles. The privileged bootstrap and routine deployment are deliberately separate.
+
+## Deploy
+
+1. Fork the Orleans repository and enable GitHub Actions.
+1. Configure a GitHub OIDC identity restricted to your fork and a protected `azure-container-apps` environment.
+1. Run the sample's one-time privileged bootstrap to create the registry, membership storage, runtime identity, and least-privilege role assignments.
+1. Copy `samples/Deployment/AzureContainerApps/deployment/deploy.yml` to `.github/workflows/deploy-orleans-container-apps.yml`.
+1. Add the environment variables listed in the sample README, then run the workflow.
+
+The workflow builds images, pushes immutable Git-SHA tags, deploys by image digest, and authenticates without a client secret.
+
+## Verify the deployment
+
+Connect from the environment's virtual network, then:
+
+1. Confirm that every expected silo is active in the dashboard.
+1. Exercise `GET /hello/0`, `GET /hello/255`, and `GET /providers`.
+1. Verify that invalid grain keys return HTTP 400.
+1. Confirm that startup, readiness, and liveness probes are healthy.
+1. Inspect traces and logs in Application Insights and confirm that requests cross the API-to-grain boundary.
+
+Before adapting this system for production, work through the [production-readiness checklist](../deployment/production-readiness.md), configure [durable grain storage](../grains/grain-persistence/index.md), and rehearse the [rolling-upgrade walkthrough](rolling-upgrade.md).

--- a/docs/site/src/content/docs/tutorials-and-samples/rolling-upgrade.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/rolling-upgrade.md
@@ -1,0 +1,93 @@
+---
+title: Perform a rolling Orleans upgrade
+description: Evolve a grain interface and state safely, validate mixed versions, roll the cluster, and rehearse rollback.
+ms.date: 08/11/2026
+ms.topic: tutorial
+---
+
+# Perform a rolling Orleans upgrade
+
+This walkthrough takes an application from version 1 to version 2 without stopping the cluster. It combines interface versioning, serializer compatibility, state evolution, deployment order, observation, and rollback.
+
+Use a staging environment with the same clustering and storage providers as production. A localhost cluster can't validate membership propagation, readiness, draining, or provider behavior.
+
+## Establish the version 1 baseline
+
+Deploy at least two version 1 silos and a version 1 client. Select a grain identity and:
+
+1. Call every operation which the upgrade changes.
+1. Persist representative state, including optional and boundary values.
+1. Record successful-call, failed-call, activation, serialization, and state-read metrics.
+1. Save the exact version 1 artifacts and configuration needed for rollback.
+
+Do not proceed until the baseline is repeatable.
+
+## Make the contract additive
+
+Create version 2 by retaining every version 1 method and adding new behavior through a new method. Apply `[Version(2)]` to the new interface. The attribute changes routing; it doesn't make an incompatible contract safe.
+
+For serialized request, response, and state types:
+
+- keep every existing `[Id]` value unchanged;
+- assign new IDs to new fields;
+- give new fields defaults which version 1 data can tolerate;
+- keep old result and exception types available; and
+- don't change the meaning of an existing field.
+
+If version 2 needs a new state representation, first deploy code which can read both representations while continuing to write the old one. Delay irreversible writes until rollback is no longer required.
+
+See the [grain contract compatibility guidelines](../grains/grain-versioning/backward-compatibility-guidelines.md) for examples.
+
+## Test mixed versions
+
+Build a matrix instead of testing each version alone:
+
+| Caller | Silo implementation | Expected result |
+| --- | --- | --- |
+| Version 1 | Version 1 | Existing operations and state remain unchanged. |
+| Version 1 | Version 2 | Existing operations retain version 1 semantics. |
+| Version 2 | Version 2 | New and existing operations succeed. |
+| Version 2 | Version 1 | New calls are routed away from incompatible activations. |
+
+Run the matrix against state first written by version 1 and state subsequently touched by version 2. Restart silos between cases to prove that compatibility doesn't depend on an existing activation.
+
+## Configure compatible routing
+
+The default rolling-upgrade policy uses `BackwardCompatible` compatibility with `AllCompatibleVersions` selection. Confirm that your application hasn't overridden these strategies. Use <xref:Orleans.Versions.Selector.LatestVersion> only when new activations should prefer the newest compatible implementation; it doesn't proactively replace existing compatible activations.
+
+## Roll forward
+
+1. Start one version 2 silo while all version 1 silos and callers remain active.
+1. Wait until membership converges and readiness checks pass.
+1. Send version 1 traffic through existing and new grain identities. Confirm that version 2 preserves old behavior.
+1. Add enough version 2 capacity for the expected traffic.
+1. Deploy version 2 callers and exercise the new operation.
+1. Watch incompatible-request deactivations, placement failures, serialization failures, state-read failures, latency, and error rate.
+1. Drain version 1 callers.
+1. Gracefully stop one version 1 silo at a time, waiting for membership convergence and stable traffic after each removal.
+
+Keep the version 1 deployment artifacts and backward-compatible state contract until the rollback window closes.
+
+## Rehearse rollback
+
+While both versions are present:
+
+1. Stop version 2 callers so that no new-only requests enter the system.
+1. Route traffic through version 1 callers.
+1. Stop version 2 silos one at a time.
+1. Confirm that version 1 silos can activate grains whose state was touched by version 2.
+1. Compare behavior and telemetry with the version 1 baseline.
+
+If version 1 can't read version 2 writes, stopping version 2 doesn't restore the service. Restore from a tested data backup or complete a forward fix according to the incident plan; don't repeatedly reactivate incompatible grains.
+
+## Complete the migration
+
+After the rollback window:
+
+1. Remove version 1 callers and silos from deployment definitions.
+1. Confirm through telemetry that the old method is unused.
+1. Enable new state writes if they were delayed.
+1. Keep old-state readers for the retention period needed to activate dormant grains.
+1. Remove compatibility code only in a later, separately reversible deployment.
+
+For strategy details, see [deploy new grain interface versions](../grains/grain-versioning/deploying-new-versions-of-grains.md) and [graceful shutdown and upgrades](../deployment/upgrades.md).

--- a/docs/site/src/content/docs/tutorials-and-samples/streaming-walkthrough.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/streaming-walkthrough.md
@@ -31,7 +31,7 @@ Without `Secrets.json`, both hosts register the named in-memory stream provider.
 Observe these transitions in the silo log:
 
 1. `ConsumerGrain` activates when the first matching event arrives.
-1. Orleans supplies an <xref:Orleans.Streams.IStreamSubscriptionHandleFactory>.
+1. Orleans supplies an <xref:Orleans.Streams.Core.IStreamSubscriptionHandleFactory>.
 1. The grain resumes the subscription with its observer.
 1. `OnNextAsync` logs the event and its sequence token.
 

--- a/docs/site/src/content/docs/tutorials-and-samples/streaming-walkthrough.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/streaming-walkthrough.md
@@ -1,0 +1,78 @@
+---
+title: Build and recover an Orleans streaming application
+description: Run producers and implicit consumers locally, then configure a persistent stream provider and verify recovery.
+ms.date: 08/11/2026
+ms.topic: tutorial
+---
+
+# Build and recover an Orleans streaming application
+
+This walkthrough uses the maintained [Simple Streaming sample](https://github.com/dotnet/orleans/tree/main/samples/Streaming/Simple) to follow an event from a producer grain to an implicit consumer. You first run with an in-memory provider, then switch to Azure Event Hubs and verify recovery.
+
+## Run the local path
+
+From an empty directory:
+
+```powershell
+git clone https://github.com/dotnet/orleans.git
+cd orleans\samples\Streaming\Simple
+dotnet build .\Streaming.sln
+```
+
+Start the silo, then the client in another terminal:
+
+```powershell
+dotnet run --project .\SiloHost
+dotnet run --project .\Client
+```
+
+Without `Secrets.json`, both hosts register the named in-memory stream provider. The client asks a producer grain to publish integer events. The stream identity determines which implicitly subscribed consumer grain receives each event.
+
+Observe these transitions in the silo log:
+
+1. `ConsumerGrain` activates when the first matching event arrives.
+1. Orleans supplies an <xref:Orleans.Streams.IStreamSubscriptionHandleFactory>.
+1. The grain resumes the subscription with its observer.
+1. `OnNextAsync` logs the event and its sequence token.
+
+No caller creates the consumer activation directly. <xref:Orleans.ImplicitStreamSubscriptionAttribute> maps the stream namespace and identity to the matching grain identity.
+
+## Trace the code
+
+Read these files in order:
+
+1. [`SiloHost/Program.cs`](https://github.com/dotnet/orleans/blob/main/samples/Streaming/Simple/SiloHost/Program.cs) registers `PubSubStore` and the stream provider.
+1. [`Grains/ProducerGrain.cs`](https://github.com/dotnet/orleans/blob/main/samples/Streaming/Simple/Grains/ProducerGrain.cs) obtains a typed stream and publishes events.
+1. [`Grains/ConsumerGrain.cs`](https://github.com/dotnet/orleans/blob/main/samples/Streaming/Simple/Grains/ConsumerGrain.cs) declares the implicit subscription and attaches an observer.
+1. [`Client/Program.cs`](https://github.com/dotnet/orleans/blob/main/samples/Streaming/Simple/Client/Program.cs) drives the scenario.
+
+The `PubSubStore` name is significant. Persistent stream providers use it for subscription metadata; register durable storage under that name in a production cluster.
+
+## Switch to a persistent provider
+
+Create an Azure Event Hubs namespace, event hub, consumer group, and Azure Storage account in a nonproduction subscription. Copy the sample's `Secrets.example.json` shape if present in your checkout and create `Secrets.json` with the Event Hubs and storage connection values. Don't commit this file.
+
+Restart the silo and client. The startup log should now report Azure Event Hub streaming instead of in-memory streaming. The silo configures:
+
+- Azure Table grain storage for `PubSubStore`;
+- the Event Hubs stream provider;
+- an Azure Table checkpointer; and
+- the configured Event Hubs consumer group.
+
+For deployed applications, replace local secrets with managed identity or your platform's secret store and grant only the required data-plane permissions.
+
+## Verify recovery
+
+1. Publish a sequence of identifiable events and record the latest observed item.
+1. Stop the silo gracefully, leaving Event Hubs and Azure Storage running.
+1. Restart the silo with the same service ID, cluster ID, provider name, hub, and consumer group.
+1. Publish more events and verify that the consumer resumes without recreating the subscription.
+1. Confirm that processing continues from the stored checkpoint rather than replaying the complete partition.
+
+Orleans stream delivery is at-least-once. A consumer can observe duplicates around failures, so production handlers should be idempotent or deduplicate using an application-owned event identity. Don't treat a sequence token as a globally meaningful business identifier.
+
+## Test failure boundaries
+
+Repeat the recovery check while terminating a silo abruptly. Monitor queue lag, delivery retries, duplicate processing, poison-event handling, and checkpoint age. Then use [streaming operations](../streaming/streaming-operations.md) to define alerts and recovery procedures for the selected provider.
+
+For provider choices and guarantees, continue with [stream providers](../streaming/stream-providers.md), [delivery semantics](../streaming/delivery-semantics.md), and [pub-sub storage](../streaming/pubsub-storage.md).

--- a/docs/site/src/content/docs/tutorials-and-samples/testing-walkthrough.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/testing-walkthrough.md
@@ -1,0 +1,78 @@
+---
+title: Test an Orleans application end to end
+description: Progress from a first grain test to reusable cluster and topology tests with Orleans.TestingHost.
+ms.date: 08/11/2026
+ms.topic: tutorial
+---
+
+# Test an Orleans application end to end
+
+This walkthrough builds a test suite in layers: pure logic tests, a real in-process Orleans cluster, a shared cluster fixture, and a topology change. The complete compiling source is in the documentation's `snippets/testing/orleans-testing` project.
+
+## Choose the right boundary
+
+Use ordinary unit tests for code which doesn't depend on activation, scheduling, serialization, placement, or providers. Use <xref:Orleans.TestingHost.InProcessTestCluster> when any of those Orleans behaviors matters. Finally, test against production providers when their external-system contract is part of the behavior.
+
+Keeping these boundaries explicit makes the fast tests fast without creating false confidence from mocked runtime behavior.
+
+## Run the first cluster test
+
+Clone the repository, then run the maintained test project:
+
+```powershell
+git clone https://github.com/dotnet/orleans.git
+cd orleans
+dotnet test .\docs\site\src\content\docs\snippets\testing\orleans-testing\Sample.OrleansTesting
+```
+
+The first test creates a cluster, deploys it, obtains a grain reference from the client, makes a call, and disposes the cluster:
+
+:::code language="csharp" source="../grains/snippets/testing/orleans-testing/Sample.OrleansTesting/HelloGrainTests.cs" id="basic_cluster_test":::
+
+This validates code generation, serialization, activation, message dispatch, and the grain implementation together. The default builder starts two silos and a client with fast in-memory test infrastructure.
+
+## Add application configuration
+
+Production grains commonly depend on services registered through dependency injection. Configure all hosts, only silos, or only the client using the matching builder scope:
+
+:::code language="csharp" source="../grains/snippets/testing/orleans-testing/Sample.OrleansTesting/ClusterConfiguration.cs" id="configure_cluster":::
+
+Each host owns a service provider. Registering a service type creates one instance per host. Registering a captured instance intentionally shares it across silos and the client, so shared test doubles must be thread-safe.
+
+Run the tests again after each configuration change. A deployment failure should fail the test setup rather than be converted into a passing assertion.
+
+## Reuse an expensive cluster
+
+Create an xUnit fixture when multiple tests need identical cluster configuration:
+
+:::code language="csharp" source="../grains/snippets/testing/orleans-testing/Sample.OrleansTesting/ClusterFixture.cs" id="cluster_fixture":::
+
+Register the fixture as a collection:
+
+:::code language="csharp" source="../grains/snippets/testing/orleans-testing/Sample.OrleansTesting/ClusterCollection.cs" id="cluster_collection":::
+
+Then consume the cluster without starting it in every test:
+
+:::code language="csharp" source="../grains/snippets/testing/orleans-testing/Sample.OrleansTesting/HelloGrainTestsWithFixture.cs" id="shared_cluster_test":::
+
+Give each test unique grain identities, reset shared external state, and don't depend on test execution order.
+
+## Exercise a topology change
+
+Add a silo, wait for membership to stabilize, then stop it gracefully:
+
+:::code language="csharp" source="../grains/snippets/testing/orleans-testing/Sample.OrleansTesting/ClusterConfiguration.cs" id="change_topology":::
+
+Use this pattern to test behavior which depends on membership changes. A same-process cluster doesn't reproduce process crashes, network partitions, socket transport, or a production membership provider. Add a separate environment for those failure modes instead of treating this test as equivalent.
+
+## Add production-provider tests
+
+For persistence, reminders, clustering, or streams, add an opt-in suite which:
+
+1. Provisions an isolated provider instance or emulator.
+1. Configures the cluster with the same provider extension used in production.
+1. Uses unique database, table, stream, and grain identifiers.
+1. Verifies behavior across a silo restart.
+1. Cleans up owned resources even when an assertion fails.
+
+Keep credentials out of source control and make missing prerequisites explicit. For API details and fidelity boundaries, see [Test Orleans applications](../grains/testing.md) and [TestingHost architecture](../implementation/testing.md).

--- a/docs/site/src/content/docs/tutorials-and-samples/testing-walkthrough.md
+++ b/docs/site/src/content/docs/tutorials-and-samples/testing-walkthrough.md
@@ -7,7 +7,7 @@ ms.topic: tutorial
 
 # Test an Orleans application end to end
 
-This walkthrough builds a test suite in layers: pure logic tests, a real in-process Orleans cluster, a shared cluster fixture, and a topology change. The complete compiling source is in the documentation's `snippets/testing/orleans-testing` project.
+This walkthrough builds a test suite in layers: pure logic tests, a real in-process Orleans cluster, a shared cluster fixture, and a topology change. The complete compiling source is in the documentation's `grains/snippets/testing/orleans-testing` project.
 
 ## Choose the right boundary
 
@@ -22,7 +22,7 @@ Clone the repository, then run the maintained test project:
 ```powershell
 git clone https://github.com/dotnet/orleans.git
 cd orleans
-dotnet test .\docs\site\src\content\docs\snippets\testing\orleans-testing\Sample.OrleansTesting
+dotnet test .\docs\site\src\content\docs\grains\snippets\testing\orleans-testing\Sample.OrleansTesting
 ```
 
 The first test creates a cluster, deploys it, obtains a grain reference from the client, makes a call, and disposes the cluster:


### PR DESCRIPTION
## Problem

The documentation learning path stops after introductory, single-project examples, leaving readers to assemble testing, streaming recovery, production deployment, and rolling-upgrade guidance from separate reference pages.

## Solution

Add four end-to-end walkthroughs which cover a production-shaped Azure Container Apps application, layered TestingHost tests, persistent streaming and recovery, and mixed-version rolling upgrades. The walkthroughs reuse maintained samples and compiling documentation snippets, include concrete verification and failure boundaries, and are registered in the tutorials catalog and site navigation.

## Rationale

Keeping these scenarios as distinct tutorials provides a guided path while linking to the deeper conceptual, operational, and API documentation for details.

Fixes #10392
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10480)