### PR TITLE
ci: capture SQL Server failure diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,6 +356,13 @@ jobs:
       env:
 # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Not a secret")]
         ORLEANSMSSQLCONNECTIONSTRING: "Server=127.0.0.1,1433;User Id=SA;Password=yourWeak(!)Password;TrustServerCertificate=True;"
+    - name: Diagnose SQL Server
+      if: failure()
+      shell: bash
+      run: |
+        docker inspect --format 'status={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} restartCount={{.RestartCount}} oomKilled={{.State.OOMKilled}} exitCode={{.State.ExitCode}} error={{json .State.Error}}' mssql || true
+        docker inspect --format '{{if .State.Health}}{{range .State.Health.Log}}{{println .Start "exitCode=" .ExitCode .Output}}{{end}}{{end}}' mssql || true
+        docker logs --timestamps mssql || true
     - name: Clean up SQL Server
       if: always()
       run: docker rm -f mssql || true


### PR DESCRIPTION
The SQL Server provider job can intermittently receive SQL Server login error 18456, but its cleanup currently removes the container before the engine log and lifecycle state are captured. The reported job passed authenticated readiness, failed four tests during a brief authentication window, and then resumed passing SQL-backed tests. A rerun and a local run against the same image digest both passed, so speculative retries or credential changes would mask the failure without explaining it.\n\nAdd a failure-only diagnostic step before cleanup which records container status, health, restart and OOM state, exit details, recent health probes, and timestamped SQL Server logs. This preserves the server-side 18456 state and surrounding engine events needed to identify the concrete cause on recurrence.\n\nRefs #10474
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10487)