### PR TITLE
test(transactions): await storage recovery before reads

### DIFF
--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/ControlledFaultInjectionTransactionTestRunner.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/ControlledFaultInjectionTransactionTestRunner.cs
@@ -76,6 +76,11 @@ namespace Orleans.Transactions.TestKit
                 grains.Count,
                 recoveryEvents,
                 GetDeadline());
+            var faultAttemptSequence = recoveryEvents.LatestRelevantSequence;
+            var hasStorageFault = injectionType is FaultInjectionType.ExceptionBeforeStore
+                or FaultInjectionType.ExceptionAfterStore
+                or FaultInjectionType.GenericExceptionAfterStore;
+            var waitForRecovery = false;
             try
             {
                 await this.ExecuteAndWaitForCommit(
@@ -88,19 +93,32 @@ namespace Orleans.Transactions.TestKit
             {
                 this.testOutput($"Fault-injected transaction aborted: {exception}");
                 expected = setval;
+                waitForRecovery = hasStorageFault;
             }
             catch (OrleansTransactionException exception)
             {
                 this.testOutput($"Fault-injected transaction failed with an ambiguous outcome: {exception}");
                 expected = null;
+                waitForRecovery = hasStorageFault;
             }
 
-            await this.ObserveFaultInjection(
+            var fault = await this.ObserveFaultInjection(
                 faultObserved.Task,
                 injectionPhase,
                 injectionType,
                 recoveryEvents,
                 GetDeadline());
+            if (waitForRecovery)
+            {
+                var recovery = await recoveryEvents.WaitForRecoveryCompletionAsync(
+                    fault.TransactionId,
+                    fault.GrainId,
+                    faultAttemptSequence,
+                    GetDeadline());
+                this.testOutput(
+                    $"Fault-injected transaction recovery completed. "
+                    + TransactionRecoveryEventObserver.FormatTransition(recovery).Trim());
+            }
 
             var actualValues = await this.ReadAfterRecovery(grains, recoveryEvents, GetDeadline());
             actualValues.Should().OnlyContain(value => value == actualValues[0]);

--- a/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
+++ b/src/Orleans.Transactions.TestKit.Base/TestRunners/TransactionRecoveryEventObserver.cs
@@ -163,6 +163,37 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
         }
     }
 
+    public async Task<RecoveryTransition> WaitForRecoveryCompletionAsync(
+        Guid transactionId,
+        GrainId faultingGrainId,
+        long afterSequence,
+        long deadline,
+        CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            long observedThrough;
+            lock (this.lockObj)
+            {
+                this.ThrowIfDisposed();
+                var completed = this.timeline.FirstOrDefault(transition =>
+                    transition.Sequence > afterSequence
+                    && this.IsCurrentlyRelevant(transition)
+                    && transition.GrainId == faultingGrainId
+                    && transition.TransactionIds.Contains(transactionId)
+                    && IsRecoveryCompletion(transition));
+                if (completed is not null)
+                {
+                    return completed;
+                }
+
+                observedThrough = this.nextSequence;
+            }
+
+            await this.WaitForNextTransitionAsync(observedThrough, deadline, cancellationToken);
+        }
+    }
+
     public IReadOnlyList<RecoveryTransition> GetTimeline()
     {
         lock (this.lockObj)
@@ -416,6 +447,13 @@ internal sealed class TransactionRecoveryEventObserver : IObserver<TransactionDi
 
     private static string FormatTransactionIds(ImmutableArray<Guid> transactionIds)
         => transactionIds.IsDefaultOrEmpty ? "<none>" : $"[{string.Join(",", transactionIds)}]";
+
+    private static bool IsRecoveryCompletion(RecoveryTransition transition)
+        => transition.Kind is RecoveryTransitionKind.AbortAndRestoreCompleted
+            or RecoveryTransitionKind.QueueRestoreCompleted
+            || ((transition.Kind is RecoveryTransitionKind.TransactionCancelCompleted
+                    or RecoveryTransitionKind.TransactionConfirmCompleted)
+                && transition.Succeeded == true);
 
     private bool IsCurrentlyRelevant(RecoveryTransition transition)
         => this.relevantGrains is null

--- a/test/Transactions/Orleans.Transactions.Tests/TransactionDiagnosticEventsTests.cs
+++ b/test/Transactions/Orleans.Transactions.Tests/TransactionDiagnosticEventsTests.cs
@@ -500,6 +500,45 @@ public class TransactionDiagnosticEventsTests
     }
 
     [Fact]
+    public async Task RecoveryObserverWaitsForCompletionAfterStorageConflict()
+    {
+        var resource = CreateParticipant(
+            "resource",
+            CreateGrainReference("resource"),
+            ParticipantId.Role.Resource);
+        var transactionId = Guid.NewGuid();
+        var transactionIds = ImmutableArray.Create(transactionId);
+        var conflict = new InconsistentStateException("etag mismatch");
+        using var observer = new TransactionRecoveryEventObserver(_ => true);
+        var completion = observer.WaitForRecoveryCompletionAsync(
+            transactionId,
+            resource.Reference.GrainId,
+            afterSequence: 0,
+            GetDeadline(RecoveryObservationTimeout));
+
+        TransactionDiagnosticEvents.EmitStorageConflictDetected(
+            resource,
+            TransactionDiagnosticEvents.StorageOperation.Store,
+            storageOutcomeInDoubt: true,
+            queuedTransactionCount: 1,
+            conflict,
+            transactionIds);
+
+        await Task.Yield();
+        Assert.False(completion.IsCompleted);
+
+        TransactionDiagnosticEvents.EmitAbortAndRestoreCompleted(
+            resource,
+            TransactionalStatus.StorageConflict,
+            storageOutcomeInDoubt: true,
+            transactionIds);
+
+        var transition = await completion;
+        Assert.Equal(TransactionRecoveryEventObserver.RecoveryTransitionKind.AbortAndRestoreCompleted, transition.Kind);
+        Assert.Equal(transactionId, transition.TransactionId);
+    }
+
+    [Fact]
     public async Task RecoveryObserverLockExpiredTransitionContainsTransactionId()
     {
         var resource = CreateParticipant("resource", ParticipantId.Role.Resource);


### PR DESCRIPTION
The controlled fault-injection runner treated any recovery diagnostic as sufficient progress before retrying verification reads. A `StorageConflict` event is emitted before `AbortAndRestore` finishes, so a successful read in that window could be accepted as final and make transient activation state appear to be durable data loss.

Wait for transaction- and grain-correlated recovery completion before verification reads after storage-exception faults. Deactivation faults retain their existing path because replacement activations restore without transaction correlation. Add a deterministic observer regression proving that `StorageConflict` alone does not complete the recovery barrier.

Fixes #10476
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/orleans/pull/10491)