### PR TITLE
test: allow full rebalancer suspension duration

### DIFF
--- a/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
+++ b/test/Orleans.Placement.Tests/ActivationRebalancingTests/ControlRebalancerTests.cs
@@ -95,8 +95,8 @@ public class ControlRebalancerTests(RebalancerFixture fixture, ITestOutputHelper
 
         Assert.Equal(RebalancerStatus.Suspended, report.Status);
         Assert.True(report.SuspensionDuration.HasValue);
-        // Must be less than the time it was told to be suspended
-        Assert.True(report.SuspensionDuration.Value < duration); 
+        // A coarse clock can report the full duration until its timestamp advances.
+        Assert.InRange(report.SuspensionDuration.Value, TimeSpan.FromTicks(1), duration);
         Assert.Equal(host, report.Host);
 
         resumed = rebalancerEvents.WaitForSessionStartAsync(


### PR DESCRIPTION
Fixes #10478.

A timed suspension report can legitimately return the full requested duration when the clock timestamp has not advanced. Validate the remaining duration as positive and no greater than the requested duration, preserving the existing status and host checks without introducing a delay.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10486)