### PR TITLE
fix(tests): avoid Coverlet multi-target race

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,6 @@
     <PackageVersion Include="CassandraCSharpDriver" Version="3.22.0" />
     <PackageVersion Include="Consul" Version="1.7.14.10" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="coverlet.msbuild" Version="8.0.0" />
     <PackageVersion Include="CsCheck" Version="4.5.0" />
     <PackageVersion Include="FSharp.Core" Version="9.0.303" />
     <PackageVersion Include="Google.Cloud.Firestore" Version="4.3.0" />

--- a/test/Orleans.CodeGenerator.Tests/Orleans.CodeGenerator.Tests.csproj
+++ b/test/Orleans.CodeGenerator.Tests/Orleans.CodeGenerator.Tests.csproj
@@ -9,9 +9,6 @@
 
   <PropertyGroup>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
-    <CollectCoverage>true</CollectCoverage>
-    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
-    <Include>[Orleans.CodeGenerator]*</Include>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,10 +21,6 @@
 
   <ItemGroup>
     <!-- due to Verify.Xunit requiring newer versions of these libraries -->
-    <PackageReference Include="coverlet.msbuild">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="System.IO.Hashing" />
     <PackageReference Include="System.CodeDom" />
     <PackageReference Include="Verify.Xunit" />


### PR DESCRIPTION
The code-generator test project always enables Coverlet's MSBuild integration, which can race between its in-process hit-file writer and out-of-process coverage reader after successful multi-target test runs. The upstream fix has merged but is not available in a released package.

Remove the project-local `coverlet.msbuild` integration and rely on Orleans' repository-wide opt-in coverage collector instead. This preserves coverage collection when requested while keeping ordinary multi-target test runs out of the unreliable post-processing path.

Fixes: #10485