### PR TITLE
docs: clarify documentation navigation

### DIFF
--- a/docs/site/src/content/docs/host/configuration-guide/index.md
+++ b/docs/site/src/content/docs/host/configuration-guide/index.md
@@ -68,3 +68,5 @@ The Generic Host combines [.NET configuration providers](https://learn.microsoft
 - Validate provider connectivity and credentials before rollout.
 
 For option types and API entry points, see [Core configuration options](list-of-options-classes.md) and <xref:Orleans.Configuration>.
+
+For task-oriented configuration recipes, see the [Orleans how-to guide index](../../how-to/index.md). For the exact signatures and defaults of configuration APIs, use the [C# API reference](https://dotnet.github.io/orleans/docs/api/csharp/).

--- a/docs/site/src/content/docs/how-to/index.md
+++ b/docs/site/src/content/docs/how-to/index.md
@@ -1,0 +1,53 @@
+---
+title: Orleans how-to guides
+description: Task-oriented recipes for configuring, deploying, and operating Orleans applications.
+ms.date: 08/11/2026
+ms.topic: how-to
+---
+
+# Orleans how-to guides
+
+Use these recipes when you have a specific task to complete. Each guide focuses on prerequisites, the shortest supported path, and the checks which confirm that the change worked.
+
+If you are learning Orleans from an empty directory, start with the [tutorials and walkthroughs](../tutorials-and-samples/index.md). For the ideas behind these tasks, see [Orleans concepts](../overview.md) and [Why Orleans?](../benefits.md). For the runtime behavior behind a recommendation, see [Architecture and internals](../implementation/index.md).
+
+## Configure hosting and providers
+
+- [Configure a silo](../host/configuration-guide/server-configuration.md)
+- [Configure an external client](../host/configuration-guide/client-configuration.md)
+- [Choose a typical configuration](../host/configuration-guide/typical-configurations.md)
+- [Configure ADO.NET providers](../host/configuration-guide/configuring-ado-dot-net-providers.md)
+- [Configure Consul clustering](../host/configuration-guide/clustering/consul.md)
+- [Configure serialization](../host/configuration-guide/serialization-configuration.md)
+- [Configure TLS](../host/transport-layer-security.md)
+- [Configure Aspire integration](../host/aspire-integration.md)
+
+## Deploy and operate
+
+- [Review production readiness](../deployment/production-readiness.md)
+- [Configure topology, networking, and clustering](../deployment/networking.md)
+- [Deploy to Kubernetes](../deployment/kubernetes.md)
+- [Deploy to Azure App Service](../deployment/deploy-to-azure-app-service.md)
+- [Deploy to Azure Container Apps](../deployment/deploy-to-azure-container-apps.md)
+- [Plan capacity and scaling](../deployment/capacity-planning.md)
+- [Perform a graceful upgrade](../deployment/upgrades.md)
+- [Plan disaster recovery](../deployment/disaster-recovery.md)
+
+## Use Orleans features
+
+- [Persist grain state](../grains/grain-persistence/index.md)
+- [Add reminders and timers](../grains/timers-and-reminders.md)
+- [Configure streams](../streaming/stream-providers.md)
+- [Use response streaming](../grains/response-streaming.md)
+- [Use stateless worker grains](../grains/stateless-worker-grains.md)
+- [Test an Orleans application](../grains/testing.md)
+
+## Diagnose and recover
+
+- [Troubleshoot a deployment](../deployment/troubleshooting-deployments.md)
+- [Troubleshoot Orleans incidents](../host/monitoring/troubleshooting.md)
+- [Monitor silo and client error codes](../host/monitoring/silo-error-code-monitoring.md)
+- [Configure signals and alerting](../host/monitoring/signals.md)
+- [Handle failures and uncertain outcomes](../deployment/handling-failures.md)
+
+For public types, defaults, exceptions, and overloads, use the [C# API reference](https://dotnet.github.io/orleans/docs/api/csharp/). Reference entries provide the precise contract; the recipes above show how to apply it.

--- a/docs/site/src/content/docs/implementation/index.md
+++ b/docs/site/src/content/docs/implementation/index.md
@@ -43,3 +43,5 @@ The pages in this track use Orleans source and tests as the specification. Inter
 | Automatic call retry after response timeout | None |
 
 Configuration values affect failure detection and resource use. This track explains their role in protocols, while the [hosting configuration guide](../host/configuration-guide/index.md) and [deployment guidance](../deployment/index.md) own operational recommendations.
+
+For the application mental model, start with [Orleans overview](../overview.md). For task-oriented recipes which apply these components, use the [how-to guide index](../how-to/index.md); for public type contracts, use the [C# API reference](https://dotnet.github.io/orleans/docs/api/csharp/).

--- a/docs/site/src/content/docs/implementation/index.md
+++ b/docs/site/src/content/docs/implementation/index.md
@@ -44,4 +44,4 @@ The pages in this track use Orleans source and tests as the specification. Inter
 
 Configuration values affect failure detection and resource use. This track explains their role in protocols, while the [hosting configuration guide](../host/configuration-guide/index.md) and [deployment guidance](../deployment/index.md) own operational recommendations.
 
-For the application mental model, start with [Orleans overview](../overview.md). For task-oriented recipes which apply these components, use the [how-to guide index](../how-to/index.md); for public type contracts, use the [C# API reference](https://dotnet.github.io/orleans/docs/api/csharp/).
+For the application mental model, start with [Orleans overview](../overview.md). For task-oriented recipes that apply these components, use the [how-to guide index](../how-to/index.md); for public type contracts, use the [C# API reference](https://dotnet.github.io/orleans/docs/api/csharp/).

--- a/docs/site/src/content/docs/index.yml
+++ b/docs/site/src/content/docs/index.yml
@@ -35,6 +35,15 @@ highlightedContent:
         - itemType: overview
           title: Orleans transactions
           url: grains/transactions.md
+        - itemType: how-to-guide
+          title: Orleans how-to guides
+          url: how-to/index.md
+        - itemType: architecture
+          title: Orleans architecture and internals
+          url: implementation/index.md
+        - itemType: reference
+          title: C# API reference
+          url: /docs/api/csharp/
 
 conceptualContent:
     title: Featured content

--- a/docs/site/src/content/docs/resources/api-reference-guide.md
+++ b/docs/site/src/content/docs/resources/api-reference-guide.md
@@ -14,6 +14,6 @@ Reference pages are most useful with the surrounding documentation:
 - Learn the programming model in [Orleans overview](../overview.md), [Develop Orleans grains](../grains/index.md), and [Streaming with Orleans](../streaming/index.md).
 - Follow task-oriented recipes in the [how-to guide index](../how-to/index.md), including [hosting configuration](../host/configuration-guide/index.md) and [deployment](../deployment/index.md).
 - Understand runtime guarantees and tradeoffs in [Architecture and internals](../implementation/index.md).
-- Diagnose production symptoms with [FAQ and troubleshooting](../host/monitoring/troubleshooting.md).
+- Diagnose production symptoms with the [troubleshooting workflow](../host/monitoring/troubleshooting.md).
 
 When a guide names a public Orleans symbol, prefer its generated xref link. Use the API reference for the contract and the conceptual or how-to page for the recommended usage and operational context.

--- a/docs/site/src/content/docs/resources/api-reference-guide.md
+++ b/docs/site/src/content/docs/resources/api-reference-guide.md
@@ -1,0 +1,19 @@
+---
+title: Orleans API reference guide
+description: Find the generated Orleans API reference and the documentation which explains how to use its public types.
+ms.date: 08/11/2026
+ms.topic: reference
+---
+
+# Orleans API reference guide
+
+The [C# API reference](https://dotnet.github.io/orleans/docs/api/csharp/) is the complete generated reference for Orleans public types and members. Use it when you need an exact signature, overload, default, exception, or inheritance relationship.
+
+Reference pages are most useful with the surrounding documentation:
+
+- Learn the programming model in [Orleans overview](../overview.md), [Develop Orleans grains](../grains/index.md), and [Streaming with Orleans](../streaming/index.md).
+- Follow task-oriented recipes in the [how-to guide index](../how-to/index.md), including [hosting configuration](../host/configuration-guide/index.md) and [deployment](../deployment/index.md).
+- Understand runtime guarantees and tradeoffs in [Architecture and internals](../implementation/index.md).
+- Diagnose production symptoms with [FAQ and troubleshooting](../host/monitoring/troubleshooting.md).
+
+When a guide names a public Orleans symbol, prefer its generated xref link. Use the API reference for the contract and the conceptual or how-to page for the recommended usage and operational context.

--- a/docs/site/src/content/docs/resources/frequently-asked-questions.md
+++ b/docs/site/src/content/docs/resources/frequently-asked-questions.md
@@ -7,6 +7,8 @@ ms.topic: faq
 
 # Frequently asked questions
 
+For symptom-based incident runbooks, see [Troubleshoot Orleans incidents](../host/monitoring/troubleshooting.md). For task-oriented setup and deployment recipes, see the [how-to guide index](../how-to/index.md).
+
 ## Availability and support
 
 ### Can I use Orleans in my project?

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -16,12 +16,40 @@ items:
         href: quickstarts/build-your-first-orleans-app.md
       - name: Deploy and scale on Azure
         href: quickstarts/deploy-scale-orleans-on-azure.md
-  - name: Tutorials
+  - name: Walkthroughs and tutorials
     items:
       - name: Model an adventure game
         href: tutorials-and-samples/adventure.md
       - name: Build custom grain storage
         href: tutorials-and-samples/custom-grain-storage.md
+  - name: Concepts
+    items:
+      - name: Orleans overview
+        href: overview.md
+      - name: Why Orleans?
+        href: benefits.md
+      - name: Grain model and programming
+        href: grains/index.md
+      - name: Persistence and durability
+        href: grains/grain-persistence/index.md
+      - name: Streaming
+        href: streaming/index.md
+      - name: Versioning and compatibility
+        href: grains/grain-versioning/grain-versioning.md
+      - name: Orleans clients
+        href: host/client.md
+  - name: How-to guides
+    items:
+      - name: Recipe index
+        href: how-to/index.md
+      - name: Configure hosting and providers
+        href: host/configuration-guide/index.md
+      - name: Deploy and operate
+        href: deployment/index.md
+      - name: Use Orleans features
+        href: grains/index.md
+      - name: Diagnose and recover
+        href: host/monitoring/troubleshooting.md
   - name: Develop applications
     items:
       - name: Grains
@@ -297,10 +325,12 @@ items:
         href: /samples/
       - name: Samples repository
         href: https://github.com/dotnet/orleans/tree/main/samples
-  - name: Reference/API
+  - name: Reference
     items:
       - name: C# API reference
         href: /docs/api/csharp/
+      - name: API context and examples
+        href: resources/api-reference-guide.md
       - name: Frequently asked questions
         href: resources/frequently-asked-questions.md
       - name: Best practices
@@ -311,6 +341,18 @@ items:
         href: resources/student-projects.md
       - name: Community and external links
         href: resources/links.md
+  - name: FAQ and troubleshooting
+    items:
+      - name: Frequently asked questions
+        href: resources/frequently-asked-questions.md
+      - name: Troubleshooting workflow
+        href: host/monitoring/troubleshooting.md
+      - name: Troubleshoot deployments
+        href: deployment/troubleshooting-deployments.md
+      - name: Silo error codes
+        href: host/monitoring/silo-error-code-monitoring.md
+      - name: Client error codes
+        href: host/monitoring/client-error-code-monitoring.md
   - name: Upgrade to Orleans 10
     items:
       - name: Migration overview

--- a/docs/site/src/content/docs/toc.yml
+++ b/docs/site/src/content/docs/toc.yml
@@ -46,8 +46,6 @@ items:
         href: host/configuration-guide/index.md
       - name: Deploy and operate
         href: deployment/index.md
-      - name: Use Orleans features
-        href: grains/index.md
       - name: Diagnose and recover
         href: host/monitoring/troubleshooting.md
   - name: Develop applications


### PR DESCRIPTION
## Problem

The six documentation types defined in docs/AGENTS.md were not legible in the published navigation, and task-oriented recipes were spread across deployment, configuration, and feature sections without a single entry point.

## Solution

- Add explicit Concepts, How-to guides, Walkthroughs and tutorials, Reference, and FAQ and troubleshooting navigation entry points while preserving existing URLs.
- Add a how-to recipe index covering hosting and providers, deployment and operations, Orleans features, and incident diagnosis.
- Add an API reference context page and strengthen links between conceptual, recipe, implementation, troubleshooting, and generated API content.

## Rationale

Readers can now choose documentation by intent without guessing whether a page is a tutorial, concept, recipe, reference, or operational runbook. Existing subject-oriented navigation remains available, while hub pages direct readers to the complementary documentation types.

Fixes #10393
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10483)